### PR TITLE
bumped version to 2025.01.1

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorzero"
-version = "2025.01.0"
+version = "2025.01.1"
 description = "The Python client for TensorZero"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/clients/python/uv.lock
+++ b/clients/python/uv.lock
@@ -157,7 +157,7 @@ wheels = [
 
 [[package]]
 name = "tensorzero"
-version = "2025.01.0"
+version = "2025.01.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/gateway/src/endpoints/status.rs
+++ b/gateway/src/endpoints/status.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::response::Json;
 use serde_json::{json, Value};
 
-const TENSORZERO_VERSION: &str = "2025.01.0";
+const TENSORZERO_VERSION: &str = "2025.01.1";
 
 /// A handler for a simple liveness check
 #[debug_handler]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump version from `2025.01.0` to `2025.01.1` in `pyproject.toml`, `uv.lock`, and `status.rs`.
> 
>   - **Version Update**:
>     - Bump version from `2025.01.0` to `2025.01.1` in `pyproject.toml`, `uv.lock`, and `status.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 199d7ebde498f83223221fcdf6be11a39ca584ad. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->