### PR TITLE
InferenceServer->Serialization in tgi provider

### DIFF
--- a/gateway/src/inference/providers/tgi.rs
+++ b/gateway/src/inference/providers/tgi.rs
@@ -212,11 +212,8 @@ impl InferenceProvider for TGIProvider {
             .into());
         }
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
+            Error::new(ErrorDetails::Serialization {
                 message: format!("Error serializing request: {e}"),
-                provider_type: PROVIDER_TYPE.to_string(),
-                raw_request: serde_json::to_string(&request_body).ok(),
-                raw_response: None,
             })
         })?;
         let request_url = get_chat_url(&self.api_base)?;


### PR DESCRIPTION
We had incorrectly used InferenceServer here. Serialization is more appropriate. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rename `ErrorDetails::InferenceServer` to `ErrorDetails::Serialization` in `infer_stream()` in `tgi.rs` for serialization errors.
> 
>   - **Error Handling**:
>     - Rename `ErrorDetails::InferenceServer` to `ErrorDetails::Serialization` in `infer_stream()` in `tgi.rs` for request serialization errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 9bcdc68361496fff8d27732ee81ad1ef62ae02be. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->