### PR TITLE
bumped version to 2025.01.2

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorzero"
-version = "2025.01.1"
+version = "2025.01.2"
 description = "The Python client for TensorZero"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/clients/python/uv.lock
+++ b/clients/python/uv.lock
@@ -157,7 +157,7 @@ wheels = [
 
 [[package]]
 name = "tensorzero"
-version = "2025.01.1"
+version = "2025.01.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/gateway/src/clickhouse_migration_manager/migrations/migration_0008.rs
+++ b/gateway/src/clickhouse_migration_manager/migrations/migration_0008.rs
@@ -16,7 +16,7 @@ pub struct Migration0008<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
-impl<'a> Migration for Migration0008<'a> {
+impl Migration for Migration0008<'_> {
     /// Check if you can connect to the database
     /// Also check that the tables that need altering already exist
     async fn can_apply(&self) -> Result<(), Error> {

--- a/gateway/src/endpoints/status.rs
+++ b/gateway/src/endpoints/status.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::response::Json;
 use serde_json::{json, Value};
 
-const TENSORZERO_VERSION: &str = "2025.01.1";
+const TENSORZERO_VERSION: &str = "2025.01.2";
 
 /// A handler for a simple liveness check
 #[debug_handler]


### PR DESCRIPTION
Bumps version to 2025.01.2
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump version to 2025.01.2 and update migration implementation in `migration_0008.rs`.
> 
>   - **Version Update**:
>     - Bump version to `2025.01.2` in `pyproject.toml`, `uv.lock`, and `status.rs`.
>   - **Code Changes**:
>     - Update `impl<'a> Migration` to `impl Migration` in `migration_0008.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2d942d6aa3a0f0c3bc9229cedd0eddf78ef3ad5c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->