### PR TITLE
Bump version 2025.01.4

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorzero"
-version = "2025.01.2"
+version = "2025.01.4"
 description = "The Python client for TensorZero"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/clients/python/uv.lock
+++ b/clients/python/uv.lock
@@ -157,7 +157,7 @@ wheels = [
 
 [[package]]
 name = "tensorzero"
-version = "2025.01.2"
+version = "2025.01.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/gateway/src/endpoints/status.rs
+++ b/gateway/src/endpoints/status.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::response::Json;
 use serde_json::{json, Value};
 
-const TENSORZERO_VERSION: &str = "2025.01.2";
+const TENSORZERO_VERSION: &str = "2025.01.4";
 
 /// A handler for a simple liveness check
 #[debug_handler]

--- a/gateway/src/inference/types/batch.rs
+++ b/gateway/src/inference/types/batch.rs
@@ -296,7 +296,7 @@ impl TryFrom<BatchEpisodeIdsWithSize> for BatchEpisodeIds {
     fn try_from(
         BatchEpisodeIdsWithSize(episode_ids, num_inferences): BatchEpisodeIdsWithSize,
     ) -> Result<Self, Self::Error> {
-        let episode_ids = match episode_ids {
+        let episode_ids: Vec<Uuid> = match episode_ids {
             Some(episode_ids) => {
                 if episode_ids.len() != num_inferences {
                     return Err(ErrorDetails::InvalidRequest {
@@ -314,7 +314,7 @@ impl TryFrom<BatchEpisodeIdsWithSize> for BatchEpisodeIds {
                     .map(|id| id.unwrap_or_else(Uuid::now_v7))
                     .collect()
             }
-            None => vec![Uuid::now_v7(); num_inferences],
+            None => (0..num_inferences).map(|_| Uuid::now_v7()).collect(),
         };
         episode_ids.iter().enumerate().try_for_each(|(i, id)| {
             validate_episode_id(*id).map_err(|e| {

--- a/gateway/src/inference/types/batch.rs
+++ b/gateway/src/inference/types/batch.rs
@@ -537,10 +537,16 @@ mod tests {
         let batch_episode_ids_with_size = BatchEpisodeIdsWithSize(None, 3);
         let batch_episode_ids = BatchEpisodeIds::try_from(batch_episode_ids_with_size).unwrap();
         assert_eq!(batch_episode_ids.len(), 3);
+        assert_ne!(batch_episode_ids[0], batch_episode_ids[1]);
+        assert_ne!(batch_episode_ids[1], batch_episode_ids[2]);
+        assert_ne!(batch_episode_ids[0], batch_episode_ids[2]);
 
         let batch_episode_ids_with_size = BatchEpisodeIdsWithSize(Some(vec![None, None, None]), 3);
         let batch_episode_ids = BatchEpisodeIds::try_from(batch_episode_ids_with_size).unwrap();
         assert_eq!(batch_episode_ids.len(), 3);
+        assert_ne!(batch_episode_ids[0], batch_episode_ids[1]);
+        assert_ne!(batch_episode_ids[1], batch_episode_ids[2]);
+        assert_ne!(batch_episode_ids[0], batch_episode_ids[2]);
 
         let episode_id_0 = Uuid::now_v7();
         let episode_id_1 = Uuid::now_v7();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `tensorzero` version to `2025.01.4` and enhance UUID generation logic and tests in `batch.rs`.
> 
>   - **Version Update**:
>     - Bump `tensorzero` version to `2025.01.4` in `pyproject.toml`, `uv.lock`, and `status.rs`.
>   - **UUID Generation**:
>     - Refactor UUID generation logic in `batch.rs` to ensure unique UUIDs for each inference.
>   - **Testing**:
>     - Add assertions in `batch.rs` tests to verify UUID uniqueness across generated IDs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2ac100399b316e7ddf1df1ae375fc7553ac3dc66. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->