### PR TITLE
Fix lifetime issues on Rust 1.84.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # ========== builder ==========
 
-FROM rust:1.83.0 AS builder
+FROM rust:latest AS builder
 
 WORKDIR /src
 

--- a/gateway/src/clickhouse_migration_manager/migrations/migration_0000.rs
+++ b/gateway/src/clickhouse_migration_manager/migrations/migration_0000.rs
@@ -18,7 +18,7 @@ pub struct Migration0000<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
-impl<'a> Migration for Migration0000<'a> {
+impl Migration for Migration0000<'_> {
     /// Check if you can connect to the database
     async fn can_apply(&self) -> Result<(), Error> {
         self.clickhouse.health().await.map_err(|e| {

--- a/gateway/src/clickhouse_migration_manager/migrations/migration_0001.rs
+++ b/gateway/src/clickhouse_migration_manager/migrations/migration_0001.rs
@@ -25,7 +25,7 @@ pub struct Migration0001<'a> {
     pub clean_start: bool,
 }
 
-impl<'a> Migration for Migration0001<'a> {
+impl Migration for Migration0001<'_> {
     /// Check if you can connect to the database
     /// Then check if the two inference tables exist as the sources for the materialized views
     /// If all of this is OK, then we can apply the migration

--- a/gateway/src/clickhouse_migration_manager/migrations/migration_0002.rs
+++ b/gateway/src/clickhouse_migration_manager/migrations/migration_0002.rs
@@ -10,7 +10,7 @@ pub struct Migration0002<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
-impl<'a> Migration for Migration0002<'a> {
+impl Migration for Migration0002<'_> {
     /// Check if you can connect to the database
     async fn can_apply(&self) -> Result<(), Error> {
         self.clickhouse.health().await.map_err(|e| {

--- a/gateway/src/clickhouse_migration_manager/migrations/migration_0003.rs
+++ b/gateway/src/clickhouse_migration_manager/migrations/migration_0003.rs
@@ -18,7 +18,7 @@ pub struct Migration0003<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
-impl<'a> Migration for Migration0003<'a> {
+impl Migration for Migration0003<'_> {
     /// Check if you can connect to the database
     /// Then check if the four feedback tables exist as the sources for the materialized views
     /// If all of this is OK, then we can apply the migration

--- a/gateway/src/clickhouse_migration_manager/migrations/migration_0004.rs
+++ b/gateway/src/clickhouse_migration_manager/migrations/migration_0004.rs
@@ -17,7 +17,7 @@ pub struct Migration0004<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
-impl<'a> Migration for Migration0004<'a> {
+impl Migration for Migration0004<'_> {
     /// Check if you can connect to the database and if the ModelInference table exists
     /// If all of this is OK, then we can apply the migration
     async fn can_apply(&self) -> Result<(), Error> {

--- a/gateway/src/clickhouse_migration_manager/migrations/migration_0005.rs
+++ b/gateway/src/clickhouse_migration_manager/migrations/migration_0005.rs
@@ -17,7 +17,7 @@ pub struct Migration0005<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
-impl<'a> Migration for Migration0005<'a> {
+impl Migration for Migration0005<'_> {
     /// Check if you can connect to the database
     /// Then check if the two inference tables exist as the sources for the materialized views
     /// If all of this is OK, then we can apply the migration

--- a/gateway/src/clickhouse_migration_manager/migrations/migration_0006.rs
+++ b/gateway/src/clickhouse_migration_manager/migrations/migration_0006.rs
@@ -19,7 +19,7 @@ pub struct Migration0006<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
-impl<'a> Migration for Migration0006<'a> {
+impl Migration for Migration0006<'_> {
     /// Check if you can connect to the database
     async fn can_apply(&self) -> Result<(), Error> {
         self.clickhouse.health().await.map_err(|e| {

--- a/gateway/src/clickhouse_migration_manager/migrations/migration_0007.rs
+++ b/gateway/src/clickhouse_migration_manager/migrations/migration_0007.rs
@@ -19,7 +19,7 @@ pub struct Migration0007<'a> {
     pub clean_start: bool,
 }
 
-impl<'a> Migration for Migration0007<'a> {
+impl Migration for Migration0007<'_> {
     /// Check if you can connect to the database
     /// Then check if the two inference tables exist as the sources for the materialized views
     /// If all of this is OK, then we can apply the migration

--- a/gateway/src/clickhouse_migration_manager/migrations/migration_0009.rs
+++ b/gateway/src/clickhouse_migration_manager/migrations/migration_0009.rs
@@ -12,7 +12,7 @@ pub struct Migration0009<'a> {
     pub clean_start: bool,
 }
 
-impl<'a> Migration for Migration0009<'a> {
+impl Migration for Migration0009<'_> {
     /// Check if you can connect to the database
     /// Then check if the four feedback tables exist
     /// If all of this is OK, then we can apply the migration

--- a/gateway/src/clickhouse_migration_manager/migrations/migration_0010.rs
+++ b/gateway/src/clickhouse_migration_manager/migrations/migration_0010.rs
@@ -26,7 +26,7 @@ pub struct Migration0010<'a> {
     pub clean_start: bool,
 }
 
-impl<'a> Migration for Migration0010<'a> {
+impl Migration for Migration0010<'_> {
     /// Check if you can connect to the database
     /// Then check if the two inference tables exist as the sources for the materialized views
     /// If all of this is OK, then we can apply the migration

--- a/gateway/src/endpoints/inference.rs
+++ b/gateway/src/endpoints/inference.rs
@@ -492,10 +492,10 @@ pub struct InferenceDatabaseInsertMetadata {
     pub tags: HashMap<String, String>,
 }
 
-async fn write_inference<'a>(
+async fn write_inference(
     clickhouse_connection_info: &ClickHouseConnectionInfo,
     input: Input,
-    result: InferenceResult<'a>,
+    result: InferenceResult<'_>,
     metadata: InferenceDatabaseInsertMetadata,
 ) {
     let model_responses: Vec<serde_json::Value> = result.get_serialized_model_inferences();

--- a/gateway/src/inference/providers/anthropic.rs
+++ b/gateway/src/inference/providers/anthropic.rs
@@ -114,7 +114,7 @@ impl InferenceProvider for AnthropicProvider {
     /// Anthropic non-streaming API request
     async fn infer<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<ProviderInferenceResponse, Error> {
@@ -198,7 +198,7 @@ impl InferenceProvider for AnthropicProvider {
     /// Anthropic streaming API request
     async fn infer_stream<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         api_key: &'a InferenceCredentials,
     ) -> Result<
@@ -258,7 +258,7 @@ impl InferenceProvider for AnthropicProvider {
 
     async fn start_batch_inference<'a>(
         &'a self,
-        _requests: &'a [ModelInferenceRequest<'a>],
+        _requests: &'a [ModelInferenceRequest<'_>],
         _client: &'a reqwest::Client,
         _dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<StartBatchProviderInferenceResponse, Error> {

--- a/gateway/src/inference/providers/aws_bedrock.rs
+++ b/gateway/src/inference/providers/aws_bedrock.rs
@@ -75,7 +75,7 @@ impl AWSBedrockProvider {
 impl InferenceProvider for AWSBedrockProvider {
     async fn infer<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         _http_client: &'a reqwest::Client,
         _dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<ProviderInferenceResponse, Error> {
@@ -185,7 +185,7 @@ impl InferenceProvider for AWSBedrockProvider {
 
     async fn infer_stream<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         _http_client: &'a reqwest::Client,
         _dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<
@@ -308,7 +308,7 @@ impl InferenceProvider for AWSBedrockProvider {
 
     async fn start_batch_inference<'a>(
         &'a self,
-        _requests: &'a [ModelInferenceRequest<'a>],
+        _requests: &'a [ModelInferenceRequest<'_>],
         _client: &'a reqwest::Client,
         _dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<StartBatchProviderInferenceResponse, Error> {

--- a/gateway/src/inference/providers/azure.rs
+++ b/gateway/src/inference/providers/azure.rs
@@ -106,7 +106,7 @@ fn default_api_key_location() -> CredentialLocation {
 impl InferenceProvider for AzureProvider {
     async fn infer<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         api_key: &'a InferenceCredentials,
     ) -> Result<ProviderInferenceResponse, Error> {
@@ -176,7 +176,7 @@ impl InferenceProvider for AzureProvider {
 
     async fn infer_stream<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<
@@ -232,7 +232,7 @@ impl InferenceProvider for AzureProvider {
 
     async fn start_batch_inference<'a>(
         &'a self,
-        _requests: &'a [ModelInferenceRequest<'a>],
+        _requests: &'a [ModelInferenceRequest<'_>],
         _client: &'a reqwest::Client,
         _dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<StartBatchProviderInferenceResponse, Error> {

--- a/gateway/src/inference/providers/dummy.rs
+++ b/gateway/src/inference/providers/dummy.rs
@@ -148,7 +148,7 @@ pub static DUMMY_RAW_REQUEST: &str = "raw request";
 impl InferenceProvider for DummyProvider {
     async fn infer<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         _http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<ProviderInferenceResponse, Error> {
@@ -272,7 +272,7 @@ impl InferenceProvider for DummyProvider {
 
     async fn infer_stream<'a>(
         &'a self,
-        _request: &'a ModelInferenceRequest<'a>,
+        _request: &'a ModelInferenceRequest<'_>,
         _http_client: &'a reqwest::Client,
         _dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<
@@ -393,7 +393,7 @@ impl InferenceProvider for DummyProvider {
 
     async fn start_batch_inference<'a>(
         &'a self,
-        requests: &'a [ModelInferenceRequest<'a>],
+        requests: &'a [ModelInferenceRequest<'_>],
         _client: &'a reqwest::Client,
         _dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<StartBatchProviderInferenceResponse, Error> {

--- a/gateway/src/inference/providers/fireworks.rs
+++ b/gateway/src/inference/providers/fireworks.rs
@@ -122,7 +122,7 @@ fn default_api_key_location() -> CredentialLocation {
 impl InferenceProvider for FireworksProvider {
     async fn infer<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         api_key: &'a InferenceCredentials,
     ) -> Result<ProviderInferenceResponse, Error> {
@@ -193,7 +193,7 @@ impl InferenceProvider for FireworksProvider {
 
     async fn infer_stream<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         api_key: &'a InferenceCredentials,
     ) -> Result<
@@ -252,7 +252,7 @@ impl InferenceProvider for FireworksProvider {
 
     async fn start_batch_inference<'a>(
         &'a self,
-        _requests: &'a [ModelInferenceRequest<'a>],
+        _requests: &'a [ModelInferenceRequest<'_>],
         _client: &'a reqwest::Client,
         _dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<StartBatchProviderInferenceResponse, Error> {

--- a/gateway/src/inference/providers/gcp_vertex_anthropic.rs
+++ b/gateway/src/inference/providers/gcp_vertex_anthropic.rs
@@ -74,7 +74,7 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
     /// Anthropic non-streaming API request
     async fn infer<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<ProviderInferenceResponse, Error> {
@@ -146,7 +146,7 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
     /// Anthropic streaming API request
     async fn infer_stream<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<
@@ -208,7 +208,7 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
 
     async fn start_batch_inference<'a>(
         &'a self,
-        _requests: &'a [ModelInferenceRequest<'a>],
+        _requests: &'a [ModelInferenceRequest<'_>],
         _client: &'a reqwest::Client,
         _dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<StartBatchProviderInferenceResponse, Error> {

--- a/gateway/src/inference/providers/gcp_vertex_gemini.rs
+++ b/gateway/src/inference/providers/gcp_vertex_gemini.rs
@@ -250,7 +250,7 @@ impl InferenceProvider for GCPVertexGeminiProvider {
     /// GCP Vertex Gemini non-streaming API request
     async fn infer<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<ProviderInferenceResponse, Error> {
@@ -320,7 +320,7 @@ impl InferenceProvider for GCPVertexGeminiProvider {
     /// GCP Vertex Gemini streaming API request
     async fn infer_stream<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<
@@ -375,7 +375,7 @@ impl InferenceProvider for GCPVertexGeminiProvider {
 
     async fn start_batch_inference<'a>(
         &'a self,
-        _requests: &'a [ModelInferenceRequest<'a>],
+        _requests: &'a [ModelInferenceRequest<'_>],
         _client: &'a reqwest::Client,
         _dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<StartBatchProviderInferenceResponse, Error> {

--- a/gateway/src/inference/providers/google_ai_studio_gemini.rs
+++ b/gateway/src/inference/providers/google_ai_studio_gemini.rs
@@ -125,7 +125,7 @@ impl InferenceProvider for GoogleAIStudioGeminiProvider {
     /// Google AI Studio Gemini non-streaming API request
     async fn infer<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<ProviderInferenceResponse, Error> {
@@ -194,7 +194,7 @@ impl InferenceProvider for GoogleAIStudioGeminiProvider {
     /// Google AI Studio Gemini streaming API request
     async fn infer_stream<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<
@@ -248,7 +248,7 @@ impl InferenceProvider for GoogleAIStudioGeminiProvider {
 
     async fn start_batch_inference<'a>(
         &'a self,
-        _requests: &'a [ModelInferenceRequest<'a>],
+        _requests: &'a [ModelInferenceRequest<'_>],
         _client: &'a reqwest::Client,
         _dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<StartBatchProviderInferenceResponse, Error> {

--- a/gateway/src/inference/providers/hyperbolic.rs
+++ b/gateway/src/inference/providers/hyperbolic.rs
@@ -106,7 +106,7 @@ impl HyperbolicCredentials {
 impl InferenceProvider for HyperbolicProvider {
     async fn infer<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<ProviderInferenceResponse, Error> {
@@ -180,7 +180,7 @@ impl InferenceProvider for HyperbolicProvider {
 
     async fn infer_stream<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<
@@ -237,7 +237,7 @@ impl InferenceProvider for HyperbolicProvider {
 
     async fn start_batch_inference<'a>(
         &'a self,
-        _requests: &'a [ModelInferenceRequest<'a>],
+        _requests: &'a [ModelInferenceRequest<'_>],
         _client: &'a reqwest::Client,
         _dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<StartBatchProviderInferenceResponse, Error> {

--- a/gateway/src/inference/providers/mistral.rs
+++ b/gateway/src/inference/providers/mistral.rs
@@ -118,7 +118,7 @@ impl MistralCredentials {
 impl InferenceProvider for MistralProvider {
     async fn infer<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<ProviderInferenceResponse, Error> {
@@ -188,7 +188,7 @@ impl InferenceProvider for MistralProvider {
 
     async fn infer_stream<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<
@@ -243,7 +243,7 @@ impl InferenceProvider for MistralProvider {
 
     async fn start_batch_inference<'a>(
         &'a self,
-        _requests: &'a [ModelInferenceRequest<'a>],
+        _requests: &'a [ModelInferenceRequest<'_>],
         _client: &'a reqwest::Client,
         _dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<StartBatchProviderInferenceResponse, Error> {

--- a/gateway/src/inference/providers/openai.rs
+++ b/gateway/src/inference/providers/openai.rs
@@ -119,7 +119,7 @@ impl OpenAICredentials {
 impl InferenceProvider for OpenAIProvider {
     async fn infer<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<ProviderInferenceResponse, Error> {
@@ -193,7 +193,7 @@ impl InferenceProvider for OpenAIProvider {
 
     async fn infer_stream<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<

--- a/gateway/src/inference/providers/provider_trait.rs
+++ b/gateway/src/inference/providers/provider_trait.rs
@@ -44,7 +44,7 @@ pub trait InferenceProvider {
 
     fn poll_batch_inference<'a>(
         &'a self,
-        batch_request: &'a BatchRequestRow,
+        batch_request: &'a BatchRequestRow<'a>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> impl Future<Output = Result<PollBatchInferenceResponse, Error>> + Send + 'a;

--- a/gateway/src/inference/providers/together.rs
+++ b/gateway/src/inference/providers/together.rs
@@ -116,7 +116,7 @@ impl TogetherCredentials {
 impl InferenceProvider for TogetherProvider {
     async fn infer<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<ProviderInferenceResponse, Error> {
@@ -184,7 +184,7 @@ impl InferenceProvider for TogetherProvider {
 
     async fn infer_stream<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<
@@ -239,7 +239,7 @@ impl InferenceProvider for TogetherProvider {
 
     async fn start_batch_inference<'a>(
         &'a self,
-        _requests: &'a [ModelInferenceRequest<'a>],
+        _requests: &'a [ModelInferenceRequest<'_>],
         _client: &'a reqwest::Client,
         _dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<StartBatchProviderInferenceResponse, Error> {

--- a/gateway/src/inference/providers/vllm.rs
+++ b/gateway/src/inference/providers/vllm.rs
@@ -104,7 +104,7 @@ impl VLLMCredentials {
 impl InferenceProvider for VLLMProvider {
     async fn infer<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<ProviderInferenceResponse, Error> {
@@ -174,7 +174,7 @@ impl InferenceProvider for VLLMProvider {
 
     async fn infer_stream<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<
@@ -233,7 +233,7 @@ impl InferenceProvider for VLLMProvider {
 
     async fn start_batch_inference<'a>(
         &'a self,
-        _requests: &'a [ModelInferenceRequest<'a>],
+        _requests: &'a [ModelInferenceRequest<'_>],
         _client: &'a reqwest::Client,
         _dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<StartBatchProviderInferenceResponse, Error> {

--- a/gateway/src/inference/providers/xai.rs
+++ b/gateway/src/inference/providers/xai.rs
@@ -107,7 +107,7 @@ impl XAICredentials {
 impl InferenceProvider for XAIProvider {
     async fn infer<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<ProviderInferenceResponse, Error> {
@@ -180,7 +180,7 @@ impl InferenceProvider for XAIProvider {
 
     async fn infer_stream<'a>(
         &'a self,
-        request: &'a ModelInferenceRequest<'a>,
+        request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<
@@ -240,7 +240,7 @@ impl InferenceProvider for XAIProvider {
 
     async fn start_batch_inference<'a>(
         &'a self,
-        _requests: &'a [ModelInferenceRequest<'a>],
+        _requests: &'a [ModelInferenceRequest<'_>],
         _client: &'a reqwest::Client,
         _dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<StartBatchProviderInferenceResponse, Error> {

--- a/gateway/src/inference/types/mod.rs
+++ b/gateway/src/inference/types/mod.rs
@@ -866,8 +866,8 @@ pub struct CollectChunksArgs<'a, 'b> {
 
 // Modify the collect_chunks function to accept CollectChunksArgs
 // 'a ends up as static and 'b ends up as stack allocated in the caller (endpoints::inference::create_stream)
-pub async fn collect_chunks<'a, 'b>(
-    args: CollectChunksArgs<'a, 'b>,
+pub async fn collect_chunks<'a>(
+    args: CollectChunksArgs<'a, '_>,
 ) -> Result<InferenceResult<'a>, Error> {
     let CollectChunksArgs {
         value,

--- a/gateway/src/variant/best_of_n_sampling.rs
+++ b/gateway/src/variant/best_of_n_sampling.rs
@@ -68,7 +68,7 @@ lazy_static! {
 }
 
 impl Variant for BestOfNSamplingConfig {
-    async fn infer<'a, 'request>(
+    async fn infer<'a: 'request, 'request>(
         &'a self,
         input: &Input,
         models: &'request InferenceModels<'a>,

--- a/gateway/src/variant/chat_completion.rs
+++ b/gateway/src/variant/chat_completion.rs
@@ -146,7 +146,7 @@ impl ChatCompletionConfig {
 }
 
 impl Variant for ChatCompletionConfig {
-    async fn infer<'a, 'request>(
+    async fn infer<'a: 'request, 'request>(
         &'a self,
         input: &Input,
         models: &'request InferenceModels<'a>,

--- a/gateway/src/variant/dicl.rs
+++ b/gateway/src/variant/dicl.rs
@@ -70,7 +70,7 @@ pub struct UninitializedDiclConfig {
 }
 
 impl Variant for DiclConfig {
-    async fn infer<'a, 'request>(
+    async fn infer<'a: 'request, 'request>(
         &'a self,
         input: &Input,
         models: &'request InferenceModels<'a>,

--- a/gateway/src/variant/mixture_of_n.rs
+++ b/gateway/src/variant/mixture_of_n.rs
@@ -50,7 +50,7 @@ pub struct FuserConfig {
 }
 
 impl Variant for MixtureOfNConfig {
-    async fn infer<'a, 'request>(
+    async fn infer<'a: 'request, 'request>(
         &'a self,
         input: &Input,
         models: &'request InferenceModels<'a>,

--- a/gateway/src/variant/mod.rs
+++ b/gateway/src/variant/mod.rs
@@ -107,7 +107,7 @@ pub trait Variant {
         models: &'request InferenceModels<'a>,
         function: &'a FunctionConfig,
         inference_config: &'request InferenceConfig<'a, 'request>,
-        clients: &'request InferenceClients,
+        clients: &'request InferenceClients<'request>,
         inference_params: InferenceParams,
     ) -> Result<InferenceResult<'a>, Error>;
 

--- a/gateway/src/variant/mod.rs
+++ b/gateway/src/variant/mod.rs
@@ -101,7 +101,7 @@ pub struct ModelUsedInfo<'a> {
 }
 
 pub trait Variant {
-    async fn infer<'a, 'request>(
+    async fn infer<'a: 'request, 'request>(
         &'a self,
         input: &Input,
         models: &'request InferenceModels<'a>,
@@ -167,7 +167,7 @@ impl Variant for VariantConfig {
         fields(function_name = %inference_config.function_name, variant_name = %inference_config.variant_name.unwrap_or("")),
         skip_all
     )]
-    async fn infer<'a, 'request>(
+    async fn infer<'a: 'request, 'request>(
         &'a self,
         input: &Input,
         models: &'request InferenceModels<'a>,


### PR DESCRIPTION
The internal compiler error on stable was caused by a missing lifetime parameter in the `Variant` trait definition. On nightly, this produces a normal lifetime error, which this PR also fixes.

Fixes https://github.com/tensorzero/tensorzero/issues/745
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes missing lifetime parameter in `Variant` trait and updates lifetime annotations for Rust 1.84.0 compatibility.
> 
>   - **Behavior**:
>     - Fixes missing lifetime parameter in `Variant` trait definition causing internal compiler error on Rust 1.84.0.
>     - Updates lifetime annotations in `migration_0000.rs`, `migration_0001.rs`, and `migration_0002.rs` to use `'_`.
>     - Changes `write_inference()` and `infer()` functions in `inference.rs` and `anthropic.rs` to use `'_` for lifetimes.
>   - **Misc**:
>     - Updates `Dockerfile` to use `rust:latest` instead of `rust:1.83.0`.
>     - Fixes issue #745.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 86eea5a7162155c4ec71959bee9a5f25b9c48f79. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->