### PR TITLE
bumped version to 2024.12.3

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorzero"
-version = "2024.12.2"
+version = "2024.12.3"
 description = "The Python client for TensorZero"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/clients/python/uv.lock
+++ b/clients/python/uv.lock
@@ -157,7 +157,7 @@ wheels = [
 
 [[package]]
 name = "tensorzero"
-version = "2024.12.2"
+version = "2024.12.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/gateway/src/endpoints/status.rs
+++ b/gateway/src/endpoints/status.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::response::Json;
 use serde_json::{json, Value};
 
-const TENSORZERO_VERSION: &str = "2024.12.2";
+const TENSORZERO_VERSION: &str = "2024.12.3";
 
 /// A handler for a simple liveness check
 #[debug_handler]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `tensorzero` version to `2024.12.3` in Python client and Rust gateway.
> 
>   - **Version Bump**:
>     - Update `version` to `2024.12.3` in `pyproject.toml` and `uv.lock` for the Python client.
>     - Update `TENSORZERO_VERSION` to `2024.12.3` in `status.rs` for the Rust gateway.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for bb69fbbd50f7309c2ef65c72753a401299b0e7a2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->