### PR TITLE
Only use '#[wasm_bindgen_test]' for wasm-only tests

### DIFF
--- a/ui/app/utils/minijinja/src/lib.rs
+++ b/ui/app/utils/minijinja/src/lib.rs
@@ -51,12 +51,12 @@ pub fn create_env(templates: JsValue) -> Result<JsExposedEnv, JsError> {
 
 #[cfg(test)]
 mod tests {
+    #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
     use super::*;
     use serde_json::json;
     use wasm_bindgen_test::*;
 
     #[wasm_bindgen_test]
-    #[test]
     fn test_basic_template_rendering() {
         // Create a simple template environment
         let templates = HashMap::from([("hello".to_string(), "Hello, {{ name }}!".to_string())]);
@@ -80,7 +80,6 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    #[test]
     fn test_template_error_handling() {
         // Test with invalid template syntax
         let templates = HashMap::from([(


### PR DESCRIPTION
These two tests call 'serde_wasm_bindgen', which causes them to panic on non-wasm targets. They should not have a `#[test]` attribute, since it only makes sense to run them on WASM.

This allows 'cargo test' to succeed without any additional arguments - previously, it would fail when trying to run the minijinja tests on non-wasm targets.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `#[test]` attribute from WASM-specific tests in `lib.rs` to prevent non-WASM target panics.
> 
>   - **Tests**:
>     - Remove `#[test]` attribute from `test_basic_template_rendering()` and `test_template_error_handling()` in `lib.rs`.
>     - Use `#[wasm_bindgen_test]` exclusively for tests that require WASM, preventing panics on non-WASM targets.
>     - Add `#![cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]` to suppress dead code warnings for non-WASM targets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a869f1bbfd62cc1fffc28888ffa4c76778fa4265. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->