### PR TITLE
Parametrize `mock-inference-provider`'s socket address (#76)

### DIFF
--- a/gateway/tests/mock-inference-provider/README.md
+++ b/gateway/tests/mock-inference-provider/README.md
@@ -1,0 +1,19 @@
+# Mock Inference Provider
+
+This is a mock inference provider that can be used to test the gateway.
+
+## Usage
+
+To run the mock inference provider, you can use the following command:
+
+```bash
+cargo run --release --bin mock-inference-provider
+```
+
+By default, the mock inference provider will bind to `0.0.0.0:3030`.
+You can optionally specify the address to bind to using the first CLI argument.
+For example, to bind to `0.0.0.0:1234`, you'd run:
+
+```bash
+cargo run --release --bin mock-inference-provider -- 0.0.0.0:1234
+```


### PR DESCRIPTION
Fixes #76 

You can specify the address with the first CLI argument, e.g.:

```bash
cargo run --release --bin mock-inference-provider -- 0.0.0.0:1234
```
