### PR TITLE
Prompt community to open a discussion instead of issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Feature Requests, Bug Reports, Questions
+    url: https://github.com/tensorzero/tensorzero/discussions/new/choose
+    about: Please open a discussion for any feature requests, bug reports, or questions. The team will triage and create an issue if appropriate.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `.github/ISSUE_TEMPLATE/config.yml` to redirect users to discussions for feature requests, bug reports, and questions.
> 
>   - **Configuration**:
>     - Adds `.github/ISSUE_TEMPLATE/config.yml` to prompt users to open discussions instead of issues for feature requests, bug reports, and questions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e59614b16e0d59ec2e8bb7165a13a6ae15e7c2f5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->