### PR TITLE
fixed regression in GCP vertex gemini streaming responses

### DIFF
--- a/gateway/src/clickhouse_migration_manager/migrations/migration_0000.rs
+++ b/gateway/src/clickhouse_migration_manager/migrations/migration_0000.rs
@@ -14,7 +14,6 @@ use super::check_table_exists;
 /// - ChatInference
 /// - JsonInference
 /// - ModelInference
-
 pub struct Migration0000<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }

--- a/gateway/src/clickhouse_migration_manager/migrations/migration_0001.rs
+++ b/gateway/src/clickhouse_migration_manager/migrations/migration_0001.rs
@@ -15,7 +15,6 @@ use super::check_table_exists;
 /// a materialized view that is indexed by inference ID and maps to the function_name that was used.
 /// Since we also would like to be able to get the original row from the inference ID we will keep the function_name,
 /// variant_name and episode_id in the materialized view so that we can use them to query the original table.
-
 pub struct Migration0001<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
     pub clean_start: bool,

--- a/gateway/src/config_parser.rs
+++ b/gateway/src/config_parser.rs
@@ -290,7 +290,6 @@ struct UninitializedConfig {
 
 impl UninitializedConfig {
     /// Load and validate the TensorZero config file
-
     /// Use a path provided as a CLI argument (`./gateway path/to/tensorzero.toml`), or default to
     /// `tensorzero.toml` in the current directory if no path is provided.
     fn get_config_path() -> String {

--- a/gateway/src/inference/providers/anthropic.rs
+++ b/gateway/src/inference/providers/anthropic.rs
@@ -186,7 +186,6 @@ impl InferenceProvider for AnthropicProvider {
 /// Maps events from Anthropic into the TensorZero format
 /// Modified from the example [here](https://github.com/64bit/async-openai/blob/5c9c817b095e3bacb2b6c9804864cdf8b15c795e/async-openai/src/client.rs#L433)
 /// At a high level, this function is handling low-level EventSource details and mapping the objects returned by Anthropic into our `InferenceResultChunk` type
-
 fn stream_anthropic(
     mut event_source: EventSource,
     start_time: Instant,

--- a/gateway/src/inference/providers/aws_bedrock.rs
+++ b/gateway/src/inference/providers/aws_bedrock.rs
@@ -568,7 +568,7 @@ struct ConverseOutputWithMetadata<'a> {
     json_mode: &'a ModelInferenceRequestJsonMode,
 }
 
-impl<'a> TryFrom<ConverseOutputWithMetadata<'a>> for ProviderInferenceResponse {
+impl TryFrom<ConverseOutputWithMetadata<'_>> for ProviderInferenceResponse {
     type Error = Error;
 
     fn try_from(value: ConverseOutputWithMetadata) -> Result<Self, Self::Error> {

--- a/gateway/src/inference/providers/gcp_vertex_anthropic.rs
+++ b/gateway/src/inference/providers/gcp_vertex_anthropic.rs
@@ -159,7 +159,6 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
 /// Maps events from Anthropic into the TensorZero format
 /// Modified from the example [here](https://github.com/64bit/async-openai/blob/5c9c817b095e3bacb2b6c9804864cdf8b15c795e/async-openai/src/client.rs#L433)
 /// At a high level, this function is handling low-level EventSource details and mapping the objects returned by Anthropic into our `InferenceResultChunk` type
-
 fn stream_anthropic(
     mut event_source: EventSource,
     start_time: Instant,

--- a/gateway/src/inference/providers/gcp_vertex_gemini.rs
+++ b/gateway/src/inference/providers/gcp_vertex_gemini.rs
@@ -812,7 +812,7 @@ struct GCPVertexGeminiResponseCandidate {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct GCPVertexGeminiUsageMetadata {
-    prompt_token_count: u32,
+    prompt_token_count: Option<u32>,
     // GCP doesn't return output tokens in certain edge cases (e.g. generation blocked by safety settings)
     #[serde(skip_serializing_if = "Option::is_none")]
     candidates_token_count: Option<u32>,
@@ -821,7 +821,7 @@ struct GCPVertexGeminiUsageMetadata {
 impl From<GCPVertexGeminiUsageMetadata> for Usage {
     fn from(usage_metadata: GCPVertexGeminiUsageMetadata) -> Self {
         Usage {
-            input_tokens: usage_metadata.prompt_token_count,
+            input_tokens: usage_metadata.prompt_token_count.unwrap_or(0),
             output_tokens: usage_metadata.candidates_token_count.unwrap_or(0),
         }
     }
@@ -1440,8 +1440,8 @@ mod tests {
         let response = GCPVertexGeminiResponse {
             candidates: vec![candidate],
             usage_metadata: Some(GCPVertexGeminiUsageMetadata {
-                prompt_token_count: 10,
-                candidates_token_count: Some(10),
+                prompt_token_count: None,
+                candidates_token_count: None,
             }),
         };
         let latency = Latency::NonStreaming {
@@ -1485,8 +1485,8 @@ mod tests {
         assert_eq!(
             model_inference_response.usage,
             Usage {
-                input_tokens: 10,
-                output_tokens: 10,
+                input_tokens: 0,
+                output_tokens: 0,
             }
         );
         assert_eq!(model_inference_response.latency, latency);
@@ -1512,7 +1512,7 @@ mod tests {
         let response = GCPVertexGeminiResponse {
             candidates: vec![candidate],
             usage_metadata: Some(GCPVertexGeminiUsageMetadata {
-                prompt_token_count: 15,
+                prompt_token_count: Some(15),
                 candidates_token_count: Some(20),
             }),
         };
@@ -1614,7 +1614,7 @@ mod tests {
         let response = GCPVertexGeminiResponse {
             candidates: vec![candidate],
             usage_metadata: Some(GCPVertexGeminiUsageMetadata {
-                prompt_token_count: 25,
+                prompt_token_count: Some(25),
                 candidates_token_count: Some(40),
             }),
         };

--- a/gateway/src/inference/providers/openai.rs
+++ b/gateway/src/inference/providers/openai.rs
@@ -656,7 +656,7 @@ pub(super) struct SpecificToolFunction<'a> {
     pub(super) name: &'a str,
 }
 
-impl<'a> Default for OpenAIToolChoice<'a> {
+impl Default for OpenAIToolChoice<'_> {
     fn default() -> Self {
         OpenAIToolChoice::String(OpenAIToolChoiceString::None)
     }

--- a/gateway/src/inference/types.rs
+++ b/gateway/src/inference/types.rs
@@ -18,10 +18,12 @@ use crate::{endpoints::inference::InferenceDatabaseInsertMetadata, variant::Infe
 use crate::{endpoints::inference::InferenceParams, error::ErrorDetails};
 use crate::{error::Error, variant::JsonMode};
 
-/// Data flow in TensorZero
-///
-/// The flow of an inference request through TensorZero can be viewed as a series of transformations between types.
-/// Most of them are defined below.
+/*
+ * Data flow in TensorZero
+ *
+ * The flow of an inference request through TensorZero can be viewed as a series of transformations between types.
+ * Most of them are defined below.
+ */
 
 /// A request is made that contains an Input
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -205,10 +207,11 @@ pub struct ModelInferenceResponseWithMetadata<'a> {
     pub model_name: &'a str,
 }
 
-/// As a Variant might make use of multiple model inferences, we then combine
-/// one or more ModelInferenceResults into a single InferenceResult (but we keep the original ModelInferenceResults around for storage).
-/// In the non-streaming case, this InferenceResult is converted into an InferenceResponse and sent to the client.
-/// See below for streaming case.
+/* As a Variant might make use of multiple model inferences, we then combine
+ * one or more ModelInferenceResults into a single InferenceResult (but we keep the original ModelInferenceResults around for storage).
+ * In the non-streaming case, this InferenceResult is converted into an InferenceResponse and sent to the client.
+ * See below for streaming case.
+ */
 
 /// This type contains the result of running a variant of a function
 #[derive(Clone, Debug, Serialize)]

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -109,7 +109,7 @@ pub async fn shutdown_signal() {
 /// ┌──────────────────────────────────────────────────────────────────────────┐
 /// │                           MAIN.RS ESCAPE HATCH                           │
 /// └──────────────────────────────────────────────────────────────────────────┘
-
+///
 /// We don't allow panic, escape, unwrap, or similar methods in the codebase,
 /// except for the private `expect_pretty` method, which is to be used only in
 /// main.rs during initialization. After initialization, we expect all code to
@@ -117,7 +117,6 @@ pub async fn shutdown_signal() {
 ///
 /// We use `expect_pretty` for better DX when handling errors in main.rs.
 /// `expect_pretty` will print an error message and exit with a status code of 1.
-
 trait ExpectPretty<T> {
     fn expect_pretty(self, msg: &str) -> T;
 }

--- a/gateway/src/minijinja_util.rs
+++ b/gateway/src/minijinja_util.rs
@@ -10,7 +10,7 @@ pub struct TemplateConfig<'c> {
     env: minijinja::Environment<'c>,
 }
 
-impl<'c> TemplateConfig<'c> {
+impl TemplateConfig<'_> {
     pub fn new() -> Self {
         let mut env = Environment::new();
         env.set_undefined_behavior(UndefinedBehavior::Strict);
@@ -125,7 +125,7 @@ impl<'c> TemplateConfig<'c> {
     }
 }
 
-impl<'c> Default for TemplateConfig<'c> {
+impl Default for TemplateConfig<'_> {
     fn default() -> Self {
         Self::new()
     }

--- a/gateway/src/tool.rs
+++ b/gateway/src/tool.rs
@@ -8,14 +8,15 @@ use crate::{
     jsonschema_util::{DynamicJSONSchema, JSONSchemaFromPath},
 };
 
-/// A Tool is a function that can be called by an LLM
-/// We represent them in various ways depending on how they are configured by the user.
-/// The primary difficulty is that tools require an input signature that we represent as a JSONSchema.
-/// JSONSchema compilation takes time so we want to do it at startup if the tool is in the config.
-/// We also don't want to clone compiled JSON schemas.
-/// If the tool is dynamic we want to run compilation while LLM inference is happening so that we can validate the tool call arguments.
-///
-/// If we are doing an implicit tool call for JSON schema enforcement, we can use the compiled schema from the output signature.
+/* A Tool is a function that can be called by an LLM
+ * We represent them in various ways depending on how they are configured by the user.
+ * The primary difficulty is that tools require an input signature that we represent as a JSONSchema.
+ * JSONSchema compilation takes time so we want to do it at startup if the tool is in the config.
+ * We also don't want to clone compiled JSON schemas.
+ * If the tool is dynamic we want to run compilation while LLM inference is happening so that we can validate the tool call arguments.
+ *
+ * If we are doing an implicit tool call for JSON schema enforcement, we can use the compiled schema from the output signature.
+ */
 
 /// A Tool object describes how a tool can be dynamically configured by the user.
 #[derive(Debug, Deserialize, PartialEq, Serialize)]

--- a/gateway/src/variant/dicl.rs
+++ b/gateway/src/variant/dicl.rs
@@ -75,7 +75,7 @@ impl Variant for DiclConfig {
         inference_config: &'request InferenceConfig<'request>,
         clients: &'request InferenceClients<'request>,
         inference_params: InferenceParams,
-    ) -> Result<InferenceResult, Error> {
+    ) -> Result<InferenceResult<'a>, Error> {
         // So this can be mutably borrowed by the prepare_request function
         let mut inference_params = inference_params;
 


### PR DESCRIPTION
Gustavo at Vest found a regression in GCP Vertex Gemini API:

Some streaming chunks look like this now:
```
Event {
    event: "message",
    data: "{\"candidates\": [{\"content\": {\"role\": \"model\",\"parts\": [{\"text\": \"Hello\"}]}}],\"usageMetadata\": {},\"modelVersion\": \"gemini-1.5-flash-001\"}",
    id: "",
    retry: None,
}
```

[these docs](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/GenerateContentResponse) tell me that the `usageMetadata` [field](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/GenerateContentResponse#UsageMetadata) should be populated. However it is not. We made the type optional on our side and default to zero. Will report to GCP somehow.

