### PR TITLE
added support for json mode setting in evaluator of `best_of_n` variants

### DIFF
--- a/tensorzero_internal/src/config_parser.rs
+++ b/tensorzero_internal/src/config_parser.rs
@@ -559,7 +559,8 @@ mod tests {
             VariantConfig::ChatCompletion(chat_config) => &chat_config.json_mode,
             _ => panic!("Expected a chat completion variant"),
         };
-        assert_eq!(prompt_b_json_mode, &JsonMode::On);
+        // The default json mode is strict, so this should be strict
+        assert_eq!(prompt_b_json_mode, &JsonMode::Strict);
         // Check that the tool choice for get_weather is set to "specific" and the correct tool
         let function = config.functions.get("weather_helper").unwrap();
         match &**function {

--- a/tensorzero_internal/src/variant/best_of_n_sampling.rs
+++ b/tensorzero_internal/src/variant/best_of_n_sampling.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::sync::Arc;
 use std::{collections::HashMap, path::PathBuf};
 
@@ -14,10 +15,11 @@ use crate::endpoints::inference::{InferenceClients, InferenceModels};
 use crate::error::ErrorDetails;
 use crate::inference::types::{
     batch::StartBatchModelInferenceWithMetadata, ContentBlock, FunctionType, ModelInferenceRequest,
-    ModelInferenceRequestJsonMode, ModelInferenceResponseWithMetadata, RequestMessage, Role, Usage,
+    ModelInferenceResponseWithMetadata, RequestMessage, Role, Usage,
 };
 use crate::jsonschema_util::JSONSchemaFromPath;
 use crate::model::ModelTable;
+use crate::tool::{ImplicitToolConfig, ToolCallConfig, ToolChoice, ToolConfig};
 use crate::{
     endpoints::inference::InferenceParams,
     error::Error,
@@ -28,7 +30,7 @@ use crate::{
     variant::chat_completion::ChatCompletionConfig,
 };
 
-use super::{InferenceConfig, ModelUsedInfo, Variant};
+use super::{InferenceConfig, JsonMode, ModelUsedInfo, Variant};
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -65,6 +67,13 @@ lazy_static! {
             "additionalProperties": false
         }))
         .expect("Failed to create schema for evaluator output")
+    };
+    static ref IMPLICIT_TOOL_CALL_CONFIG: ToolCallConfig = ToolCallConfig {
+        tools_available: vec![ToolConfig::Implicit(ImplicitToolConfig {
+            parameters: EVALUATOR_OUTPUT_SCHEMA.clone(),
+        })],
+        tool_choice: ToolChoice::Specific("respond".to_string()),
+        parallel_tool_calls: false,
     };
 }
 
@@ -380,11 +389,12 @@ async fn inner_select_best_candidate<'a, 'request>(
         model_inference_response,
         evaluator.inner.model.clone(),
     );
-    let text_content = match model_inference_result
+    let raw = match model_inference_result
         .output
         .iter()
         .find_map(|block| match block {
-            ContentBlock::Text(text) => Some(text),
+            ContentBlock::Text(text) => Some(&text.text),
+            ContentBlock::ToolCall(tool_call) => Some(&tool_call.arguments),
             _ => None,
         }) {
         Some(text) => text,
@@ -395,7 +405,7 @@ async fn inner_select_best_candidate<'a, 'request>(
             return Ok((None, Some(model_inference_result)));
         }
     };
-    let parsed_output = match serde_json::from_str::<Value>(&text_content.text) {
+    let parsed_output = match serde_json::from_str::<Value>(raw) {
         Ok(value) => value,
         Err(e) => {
             Error::new(ErrorDetails::Inference {
@@ -592,11 +602,15 @@ impl EvaluatorConfig {
                 self.inner.presence_penalty,
                 self.inner.frequency_penalty,
             );
+        let tool_config = match self.inner.json_mode {
+            JsonMode::ImplicitTool => Some(Cow::Borrowed(&*IMPLICIT_TOOL_CALL_CONFIG)),
+            _ => None,
+        };
         Ok((
             ModelInferenceRequest {
                 messages,
                 system,
-                tool_config: None,
+                tool_config,
                 temperature: inference_params.chat_completion.temperature,
                 max_tokens: inference_params.chat_completion.max_tokens,
                 seed: inference_params.chat_completion.seed,
@@ -604,7 +618,7 @@ impl EvaluatorConfig {
                 presence_penalty: inference_params.chat_completion.presence_penalty,
                 frequency_penalty: inference_params.chat_completion.frequency_penalty,
                 stream: false,
-                json_mode: ModelInferenceRequestJsonMode::Strict, // TODO (#338): Handle Anthropic models better here.
+                json_mode: (&self.inner.json_mode).into(),
                 function_type: FunctionType::Json,
                 output_schema: Some(EVALUATOR_OUTPUT_SCHEMA.value),
             },

--- a/tensorzero_internal/src/variant/chat_completion.rs
+++ b/tensorzero_internal/src/variant/chat_completion.rs
@@ -1691,7 +1691,10 @@ mod tests {
         assert_eq!(model_request.top_p, Some(0.9));
         assert_eq!(model_request.presence_penalty, Some(0.1));
         assert_eq!(model_request.frequency_penalty, Some(0.2));
-        assert_eq!(model_request.json_mode, ModelInferenceRequestJsonMode::On);
+        assert_eq!(
+            model_request.json_mode,
+            ModelInferenceRequestJsonMode::Strict
+        );
         assert_eq!(model_request.output_schema, Some(&output_schema_value));
         assert_eq!(inference_params.chat_completion.temperature, Some(0.5));
         assert_eq!(inference_params.chat_completion.max_tokens, Some(100));

--- a/tensorzero_internal/src/variant/mod.rs
+++ b/tensorzero_internal/src/variant/mod.rs
@@ -48,8 +48,8 @@ pub enum VariantConfig {
 #[serde(rename_all = "snake_case")]
 pub enum JsonMode {
     Off,
-    #[default]
     On,
+    #[default]
     Strict,
     ImplicitTool,
 }

--- a/tensorzero_internal/tests/e2e/best_of_n.rs
+++ b/tensorzero_internal/tests/e2e/best_of_n.rs
@@ -311,6 +311,7 @@ async fn e2e_test_best_of_n_json_real_judge() {
 
     let payload = json!({
         "function_name": "best_of_n_json",
+        "variant_name": "best_of_n_variant",
         "episode_id": episode_id,
         "input":{
             "system": {"assistant_name": "AskJeeves"},
@@ -569,5 +570,288 @@ async fn e2e_test_best_of_n_json_real_judge() {
             .iter()
             .map(|s| s.to_string())
             .collect();
+    assert_eq!(model_names, expected_model_names);
+}
+
+/// This test calls a function which currently uses best of n.
+/// We call 3 dummy models, one that gives malformed JSON, one that gives a correct JSON response,
+/// and one that gives an incorrect but well-formed JSON response.
+/// We check that the good response is selected and that the other responses are not
+/// but they get stored to the ModelInference table.
+/// This test uses implicit_tool in the evaluator, so we also check that there was actually a tool call made under the hood.
+#[tokio::test]
+async fn e2e_test_best_of_n_json_real_judge_implicit_tool() {
+    let episode_id = Uuid::now_v7();
+
+    let payload = json!({
+        "function_name": "best_of_n_json",
+        "variant_name": "best_of_n_variant_implicit_tool",
+        "episode_id": episode_id,
+        "input":{
+            "system": {"assistant_name": "AskJeeves"},
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "What's the first word in the typical output of one's first program. Answer as a json object with a single field 'answer' containing the string."
+                }
+            ]},
+        "stream": false,
+    });
+
+    let response = Client::new()
+        .post(get_gateway_endpoint("/inference"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    // Check Response is OK, then fields in order
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_json = response.json::<Value>().await.unwrap();
+    // Check that inference_id is here
+    let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
+    let inference_id = Uuid::parse_str(inference_id).unwrap();
+    // Check that raw_content is same as content
+    let output = response_json.get("output").unwrap();
+    let parsed_output = output.get("parsed").unwrap();
+    let answer = parsed_output.get("answer").unwrap().as_str().unwrap();
+    assert_eq!(answer, "Hello");
+    // Check that usage is correct
+    let usage = response_json.get("usage").unwrap();
+    let usage = usage.as_object().unwrap();
+    let input_tokens = usage.get("input_tokens").unwrap().as_u64().unwrap();
+    let output_tokens = usage.get("output_tokens").unwrap().as_u64().unwrap();
+    assert!(input_tokens > 100);
+    assert!(output_tokens > 20);
+    // Sleep for 1 second to allow time for data to be inserted into ClickHouse (trailing writes from API)
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    // Check ClickHouse
+    let clickhouse = get_clickhouse().await;
+    let result = select_json_inference_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+    let id = result.get("id").unwrap().as_str().unwrap();
+    let id_uuid = Uuid::parse_str(id).unwrap();
+    assert_eq!(id_uuid, inference_id);
+    let input: Value =
+        serde_json::from_str(result.get("input").unwrap().as_str().unwrap()).unwrap();
+    let correct_input: Value = json!(
+        {
+            "system": {
+                "assistant_name": "AskJeeves"
+            },
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "value": "What's the first word in the typical output of one's first program. Answer as a json object with a single field 'answer' containing the string."}]
+                }
+            ]
+        }
+    );
+    assert_eq!(input, correct_input);
+    // Check that json parsed output is correct
+    let output = result.get("output").unwrap().as_str().unwrap();
+    let output: Value = serde_json::from_str(output).unwrap();
+    let parsed_output = output.get("parsed").unwrap();
+    let answer = parsed_output.get("answer").unwrap().as_str().unwrap();
+    assert_eq!(answer, "Hello");
+    // Check that episode_id is here and correct
+    let retrieved_episode_id = result.get("episode_id").unwrap().as_str().unwrap();
+    let retrieved_episode_id = Uuid::parse_str(retrieved_episode_id).unwrap();
+    assert_eq!(retrieved_episode_id, episode_id);
+    // Check the variant name
+    let variant_name = result.get("variant_name").unwrap().as_str().unwrap();
+    assert_eq!(variant_name, "best_of_n_variant_implicit_tool");
+
+    // Check the ModelInference Table
+    let results = select_model_inferences_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 4);
+
+    // Collect model names
+    let mut model_names = std::collections::HashSet::new();
+
+    for result in results {
+        let id = result.get("id").unwrap().as_str().unwrap();
+        let _ = Uuid::parse_str(id).unwrap();
+        let inference_id_result = result.get("inference_id").unwrap().as_str().unwrap();
+        let inference_id_result = Uuid::parse_str(inference_id_result).unwrap();
+        assert_eq!(inference_id_result, inference_id);
+
+        // Collect model_name
+        let model_name = result.get("model_name").unwrap().as_str().unwrap();
+        model_names.insert(model_name.to_string());
+
+        // Check that all expected fields are present
+        assert!(result.get("model_provider_name").is_some());
+        assert!(result.get("raw_request").is_some());
+        assert!(result.get("raw_response").is_some());
+        assert!(result.get("input_tokens").is_some());
+        assert!(result.get("output_tokens").is_some());
+        assert!(result.get("response_time_ms").is_some());
+        assert!(result.get("ttft_ms").is_some());
+
+        let input_tokens = result.get("input_tokens").unwrap().as_u64().unwrap();
+        assert!(input_tokens > 0);
+        let output_tokens = result.get("output_tokens").unwrap().as_u64().unwrap();
+        assert!(output_tokens > 0);
+        let response_time_ms = result.get("response_time_ms").unwrap().as_u64().unwrap();
+        assert!(response_time_ms > 0);
+        assert!(result.get("ttft_ms").unwrap().is_null());
+        let system = result.get("system").unwrap().as_str().unwrap();
+        let input_messages = result.get("input_messages").unwrap().as_str().unwrap();
+        let input_messages: Vec<RequestMessage> = serde_json::from_str(input_messages).unwrap();
+        let output = result.get("output").unwrap().as_str().unwrap();
+        let output: Vec<ContentBlock> = serde_json::from_str(output).unwrap();
+        if model_name == "json" {
+            assert_eq!(
+                system,
+                "You are a helpful and friendly assistant named AskJeeves"
+            );
+            assert_eq!(input_messages.len(), 1);
+            assert_eq!(
+                input_messages[0],
+                RequestMessage {
+                    role: Role::User,
+                    content: vec![
+                        "What's the first word in the typical output of one's first program. Answer as a json object with a single field 'answer' containing the string."
+                            .to_string()
+                            .into()
+                    ],
+                }
+            );
+            assert_eq!(output.len(), 1);
+            match &output[0] {
+                ContentBlock::Text(text) => {
+                    let parsed: Value = serde_json::from_str(&text.text).unwrap();
+                    let answer = parsed.get("answer").unwrap().as_str().unwrap();
+                    assert_eq!(answer, "Hello");
+                }
+                _ => {
+                    panic!("Expected a text block, got {:?}", output[0]);
+                }
+            }
+        }
+        if model_name == "test" {
+            assert_eq!(
+                system,
+                "You are a helpful and friendly assistant named AskJeeves"
+            );
+            assert_eq!(input_messages.len(), 1);
+            assert_eq!(
+                input_messages[0],
+                RequestMessage {
+                    role: Role::User,
+                    content: vec![
+                        "What's the first word in the typical output of one's first program. Answer as a json object with a single field 'answer' containing the string."
+                            .to_string()
+                            .into()
+                    ],
+                }
+            );
+            assert_eq!(output.len(), 1);
+            match &output[0] {
+                ContentBlock::Text(text) => {
+                    assert_eq!(text.text, "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake.");
+                }
+                _ => {
+                    panic!("Expected a text block, got {:?}", output[0]);
+                }
+            }
+        }
+        if model_name == "json_goodbye" {
+            assert_eq!(
+                system,
+                "You are a helpful and friendly assistant named AskJeeves"
+            );
+            assert_eq!(input_messages.len(), 1);
+            assert_eq!(
+              input_messages[0],
+              RequestMessage {
+                  role: Role::User,
+                  content: vec![
+                      "What's the first word in the typical output of one's first program. Answer as a json object with a single field 'answer' containing the string."
+                          .to_string()
+                          .into()
+                  ],
+              }
+          );
+            assert_eq!(output.len(), 1);
+            match &output[0] {
+                ContentBlock::Text(text) => {
+                    let parsed: Value = serde_json::from_str(&text.text).unwrap();
+                    let answer = parsed.get("answer").unwrap().as_str().unwrap();
+                    assert_eq!(answer, "Goodbye");
+                }
+                _ => {
+                    panic!("Expected a text block, got {:?}", output[0]);
+                }
+            }
+        }
+        // For the judge model we want to check that the raw_request is corredt
+        if model_name == "claude-3-haiku-20240307-anthropic" {
+            let raw_request = result.get("raw_request").unwrap().as_str().unwrap();
+            let raw_request: Value = serde_json::from_str(raw_request).unwrap();
+            let expected_request = json!({
+                "model": "claude-3-haiku-20240307",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "What's the first word in the typical output of one's first program. Answer as a json object with a single field 'answer' containing the string."
+                            }
+                        ]
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "Here are the candidate answers (with the index and a row of ------ separating):\n0: {\"answer\":\"Hello\"}\n------1: {\"answer\":\"Goodbye\"}\n------\nPlease evaluate these candidates and provide the index of the best one."
+                            }
+                        ]
+                    }
+                ],
+                "max_tokens": 4096,
+                "stream": false,
+                "system": "You are an assistant tasked with re-ranking candidate answers to the following problem:\n------\nYou are a helpful and friendly assistant named AskJeeves\n------\nThe messages below are the conversation history between the user and the assistant along with a final message giving a set of candidate responses.\nPlease evaluate the following candidate responses and provide your reasoning along with the index of the best candidate in the following JSON format:\n{\n    \"thinking\": \"your reasoning here\",\n    \"answer_choice\": int  // Range: 0 to 1\n}\nIn the \"thinking\" block:\nFirst, you should analyze each response itself against the conversation history and determine if it is a good response or not.\nThen you should think out loud about which is best and most faithful to instructions.\nIn the \"answer_choice\" block: you should output the index of the best response.",
+                "tool_choice": {
+                    "type": "tool",
+                    "name": "respond",
+                    "disable_parallel_tool_use": true
+                },
+                "tools": [
+                    {
+                        "name": "respond",
+                        "description": "Respond to the user using the output schema provided.",
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {
+                                "thinking": {"type": "string"},
+                                "answer_choice": {"type": "integer"}
+                            },
+                            "required": ["thinking", "answer_choice"],
+                            "additionalProperties": false
+                        }
+                    }
+                ]
+            });
+            assert_eq!(raw_request, expected_request);
+        }
+    }
+
+    // Check that all expected model names are present
+    let expected_model_names: std::collections::HashSet<String> = [
+        "test",
+        "json",
+        "json_goodbye",
+        "claude-3-haiku-20240307-anthropic",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
     assert_eq!(model_names, expected_model_names);
 }

--- a/tensorzero_internal/tests/e2e/tensorzero.toml
+++ b/tensorzero_internal/tests/e2e/tensorzero.toml
@@ -1443,6 +1443,16 @@ candidates = ["variant0", "variant1", "variant2"]
 model = "gemini-1.5-flash-001"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 
+[functions.best_of_n_json.variants.best_of_n_variant_implicit_tool]
+type = "experimental_best_of_n_sampling"
+weight = 1
+candidates = ["variant0", "variant1", "variant2"]
+
+[functions.best_of_n_json.variants.best_of_n_variant_implicit_tool.evaluator]
+model = "claude-3-haiku-20240307-anthropic"
+system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
+json_mode = "implicit_tool"
+
 [functions.mixture_of_n]
 type = "chat"
 system_schema = "../../fixtures/config/functions/basic_test/system_schema.json"


### PR DESCRIPTION
other important change: changed default json mode setting to Strict.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for JSON mode settings in `best_of_n` variants with default set to `Strict`.
> 
>   - **Behavior**:
>     - Added support for JSON mode settings in `best_of_n` variants, including `Off`, `On`, `Strict`, and `ImplicitTool` modes.
>     - Changed default JSON mode to `Strict` in `config_parser.rs` and `chat_completion.rs`.
>   - **Implementation**:
>     - Updated `BestOfNSamplingConfig` in `best_of_n_sampling.rs` to handle JSON mode settings.
>     - Modified `EvaluatorConfig` to support `ImplicitTool` JSON mode.
>     - Adjusted `prepare_request` in `chat_completion.rs` to incorporate JSON mode settings.
>   - **Testing**:
>     - Added tests in `best_of_n.rs` to verify JSON mode behavior, including `ImplicitTool` mode.
>     - Updated `tensorzero.toml` to include new variants and configurations for testing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 339ce372176e5748af3b9cda81f982dd54f6a83d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->