### PR TITLE
Explicitly set AWS bedrock region in e2e tensorzero.toml

### DIFF
--- a/tensorzero_internal/tests/e2e/tensorzero.toml
+++ b/tensorzero_internal/tests/e2e/tensorzero.toml
@@ -58,6 +58,7 @@ model_name = "claude-3-haiku-20240307"
 [models.claude-3-haiku-20240307.providers.aws-bedrock]
 type = "aws_bedrock"
 model_id = "anthropic.claude-3-haiku-20240307-v1:0"
+region = "us-east-1"
 
 [models.claude-3-haiku-20240307-us-east-1]
 routing = ["aws-bedrock-us-east-1"]
@@ -98,6 +99,7 @@ routing = ["aws-bedrock"]
 [models.claude-3-haiku-20240307-aws-bedrock.providers.aws-bedrock]
 type = "aws_bedrock"
 model_id = "anthropic.claude-3-haiku-20240307-v1:0"
+region = "us-east-1"
 
 [models.claude-3-haiku-20240307-gcp-vertex]
 routing = ["gcp_vertex_anthropic"]


### PR DESCRIPTION
The default provider in the AWS `RegionProviderChain` will try many different strategies to detect the region, including making network requests to '169.254.169.254' (which will time out when not running on AWS).

We should change our behavior to avoid this footgun (e.g. require an explicit opt-in for this network-based region detection behavior). For now, let's speed up the test server by explicitly setting the region, which will skip the region-detection logic
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Explicitly set AWS region in `tensorzero.toml` to prevent network-based region detection and speed up tests.
> 
>   - **Behavior**:
>     - Explicitly sets `region = "us-east-1"` for `aws-bedrock` providers in `tensorzero.toml`.
>     - Skips network-based region detection, preventing timeouts when not on AWS.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2fefbc66156c93006a7dd43fae49bd7d5a584620. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->