### PR TITLE
Remove comments intended for Firework provider

### DIFF
--- a/gateway/src/inference/providers/mistral.rs
+++ b/gateway/src/inference/providers/mistral.rs
@@ -440,8 +440,6 @@ impl<'a> MistralRequest<'a> {
         model: &'a str,
         request: &'a ModelInferenceRequest,
     ) -> Result<MistralRequest<'a>, Error> {
-        // NB: Fireworks will throw an error if you give FireworksResponseFormat::Text and then also include tools.
-        // So we just don't include it as Text is the same as None anyway.
         let response_format = match request.json_mode {
             ModelInferenceRequestJsonMode::On | ModelInferenceRequestJsonMode::Strict => {
                 Some(MistralResponseFormat::JsonObject)


### PR DESCRIPTION
I noticed these comments appear to be misplaced. they seem to have been intended for the Firework provider since identical comments exist there.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove misplaced comments in `mistral.rs` intended for the Firework provider.
> 
>   - **Comments**:
>     - Remove misplaced comments in `mistral.rs` intended for the Firework provider.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7e13891520ce8436a8e114bc5e2945b931cb3cbc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->