### PR TITLE
Add test groups for rate-limited providers

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,9 +13,25 @@ slow-timeout = { period = "2s", terminate-after = 1 }
 # cargo nextest show-config test-groups
 # cargo nextest show-config test-groups --features e2e_tests
 
+# Run E2E provider tests sequentially to avoid rate limits
 [test-groups]
-e2e-xai = { max-threads = 1 }  # run XAI E2E tests sequentially to avoid rate limits
+e2e_aws_bedrock = { max-threads = 1 }
+e2e_fireworks = { max-threads = 1 }
+e2e_together = { max-threads = 1 }
+e2e_xai = { max-threads = 1 }
 
 [[profile.default.overrides]]
-filter = 'test(providers::xai::) and binary(e2e)'
-test-group = 'e2e-xai'
+filter = 'binary(e2e) and test(providers::aws_bedrock::)'
+test-group = 'e2e_aws_bedrock'
+
+[[profile.default.overrides]]
+filter = 'binary(e2e) and test(providers::fireworks::)'
+test-group = 'e2e_fireworks'
+
+[[profile.default.overrides]]
+filter = 'binary(e2e) and test(providers::together::)'
+test-group = 'e2e_together'
+
+[[profile.default.overrides]]
+filter = 'binary(e2e) and test(providers::xai::)'
+test-group = 'e2e_xai'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add test groups for rate-limited providers to run E2E tests sequentially in `.config/nextest.toml`.
> 
>   - **Test Groups**:
>     - Add `e2e_aws_bedrock`, `e2e_fireworks`, `e2e_together`, and `e2e_xai` test groups with `max-threads = 1` in `.config/nextest.toml`.
>   - **Profile Overrides**:
>     - Add overrides for `e2e_aws_bedrock`, `e2e_fireworks`, `e2e_together`, and `e2e_xai` in `profile.default` to run tests sequentially.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6a58263da109343ee95fef128808447e122865ce. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->