### PR TITLE
Use `Arc<Config>` instead of `&'static Config`

### DIFF
--- a/gateway/src/config_parser.rs
+++ b/gateway/src/config_parser.rs
@@ -25,9 +25,9 @@ pub struct Config<'c> {
     pub gateway: GatewayConfig,
     pub models: ModelTable, // model name => model config
     pub embedding_models: HashMap<Arc<str>, EmbeddingModelConfig>, // embedding model name => embedding model config
-    pub functions: HashMap<String, FunctionConfig>, // function name => function config
-    pub metrics: HashMap<String, MetricConfig>,     // metric name => metric config
-    pub tools: HashMap<String, Arc<StaticToolConfig>>, // tool name => tool config
+    pub functions: HashMap<String, Arc<FunctionConfig>>, // function name => function config
+    pub metrics: HashMap<String, MetricConfig>,          // metric name => metric config
+    pub tools: HashMap<String, Arc<StaticToolConfig>>,   // tool name => tool config
     pub templates: TemplateConfig<'c>,
 }
 
@@ -108,8 +108,8 @@ impl<'c> Config<'c> {
         let functions = config
             .functions
             .into_iter()
-            .map(|(name, config)| config.load(&base_path).map(|c| (name, c)))
-            .collect::<Result<HashMap<String, FunctionConfig>, Error>>()?;
+            .map(|(name, config)| config.load(&base_path).map(|c| (name, Arc::new(c))))
+            .collect::<Result<HashMap<String, Arc<FunctionConfig>>, Error>>()?;
 
         let tools = config
             .tools
@@ -216,7 +216,10 @@ impl<'c> Config<'c> {
     }
 
     /// Get a function by name
-    pub fn get_function<'a>(&'a self, function_name: &str) -> Result<&'a FunctionConfig, Error> {
+    pub fn get_function<'a>(
+        &'a self,
+        function_name: &str,
+    ) -> Result<&'a Arc<FunctionConfig>, Error> {
         self.functions.get(function_name).ok_or_else(|| {
             Error::new(ErrorDetails::UnknownFunction {
                 name: function_name.to_string(),
@@ -558,7 +561,7 @@ mod tests {
         assert_eq!(prompt_b_json_mode, &JsonMode::On);
         // Check that the tool choice for get_weather is set to "specific" and the correct tool
         let function = config.functions.get("weather_helper").unwrap();
-        match function {
+        match &**function {
             FunctionConfig::Chat(chat_config) => {
                 assert_eq!(
                     chat_config.tool_choice,
@@ -572,7 +575,7 @@ mod tests {
             .functions
             .get("templates_with_variables_chat")
             .unwrap();
-        match function {
+        match &**function {
             FunctionConfig::Chat(chat_config) => {
                 if let Some(variant) = chat_config.variants.get("best_of_n") {
                     match variant {
@@ -598,7 +601,7 @@ mod tests {
             .functions
             .get("templates_with_variables_json")
             .unwrap();
-        match json_function {
+        match &**json_function {
             FunctionConfig::Json(json_config) => {
                 let variant = json_config.variants.get("variant_with_variables").unwrap();
                 match variant {
@@ -913,7 +916,7 @@ mod tests {
         let result = Config::load_from_toml(config, base_path);
         let config = result.unwrap();
         // Check that the output schema is set to {}
-        let output_schema = match config.functions.get("json_with_schemas").unwrap() {
+        let output_schema = match &**config.functions.get("json_with_schemas").unwrap() {
             FunctionConfig::Json(json_config) => &json_config.output_schema,
             _ => panic!("Expected a JSON function"),
         };

--- a/gateway/src/endpoints/batch_inference.rs
+++ b/gateway/src/endpoints/batch_inference.rs
@@ -331,7 +331,7 @@ pub async fn poll_batch_inference_handler(
                 &clickhouse_connection_info,
                 &batch_request,
                 response,
-                config,
+                &config,
             )
             .await?;
             Ok(Json(response.filter_by_query(path_params)).into_response())
@@ -864,7 +864,7 @@ pub async fn write_completed_batch_inference<'a>(
         }
     }
     // Write all the *Inference rows to the database
-    match function {
+    match &**function {
         FunctionConfig::Chat(_chat_function) => {
             clickhouse_connection_info
                 .write(&inference_rows_to_write, "ChatInference")

--- a/gateway/src/endpoints/feedback.rs
+++ b/gateway/src/endpoints/feedback.rs
@@ -80,7 +80,7 @@ pub async fn feedback_handler(
 ) -> Result<Json<Value>, Error> {
     // Get the metric config or return an error if it doesn't exist
     let feedback_metadata = get_feedback_metadata(
-        config,
+        &config,
         &params.metric_name,
         params.episode_id,
         params.inference_id,
@@ -115,7 +115,7 @@ pub async fn feedback_handler(
         FeedbackType::Demonstration => {
             write_demonstration(
                 clickhouse_connection_info,
-                config,
+                &config,
                 &params,
                 feedback_metadata.target_id,
                 feedback_id,
@@ -126,7 +126,7 @@ pub async fn feedback_handler(
         FeedbackType::Float => {
             write_float(
                 clickhouse_connection_info,
-                config,
+                &config,
                 &params,
                 feedback_metadata.target_id,
                 feedback_id,
@@ -137,7 +137,7 @@ pub async fn feedback_handler(
         FeedbackType::Boolean => {
             write_boolean(
                 clickhouse_connection_info,
-                config,
+                &config,
                 &params,
                 feedback_metadata.target_id,
                 feedback_id,
@@ -245,7 +245,7 @@ async fn write_comment(
 
 async fn write_demonstration(
     connection_info: ClickHouseConnectionInfo,
-    config: &'static Config<'_>,
+    config: &Config<'_>,
     params: &Params,
     inference_id: Uuid,
     feedback_id: Uuid,
@@ -273,7 +273,7 @@ async fn write_demonstration(
 
 async fn write_float(
     connection_info: ClickHouseConnectionInfo,
-    config: &'static Config<'_>,
+    config: &Config<'_>,
     params: &Params,
     target_id: Uuid,
     feedback_id: Uuid,
@@ -308,7 +308,7 @@ async fn write_float(
 
 async fn write_boolean(
     connection_info: ClickHouseConnectionInfo,
-    config: &'static Config<'_>,
+    config: &Config<'_>,
     params: &Params,
     target_id: Uuid,
     feedback_id: Uuid,
@@ -772,7 +772,7 @@ mod tests {
     #[tokio::test]
     async fn test_feedback_handler() {
         // Test a Comment Feedback
-        let config = Box::leak(Box::new(Config {
+        let config = Arc::new(Config {
             gateway: GatewayConfig::default(),
             models: ModelTable::default(),
             embedding_models: HashMap::new(),
@@ -780,7 +780,7 @@ mod tests {
             functions: HashMap::new(),
             tools: HashMap::new(),
             templates: TemplateConfig::new(),
-        }));
+        });
         let app_state_data = get_unit_test_app_state_data(config, true);
         let timestamp = uuid::Timestamp::from_unix_time(1579751960, 0, 0, 0);
         let episode_id = Uuid::new_v7(timestamp);
@@ -855,7 +855,7 @@ mod tests {
                 optimize: MetricConfigOptimize::Max,
             },
         );
-        let config = Box::leak(Box::new(Config {
+        let config = Arc::new(Config {
             gateway: GatewayConfig::default(),
             models: ModelTable::default(),
             embedding_models: HashMap::new(),
@@ -863,8 +863,8 @@ mod tests {
             functions: HashMap::new(),
             tools: HashMap::new(),
             templates: TemplateConfig::new(),
-        }));
-        let app_state_data = get_unit_test_app_state_data(config, true);
+        });
+        let app_state_data = get_unit_test_app_state_data(config.clone(), true);
         let value = json!(4.5);
         let inference_id = Uuid::new_v7(timestamp);
         let episode_id = Uuid::new_v7(timestamp);
@@ -915,7 +915,7 @@ mod tests {
                 optimize: MetricConfigOptimize::Max,
             },
         );
-        let config = Box::leak(Box::new(Config {
+        let config = Arc::new(Config {
             gateway: GatewayConfig::default(),
             models: ModelTable::default(),
             embedding_models: HashMap::new(),
@@ -923,8 +923,8 @@ mod tests {
             functions: HashMap::new(),
             tools: HashMap::new(),
             templates: TemplateConfig::new(),
-        }));
-        let app_state_data = get_unit_test_app_state_data(config, true);
+        });
+        let app_state_data = get_unit_test_app_state_data(config.clone(), true);
         let value = json!(true);
         let inference_id = Uuid::new_v7(timestamp);
         let params = Params {

--- a/gateway/src/endpoints/status.rs
+++ b/gateway/src/endpoints/status.rs
@@ -35,6 +35,8 @@ pub async fn health_handler(
 #[cfg(test)]
 mod tests {
 
+    use std::sync::Arc;
+
     use crate::config_parser::Config;
     use crate::testing::get_unit_test_app_state_data;
 
@@ -42,8 +44,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_health_handler() {
-        let config = Box::leak(Box::new(Config::default()));
-        let app_state_data = get_unit_test_app_state_data(config, true);
+        let config = Arc::new(Config::default());
+        let app_state_data = get_unit_test_app_state_data(config.clone(), true);
         let response = health_handler(State(app_state_data)).await;
         assert!(response.is_ok());
         let response_value = response.unwrap();

--- a/gateway/src/function.rs
+++ b/gateway/src/function.rs
@@ -103,9 +103,9 @@ impl FunctionConfig {
     /// well as the dynamic tool calling information passed in `dynamic_tool_params`.
     /// JSON functions do not get tool_configs even if they end up using tools under the hood.
     pub fn prepare_tool_config(
-        &'static self,
+        &self,
         dynamic_tool_params: DynamicToolParams,
-        static_tools: &'static HashMap<String, StaticToolConfig>,
+        static_tools: &HashMap<String, Arc<StaticToolConfig>>,
     ) -> Result<Option<ToolCallConfig>, Error> {
         match self {
             FunctionConfig::Chat(params) => Ok(ToolCallConfig::new(
@@ -246,7 +246,7 @@ impl FunctionConfig {
     #[instrument(skip_all, fields(function_name = %function_name))]
     pub fn validate(
         &self,
-        static_tools: &HashMap<String, StaticToolConfig>,
+        static_tools: &HashMap<String, Arc<StaticToolConfig>>,
         models: &mut ModelTable,
         embedding_models: &HashMap<Arc<str>, EmbeddingModelConfig>,
         templates: &TemplateConfig,

--- a/gateway/src/function.rs
+++ b/gateway/src/function.rs
@@ -24,6 +24,21 @@ pub enum FunctionConfig {
     Json(FunctionConfigJson),
 }
 
+#[derive(Copy, Clone, Debug)]
+pub enum FunctionConfigType {
+    Chat,
+    Json,
+}
+
+impl FunctionConfig {
+    pub fn config_type(&self) -> FunctionConfigType {
+        match self {
+            FunctionConfig::Chat(_) => FunctionConfigType::Chat,
+            FunctionConfig::Json(_) => FunctionConfigType::Json,
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct FunctionConfigChat {
     pub variants: HashMap<String, VariantConfig>, // variant name => variant config

--- a/gateway/src/inference/providers/common.rs
+++ b/gateway/src/inference/providers/common.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::jsonschema_util::JSONSchemaFromPath;
 use crate::tool::{StaticToolConfig, ToolCallConfig, ToolChoice, ToolConfig};
 use lazy_static::lazy_static;
@@ -5,7 +7,7 @@ use serde_json::json;
 
 lazy_static! {
     /// These are useful for tests which don't need mutable tools.
-    pub static ref WEATHER_TOOL_CONFIG_STATIC: StaticToolConfig = StaticToolConfig {
+    pub static ref WEATHER_TOOL_CONFIG_STATIC: Arc<StaticToolConfig> = Arc::new(StaticToolConfig {
         name: "get_temperature".to_string(),
         description: "Get the current temperature in a given location".to_string(),
         parameters: JSONSchemaFromPath::from_value(&json!({
@@ -17,15 +19,15 @@ lazy_static! {
             "required": ["location"]
         })).unwrap(),
         strict: false,
-    };
-    pub static ref WEATHER_TOOL: ToolConfig = ToolConfig::Static(&WEATHER_TOOL_CONFIG_STATIC);
+    });
+    pub static ref WEATHER_TOOL: ToolConfig = ToolConfig::Static(WEATHER_TOOL_CONFIG_STATIC.clone());
     pub static ref WEATHER_TOOL_CHOICE: ToolChoice = ToolChoice::Specific("get_temperature".to_string());
     pub static ref WEATHER_TOOL_CONFIG: ToolCallConfig = ToolCallConfig {
-        tools_available: vec![ToolConfig::Static(&WEATHER_TOOL_CONFIG_STATIC)],
+        tools_available: vec![ToolConfig::Static(WEATHER_TOOL_CONFIG_STATIC.clone())],
         tool_choice: ToolChoice::Specific("get_temperature".to_string()),
         parallel_tool_calls: false,
     };
-    pub static ref QUERY_TOOL_CONFIG_STATIC: StaticToolConfig = StaticToolConfig {
+    pub static ref QUERY_TOOL_CONFIG_STATIC: Arc<StaticToolConfig> = Arc::new(StaticToolConfig {
         name: "query_articles".to_string(),
         description: "Query articles from Wikipedia".to_string(),
         parameters: JSONSchemaFromPath::from_value(&json!({
@@ -37,13 +39,13 @@ lazy_static! {
             "required": ["query", "year"]
         })).unwrap(),
         strict: true,
-    };
-    pub static ref QUERY_TOOL: ToolConfig = ToolConfig::Static(&QUERY_TOOL_CONFIG_STATIC);
+    });
+    pub static ref QUERY_TOOL: ToolConfig = ToolConfig::Static(QUERY_TOOL_CONFIG_STATIC.clone());
     pub static ref ANY_TOOL_CHOICE: ToolChoice = ToolChoice::Required;
     pub static ref MULTI_TOOL_CONFIG: ToolCallConfig = ToolCallConfig {
         tools_available: vec![
-            ToolConfig::Static(&WEATHER_TOOL_CONFIG_STATIC),
-            ToolConfig::Static(&QUERY_TOOL_CONFIG_STATIC)
+            ToolConfig::Static(WEATHER_TOOL_CONFIG_STATIC.clone()),
+            ToolConfig::Static(QUERY_TOOL_CONFIG_STATIC.clone())
         ],
         tool_choice: ToolChoice::Required,
         parallel_tool_calls: true,
@@ -52,7 +54,7 @@ lazy_static! {
 
 // For use in tests which need a mutable tool config.
 pub fn get_temperature_tool_config() -> ToolCallConfig {
-    let weather_tool = ToolConfig::Static(&WEATHER_TOOL_CONFIG_STATIC);
+    let weather_tool = ToolConfig::Static(WEATHER_TOOL_CONFIG_STATIC.clone());
     ToolCallConfig {
         tools_available: vec![weather_tool],
         tool_choice: ToolChoice::Specific("get_temperature".to_string()),

--- a/gateway/src/inference/types/mod.rs
+++ b/gateway/src/inference/types/mod.rs
@@ -12,11 +12,14 @@ use std::{
 };
 use uuid::Uuid;
 
-use crate::tool::{ToolCall, ToolCallChunk, ToolCallConfig, ToolCallOutput, ToolResult};
 use crate::{endpoints::inference::InferenceDatabaseInsertMetadata, variant::InferenceConfig};
 use crate::{endpoints::inference::InferenceParams, error::ErrorDetails};
 use crate::{error::Error, variant::JsonMode};
 use crate::{function::FunctionConfig, minijinja_util::TemplateConfig};
+use crate::{
+    function::FunctionConfigType,
+    tool::{ToolCall, ToolCallChunk, ToolCallConfig, ToolCallOutput, ToolResult},
+};
 use crate::{jsonschema_util::DynamicJSONSchema, tool::ToolCallConfigDatabaseInsert};
 
 pub mod batch;
@@ -781,10 +784,10 @@ impl InferenceResultChunk {
 }
 
 impl InferenceResultChunk {
-    pub fn new(chunk: ProviderInferenceResponseChunk, function: &FunctionConfig) -> Self {
+    pub fn new(chunk: ProviderInferenceResponseChunk, function: FunctionConfigType) -> Self {
         match function {
-            FunctionConfig::Chat(_) => Self::Chat(chunk.into()),
-            FunctionConfig::Json(_) => Self::Json(chunk.into()),
+            FunctionConfigType::Chat => Self::Chat(chunk.into()),
+            FunctionConfigType::Json => Self::Json(chunk.into()),
         }
     }
 }

--- a/gateway/src/inference/types/mod.rs
+++ b/gateway/src/inference/types/mod.rs
@@ -852,7 +852,7 @@ impl From<ProviderInferenceResponseChunk> for JsonInferenceResultChunk {
 // Define the CollectChunksArgs struct with existing and new fields
 pub struct CollectChunksArgs<'a, 'b> {
     pub value: Vec<InferenceResultChunk>,
-    pub function: &'a FunctionConfig,
+    pub function: Arc<FunctionConfig>,
     pub model_name: Arc<str>,
     pub model_provider_name: Arc<str>,
     pub raw_request: String,
@@ -1704,7 +1704,7 @@ mod tests {
         let templates = TemplateConfig::default();
 
         let chunks = vec![];
-        let function_config = FunctionConfig::Chat(FunctionConfigChat::default());
+        let function_config = Arc::new(FunctionConfig::Chat(FunctionConfigChat::default()));
         let model_name = "test_model";
         let model_provider_name = "test_provider";
         let raw_request = "raw request".to_string();
@@ -1712,7 +1712,7 @@ mod tests {
             value: chunks,
             system: None,
             input_messages: vec![],
-            function: &function_config,
+            function: function_config.clone(),
             model_name: model_name.into(),
             model_provider_name: model_provider_name.into(),
             raw_request: raw_request.clone(),
@@ -1770,7 +1770,7 @@ mod tests {
             value: chunks,
             system: None,
             input_messages: vec![],
-            function: &function_config,
+            function: function_config.clone(),
             model_name: model_name.into(),
             model_provider_name: model_provider_name.into(),
             raw_request: raw_request.clone(),
@@ -1819,14 +1819,14 @@ mod tests {
         });
         let implicit_tool_call_config = ToolCallConfig::implicit_from_value(&output_schema);
         let output_schema = JSONSchemaFromPath::from_value(&output_schema).unwrap();
-        let json_function_config = FunctionConfig::Json(FunctionConfigJson {
+        let json_function_config = Arc::new(FunctionConfig::Json(FunctionConfigJson {
             variants: HashMap::new(),
             system_schema: None,
             user_schema: None,
             assistant_schema: None,
             implicit_tool_call_config,
             output_schema,
-        });
+        }));
         let usage1 = Usage {
             input_tokens: 10,
             output_tokens: 5,
@@ -1857,7 +1857,7 @@ mod tests {
             value: chunks,
             system: None,
             input_messages: vec![],
-            function: &json_function_config,
+            function: json_function_config.clone(),
             model_name: model_name.into(),
             model_provider_name: model_provider_name.into(),
             raw_request: raw_request.clone(),
@@ -1928,7 +1928,7 @@ mod tests {
             value: chunks,
             system: None,
             input_messages: vec![],
-            function: &json_function_config,
+            function: json_function_config.clone(),
             model_name: model_name.into(),
             model_provider_name: model_provider_name.into(),
             raw_request: raw_request.clone(),
@@ -1997,7 +1997,7 @@ mod tests {
             value: chunks,
             system: None,
             input_messages: vec![],
-            function: &function_config,
+            function: function_config.clone(),
             model_name: model_name.into(),
             model_provider_name: model_provider_name.into(),
             raw_request: raw_request.clone(),
@@ -2042,14 +2042,14 @@ mod tests {
         });
         let implicit_tool_call_config = ToolCallConfig::implicit_from_value(&output_schema);
         let output_schema = JSONSchemaFromPath::from_value(&output_schema).unwrap();
-        let json_function_config = FunctionConfig::Json(FunctionConfigJson {
+        let json_function_config = Arc::new(FunctionConfig::Json(FunctionConfigJson {
             variants: HashMap::new(),
             system_schema: None,
             user_schema: None,
             assistant_schema: None,
             implicit_tool_call_config,
             output_schema,
-        });
+        }));
         let usage1 = Usage {
             input_tokens: 10,
             output_tokens: 5,
@@ -2080,7 +2080,7 @@ mod tests {
             value: chunks,
             system: None,
             input_messages: vec![],
-            function: &json_function_config,
+            function: json_function_config.clone(),
             model_name: model_name.into(),
             model_provider_name: model_provider_name.into(),
             raw_request: raw_request.clone(),
@@ -2132,14 +2132,14 @@ mod tests {
         });
         let implicit_tool_call_config = ToolCallConfig::implicit_from_value(&static_output_schema);
         let output_schema = JSONSchemaFromPath::from_value(&static_output_schema).unwrap();
-        let json_function_config = FunctionConfig::Json(FunctionConfigJson {
+        let json_function_config = Arc::new(FunctionConfig::Json(FunctionConfigJson {
             variants: HashMap::new(),
             system_schema: None,
             user_schema: None,
             assistant_schema: None,
             implicit_tool_call_config,
             output_schema,
-        });
+        }));
         let usage1 = Usage {
             input_tokens: 10,
             output_tokens: 5,
@@ -2179,7 +2179,7 @@ mod tests {
             value: chunks,
             system: None,
             input_messages: vec![],
-            function: &json_function_config,
+            function: json_function_config.clone(),
             model_name: model_name.into(),
             model_provider_name: model_provider_name.into(),
             raw_request: raw_request.clone(),

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -3,6 +3,7 @@ use axum::Router;
 use mimalloc::MiMalloc;
 use std::fmt::Display;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::signal;
 
@@ -23,12 +24,10 @@ async fn main() {
     let metrics_handle = observability::setup_metrics().expect_pretty("Failed to set up metrics");
 
     // Load config
-    let config: &'static Config = Box::leak(Box::new(
-        Config::load().expect_pretty("Failed to load config"),
-    ));
+    let config: Arc<Config> = Arc::new(Config::load().expect_pretty("Failed to load config"));
 
     // Initialize AppState
-    let app_state = gateway_util::AppStateData::new(config)
+    let app_state = gateway_util::AppStateData::new(config.clone())
         .await
         .expect_pretty("Failed to initialize AppState");
 

--- a/gateway/src/testing.rs
+++ b/gateway/src/testing.rs
@@ -1,11 +1,13 @@
 #![cfg(test)]
 
+use std::sync::Arc;
+
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::config_parser::Config;
 use crate::gateway_util::AppStateData;
 
 pub fn get_unit_test_app_state_data(
-    config: &'static Config<'static>,
+    config: Arc<Config<'static>>,
     clickhouse_healthy: bool,
 ) -> AppStateData {
     let http_client = reqwest::Client::new();

--- a/gateway/src/variant/best_of_n_sampling.rs
+++ b/gateway/src/variant/best_of_n_sampling.rs
@@ -70,11 +70,11 @@ lazy_static! {
 
 impl Variant for BestOfNSamplingConfig {
     async fn infer<'a: 'request, 'request>(
-        &'a self,
+        &self,
         input: &Input,
         models: &'request InferenceModels<'a>,
         function: &'a FunctionConfig,
-        inference_config: &'request InferenceConfig<'a, 'request>,
+        inference_config: &'request InferenceConfig<'static, 'request>,
         clients: &'request InferenceClients<'request>,
         _inference_params: InferenceParams,
     ) -> Result<InferenceResult, Error> {
@@ -94,7 +94,7 @@ impl Variant for BestOfNSamplingConfig {
     async fn infer_stream<'request>(
         &self,
         _input: &Input,
-        _models: &'request InferenceModels<'static>,
+        _models: &'request InferenceModels<'_>,
         _function: &FunctionConfig,
         _inference_config: &'request InferenceConfig<'static, 'request>,
         _clients: &'request InferenceClients<'request>,
@@ -177,7 +177,7 @@ impl BestOfNSamplingConfig {
         input: &Input,
         models: &'request InferenceModels<'a>,
         function: &'a FunctionConfig,
-        inference_config: &'request InferenceConfig<'a, 'request>,
+        inference_config: &'request InferenceConfig<'static, 'request>,
         clients: &'request InferenceClients<'request>,
     ) -> Result<Vec<InferenceResult>, Error> {
         // Get all the variants we are going to infer

--- a/gateway/src/variant/best_of_n_sampling.rs
+++ b/gateway/src/variant/best_of_n_sampling.rs
@@ -92,10 +92,10 @@ impl Variant for BestOfNSamplingConfig {
     }
 
     async fn infer_stream<'request>(
-        &'static self,
+        &self,
         _input: &Input,
         _models: &'request InferenceModels<'static>,
-        _function: &'static FunctionConfig,
+        _function: &FunctionConfig,
         _inference_config: &'request InferenceConfig<'static, 'request>,
         _clients: &'request InferenceClients<'request>,
         _inference_params: InferenceParams,

--- a/gateway/src/variant/chat_completion.rs
+++ b/gateway/src/variant/chat_completion.rs
@@ -183,10 +183,10 @@ impl Variant for ChatCompletionConfig {
     }
 
     async fn infer_stream<'request>(
-        &'static self,
+        &self,
         input: &Input,
         models: &'request InferenceModels<'static>,
-        function: &'static FunctionConfig,
+        function: &FunctionConfig,
         inference_config: &'request InferenceConfig<'static, 'request>,
         clients: &'request InferenceClients<'request>,
         inference_params: InferenceParams,

--- a/gateway/src/variant/chat_completion.rs
+++ b/gateway/src/variant/chat_completion.rs
@@ -211,7 +211,7 @@ impl Variant for ChatCompletionConfig {
             function,
             clients,
             inference_params,
-            &self.retries,
+            self.retries,
         )
         .await
     }

--- a/gateway/src/variant/chat_completion.rs
+++ b/gateway/src/variant/chat_completion.rs
@@ -148,11 +148,11 @@ impl ChatCompletionConfig {
 
 impl Variant for ChatCompletionConfig {
     async fn infer<'a: 'request, 'request>(
-        &'a self,
+        &self,
         input: &Input,
         models: &'request InferenceModels<'a>,
         function: &'a FunctionConfig,
-        inference_config: &'request InferenceConfig<'a, 'request>,
+        inference_config: &'request InferenceConfig<'static, 'request>,
         clients: &'request InferenceClients<'request>,
         inference_params: InferenceParams,
     ) -> Result<InferenceResult, Error> {
@@ -185,7 +185,7 @@ impl Variant for ChatCompletionConfig {
     async fn infer_stream<'request>(
         &self,
         input: &Input,
-        models: &'request InferenceModels<'static>,
+        models: &'request InferenceModels<'_>,
         function: &FunctionConfig,
         inference_config: &'request InferenceConfig<'static, 'request>,
         clients: &'request InferenceClients<'request>,

--- a/gateway/src/variant/dicl.rs
+++ b/gateway/src/variant/dicl.rs
@@ -138,10 +138,10 @@ impl Variant for DiclConfig {
     }
 
     async fn infer_stream<'request>(
-        &'static self,
+        &self,
         input: &Input,
         models: &'request InferenceModels<'static>,
-        function: &'static FunctionConfig,
+        function: &FunctionConfig,
         inference_config: &'request InferenceConfig<'static, 'request>,
         clients: &'request InferenceClients<'request>,
         inference_params: InferenceParams,

--- a/gateway/src/variant/dicl.rs
+++ b/gateway/src/variant/dicl.rs
@@ -189,7 +189,7 @@ impl Variant for DiclConfig {
                 function,
                 clients,
                 inference_params,
-                &self.retries,
+                self.retries,
             )
             .await?;
 

--- a/gateway/src/variant/dicl.rs
+++ b/gateway/src/variant/dicl.rs
@@ -72,11 +72,11 @@ pub struct UninitializedDiclConfig {
 
 impl Variant for DiclConfig {
     async fn infer<'a: 'request, 'request>(
-        &'a self,
+        &self,
         input: &Input,
         models: &'request InferenceModels<'a>,
         function: &'a FunctionConfig,
-        inference_config: &'request InferenceConfig<'a, 'request>,
+        inference_config: &'request InferenceConfig<'static, 'request>,
         clients: &'request InferenceClients<'request>,
         inference_params: InferenceParams,
     ) -> Result<InferenceResult, Error> {
@@ -140,7 +140,7 @@ impl Variant for DiclConfig {
     async fn infer_stream<'request>(
         &self,
         input: &Input,
-        models: &'request InferenceModels<'static>,
+        models: &'request InferenceModels<'_>,
         function: &FunctionConfig,
         inference_config: &'request InferenceConfig<'static, 'request>,
         clients: &'request InferenceClients<'request>,

--- a/gateway/src/variant/mixture_of_n.rs
+++ b/gateway/src/variant/mixture_of_n.rs
@@ -52,11 +52,11 @@ pub struct FuserConfig {
 
 impl Variant for MixtureOfNConfig {
     async fn infer<'a: 'request, 'request>(
-        &'a self,
+        &self,
         input: &Input,
         models: &'request InferenceModels<'a>,
         function: &'a FunctionConfig,
-        inference_config: &'request InferenceConfig<'a, 'request>,
+        inference_config: &'request InferenceConfig<'static, 'request>,
         clients: &'request InferenceClients<'request>,
         _inference_params: InferenceParams,
     ) -> Result<InferenceResult, Error> {
@@ -77,7 +77,7 @@ impl Variant for MixtureOfNConfig {
     async fn infer_stream<'request>(
         &self,
         _input: &Input,
-        _models: &'request InferenceModels<'static>,
+        _models: &'request InferenceModels<'_>,
         _function: &FunctionConfig,
         _inference_config: &'request InferenceConfig<'static, 'request>,
         _clients: &'request InferenceClients<'request>,
@@ -160,7 +160,7 @@ impl MixtureOfNConfig {
         input: &Input,
         models: &'request InferenceModels<'a>,
         function: &'a FunctionConfig,
-        inference_config: &'request InferenceConfig<'a, 'request>,
+        inference_config: &'request InferenceConfig<'static, 'request>,
         clients: &'request InferenceClients<'request>,
     ) -> Result<Vec<InferenceResult>, Error> {
         // Get all the variants we are going to infer

--- a/gateway/src/variant/mixture_of_n.rs
+++ b/gateway/src/variant/mixture_of_n.rs
@@ -75,10 +75,10 @@ impl Variant for MixtureOfNConfig {
     }
 
     async fn infer_stream<'request>(
-        &'static self,
+        &self,
         _input: &Input,
         _models: &'request InferenceModels<'static>,
-        _function: &'static FunctionConfig,
+        _function: &FunctionConfig,
         _inference_config: &'request InferenceConfig<'static, 'request>,
         _clients: &'request InferenceClients<'request>,
         _inference_params: InferenceParams,

--- a/gateway/src/variant/mod.rs
+++ b/gateway/src/variant/mod.rs
@@ -113,10 +113,10 @@ pub trait Variant {
     ) -> Result<InferenceResult, Error>;
 
     async fn infer_stream<'request>(
-        &'static self,
+        &self,
         input: &Input,
         models: &'request InferenceModels<'static>,
-        function: &'static FunctionConfig,
+        function: &FunctionConfig,
         inference_config: &'request InferenceConfig<'static, 'request>,
         clients: &'request InferenceClients<'request>,
         inference_params: InferenceParams,
@@ -228,10 +228,10 @@ impl Variant for VariantConfig {
         skip_all
     )]
     async fn infer_stream<'request>(
-        &'static self,
+        &self,
         input: &Input,
         models: &'request InferenceModels<'static>,
-        function: &'static FunctionConfig,
+        function: &FunctionConfig,
         inference_config: &'request InferenceConfig<'static, 'request>,
         clients: &'request InferenceClients<'request>,
         inference_params: InferenceParams,

--- a/gateway/src/variant/mod.rs
+++ b/gateway/src/variant/mod.rs
@@ -58,7 +58,7 @@ pub enum JsonMode {
 #[derive(Debug)]
 pub struct InferenceConfig<'a, 'request> {
     pub tool_config: Option<&'request ToolCallConfig>,
-    pub templates: &'a TemplateConfig<'a>,
+    pub templates: &'request TemplateConfig<'a>,
     pub dynamic_output_schema: Option<&'request DynamicJSONSchema>,
     pub function_name: &'request str,
     pub variant_name: Option<&'request str>,
@@ -103,11 +103,11 @@ pub struct ModelUsedInfo {
 
 pub trait Variant {
     async fn infer<'a: 'request, 'request>(
-        &'a self,
+        &self,
         input: &Input,
         models: &'request InferenceModels<'a>,
         function: &'a FunctionConfig,
-        inference_config: &'request InferenceConfig<'a, 'request>,
+        inference_config: &'request InferenceConfig<'static, 'request>,
         clients: &'request InferenceClients<'request>,
         inference_params: InferenceParams,
     ) -> Result<InferenceResult, Error>;
@@ -115,7 +115,7 @@ pub trait Variant {
     async fn infer_stream<'request>(
         &self,
         input: &Input,
-        models: &'request InferenceModels<'static>,
+        models: &'request InferenceModels<'_>,
         function: &FunctionConfig,
         inference_config: &'request InferenceConfig<'static, 'request>,
         clients: &'request InferenceClients<'request>,
@@ -162,11 +162,11 @@ impl Variant for VariantConfig {
         skip_all
     )]
     async fn infer<'a: 'request, 'request>(
-        &'a self,
+        &self,
         input: &Input,
         models: &'request InferenceModels<'a>,
         function: &'a FunctionConfig,
-        inference_config: &'request InferenceConfig<'a, 'request>,
+        inference_config: &'request InferenceConfig<'static, 'request>,
         clients: &'request InferenceClients<'request>,
         inference_params: InferenceParams,
     ) -> Result<InferenceResult, Error> {
@@ -227,10 +227,10 @@ impl Variant for VariantConfig {
         fields(function_name = %inference_config.function_name, variant_name = %inference_config.variant_name.unwrap_or("")),
         skip_all
     )]
-    async fn infer_stream<'request>(
+    async fn infer_stream<'a, 'request>(
         &self,
         input: &Input,
-        models: &'request InferenceModels<'static>,
+        models: &'request InferenceModels<'a>,
         function: &FunctionConfig,
         inference_config: &'request InferenceConfig<'static, 'request>,
         clients: &'request InferenceClients<'request>,

--- a/gateway/tests/e2e/batch.rs
+++ b/gateway/tests/e2e/batch.rs
@@ -5,6 +5,7 @@ mod providers;
 
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use gateway::clickhouse::ClickHouseConnectionInfo;
 use gateway::config_parser::Config;
@@ -326,10 +327,10 @@ async fn test_write_read_completed_batch_inference_chat() {
         status,
         errors,
     });
-    let function_config = FunctionConfig::Chat(FunctionConfigChat {
+    let function_config = Arc::new(FunctionConfig::Chat(FunctionConfigChat {
         variants: HashMap::new(),
         ..Default::default()
-    });
+    }));
     let config = Config {
         functions: HashMap::from([(function_name.to_string(), function_config)]),
         ..Default::default()
@@ -519,11 +520,11 @@ async fn test_write_read_completed_batch_inference_json() {
         "required": ["answer"]
     }))
     .unwrap();
-    let function_config = FunctionConfig::Json(FunctionConfigJson {
+    let function_config = Arc::new(FunctionConfig::Json(FunctionConfigJson {
         variants: HashMap::new(),
         output_schema,
         ..Default::default()
-    });
+    }));
     let config = Config {
         functions: HashMap::from([(function_name.to_string(), function_config)]),
         ..Default::default()


### PR DESCRIPTION
This required many lifetime-related factors (such as introducing `Arc`s and removing unnecessary `'static` lifetimes), and is best reviewed commit-by-commit.

Depends on https://github.com/tensorzero/tensorzero/pull/772
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor codebase to use `Arc<Config>` instead of `&'static Config` for improved memory management and flexibility.
> 
>   - **Behavior**:
>     - Replace `&'static Config` with `Arc<Config>` in function signatures and struct fields across multiple files for better memory management.
>     - Update function calls and logic to accommodate `Arc<Config>`.
>   - **Files and Functions**:
>     - `config_parser.rs`: Modify `Config` struct and related functions to use `Arc<Config>`.
>     - `endpoints/batch_inference.rs`, `endpoints/feedback.rs`, `endpoints/inference.rs`: Update function signatures and logic to use `Arc<Config>`.
>     - `tool.rs`, `variant/best_of_n_sampling.rs`, `variant/chat_completion.rs`, `variant/dicl.rs`, `variant/mixture_of_n.rs`: Adjust tool and variant configurations to use `Arc<Config>`.
>   - **Tests**:
>     - Update test cases in `tests/e2e/batch.rs` and other test files to reflect changes in configuration handling.
>     - Ensure tests accommodate `Arc<Config>` usage in setup and assertions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for daa6a6b77114c2c3cbc8f50a5d9b52752442edef. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->