### PR TITLE
fix: format timestamps as ISO 8601 in queryInferenceById

### DIFF
--- a/ui/app/utils/clickhouse/inference.ts
+++ b/ui/app/utils/clickhouse/inference.ts
@@ -627,7 +627,10 @@ export async function queryInferenceById(
   IF(i.function_type = 'json', j.output_schema, '') AS output_schema,
 
   -- Timestamps & tags
-  IF(i.function_type = 'chat', c.timestamp, j.timestamp) AS timestamp,
+  IF(i.function_type = 'chat',
+   formatDateTime(c.timestamp, '%Y-%m-%dT%H:%i:%SZ'),
+   formatDateTime(j.timestamp, '%Y-%m-%dT%H:%i:%SZ')
+) AS timestamp,
   IF(i.function_type = 'chat', c.tags,      j.tags)      AS tags,
 
   -- Discriminator itself


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Format timestamps as ISO 8601 in `queryInferenceById` function in `inference.ts`.
> 
>   - **Behavior**:
>     - In `queryInferenceById` in `inference.ts`, format timestamps as ISO 8601 using `formatDateTime()` for both `chat` and `json` function types.
>   - **Misc**:
>     - No changes to logic or additional functionality, only timestamp formatting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8ab163dfffc5f9ae3fe0b419ef4083e9618981d6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->