### PR TITLE
Add a `debug` mode to the gateway where the bodies of requests and responses are logged / returned as much as possible

### DIFF
--- a/gateway/src/config_parser.rs
+++ b/gateway/src/config_parser.rs
@@ -36,6 +36,8 @@ pub struct GatewayConfig {
     pub bind_address: Option<std::net::SocketAddr>,
     #[serde(default)]
     pub disable_observability: bool,
+    #[serde(default)]
+    pub debug: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/gateway/src/error.rs
+++ b/gateway/src/error.rs
@@ -444,6 +444,7 @@ impl std::fmt::Display for ErrorDetails {
                 raw_response,
                 status_code,
             } => {
+                // `debug` defaults to false so we don't log raw request and response by default
                 if *DEBUG.get().unwrap_or(&false) {
                     write!(
                         f,
@@ -470,8 +471,27 @@ impl std::fmt::Display for ErrorDetails {
             ErrorDetails::InferenceServer {
                 message,
                 provider_type,
-                ..
-            } => write!(f, "Error from {} server: {}", provider_type, message),
+                raw_request,
+                raw_response,
+            } => {
+                // `debug` defaults to false so we don't log raw request and response by default
+                if *DEBUG.get().unwrap_or(&false) {
+                    write!(
+                        f,
+                        "Error from {} server: {}{}{}",
+                        provider_type,
+                        message,
+                        raw_request
+                            .as_ref()
+                            .map_or("".to_string(), |r| format!("\nRaw request: {}", r)),
+                        raw_response
+                            .as_ref()
+                            .map_or("".to_string(), |r| format!("\nRaw response: {}", r))
+                    )
+                } else {
+                    write!(f, "Error from {} server: {}", provider_type, message)
+                }
+            }
             ErrorDetails::InferenceTimeout { variant_name } => {
                 write!(f, "Inference timed out for variant: {}", variant_name)
             }

--- a/gateway/src/error.rs
+++ b/gateway/src/error.rs
@@ -460,8 +460,8 @@ impl std::fmt::Display for ErrorDetails {
                 } else {
                     write!(
                         f,
-                        "Error {} from {} client: {}",
-                        status_code.map_or("".to_string(), |s| s.to_string()),
+                        "Error{} from {} client: {}",
+                        status_code.map_or("".to_string(), |s| format!(" {}", s)),
                         provider_type,
                         message
                     )

--- a/gateway/src/error.rs
+++ b/gateway/src/error.rs
@@ -5,6 +5,15 @@ use axum::response::{IntoResponse, Json, Response};
 use serde_json::{json, Value};
 use tokio::sync::OnceCell;
 
+/// Controls whether to include raw request/response details in error output
+///
+/// When true:
+/// - Raw request/response details are logged for inference provider errors
+/// - Raw details are included in error response bodies
+/// - Most commonly affects errors from provider API requests/responses
+///
+/// WARNING: Setting this to true will expose potentially sensitive request/response
+/// data in logs and error responses. Use with caution.
 static DEBUG: OnceCell<bool> = OnceCell::const_new();
 
 pub fn set_debug(debug: bool) -> Result<(), Error> {

--- a/gateway/src/gateway_util.rs
+++ b/gateway/src/gateway_util.rs
@@ -113,6 +113,7 @@ mod tests {
         let gateway_config = GatewayConfig {
             disable_observability: true,
             bind_address: None,
+            debug: false,
         };
 
         let config = Box::leak(Box::new(Config {
@@ -131,6 +132,7 @@ mod tests {
         let gateway_config = GatewayConfig {
             disable_observability: false,
             bind_address: None,
+            debug: false,
         };
 
         let config = Box::leak(Box::new(Config {
@@ -148,6 +150,7 @@ mod tests {
         let gateway_config = GatewayConfig {
             disable_observability: false,
             bind_address: None,
+            debug: false,
         };
         let config = Box::leak(Box::new(Config {
             gateway: gateway_config,
@@ -165,6 +168,7 @@ mod tests {
         let gateway_config = GatewayConfig {
             disable_observability: false,
             bind_address: None,
+            debug: false,
         };
         let config = Box::leak(Box::new(Config {
             gateway: gateway_config,

--- a/gateway/src/inference/providers/anthropic.rs
+++ b/gateway/src/inference/providers/anthropic.rs
@@ -132,6 +132,8 @@ impl InferenceProvider for AnthropicProvider {
                     message: format!("Error sending request: {e}"),
                     status_code: e.status(),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                 })
             })?;
         let latency = Latency::NonStreaming {
@@ -142,6 +144,8 @@ impl InferenceProvider for AnthropicProvider {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing text response: {e}"),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                 })
             })?;
 
@@ -149,6 +153,8 @@ impl InferenceProvider for AnthropicProvider {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing JSON response: {e}: {response}"),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: Some(response.to_string()),
                 })
             })?;
 
@@ -163,13 +169,27 @@ impl InferenceProvider for AnthropicProvider {
             Ok(response_with_latency.try_into()?)
         } else {
             let response_code = res.status();
-            let error_body = res.json::<AnthropicError>().await.map_err(|e| {
+            let response_text = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing response: {e}"),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                 })
             })?;
-            handle_anthropic_error(response_code, error_body.error)
+            let error_body: AnthropicError = serde_json::from_str(&response_text).map_err(|e| {
+                Error::new(ErrorDetails::InferenceServer {
+                    message: format!("Error parsing response: {e}"),
+                    provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: Some(response_text),
+                })
+            })?;
+            handle_anthropic_error(
+                response_code,
+                error_body.error,
+                serde_json::to_string(&request_body).unwrap_or_default(),
+            )
         }
     }
 
@@ -189,9 +209,8 @@ impl InferenceProvider for AnthropicProvider {
     > {
         let request_body = AnthropicRequestBody::new(&self.model_name, request)?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
+            Error::new(ErrorDetails::Serialization {
                 message: format!("Error serializing request body as JSON: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
         let start_time = Instant::now();
@@ -208,6 +227,8 @@ impl InferenceProvider for AnthropicProvider {
                     message: format!("Error sending request: {e}"),
                     status_code: None,
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(raw_request.clone()),
+                    raw_response: None,
                 })
             })?;
         let mut stream = Box::pin(stream_anthropic(event_source, start_time));
@@ -218,6 +239,8 @@ impl InferenceProvider for AnthropicProvider {
                 return Err(Error::new(ErrorDetails::InferenceServer {
                     message: "Stream ended before first chunk".to_string(),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(raw_request.clone()),
+                    raw_response: None,
                 }))
             }
         };
@@ -261,6 +284,8 @@ fn stream_anthropic(
                     yield Err(ErrorDetails::InferenceServer {
                         message: e.to_string(),
                         provider_type: PROVIDER_TYPE.to_string(),
+                        raw_request: None,
+                        raw_response: None,
                     }.into());
                 }
                 Ok(event) => match event {
@@ -273,7 +298,8 @@ fn stream_anthropic(
                                     e, message.data
                                 ),
                                 provider_type: PROVIDER_TYPE.to_string(),
-
+                                raw_request: None,
+                                raw_response: Some(message.data.clone()),
                             }));
                         // Anthropic streaming API docs specify that this is the last message
                         if let Ok(AnthropicStreamMessage::MessageStop) = data {
@@ -417,6 +443,8 @@ impl<'a> TryFrom<&'a ContentBlock> for AnthropicMessageContent<'a> {
                         status_code: Some(StatusCode::BAD_REQUEST),
                         message: format!("Error parsing tool call arguments as JSON Value: {e}"),
                         provider_type: PROVIDER_TYPE.to_string(),
+                        raw_request: None,
+                        raw_response: Some(tool_call.arguments.clone()),
                     })
                 })?;
 
@@ -425,6 +453,8 @@ impl<'a> TryFrom<&'a ContentBlock> for AnthropicMessageContent<'a> {
                         status_code: Some(StatusCode::BAD_REQUEST),
                         message: "Tool call arguments must be a JSON object".to_string(),
                         provider_type: PROVIDER_TYPE.to_string(),
+                        raw_request: None,
+                        raw_response: Some(tool_call.arguments.clone()),
                     }));
                 }
 
@@ -661,7 +691,7 @@ struct AnthropicError {
     error: AnthropicErrorBody,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 struct AnthropicErrorBody {
     r#type: String,
     message: String,
@@ -693,6 +723,8 @@ impl TryFrom<AnthropicContentBlock> for ContentBlock {
                         Error::new(ErrorDetails::InferenceServer {
                             message: format!("Error parsing input for tool call: {e}"),
                             provider_type: PROVIDER_TYPE.to_string(),
+                            raw_request: None,
+                            raw_response: Some(serde_json::to_string(&input).unwrap_or_default()),
                         })
                     })?,
                 }))
@@ -753,16 +785,14 @@ impl<'a> TryFrom<AnthropicResponseWithMetadata<'a>> for ProviderInferenceRespons
         } = value;
 
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
+            Error::new(ErrorDetails::Serialization {
                 message: format!("Error serializing request body as JSON: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
 
         let raw_response = serde_json::to_string(&response).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
+            Error::new(ErrorDetails::Serialization {
                 message: format!("Error parsing response from Anthropic: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
 
@@ -796,22 +826,27 @@ impl<'a> TryFrom<AnthropicResponseWithMetadata<'a>> for ProviderInferenceRespons
 fn handle_anthropic_error(
     response_code: StatusCode,
     response_body: AnthropicErrorBody,
+    raw_request: String,
 ) -> Result<ProviderInferenceResponse, Error> {
     match response_code {
         StatusCode::UNAUTHORIZED
         | StatusCode::BAD_REQUEST
         | StatusCode::PAYLOAD_TOO_LARGE
         | StatusCode::TOO_MANY_REQUESTS => Err(ErrorDetails::InferenceClient {
-            message: response_body.message,
             status_code: Some(response_code),
             provider_type: PROVIDER_TYPE.to_string(),
+            raw_request: Some(raw_request),
+            raw_response: serde_json::to_string(&response_body).ok(),
+            message: response_body.message,
         }
         .into()),
         // StatusCode::NOT_FOUND | StatusCode::FORBIDDEN | StatusCode::INTERNAL_SERVER_ERROR | 529: Overloaded
         // These are all captured in _ since they have the same error behavior
         _ => Err(ErrorDetails::InferenceServer {
+            raw_response: serde_json::to_string(&response_body).ok(),
             message: response_body.message,
             provider_type: PROVIDER_TYPE.to_string(),
+            raw_request: Some(raw_request),
         }
         .into()),
     }
@@ -878,9 +913,8 @@ fn anthropic_to_tensorzero_stream_message(
     current_tool_name: &mut Option<String>,
 ) -> Result<Option<ProviderInferenceResponseChunk>, Error> {
     let raw_message = serde_json::to_string(&message).map_err(|e| {
-        Error::new(ErrorDetails::InferenceServer {
-            message: format!("Error parsing response from Anthropic: {e}"),
-            provider_type: PROVIDER_TYPE.to_string(),
+        Error::new(ErrorDetails::Serialization {
+            message: format!("Error serializing stream message from Anthropic: {e}"),
         })
     })?;
     match message {
@@ -907,10 +941,14 @@ fn anthropic_to_tensorzero_stream_message(
                         raw_name: current_tool_name.clone().ok_or_else(|| Error::new(ErrorDetails::InferenceServer {
                             message: "Got InputJsonDelta chunk from Anthropic without current tool name being set by a ToolUse".to_string(),
                             provider_type: PROVIDER_TYPE.to_string(),
+                            raw_request: None,
+                            raw_response: None,
                         }))?,
                         id: current_tool_id.clone().ok_or_else(|| Error::new(ErrorDetails::InferenceServer {
                             message: "Got InputJsonDelta chunk from Anthropic without current tool id being set by a ToolUse".to_string(),
                             provider_type: PROVIDER_TYPE.to_string(),
+                            raw_request: None,
+                            raw_response: None,
                         }))?,
                         raw_arguments: partial_json,
                     })],
@@ -922,6 +960,8 @@ fn anthropic_to_tensorzero_stream_message(
             _ => Err(ErrorDetails::InferenceServer {
                 message: "Unsupported content block type for ContentBlockDelta".to_string(),
                 provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: None,
+                raw_response: Some(serde_json::to_string(&delta).unwrap_or_default()),
             }
             .into()),
         },
@@ -962,6 +1002,8 @@ fn anthropic_to_tensorzero_stream_message(
             _ => Err(ErrorDetails::InferenceServer {
                 message: "Unsupported content block type for ContentBlockStart".to_string(),
                 provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: None,
+                raw_response: Some(serde_json::to_string(&content_block).unwrap_or_default()),
             }
             .into()),
         },
@@ -969,6 +1011,8 @@ fn anthropic_to_tensorzero_stream_message(
         AnthropicStreamMessage::Error { error } => Err(ErrorDetails::InferenceServer {
             message: error.to_string(),
             provider_type: PROVIDER_TYPE.to_string(),
+            raw_request: None,
+            raw_response: None,
         }
         .into()),
         AnthropicStreamMessage::MessageDelta { usage, .. } => {
@@ -1585,7 +1629,8 @@ mod tests {
             message: "test_message".to_string(),
         };
         let response_code = StatusCode::BAD_REQUEST;
-        let result = handle_anthropic_error(response_code, error_body.clone());
+        let result =
+            handle_anthropic_error(response_code, error_body.clone(), "raw request".to_string());
         let details = result.unwrap_err().get_owned_details();
         assert_eq!(
             details,
@@ -1593,10 +1638,13 @@ mod tests {
                 message: "test_message".to_string(),
                 status_code: Some(response_code),
                 provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: Some("raw request".to_string()),
+                raw_response: None,
             }
         );
         let response_code = StatusCode::UNAUTHORIZED;
-        let result = handle_anthropic_error(response_code, error_body.clone());
+        let result =
+            handle_anthropic_error(response_code, error_body.clone(), "raw request".to_string());
         let details = result.unwrap_err().get_owned_details();
         assert_eq!(
             details,
@@ -1604,10 +1652,13 @@ mod tests {
                 message: "test_message".to_string(),
                 status_code: Some(response_code),
                 provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: Some("raw request".to_string()),
+                raw_response: None,
             }
         );
         let response_code = StatusCode::TOO_MANY_REQUESTS;
-        let result = handle_anthropic_error(response_code, error_body.clone());
+        let result =
+            handle_anthropic_error(response_code, error_body.clone(), "raw request".to_string());
         let details = result.unwrap_err().get_owned_details();
         assert_eq!(
             details,
@@ -1615,25 +1666,33 @@ mod tests {
                 message: "test_message".to_string(),
                 status_code: Some(response_code),
                 provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: Some("raw request".to_string()),
+                raw_response: None,
             }
         );
         let response_code = StatusCode::NOT_FOUND;
-        let result = handle_anthropic_error(response_code, error_body.clone());
+        let result =
+            handle_anthropic_error(response_code, error_body.clone(), "raw request".to_string());
         let details = result.unwrap_err().get_owned_details();
         assert_eq!(
             details,
             ErrorDetails::InferenceServer {
                 message: "test_message".to_string(),
+                raw_request: Some("raw request".to_string()),
+                raw_response: None,
                 provider_type: PROVIDER_TYPE.to_string(),
             }
         );
         let response_code = StatusCode::INTERNAL_SERVER_ERROR;
-        let result = handle_anthropic_error(response_code, error_body.clone());
+        let result =
+            handle_anthropic_error(response_code, error_body.clone(), "raw request".to_string());
         let details = result.unwrap_err().get_owned_details();
         assert_eq!(
             details,
             ErrorDetails::InferenceServer {
                 message: "test_message".to_string(),
+                raw_request: Some("raw request".to_string()),
+                raw_response: None,
                 provider_type: PROVIDER_TYPE.to_string(),
             }
         );
@@ -1904,6 +1963,8 @@ mod tests {
             details,
             ErrorDetails::InferenceServer {
                 message: "Got InputJsonDelta chunk from Anthropic without current tool name being set by a ToolUse".to_string(),
+                raw_request: None,
+                raw_response: None,
                 provider_type: PROVIDER_TYPE.to_string(),
             }
         );
@@ -2021,6 +2082,8 @@ mod tests {
             ErrorDetails::InferenceServer {
                 message: "Unsupported content block type for ContentBlockStart".to_string(),
                 provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: None,
+                raw_response: None,
             }
         );
 
@@ -2054,6 +2117,8 @@ mod tests {
             details,
             ErrorDetails::InferenceServer {
                 message: r#"{"message":"Test error"}"#.to_string(),
+                raw_request: None,
+                raw_response: None,
                 provider_type: PROVIDER_TYPE.to_string(),
             }
         );

--- a/gateway/src/inference/providers/anthropic.rs
+++ b/gateway/src/inference/providers/anthropic.rs
@@ -1639,7 +1639,7 @@ mod tests {
                 status_code: Some(response_code),
                 provider_type: PROVIDER_TYPE.to_string(),
                 raw_request: Some("raw request".to_string()),
-                raw_response: None,
+                raw_response: Some("{\"type\":\"error\",\"message\":\"test_message\"}".to_string()),
             }
         );
         let response_code = StatusCode::UNAUTHORIZED;
@@ -1653,7 +1653,7 @@ mod tests {
                 status_code: Some(response_code),
                 provider_type: PROVIDER_TYPE.to_string(),
                 raw_request: Some("raw request".to_string()),
-                raw_response: None,
+                raw_response: Some("{\"type\":\"error\",\"message\":\"test_message\"}".to_string()),
             }
         );
         let response_code = StatusCode::TOO_MANY_REQUESTS;
@@ -1667,7 +1667,7 @@ mod tests {
                 status_code: Some(response_code),
                 provider_type: PROVIDER_TYPE.to_string(),
                 raw_request: Some("raw request".to_string()),
-                raw_response: None,
+                raw_response: Some("{\"type\":\"error\",\"message\":\"test_message\"}".to_string()),
             }
         );
         let response_code = StatusCode::NOT_FOUND;
@@ -1679,7 +1679,7 @@ mod tests {
             ErrorDetails::InferenceServer {
                 message: "test_message".to_string(),
                 raw_request: Some("raw request".to_string()),
-                raw_response: None,
+                raw_response: Some("{\"type\":\"error\",\"message\":\"test_message\"}".to_string()),
                 provider_type: PROVIDER_TYPE.to_string(),
             }
         );
@@ -1692,7 +1692,7 @@ mod tests {
             ErrorDetails::InferenceServer {
                 message: "test_message".to_string(),
                 raw_request: Some("raw request".to_string()),
-                raw_response: None,
+                raw_response: Some("{\"type\":\"error\",\"message\":\"test_message\"}".to_string()),
                 provider_type: PROVIDER_TYPE.to_string(),
             }
         );
@@ -2083,7 +2083,9 @@ mod tests {
                 message: "Unsupported content block type for ContentBlockStart".to_string(),
                 provider_type: PROVIDER_TYPE.to_string(),
                 raw_request: None,
-                raw_response: None,
+                raw_response: Some(
+                    "{\"type\":\"input_json_delta\",\"partial_json\":\"aaaa: bbbbb\"}".to_string()
+                ),
             }
         );
 

--- a/gateway/src/inference/providers/aws_bedrock.rs
+++ b/gateway/src/inference/providers/aws_bedrock.rs
@@ -53,6 +53,8 @@ impl AWSBedrockProvider {
             .await
             .ok_or_else(|| {
                 Error::new(ErrorDetails::InferenceClient {
+                    raw_request: None,
+                    raw_response: None,
                     status_code: Some(StatusCode::INTERNAL_SERVER_ERROR),
                     message: "Failed to determine AWS region.".to_string(),
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -134,6 +136,8 @@ impl InferenceProvider for AWSBedrockProvider {
                     .build()
                     .map_err(|e| {
                         Error::new(ErrorDetails::InferenceClient {
+                            raw_request: None,
+                            raw_response: None,
                             status_code: Some(StatusCode::INTERNAL_SERVER_ERROR),
                             message: format!("Error configuring AWS Bedrock tool config: {e}"),
                             provider_type: PROVIDER_TYPE.to_string(),
@@ -154,6 +158,8 @@ impl InferenceProvider for AWSBedrockProvider {
                     "Error sending request to AWS Bedrock: {}",
                     DisplayErrorContext(&e)
                 ),
+                raw_request: None,
+                raw_response: None,
                 provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
@@ -245,6 +251,8 @@ impl InferenceProvider for AWSBedrockProvider {
                     .build()
                     .map_err(|e| {
                         Error::new(ErrorDetails::InferenceClient {
+                            raw_request: None,
+                            raw_response: None,
                             status_code: Some(StatusCode::INTERNAL_SERVER_ERROR),
                             message: format!("Error configuring AWS Bedrock tool config: {e}"),
                             provider_type: PROVIDER_TYPE.to_string(),
@@ -260,6 +268,8 @@ impl InferenceProvider for AWSBedrockProvider {
         let start_time = Instant::now();
         let stream = bedrock_request.send().await.map_err(|e| {
             Error::new(ErrorDetails::InferenceServer {
+                raw_request: Some(raw_request.clone()),
+                raw_response: None,
                 message: format!(
                     "Error sending request to AWS Bedrock: {}",
                     DisplayErrorContext(&e)
@@ -274,6 +284,8 @@ impl InferenceProvider for AWSBedrockProvider {
             Some(Err(e)) => return Err(e),
             None => {
                 return Err(Error::new(ErrorDetails::InferenceServer {
+                    raw_request: Some(raw_request.clone()),
+                    raw_response: None,
                     message: "Stream ended before first chunk".to_string(),
                     provider_type: PROVIDER_TYPE.to_string(),
                 }))
@@ -320,6 +332,8 @@ fn stream_bedrock(
             match ev {
                 Err(e) => {
                     yield Err(ErrorDetails::InferenceServer {
+                        raw_request: None,
+                        raw_response: None,
                         message: e.to_string(),
                         provider_type: PROVIDER_TYPE.to_string(),
 
@@ -378,12 +392,14 @@ fn bedrock_to_tensorzero_stream_message(
                                 raw_name: current_tool_name.clone().ok_or_else(|| Error::new(ErrorDetails::InferenceServer {
                                     message: "Got InputJsonDelta chunk from AWS Bedrock without current tool name being set by a ToolUse".to_string(),
                                     provider_type: PROVIDER_TYPE.to_string(),
-
+                                    raw_request: None,
+                                    raw_response: None,
                                 }))?,
                                 id: current_tool_id.clone().ok_or_else(|| Error::new(ErrorDetails::InferenceServer {
                                     message: "Got InputJsonDelta chunk from AWS Bedrock without current tool id being set by a ToolUse".to_string(),
                                     provider_type: PROVIDER_TYPE.to_string(),
-
+                                    raw_request: None,
+                                    raw_response: None,
                                 }))?,
                                 raw_arguments: tool_use.input,
                             })],
@@ -393,6 +409,8 @@ fn bedrock_to_tensorzero_stream_message(
                         )))
                     }
                     _ => Err(ErrorDetails::InferenceServer {
+                        raw_request: None,
+                        raw_response: None,
                         message: "Unsupported content block delta type for AWS Bedrock".to_string(),
                         provider_type: PROVIDER_TYPE.to_string(),
                     }
@@ -423,6 +441,8 @@ fn bedrock_to_tensorzero_stream_message(
                     )))
                 }
                 _ => Err(ErrorDetails::InferenceServer {
+                    raw_request: None,
+                    raw_response: None,
                     message: "Unsupported content block start type for AWS Bedrock".to_string(),
                     provider_type: PROVIDER_TYPE.to_string(),
                 }
@@ -456,6 +476,8 @@ fn bedrock_to_tensorzero_stream_message(
             }
         }
         _ => Err(ErrorDetails::InferenceServer {
+            raw_request: None,
+            raw_response: None,
             message: "Unknown event type from AWS Bedrock".to_string(),
             provider_type: PROVIDER_TYPE.to_string(),
         }
@@ -494,6 +516,8 @@ impl TryFrom<&ContentBlock> for BedrockContentBlock {
                 // Convert the tool call arguments from String to JSON Value...
                 let input = serde_json::from_str(&tool_call.arguments).map_err(|e| {
                     Error::new(ErrorDetails::InferenceClient {
+                        raw_request: None,
+                        raw_response: Some(tool_call.arguments.clone()),
                         status_code: Some(StatusCode::BAD_REQUEST),
                         message: format!("Error parsing tool call arguments as JSON Value: {e}"),
                         provider_type: PROVIDER_TYPE.to_string(),
@@ -503,6 +527,8 @@ impl TryFrom<&ContentBlock> for BedrockContentBlock {
                 // ...then convert the JSON Value to an AWS SDK Document
                 let input = serde_json::from_value(input).map_err(|e| {
                     Error::new(ErrorDetails::InferenceServer {
+                        raw_request: None,
+                        raw_response: None,
                         message: format!(
                             "Error converting tool call arguments to AWS SDK Document: {e}"
                         ),
@@ -517,6 +543,8 @@ impl TryFrom<&ContentBlock> for BedrockContentBlock {
                     .build()
                     .map_err(|_| {
                         Error::new(ErrorDetails::InferenceClient {
+                            raw_request: None,
+                            raw_response: None,
                             status_code: Some(StatusCode::BAD_REQUEST),
                             message: "Error serializing tool call block".to_string(),
                             provider_type: PROVIDER_TYPE.to_string(),
@@ -533,6 +561,8 @@ impl TryFrom<&ContentBlock> for BedrockContentBlock {
                     .build()
                     .map_err(|_| {
                         Error::new(ErrorDetails::InferenceClient {
+                            raw_request: None,
+                            raw_response: None,
                             status_code: Some(StatusCode::BAD_REQUEST),
                             message: "Error serializing tool result block".to_string(),
                             provider_type: PROVIDER_TYPE.to_string(),
@@ -554,6 +584,8 @@ impl TryFrom<BedrockContentBlock> for ContentBlock {
             BedrockContentBlock::ToolUse(tool_use) => {
                 let arguments = serde_json::to_string(&tool_use.input).map_err(|e| {
                     Error::new(ErrorDetails::InferenceServer {
+                        raw_request: None,
+                        raw_response: None,
                         message: format!("Error parsing tool call arguments from AWS Bedrock: {e}"),
                         provider_type: PROVIDER_TYPE.to_string(),
                     })
@@ -632,6 +664,8 @@ impl TryFrom<ConverseOutputWithMetadata<'_>> for ProviderInferenceResponse {
             Some(ConverseOutputType::Message(message)) => Some(message),
             _ => {
                 return Err(ErrorDetails::InferenceServer {
+                    raw_request: None,
+                    raw_response: Some(raw_response.clone()),
                     message: "AWS Bedrock returned an unknown output type.".to_string(),
                     provider_type: PROVIDER_TYPE.to_string(),
                 }
@@ -642,6 +676,8 @@ impl TryFrom<ConverseOutputWithMetadata<'_>> for ProviderInferenceResponse {
         let mut content: Vec<ContentBlock> = message
             .ok_or_else(|| {
                 Error::new(ErrorDetails::InferenceServer {
+                    raw_request: None,
+                    raw_response: Some(raw_response.clone()),
                     message: "AWS Bedrock returned an empty message.".to_string(),
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
@@ -667,6 +703,8 @@ impl TryFrom<ConverseOutputWithMetadata<'_>> for ProviderInferenceResponse {
             })
             .ok_or_else(|| {
                 Error::new(ErrorDetails::InferenceServer {
+                    raw_request: None,
+                    raw_response: Some(raw_response.clone()),
                     message: "AWS Bedrock returned a message without usage information."
                         .to_string(),
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -695,6 +733,8 @@ impl TryFrom<ConverseOutputWithMetadata<'_>> for ProviderInferenceResponse {
 fn serialize_aws_bedrock_struct<T: std::fmt::Debug>(output: &T) -> Result<String, Error> {
     serde_json::to_string(&serde_json::json!({"debug": format!("{:?}", output)})).map_err(|e| {
         Error::new(ErrorDetails::InferenceServer {
+            raw_request: None,
+            raw_response: Some(format!("{:?}", output)),
             message: format!("Error parsing response from AWS Bedrock: {e}"),
             provider_type: PROVIDER_TYPE.to_string(),
         })
@@ -708,6 +748,8 @@ impl TryFrom<&ToolConfig> for Tool {
         let tool_input_schema = ToolInputSchema::Json(
             serde_json::from_value(tool_config.parameters().clone()).map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
+                    raw_request: None,
+                    raw_response: Some(format!("{:?}", tool_config.parameters())),
                     status_code: Some(StatusCode::INTERNAL_SERVER_ERROR),
                     message: format!("Error parsing tool input schema: {e}"),
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -722,6 +764,8 @@ impl TryFrom<&ToolConfig> for Tool {
             .build()
             .map_err(|_| {
                 Error::new(ErrorDetails::InferenceClient {
+                    raw_request: None,
+                    raw_response: Some(format!("{:?}", tool_config.parameters())),
                     status_code: Some(StatusCode::INTERNAL_SERVER_ERROR),
                     message: "Error configuring AWS Bedrock tool choice (this should never happen). Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new"
                         .to_string(),
@@ -753,6 +797,8 @@ impl TryFrom<ToolChoice> for AWSBedrockToolChoice {
                     .name(tool_name)
                     .build()
                     .map_err(|_| Error::new(ErrorDetails::InferenceClient {
+                        raw_request: None,
+                        raw_response: None,
                         status_code: Some(StatusCode::INTERNAL_SERVER_ERROR),
                         message:
                             "Error configuring AWS Bedrock tool choice (this should never happen). Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new"

--- a/gateway/src/inference/providers/azure.rs
+++ b/gateway/src/inference/providers/azure.rs
@@ -124,6 +124,8 @@ impl InferenceProvider for AzureProvider {
                     message: e.to_string(),
                     status_code: Some(e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                 })
             })?;
         if res.status().is_success() {
@@ -135,6 +137,8 @@ impl InferenceProvider for AzureProvider {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing text response: {e}"),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                 })
             })?;
 
@@ -142,6 +146,8 @@ impl InferenceProvider for AzureProvider {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing JSON response: {e}: {response}"),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: Some(response.clone()),
                 })
             })?;
 
@@ -153,15 +159,16 @@ impl InferenceProvider for AzureProvider {
             }
             .try_into()?)
         } else {
-            Err(handle_openai_error(
-                res.status(),
-                &res.text().await.map_err(|e| {
-                    Error::new(ErrorDetails::InferenceServer {
-                        message: format!("Error parsing error response: {e}"),
-                        provider_type: PROVIDER_TYPE.to_string(),
-                    })
-                })?,
-            ))
+            let status = res.status();
+            let response = res.text().await.map_err(|e| {
+                Error::new(ErrorDetails::InferenceServer {
+                    message: format!("Error parsing error response: {e}"),
+                    provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
+                })
+            })?;
+            Err(handle_openai_error(status, &response))
         }
     }
 
@@ -180,9 +187,8 @@ impl InferenceProvider for AzureProvider {
     > {
         let request_body = AzureRequest::new(request);
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
+            Error::new(ErrorDetails::Serialization {
                 message: format!("Error serializing request body as JSON: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
         let request_url = get_azure_chat_url(&self.endpoint, &self.deployment_id)?;
@@ -199,6 +205,8 @@ impl InferenceProvider for AzureProvider {
                     message: format!("Error sending request to Azure: {e}"),
                     status_code: None,
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(raw_request.clone()),
+                    raw_response: None,
                 })
             })?;
         let mut stream = Box::pin(stream_openai(event_source, start_time));
@@ -211,6 +219,8 @@ impl InferenceProvider for AzureProvider {
                 return Err(ErrorDetails::InferenceServer {
                     message: "Stream ended before first chunk".to_string(),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(raw_request.clone()),
+                    raw_response: None,
                 }
                 .into())
             }
@@ -238,6 +248,8 @@ fn get_azure_chat_url(endpoint: &Url, deployment_id: &str) -> Result<Url, Error>
             Error::new(ErrorDetails::InferenceServer {
                 message: format!("Error parsing URL: {e:?}"),
                 provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: None,
+                raw_response: None,
             })
         })?
         .push("openai")
@@ -368,9 +380,8 @@ impl<'a> TryFrom<AzureResponseWithMetadata<'a>> for ProviderInferenceResponse {
             generic_request,
         } = value;
         let raw_response = serde_json::to_string(&response).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
+            Error::new(ErrorDetails::Serialization {
                 message: format!("Error parsing response: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
         if response.choices.len() != 1 {
@@ -380,6 +391,8 @@ impl<'a> TryFrom<AzureResponseWithMetadata<'a>> for ProviderInferenceResponse {
                     response.choices.len()
                 ),
                 provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: None,
+                raw_response: Some(raw_response.clone()),
             }
             .into());
         }
@@ -393,6 +406,8 @@ impl<'a> TryFrom<AzureResponseWithMetadata<'a>> for ProviderInferenceResponse {
                 Error::new(ErrorDetails::InferenceServer {
                     message: "Response has no choices (this should never happen)".to_string(),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: None,
+                    raw_response: Some(raw_response.clone()),
                 })
             })?
             .message;
@@ -406,9 +421,8 @@ impl<'a> TryFrom<AzureResponseWithMetadata<'a>> for ProviderInferenceResponse {
             }
         }
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
+            Error::new(ErrorDetails::Serialization {
                 message: format!("Error serializing request body as JSON: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
 

--- a/gateway/src/inference/providers/azure.rs
+++ b/gateway/src/inference/providers/azure.rs
@@ -168,7 +168,7 @@ impl InferenceProvider for AzureProvider {
                     raw_response: None,
                 })
             })?;
-            Err(handle_openai_error(status, &response))
+            Err(handle_openai_error(status, &response, PROVIDER_TYPE))
         }
     }
 

--- a/gateway/src/inference/providers/dummy.rs
+++ b/gateway/src/inference/providers/dummy.rs
@@ -163,6 +163,8 @@ impl InferenceProvider for DummyProvider {
             // Fail on even-numbered calls
             if *counter % 2 == 0 {
                 return Err(ErrorDetails::InferenceClient {
+                    raw_request: Some("raw request".to_string()),
+                    raw_response: None,
                     message: format!(
                         "Flaky model '{}' failed on call number {}",
                         self.model_name, *counter
@@ -177,6 +179,8 @@ impl InferenceProvider for DummyProvider {
         if self.model_name == "error" {
             return Err(ErrorDetails::InferenceClient {
                 message: "Error sending request to Dummy provider.".to_string(),
+                raw_request: Some("raw request".to_string()),
+                raw_response: None,
                 status_code: None,
                 provider_type: PROVIDER_TYPE.to_string(),
             }
@@ -188,6 +192,8 @@ impl InferenceProvider for DummyProvider {
                 if api_key.expose_secret() != "good_key" {
                     return Err(ErrorDetails::InferenceClient {
                         message: "Invalid API key for Dummy provider".to_string(),
+                        raw_request: Some("raw request".to_string()),
+                        raw_response: None,
                         status_code: None,
                         provider_type: PROVIDER_TYPE.to_string(),
                     }
@@ -288,6 +294,8 @@ impl InferenceProvider for DummyProvider {
             // Fail on even-numbered calls
             if *counter % 2 == 0 {
                 return Err(ErrorDetails::InferenceClient {
+                    raw_request: Some("raw request".to_string()),
+                    raw_response: None,
                     message: format!(
                         "Flaky model '{}' failed on call number {}",
                         self.model_name, *counter
@@ -302,6 +310,8 @@ impl InferenceProvider for DummyProvider {
         if self.model_name == "error" {
             return Err(ErrorDetails::InferenceClient {
                 message: "Error sending request to Dummy provider.".to_string(),
+                raw_request: Some("raw request".to_string()),
+                raw_response: None,
                 status_code: None,
                 provider_type: PROVIDER_TYPE.to_string(),
             }
@@ -414,6 +424,8 @@ impl EmbeddingProvider for DummyProvider {
         if self.model_name == "error" {
             return Err(ErrorDetails::InferenceClient {
                 message: "Error sending request to Dummy provider.".to_string(),
+                raw_request: Some("raw request".to_string()),
+                raw_response: None,
                 status_code: None,
                 provider_type: PROVIDER_TYPE.to_string(),
             }

--- a/gateway/src/inference/providers/fireworks.rs
+++ b/gateway/src/inference/providers/fireworks.rs
@@ -141,23 +141,29 @@ impl InferenceProvider for FireworksProvider {
                     message: format!("Error sending request to Fireworks: {e}"),
                     status_code: e.status(),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                 })
             })?;
         let latency = Latency::NonStreaming {
             response_time: start_time.elapsed(),
         };
         if res.status().is_success() {
-            let response = res.text().await.map_err(|e| {
+            let response_text = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing text response: {e}"),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                 })
             })?;
 
-            let response = serde_json::from_str(&response).map_err(|e| {
+            let response = serde_json::from_str(&response_text).map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing JSON response: {e}: {response}"),
+                    message: format!("Error parsing JSON response: {e}: {response_text}"),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: Some(response_text.clone()),
                 })
             })?;
 
@@ -175,6 +181,8 @@ impl InferenceProvider for FireworksProvider {
                     Error::new(ErrorDetails::InferenceServer {
                         message: format!("Error parsing error response: {e}"),
                         provider_type: PROVIDER_TYPE.to_string(),
+                        raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                        raw_response: None,
                     })
                 })?,
             ))
@@ -199,6 +207,8 @@ impl InferenceProvider for FireworksProvider {
             Error::new(ErrorDetails::InferenceServer {
                 message: format!("Error serializing request body: {e}"),
                 provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                raw_response: None,
             })
         })?;
         let request_url = get_chat_url(Some(&FIREWORKS_API_BASE))?;
@@ -215,6 +225,8 @@ impl InferenceProvider for FireworksProvider {
                     message: format!("Error sending request to Fireworks: {e}"),
                     status_code: None,
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(raw_request.clone()),
+                    raw_response: None,
                 })
             })?;
         let mut stream = Box::pin(stream_openai(event_source, start_time));
@@ -227,6 +239,8 @@ impl InferenceProvider for FireworksProvider {
                 return Err(ErrorDetails::InferenceServer {
                     message: "Stream ended before first chunk".to_string(),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(raw_request.clone()),
+                    raw_response: None,
                 }
                 .into())
             }
@@ -377,9 +391,8 @@ impl<'a> TryFrom<FireworksResponseWithMetadata<'a>> for ProviderInferenceRespons
             generic_request,
         } = value;
         let raw_response = serde_json::to_string(&response).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
+            Error::new(ErrorDetails::Serialization {
                 message: format!("Error parsing response: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
         if response.choices.len() != 1 {
@@ -389,6 +402,8 @@ impl<'a> TryFrom<FireworksResponseWithMetadata<'a>> for ProviderInferenceRespons
                     response.choices.len()
                 ),
                 provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                raw_response: Some(raw_response.clone()),
             }
             .into());
         }
@@ -399,6 +414,8 @@ impl<'a> TryFrom<FireworksResponseWithMetadata<'a>> for ProviderInferenceRespons
             .ok_or_else(|| Error::new(ErrorDetails::InferenceServer {
                 message: "Response has no choices (this should never happen). Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new".to_string(),
                 provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                raw_response: Some(raw_response.clone()),
             }
             ))?
             .message;
@@ -412,9 +429,8 @@ impl<'a> TryFrom<FireworksResponseWithMetadata<'a>> for ProviderInferenceRespons
             }
         }
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
+            Error::new(ErrorDetails::Serialization {
                 message: format!("Error serializing request body as JSON: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
         let system = generic_request.system.clone();

--- a/gateway/src/inference/providers/fireworks.rs
+++ b/gateway/src/inference/providers/fireworks.rs
@@ -185,6 +185,7 @@ impl InferenceProvider for FireworksProvider {
                         raw_response: None,
                     })
                 })?,
+                PROVIDER_TYPE,
             ))
         }
     }

--- a/gateway/src/inference/providers/gcp_vertex_anthropic.rs
+++ b/gateway/src/inference/providers/gcp_vertex_anthropic.rs
@@ -1567,7 +1567,7 @@ mod tests {
                 status_code: Some(response_code),
                 provider_type: PROVIDER_TYPE.to_string(),
                 raw_request: None,
-                raw_response: None,
+                raw_response: Some("{\"type\":\"error\",\"message\":\"test_message\"}".to_string()),
             }
         );
         let response_code = StatusCode::UNAUTHORIZED;
@@ -1580,7 +1580,7 @@ mod tests {
                 status_code: Some(response_code),
                 provider_type: PROVIDER_TYPE.to_string(),
                 raw_request: None,
-                raw_response: None,
+                raw_response: Some("{\"type\":\"error\",\"message\":\"test_message\"}".to_string()),
             }
         );
         let response_code = StatusCode::TOO_MANY_REQUESTS;
@@ -1593,7 +1593,7 @@ mod tests {
                 status_code: Some(response_code),
                 provider_type: PROVIDER_TYPE.to_string(),
                 raw_request: None,
-                raw_response: None,
+                raw_response: Some("{\"type\":\"error\",\"message\":\"test_message\"}".to_string()),
             }
         );
         let response_code = StatusCode::NOT_FOUND;
@@ -1605,7 +1605,7 @@ mod tests {
             ErrorDetails::InferenceServer {
                 message: "test_message".to_string(),
                 raw_request: None,
-                raw_response: None,
+                raw_response: Some("{\"type\":\"error\",\"message\":\"test_message\"}".to_string()),
                 provider_type: PROVIDER_TYPE.to_string()
             }
         );
@@ -1617,7 +1617,7 @@ mod tests {
             ErrorDetails::InferenceServer {
                 message: "test_message".to_string(),
                 raw_request: None,
-                raw_response: None,
+                raw_response: Some("{\"type\":\"error\",\"message\":\"test_message\"}".to_string()),
                 provider_type: PROVIDER_TYPE.to_string()
             }
         );
@@ -2067,6 +2067,8 @@ mod tests {
             details,
             ErrorDetails::InferenceServer {
                 message: "Unsupported content block type for ContentBlockStart".to_string(),
+                raw_request: None,
+                raw_response: None,
                 provider_type: PROVIDER_TYPE.to_string()
             }
         );
@@ -2101,6 +2103,8 @@ mod tests {
             details,
             ErrorDetails::InferenceServer {
                 message: r#"{"message":"Test error"}"#.to_string(),
+                raw_request: None,
+                raw_response: None,
                 provider_type: PROVIDER_TYPE.to_string(),
             }
         );

--- a/gateway/src/inference/providers/gcp_vertex_anthropic.rs
+++ b/gateway/src/inference/providers/gcp_vertex_anthropic.rs
@@ -92,6 +92,8 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
                     message: format!("Error sending request: {e}"),
                     status_code: e.status(),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                 })
             })?;
         let latency = Latency::NonStreaming {
@@ -102,6 +104,8 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing text response: {e}"),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                 })
             })?;
 
@@ -109,6 +113,8 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing JSON response: {e}: {response}"),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: Some(response.clone()),
                 })
             })?;
 
@@ -127,6 +133,8 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing response: {e}"),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                 })
             })?;
             handle_anthropic_error(response_code, error_body.error)
@@ -149,9 +157,8 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
     > {
         let request_body = GCPVertexAnthropicRequestBody::new(request)?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
+            Error::new(ErrorDetails::Serialization {
                 message: format!("Error serializing request body as JSON: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
         let api_key = self
@@ -166,9 +173,11 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
             .eventsource()
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
-                    message: format!("Error sending request to Anthropic: {e}"),
+                    message: format!("Error sending request: {e}"),
                     status_code: None,
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                 })
             })?;
         let mut stream = Box::pin(stream_anthropic(event_source, start_time));
@@ -179,6 +188,8 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
                 return Err(ErrorDetails::InferenceServer {
                     message: "Stream ended before first chunk".to_string(),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                 }
                 .into())
             }
@@ -222,7 +233,9 @@ fn stream_anthropic(
                 Err(e) => {
                     yield Err(ErrorDetails::InferenceServer {
                         message: e.to_string(),
-                        provider_type: PROVIDER_TYPE.to_string()
+                        provider_type: PROVIDER_TYPE.to_string(),
+                        raw_request: None,
+                        raw_response: None,
                     }.into());
                 }
                 Ok(event) => match event {
@@ -234,7 +247,9 @@ fn stream_anthropic(
                                     "Error parsing message: {}, Data: {}",
                                     e, message.data
                                 ),
-                                provider_type: PROVIDER_TYPE.to_string()
+                                provider_type: PROVIDER_TYPE.to_string(),
+                                raw_request: None,
+                                raw_response: None,
                             }));
                         // Anthropic streaming API docs specify that this is the last message
                         if let Ok(GCPVertexAnthropicStreamMessage::MessageStop) = data {
@@ -365,6 +380,8 @@ impl<'a> TryFrom<&'a ContentBlock> for GCPVertexAnthropicMessageContent<'a> {
                         status_code: Some(StatusCode::BAD_REQUEST),
                         message: format!("Error parsing tool call arguments as JSON Value: {e}"),
                         provider_type: PROVIDER_TYPE.to_string(),
+                        raw_request: None,
+                        raw_response: Some(tool_call.arguments.clone()),
                     })
                 })?;
 
@@ -373,6 +390,8 @@ impl<'a> TryFrom<&'a ContentBlock> for GCPVertexAnthropicMessageContent<'a> {
                         status_code: Some(StatusCode::BAD_REQUEST),
                         message: "Tool call arguments must be a JSON object".to_string(),
                         provider_type: PROVIDER_TYPE.to_string(),
+                        raw_request: None,
+                        raw_response: Some(tool_call.arguments.clone()),
                     }
                     .into());
                 }
@@ -587,7 +606,7 @@ struct GCPVertexAnthropicError {
     error: GCPVertexAnthropicErrorBody,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 struct GCPVertexAnthropicErrorBody {
     r#type: String,
     message: String,
@@ -616,9 +635,8 @@ impl TryFrom<GCPVertexAnthropicContentBlock> for ContentBlock {
                     id,
                     name,
                     arguments: serde_json::to_string(&input).map_err(|e| {
-                        Error::new(ErrorDetails::InferenceServer {
+                        Error::new(ErrorDetails::Serialization {
                             message: format!("Error parsing input for tool call: {e}"),
-                            provider_type: PROVIDER_TYPE.to_string(),
                         })
                     })?,
                 }))
@@ -679,9 +697,8 @@ impl<'a> TryFrom<GCPVertexAnthropicResponseWithMetadata<'a>> for ProviderInferen
         } = value;
 
         let raw_response = serde_json::to_string(&response).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
+            Error::new(ErrorDetails::Serialization {
                 message: format!("Error parsing response from GCP Vertex Anthropic: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
 
@@ -691,9 +708,8 @@ impl<'a> TryFrom<GCPVertexAnthropicResponseWithMetadata<'a>> for ProviderInferen
             .map(|block| block.try_into())
             .collect::<Result<Vec<_>, _>>()?;
         let raw_request = serde_json::to_string(&request).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
+            Error::new(ErrorDetails::Serialization {
                 message: format!("Error serializing request to GCP Vertex Anthropic: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
 
@@ -731,16 +747,20 @@ fn handle_anthropic_error(
         | StatusCode::BAD_REQUEST
         | StatusCode::PAYLOAD_TOO_LARGE
         | StatusCode::TOO_MANY_REQUESTS => Err(ErrorDetails::InferenceClient {
+            raw_response: Some(serde_json::to_string(&response_body).unwrap_or_default()),
             message: response_body.message,
             status_code: Some(response_code),
             provider_type: PROVIDER_TYPE.to_string(),
+            raw_request: None,
         }
         .into()),
         // StatusCode::NOT_FOUND | StatusCode::FORBIDDEN | StatusCode::INTERNAL_SERVER_ERROR | 529: Overloaded
         // These are all captured in _ since they have the same error behavior
         _ => Err(ErrorDetails::InferenceServer {
+            raw_response: Some(serde_json::to_string(&response_body).unwrap_or_default()),
             message: response_body.message,
             provider_type: PROVIDER_TYPE.to_string(),
+            raw_request: None,
         }
         .into()),
     }
@@ -807,9 +827,8 @@ fn anthropic_to_tensorzero_stream_message(
     current_tool_name: &mut Option<String>,
 ) -> Result<Option<ProviderInferenceResponseChunk>, Error> {
     let raw_message = serde_json::to_string(&message).map_err(|e| {
-        Error::new(ErrorDetails::InferenceServer {
+        Error::new(ErrorDetails::Serialization {
             message: format!("Error parsing response from Anthropic: {e}"),
-            provider_type: PROVIDER_TYPE.to_string(),
         })
     })?;
     match message {
@@ -835,11 +854,15 @@ fn anthropic_to_tensorzero_stream_message(
                     vec![ContentBlockChunk::ToolCall(ToolCallChunk {
                         raw_name: current_tool_name.clone().ok_or_else(|| Error::new(ErrorDetails::InferenceServer {
                             message: "Got InputJsonDelta chunk from Anthropic without current tool name being set by a ToolUse".to_string(),
-                            provider_type: PROVIDER_TYPE.to_string()
+                            provider_type: PROVIDER_TYPE.to_string(),
+                            raw_request: None,
+                            raw_response: None,
                         }))?,
                         id: current_tool_id.clone().ok_or_else(|| Error::new(ErrorDetails::InferenceServer {
                             message: "Got InputJsonDelta chunk from Anthropic without current tool id being set by a ToolUse".to_string(),
-                            provider_type: PROVIDER_TYPE.to_string()
+                            provider_type: PROVIDER_TYPE.to_string(),
+                            raw_request: None,
+                            raw_response: None,
                         }))?,
                         raw_arguments: partial_json,
                     })],
@@ -851,6 +874,8 @@ fn anthropic_to_tensorzero_stream_message(
             _ => Err(ErrorDetails::InferenceServer {
                 message: "Unsupported content block type for ContentBlockDelta".to_string(),
                 provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: None,
+                raw_response: None,
             }
             .into()),
         },
@@ -891,6 +916,8 @@ fn anthropic_to_tensorzero_stream_message(
             _ => Err(ErrorDetails::InferenceServer {
                 message: "Unsupported content block type for ContentBlockStart".to_string(),
                 provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: None,
+                raw_response: None,
             }
             .into()),
         },
@@ -898,6 +925,8 @@ fn anthropic_to_tensorzero_stream_message(
         GCPVertexAnthropicStreamMessage::Error { error } => Err(ErrorDetails::InferenceServer {
             message: error.to_string(),
             provider_type: PROVIDER_TYPE.to_string(),
+            raw_request: None,
+            raw_response: None,
         }
         .into()),
         GCPVertexAnthropicStreamMessage::MessageDelta { usage, .. } => {
@@ -1536,7 +1565,9 @@ mod tests {
             ErrorDetails::InferenceClient {
                 message: "test_message".to_string(),
                 status_code: Some(response_code),
-                provider_type: PROVIDER_TYPE.to_string()
+                provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: None,
+                raw_response: None,
             }
         );
         let response_code = StatusCode::UNAUTHORIZED;
@@ -1547,7 +1578,9 @@ mod tests {
             ErrorDetails::InferenceClient {
                 message: "test_message".to_string(),
                 status_code: Some(response_code),
-                provider_type: PROVIDER_TYPE.to_string()
+                provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: None,
+                raw_response: None,
             }
         );
         let response_code = StatusCode::TOO_MANY_REQUESTS;
@@ -1558,7 +1591,9 @@ mod tests {
             ErrorDetails::InferenceClient {
                 message: "test_message".to_string(),
                 status_code: Some(response_code),
-                provider_type: PROVIDER_TYPE.to_string()
+                provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: None,
+                raw_response: None,
             }
         );
         let response_code = StatusCode::NOT_FOUND;
@@ -1569,6 +1604,8 @@ mod tests {
             details,
             ErrorDetails::InferenceServer {
                 message: "test_message".to_string(),
+                raw_request: None,
+                raw_response: None,
                 provider_type: PROVIDER_TYPE.to_string()
             }
         );
@@ -1579,6 +1616,8 @@ mod tests {
             details,
             ErrorDetails::InferenceServer {
                 message: "test_message".to_string(),
+                raw_request: None,
+                raw_response: None,
                 provider_type: PROVIDER_TYPE.to_string()
             }
         );
@@ -1910,6 +1949,8 @@ mod tests {
             details,
             ErrorDetails::InferenceServer {
                 message: "Got InputJsonDelta chunk from Anthropic without current tool name being set by a ToolUse".to_string(),
+                raw_request: None,
+                raw_response: None,
                 provider_type: PROVIDER_TYPE.to_string()
             }
         );

--- a/gateway/src/inference/providers/hyperbolic.rs
+++ b/gateway/src/inference/providers/hyperbolic.rs
@@ -126,6 +126,8 @@ impl InferenceProvider for HyperbolicProvider {
                 Error::new(ErrorDetails::InferenceClient {
                     message: format!("Error sending request to Hyperbolic: {e}"),
                     status_code: e.status(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
@@ -134,6 +136,8 @@ impl InferenceProvider for HyperbolicProvider {
             let response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing text response: {e}"),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
@@ -142,6 +146,8 @@ impl InferenceProvider for HyperbolicProvider {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing JSON response: {e}: {response}"),
                     provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: Some(response.clone()),
                 })
             })?;
 
@@ -161,9 +167,12 @@ impl InferenceProvider for HyperbolicProvider {
                 &res.text().await.map_err(|e| {
                     Error::new(ErrorDetails::InferenceServer {
                         message: format!("Error parsing error response: {e}"),
+                        raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                        raw_response: None,
                         provider_type: PROVIDER_TYPE.to_string(),
                     })
                 })?,
+                PROVIDER_TYPE,
             ))
         }
     }
@@ -183,9 +192,8 @@ impl InferenceProvider for HyperbolicProvider {
     > {
         let request_body = HyperbolicRequest::new(&self.model_name, request)?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
+            Error::new(ErrorDetails::Serialization {
                 message: format!("Error serializing request: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
         let request_url = get_chat_url(Some(&HYPERBOLIC_DEFAULT_BASE_URL))?;
@@ -201,6 +209,8 @@ impl InferenceProvider for HyperbolicProvider {
                 Error::new(ErrorDetails::InferenceClient {
                     message: format!("Error sending request to Hyperbolic: {e}"),
                     status_code: None,
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
@@ -214,6 +224,8 @@ impl InferenceProvider for HyperbolicProvider {
             None => {
                 return Err(ErrorDetails::InferenceServer {
                     message: "Stream ended before first chunk".to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                 }
                 .into())
@@ -307,9 +319,8 @@ impl<'a> TryFrom<HyperbolicResponseWithMetadata<'a>> for ProviderInferenceRespon
         } = value;
 
         let raw_response = serde_json::to_string(&response).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
-                message: format!("Error parsing response: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
+            Error::new(ErrorDetails::Serialization {
+                message: format!("Error serializing response: {e}"),
             })
         })?;
 
@@ -319,6 +330,8 @@ impl<'a> TryFrom<HyperbolicResponseWithMetadata<'a>> for ProviderInferenceRespon
                     "Response has invalid number of choices {}, Expected 1",
                     response.choices.len()
                 ),
+                raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                raw_response: Some(raw_response.clone()),
                 provider_type: PROVIDER_TYPE.to_string(),
             }
             .into());
@@ -330,6 +343,8 @@ impl<'a> TryFrom<HyperbolicResponseWithMetadata<'a>> for ProviderInferenceRespon
             .pop()
             .ok_or_else(|| Error::new(ErrorDetails::InferenceServer {
                 message: "Response has no choices (this should never happen). Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new".to_string(),
+                raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                raw_response: Some(raw_response.clone()),
                 provider_type: PROVIDER_TYPE.to_string(),
             }))?
             .message;
@@ -343,9 +358,8 @@ impl<'a> TryFrom<HyperbolicResponseWithMetadata<'a>> for ProviderInferenceRespon
             }
         }
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
+            Error::new(ErrorDetails::Serialization {
                 message: format!("Error serializing request body as JSON: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
         let system = generic_request.system.clone();

--- a/gateway/src/inference/providers/mistral.rs
+++ b/gateway/src/inference/providers/mistral.rs
@@ -440,8 +440,6 @@ impl<'a> MistralRequest<'a> {
         model: &'a str,
         request: &'a ModelInferenceRequest,
     ) -> Result<MistralRequest<'a>, Error> {
-        // NB: Fireworks will throw an error if you give FireworksResponseFormat::Text and then also include tools.
-        // So we just don't include it as Text is the same as None anyway.
         let response_format = match request.json_mode {
             ModelInferenceRequestJsonMode::On | ModelInferenceRequestJsonMode::Strict => {
                 Some(MistralResponseFormat::JsonObject)

--- a/gateway/src/inference/providers/together.rs
+++ b/gateway/src/inference/providers/together.rs
@@ -135,6 +135,8 @@ impl InferenceProvider for TogetherProvider {
                 Error::new(ErrorDetails::InferenceClient {
                     message: format!("{e}"),
                     status_code: Some(e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
@@ -142,6 +144,8 @@ impl InferenceProvider for TogetherProvider {
             let response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing text response: {e}"),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
@@ -149,6 +153,8 @@ impl InferenceProvider for TogetherProvider {
             let response = serde_json::from_str(&response).map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing JSON response: {e}: {response}"),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: Some(response.clone()),
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
@@ -163,15 +169,16 @@ impl InferenceProvider for TogetherProvider {
             }
             .try_into()?)
         } else {
-            Err(handle_openai_error(
-                res.status(),
-                &res.text().await.map_err(|e| {
-                    Error::new(ErrorDetails::InferenceServer {
-                        message: format!("Error parsing error response: {e}"),
-                        provider_type: PROVIDER_TYPE.to_string(),
-                    })
-                })?,
-            ))
+            let status = res.status();
+            let raw_response = res.text().await.map_err(|e| {
+                Error::new(ErrorDetails::InferenceServer {
+                    message: format!("Error parsing error response: {e}"),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
+                    provider_type: PROVIDER_TYPE.to_string(),
+                })
+            })?;
+            Err(handle_openai_error(status, &raw_response, PROVIDER_TYPE))
         }
     }
 
@@ -190,9 +197,8 @@ impl InferenceProvider for TogetherProvider {
     > {
         let request_body = TogetherRequest::new(&self.model_name, request);
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
+            Error::new(ErrorDetails::Serialization {
                 message: format!("Error serializing request: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
         let api_key = self.credentials.get_api_key(dynamic_api_keys)?;
@@ -208,6 +214,8 @@ impl InferenceProvider for TogetherProvider {
                 Error::new(ErrorDetails::InferenceClient {
                     message: format!("Error sending request to Together: {e}"),
                     status_code: None,
+                    raw_request: Some(raw_request.clone()),
+                    raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
@@ -220,6 +228,8 @@ impl InferenceProvider for TogetherProvider {
             None => {
                 return Err(Error::new(ErrorDetails::InferenceServer {
                     message: "Stream ended before first chunk".to_string(),
+                    raw_request: Some(raw_request.clone()),
+                    raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                 }));
             }
@@ -354,6 +364,8 @@ impl<'a> TryFrom<TogetherResponseWithMetadata<'a>> for ProviderInferenceResponse
         let raw_response = serde_json::to_string(&response).map_err(|e| {
             Error::new(ErrorDetails::InferenceServer {
                 message: format!("Error parsing response: {e}"),
+                raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                raw_response: None,
                 provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
@@ -363,6 +375,8 @@ impl<'a> TryFrom<TogetherResponseWithMetadata<'a>> for ProviderInferenceResponse
                     "Response has invalid number of choices: {}. Expected 1.",
                     response.choices.len()
                 ),
+                raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                raw_response: Some(raw_response.clone()),
                 provider_type: PROVIDER_TYPE.to_string(),
             }
             .into());
@@ -373,6 +387,8 @@ impl<'a> TryFrom<TogetherResponseWithMetadata<'a>> for ProviderInferenceResponse
             .pop()
             .ok_or_else(|| Error::new(ErrorDetails::InferenceServer {
                 message: "Response has no choices (this should never happen). Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new".to_string(),
+                raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                raw_response: Some(raw_response.clone()),
                 provider_type: PROVIDER_TYPE.to_string(),
             }))?
             .message;
@@ -388,6 +404,8 @@ impl<'a> TryFrom<TogetherResponseWithMetadata<'a>> for ProviderInferenceResponse
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::InferenceServer {
                 message: format!("Error serializing request body as JSON: {e}"),
+                raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                raw_response: Some(raw_response.clone()),
                 provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;

--- a/gateway/src/inference/providers/vllm.rs
+++ b/gateway/src/inference/providers/vllm.rs
@@ -125,6 +125,8 @@ impl InferenceProvider for VLLMProvider {
                 Error::new(ErrorDetails::InferenceClient {
                     message: format!("Error sending request to vLLM: {e}"),
                     status_code: e.status(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
@@ -132,9 +134,19 @@ impl InferenceProvider for VLLMProvider {
             response_time: start_time.elapsed(),
         };
         if res.status().is_success() {
-            let response_body = res.json::<OpenAIResponse>().await.map_err(|e| {
+            let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing response: {e}"),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
+                    provider_type: PROVIDER_TYPE.to_string(),
+                })
+            })?;
+            let response_body = serde_json::from_str(&raw_response).map_err(|e| {
+                Error::new(ErrorDetails::InferenceServer {
+                    message: format!("Error parsing response: {e}"),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: Some(raw_response.clone()),
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
@@ -146,15 +158,16 @@ impl InferenceProvider for VLLMProvider {
             }
             .try_into()?)
         } else {
-            Err(handle_openai_error(
-                res.status(),
-                &res.text().await.map_err(|e| {
-                    Error::new(ErrorDetails::InferenceServer {
-                        message: format!("Error parsing error response: {e}"),
-                        provider_type: PROVIDER_TYPE.to_string(),
-                    })
-                })?,
-            ))
+            let status = res.status();
+            let raw_response = res.text().await.map_err(|e| {
+                Error::new(ErrorDetails::InferenceServer {
+                    message: format!("Error parsing error response: {e}"),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
+                    provider_type: PROVIDER_TYPE.to_string(),
+                })
+            })?;
+            Err(handle_openai_error(status, &raw_response, PROVIDER_TYPE))
         }
     }
 
@@ -173,9 +186,8 @@ impl InferenceProvider for VLLMProvider {
     > {
         let request_body = VLLMRequest::new(&self.model_name, request)?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
+            Error::new(ErrorDetails::Serialization {
                 message: format!("Error serializing request: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
         let api_key = self.credentials.get_api_key(dynamic_api_keys)?;
@@ -194,6 +206,8 @@ impl InferenceProvider for VLLMProvider {
                 Error::new(ErrorDetails::InferenceClient {
                     message: format!("Error sending request to vLLM: {e}"),
                     status_code: None,
+                    raw_request: Some(raw_request.clone()),
+                    raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
@@ -206,6 +220,8 @@ impl InferenceProvider for VLLMProvider {
             None => {
                 return Err(ErrorDetails::InferenceServer {
                     message: "Stream ended before first chunk".to_string(),
+                    raw_request: Some(raw_request.clone()),
+                    raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                 }
                 .into())
@@ -276,8 +292,10 @@ impl<'a> VLLMRequest<'a> {
         // TODO (#169): Implement tool calling.
         if request.tool_config.is_some() {
             return Err(ErrorDetails::InferenceClient {
-                status_code: Some(reqwest::StatusCode::BAD_REQUEST),
                 message: "TensorZero does not support tool use with vLLM. Please use a different provider.".to_string(),
+                status_code: Some(reqwest::StatusCode::BAD_REQUEST),
+                raw_request: None,
+                raw_response: None,
                 provider_type: PROVIDER_TYPE.to_string(),
             }.into());
         }
@@ -317,6 +335,8 @@ impl<'a> TryFrom<VLLMResponseWithMetadata<'a>> for ProviderInferenceResponse {
         let raw_response = serde_json::to_string(&response).map_err(|e| {
             Error::new(ErrorDetails::InferenceServer {
                 message: format!("Error parsing response: {e}"),
+                raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                raw_response: None,
                 provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
@@ -326,6 +346,8 @@ impl<'a> TryFrom<VLLMResponseWithMetadata<'a>> for ProviderInferenceResponse {
                     "Response has invalid number of choices: {}. Expected 1.",
                     response.choices.len()
                 ),
+                raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                raw_response: Some(raw_response.clone()),
                 provider_type: PROVIDER_TYPE.to_string(),
             }
             .into());
@@ -336,6 +358,8 @@ impl<'a> TryFrom<VLLMResponseWithMetadata<'a>> for ProviderInferenceResponse {
             .pop()
             .ok_or_else(|| Error::new(ErrorDetails::InferenceServer {
                 message: "Response has no choices (this should never happen). Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new".to_string(),
+                raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                raw_response: Some(raw_response.clone()),
                 provider_type: PROVIDER_TYPE.to_string(),
             }))?
             .message;
@@ -351,6 +375,8 @@ impl<'a> TryFrom<VLLMResponseWithMetadata<'a>> for ProviderInferenceResponse {
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::InferenceServer {
                 message: format!("Error serializing request body as JSON: {e}"),
+                raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                raw_response: Some(raw_response.clone()),
                 provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;

--- a/gateway/src/inference/providers/xai.rs
+++ b/gateway/src/inference/providers/xai.rs
@@ -127,6 +127,8 @@ impl InferenceProvider for XAIProvider {
                 Error::new(ErrorDetails::InferenceClient {
                     message: format!("Error sending request to xAI: {e}"),
                     status_code: e.status(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
@@ -135,6 +137,8 @@ impl InferenceProvider for XAIProvider {
             let response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing text response: {e}"),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
@@ -142,6 +146,8 @@ impl InferenceProvider for XAIProvider {
             let response = serde_json::from_str(&response).map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing JSON response: {e}: {response}"),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: Some(response.clone()),
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
@@ -157,15 +163,17 @@ impl InferenceProvider for XAIProvider {
             }
             .try_into()?)
         } else {
-            Err(handle_openai_error(
-                res.status(),
-                &res.text().await.map_err(|e| {
-                    Error::new(ErrorDetails::InferenceServer {
-                        message: format!("Error parsing error response: {e}"),
-                        provider_type: PROVIDER_TYPE.to_string(),
-                    })
-                })?,
-            ))
+            let status = res.status();
+
+            let response = res.text().await.map_err(|e| {
+                Error::new(ErrorDetails::InferenceServer {
+                    message: format!("Error parsing error response: {e}"),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
+                    provider_type: PROVIDER_TYPE.to_string(),
+                })
+            })?;
+            Err(handle_openai_error(status, &response, PROVIDER_TYPE))
         }
     }
 
@@ -186,6 +194,8 @@ impl InferenceProvider for XAIProvider {
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::InferenceServer {
                 message: format!("Error serializing request: {e}"),
+                raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                raw_response: None,
                 provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
@@ -202,6 +212,8 @@ impl InferenceProvider for XAIProvider {
                 Error::new(ErrorDetails::InferenceClient {
                     message: format!("Error sending request to xAI: {e}"),
                     status_code: None,
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
@@ -215,6 +227,8 @@ impl InferenceProvider for XAIProvider {
             None => {
                 return Err(ErrorDetails::InferenceServer {
                     message: "Stream ended before first chunk".to_string(),
+                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                 }
                 .into())
@@ -336,9 +350,8 @@ impl<'a> TryFrom<XAIResponseWithMetadata<'a>> for ProviderInferenceResponse {
         } = value;
 
         let raw_response = serde_json::to_string(&response).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
+            Error::new(ErrorDetails::Serialization {
                 message: format!("Error parsing response: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
 
@@ -348,6 +361,8 @@ impl<'a> TryFrom<XAIResponseWithMetadata<'a>> for ProviderInferenceResponse {
                     "Response has invalid number of choices {}, Expected 1",
                     response.choices.len()
                 ),
+                raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                raw_response: Some(raw_response.clone()),
                 provider_type: PROVIDER_TYPE.to_string(),
             }
             .into());
@@ -359,6 +374,8 @@ impl<'a> TryFrom<XAIResponseWithMetadata<'a>> for ProviderInferenceResponse {
             .pop()
             .ok_or_else(|| Error::new(ErrorDetails::InferenceServer {
                 message: "Response has no choices (this should never happen). Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new".to_string(),
+                raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                raw_response: Some(raw_response.clone()),
                 provider_type: PROVIDER_TYPE.to_string(),
             }))?
             .message;
@@ -372,9 +389,8 @@ impl<'a> TryFrom<XAIResponseWithMetadata<'a>> for ProviderInferenceResponse {
             }
         }
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
+            Error::new(ErrorDetails::Serialization {
                 message: format!("Error serializing request body as JSON: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
         let system = generic_request.system.clone();

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -3,7 +3,7 @@ pub mod clickhouse_migration_manager;
 pub mod config_parser; // TensorZero config file
 pub mod embeddings; // embedding inference
 pub mod endpoints; // API endpoints
-mod error; // error handling
+pub mod error; // error handling
 mod function; // types and methods for working with TensorZero functions
 pub mod gateway_util; // utilities for gateway
 pub mod inference; // model inference

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -9,6 +9,7 @@ use tokio::signal;
 use gateway::clickhouse_migration_manager;
 use gateway::config_parser::Config;
 use gateway::endpoints;
+use gateway::error;
 use gateway::gateway_util;
 use gateway::observability;
 
@@ -35,6 +36,9 @@ async fn main() {
             .await
             .expect_pretty("Failed to run ClickHouse migrations");
     }
+
+    // Set debug mode
+    error::set_debug(config.gateway.debug).expect_pretty("Failed to set debug mode");
 
     let router = Router::new()
         .route("/inference", post(endpoints::inference::inference_handler))

--- a/gateway/src/model.rs
+++ b/gateway/src/model.rs
@@ -919,7 +919,7 @@ mod tests {
                         message: "Error sending request to Dummy provider.".to_string(),
                         status_code: None,
                         provider_type: "dummy".to_string(),
-                        raw_request: "".to_string(),
+                        raw_request: Some("raw request".to_string()),
                         raw_response: None,
                     }
                     .into()
@@ -1075,7 +1075,7 @@ mod tests {
                         message: "Error sending request to Dummy provider.".to_string(),
                         status_code: None,
                         provider_type: "dummy".to_string(),
-                        raw_request: "".to_string(),
+                        raw_request: Some("raw request".to_string()),
                         raw_response: None,
                     }
                     .into()
@@ -1226,7 +1226,7 @@ mod tests {
                         message: "Invalid API key for Dummy provider".to_string(),
                         status_code: None,
                         provider_type: "dummy".to_string(),
-                        raw_request: "".to_string(),
+                        raw_request: None,
                         raw_response: None,
                     }
                     .into()

--- a/gateway/src/model.rs
+++ b/gateway/src/model.rs
@@ -1226,7 +1226,7 @@ mod tests {
                         message: "Invalid API key for Dummy provider".to_string(),
                         status_code: None,
                         provider_type: "dummy".to_string(),
-                        raw_request: None,
+                        raw_request: Some("raw request".to_string()),
                         raw_response: None,
                     }
                     .into()

--- a/gateway/src/model.rs
+++ b/gateway/src/model.rs
@@ -919,6 +919,8 @@ mod tests {
                         message: "Error sending request to Dummy provider.".to_string(),
                         status_code: None,
                         provider_type: "dummy".to_string(),
+                        raw_request: "".to_string(),
+                        raw_response: None,
                     }
                     .into()
                 )])
@@ -1073,6 +1075,8 @@ mod tests {
                         message: "Error sending request to Dummy provider.".to_string(),
                         status_code: None,
                         provider_type: "dummy".to_string(),
+                        raw_request: "".to_string(),
+                        raw_response: None,
                     }
                     .into()
                 )])
@@ -1222,6 +1226,8 @@ mod tests {
                         message: "Invalid API key for Dummy provider".to_string(),
                         status_code: None,
                         provider_type: "dummy".to_string(),
+                        raw_request: "".to_string(),
+                        raw_response: None,
                     }
                     .into()
                 )])

--- a/gateway/src/variant/chat_completion.rs
+++ b/gateway/src/variant/chat_completion.rs
@@ -883,6 +883,8 @@ mod tests {
                     Error::new(ErrorDetails::InferenceClient {
                         message: "Error sending request to Dummy provider.".to_string(),
                         status_code: None,
+                        raw_request: None,
+                        raw_response: None,
                         provider_type: "dummy".to_string(),
                     })
                 )])

--- a/gateway/src/variant/chat_completion.rs
+++ b/gateway/src/variant/chat_completion.rs
@@ -883,7 +883,7 @@ mod tests {
                     Error::new(ErrorDetails::InferenceClient {
                         message: "Error sending request to Dummy provider.".to_string(),
                         status_code: None,
-                        raw_request: None,
+                        raw_request: Some("raw request".to_string()),
                         raw_response: None,
                         provider_type: "dummy".to_string(),
                     })


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a debug mode to the gateway to log request and response bodies, with changes to configuration, error handling, and provider implementations.
> 
>   - **Behavior**:
>     - Adds `debug` field to `GatewayConfig` in `config_parser.rs` to enable logging of request and response bodies.
>     - Introduces `set_debug()` function in `error.rs` to set debug mode globally.
>     - Modifies error handling in `error.rs` and various provider files to include raw request and response bodies when debug mode is enabled.
>   - **Providers**:
>     - Updates `AnthropicProvider`, `AWSBedrockProvider`, `AzureProvider`, `DummyProvider`, `FireworksProvider`, `GCPVertexAnthropicProvider`, `GCPVertexGeminiProvider`, `GoogleAIStudioGeminiProvider`, `HyperbolicProvider`, `MistralProvider`, `OpenAIProvider`, `TogetherProvider`, `VLLMProvider`, and `XAIProvider` to support debug mode by logging raw request and response bodies.
>   - **Misc**:
>     - Changes `error.rs` to be a public module in `lib.rs`.
>     - Updates `main.rs` to set debug mode during initialization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 73498564b8d5888701e5400bac920c75541b4833. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->