### PR TITLE
made it so there is no cutover for migrations that were run clean start

### DIFF
--- a/gateway/src/clickhouse_migration_manager/migrations/migration_0001.rs
+++ b/gateway/src/clickhouse_migration_manager/migrations/migration_0001.rs
@@ -59,11 +59,7 @@ impl<'a> Migration for Migration0001<'a> {
 
     async fn apply(&self) -> Result<(), Error> {
         // If there is no data, we don't need to wait for the view to catch up
-        let view_offset = if self.clean_start {
-            Duration::from_secs(0)
-        } else {
-            Duration::from_secs(15)
-        };
+        let view_offset = Duration::from_secs(15);
 
         let view_timestamp = (std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -89,8 +85,13 @@ impl<'a> Migration for Migration0001<'a> {
             ORDER BY id;
         "#;
         let _ = self.clickhouse.run_query(query.to_string()).await?;
-
         // Create the materialized view for the `InferencesById` table from ChatInference
+        // If we are not doing a clean start, we need to add a where clause to the view to only include rows that have been created after the view_timestamp
+        let view_where_clause = if !self.clean_start {
+            format!("WHERE UUIDv7ToDateTime(id) >= toDateTime(toUnixTimestamp({view_timestamp}))")
+        } else {
+            String::new()
+        };
         let query = format!(
             r#"
             CREATE MATERIALIZED VIEW ChatInferenceByIdView
@@ -103,13 +104,14 @@ impl<'a> Migration for Migration0001<'a> {
                     episode_id,
                     'chat'
                 FROM ChatInference
-                WHERE UUIDv7ToDateTime(id) >= toDateTime(toUnixTimestamp({view_timestamp}));
+                {view_where_clause};
             "#,
-            view_timestamp = view_timestamp
+            view_where_clause = view_where_clause
         );
         let _ = self.clickhouse.run_query(query).await?;
 
         // Create the materialized view for the `InferencesById` table from JsonInference
+        // If we are not doing a clean start, we need to add a where clause to the view to only include rows that have been created after the view_timestamp
         let query = format!(
             r#"
             CREATE MATERIALIZED VIEW JsonInferenceByIdView
@@ -122,53 +124,54 @@ impl<'a> Migration for Migration0001<'a> {
                     episode_id,
                     'json'
                 FROM JsonInference
-                WHERE UUIDv7ToDateTime(id) >= toDateTime(toUnixTimestamp({view_timestamp}));
-        "#,
-            view_timestamp = view_timestamp
+                {view_where_clause};
+            "#,
+            view_where_clause = view_where_clause
         );
         let _ = self.clickhouse.run_query(query).await?;
 
-        // Sleep for the duration specified by view_offset to allow the materialized views to catch up
-        tokio::time::sleep(view_offset).await;
-
         // Insert the data from the original tables into the new table (we do this concurrently since it could theoretically take a long time)
-        let insert_chat_inference = async {
-            let query = format!(
-                r#"
-                INSERT INTO InferenceById
-                SELECT
-                    id,
-                    function_name,
-                    variant_name,
-                    episode_id,
-                    'chat'
-                FROM ChatInference
-                WHERE UUIDv7ToDateTime(id) < toDateTime(toUnixTimestamp({view_timestamp}));
-            "#,
-                view_timestamp = view_timestamp
-            );
-            self.clickhouse.run_query(query).await
-        };
+        if !self.clean_start {
+            // Sleep for the duration specified by view_offset to allow the materialized views to catch up
+            tokio::time::sleep(view_offset).await;
+            let insert_chat_inference = async {
+                let query = format!(
+                    r#"
+                    INSERT INTO InferenceById
+                    SELECT
+                        id,
+                        function_name,
+                        variant_name,
+                        episode_id,
+                        'chat'
+                    FROM ChatInference
+                    WHERE UUIDv7ToDateTime(id) < toDateTime(toUnixTimestamp({view_timestamp}));
+                "#,
+                    view_timestamp = view_timestamp
+                );
+                self.clickhouse.run_query(query).await
+            };
 
-        let insert_json_inference = async {
-            let query = format!(
-                r#"
-                INSERT INTO InferenceById
-                SELECT
-                    id,
-                    function_name,
-                    variant_name,
-                    episode_id,
-                    'json'
-                FROM JsonInference
-                WHERE UUIDv7ToDateTime(id) < toDateTime(toUnixTimestamp({view_timestamp}));
-            "#,
-                view_timestamp = view_timestamp
-            );
-            self.clickhouse.run_query(query).await
-        };
+            let insert_json_inference = async {
+                let query = format!(
+                    r#"
+                    INSERT INTO InferenceById
+                    SELECT
+                        id,
+                        function_name,
+                        variant_name,
+                        episode_id,
+                        'json'
+                    FROM JsonInference
+                    WHERE UUIDv7ToDateTime(id) < toDateTime(toUnixTimestamp({view_timestamp}));
+                "#,
+                    view_timestamp = view_timestamp
+                );
+                self.clickhouse.run_query(query).await
+            };
 
-        tokio::try_join!(insert_chat_inference, insert_json_inference)?;
+            tokio::try_join!(insert_chat_inference, insert_json_inference)?;
+        }
 
         Ok(())
     }

--- a/gateway/src/clickhouse_migration_manager/migrations/migration_0001.rs
+++ b/gateway/src/clickhouse_migration_manager/migrations/migration_0001.rs
@@ -58,9 +58,8 @@ impl<'a> Migration for Migration0001<'a> {
     }
 
     async fn apply(&self) -> Result<(), Error> {
-        // If there is no data, we don't need to wait for the view to catch up
+        // Only gets used when we are not doing a clean start
         let view_offset = Duration::from_secs(15);
-
         let view_timestamp = (std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_err(|e| {

--- a/gateway/src/clickhouse_migration_manager/migrations/migration_0007.rs
+++ b/gateway/src/clickhouse_migration_manager/migrations/migration_0007.rs
@@ -57,9 +57,8 @@ impl<'a> Migration for Migration0007<'a> {
     }
 
     async fn apply(&self) -> Result<(), Error> {
-        // If there is no data, we don't need to wait for the view to catch up
+        // Only gets used when we are not doing a clean start
         let view_offset = Duration::from_secs(15);
-
         let view_timestamp = (std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_err(|e| {

--- a/gateway/src/clickhouse_migration_manager/migrations/migration_0007.rs
+++ b/gateway/src/clickhouse_migration_manager/migrations/migration_0007.rs
@@ -58,11 +58,7 @@ impl<'a> Migration for Migration0007<'a> {
 
     async fn apply(&self) -> Result<(), Error> {
         // If there is no data, we don't need to wait for the view to catch up
-        let view_offset = if self.clean_start {
-            Duration::from_secs(0)
-        } else {
-            Duration::from_secs(15)
-        };
+        let view_offset = Duration::from_secs(15);
 
         let view_timestamp = (std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -90,7 +86,12 @@ impl<'a> Migration for Migration0007<'a> {
         "#;
         let _ = self.clickhouse.run_query(query.to_string()).await?;
 
-        // Create the materialized view for the `InferenceByEpisodeId` table from ChatInference
+        // If we are not doing a clean start, we need to add a where clause to the view to only include rows that have been created after the view_timestamp
+        let view_where_clause = if !self.clean_start {
+            format!("WHERE UUIDv7ToDateTime(id) >= toDateTime(toUnixTimestamp({view_timestamp}))")
+        } else {
+            String::new()
+        };
         let query = format!(
             r#"
             CREATE MATERIALIZED VIEW ChatInferenceByEpisodeIdView
@@ -103,9 +104,9 @@ impl<'a> Migration for Migration0007<'a> {
                     variant_name,
                     'chat'
                 FROM ChatInference
-                WHERE UUIDv7ToDateTime(id) >= toDateTime(toUnixTimestamp({view_timestamp}));
+                {view_where_clause};
             "#,
-            view_timestamp = view_timestamp
+            view_where_clause = view_where_clause
         );
         let _ = self.clickhouse.run_query(query).await?;
 
@@ -122,53 +123,55 @@ impl<'a> Migration for Migration0007<'a> {
                     variant_name,
                     'json'
                 FROM JsonInference
-                WHERE UUIDv7ToDateTime(id) >= toDateTime(toUnixTimestamp({view_timestamp}));
-        "#,
-            view_timestamp = view_timestamp
+                {view_where_clause};
+            "#,
+            view_where_clause = view_where_clause
         );
         let _ = self.clickhouse.run_query(query).await?;
 
-        // Sleep for the duration specified by view_offset to allow the materialized views to catch up
-        tokio::time::sleep(view_offset).await;
+        if !self.clean_start {
+            // Sleep for the duration specified by view_offset to allow the materialized views to catch up
+            tokio::time::sleep(view_offset).await;
 
-        // Insert the data from the original tables into the new table (we do this concurrently since it could theoretically take a long time)
-        let insert_chat_inference = async {
-            let query = format!(
-                r#"
-                INSERT INTO InferenceByEpisodeId
-                SELECT
-                    episode_id,
-                    id,
-                    function_name,
-                    variant_name,
-                    'chat'
-                FROM ChatInference
-                WHERE UUIDv7ToDateTime(id) < toDateTime(toUnixTimestamp({view_timestamp}));
-            "#,
-                view_timestamp = view_timestamp
-            );
-            self.clickhouse.run_query(query).await
-        };
+            // Insert the data from the original tables into the new table (we do this concurrently since it could theoretically take a long time)
+            let insert_chat_inference = async {
+                let query = format!(
+                    r#"
+                    INSERT INTO InferenceByEpisodeId
+                    SELECT
+                        episode_id,
+                        id,
+                        function_name,
+                        variant_name,
+                        'chat'
+                    FROM ChatInference
+                    WHERE UUIDv7ToDateTime(id) < toDateTime(toUnixTimestamp({view_timestamp}));
+                "#,
+                    view_timestamp = view_timestamp
+                );
+                self.clickhouse.run_query(query).await
+            };
 
-        let insert_json_inference = async {
-            let query = format!(
-                r#"
-                INSERT INTO InferenceByEpisodeId
-                SELECT
-                    episode_id,
-                    id,
-                    function_name,
-                    variant_name,
-                    'json'
-                FROM JsonInference
-                WHERE UUIDv7ToDateTime(id) < toDateTime(toUnixTimestamp({view_timestamp}));
-            "#,
-                view_timestamp = view_timestamp
-            );
-            self.clickhouse.run_query(query).await
-        };
+            let insert_json_inference = async {
+                let query = format!(
+                    r#"
+                    INSERT INTO InferenceByEpisodeId
+                    SELECT
+                        episode_id,
+                        id,
+                        function_name,
+                        variant_name,
+                        'json'
+                    FROM JsonInference
+                    WHERE UUIDv7ToDateTime(id) < toDateTime(toUnixTimestamp({view_timestamp}));
+                "#,
+                    view_timestamp = view_timestamp
+                );
+                self.clickhouse.run_query(query).await
+            };
 
-        tokio::try_join!(insert_chat_inference, insert_json_inference)?;
+            tokio::try_join!(insert_chat_inference, insert_json_inference)?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove cutover period for clean start migrations in `migration_0001.rs` and `migration_0007.rs`, optimizing view creation and data insertion.
> 
>   - **Behavior**:
>     - Remove cutover period for migrations with `clean_start` in `migration_0001.rs` and `migration_0007.rs`.
>     - Skip waiting and data insertion steps if `clean_start` is true.
>   - **Logic**:
>     - Adjust `apply()` in `Migration0001` and `Migration0007` to conditionally execute view creation and data insertion based on `clean_start`.
>     - Add conditional `view_where_clause` for materialized views based on `clean_start`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for eabbc06004258546f5fc65dfb42807710b21b24e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->