### PR TITLE
Rename `content` to `output` in streaming responses

### DIFF
--- a/gateway/src/endpoints/inference.rs
+++ b/gateway/src/endpoints/inference.rs
@@ -445,7 +445,7 @@ struct ChatInferenceResponseChunk {
     inference_id: Uuid,
     episode_id: Uuid,
     variant_name: String,
-    content: Vec<ContentBlockChunk>,
+    output: Vec<ContentBlockChunk>,
     #[serde(skip_serializing_if = "Option::is_none")]
     usage: Option<Usage>,
 }
@@ -468,7 +468,7 @@ impl InferenceResponseChunk {
                     inference_id: result.inference_id,
                     episode_id,
                     variant_name,
-                    content: result.content,
+                    output: result.content,
                     usage: result.usage,
                 })
             }

--- a/gateway/tests/e2e/inference.rs
+++ b/gateway/tests/e2e/inference.rs
@@ -974,16 +974,16 @@ async fn e2e_test_streaming() {
     for (i, chunk) in chunks.iter().enumerate() {
         let chunk_json: Value = serde_json::from_str(chunk).unwrap();
         if i < DUMMY_STREAMING_RESPONSE.len() {
-            let content = chunk_json.get("content").unwrap().as_array().unwrap();
-            assert_eq!(content.len(), 1);
-            let content_block = content.first().unwrap();
+            let output = chunk_json.get("output").unwrap().as_array().unwrap();
+            assert_eq!(output.len(), 1);
+            let content_block = output.first().unwrap();
             let content_block_type = content_block.get("type").unwrap().as_str().unwrap();
             assert_eq!(content_block_type, "text");
             let content = content_block.get("text").unwrap().as_str().unwrap();
             assert_eq!(content, DUMMY_STREAMING_RESPONSE[i]);
         } else {
             assert!(chunk_json
-                .get("content")
+                .get("output")
                 .unwrap()
                 .as_array()
                 .unwrap()
@@ -1124,16 +1124,16 @@ async fn e2e_test_streaming_dryrun() {
     for (i, chunk) in chunks.iter().enumerate() {
         let chunk_json: Value = serde_json::from_str(chunk).unwrap();
         if i < DUMMY_STREAMING_RESPONSE.len() {
-            let content = chunk_json.get("content").unwrap().as_array().unwrap();
-            assert_eq!(content.len(), 1);
-            let content_block = content.first().unwrap();
+            let output = chunk_json.get("output").unwrap().as_array().unwrap();
+            assert_eq!(output.len(), 1);
+            let content_block = output.first().unwrap();
             let content_block_type = content_block.get("type").unwrap().as_str().unwrap();
             assert_eq!(content_block_type, "text");
             let content = content_block.get("text").unwrap().as_str().unwrap();
             assert_eq!(content, DUMMY_STREAMING_RESPONSE[i]);
         } else {
             assert!(chunk_json
-                .get("content")
+                .get("output")
                 .unwrap()
                 .as_array()
                 .unwrap()
@@ -1197,9 +1197,9 @@ async fn e2e_test_tool_call_streaming() {
     for (i, chunk) in chunks.iter().enumerate() {
         let chunk_json: Value = serde_json::from_str(chunk).unwrap();
         if i < DUMMY_STREAMING_TOOL_RESPONSE.len() {
-            let content = chunk_json.get("content").unwrap().as_array().unwrap();
-            assert_eq!(content.len(), 1);
-            let content_block = content.first().unwrap();
+            let output = chunk_json.get("output").unwrap().as_array().unwrap();
+            assert_eq!(output.len(), 1);
+            let content_block = output.first().unwrap();
             let content_block_type = content_block.get("type").unwrap().as_str().unwrap();
             assert_eq!(content_block_type, "tool_call");
             let new_arguments = content_block.get("arguments").unwrap().as_str().unwrap();
@@ -1218,7 +1218,7 @@ async fn e2e_test_tool_call_streaming() {
             }
         } else {
             assert!(chunk_json
-                .get("content")
+                .get("output")
                 .unwrap()
                 .as_array()
                 .unwrap()

--- a/gateway/tests/e2e/providers/common.rs
+++ b/gateway/tests/e2e/providers/common.rs
@@ -491,7 +491,7 @@ pub async fn test_simple_streaming_inference_request_with_provider(provider: E2E
         let chunk_episode_id = Uuid::parse_str(chunk_episode_id).unwrap();
         assert_eq!(chunk_episode_id, episode_id);
 
-        let content_blocks = chunk_json.get("content").unwrap().as_array().unwrap();
+        let content_blocks = chunk_json.get("output").unwrap().as_array().unwrap();
         if !content_blocks.is_empty() {
             let content_block = content_blocks.first().unwrap();
             let content = content_block.get("text").unwrap().as_str().unwrap();
@@ -901,7 +901,7 @@ pub async fn test_inference_params_streaming_inference_request_with_provider(
         let chunk_episode_id = Uuid::parse_str(chunk_episode_id).unwrap();
         assert_eq!(chunk_episode_id, episode_id);
 
-        let content_blocks = chunk_json.get("content").unwrap().as_array().unwrap();
+        let content_blocks = chunk_json.get("output").unwrap().as_array().unwrap();
         if !content_blocks.is_empty() {
             let content_block = content_blocks.first().unwrap();
             let content = content_block.get("text").unwrap().as_str().unwrap();
@@ -1352,7 +1352,7 @@ pub async fn test_tool_use_tool_choice_auto_used_streaming_inference_request_wit
         let chunk_episode_id = Uuid::parse_str(chunk_episode_id).unwrap();
         assert_eq!(chunk_episode_id, episode_id);
 
-        for block in chunk_json.get("content").unwrap().as_array().unwrap() {
+        for block in chunk_json.get("output").unwrap().as_array().unwrap() {
             assert!(block.get("id").is_some());
 
             let block_type = block.get("type").unwrap().as_str().unwrap();
@@ -1846,7 +1846,7 @@ pub async fn test_tool_use_tool_choice_auto_unused_streaming_inference_request_w
         let chunk_episode_id = Uuid::parse_str(chunk_episode_id).unwrap();
         assert_eq!(chunk_episode_id, episode_id);
 
-        for block in chunk_json.get("content").unwrap().as_array().unwrap() {
+        for block in chunk_json.get("output").unwrap().as_array().unwrap() {
             assert!(block.get("id").is_some());
 
             let block_type = block.get("type").unwrap().as_str().unwrap();
@@ -2387,7 +2387,7 @@ pub async fn test_tool_use_tool_choice_required_streaming_inference_request_with
         let chunk_episode_id = Uuid::parse_str(chunk_episode_id).unwrap();
         assert_eq!(chunk_episode_id, episode_id);
 
-        for block in chunk_json.get("content").unwrap().as_array().unwrap() {
+        for block in chunk_json.get("output").unwrap().as_array().unwrap() {
             assert!(block.get("id").is_some());
 
             let block_type = block.get("type").unwrap().as_str().unwrap();
@@ -2897,7 +2897,7 @@ pub async fn test_tool_use_tool_choice_none_streaming_inference_request_with_pro
         let chunk_episode_id = Uuid::parse_str(chunk_episode_id).unwrap();
         assert_eq!(chunk_episode_id, episode_id);
 
-        for block in chunk_json.get("content").unwrap().as_array().unwrap() {
+        for block in chunk_json.get("output").unwrap().as_array().unwrap() {
             assert!(block.get("id").is_some());
 
             let block_type = block.get("type").unwrap().as_str().unwrap();
@@ -3473,7 +3473,7 @@ pub async fn test_tool_use_tool_choice_specific_streaming_inference_request_with
         let chunk_episode_id = Uuid::parse_str(chunk_episode_id).unwrap();
         assert_eq!(chunk_episode_id, episode_id);
 
-        for block in chunk_json.get("content").unwrap().as_array().unwrap() {
+        for block in chunk_json.get("output").unwrap().as_array().unwrap() {
             assert!(block.get("id").is_some());
 
             let block_type = block.get("type").unwrap().as_str().unwrap();
@@ -4034,7 +4034,7 @@ pub async fn test_tool_use_allowed_tools_streaming_inference_request_with_provid
         let chunk_episode_id = Uuid::parse_str(chunk_episode_id).unwrap();
         assert_eq!(chunk_episode_id, episode_id);
 
-        for block in chunk_json.get("content").unwrap().as_array().unwrap() {
+        for block in chunk_json.get("output").unwrap().as_array().unwrap() {
             assert!(block.get("id").is_some());
 
             let block_type = block.get("type").unwrap().as_str().unwrap();
@@ -4544,7 +4544,7 @@ pub async fn test_tool_multi_turn_streaming_inference_request_with_provider(
         let chunk_episode_id = Uuid::parse_str(chunk_episode_id).unwrap();
         assert_eq!(chunk_episode_id, episode_id);
 
-        let content_blocks = chunk_json.get("content").unwrap().as_array().unwrap();
+        let content_blocks = chunk_json.get("output").unwrap().as_array().unwrap();
         if !content_blocks.is_empty() {
             let content_block = content_blocks.first().unwrap();
             let content = content_block.get("text").unwrap().as_str().unwrap();
@@ -5056,7 +5056,7 @@ pub async fn test_dynamic_tool_use_streaming_inference_request_with_provider(
         let chunk_episode_id = Uuid::parse_str(chunk_episode_id).unwrap();
         assert_eq!(chunk_episode_id, episode_id);
 
-        for block in chunk_json.get("content").unwrap().as_array().unwrap() {
+        for block in chunk_json.get("output").unwrap().as_array().unwrap() {
             assert!(block.get("id").is_some());
 
             let block_type = block.get("type").unwrap().as_str().unwrap();
@@ -5634,7 +5634,7 @@ pub async fn test_parallel_tool_use_streaming_inference_request_with_provider(
         let chunk_episode_id = Uuid::parse_str(chunk_episode_id).unwrap();
         assert_eq!(chunk_episode_id, episode_id);
 
-        for block in chunk_json.get("content").unwrap().as_array().unwrap() {
+        for block in chunk_json.get("output").unwrap().as_array().unwrap() {
             assert!(block.get("id").is_some());
 
             let block_type = block.get("type").unwrap().as_str().unwrap();


### PR DESCRIPTION
Closes #244 