### PR TITLE
Introduce `get_metric_or_err` helper and avoid spurious errors

### DIFF
--- a/gateway/src/config_parser.rs
+++ b/gateway/src/config_parser.rs
@@ -219,13 +219,18 @@ impl<'c> Config<'c> {
         })
     }
 
-    /// Get a metric by name
-    pub fn get_metric<'a>(&'a self, metric_name: &str) -> Result<&'a MetricConfig, Error> {
+    /// Get a metric by name, producing an error if it's not found
+    pub fn get_metric_or_err<'a>(&'a self, metric_name: &str) -> Result<&'a MetricConfig, Error> {
         self.metrics.get(metric_name).ok_or_else(|| {
             Error::new(ErrorDetails::UnknownMetric {
                 name: metric_name.to_string(),
             })
         })
+    }
+
+    /// Get a metric by name
+    pub fn get_metric<'a>(&'a self, metric_name: &str) -> Option<&'a MetricConfig> {
+        self.metrics.get(metric_name)
     }
 
     /// Get a tool by name


### PR DESCRIPTION
We now avoid constructing an error when looking up the special "comment" and "demonstration" metrics (since constructing an error logs an error message).

In the future, we might want to consider using something like `tracing-error` to capture spans, and defer the error logging until we know that it's a "real" error.

Fixes #759
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduce `get_metric_or_err` to handle special metrics without logging errors in `feedback.rs`.
> 
>   - **Behavior**:
>     - Introduce `get_metric_or_err` in `config_parser.rs` to retrieve metrics with error handling.
>     - Modify `get_feedback_metadata` in `feedback.rs` to use `get_metric` for 'comment' and 'demonstration' metrics, avoiding error logging.
>   - **Functions**:
>     - Add `get_metric_or_err` to `Config` in `config_parser.rs`.
>     - Update `get_feedback_metadata` in `feedback.rs` to handle special metrics without errors.
>   - **Tests**:
>     - Add `test_feedback_missing_metric` in `feedback.rs` to verify behavior when metrics are missing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f167fc61d96e53d74078758e299dffa811730462. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->