### PR TITLE
feat: require function selection before metric and filter irrelevant metrics

### DIFF
--- a/ui/app/routes.ts
+++ b/ui/app/routes.ts
@@ -11,8 +11,8 @@ export default [
     "routes/api/curated_inferences/count.route.ts",
   ),
   route(
-    "api/metrics/with_feedback",
-    "routes/api/metrics/with_feedback.route.ts",
+    "api/function/:function_name/feedback_counts",
+    "routes/api/function/$function_name/feedback_counts.route.ts",
   ),
   route(
     "observability/inferences",

--- a/ui/app/routes.ts
+++ b/ui/app/routes.ts
@@ -11,6 +11,10 @@ export default [
     "routes/api/curated_inferences/count.route.ts",
   ),
   route(
+    "api/metrics/with_feedback",
+    "routes/api/metrics/with_feedback.route.ts",
+  ),
+  route(
     "observability/inferences",
     "routes/observability/inferences/route.tsx",
   ),

--- a/ui/app/routes/api/function/$function_name/feedback_counts.route.ts
+++ b/ui/app/routes/api/function/$function_name/feedback_counts.route.ts
@@ -7,10 +7,9 @@ import {
 } from "~/utils/clickhouse/feedback";
 
 export async function loader({
-  request,
+  params,
 }: LoaderFunctionArgs): Promise<Response> {
-  const url = new URL(request.url);
-  const functionName = url.searchParams.get("function");
+  const functionName = params.function_name;
 
   if (!functionName) {
     return Response.json({ metrics: [] } as MetricsWithFeedbackData);

--- a/ui/app/routes/api/metrics/with_feedback.route.ts
+++ b/ui/app/routes/api/metrics/with_feedback.route.ts
@@ -1,0 +1,38 @@
+import type { LoaderFunctionArgs } from "react-router";
+import { getConfig } from "~/utils/config/index.server";
+import { getInferenceTableName } from "~/utils/clickhouse/common";
+import {
+  queryMetricsWithFeedback,
+  type MetricsWithFeedbackData,
+} from "~/utils/clickhouse/feedback";
+
+export async function loader({
+  request,
+}: LoaderFunctionArgs): Promise<Response> {
+  const url = new URL(request.url);
+  const functionName = url.searchParams.get("function");
+
+  if (!functionName) {
+    return Response.json({ metrics: [] } as MetricsWithFeedbackData);
+  }
+
+  try {
+    const config = await getConfig();
+    const functionConfig = config.functions[functionName];
+    const inferenceTable = getInferenceTableName(functionConfig);
+
+    const result = await queryMetricsWithFeedback({
+      function_name: functionName,
+      inference_table: inferenceTable,
+      metrics: config.metrics,
+    });
+
+    return Response.json(result);
+  } catch (error) {
+    console.error("Error fetching metrics with feedback:", error);
+    throw new Response("Error fetching metrics with feedback", {
+      status: 500,
+      statusText: "Failed to fetch metrics with feedback",
+    });
+  }
+}

--- a/ui/app/routes/optimization/supervised-fine-tuning/MetricSelector.tsx
+++ b/ui/app/routes/optimization/supervised-fine-tuning/MetricSelector.tsx
@@ -15,6 +15,7 @@ import { MetricBadges } from "~/components/metric/MetricBadges";
 import { useEffect, useMemo } from "react";
 import { useFetcher } from "react-router";
 import type { MetricsWithFeedbackData } from "~/utils/clickhouse/feedback";
+import { Badge } from "~/components/ui/badge";
 
 type MetricSelectorProps = {
   control: Control<SFTFormValues>;
@@ -40,7 +41,7 @@ export function MetricSelector({
   useEffect(() => {
     if (functionValue) {
       metricsFetcher.load(
-        `/api/metrics/with_feedback?function=${encodeURIComponent(functionValue)}`,
+        `/api/function/${encodeURIComponent(functionValue)}/feedback_counts`,
       );
     }
   }, [functionValue]);
@@ -103,9 +104,9 @@ export function MetricSelector({
                             <span>{name}</span>
                             <div className="ml-2 flex items-center gap-2">
                               {metricFeedback && (
-                                <span className="text-sm text-muted-foreground">
-                                  ({metricFeedback.feedback_count})
-                                </span>
+                                <Badge className="bg-gray-200 text-gray-800 dark:bg-gray-900 dark:text-gray-300">
+                                  Count: {metricFeedback.feedback_count}
+                                </Badge>
                               )}
                               <MetricBadges metric={metric} />
                             </div>

--- a/ui/app/utils/clickhouse/curation.ts
+++ b/ui/app/utils/clickhouse/curation.ts
@@ -11,7 +11,9 @@ import {
 import { clickhouseClient } from "./common";
 import type { FunctionConfig } from "../config/function";
 
-function getInferenceJoinKey(metric_config: MetricConfig): InferenceJoinKey {
+export function getInferenceJoinKey(
+  metric_config: MetricConfig,
+): InferenceJoinKey {
   if ("level" in metric_config) {
     switch (metric_config.level) {
       case "inference":


### PR DESCRIPTION
Fixes #741 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds function-based metric filtering and selection requirement in UI, with backend support for fetching relevant metrics with feedback.
> 
>   - **Behavior**:
>     - Adds new API route `api/metrics/with_feedback` in `routes.ts` and `with_feedback.route.ts` to fetch metrics with feedback based on selected function.
>     - Updates `MetricSelector.tsx` to require function selection before metric selection and filter metrics based on function.
>     - Disables metric selection dropdown until function is selected and shows loading state.
>   - **Backend**:
>     - Implements `queryMetricsWithFeedback` in `feedback.ts` to fetch metrics with feedback counts.
>     - Handles both inference and episode level metrics.
>   - **Tests**:
>     - Adds tests for `queryMetricsWithFeedback` in `feedback.test.ts` to verify correct feedback counts and error handling for nonexistent functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for fe98d16fc55e7610f109f676788cb0b60ea57ea7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->