### PR TITLE
added additional specification to streaming inference parameters request

### DIFF
--- a/gateway/tests/e2e/providers/common.rs
+++ b/gateway/tests/e2e/providers/common.rs
@@ -1029,7 +1029,7 @@ pub async fn test_inference_params_streaming_inference_request_with_provider(
                "messages": [
                 {
                     "role": "user",
-                    "content": "What is the capital city of Japan?"
+                    "content": "What is the name of the capital city of Japan?"
                 }
             ]},
         "params": {
@@ -1150,7 +1150,7 @@ pub async fn test_inference_params_streaming_inference_request_with_provider(
         "messages": [
             {
                 "role": "user",
-                "content": [{"type": "text", "value": "What is the capital city of Japan?"}]
+                "content": [{"type": "text", "value": "What is the name of the capital city of Japan?"}]
             }
         ]
     });
@@ -1264,7 +1264,9 @@ pub async fn test_inference_params_streaming_inference_request_with_provider(
     let input_messages: Vec<RequestMessage> = serde_json::from_str(input_messages).unwrap();
     let expected_input_messages = vec![RequestMessage {
         role: Role::User,
-        content: vec!["What is the capital city of Japan?".to_string().into()],
+        content: vec!["What is the name of the capital city of Japan?"
+            .to_string()
+            .into()],
     }];
     assert_eq!(input_messages, expected_input_messages);
     let output = result.get("output").unwrap().as_str().unwrap();


### PR DESCRIPTION
TGI inference parameters and streaming inference parameters tests were failing bc the model was yapping about japan rather than saying Tokyo. So I made the wording of the question more clear in the test.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Clarified test questions to ensure model responds with "Tokyo" instead of "Japan".
> 
>   - **Tests**:
>     - Update question in `test_inference_params_streaming_inference_request_with_provider()` to "What is the name of the capital city of Japan?" for clarity.
>     - Similar update in `test_inference_params_inference_request_with_provider()` and `test_simple_inference_request_with_provider()`.
>     - Ensures model responds with "Tokyo" instead of "Japan".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c1d80269e29c6f9081edda7163650f54b6c2bd58. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->