### PR TITLE
Save and print e2e logs to a file in CI

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Launch the gateway for E2E tests
         run: |
-          cargo run-e2e &
+          cargo run-e2e > e2e_logs.txt 2>&1 &
           while ! curl -s -f http://localhost:3000/health >/dev/null 2>&1; do
             echo "Waiting for gateway to be healthy..."
             sleep 1
@@ -87,6 +87,10 @@ jobs:
       - name: Run all tests (including E2E tests)
         run: |
           cargo test-all --profile ci ${{ vars.CARGO_NEXTEST_ARGS }}
+
+      - name: Print e2e logs
+        if: always()
+        run: cat e2e_logs.txt
 
       - name: Install Python for python async client tests
         run: uv python install 3.10


### PR DESCRIPTION
This will help us debug 5xx errors from the gateway in the merge queue
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Redirects E2E test logs to a file and prints them in CI for debugging 5xx errors in `merge-queue.yml`.
> 
>   - **CI Workflow**:
>     - Redirects `cargo run-e2e` output to `e2e_logs.txt` in `merge-queue.yml`.
>     - Adds a step to print `e2e_logs.txt` after tests, using `cat` command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 48ecc91de657a839ef95346e13c565b7a95b508b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->