### PR TITLE
fix: limit raw data history to prevent performance issues

### DIFF
--- a/ui/app/routes/optimization/supervised-fine-tuning/RawDataAccordion.tsx
+++ b/ui/app/routes/optimization/supervised-fine-tuning/RawDataAccordion.tsx
@@ -16,6 +16,8 @@ type RawDataWithTimestamp = RawData & {
   timestamp: Date;
 };
 
+const MAX_HISTORY_ITEMS = 20;
+
 export function RawDataAccordion({ rawData }: RawDataAccordionProps) {
   const [history, setHistory] = useState<RawDataWithTimestamp[]>([]);
   // Add state for accordion value
@@ -35,7 +37,11 @@ export function RawDataAccordion({ rawData }: RawDataAccordionProps) {
   // Add new raw data to history when it changes
   useEffect(() => {
     if (rawData) {
-      setHistory((prev) => [...prev, { ...rawData, timestamp: new Date() }]);
+      setHistory((prev) =>
+        [...prev, { ...rawData, timestamp: new Date() }].slice(
+          -MAX_HISTORY_ITEMS,
+        ),
+      );
     }
   }, [rawData]);
 


### PR DESCRIPTION
Fixes #839 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Limits raw data history to 20 items in `RawDataAccordion` to prevent performance issues.
> 
>   - **Behavior**:
>     - Limits raw data history to 20 items in `RawDataAccordion` to prevent performance issues.
>     - Uses `MAX_HISTORY_ITEMS` constant to define the limit.
>   - **Implementation**:
>     - Modifies `useEffect` in `RawDataAccordion` to slice history array to last 20 items when new data is added.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7b5090d057ccbbabdcf6cd335a3728fcd5ee183f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->