### PR TITLE
Disable GHA Docker mount cache

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -49,35 +49,39 @@ jobs:
           GCP_JWT_KEY: ${{ secrets.GCP_JWT_KEY }}
         run: echo "$GCP_JWT_KEY" > $GITHUB_WORKSPACE/gcp_jwt_key.json
 
-      - name: Cache Docker mounts
-        uses: actions/cache@v3
-        id: cache-docker-mounts
-        with:
-          path: |
-            docker-gateway-usr-local-cargo-registry
-            docker-gateway-usr-local-cargo-git
-            docker-gateway-src-target
-          key: cache-docker-mounts-${{ runner.os }}
+      # NOTE:
+      # Setting up and spinning down the Docker mount cache takes ~5min so it's slower than doing it from scratch right now.
+      # We can re-introduce the cache if building starts taking longer than 10min.
 
-      - name: Inject cache into Docker
-        uses: reproducible-containers/buildkit-cache-dance@v3.1.0
-        with:
-          cache-map: |
-            {
-              "docker-gateway-usr-local-cargo-registry": {
-                "target": "/usr/local/cargo/registry",
-                "id": "tensorzero-gateway-release"
-              },
-              "docker-gateway-usr-local-cargo-git": {
-                "target": "/usr/local/cargo/git",
-                "id": "tensorzero-gateway-release"
-              },
-              "docker-gateway-src-target": {
-                "target": "/src/target",
-                "id": "tensorzero-gateway-release"
-              }
-            }
-          skip-extraction: ${{ steps.cache-docker-mounts.outputs.cache-hit }}
+      # - name: Cache Docker mounts
+      #   uses: actions/cache@v3
+      #   id: cache-docker-mounts
+      #   with:
+      #     path: |
+      #       docker-gateway-usr-local-cargo-registry
+      #       docker-gateway-usr-local-cargo-git
+      #       docker-gateway-src-target
+      #     key: cache-docker-mounts-${{ runner.os }}
+
+      # - name: Inject cache into Docker
+      #   uses: reproducible-containers/buildkit-cache-dance@v3.1.0
+      #   with:
+      #     cache-map: |
+      #       {
+      #         "docker-gateway-usr-local-cargo-registry": {
+      #           "target": "/usr/local/cargo/registry",
+      #           "id": "tensorzero-gateway-release"
+      #         },
+      #         "docker-gateway-usr-local-cargo-git": {
+      #           "target": "/usr/local/cargo/git",
+      #           "id": "tensorzero-gateway-release"
+      #         },
+      #         "docker-gateway-src-target": {
+      #           "target": "/src/target",
+      #           "id": "tensorzero-gateway-release"
+      #         }
+      #       }
+      #     skip-extraction: ${{ steps.cache-docker-mounts.outputs.cache-hit }}
 
       - name: Build Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Setting up and spinning down the Docker mount cache takes ~5min so it's slower than doing it from scratch right now. We can re-introduce the cache if building starts taking longer than 10min.
