### PR TITLE
Add status handler

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = "0.7.5"
+axum = { version = "0.7.5", features = ["macros"] }
+serde_json = "1.0.120"
 tokio = { version = "1.38.1", features = ["full"] }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -2,11 +2,15 @@
 
 use axum::response::IntoResponse;
 use axum::routing::get;
-use axum::Router;
+use axum::{debug_handler, Router};
+
+mod status;
 
 #[tokio::main]
 async fn main() {
-    let router = Router::new().route("/", get(hello_world));
+    let router = Router::new()
+        .route("/", get(hello_world))
+        .route("/status", get(status::status_handler));
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
         .await
@@ -17,6 +21,7 @@ async fn main() {
         .expect("Failed to start server")
 }
 
+#[debug_handler]
 async fn hello_world() -> impl IntoResponse {
     "HELL0 W0RLD"
 }

--- a/api/src/status.rs
+++ b/api/src/status.rs
@@ -1,0 +1,9 @@
+use axum::debug_handler;
+use axum::response::Json;
+use serde_json::json;
+
+/// A handler for a simple liveness check
+#[debug_handler]
+pub async fn status_handler() -> Json<serde_json::Value> {
+    Json(json!({ "status": "ok" }))
+}


### PR DESCRIPTION
Add endpoint `/status` with a simple liveness check.