### PR TITLE
bumped version to 2025.01.8

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorzero"
-version = "2025.01.7"
+version = "2025.01.8"
 description = "The Python client for TensorZero"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/clients/python/uv.lock
+++ b/clients/python/uv.lock
@@ -157,7 +157,7 @@ wheels = [
 
 [[package]]
 name = "tensorzero"
-version = "2025.01.7"
+version = "2025.01.8"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/tensorzero_internal/src/endpoints/status.rs
+++ b/tensorzero_internal/src/endpoints/status.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::response::Json;
 use serde_json::{json, Value};
 
-pub const TENSORZERO_VERSION: &str = "2025.01.7";
+pub const TENSORZERO_VERSION: &str = "2025.01.8";
 
 /// A handler for a simple liveness check
 #[debug_handler]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump version to `2025.01.8` in `pyproject.toml`, `uv.lock`, and `status.rs`.
> 
>   - **Version Bump**:
>     - Updated version to `2025.01.8` in `pyproject.toml`, `uv.lock`, and `status.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 054040ac09bd3e384366eec83c311f23280b7d96. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->