### PR TITLE
Sleep in the feedback hander before validating so that we can be sure that the inferences have been written

### DIFF
--- a/gateway/src/endpoints/feedback.rs
+++ b/gateway/src/endpoints/feedback.rs
@@ -18,6 +18,11 @@ use crate::inference::types::{parse_chat_output, ContentBlock, ContentBlockOutpu
 use crate::tool::{DynamicToolParams, StaticToolConfig, ToolCall, ToolCallConfig};
 use crate::uuid_util::uuid_elapsed;
 
+/// There is a potential issue here where if we write an inference and then immediately write feedback for it,
+/// we might not be able to find the inference in the database because it hasn't been written yet.
+///
+/// This is the amount of time we want to wait after the target was supposed to have been written
+/// before we decide that the target was actually not written because we can't find it in the database.
 const FEEDBACK_COOLDOWN_PERIOD: Duration = Duration::from_secs(5);
 
 /// The expected payload is a JSON object with the following fields:
@@ -336,7 +341,7 @@ async fn write_boolean(
 
 /// This function throttles the check that an id is valid if it was created very recently.
 /// This is to avoid a race condition where the id was created (e.g. an inference was made)
-/// but the feedback is received before the id is written to the database.o
+/// but the feedback is received before the id is written to the database.
 ///
 /// The current behavior is to immediately check and return the result if the id was created
 /// more than FEEDBACK_COOLDOWN_PERIOD ago.

--- a/gateway/src/endpoints/feedback.rs
+++ b/gateway/src/endpoints/feedback.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
 use axum::extract::State;
 use axum::{debug_handler, Json};
@@ -15,6 +16,9 @@ use crate::function::FunctionConfig;
 use crate::gateway_util::{AppState, AppStateData, StructuredJson};
 use crate::inference::types::{parse_chat_output, ContentBlock, ContentBlockOutput, Text};
 use crate::tool::{DynamicToolParams, StaticToolConfig, ToolCall, ToolCallConfig};
+use crate::uuid_util::uuid_elapsed;
+
+const FEEDBACK_COOLDOWN_PERIOD: Duration = Duration::from_secs(5);
 
 /// The expected payload is a JSON object with the following fields:
 #[derive(Debug, Deserialize)]
@@ -214,7 +218,7 @@ async fn write_comment(
 ) -> Result<(), Error> {
     let Params { value, tags, .. } = params;
     // Verify that the target_id exists.
-    let _ = get_target_identifier(&connection_info, level, &target_id).await?;
+    let _ = throttled_get_target_identifier(&connection_info, level, &target_id).await?;
     let value = value.as_str().ok_or_else(|| ErrorDetails::InvalidRequest {
         message: "Feedback value for a comment must be a string".to_string(),
     })?;
@@ -242,7 +246,7 @@ async fn write_demonstration(
     dryrun: bool,
 ) -> Result<(), Error> {
     let Params { value, tags, .. } = params;
-    let function_name = get_target_identifier(
+    let function_name = throttled_get_target_identifier(
         &connection_info,
         &MetricConfigLevel::Inference,
         &inference_id,
@@ -277,7 +281,8 @@ async fn write_float(
     } = params;
     let metric_config: &crate::config_parser::MetricConfig = config.get_metric(metric_name)?;
     // Verify that the target_id exists.
-    let _ = get_target_identifier(&connection_info, &metric_config.level, &target_id).await?;
+    let _ =
+        throttled_get_target_identifier(&connection_info, &metric_config.level, &target_id).await?;
 
     let value = value.as_f64().ok_or_else(|| {
         Error::new(ErrorDetails::InvalidRequest {
@@ -311,7 +316,8 @@ async fn write_boolean(
     } = params;
     let metric_config = config.get_metric(metric_name)?;
     // Verify that the target_id exists.
-    let _ = get_target_identifier(&connection_info, &metric_config.level, &target_id).await?;
+    let _ =
+        throttled_get_target_identifier(&connection_info, &metric_config.level, &target_id).await?;
     let value = value.as_bool().ok_or_else(|| {
         Error::new(ErrorDetails::InvalidRequest {
             message: format!("Feedback value for metric `{metric_name}` must be a boolean"),
@@ -326,6 +332,39 @@ async fn write_boolean(
         });
     }
     Ok(())
+}
+
+/// This function throttles the check that an id is valid if it was created very recently.
+/// This is to avoid a race condition where the id was created (e.g. an inference was made)
+/// but the feedback is received before the id is written to the database.o
+///
+/// The current behavior is to immediately check and return the result if the id was created
+/// more than FEEDBACK_COOLDOWN_PERIOD ago.
+///
+/// Otherwise, it will poll the database every second until the cooldown period has passed.
+/// Then, if the id has still not been created, it will return an error.
+async fn throttled_get_target_identifier(
+    connection_info: &ClickHouseConnectionInfo,
+    metric_config_level: &MetricConfigLevel,
+    target_id: &Uuid,
+) -> Result<String, Error> {
+    let mut elapsed = uuid_elapsed(target_id)?;
+    if elapsed > FEEDBACK_COOLDOWN_PERIOD {
+        return get_target_identifier(connection_info, metric_config_level, target_id).await;
+    }
+
+    loop {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        elapsed = uuid_elapsed(target_id)?;
+        match get_target_identifier(connection_info, metric_config_level, target_id).await {
+            Ok(identifier) => return Ok(identifier),
+            Err(e) => {
+                if elapsed > FEEDBACK_COOLDOWN_PERIOD {
+                    return Err(e);
+                }
+            }
+        }
+    }
 }
 
 /// Retrieves the identifier associated with a given `target_id` based on the specified metric configuration level.
@@ -716,7 +755,8 @@ mod tests {
             templates: TemplateConfig::new(),
         }));
         let app_state_data = get_unit_test_app_state_data(config, true);
-        let episode_id = Uuid::now_v7();
+        let timestamp = uuid::Timestamp::from_unix_time(1579751960, 0, 0, 0);
+        let episode_id = Uuid::new_v7(timestamp);
         let value = json!("test comment");
         let params = Params {
             episode_id: Some(episode_id),
@@ -754,7 +794,6 @@ mod tests {
         );
 
         // Test dryrun
-        let episode_id = Uuid::now_v7();
         let params = Params {
             episode_id: Some(episode_id),
             inference_id: None,
@@ -772,7 +811,6 @@ mod tests {
         sleep(Duration::from_millis(200)).await;
 
         // Test a Demonstration Feedback
-        let episode_id = Uuid::now_v7();
         let value = json!("test demonstration");
         let params = Params {
             // Demonstrations shouldn't work with episode id
@@ -795,7 +833,7 @@ mod tests {
             }
         );
 
-        let inference_id = Uuid::now_v7();
+        let inference_id = Uuid::new_v7(timestamp);
         let params = Params {
             episode_id: None,
             inference_id: Some(inference_id),
@@ -835,8 +873,8 @@ mod tests {
         }));
         let app_state_data = get_unit_test_app_state_data(config, true);
         let value = json!(4.5);
-        let inference_id = Uuid::now_v7();
-        let episode_id = Uuid::now_v7();
+        let inference_id = Uuid::new_v7(timestamp);
+        let episode_id = Uuid::new_v7(timestamp);
         let params = Params {
             episode_id: None,
             inference_id: Some(inference_id),
@@ -923,7 +961,7 @@ mod tests {
         }));
         let app_state_data = get_unit_test_app_state_data(config, true);
         let value = json!(true);
-        let inference_id = Uuid::now_v7();
+        let inference_id = Uuid::new_v7(timestamp);
         let params = Params {
             episode_id: None,
             inference_id: Some(inference_id),

--- a/gateway/src/error.rs
+++ b/gateway/src/error.rs
@@ -133,6 +133,9 @@ pub enum ErrorDetails {
     InvalidTool {
         message: String,
     },
+    InvalidUuid {
+        raw_uuid: String,
+    },
     JsonRequest {
         message: String,
     },
@@ -247,6 +250,7 @@ impl ErrorDetails {
             ErrorDetails::InvalidRequest { .. } => tracing::Level::WARN,
             ErrorDetails::InvalidTemplatePath => tracing::Level::ERROR,
             ErrorDetails::InvalidTool { .. } => tracing::Level::ERROR,
+            ErrorDetails::InvalidUuid { .. } => tracing::Level::ERROR,
             ErrorDetails::JsonRequest { .. } => tracing::Level::WARN,
             ErrorDetails::JsonSchema { .. } => tracing::Level::ERROR,
             ErrorDetails::JsonSchemaValidation { .. } => tracing::Level::ERROR,
@@ -297,6 +301,7 @@ impl ErrorDetails {
             ErrorDetails::InferenceServer { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::InferenceTimeout { .. } => StatusCode::REQUEST_TIMEOUT,
             ErrorDetails::InvalidEpisodeId { .. } => StatusCode::BAD_REQUEST,
+            ErrorDetails::InvalidUuid { .. } => StatusCode::BAD_REQUEST,
             ErrorDetails::InputValidation { .. } => StatusCode::BAD_REQUEST,
             ErrorDetails::InvalidBaseUrl { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::InvalidCandidate { .. } => StatusCode::INTERNAL_SERVER_ERROR,
@@ -452,6 +457,9 @@ impl std::fmt::Display for ErrorDetails {
                 write!(f, "Template path failed to convert to Rust string")
             }
             ErrorDetails::InvalidTool { message } => write!(f, "{}", message),
+            ErrorDetails::InvalidUuid { raw_uuid } => {
+                write!(f, "Failed to parse UUID as v7: {}", raw_uuid)
+            }
             ErrorDetails::JsonRequest { message } => write!(f, "{}", message),
             ErrorDetails::JsonSchema { message } => write!(f, "{}", message),
             ErrorDetails::JsonSchemaValidation {

--- a/gateway/src/error.rs
+++ b/gateway/src/error.rs
@@ -216,6 +216,9 @@ pub enum ErrorDetails {
     UnsupportedVariantForBatchInference {
         variant_name: Option<String>,
     },
+    UuidInFuture {
+        raw_uuid: String,
+    },
 }
 
 impl ErrorDetails {
@@ -276,6 +279,7 @@ impl ErrorDetails {
             ErrorDetails::UnknownMetric { .. } => tracing::Level::WARN,
             ErrorDetails::UnsupportedModelProviderForBatchInference { .. } => tracing::Level::WARN,
             ErrorDetails::UnsupportedVariantForBatchInference { .. } => tracing::Level::WARN,
+            ErrorDetails::UuidInFuture { .. } => tracing::Level::WARN,
         }
     }
 
@@ -340,6 +344,7 @@ impl ErrorDetails {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
             ErrorDetails::UnsupportedVariantForBatchInference { .. } => StatusCode::BAD_REQUEST,
+            ErrorDetails::UuidInFuture { .. } => StatusCode::BAD_REQUEST,
         }
     }
 
@@ -561,6 +566,9 @@ impl std::fmt::Display for ErrorDetails {
                     ),
                     None => write!(f, "Unsupported variant for batch inference"),
                 }
+            }
+            ErrorDetails::UuidInFuture { raw_uuid } => {
+                write!(f, "UUID is in the future: {}", raw_uuid)
             }
         }
     }

--- a/gateway/src/inference/providers/dummy.rs
+++ b/gateway/src/inference/providers/dummy.rs
@@ -193,11 +193,7 @@ impl InferenceProvider for DummyProvider {
             }
         }
         let id = Uuid::now_v7();
-        #[allow(clippy::expect_used)]
-        let created = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_secs();
+        let created = current_timestamp();
         let content = match self.model_name.as_str() {
             "tool" => vec![ContentBlock::ToolCall(ToolCall {
                 name: "get_temperature".to_string(),
@@ -309,11 +305,7 @@ impl InferenceProvider for DummyProvider {
             .into());
         }
         let id = Uuid::now_v7();
-        #[allow(clippy::expect_used)]
-        let created = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_secs();
+        let created = current_timestamp();
 
         let (content_chunks, is_tool_call) = if self.model_name == "tool" {
             (DUMMY_STREAMING_TOOL_RESPONSE.to_vec(), true)

--- a/gateway/src/inference/types/mod.rs
+++ b/gateway/src/inference/types/mod.rs
@@ -611,11 +611,7 @@ impl<'a> ChatInferenceResult<'a> {
         tool_config: Option<&ToolCallConfig>,
         inference_params: InferenceParams,
     ) -> Self {
-        #[allow(clippy::expect_used)]
-        let created = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_secs();
+        let created = current_timestamp();
         let content = parse_chat_output(raw_content, tool_config).await;
         Self {
             inference_id,

--- a/gateway/src/uuid_util.rs
+++ b/gateway/src/uuid_util.rs
@@ -1,7 +1,10 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
-use crate::error::{Error, ErrorDetails};
+use crate::{
+    error::{Error, ErrorDetails},
+    inference::types::current_timestamp,
+};
 
 /// Timestamp when Scaling Laws for Neural Language Models was published.
 /// No way anyone could use TensorZero prior to this.
@@ -28,11 +31,7 @@ pub fn validate_episode_id(episode_id: Uuid) -> Result<(), Error> {
             message: "Timestamp is too early".to_string(),
         }));
     }
-    #[allow(clippy::expect_used)]
-    let current_timestamp: u64 = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards")
-        .as_secs();
+    let current_timestamp: u64 = current_timestamp();
     if timestamp > current_timestamp {
         return Err(ErrorDetails::InvalidEpisodeId {
             message: "Timestamp is in the future".to_string(),
@@ -40,6 +39,31 @@ pub fn validate_episode_id(episode_id: Uuid) -> Result<(), Error> {
         .into());
     }
     Ok(())
+}
+
+pub fn uuid_elapsed(uuid: &Uuid) -> Result<Duration, Error> {
+    let version = uuid.get_version_num();
+    if version != 7 {
+        return Err(ErrorDetails::InvalidUuid {
+            raw_uuid: uuid.to_string(),
+        }
+        .into());
+    }
+    let (seconds, subsec_nanos) = uuid
+        .get_timestamp()
+        .ok_or_else(|| {
+            Error::new(ErrorDetails::InvalidUuid {
+                raw_uuid: uuid.to_string(),
+            })
+        })?
+        .to_unix();
+    let uuid_system_time =
+        UNIX_EPOCH + Duration::from_secs(seconds) + Duration::from_nanos(subsec_nanos as u64);
+    let elapsed = match SystemTime::now().duration_since(uuid_system_time) {
+        Ok(duration) => duration,
+        Err(_) => Duration::from_secs(0),
+    };
+    Ok(elapsed)
 }
 
 #[cfg(test)]
@@ -70,5 +94,32 @@ mod tests {
             + 10;
         let late_uuid = Uuid::new_v7(Timestamp::from_unix(NoContext, late_timestamp, 0));
         assert!(validate_episode_id(late_uuid).is_err());
+    }
+
+    #[test]
+    fn test_uuid_elapsed() {
+        // Get current time
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards");
+
+        // Subtract 5 seconds
+        let five_seconds_ago = now
+            .checked_sub(std::time::Duration::from_secs(5))
+            .expect("Timestamp arithmetic overflow");
+
+        // Extract seconds and subsec_nanos
+        let seconds = five_seconds_ago.as_secs();
+        let subsec_nanos = five_seconds_ago.subsec_nanos();
+
+        // Create the timestamp
+        let timestamp = Timestamp::from_unix_time(seconds, subsec_nanos, 0, 0);
+        let uuid = Uuid::new_v7(timestamp);
+        let elapsed = uuid_elapsed(&uuid).unwrap();
+        assert!(elapsed > Duration::from_secs(4) && elapsed < Duration::from_secs(6));
+
+        let uuid = Uuid::now_v7();
+        let elapsed = uuid_elapsed(&uuid).unwrap();
+        assert!(elapsed > Duration::from_secs(0) && elapsed < Duration::from_millis(1));
     }
 }

--- a/gateway/tests/e2e/feedback.rs
+++ b/gateway/tests/e2e/feedback.rs
@@ -627,7 +627,10 @@ async fn e2e_test_float_feedback() {
     let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
     let inference_id = Uuid::parse_str(inference_id).unwrap();
 
-    // No sleeping, we should throttle in the gateway
+    // Just this once, we sleep longer than the duration of the feedback cooldown period (5s)
+    // to make sure that the feedback is written after the inference.
+    sleep(Duration::from_millis(5500)).await;
+
     // Test float feedback on different metric for inference.
     let payload =
         json!({"inference_id": inference_id, "metric_name": "brevity_score", "value": 0.5});

--- a/gateway/tests/e2e/feedback.rs
+++ b/gateway/tests/e2e/feedback.rs
@@ -86,9 +86,8 @@ async fn e2e_test_comment_feedback() {
     let response_json = response.json::<Value>().await.unwrap();
     let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
     let inference_id = Uuid::parse_str(inference_id).unwrap();
-    // Sleep for 1 second to allow ClickHouse to write
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
+    // No sleeping, we should throttle in the gateway
     let payload =
         json!({"inference_id": inference_id, "metric_name": "comment", "value": "bad job!"});
     let response = client
@@ -161,9 +160,8 @@ async fn e2e_test_demonstration_feedback() {
     let response_json = response.json::<Value>().await.unwrap();
     let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
     let inference_id = Uuid::parse_str(inference_id).unwrap();
-    // Sleep for 1 second to allow ClickHouse to write
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
+    // No sleeping, we should throttle in the gateway
     // Test demonstration feedback on Inference
     let tag_value = Uuid::now_v7().to_string();
     let payload = json!({
@@ -285,10 +283,9 @@ async fn e2e_test_demonstration_feedback_json() {
     let response_json = response.json::<Value>().await.unwrap();
     let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
     let inference_id = Uuid::parse_str(inference_id).unwrap();
-    // Sleep for 1 second to allow ClickHouse to write
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
-    // Test demonstration feedback on Inference
+    // No sleeping, we should throttle in the gateway
+    // Test demonstration feedback on an inference
     let payload = json!({
         "inference_id": inference_id,
         "metric_name": "demonstration",
@@ -398,9 +395,8 @@ async fn e2e_test_demonstration_feedback_tool() {
     let response_json = response.json::<Value>().await.unwrap();
     let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
     let inference_id = Uuid::parse_str(inference_id).unwrap();
-    // Sleep for 1 second to allow ClickHouse to write
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
+    // No sleeping, we should throttle in the gateway
     // Test demonstration feedback on Inference (string shortcut)
     let payload = json!({
         "inference_id": inference_id,
@@ -630,9 +626,8 @@ async fn e2e_test_float_feedback() {
     let response_json = response.json::<Value>().await.unwrap();
     let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
     let inference_id = Uuid::parse_str(inference_id).unwrap();
-    // Sleep for 1 second to allow ClickHouse to write
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
+    // No sleeping, we should throttle in the gateway
     // Test float feedback on different metric for inference.
     let payload =
         json!({"inference_id": inference_id, "metric_name": "brevity_score", "value": 0.5});
@@ -702,8 +697,8 @@ async fn e2e_test_boolean_feedback() {
     let response_json = response.json::<Value>().await.unwrap();
     let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
     let inference_id = Uuid::parse_str(inference_id).unwrap();
-    // Sleep for 1 second to allow ClickHouse to write
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    // No sleeping, we should throttle in the gateway
 
     let payload = json!({"inference_id": inference_id, "metric_name": "task_success", "value": true, "tags": {"key": tag_value, "key2": tag_value2}});
     let response = client

--- a/gateway/tests/e2e/prometheus.rs
+++ b/gateway/tests/e2e/prometheus.rs
@@ -315,8 +315,6 @@ async fn test_prometheus_metrics_feedback_float() {
     let response_json = response.json::<Value>().await.unwrap();
     let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
     let inference_id = Uuid::parse_str(inference_id).unwrap();
-    // Sleep for 1 second to allow ClickHouse to write
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     // Send feedback for task_success
     let feedback_payload = serde_json::json!({
         "inference_id": inference_id,
@@ -375,8 +373,6 @@ async fn test_prometheus_metrics_feedback_float_dryrun() {
     let response_json = response.json::<Value>().await.unwrap();
     let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
     let inference_id = Uuid::parse_str(inference_id).unwrap();
-    // Sleep for 1 second to allow ClickHouse to write
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     // Send feedback for task_success
     let feedback_payload = serde_json::json!({
         "inference_id": inference_id,
@@ -440,8 +436,6 @@ async fn test_prometheus_metrics_feedback_comment() {
     let response_json = response.json::<Value>().await.unwrap();
     let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
     let inference_id = Uuid::parse_str(inference_id).unwrap();
-    // Sleep for 1 second to allow ClickHouse to write
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     // Send feedback for comment
     let feedback_payload = serde_json::json!({
         "inference_id": inference_id,

--- a/gateway/tests/e2e/prometheus.rs
+++ b/gateway/tests/e2e/prometheus.rs
@@ -193,8 +193,6 @@ async fn test_prometheus_metrics_feedback_boolean() {
     let response_json = response.json::<Value>().await.unwrap();
     let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
     let inference_id = Uuid::parse_str(inference_id).unwrap();
-    // Sleep for 1 second to allow ClickHouse to write
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     // Send feedback for task_success
     let feedback_payload = serde_json::json!({
@@ -254,8 +252,6 @@ async fn test_prometheus_metrics_feedback_boolean_dryrun() {
     let response_json = response.json::<Value>().await.unwrap();
     let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
     let inference_id = Uuid::parse_str(inference_id).unwrap();
-    // Sleep for 1 second to allow ClickHouse to write
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     // Send feedback for task_success
     let feedback_payload = serde_json::json!({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces a delay mechanism in feedback validation to ensure inferences are written, with updates to error handling and tests.
> 
>   - **Behavior**:
>     - Introduces `throttled_get_target_identifier` in `feedback.rs` to delay validation until inferences are written, using a 5-second cooldown.
>     - Replaces `get_target_identifier` with `throttled_get_target_identifier` in `write_comment`, `write_demonstration`, `write_float`, and `write_boolean` functions.
>   - **Error Handling**:
>     - Adds `InvalidUuid` error type in `error.rs` for handling invalid UUIDs.
>   - **Utilities**:
>     - Adds `uuid_elapsed` function in `uuid_util.rs` to calculate elapsed time since UUID creation.
>   - **Tests**:
>     - Updates tests in `feedback.rs` and `prometheus.rs` to remove sleep calls, relying on throttling instead.
>     - Adds tests for `uuid_elapsed` in `uuid_util.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 93c66f1c05d702a0ae061055914543acd40ce558. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->