### PR TITLE
Expand `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
-target/
+**/target/
+**/.venv/
+**/node_modules/


### PR DESCRIPTION
Faster Docker builds 🐎 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Expand `.dockerignore` to exclude `**/target/`, `**/.venv/`, and `**/node_modules/` for faster Docker builds.
> 
>   - **Dockerignore**:
>     - Add `**/target/`, `**/.venv/`, and `**/node_modules/` to `.dockerignore` to exclude these directories from Docker build context.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2ecd0e930c7ae37ab54d42e05b156a8019114433. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->