### PR TITLE
Rename field in batch inference endpoint in advance of public release

### DIFF
--- a/gateway/src/endpoints/batch_inference.rs
+++ b/gateway/src/endpoints/batch_inference.rs
@@ -392,14 +392,14 @@ impl CompletedBatchInferenceResponse {
                 inference_id: Some(inference_id),
                 ..
             } => {
-                let responses = self
+                let inferences = self
                     .inferences
                     .into_iter()
                     .filter(|r| r.inference_id() == inference_id)
                     .collect();
                 CompletedBatchInferenceResponse {
                     batch_id: self.batch_id,
-                    inferences: responses,
+                    inferences,
                 }
             }
         }
@@ -664,7 +664,7 @@ pub async fn write_poll_batch_inference<'a>(
             Ok(PollInferenceResponse::Pending)
         }
         PollBatchInferenceResponse::Completed(response) => {
-            let responses = write_completed_batch_inference(
+            let inferences = write_completed_batch_inference(
                 clickhouse_connection_info,
                 batch_request,
                 response,
@@ -674,7 +674,7 @@ pub async fn write_poll_batch_inference<'a>(
             Ok(PollInferenceResponse::Completed(
                 CompletedBatchInferenceResponse {
                     batch_id: batch_request.batch_id,
-                    inferences: responses,
+                    inferences,
                 },
             ))
         }

--- a/gateway/src/endpoints/batch_inference.rs
+++ b/gateway/src/endpoints/batch_inference.rs
@@ -376,7 +376,7 @@ impl PollInferenceResponse {
 #[derive(Debug, PartialEq, Serialize)]
 pub struct CompletedBatchInferenceResponse {
     pub batch_id: Uuid,
-    pub responses: Vec<InferenceResponse>,
+    pub inferences: Vec<InferenceResponse>,
 }
 
 impl CompletedBatchInferenceResponse {
@@ -393,13 +393,13 @@ impl CompletedBatchInferenceResponse {
                 ..
             } => {
                 let responses = self
-                    .responses
+                    .inferences
                     .into_iter()
                     .filter(|r| r.inference_id() == inference_id)
                     .collect();
                 CompletedBatchInferenceResponse {
                     batch_id: self.batch_id,
-                    responses,
+                    inferences: responses,
                 }
             }
         }
@@ -674,7 +674,7 @@ pub async fn write_poll_batch_inference<'a>(
             Ok(PollInferenceResponse::Completed(
                 CompletedBatchInferenceResponse {
                     batch_id: batch_request.batch_id,
-                    responses,
+                    inferences: responses,
                 },
             ))
         }
@@ -763,7 +763,7 @@ pub async fn write_completed_batch_inference<'a>(
         .function_name
         .clone();
     let function = config.get_function(function_name)?;
-    let mut responses: Vec<InferenceResponse> = Vec::new();
+    let mut inferences: Vec<InferenceResponse> = Vec::new();
     let mut inference_rows_to_write: Vec<InferenceDatabaseInsert> = Vec::new();
     let mut model_inference_rows_to_write: Vec<Value> = Vec::new();
     for batch_model_inference in batch_model_inferences {
@@ -841,7 +841,7 @@ pub async fn write_completed_batch_inference<'a>(
             episode_id,
             variant_name.to_string(),
         );
-        responses.push(inference_response);
+        inferences.push(inference_response);
         let metadata = InferenceDatabaseInsertMetadata {
             function_name: function_name.to_string(),
             variant_name: variant_name.to_string(),
@@ -880,7 +880,7 @@ pub async fn write_completed_batch_inference<'a>(
         .write(&model_inference_rows_to_write, "ModelInference")
         .await?;
 
-    Ok(responses)
+    Ok(inferences)
 }
 
 /// This function gets the batch inferences from the database for a given batch id and inference ids
@@ -960,7 +960,7 @@ pub async fn get_completed_batch_inference_response(
                 }
                 Ok(CompletedBatchInferenceResponse {
                     batch_id: *batch_id,
-                    responses: inference_responses,
+                    inferences: inference_responses,
                 })
             }
             PollPathParams {
@@ -1009,7 +1009,7 @@ pub async fn get_completed_batch_inference_response(
                 let inference_response = InferenceResponse::Chat(inference_response.try_into()?);
                 Ok(CompletedBatchInferenceResponse {
                     batch_id: batch_request.batch_id,
-                    responses: vec![inference_response],
+                    inferences: vec![inference_response],
                 })
             }
         },
@@ -1053,7 +1053,7 @@ pub async fn get_completed_batch_inference_response(
                 }
                 Ok(CompletedBatchInferenceResponse {
                     batch_id: batch_request.batch_id,
-                    responses: inference_responses,
+                    inferences: inference_responses,
                 })
             }
             PollPathParams {
@@ -1102,7 +1102,7 @@ pub async fn get_completed_batch_inference_response(
                 let inference_response = InferenceResponse::Json(inference_response.try_into()?);
                 Ok(CompletedBatchInferenceResponse {
                     batch_id: batch_request.batch_id,
-                    responses: vec![inference_response],
+                    inferences: vec![inference_response],
                 })
             }
         },

--- a/gateway/tests/e2e/batch.rs
+++ b/gateway/tests/e2e/batch.rs
@@ -361,17 +361,17 @@ async fn test_write_read_completed_batch_inference_chat() {
         raw_request: raw_request.clone(),
         raw_response: raw_response.clone(),
     };
-    let mut inference_responses =
+    let mut inference_inference =
         write_completed_batch_inference(&clickhouse, &batch_request, response, &config)
             .await
             .unwrap();
 
-    // Sort responses by inference_id to ensure consistent ordering
-    inference_responses.sort_by_key(|response| response.inference_id());
+    // Sort inference by inference_id to ensure consistent ordering
+    inference_inference.sort_by_key(|response| response.inference_id());
 
-    assert_eq!(inference_responses.len(), 2);
-    let inference_response_1 = &inference_responses[0];
-    let inference_response_2 = &inference_responses[1];
+    assert_eq!(inference_inference.len(), 2);
+    let inference_response_1 = &inference_inference[0];
+    let inference_response_2 = &inference_inference[1];
 
     match inference_response_1 {
         InferenceResponse::Chat(chat_inference_response) => {
@@ -448,21 +448,21 @@ async fn test_write_read_completed_batch_inference_chat() {
     .await
     .unwrap();
     assert_eq!(completed_inference_response.batch_id, batch_id);
-    assert_eq!(completed_inference_response.responses.len(), 2);
+    assert_eq!(completed_inference_response.inferences.len(), 2);
 
-    // Create HashMaps keyed by inference_id for both sets of responses
-    let completed_responses: HashMap<_, _> = completed_inference_response
-        .responses
+    // Create HashMaps keyed by inference_id for both sets of inference
+    let completed_inference: HashMap<_, _> = completed_inference_response
+        .inferences
         .iter()
         .map(|r| (r.inference_id(), r))
         .collect();
-    let original_responses: HashMap<_, _> = [inference_response_1, inference_response_2]
+    let original_inference: HashMap<_, _> = [inference_response_1, inference_response_2]
         .into_iter()
         .map(|r| (r.inference_id(), r))
         .collect();
 
     // Compare the HashMaps
-    assert_eq!(completed_responses, original_responses);
+    assert_eq!(completed_inference, original_inference);
 
     // Now let's read using `get_completed_batch_inference_response` with a `PollInferenceQuery::Inference`
     let query = PollPathParams {
@@ -478,8 +478,8 @@ async fn test_write_read_completed_batch_inference_chat() {
     .await
     .unwrap();
     assert_eq!(
-        &completed_inference_response.responses[0],
-        original_responses[&inference_id1]
+        &completed_inference_response.inferences[0],
+        original_inference[&inference_id1]
     );
 }
 
@@ -557,24 +557,24 @@ async fn test_write_read_completed_batch_inference_json() {
         raw_request,
         raw_response,
     };
-    let inference_responses =
+    let inference_inference =
         write_completed_batch_inference(&clickhouse, &batch_request, response, &config)
             .await
             .unwrap();
 
-    assert_eq!(inference_responses.len(), 2);
+    assert_eq!(inference_inference.len(), 2);
 
-    // Create a map of responses by inference_id for easier lookup
-    let responses_by_id: HashMap<_, _> = inference_responses
+    // Create a map of inference by inference_id for easier lookup
+    let inference_by_id: HashMap<_, _> = inference_inference
         .iter()
         .map(|r| (r.inference_id(), r))
         .collect();
 
     // Now we can safely access each response by its ID
-    let response_1 = responses_by_id
+    let response_1 = inference_by_id
         .get(&inference_id1)
         .expect("Missing response for inference_id1");
-    let response_2 = responses_by_id
+    let response_2 = inference_by_id
         .get(&inference_id2)
         .expect("Missing response for inference_id2");
 
@@ -677,21 +677,21 @@ async fn test_write_read_completed_batch_inference_json() {
     .await
     .unwrap();
     assert_eq!(completed_inference_response.batch_id, batch_id);
-    assert_eq!(completed_inference_response.responses.len(), 2);
+    assert_eq!(completed_inference_response.inferences.len(), 2);
 
-    // Create HashMaps keyed by inference_id for both sets of responses
-    let completed_responses: HashMap<_, _> = completed_inference_response
-        .responses
+    // Create HashMaps keyed by inference_id for both sets of inference
+    let completed_inference: HashMap<_, _> = completed_inference_response
+        .inferences
         .iter()
         .map(|r| (r.inference_id(), r))
         .collect();
-    let original_responses: HashMap<_, _> = [response_1, response_2]
+    let original_inference: HashMap<_, _> = [response_1, response_2]
         .into_iter()
         .map(|r| (r.inference_id(), *r))
         .collect();
 
     // Compare the HashMaps
-    assert_eq!(completed_responses, original_responses);
+    assert_eq!(completed_inference, original_inference);
 
     // Now let's read using `get_completed_batch_inference_response` with a `PollInferenceQuery::Inference`
     let query = PollPathParams {
@@ -707,7 +707,7 @@ async fn test_write_read_completed_batch_inference_json() {
     .await
     .unwrap();
     assert_eq!(
-        &completed_inference_response.responses[0],
-        original_responses[&inference_id1]
+        &completed_inference_response.inferences[0],
+        original_inference[&inference_id1]
     );
 }

--- a/gateway/tests/e2e/batch.rs
+++ b/gateway/tests/e2e/batch.rs
@@ -366,7 +366,7 @@ async fn test_write_read_completed_batch_inference_chat() {
             .await
             .unwrap();
 
-    // Sort inference by inference_id to ensure consistent ordering
+    // Sort inferences by inference_id to ensure consistent ordering
     inference_responses.sort_by_key(|response| response.inference_id());
 
     assert_eq!(inference_responses.len(), 2);
@@ -450,19 +450,19 @@ async fn test_write_read_completed_batch_inference_chat() {
     assert_eq!(completed_inference_response.batch_id, batch_id);
     assert_eq!(completed_inference_response.inferences.len(), 2);
 
-    // Create HashMaps keyed by inference_id for both sets of inference
-    let completed_inference: HashMap<_, _> = completed_inference_response
+    // Create HashMaps keyed by inference_id for both sets of inferences
+    let completed_inferences: HashMap<_, _> = completed_inference_response
         .inferences
         .iter()
         .map(|r| (r.inference_id(), r))
         .collect();
-    let original_inference: HashMap<_, _> = [inference_response_1, inference_response_2]
+    let original_inferences: HashMap<_, _> = [inference_response_1, inference_response_2]
         .into_iter()
         .map(|r| (r.inference_id(), r))
         .collect();
 
     // Compare the HashMaps
-    assert_eq!(completed_inference, original_inference);
+    assert_eq!(completed_inferences, original_inferences);
 
     // Now let's read using `get_completed_batch_inference_response` with a `PollInferenceQuery::Inference`
     let query = PollPathParams {
@@ -479,7 +479,7 @@ async fn test_write_read_completed_batch_inference_chat() {
     .unwrap();
     assert_eq!(
         &completed_inference_response.inferences[0],
-        original_inference[&inference_id1]
+        original_inferences[&inference_id1]
     );
 }
 
@@ -564,17 +564,17 @@ async fn test_write_read_completed_batch_inference_json() {
 
     assert_eq!(inference_responses.len(), 2);
 
-    // Create a map of inference by inference_id for easier lookup
-    let inference_by_id: HashMap<_, _> = inference_responses
+    // Create a map of inferences by inference_id for easier lookup
+    let inferences_by_id: HashMap<_, _> = inference_responses
         .iter()
         .map(|r| (r.inference_id(), r))
         .collect();
 
     // Now we can safely access each response by its ID
-    let response_1 = inference_by_id
+    let response_1 = inferences_by_id
         .get(&inference_id1)
         .expect("Missing response for inference_id1");
-    let response_2 = inference_by_id
+    let response_2 = inferences_by_id
         .get(&inference_id2)
         .expect("Missing response for inference_id2");
 
@@ -679,19 +679,19 @@ async fn test_write_read_completed_batch_inference_json() {
     assert_eq!(completed_inference_response.batch_id, batch_id);
     assert_eq!(completed_inference_response.inferences.len(), 2);
 
-    // Create HashMaps keyed by inference_id for both sets of inference
-    let completed_inference: HashMap<_, _> = completed_inference_response
+    // Create HashMaps keyed by inference_id for both sets of inferences
+    let completed_inferences: HashMap<_, _> = completed_inference_response
         .inferences
         .iter()
         .map(|r| (r.inference_id(), r))
         .collect();
-    let original_inference: HashMap<_, _> = [response_1, response_2]
+    let original_inferences: HashMap<_, _> = [response_1, response_2]
         .into_iter()
         .map(|r| (r.inference_id(), *r))
         .collect();
 
     // Compare the HashMaps
-    assert_eq!(completed_inference, original_inference);
+    assert_eq!(completed_inferences, original_inferences);
 
     // Now let's read using `get_completed_batch_inference_response` with a `PollInferenceQuery::Inference`
     let query = PollPathParams {
@@ -708,6 +708,6 @@ async fn test_write_read_completed_batch_inference_json() {
     .unwrap();
     assert_eq!(
         &completed_inference_response.inferences[0],
-        original_inference[&inference_id1]
+        original_inferences[&inference_id1]
     );
 }

--- a/gateway/tests/e2e/batch.rs
+++ b/gateway/tests/e2e/batch.rs
@@ -361,17 +361,17 @@ async fn test_write_read_completed_batch_inference_chat() {
         raw_request: raw_request.clone(),
         raw_response: raw_response.clone(),
     };
-    let mut inference_inference =
+    let mut inference_responses =
         write_completed_batch_inference(&clickhouse, &batch_request, response, &config)
             .await
             .unwrap();
 
     // Sort inference by inference_id to ensure consistent ordering
-    inference_inference.sort_by_key(|response| response.inference_id());
+    inference_responses.sort_by_key(|response| response.inference_id());
 
-    assert_eq!(inference_inference.len(), 2);
-    let inference_response_1 = &inference_inference[0];
-    let inference_response_2 = &inference_inference[1];
+    assert_eq!(inference_responses.len(), 2);
+    let inference_response_1 = &inference_responses[0];
+    let inference_response_2 = &inference_responses[1];
 
     match inference_response_1 {
         InferenceResponse::Chat(chat_inference_response) => {
@@ -557,15 +557,15 @@ async fn test_write_read_completed_batch_inference_json() {
         raw_request,
         raw_response,
     };
-    let inference_inference =
+    let inference_responses =
         write_completed_batch_inference(&clickhouse, &batch_request, response, &config)
             .await
             .unwrap();
 
-    assert_eq!(inference_inference.len(), 2);
+    assert_eq!(inference_responses.len(), 2);
 
     // Create a map of inference by inference_id for easier lookup
-    let inference_by_id: HashMap<_, _> = inference_inference
+    let inference_by_id: HashMap<_, _> = inference_responses
         .iter()
         .map(|r| (r.inference_id(), r))
         .collect();

--- a/gateway/tests/e2e/providers/batch.rs
+++ b/gateway/tests/e2e/providers/batch.rs
@@ -747,7 +747,7 @@ pub async fn test_poll_existing_simple_batch_inference_request_with_provider(
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
     // Check the response from polling by batch_id
     check_simple_inference_response(inferences_json[0].clone(), None, &provider, true).await;
@@ -773,7 +773,7 @@ pub async fn test_poll_existing_simple_batch_inference_request_with_provider(
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
     check_simple_inference_response(inferences_json[0].clone(), None, &provider, true).await;
 }
@@ -827,7 +827,7 @@ pub async fn test_poll_completed_simple_batch_inference_request_with_provider(
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, ids.batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
 
     check_simple_inference_response(inferences_json[0].clone(), None, &provider, true).await;
@@ -852,7 +852,7 @@ pub async fn test_poll_completed_simple_batch_inference_request_with_provider(
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, ids.batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
 
     check_simple_inference_response(inferences_json[0].clone(), None, &provider, true).await;
@@ -1110,7 +1110,7 @@ pub async fn test_poll_existing_inference_params_batch_inference_request_with_pr
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
     // Check the response from polling by batch_id
     check_inference_params_response(inferences_json[0].clone(), &provider, None, true).await;
@@ -1137,7 +1137,7 @@ pub async fn test_poll_existing_inference_params_batch_inference_request_with_pr
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
     check_inference_params_response(inferences_json[0].clone(), &provider, None, true).await;
 }
@@ -1191,7 +1191,7 @@ pub async fn test_poll_completed_inference_params_batch_inference_request_with_p
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, ids.batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
 
     check_simple_inference_response(inferences_json[0].clone(), None, &provider, true).await;
@@ -1216,7 +1216,7 @@ pub async fn test_poll_completed_inference_params_batch_inference_request_with_p
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, ids.batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
 
     check_inference_params_response(inferences_json[0].clone(), &provider, None, true).await;
@@ -1755,7 +1755,7 @@ pub async fn test_poll_existing_tool_choice_batch_inference_request_with_provide
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
 
     let mut test_types_seen = HashSet::new();
     for inference_json in inferences_json {
@@ -1874,7 +1874,7 @@ pub async fn test_poll_completed_tool_use_batch_inference_request_with_provider(
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
 
     let mut test_types_seen = HashSet::new();
     for inference_json in inferences_json {
@@ -2178,7 +2178,7 @@ pub async fn test_poll_existing_allowed_tools_batch_inference_request_with_provi
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
     // Check the response from polling by batch_id
     check_tool_use_tool_choice_allowed_tools_inference_response(
@@ -2210,7 +2210,7 @@ pub async fn test_poll_existing_allowed_tools_batch_inference_request_with_provi
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
     check_tool_use_tool_choice_allowed_tools_inference_response(
         inferences_json[0].clone(),
@@ -2270,7 +2270,7 @@ pub async fn test_poll_completed_allowed_tools_batch_inference_request_with_prov
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, ids.batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
 
     check_tool_use_tool_choice_allowed_tools_inference_response(
@@ -2301,7 +2301,7 @@ pub async fn test_poll_completed_allowed_tools_batch_inference_request_with_prov
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, ids.batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
 
     check_tool_use_tool_choice_allowed_tools_inference_response(
@@ -2583,7 +2583,7 @@ pub async fn test_poll_existing_multi_turn_batch_inference_request_with_provider
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
     // Check the response from polling by batch_id
     check_tool_use_multi_turn_inference_response(inferences_json[0].clone(), &provider, None, true)
@@ -2610,7 +2610,7 @@ pub async fn test_poll_existing_multi_turn_batch_inference_request_with_provider
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
     check_tool_use_multi_turn_inference_response(inferences_json[0].clone(), &provider, None, true)
         .await;
@@ -2665,7 +2665,7 @@ pub async fn test_poll_completed_multi_turn_batch_inference_request_with_provide
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, ids.batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
 
     check_tool_use_multi_turn_inference_response(inferences_json[0].clone(), &provider, None, true)
@@ -2691,7 +2691,7 @@ pub async fn test_poll_completed_multi_turn_batch_inference_request_with_provide
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, ids.batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
 
     check_tool_use_multi_turn_inference_response(inferences_json[0].clone(), &provider, None, true)
@@ -2961,7 +2961,7 @@ pub async fn test_poll_existing_dynamic_tool_use_batch_inference_request_with_pr
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
     // Check the response from polling by batch_id
     check_dynamic_tool_use_inference_response(inferences_json[0].clone(), &provider, None, true)
@@ -2988,7 +2988,7 @@ pub async fn test_poll_existing_dynamic_tool_use_batch_inference_request_with_pr
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
     check_dynamic_tool_use_inference_response(inferences_json[0].clone(), &provider, None, true)
         .await;
@@ -3043,7 +3043,7 @@ pub async fn test_poll_completed_dynamic_tool_use_batch_inference_request_with_p
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, ids.batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
 
     check_dynamic_tool_use_inference_response(inferences_json[0].clone(), &provider, None, true)
@@ -3069,7 +3069,7 @@ pub async fn test_poll_completed_dynamic_tool_use_batch_inference_request_with_p
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, ids.batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
 
     check_dynamic_tool_use_inference_response(inferences_json[0].clone(), &provider, None, true)
@@ -3336,7 +3336,7 @@ pub async fn test_poll_existing_parallel_tool_use_batch_inference_request_with_p
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
     // Check the response from polling by batch_id
     check_parallel_tool_use_inference_response(inferences_json[0].clone(), &provider, None, true)
@@ -3364,7 +3364,7 @@ pub async fn test_poll_existing_parallel_tool_use_batch_inference_request_with_p
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
     check_parallel_tool_use_inference_response(inferences_json[0].clone(), &provider, None, true)
         .await;
@@ -3419,7 +3419,7 @@ pub async fn test_poll_completed_parallel_tool_use_batch_inference_request_with_
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, ids.batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
 
     check_parallel_tool_use_inference_response(inferences_json[0].clone(), &provider, None, true)
@@ -3445,7 +3445,7 @@ pub async fn test_poll_completed_parallel_tool_use_batch_inference_request_with_
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, ids.batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
 
     check_parallel_tool_use_inference_response(inferences_json[0].clone(), &provider, None, true)
@@ -3669,7 +3669,7 @@ pub async fn test_poll_existing_json_mode_batch_inference_request_with_provider(
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
     // Check the response from polling by batch_id
     check_json_mode_inference_response(inferences_json[0].clone(), &provider, None, true).await;
@@ -3695,7 +3695,7 @@ pub async fn test_poll_existing_json_mode_batch_inference_request_with_provider(
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
     check_json_mode_inference_response(inferences_json[0].clone(), &provider, None, true).await;
 }
@@ -3749,7 +3749,7 @@ pub async fn test_poll_completed_json_mode_batch_inference_request_with_provider
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, ids.batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
 
     check_json_mode_inference_response(inferences_json[0].clone(), &provider, None, true).await;
@@ -3774,7 +3774,7 @@ pub async fn test_poll_completed_json_mode_batch_inference_request_with_provider
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, ids.batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
 
     check_json_mode_inference_response(inferences_json[0].clone(), &provider, None, true).await;
@@ -4012,7 +4012,7 @@ pub async fn test_poll_existing_dynamic_json_mode_batch_inference_request_with_p
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
     // Check the response from polling by batch_id
     check_dynamic_json_mode_inference_response(
@@ -4045,7 +4045,7 @@ pub async fn test_poll_existing_dynamic_json_mode_batch_inference_request_with_p
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
     check_dynamic_json_mode_inference_response(
         inferences_json[0].clone(),
@@ -4106,7 +4106,7 @@ pub async fn test_poll_completed_dynamic_json_mode_batch_inference_request_with_
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, ids.batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
 
     check_dynamic_json_mode_inference_response(
@@ -4138,7 +4138,7 @@ pub async fn test_poll_completed_dynamic_json_mode_batch_inference_request_with_
     let returned_batch_id = Uuid::parse_str(returned_batch_id).unwrap();
     assert_eq!(returned_batch_id, ids.batch_id);
 
-    let inferences_json = response_json.get("responses").unwrap().as_array().unwrap();
+    let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
 
     check_dynamic_json_mode_inference_response(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename `responses` to `inferences` in batch inference endpoint and update related tests.
> 
>   - **Behavior**:
>     - Rename `responses` to `inferences` in `CompletedBatchInferenceResponse` in `batch_inference.rs`.
>     - Update all references to `responses` to `inferences` in `batch_inference.rs`.
>   - **Tests**:
>     - Update test cases in `batch.rs` and `providers/batch.rs` to reflect the field rename from `responses` to `inferences`.
>     - Ensure all assertions and data handling in tests use `inferences` instead of `responses`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b314b517e6cb5d04a3af865f43093dc24a9a7e36. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->