### PR TITLE
Reject all names / tags that start with `tensorzero::`

### DIFF
--- a/tensorzero_internal/src/endpoints/feedback.rs
+++ b/tensorzero_internal/src/endpoints/feedback.rs
@@ -19,7 +19,7 @@ use crate::inference::types::{parse_chat_output, ContentBlock, ContentBlockOutpu
 use crate::tool::{DynamicToolParams, StaticToolConfig, ToolCall, ToolCallConfig};
 use crate::uuid_util::uuid_elapsed;
 
-use super::check_tags;
+use super::validate_tags;
 
 /// There is a potential issue here where if we write an inference and then immediately write feedback for it,
 /// we might not be able to find the inference in the database because it hasn't been written yet.
@@ -80,7 +80,7 @@ pub async fn feedback_handler(
     }): AppState,
     StructuredJson(params): StructuredJson<Params>,
 ) -> Result<Json<Value>, Error> {
-    check_tags(&params.tags)?;
+    validate_tags(&params.tags)?;
     // Get the metric config or return an error if it doesn't exist
     let feedback_metadata = get_feedback_metadata(
         &config,

--- a/tensorzero_internal/src/endpoints/feedback.rs
+++ b/tensorzero_internal/src/endpoints/feedback.rs
@@ -19,6 +19,8 @@ use crate::inference::types::{parse_chat_output, ContentBlock, ContentBlockOutpu
 use crate::tool::{DynamicToolParams, StaticToolConfig, ToolCall, ToolCallConfig};
 use crate::uuid_util::uuid_elapsed;
 
+use super::check_tags;
+
 /// There is a potential issue here where if we write an inference and then immediately write feedback for it,
 /// we might not be able to find the inference in the database because it hasn't been written yet.
 ///
@@ -78,6 +80,7 @@ pub async fn feedback_handler(
     }): AppState,
     StructuredJson(params): StructuredJson<Params>,
 ) -> Result<Json<Value>, Error> {
+    check_tags(&params.tags)?;
     // Get the metric config or return an error if it doesn't exist
     let feedback_metadata = get_feedback_metadata(
         &config,

--- a/tensorzero_internal/src/endpoints/inference.rs
+++ b/tensorzero_internal/src/endpoints/inference.rs
@@ -36,6 +36,8 @@ use crate::tool::{DynamicToolParams, ToolCallConfig};
 use crate::uuid_util::validate_episode_id;
 use crate::variant::{InferenceConfig, Variant};
 
+use super::check_tags;
+
 /// The expected payload is a JSON object with the following fields:
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -147,6 +149,7 @@ pub async fn inference(
 ) -> Result<InferenceOutput, Error> {
     // To be used for the Inference table processing_time measurements
     let start_time = Instant::now();
+    check_tags(&params.tags)?;
     // Get the function config or return an error if it doesn't exist
     let function = config.get_function(&params.function_name)?.clone();
     let tool_config = function.prepare_tool_config(params.dynamic_tool_params, &config.tools)?;

--- a/tensorzero_internal/src/endpoints/inference.rs
+++ b/tensorzero_internal/src/endpoints/inference.rs
@@ -36,7 +36,7 @@ use crate::tool::{DynamicToolParams, ToolCallConfig};
 use crate::uuid_util::validate_episode_id;
 use crate::variant::{InferenceConfig, Variant};
 
-use super::check_tags;
+use super::validate_tags;
 
 /// The expected payload is a JSON object with the following fields:
 #[derive(Debug, Deserialize)]
@@ -149,7 +149,7 @@ pub async fn inference(
 ) -> Result<InferenceOutput, Error> {
     // To be used for the Inference table processing_time measurements
     let start_time = Instant::now();
-    check_tags(&params.tags)?;
+    validate_tags(&params.tags)?;
     // Get the function config or return an error if it doesn't exist
     let function = config.get_function(&params.function_name)?.clone();
     let tool_config = function.prepare_tool_config(params.dynamic_tool_params, &config.tools)?;

--- a/tensorzero_internal/src/endpoints/mod.rs
+++ b/tensorzero_internal/src/endpoints/mod.rs
@@ -9,7 +9,7 @@ pub mod inference;
 pub mod openai_compatible;
 pub mod status;
 
-fn check_tags(tags: &HashMap<String, String>) -> Result<(), Error> {
+fn validate_tags(tags: &HashMap<String, String>) -> Result<(), Error> {
     for tag_name in tags.keys() {
         if tag_name.starts_with("tensorzero::") {
             return Err(Error::new(ErrorDetails::InvalidRequest {
@@ -18,4 +18,17 @@ fn check_tags(tags: &HashMap<String, String>) -> Result<(), Error> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_tags() {
+        let mut tags = HashMap::new();
+        assert!(validate_tags(&tags).is_ok());
+        tags.insert("tensorzero::test".to_string(), "test".to_string());
+        assert!(validate_tags(&tags).is_err());
+    }
 }

--- a/tensorzero_internal/src/endpoints/mod.rs
+++ b/tensorzero_internal/src/endpoints/mod.rs
@@ -1,6 +1,21 @@
+use std::collections::HashMap;
+
+use crate::error::{Error, ErrorDetails};
+
 pub mod batch_inference;
 pub mod fallback;
 pub mod feedback;
 pub mod inference;
 pub mod openai_compatible;
 pub mod status;
+
+fn check_tags(tags: &HashMap<String, String>) -> Result<(), Error> {
+    for tag_name in tags.keys() {
+        if tag_name.starts_with("tensorzero::") {
+            return Err(Error::new(ErrorDetails::InvalidRequest {
+                message: format!("Tag name cannot start with 'tensorzero::': {tag_name}"),
+            }));
+        }
+    }
+    Ok(())
+}

--- a/tensorzero_internal/src/function.rs
+++ b/tensorzero_internal/src/function.rs
@@ -254,6 +254,14 @@ impl FunctionConfig {
     ) -> Result<(), Error> {
         // Validate each variant
         for (variant_name, variant) in self.variants() {
+            if variant_name.starts_with("tensorzero::") {
+                return Err(ErrorDetails::Config {
+                    message: format!(
+                        "Variant name cannot start with 'tensorzero::': {variant_name}"
+                    ),
+                }
+                .into());
+            }
             variant.validate(
                 self,
                 models,

--- a/tensorzero_internal/src/model.rs
+++ b/tensorzero_internal/src/model.rs
@@ -166,8 +166,52 @@ impl ModelConfig {
         }))
     }
 
-    pub fn validate(&self) -> Result<(), Error> {
-        // Placeholder in case we want to add validation in the future
+    pub fn validate(&self, model_name: &str) -> Result<(), Error> {
+        // Ensure that the model has at least one provider
+        if self.routing.is_empty() {
+            return Err(ErrorDetails::Config {
+                message: format!("`models.{model_name}`: `routing` must not be empty"),
+            }
+            .into());
+        }
+
+        // Ensure that routing entries are unique and exist as keys in providers
+        let mut seen_providers = std::collections::HashSet::new();
+        for provider in &self.routing {
+            if provider.starts_with("tensorzero::") {
+                return Err(ErrorDetails::Config {
+                    message: format!("`models.{model_name}.routing`: Provider name cannot start with 'tensorzero::': {provider}"),
+                }
+                .into());
+            }
+            if !seen_providers.insert(provider) {
+                return Err(ErrorDetails::Config {
+                    message: format!("`models.{model_name}.routing`: duplicate entry `{provider}`"),
+                }
+                .into());
+            }
+
+            if !self.providers.contains_key(provider) {
+                return Err(ErrorDetails::Config {
+            message: format!(
+                "`models.{model_name}`: `routing` contains entry `{provider}` that does not exist in `providers`"
+            ),
+        }
+        .into());
+            }
+        }
+
+        // Validate each provider
+        for provider_name in self.providers.keys() {
+            if !seen_providers.contains(provider_name) {
+                return Err(ErrorDetails::Config {
+                    message: format!(
+                "`models.{model_name}`: Provider `{provider_name}` is not listed in `routing`"
+            ),
+                }
+                .into());
+            }
+        }
         Ok(())
     }
 }
@@ -862,10 +906,14 @@ impl TryFrom<(CredentialLocation, &str)> for Credential {
 }
 
 lazy_static! {
-    static ref RESERVED_MODEL_PREFIXES: Vec<String> = ProviderConfigHelper::VARIANTS
-        .iter()
-        .map(|&v| format!("{}::", v))
-        .collect();
+    static ref RESERVED_MODEL_PREFIXES: Vec<String> = {
+        let mut prefixes: Vec<String> = ProviderConfigHelper::VARIANTS
+            .iter()
+            .map(|&v| format!("{}::", v))
+            .collect();
+        prefixes.push("tensorzero::".to_string());
+        prefixes
+    };
 }
 
 const SHORTHAND_MODEL_PREFIXES: &[&str] = &[
@@ -916,7 +964,7 @@ impl ModelTable {
         // Try direct lookup (if it's blacklisted, it's not in the table)
         // If it's shorthand and already in the table, it's valid
         if let Some(model_config) = self.0.get(key) {
-            model_config.validate()?;
+            model_config.validate(key)?;
             return Ok(());
         }
 
@@ -940,7 +988,7 @@ impl ModelTable {
             // Remove the last two characters of the prefix to get the provider type
             let provider_type = &prefix[..prefix.len() - 2];
             let model_config = model_config_from_shorthand(provider_type, model_name)?;
-            model_config.validate()?;
+            model_config.validate(key)?;
             self.0.insert(key.into(), model_config);
             return Ok(());
         }


### PR DESCRIPTION
Closes #597 

This PR should cover:
* Functions
* Variants
* Models
* Providers
* Tools
* Metrics
* Embedding models
* Tag keys for inferences and feedback
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rejects all names and tags starting with `tensorzero::` across various components, adding validation and tests.
> 
>   - **Validation**:
>     - Rejects names starting with `tensorzero::` for functions, models, tools, metrics, embedding models, and variants in `config_parser.rs` and `function.rs`.
>     - Adds `validate_tags()` in `endpoints/mod.rs` to reject tags starting with `tensorzero::`.
>   - **Tests**:
>     - Adds tests in `config_parser.rs` to ensure validation fails for names starting with `tensorzero::`.
>     - Adds tests in `endpoints/mod.rs` to ensure `validate_tags()` works correctly.
>   - **Misc**:
>     - Updates `ModelConfig::validate()` in `model.rs` to include new validation logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 9a3882c3356615dd8c8155b29eae2819ea772f4d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->