### PR TITLE
Assign different episode IDs to batch inferences if none are specified

### DIFF
--- a/gateway/src/inference/types/batch.rs
+++ b/gateway/src/inference/types/batch.rs
@@ -296,7 +296,7 @@ impl TryFrom<BatchEpisodeIdsWithSize> for BatchEpisodeIds {
     fn try_from(
         BatchEpisodeIdsWithSize(episode_ids, num_inferences): BatchEpisodeIdsWithSize,
     ) -> Result<Self, Self::Error> {
-        let episode_ids = match episode_ids {
+        let episode_ids: Vec<Uuid> = match episode_ids {
             Some(episode_ids) => {
                 if episode_ids.len() != num_inferences {
                     return Err(ErrorDetails::InvalidRequest {
@@ -314,7 +314,7 @@ impl TryFrom<BatchEpisodeIdsWithSize> for BatchEpisodeIds {
                     .map(|id| id.unwrap_or_else(Uuid::now_v7))
                     .collect()
             }
-            None => vec![Uuid::now_v7(); num_inferences],
+            None => (0..num_inferences).map(|_| Uuid::now_v7()).collect(),
         };
         episode_ids.iter().enumerate().try_for_each(|(i, id)| {
             validate_episode_id(*id).map_err(|e| {

--- a/gateway/src/inference/types/batch.rs
+++ b/gateway/src/inference/types/batch.rs
@@ -537,10 +537,16 @@ mod tests {
         let batch_episode_ids_with_size = BatchEpisodeIdsWithSize(None, 3);
         let batch_episode_ids = BatchEpisodeIds::try_from(batch_episode_ids_with_size).unwrap();
         assert_eq!(batch_episode_ids.len(), 3);
+        assert_ne!(batch_episode_ids[0], batch_episode_ids[1]);
+        assert_ne!(batch_episode_ids[1], batch_episode_ids[2]);
+        assert_ne!(batch_episode_ids[0], batch_episode_ids[2]);
 
         let batch_episode_ids_with_size = BatchEpisodeIdsWithSize(Some(vec![None, None, None]), 3);
         let batch_episode_ids = BatchEpisodeIds::try_from(batch_episode_ids_with_size).unwrap();
         assert_eq!(batch_episode_ids.len(), 3);
+        assert_ne!(batch_episode_ids[0], batch_episode_ids[1]);
+        assert_ne!(batch_episode_ids[1], batch_episode_ids[2]);
+        assert_ne!(batch_episode_ids[0], batch_episode_ids[2]);
 
         let episode_id_0 = Uuid::now_v7();
         let episode_id_1 = Uuid::now_v7();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes bug in `BatchEpisodeIdsWithSize` conversion to ensure unique episode IDs for each inference in `batch.rs`.
> 
>   - **Behavior**:
>     - Fixes bug in `try_from` for `BatchEpisodeIdsWithSize` in `batch.rs` to ensure unique episode IDs for each inference.
>     - Changes `None` case to generate unique IDs using `Uuid::now_v7()` for each inference.
>   - **Tests**:
>     - Adds assertions in `test_try_from_batch_episode_ids_with_size` to verify unique episode IDs are generated for each inference.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ae37f46bc160b1bbf3aeea5093562e32a0d953bb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->