### PR TITLE
Use Arc<str> for model/provider name

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -65,7 +65,7 @@ reqwest = { version = "0.12.10", features = [
 ], default-features = false }
 reqwest-eventsource = "0.6.0"
 secrecy = { version = "0.10.2", features = ["serde"] }
-serde = { version = "1.0.204", features = ["derive"] }
+serde = { version = "1.0.204", features = ["derive", "rc"] }
 serde_json = { version = "1.0.134", features = ["preserve_order"] }
 serde_path_to_error = "0.1.16"
 sha2 = "0.10.8"

--- a/gateway/src/endpoints/batch_inference.rs
+++ b/gateway/src/endpoints/batch_inference.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::iter::repeat;
+use std::sync::Arc;
 use tracing::instrument;
 use uuid::Uuid;
 
@@ -492,7 +493,7 @@ pub async fn get_batch_request(
 async fn poll_batch_inference(
     batch_request: &BatchRequestRow<'static>,
     http_client: reqwest::Client,
-    models: &HashMap<String, ModelConfig>,
+    models: &HashMap<Arc<str>, ModelConfig>,
     credentials: &InferenceCredentials,
 ) -> Result<PollBatchInferenceResponse, Error> {
     // Retrieve the relevant model provider
@@ -808,8 +809,8 @@ pub async fn write_completed_batch_inference<'a>(
             raw_response,
             usage: usage.clone(),
             latency: Latency::Batch,
-            model_name: &batch_request.model_name,
-            model_provider_name: &batch_request.model_provider_name,
+            model_name: batch_request.model_name.clone(),
+            model_provider_name: batch_request.model_provider_name.clone().into(),
         };
         let tool_config: Option<ToolCallConfig> = tool_params.map(|t| t.into());
         let output_schema = match output_schema

--- a/gateway/src/endpoints/inference.rs
+++ b/gateway/src/endpoints/inference.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::Instant;
 use tokio_stream::StreamExt;
@@ -81,7 +82,7 @@ pub struct Params {
 }
 
 #[derive(Clone, Debug)]
-struct InferenceMetadata<'a> {
+struct InferenceMetadata {
     pub function_name: String,
     pub variant_name: String,
     pub episode_id: Uuid,
@@ -89,12 +90,12 @@ struct InferenceMetadata<'a> {
     pub dryrun: bool,
     pub start_time: Instant,
     pub inference_params: InferenceParams,
-    pub model_name: &'a str,
-    pub model_provider_name: &'a str,
+    pub model_name: Arc<str>,
+    pub model_provider_name: Arc<str>,
     pub raw_request: String,
     pub system: Option<String>,
     pub input_messages: Vec<RequestMessage>,
-    pub previous_model_inference_results: Vec<ModelInferenceResponseWithMetadata<'a>>,
+    pub previous_model_inference_results: Vec<ModelInferenceResponseWithMetadata>,
     pub tags: HashMap<String, String>,
     pub tool_config: Option<ToolCallConfig>,
     pub dynamic_output_schema: Option<DynamicJSONSchema>,
@@ -360,7 +361,7 @@ pub async fn inference(
 fn create_stream<'a>(
     function: &'static FunctionConfig,
     templates: &'static TemplateConfig<'static>,
-    metadata: InferenceMetadata<'static>,
+    metadata: InferenceMetadata,
     first_chunk: InferenceResultChunk,
     mut stream: InferenceResultStream,
     clickhouse_connection_info: ClickHouseConnectionInfo,
@@ -495,7 +496,7 @@ pub struct InferenceDatabaseInsertMetadata {
 async fn write_inference(
     clickhouse_connection_info: &ClickHouseConnectionInfo,
     input: Input,
-    result: InferenceResult<'_>,
+    result: InferenceResult,
     metadata: InferenceDatabaseInsertMetadata,
 ) {
     let model_responses: Vec<serde_json::Value> = result.get_serialized_model_inferences();
@@ -640,7 +641,7 @@ pub struct InferenceClients<'a> {
 #[derive(Debug)]
 pub struct InferenceModels<'a> {
     pub models: &'a ModelTable,
-    pub embedding_models: &'a HashMap<String, EmbeddingModelConfig>,
+    pub embedding_models: &'a HashMap<Arc<str>, EmbeddingModelConfig>,
 }
 
 /// InferenceParams is the top-level struct for inference parameters.
@@ -738,8 +739,8 @@ mod tests {
             dryrun: false,
             inference_params: InferenceParams::default(),
             start_time: Instant::now(),
-            model_name: "test_model",
-            model_provider_name: "test_provider",
+            model_name: "test_model".into(),
+            model_provider_name: "test_provider".into(),
             raw_request: raw_request.clone(),
             system: None,
             input_messages: vec![],
@@ -788,8 +789,8 @@ mod tests {
             dryrun: false,
             inference_params: InferenceParams::default(),
             start_time: Instant::now(),
-            model_name: "test_model",
-            model_provider_name: "test_provider",
+            model_name: "test_model".into(),
+            model_provider_name: "test_provider".into(),
             raw_request: raw_request.clone(),
             system: None,
             input_messages: vec![],

--- a/gateway/src/endpoints/openai_compatible.rs
+++ b/gateway/src/endpoints/openai_compatible.rs
@@ -728,7 +728,7 @@ mod tests {
             headers,
             OpenAICompatibleParams {
                 messages,
-                model: "tensorzero::test_function".to_string(),
+                model: "tensorzero::test_function".into(),
                 frequency_penalty: Some(0.5),
                 max_tokens: Some(100),
                 max_completion_tokens: Some(50),

--- a/gateway/src/function.rs
+++ b/gateway/src/function.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::sync::Arc;
 use tracing::instrument;
 use uuid::Uuid;
 
@@ -135,10 +136,10 @@ impl FunctionConfig {
         inference_id: Uuid,
         content_blocks: Vec<ContentBlock>,
         usage: Usage,
-        model_inference_results: Vec<ModelInferenceResponseWithMetadata<'a>>,
+        model_inference_results: Vec<ModelInferenceResponseWithMetadata>,
         inference_config: &'request InferenceConfig<'a, 'request>,
         inference_params: InferenceParams,
-    ) -> Result<InferenceResult<'a>, Error> {
+    ) -> Result<InferenceResult, Error> {
         match self {
             FunctionConfig::Chat(..) => Ok(InferenceResult::Chat(
                 ChatInferenceResult::new(
@@ -232,7 +233,7 @@ impl FunctionConfig {
         &self,
         static_tools: &HashMap<String, StaticToolConfig>,
         models: &mut ModelTable,
-        embedding_models: &HashMap<String, EmbeddingModelConfig>,
+        embedding_models: &HashMap<Arc<str>, EmbeddingModelConfig>,
         templates: &TemplateConfig,
         function_name: &str,
     ) -> Result<(), Error> {
@@ -1106,7 +1107,7 @@ mod tests {
                         name.to_string(),
                         VariantConfig::ChatCompletion(ChatCompletionConfig {
                             weight,
-                            model: "model-name".to_string(),
+                            model: "model-name".into(),
                             ..Default::default()
                         }),
                     )
@@ -1274,8 +1275,8 @@ mod tests {
             raw_request: raw_request.clone(),
             raw_response: "content".to_string(),
             usage: usage.clone(),
-            model_provider_name: "model_provider_name",
-            model_name: "model_name",
+            model_provider_name: "model_provider_name".into(),
+            model_name: "model_name".into(),
             latency,
         };
         let templates = TemplateConfig::default();
@@ -1330,8 +1331,8 @@ mod tests {
             raw_request: raw_request.clone(),
             raw_response: "content".to_string(),
             usage: usage.clone(),
-            model_provider_name: "model_provider_name",
-            model_name: "model_name",
+            model_provider_name: "model_provider_name".into(),
+            model_name: "model_name".into(),
             latency,
         };
         let response = function_config
@@ -1378,8 +1379,8 @@ mod tests {
             raw_request: raw_request.clone(),
             raw_response: "content".to_string(),
             usage: usage.clone(),
-            model_provider_name: "model_provider_name",
-            model_name: "model_name",
+            model_provider_name: "model_provider_name".into(),
+            model_name: "model_name".into(),
             latency,
         };
         let response = function_config
@@ -1425,8 +1426,8 @@ mod tests {
             raw_request: raw_request.clone(),
             raw_response: "content".to_string(),
             usage: usage.clone(),
-            model_provider_name: "model_provider_name",
-            model_name: "model_name",
+            model_provider_name: "model_provider_name".into(),
+            model_name: "model_name".into(),
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(100),
             },
@@ -1475,8 +1476,8 @@ mod tests {
             raw_request: raw_request.clone(),
             raw_response: "content".to_string(),
             usage: usage.clone(),
-            model_provider_name: "model_provider_name",
-            model_name: "model_name",
+            model_provider_name: "model_provider_name".into(),
+            model_name: "model_name".into(),
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(100),
             },
@@ -1522,8 +1523,8 @@ mod tests {
             raw_request: raw_request.clone(),
             raw_response: "content".to_string(),
             usage: usage.clone(),
-            model_provider_name: "model_provider_name",
-            model_name: "model_name",
+            model_provider_name: "model_provider_name".into(),
+            model_name: "model_name".into(),
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(100),
             },
@@ -1582,8 +1583,8 @@ mod tests {
             raw_request: raw_request.clone(),
             raw_response: "content".to_string(),
             usage: usage.clone(),
-            model_provider_name: "model_provider_name",
-            model_name: "model_name",
+            model_provider_name: "model_provider_name".into(),
+            model_name: "model_name".into(),
             latency,
         };
         let response = function_config
@@ -1627,8 +1628,8 @@ mod tests {
             raw_request: raw_request.clone(),
             raw_response: "content".to_string(),
             usage: usage.clone(),
-            model_provider_name: "model_provider_name",
-            model_name: "model_name",
+            model_provider_name: "model_provider_name".into(),
+            model_name: "model_name".into(),
             latency,
         };
         let response = function_config
@@ -1674,8 +1675,8 @@ mod tests {
             raw_request: raw_request.clone(),
             raw_response: "content".to_string(),
             usage: usage.clone(),
-            model_provider_name: "model_provider_name",
-            model_name: "model_name",
+            model_provider_name: "model_provider_name".into(),
+            model_name: "model_name".into(),
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(100),
             },
@@ -1724,8 +1725,8 @@ mod tests {
             raw_request: raw_request.clone(),
             raw_response: "content".to_string(),
             usage: usage.clone(),
-            model_provider_name: "model_provider_name",
-            model_name: "model_name",
+            model_provider_name: "model_provider_name".into(),
+            model_name: "model_name".into(),
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(100),
             },
@@ -1782,8 +1783,8 @@ mod tests {
             raw_request: raw_request.clone(),
             raw_response: "content".to_string(),
             usage: usage.clone(),
-            model_provider_name: "model_provider_name",
-            model_name: "model_name",
+            model_provider_name: "model_provider_name".into(),
+            model_name: "model_name".into(),
             latency,
         };
         let response = function_config

--- a/gateway/src/inference/providers/anthropic.rs
+++ b/gateway/src/inference/providers/anthropic.rs
@@ -1735,7 +1735,7 @@ mod tests {
             content: vec![AnthropicContentBlock::Text {
                 text: "Response text".to_string(),
             }],
-            model: "model-name".to_string(),
+            model: "model-name".into(),
             stop_reason: Some("stop reason".to_string()),
             stop_sequence: Some("stop sequence".to_string()),
             usage: AnthropicUsage {
@@ -1795,7 +1795,7 @@ mod tests {
                 name: "get_temperature".to_string(),
                 input: json!({"location": "New York"}),
             }],
-            model: "model-name".to_string(),
+            model: "model-name".into(),
             stop_reason: Some("tool_call".to_string()),
             stop_sequence: None,
             usage: AnthropicUsage {
@@ -1862,7 +1862,7 @@ mod tests {
                     input: json!({"location": "London"}),
                 },
             ],
-            model: "model-name".to_string(),
+            model: "model-name".into(),
             stop_reason: None,
             stop_sequence: None,
             usage: AnthropicUsage {

--- a/gateway/src/inference/providers/gcp_vertex_anthropic.rs
+++ b/gateway/src/inference/providers/gcp_vertex_anthropic.rs
@@ -1658,7 +1658,7 @@ mod tests {
             content: vec![GCPVertexAnthropicContentBlock::Text {
                 text: "Response text".to_string(),
             }],
-            model: "model-name".to_string(),
+            model: "model-name".into(),
             stop_reason: Some("stop reason".to_string()),
             stop_sequence: Some("stop sequence".to_string()),
             usage: GCPVertexAnthropic {
@@ -1738,7 +1738,7 @@ mod tests {
                 name: "get_temperature".to_string(),
                 input: json!({"location": "New York"}),
             }],
-            model: "model-name".to_string(),
+            model: "model-name".into(),
             stop_reason: Some("tool_call".to_string()),
             stop_sequence: None,
             usage: GCPVertexAnthropic {
@@ -1825,7 +1825,7 @@ mod tests {
                     input: json!({"location": "London"}),
                 },
             ],
-            model: "model-name".to_string(),
+            model: "model-name".into(),
             stop_reason: None,
             stop_sequence: None,
             usage: GCPVertexAnthropic {

--- a/gateway/src/inference/types/batch.rs
+++ b/gateway/src/inference/types/batch.rs
@@ -12,7 +12,7 @@ use crate::{
 use super::{ContentBlock, Input, ModelInferenceRequest, RequestMessage, Usage};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::HashMap, sync::Arc};
 use uuid::Uuid;
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
@@ -151,7 +151,7 @@ pub struct BatchRequestRow<'a> {
     pub id: Uuid,
     #[serde(deserialize_with = "deserialize_json_string")]
     pub batch_params: Cow<'a, Value>,
-    pub model_name: Cow<'a, str>,
+    pub model_name: Arc<str>,
     pub raw_request: Cow<'a, str>,
     pub raw_response: Cow<'a, str>,
     pub model_provider_name: Cow<'a, str>,
@@ -272,7 +272,7 @@ impl<'a> BatchRequestRow<'a> {
             batch_params: Cow::Borrowed(batch_params),
             function_name: Cow::Borrowed(function_name),
             variant_name: Cow::Borrowed(variant_name),
-            model_name: Cow::Borrowed(model_name),
+            model_name: Arc::from(model_name),
             raw_request: Cow::Borrowed(raw_request),
             raw_response: Cow::Borrowed(raw_response),
             model_provider_name: Cow::Borrowed(model_provider_name),

--- a/gateway/src/model.rs
+++ b/gateway/src/model.rs
@@ -3,6 +3,7 @@ use reqwest::Client;
 use secrecy::SecretString;
 use serde::de::Error as SerdeError;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::{env, fs};
 use strum::VariantNames;
 #[allow(unused_imports)]
@@ -41,32 +42,36 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ModelConfig {
-    pub routing: Vec<String>, // [provider name A, provider name B, ...]
-    pub providers: HashMap<String, ProviderConfig>, // provider name => provider config
+    pub routing: Vec<Arc<str>>, // [provider name A, provider name B, ...]
+    pub providers: HashMap<Arc<str>, ProviderConfig>, // provider name => provider config
 }
 
 impl ModelConfig {
-    pub async fn infer<'a, 'request>(
-        &'a self,
+    pub async fn infer<'request>(
+        &self,
         request: &'request ModelInferenceRequest<'request>,
         client: &'request Client,
         api_keys: &'request InferenceCredentials,
-    ) -> Result<ModelInferenceResponse<'a>, Error> {
+    ) -> Result<ModelInferenceResponse, Error> {
         let mut provider_errors: HashMap<String, Error> = HashMap::new();
         for provider_name in &self.routing {
             let provider_config = self.providers.get(provider_name).ok_or_else(|| {
                 Error::new(ErrorDetails::ProviderNotFound {
-                    provider_name: provider_name.clone(),
+                    provider_name: provider_name.to_string(),
                 })
             })?;
             let response = provider_config
                 .infer(request, client, api_keys)
-                .instrument(span!(Level::INFO, "infer", provider_name))
+                .instrument(span!(
+                    Level::INFO,
+                    "infer",
+                    provider_name = &**provider_name
+                ))
                 .await;
             match response {
                 Ok(response) => {
                     let model_inference_response =
-                        ModelInferenceResponse::new(response, provider_name);
+                        ModelInferenceResponse::new(response, provider_name.clone());
                     return Ok(model_inference_response);
                 }
                 Err(error) => {
@@ -78,8 +83,8 @@ impl ModelConfig {
         Err(err)
     }
 
-    pub async fn infer_stream<'a, 'request>(
-        &'a self,
+    pub async fn infer_stream<'request>(
+        &self,
         request: &'request ModelInferenceRequest<'request>,
         client: &'request Client,
         api_keys: &'request InferenceCredentials,
@@ -88,7 +93,7 @@ impl ModelConfig {
             ProviderInferenceResponseChunk,
             ProviderInferenceResponseStream,
             String,
-            &'a str,
+            Arc<str>,
         ),
         Error,
     > {
@@ -96,17 +101,21 @@ impl ModelConfig {
         for provider_name in &self.routing {
             let provider_config = self.providers.get(provider_name).ok_or_else(|| {
                 Error::new(ErrorDetails::ProviderNotFound {
-                    provider_name: provider_name.clone(),
+                    provider_name: provider_name.to_string(),
                 })
             })?;
             let response = provider_config
                 .infer_stream(request, client, api_keys)
-                .instrument(span!(Level::INFO, "infer_stream", provider_name))
+                .instrument(span!(
+                    Level::INFO,
+                    "infer_stream",
+                    provider_name = &**provider_name
+                ))
                 .await;
             match response {
                 Ok(response) => {
                     let (chunk, stream, raw_request) = response;
-                    return Ok((chunk, stream, raw_request, provider_name));
+                    return Ok((chunk, stream, raw_request, provider_name.clone()));
                 }
                 Err(error) => {
                     provider_errors.insert(provider_name.to_string(), error);
@@ -128,12 +137,16 @@ impl ModelConfig {
         for provider_name in &self.routing {
             let provider_config = self.providers.get(provider_name).ok_or_else(|| {
                 Error::new(ErrorDetails::ProviderNotFound {
-                    provider_name: provider_name.clone(),
+                    provider_name: provider_name.to_string(),
                 })
             })?;
             let response = provider_config
                 .start_batch_inference(requests, client, api_keys)
-                .instrument(span!(Level::INFO, "start_batch_inference", provider_name))
+                .instrument(span!(
+                    Level::INFO,
+                    "start_batch_inference",
+                    provider_name = &**provider_name
+                ))
                 .await;
             match response {
                 Ok(response) => {
@@ -839,13 +852,13 @@ const SHORTHAND_MODEL_PREFIXES: &[&str] = &[
 ];
 
 #[derive(Debug, Default, Deserialize)]
-#[serde(try_from = "HashMap<String, ModelConfig>")]
-pub struct ModelTable(HashMap<String, ModelConfig>);
+#[serde(try_from = "HashMap<Arc<str>, ModelConfig>")]
+pub struct ModelTable(HashMap<Arc<str>, ModelConfig>);
 
-impl TryFrom<HashMap<String, ModelConfig>> for ModelTable {
+impl TryFrom<HashMap<Arc<str>, ModelConfig>> for ModelTable {
     type Error = String;
 
-    fn try_from(map: HashMap<String, ModelConfig>) -> Result<Self, Self::Error> {
+    fn try_from(map: HashMap<Arc<str>, ModelConfig>) -> Result<Self, Self::Error> {
         for key in map.keys() {
             if RESERVED_MODEL_PREFIXES
                 .iter()
@@ -859,7 +872,7 @@ impl TryFrom<HashMap<String, ModelConfig>> for ModelTable {
 }
 
 impl std::ops::Deref for ModelTable {
-    type Target = HashMap<String, ModelConfig>;
+    type Target = HashMap<Arc<str>, ModelConfig>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -899,7 +912,7 @@ impl ModelTable {
             let provider_type = &prefix[..prefix.len() - 2];
             let model_config = model_config_from_shorthand(provider_type, model_name)?;
             model_config.validate()?;
-            self.0.insert(key.to_string(), model_config);
+            self.0.insert(key.into(), model_config);
             return Ok(());
         }
 
@@ -936,8 +949,8 @@ fn model_config_from_shorthand(
         }
     };
     Ok(ModelConfig {
-        routing: vec![provider_type.to_string()],
-        providers: HashMap::from([(provider_type.to_string(), provider_config)]),
+        routing: vec![provider_type.to_string().into()],
+        providers: HashMap::from([(provider_type.to_string().into(), provider_config)]),
     })
 }
 
@@ -962,16 +975,16 @@ mod tests {
     #[tokio::test]
     async fn test_model_config_infer_routing() {
         let good_provider_config = ProviderConfig::Dummy(DummyProvider {
-            model_name: "good".to_string(),
+            model_name: "good".into(),
             credentials: DummyCredentials::None,
         });
         let bad_provider_config = ProviderConfig::Dummy(DummyProvider {
-            model_name: "error".to_string(),
+            model_name: "error".into(),
             credentials: DummyCredentials::None,
         });
         let model_config = ModelConfig {
-            routing: vec!["good_provider".to_string()],
-            providers: HashMap::from([("good_provider".to_string(), good_provider_config)]),
+            routing: vec!["good_provider".into()],
+            providers: HashMap::from([("good_provider".into(), good_provider_config)]),
         };
         let tool_config = ToolCallConfig {
             tools_available: vec![],
@@ -1009,12 +1022,12 @@ mod tests {
         assert_eq!(raw, DUMMY_INFER_RESPONSE_RAW);
         let usage = response.usage;
         assert_eq!(usage, DUMMY_INFER_USAGE);
-        assert_eq!(response.model_provider_name, "good_provider");
+        assert_eq!(&*response.model_provider_name, "good_provider");
 
         // Try inferring the bad model
         let model_config = ModelConfig {
-            routing: vec!["error".to_string()],
-            providers: HashMap::from([("error".to_string(), bad_provider_config)]),
+            routing: vec!["error".into()],
+            providers: HashMap::from([("error".into(), bad_provider_config)]),
         };
         let response = model_config
             .infer(&request, &Client::new(), &api_keys)
@@ -1045,11 +1058,11 @@ mod tests {
         // Test that fallback works with bad --> good model provider
 
         let good_provider_config = ProviderConfig::Dummy(DummyProvider {
-            model_name: "good".to_string(),
+            model_name: "good".into(),
             credentials: DummyCredentials::None,
         });
         let bad_provider_config = ProviderConfig::Dummy(DummyProvider {
-            model_name: "error".to_string(),
+            model_name: "error".into(),
             credentials: DummyCredentials::None,
         });
         let api_keys = InferenceCredentials::default();
@@ -1071,10 +1084,13 @@ mod tests {
         };
 
         let model_config = ModelConfig {
-            routing: vec!["error_provider".to_string(), "good_provider".to_string()],
+            routing: vec![
+                "error_provider".to_string().into(),
+                "good_provider".to_string().into(),
+            ],
             providers: HashMap::from([
-                ("error_provider".to_string(), bad_provider_config),
-                ("good_provider".to_string(), good_provider_config),
+                ("error_provider".to_string().into(), bad_provider_config),
+                ("good_provider".to_string().into(), good_provider_config),
             ]),
         };
 
@@ -1093,17 +1109,17 @@ mod tests {
         assert_eq!(raw, DUMMY_INFER_RESPONSE_RAW);
         let usage = response.usage;
         assert_eq!(usage, DUMMY_INFER_USAGE);
-        assert_eq!(response.model_provider_name, "good_provider");
+        assert_eq!(&*response.model_provider_name, "good_provider");
     }
 
     #[tokio::test]
     async fn test_model_config_infer_stream_routing() {
         let good_provider_config = ProviderConfig::Dummy(DummyProvider {
-            model_name: "good".to_string(),
+            model_name: "good".into(),
             credentials: DummyCredentials::None,
         });
         let bad_provider_config = ProviderConfig::Dummy(DummyProvider {
-            model_name: "error".to_string(),
+            model_name: "error".into(),
             credentials: DummyCredentials::None,
         });
         let api_keys = InferenceCredentials::default();
@@ -1125,8 +1141,8 @@ mod tests {
 
         // Test good model
         let model_config = ModelConfig {
-            routing: vec!["good_provider".to_string()],
-            providers: HashMap::from([("good_provider".to_string(), good_provider_config)]),
+            routing: vec!["good_provider".to_string().into()],
+            providers: HashMap::from([("good_provider".to_string().into(), good_provider_config)]),
         };
         let (initial_chunk, stream, raw_request, model_provider_name) = model_config
             .infer_stream(&request, &Client::new(), &api_keys)
@@ -1140,7 +1156,7 @@ mod tests {
             })],
         );
         assert_eq!(raw_request, "raw request");
-        assert_eq!(model_provider_name, "good_provider");
+        assert_eq!(&*model_provider_name, "good_provider");
         let mut collected_content: Vec<ContentBlockChunk> =
             vec![ContentBlockChunk::Text(TextChunk {
                 text: DUMMY_STREAMING_RESPONSE[0].to_string(),
@@ -1165,8 +1181,8 @@ mod tests {
 
         // Test bad model
         let model_config = ModelConfig {
-            routing: vec!["error".to_string()],
-            providers: HashMap::from([("error".to_string(), bad_provider_config)]),
+            routing: vec!["error".to_string().into()],
+            providers: HashMap::from([("error".to_string().into(), bad_provider_config)]),
         };
         let response = model_config
             .infer_stream(&request, &Client::new(), &api_keys)
@@ -1201,11 +1217,11 @@ mod tests {
         // Test that fallback works with bad --> good model provider (streaming)
 
         let good_provider_config = ProviderConfig::Dummy(DummyProvider {
-            model_name: "good".to_string(),
+            model_name: "good".into(),
             credentials: DummyCredentials::None,
         });
         let bad_provider_config = ProviderConfig::Dummy(DummyProvider {
-            model_name: "error".to_string(),
+            model_name: "error".into(),
             credentials: DummyCredentials::None,
         });
         let api_keys = InferenceCredentials::default();
@@ -1227,17 +1243,17 @@ mod tests {
 
         // Test fallback
         let model_config = ModelConfig {
-            routing: vec!["error_provider".to_string(), "good_provider".to_string()],
+            routing: vec!["error_provider".into(), "good_provider".into()],
             providers: HashMap::from([
-                ("error_provider".to_string(), bad_provider_config),
-                ("good_provider".to_string(), good_provider_config),
+                ("error_provider".into(), bad_provider_config),
+                ("good_provider".into(), good_provider_config),
             ]),
         };
         let (initial_chunk, stream, raw_request, model_provider_name) = model_config
             .infer_stream(&request, &Client::new(), &api_keys)
             .await
             .unwrap();
-        assert_eq!(model_provider_name, "good_provider");
+        assert_eq!(&*model_provider_name, "good_provider");
         // Ensure that the error for the bad provider was logged, but the request worked nonetheless
         assert!(logs_contain("Error sending request to Dummy provider"));
         assert_eq!(raw_request, "raw request");
@@ -1272,12 +1288,12 @@ mod tests {
     #[tokio::test]
     async fn test_dynamic_api_keys() {
         let provider_config = ProviderConfig::Dummy(DummyProvider {
-            model_name: "test_key".to_string(),
+            model_name: "test_key".into(),
             credentials: DummyCredentials::Dynamic("TEST_KEY".to_string()),
         });
         let model_config = ModelConfig {
-            routing: vec!["model".to_string()],
-            providers: HashMap::from([("model".to_string(), provider_config)]),
+            routing: vec!["model".into()],
+            providers: HashMap::from([("model".into(), provider_config)]),
         };
         let tool_config = ToolCallConfig {
             tools_available: vec![],
@@ -1346,12 +1362,12 @@ mod tests {
         );
 
         let provider_config = ProviderConfig::Dummy(DummyProvider {
-            model_name: "test_key".to_string(),
+            model_name: "test_key".into(),
             credentials: DummyCredentials::Dynamic("TEST_KEY".to_string()),
         });
         let model_config = ModelConfig {
-            routing: vec!["model".to_string()],
-            providers: HashMap::from([("model".to_string(), provider_config)]),
+            routing: vec!["model".to_string().into()],
+            providers: HashMap::from([("model".to_string().into(), provider_config)]),
         };
         let tool_config = ToolCallConfig {
             tools_available: vec![],
@@ -1414,10 +1430,10 @@ mod tests {
         model_table.validate_or_create("dummy::gpt-4o").unwrap();
         assert_eq!(model_table.len(), 1);
         let model_config = model_table.get("dummy::gpt-4o").unwrap();
-        assert_eq!(model_config.routing, vec!["dummy".to_string()]);
+        assert_eq!(model_config.routing, vec!["dummy".into()]);
         let provider_config = model_config.providers.get("dummy").unwrap();
         match provider_config {
-            ProviderConfig::Dummy(provider) => assert_eq!(provider.model_name, "gpt-4o"),
+            ProviderConfig::Dummy(provider) => assert_eq!(&*provider.model_name, "gpt-4o"),
             _ => panic!("Expected Dummy provider"),
         }
 
@@ -1425,10 +1441,10 @@ mod tests {
         model_table.validate_or_create("dummy::gpt-4o").unwrap();
         assert_eq!(model_table.len(), 1);
         let model_config = model_table.get("dummy::gpt-4o").unwrap();
-        assert_eq!(model_config.routing, vec!["dummy".to_string()]);
+        assert_eq!(model_config.routing, vec!["dummy".into()]);
         let provider_config = model_config.providers.get("dummy").unwrap();
         match provider_config {
-            ProviderConfig::Dummy(provider) => assert_eq!(provider.model_name, "gpt-4o"),
+            ProviderConfig::Dummy(provider) => assert_eq!(&*provider.model_name, "gpt-4o"),
             _ => panic!("Expected Dummy provider"),
         }
 
@@ -1446,11 +1462,11 @@ mod tests {
         let anthropic_provider_config =
             ProviderConfig::Anthropic(AnthropicProvider::new("claude".to_string(), None).unwrap());
         let anthropic_model_config = ModelConfig {
-            routing: vec!["anthropic".to_string()],
-            providers: HashMap::from([("anthropic".to_string(), anthropic_provider_config)]),
+            routing: vec!["anthropic".into()],
+            providers: HashMap::from([("anthropic".into(), anthropic_provider_config)]),
         };
         let mut model_table: ModelTable =
-            HashMap::from([("claude".to_string(), anthropic_model_config)])
+            HashMap::from([("claude".into(), anthropic_model_config)])
                 .try_into()
                 .unwrap();
 

--- a/gateway/tests/e2e/batch.rs
+++ b/gateway/tests/e2e/batch.rs
@@ -72,8 +72,8 @@ async fn test_get_batch_request() {
     assert_eq!(batch_request.batch_params.into_owned(), batch_params);
     assert_eq!(batch_request.function_name, function_name);
     assert_eq!(batch_request.variant_name, variant_name);
-    assert_eq!(batch_request.model_name, model_name);
-    assert_eq!(batch_request.model_provider_name, model_provider_name);
+    assert_eq!(&*batch_request.model_name, model_name);
+    assert_eq!(&*batch_request.model_provider_name, model_provider_name);
     assert_eq!(batch_request.status, BatchStatus::Pending);
     assert_eq!(batch_request.raw_request, raw_request);
     assert_eq!(batch_request.raw_response, raw_response);
@@ -120,8 +120,8 @@ async fn test_get_batch_request() {
     assert_eq!(batch_request.batch_id, batch_id);
     assert_eq!(batch_request.function_name, function_name);
     assert_eq!(batch_request.variant_name, variant_name);
-    assert_eq!(batch_request.model_name, model_name);
-    assert_eq!(batch_request.model_provider_name, model_provider_name);
+    assert_eq!(&*batch_request.model_name, model_name);
+    assert_eq!(&*batch_request.model_provider_name, model_provider_name);
 }
 
 #[tokio::test]

--- a/gateway/tests/e2e/providers/anthropic.rs
+++ b/gateway/tests/e2e/providers/anthropic.rs
@@ -15,29 +15,29 @@ async fn get_providers() -> E2ETestProviders {
 
     let standard_providers = vec![E2ETestProvider {
         variant_name: "anthropic".to_string(),
-        model_name: "claude-3-haiku-20240307-anthropic".to_string(),
-        model_provider_name: "anthropic".to_string(),
+        model_name: "claude-3-haiku-20240307-anthropic".into(),
+        model_provider_name: "anthropic".into(),
         credentials: HashMap::new(),
     }];
 
     let inference_params_providers = vec![E2ETestProvider {
         variant_name: "anthropic-dynamic".to_string(),
-        model_name: "claude-3-haiku-20240307-anthropic-dynamic".to_string(),
-        model_provider_name: "anthropic".to_string(),
+        model_name: "claude-3-haiku-20240307-anthropic-dynamic".into(),
+        model_provider_name: "anthropic".into(),
         credentials,
     }];
 
     let json_providers = vec![
         E2ETestProvider {
             variant_name: "anthropic".to_string(),
-            model_name: "claude-3-haiku-20240307-anthropic".to_string(),
-            model_provider_name: "anthropic".to_string(),
+            model_name: "claude-3-haiku-20240307-anthropic".into(),
+            model_provider_name: "anthropic".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             variant_name: "anthropic-implicit".to_string(),
-            model_name: "claude-3-haiku-20240307-anthropic".to_string(),
-            model_provider_name: "anthropic".to_string(),
+            model_name: "claude-3-haiku-20240307-anthropic".into(),
+            model_provider_name: "anthropic".into(),
             credentials: HashMap::new(),
         },
     ];
@@ -45,8 +45,8 @@ async fn get_providers() -> E2ETestProviders {
     #[cfg(feature = "e2e_tests")]
     let shorthand_providers = vec![E2ETestProvider {
         variant_name: "anthropic-shorthand".to_string(),
-        model_name: "anthropic::claude-3-haiku-20240307".to_string(),
-        model_provider_name: "anthropic".to_string(),
+        model_name: "anthropic::claude-3-haiku-20240307".into(),
+        model_provider_name: "anthropic".into(),
         credentials: HashMap::new(),
     }];
 

--- a/gateway/tests/e2e/providers/aws_bedrock.rs
+++ b/gateway/tests/e2e/providers/aws_bedrock.rs
@@ -24,22 +24,22 @@ crate::generate_batch_inference_tests!(get_providers);
 async fn get_providers() -> E2ETestProviders {
     let standard_providers = vec![E2ETestProvider {
         variant_name: "aws-bedrock".to_string(),
-        model_name: "claude-3-haiku-20240307-aws-bedrock".to_string(),
-        model_provider_name: "aws-bedrock".to_string(),
+        model_name: "claude-3-haiku-20240307-aws-bedrock".into(),
+        model_provider_name: "aws-bedrock".into(),
         credentials: HashMap::new(),
     }];
 
     let json_providers = vec![
         E2ETestProvider {
             variant_name: "aws-bedrock".to_string(),
-            model_name: "claude-3-haiku-20240307-aws-bedrock".to_string(),
-            model_provider_name: "aws-bedrock".to_string(),
+            model_name: "claude-3-haiku-20240307-aws-bedrock".into(),
+            model_provider_name: "aws-bedrock".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             variant_name: "aws-bedrock-implicit".to_string(),
-            model_name: "claude-3-haiku-20240307-aws-bedrock".to_string(),
-            model_provider_name: "aws-bedrock".to_string(),
+            model_name: "claude-3-haiku-20240307-aws-bedrock".into(),
+            model_provider_name: "aws-bedrock".into(),
             credentials: HashMap::new(),
         },
     ];

--- a/gateway/tests/e2e/providers/azure.rs
+++ b/gateway/tests/e2e/providers/azure.rs
@@ -15,29 +15,29 @@ async fn get_providers() -> E2ETestProviders {
 
     let standard_providers = vec![E2ETestProvider {
         variant_name: "azure".to_string(),
-        model_name: "gpt-4o-mini-azure".to_string(),
-        model_provider_name: "azure".to_string(),
+        model_name: "gpt-4o-mini-azure".into(),
+        model_provider_name: "azure".into(),
         credentials: HashMap::new(),
     }];
 
     let inference_params_providers = vec![E2ETestProvider {
         variant_name: "azure-dynamic".to_string(),
-        model_name: "gpt-4o-mini-azure-dynamic".to_string(),
-        model_provider_name: "azure".to_string(),
+        model_name: "gpt-4o-mini-azure-dynamic".into(),
+        model_provider_name: "azure".into(),
         credentials,
     }];
 
     let json_providers = vec![
         E2ETestProvider {
             variant_name: "azure".to_string(),
-            model_name: "gpt-4o-mini-azure".to_string(),
-            model_provider_name: "azure".to_string(),
+            model_name: "gpt-4o-mini-azure".into(),
+            model_provider_name: "azure".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             variant_name: "azure-implicit".to_string(),
-            model_name: "gpt-4o-mini-azure".to_string(),
-            model_provider_name: "azure".to_string(),
+            model_name: "gpt-4o-mini-azure".into(),
+            model_provider_name: "azure".into(),
             credentials: HashMap::new(),
         },
     ];

--- a/gateway/tests/e2e/providers/fireworks.rs
+++ b/gateway/tests/e2e/providers/fireworks.rs
@@ -15,23 +15,23 @@ async fn get_providers() -> E2ETestProviders {
 
     let providers = vec![E2ETestProvider {
         variant_name: "fireworks".to_string(),
-        model_name: "llama3.1-8b-instruct-fireworks".to_string(),
-        model_provider_name: "fireworks".to_string(),
+        model_name: "llama3.1-8b-instruct-fireworks".into(),
+        model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];
 
     let inference_params_providers = vec![E2ETestProvider {
         variant_name: "fireworks-dynamic".to_string(),
-        model_name: "llama3.1-8b-instruct-fireworks-dynamic".to_string(),
-        model_provider_name: "fireworks".to_string(),
+        model_name: "llama3.1-8b-instruct-fireworks-dynamic".into(),
+        model_provider_name: "fireworks".into(),
         credentials,
     }];
 
     // NOTE: FireFunction might not be available serverlessly anymore so we have temporarily disabled it
     // let tool_providers = vec![E2ETestProvider {
     //     variant_name: "fireworks-firefunction".to_string(),
-    //     model_name: "firefunction-v2".to_string(),
-    //     model_provider_name: "fireworks".to_string(),
+    //     model_name: "firefunction-v2".into(),
+    //     model_provider_name: "fireworks".into(),
     //     credentials: HashMap::new(),
     // }];
     let tool_providers = vec![];
@@ -39,14 +39,14 @@ async fn get_providers() -> E2ETestProviders {
     let json_providers = vec![
         E2ETestProvider {
             variant_name: "fireworks".to_string(),
-            model_name: "llama3.1-8b-instruct-fireworks".to_string(),
-            model_provider_name: "fireworks".to_string(),
+            model_name: "llama3.1-8b-instruct-fireworks".into(),
+            model_provider_name: "fireworks".into(),
             credentials: HashMap::new(),
         },
         // E2ETestProvider {
         //     variant_name: "fireworks-implicit".to_string(),
-        //     model_name: "firefunction-v2".to_string(),
-        //     model_provider_name: "fireworks".to_string(),
+        //     model_name: "firefunction-v2".into(),
+        //     model_provider_name: "fireworks".into(),
         //     credentials: HashMap::new(),
         // },
     ];
@@ -54,8 +54,8 @@ async fn get_providers() -> E2ETestProviders {
     #[cfg(feature = "e2e_tests")]
     let shorthand_providers = vec![E2ETestProvider {
         variant_name: "fireworks-shorthand".to_string(),
-        model_name: "fireworks::accounts/fireworks/models/llama-v3p1-8b-instruct".to_string(),
-        model_provider_name: "fireworks".to_string(),
+        model_name: "fireworks::accounts/fireworks/models/llama-v3p1-8b-instruct".into(),
+        model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];
 

--- a/gateway/tests/e2e/providers/gcp_vertex_anthropic.rs
+++ b/gateway/tests/e2e/providers/gcp_vertex_anthropic.rs
@@ -10,22 +10,22 @@ crate::generate_batch_inference_tests!(get_providers);
 async fn get_providers() -> E2ETestProviders {
     let standard_providers = vec![E2ETestProvider {
         variant_name: "gcp-vertex-haiku".to_string(),
-        model_name: "claude-3-haiku-20240307-gcp-vertex".to_string(),
-        model_provider_name: "gcp_vertex_anthropic".to_string(),
+        model_name: "claude-3-haiku-20240307-gcp-vertex".into(),
+        model_provider_name: "gcp_vertex_anthropic".into(),
         credentials: HashMap::new(),
     }];
 
     let json_providers = vec![
         E2ETestProvider {
             variant_name: "gcp-vertex-haiku".to_string(),
-            model_name: "claude-3-haiku-20240307-gcp-vertex".to_string(),
-            model_provider_name: "gcp_vertex_anthropic".to_string(),
+            model_name: "claude-3-haiku-20240307-gcp-vertex".into(),
+            model_provider_name: "gcp_vertex_anthropic".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             variant_name: "gcp-vertex-haiku-implicit".to_string(),
-            model_name: "claude-3-haiku-20240307-gcp-vertex".to_string(),
-            model_provider_name: "gcp_vertex_anthropic".to_string(),
+            model_name: "claude-3-haiku-20240307-gcp-vertex".into(),
+            model_provider_name: "gcp_vertex_anthropic".into(),
             credentials: HashMap::new(),
         },
     ];

--- a/gateway/tests/e2e/providers/gcp_vertex_gemini.rs
+++ b/gateway/tests/e2e/providers/gcp_vertex_gemini.rs
@@ -11,14 +11,14 @@ async fn get_providers() -> E2ETestProviders {
     let standard_providers = vec![
         E2ETestProvider {
             variant_name: "gcp-vertex-gemini-flash".to_string(),
-            model_name: "gemini-1.5-flash-001".to_string(),
-            model_provider_name: "gcp_vertex_gemini".to_string(),
+            model_name: "gemini-1.5-flash-001".into(),
+            model_provider_name: "gcp_vertex_gemini".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             variant_name: "gcp-vertex-gemini-pro".to_string(),
-            model_name: "gemini-1.5-pro-001".to_string(),
-            model_provider_name: "gcp_vertex_gemini".to_string(),
+            model_name: "gemini-1.5-pro-001".into(),
+            model_provider_name: "gcp_vertex_gemini".into(),
             credentials: HashMap::new(),
         },
     ];
@@ -26,26 +26,26 @@ async fn get_providers() -> E2ETestProviders {
     let json_providers = vec![
         E2ETestProvider {
             variant_name: "gcp-vertex-gemini-flash".to_string(),
-            model_name: "gemini-1.5-flash-001".to_string(),
-            model_provider_name: "gcp_vertex_gemini".to_string(),
+            model_name: "gemini-1.5-flash-001".into(),
+            model_provider_name: "gcp_vertex_gemini".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             variant_name: "gcp-vertex-gemini-flash-implicit".to_string(),
-            model_name: "gemini-1.5-flash-001".to_string(),
-            model_provider_name: "gcp_vertex_gemini".to_string(),
+            model_name: "gemini-1.5-flash-001".into(),
+            model_provider_name: "gcp_vertex_gemini".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             variant_name: "gcp-vertex-gemini-pro".to_string(),
-            model_name: "gemini-1.5-pro-001".to_string(),
-            model_provider_name: "gcp_vertex_gemini".to_string(),
+            model_name: "gemini-1.5-pro-001".into(),
+            model_provider_name: "gcp_vertex_gemini".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             variant_name: "gcp-vertex-gemini-pro-implicit".to_string(),
-            model_name: "gemini-1.5-pro-001".to_string(),
-            model_provider_name: "gcp_vertex_gemini".to_string(),
+            model_name: "gemini-1.5-pro-001".into(),
+            model_provider_name: "gcp_vertex_gemini".into(),
             credentials: HashMap::new(),
         },
     ];

--- a/gateway/tests/e2e/providers/google_ai_studio_gemini.rs
+++ b/gateway/tests/e2e/providers/google_ai_studio_gemini.rs
@@ -16,14 +16,14 @@ async fn get_providers() -> E2ETestProviders {
     let standard_providers = vec![
         E2ETestProvider {
             variant_name: "google-ai-studio-gemini-flash-8b".to_string(),
-            model_name: "gemini-1.5-flash-8b".to_string(),
-            model_provider_name: "google_ai_studio_gemini".to_string(),
+            model_name: "gemini-1.5-flash-8b".into(),
+            model_provider_name: "google_ai_studio_gemini".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             variant_name: "google-ai-studio-gemini-pro-002".to_string(),
-            model_name: "gemini-1.5-pro-002".to_string(),
-            model_provider_name: "google_ai_studio_gemini".to_string(),
+            model_name: "gemini-1.5-pro-002".into(),
+            model_provider_name: "google_ai_studio_gemini".into(),
             credentials: HashMap::new(),
         },
     ];
@@ -31,48 +31,48 @@ async fn get_providers() -> E2ETestProviders {
     let inference_params_providers = vec![
         E2ETestProvider {
             variant_name: "google-ai-studio-gemini-flash-8b-dynamic".to_string(),
-            model_name: "gemini-1.5-flash-8b-dynamic".to_string(),
-            model_provider_name: "google_ai_studio_gemini".to_string(),
+            model_name: "gemini-1.5-flash-8b-dynamic".into(),
+            model_provider_name: "google_ai_studio_gemini".into(),
             credentials: credentials.clone(),
         },
         E2ETestProvider {
             variant_name: "google-ai-studio-gemini-pro-002-dynamic".to_string(),
-            model_name: "gemini-1.5-pro-002-dynamic".to_string(),
-            model_provider_name: "google_ai_studio_gemini".to_string(),
+            model_name: "gemini-1.5-pro-002-dynamic".into(),
+            model_provider_name: "google_ai_studio_gemini".into(),
             credentials,
         },
     ];
 
     let tool_providers = vec![E2ETestProvider {
         variant_name: "google-ai-studio-gemini-flash-8b".to_string(),
-        model_name: "gemini-1.5-flash-8b".to_string(),
-        model_provider_name: "google_ai_studio_gemini".to_string(),
+        model_name: "gemini-1.5-flash-8b".into(),
+        model_provider_name: "google_ai_studio_gemini".into(),
         credentials: HashMap::new(),
     }];
 
     let json_providers = vec![
         E2ETestProvider {
             variant_name: "google-ai-studio-gemini-flash-8b".to_string(),
-            model_name: "gemini-1.5-flash-8b".to_string(),
-            model_provider_name: "google_ai_studio_gemini".to_string(),
+            model_name: "gemini-1.5-flash-8b".into(),
+            model_provider_name: "google_ai_studio_gemini".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             variant_name: "google-ai-studio-gemini-flash-8b-implicit".to_string(),
-            model_name: "gemini-1.5-flash-8b".to_string(),
-            model_provider_name: "google_ai_studio_gemini".to_string(),
+            model_name: "gemini-1.5-flash-8b".into(),
+            model_provider_name: "google_ai_studio_gemini".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             variant_name: "google-ai-studio-gemini-pro-002".to_string(),
-            model_name: "gemini-1.5-pro-002".to_string(),
-            model_provider_name: "google_ai_studio_gemini".to_string(),
+            model_name: "gemini-1.5-pro-002".into(),
+            model_provider_name: "google_ai_studio_gemini".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             variant_name: "google-ai-studio-gemini-pro-002-implicit".to_string(),
-            model_name: "gemini-1.5-pro-002".to_string(),
-            model_provider_name: "google_ai_studio_gemini".to_string(),
+            model_name: "gemini-1.5-pro-002".into(),
+            model_provider_name: "google_ai_studio_gemini".into(),
             credentials: HashMap::new(),
         },
     ];
@@ -80,8 +80,8 @@ async fn get_providers() -> E2ETestProviders {
     #[cfg(feature = "e2e_tests")]
     let shorthand_providers = vec![E2ETestProvider {
         variant_name: "google-ai-studio-gemini-flash-8b-shorthand".to_string(),
-        model_name: "google_ai_studio_gemini::gemini-1.5-flash-8b".to_string(),
-        model_provider_name: "google_ai_studio_gemini".to_string(),
+        model_name: "google_ai_studio_gemini::gemini-1.5-flash-8b".into(),
+        model_provider_name: "google_ai_studio_gemini".into(),
         credentials: HashMap::new(),
     }];
 

--- a/gateway/tests/e2e/providers/hyperbolic.rs
+++ b/gateway/tests/e2e/providers/hyperbolic.rs
@@ -15,23 +15,23 @@ async fn get_providers() -> E2ETestProviders {
 
     let standard_providers = vec![E2ETestProvider {
         variant_name: "hyperbolic".to_string(),
-        model_name: "meta-llama/Meta-Llama-3-70B-Instruct".to_string(),
-        model_provider_name: "hyperbolic".to_string(),
+        model_name: "meta-llama/Meta-Llama-3-70B-Instruct".into(),
+        model_provider_name: "hyperbolic".into(),
         credentials: HashMap::new(),
     }];
 
     let inference_params_providers = vec![E2ETestProvider {
         variant_name: "hyperbolic-dynamic".to_string(),
-        model_name: "meta-llama/Meta-Llama-3-70B-Instruct-dynamic".to_string(),
-        model_provider_name: "hyperbolic".to_string(),
+        model_name: "meta-llama/Meta-Llama-3-70B-Instruct-dynamic".into(),
+        model_provider_name: "hyperbolic".into(),
         credentials,
     }];
 
     #[cfg(feature = "e2e_tests")]
     let shorthand_providers = vec![E2ETestProvider {
         variant_name: "hyperbolic-shorthand".to_string(),
-        model_name: "hyperbolic::meta-llama/Meta-Llama-3-70B-Instruct".to_string(),
-        model_provider_name: "hyperbolic".to_string(),
+        model_name: "hyperbolic::meta-llama/Meta-Llama-3-70B-Instruct".into(),
+        model_provider_name: "hyperbolic".into(),
         credentials: HashMap::new(),
     }];
 

--- a/gateway/tests/e2e/providers/mistral.rs
+++ b/gateway/tests/e2e/providers/mistral.rs
@@ -15,23 +15,23 @@ async fn get_providers() -> E2ETestProviders {
 
     let providers = vec![E2ETestProvider {
         variant_name: "mistral".to_string(),
-        model_name: "open-mistral-nemo-2407".to_string(),
-        model_provider_name: "mistral".to_string(),
+        model_name: "open-mistral-nemo-2407".into(),
+        model_provider_name: "mistral".into(),
         credentials: HashMap::new(),
     }];
 
     let inference_params_providers = vec![E2ETestProvider {
         variant_name: "mistral-dynamic".to_string(),
-        model_name: "open-mistral-nemo-2407-dynamic".to_string(),
-        model_provider_name: "mistral".to_string(),
+        model_name: "open-mistral-nemo-2407-dynamic".into(),
+        model_provider_name: "mistral".into(),
         credentials,
     }];
 
     #[cfg(feature = "e2e_tests")]
     let shorthand_providers = vec![E2ETestProvider {
         variant_name: "mistral-shorthand".to_string(),
-        model_name: "mistral::open-mistral-nemo-2407".to_string(),
-        model_provider_name: "mistral".to_string(),
+        model_name: "mistral::open-mistral-nemo-2407".into(),
+        model_provider_name: "mistral".into(),
         credentials: HashMap::new(),
     }];
 

--- a/gateway/tests/e2e/providers/openai.rs
+++ b/gateway/tests/e2e/providers/openai.rs
@@ -34,35 +34,35 @@ async fn get_providers() -> E2ETestProviders {
 
     let standard_providers = vec![E2ETestProvider {
         variant_name: "openai".to_string(),
-        model_name: "gpt-4o-mini-2024-07-18".to_string(),
-        model_provider_name: "openai".to_string(),
+        model_name: "gpt-4o-mini-2024-07-18".into(),
+        model_provider_name: "openai".into(),
         credentials: HashMap::new(),
     }];
 
     let inference_params_providers = vec![E2ETestProvider {
         variant_name: "openai-dynamic".to_string(),
-        model_name: "gpt-4o-mini-2024-07-18-dynamic".to_string(),
-        model_provider_name: "openai".to_string(),
+        model_name: "gpt-4o-mini-2024-07-18-dynamic".into(),
+        model_provider_name: "openai".into(),
         credentials,
     }];
 
     let json_providers = vec![
         E2ETestProvider {
             variant_name: "openai".to_string(),
-            model_name: "gpt-4o-mini-2024-07-18".to_string(),
-            model_provider_name: "openai".to_string(),
+            model_name: "gpt-4o-mini-2024-07-18".into(),
+            model_provider_name: "openai".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             variant_name: "openai-implicit".to_string(),
-            model_name: "gpt-4o-mini-2024-07-18".to_string(),
-            model_provider_name: "openai".to_string(),
+            model_name: "gpt-4o-mini-2024-07-18".into(),
+            model_provider_name: "openai".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             variant_name: "openai-strict".to_string(),
-            model_name: "gpt-4o-mini-2024-07-18".to_string(),
-            model_provider_name: "openai".to_string(),
+            model_name: "gpt-4o-mini-2024-07-18".into(),
+            model_provider_name: "openai".into(),
             credentials: HashMap::new(),
         },
     ];
@@ -70,8 +70,8 @@ async fn get_providers() -> E2ETestProviders {
     #[cfg(feature = "e2e_tests")]
     let shorthand_providers = vec![E2ETestProvider {
         variant_name: "openai-shorthand".to_string(),
-        model_name: "openai::gpt-4o-mini-2024-07-18".to_string(),
-        model_provider_name: "openai".to_string(),
+        model_name: "openai::gpt-4o-mini-2024-07-18".into(),
+        model_provider_name: "openai".into(),
         credentials: HashMap::new(),
     }];
 

--- a/gateway/tests/e2e/providers/tgi.rs
+++ b/gateway/tests/e2e/providers/tgi.rs
@@ -10,7 +10,7 @@ async fn get_providers() -> E2ETestProviders {
     let standard_providers = vec![E2ETestProvider {
         variant_name: "tgi".to_string(),
         model_name: model_name.clone(),
-        model_provider_name: "tgi".to_string(),
+        model_provider_name: "tgi".into(),
         credentials: HashMap::new(),
     }];
     E2ETestProviders {

--- a/gateway/tests/e2e/providers/together.rs
+++ b/gateway/tests/e2e/providers/together.rs
@@ -15,23 +15,23 @@ async fn get_providers() -> E2ETestProviders {
 
     let standard_providers = vec![E2ETestProvider {
         variant_name: "together".to_string(),
-        model_name: "llama3.1-8b-instruct-together".to_string(),
-        model_provider_name: "together".to_string(),
+        model_name: "llama3.1-8b-instruct-together".into(),
+        model_provider_name: "together".into(),
         credentials: HashMap::new(),
     }];
 
     let inference_params_providers = vec![E2ETestProvider {
         variant_name: "together-dynamic".to_string(),
-        model_name: "llama3.1-8b-instruct-together-dynamic".to_string(),
-        model_provider_name: "together".to_string(),
+        model_name: "llama3.1-8b-instruct-together-dynamic".into(),
+        model_provider_name: "together".into(),
         credentials,
     }];
 
     let json_providers = vec![
         E2ETestProvider {
             variant_name: "together".to_string(),
-            model_name: "llama3.1-8b-instruct-together".to_string(),
-            model_provider_name: "together".to_string(),
+            model_name: "llama3.1-8b-instruct-together".into(),
+            model_provider_name: "together".into(),
             credentials: HashMap::new(),
         },
         // TODOs (#80): see below
@@ -43,8 +43,8 @@ async fn get_providers() -> E2ETestProviders {
     #[cfg(feature = "e2e_tests")]
     let shorthand_providers = vec![E2ETestProvider {
         variant_name: "together-shorthand".to_string(),
-        model_name: "together::meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo".to_string(),
-        model_provider_name: "together".to_string(),
+        model_name: "together::meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo".into(),
+        model_provider_name: "together".into(),
         credentials: HashMap::new(),
     }];
 

--- a/gateway/tests/e2e/providers/vllm.rs
+++ b/gateway/tests/e2e/providers/vllm.rs
@@ -15,15 +15,15 @@ async fn get_providers() -> E2ETestProviders {
 
     let providers = vec![E2ETestProvider {
         variant_name: "vllm".to_string(),
-        model_name: "microsoft/Phi-3.5-mini-instruct".to_string(),
-        model_provider_name: "vllm".to_string(),
+        model_name: "microsoft/Phi-3.5-mini-instruct".into(),
+        model_provider_name: "vllm".into(),
         credentials: HashMap::new(),
     }];
 
     let inference_params_providers = vec![E2ETestProvider {
         variant_name: "vllm-dynamic".to_string(),
-        model_name: "microsoft/Phi-3.5-mini-instruct-dynamic".to_string(),
-        model_provider_name: "vllm".to_string(),
+        model_name: "microsoft/Phi-3.5-mini-instruct-dynamic".into(),
+        model_provider_name: "vllm".into(),
         credentials,
     }];
 

--- a/gateway/tests/e2e/providers/xai.rs
+++ b/gateway/tests/e2e/providers/xai.rs
@@ -15,23 +15,23 @@ async fn get_providers() -> E2ETestProviders {
 
     let standard_providers = vec![E2ETestProvider {
         variant_name: "xai".to_string(),
-        model_name: "grok_2_1212".to_string(),
-        model_provider_name: "xai".to_string(),
+        model_name: "grok_2_1212".into(),
+        model_provider_name: "xai".into(),
         credentials: HashMap::new(),
     }];
 
     let inference_params_providers = vec![E2ETestProvider {
         variant_name: "xai".to_string(),
-        model_name: "grok_2_1212".to_string(),
-        model_provider_name: "xai".to_string(),
+        model_name: "grok_2_1212".into(),
+        model_provider_name: "xai".into(),
         credentials,
     }];
 
     #[cfg(feature = "e2e_tests")]
     let shorthand_providers = vec![E2ETestProvider {
         variant_name: "xai-shorthand".to_string(),
-        model_name: "xai::grok-2-1212".to_string(),
-        model_provider_name: "xai".to_string(),
+        model_name: "xai::grok-2-1212".into(),
+        model_provider_name: "xai".into(),
         credentials: HashMap::new(),
     }];
 


### PR DESCRIPTION
This keeps the names cheap to clone/access, which avoiding the need to have `'static` lifetimes for use with `tokio::spawn`. It's an intermediate step towards removing all `Box::leak` calls.

Unfortunately, this creates a very large diff, mostly due to the need to adjust tests to call '.into()' instead of '.to_string() /.to_owned()' when constructing configs.

Most of the changes are purely mechanical, with a few exceptions:
* We now store `Arc<str>` instead of `String` in some places (e.g. `HashMap`s. This avoids the need to frequently convert between `String` and `Arc<str>`.
* Error messages still use `String`, so we convert from `Arc<str>` to `String` when an error occurs.
* We now use the `rc` feature of `Serde`, which allows us to deserialize directly to `Arc<str>`. This means that we should not rely on the results of `Arc` pointer comparisons across serialization/deserialization - however, we have no reason to use pointer comparisons, and the `Arc::eq` impl does a normal `PartialEq` comparison.
* Several structs no longer take lifetime parameters
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch model and provider names to `Arc<str>` for performance optimization and update related code and tests.
> 
>   - **Behavior**:
>     - Switch from `String` to `Arc<str>` for model and provider names to reduce cloning costs and avoid static lifetimes.
>     - Update error handling to convert `Arc<str>` to `String` for error messages.
>     - Use Serde's `rc` feature to deserialize directly to `Arc<str>`.
>   - **Code Changes**:
>     - Modify `Config`, `EmbeddingModelConfig`, `ModelConfig`, and `BatchRequestRow` to use `Arc<str>`.
>     - Update functions like `infer()`, `infer_stream()`, and `prepare_request()` to handle `Arc<str>`.
>     - Adjust tests to use `.into()` for `Arc<str>` conversion.
>   - **Misc**:
>     - Add `rc` feature to `serde` in `Cargo.toml`.
>     - Remove lifetime parameters from several structs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8164b0e9c90556479bae17c6c4daa9a9a277798e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->