### PR TITLE
pinned rust version to 1.83.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # ========== builder ==========
 
-FROM rust:latest AS builder
+FROM rust:1.83.0 AS builder
 
 WORKDIR /src
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Pin Rust version to 1.83.0 in Dockerfile to ensure consistent build environment.
> 
>   - **Dockerfile**:
>     - Pin Rust version to `1.83.0` in the `FROM rust:1.83.0 AS builder` line to ensure consistent build environment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e45dfa82bd5898075a7dd3e7d6245e384daf7084. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->