### PR TITLE
Fix error paths for nested variants in tensorzero.toml

### DIFF
--- a/examples/chess-puzzles-best-of-n-sampling/config/tensorzero_missing_field.toml
+++ b/examples/chess-puzzles-best-of-n-sampling/config/tensorzero_missing_field.toml
@@ -1,0 +1,10 @@
+[functions.my_function]
+type = "chat"
+
+[functions.my_function.variants.my_variant]
+# The following entry is mandatory but it's missing
+# type = "chat_completion"
+model = "anthropic::claude-3-haiku-20240307"
+
+[gateway]
+disable_observability = true

--- a/gateway/src/config_parser.rs
+++ b/gateway/src/config_parser.rs
@@ -321,9 +321,8 @@ impl TryFrom<toml::Table> for UninitializedConfig {
     type Error = Error;
 
     fn try_from(table: toml::Table) -> Result<Self, Self::Error> {
-        // NOTE: We'd like to use `serde_path_to_error` here but it has a bug with enums:
-        //       https://github.com/dtolnay/path-to-error/issues/1
-        match table.try_into() {
+        let deserializer = serde_path_to_error::Deserializer::new(table);
+        match UninitializedConfig::deserialize(deserializer) {
             Ok(config) => Ok(config),
             Err(e) => Err(Error::new(ErrorDetails::Config {
                 message: format!("{e}"),

--- a/gateway/src/error.rs
+++ b/gateway/src/error.rs
@@ -76,6 +76,7 @@ pub enum ErrorDetails {
     },
     Config {
         message: String,
+        path: Option<String>,
     },
     DynamicJsonSchema {
         message: String,
@@ -402,8 +403,12 @@ impl std::fmt::Display for ErrorDetails {
             ErrorDetails::ClickHouseQuery { message } => {
                 write!(f, "Failed to run ClickHouse query: {}", message)
             }
-            ErrorDetails::Config { message } => {
-                write!(f, "{}", message)
+            ErrorDetails::Config { message, path } => {
+                if let Some(path) = path {
+                    write!(f, "{}\nin `{}`\n", message, path)
+                } else {
+                    write!(f, "{}", message)
+                }
             }
             ErrorDetails::DynamicJsonSchema { message } => {
                 write!(


### PR DESCRIPTION
Related to #335

Update error handling to provide accurate paths for missing fields in `tensorzero.toml` configuration.

* **`gateway/src/config_parser.rs`**
  - Use `serde_path_to_error` for deserialization in `load_from_toml` function.
  - Modify `try_from` implementation for `UninitializedConfig` to use `serde_path_to_error`.

* **`gateway/src/error.rs`**
  - Update `ErrorDetails::Config` variant to include the full path to the missing field.
  - Modify `fmt` implementation for `ErrorDetails::Config` to display the full path.

* **`examples/chess-puzzles-best-of-n-sampling/config/tensorzero_missing_field.toml`**
  - Add a new TOML file with a missing `type` field in a nested variant.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tensorzero/tensorzero/pull/724?shareId=675aa5a2-9d4e-46d8-873e-74058ef7ed2a).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve error handling in `tensorzero.toml` by using `serde_path_to_error` for better path reporting and updating error display to include full paths.
> 
>   - **Behavior**:
>     - Use `serde_path_to_error` in `load_from_toml` and `try_from` in `config_parser.rs` for better error path reporting.
>     - Update `ErrorDetails::Config` in `error.rs` to include full path to missing field.
>     - Modify `fmt` for `ErrorDetails::Config` to display full path.
>   - **Examples**:
>     - Add `tensorzero_missing_field.toml` with missing `type` field in a nested variant.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0394f6cee6c063410f03bdafd5de1846e1781ad7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->