### PR TITLE
Add new `model_name` parameter to `/inference`

### DIFF
--- a/clients/rust/examples/inference_demo/main.rs
+++ b/clients/rust/examples/inference_demo/main.rs
@@ -65,7 +65,7 @@ async fn main() {
 
     let res = client
         .inference(ClientInferenceParams {
-            function_name: args.function_name,
+            function_name: Some(args.function_name),
             stream: Some(args.streaming),
             input: Input {
                 messages: vec![InputMessage {

--- a/clients/rust/src/client_inference_params.rs
+++ b/clients/rust/src/client_inference_params.rs
@@ -15,8 +15,10 @@ use uuid::Uuid;
 /// The expected payload is a JSON object with the following fields:
 #[derive(Debug, Serialize, Default)]
 pub struct ClientInferenceParams {
-    // the function name
-    pub function_name: String,
+    // The function name. Exactly one of `function_name` or `model_name` must be provided.
+    pub function_name: Option<String>,
+    // The model name to run using a default function. Exactly one of `function_name` or `model_name` must be provided.
+    pub model_name: Option<String>,
     // the episode ID (if not provided, it'll be set to inference_id)
     // NOTE: DO NOT GENERATE EPISODE IDS MANUALLY. THE API WILL DO THAT FOR YOU.
     pub episode_id: Option<Uuid>,
@@ -56,6 +58,7 @@ impl From<ClientInferenceParams> for Params {
     fn from(this: ClientInferenceParams) -> Self {
         Params {
             function_name: this.function_name,
+            model_name: this.model_name,
             episode_id: this.episode_id,
             input: this.input,
             stream: this.stream,
@@ -82,6 +85,7 @@ impl From<ClientInferenceParams> for Params {
 fn assert_params_match(client_params: ClientInferenceParams) {
     let ClientInferenceParams {
         function_name,
+        model_name,
         episode_id,
         input,
         stream,
@@ -95,6 +99,7 @@ fn assert_params_match(client_params: ClientInferenceParams) {
     } = client_params;
     let _ = Params {
         function_name,
+        model_name,
         episode_id,
         input,
         stream,

--- a/tensorzero_internal/src/endpoints/openai_compatible.rs
+++ b/tensorzero_internal/src/endpoints/openai_compatible.rs
@@ -331,7 +331,8 @@ impl TryFrom<(HeaderMap, OpenAICompatibleParams)> for Params {
             _ => None,
         };
         Ok(Params {
-            function_name: function_name.to_string(),
+            function_name: Some(function_name.to_string()),
+            model_name: None,
             episode_id,
             input,
             stream: openai_compatible_params.stream,
@@ -753,7 +754,7 @@ mod tests {
         )
             .try_into()
             .unwrap();
-        assert_eq!(params.function_name, "test_function");
+        assert_eq!(params.function_name, Some("test_function".to_string()));
         assert_eq!(params.episode_id, Some(episode_id));
         assert_eq!(params.variant_name, Some("test_variant".to_string()));
         assert_eq!(params.input.messages.len(), 1);

--- a/tensorzero_internal/src/error.rs
+++ b/tensorzero_internal/src/error.rs
@@ -69,6 +69,9 @@ pub enum ErrorDetails {
     AllVariantsFailed {
         errors: HashMap<String, Error>,
     },
+    InvalidInferenceTarget {
+        message: String,
+    },
     ApiKeyMissing {
         provider_name: String,
     },
@@ -282,6 +285,7 @@ impl ErrorDetails {
             ErrorDetails::AllVariantsFailed { .. } => tracing::Level::ERROR,
             ErrorDetails::ApiKeyMissing { .. } => tracing::Level::ERROR,
             ErrorDetails::AppState { .. } => tracing::Level::ERROR,
+            ErrorDetails::InvalidInferenceTarget { .. } => tracing::Level::ERROR,
             ErrorDetails::BadCredentialsPreInference { .. } => tracing::Level::ERROR,
             ErrorDetails::BatchInputValidation { .. } => tracing::Level::WARN,
             ErrorDetails::BatchNotFound { .. } => tracing::Level::WARN,
@@ -363,6 +367,7 @@ impl ErrorDetails {
             ErrorDetails::Config { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::DynamicJsonSchema { .. } => StatusCode::BAD_REQUEST,
             ErrorDetails::GCPCredentials { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorDetails::InvalidInferenceTarget { .. } => StatusCode::BAD_REQUEST,
             ErrorDetails::Inference { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::InferenceClient { status_code, .. } => {
                 status_code.unwrap_or_else(|| StatusCode::INTERNAL_SERVER_ERROR)
@@ -445,6 +450,9 @@ impl std::fmt::Display for ErrorDetails {
                         .collect::<Vec<_>>()
                         .join("\n")
                 )
+            }
+            ErrorDetails::InvalidInferenceTarget { message } => {
+                write!(f, "Invalid inference target: {message}")
             }
             ErrorDetails::ApiKeyMissing { provider_name } => {
                 write!(f, "API key missing for provider: {}", provider_name)

--- a/tensorzero_internal/src/error.rs
+++ b/tensorzero_internal/src/error.rs
@@ -285,7 +285,7 @@ impl ErrorDetails {
             ErrorDetails::AllVariantsFailed { .. } => tracing::Level::ERROR,
             ErrorDetails::ApiKeyMissing { .. } => tracing::Level::ERROR,
             ErrorDetails::AppState { .. } => tracing::Level::ERROR,
-            ErrorDetails::InvalidInferenceTarget { .. } => tracing::Level::ERROR,
+            ErrorDetails::InvalidInferenceTarget { .. } => tracing::Level::WARN,
             ErrorDetails::BadCredentialsPreInference { .. } => tracing::Level::ERROR,
             ErrorDetails::BatchInputValidation { .. } => tracing::Level::WARN,
             ErrorDetails::BatchNotFound { .. } => tracing::Level::WARN,

--- a/tensorzero_internal/src/inference/types/batch.rs
+++ b/tensorzero_internal/src/inference/types/batch.rs
@@ -40,22 +40,22 @@ pub struct StartBatchProviderInferenceResponse {
 
 /// Returned from start_batch_inference from a model
 /// Adds the model provider name to the response
-pub struct StartBatchModelInferenceResponse<'a> {
+pub struct StartBatchModelInferenceResponse {
     pub batch_id: Uuid,
     pub inference_ids: Vec<Uuid>,
     pub raw_requests: Vec<String>,
     pub batch_params: Value,
     pub raw_request: String,  // The raw text of the batch request body
     pub raw_response: String, // The raw text of the response from the batch request
-    pub model_provider_name: &'a str,
+    pub model_provider_name: Arc<str>,
     pub status: BatchStatus,
     pub errors: Vec<Value>,
 }
 
-impl<'a> StartBatchModelInferenceResponse<'a> {
+impl StartBatchModelInferenceResponse {
     pub fn new(
         provider_batch_response: StartBatchProviderInferenceResponse,
-        model_provider_name: &'a str,
+        model_provider_name: Arc<str>,
     ) -> Self {
         Self {
             batch_id: provider_batch_response.batch_id,
@@ -87,14 +87,14 @@ pub struct StartBatchModelInferenceWithMetadata<'a> {
     pub raw_request: String,
     pub raw_response: String,
     pub batch_params: Value,
-    pub model_provider_name: &'a str,
+    pub model_provider_name: Arc<str>,
     pub model_name: &'a str,
     pub status: BatchStatus,
 }
 
 impl<'a> StartBatchModelInferenceWithMetadata<'a> {
     pub fn new(
-        model_batch_response: StartBatchModelInferenceResponse<'a>,
+        model_batch_response: StartBatchModelInferenceResponse,
         model_inference_requests: Vec<ModelInferenceRequest<'a>>,
         model_name: &'a str,
         inference_params: Vec<InferenceParams>,

--- a/tensorzero_internal/src/model.rs
+++ b/tensorzero_internal/src/model.rs
@@ -1052,7 +1052,6 @@ impl ModelTable {
             return Ok(Some(CowNoClone::Borrowed(model_config)));
         }
         if let Some(shorthand) = check_shorthand(key) {
-            // TODO - should we cache this?
             return Ok(Some(CowNoClone::Owned(model_config_from_shorthand(
                 shorthand.provider_type,
                 shorthand.model_name,

--- a/tensorzero_internal/src/model.rs
+++ b/tensorzero_internal/src/model.rs
@@ -3,6 +3,7 @@ use reqwest::Client;
 use secrecy::SecretString;
 use serde::de::Error as SerdeError;
 use std::collections::HashMap;
+use std::ops::Deref;
 use std::sync::{Arc, OnceLock};
 use std::{env, fs};
 use strum::VariantNames;
@@ -45,6 +46,23 @@ use serde::Deserialize;
 pub struct ModelConfig {
     pub routing: Vec<Arc<str>>, // [provider name A, provider name B, ...]
     pub providers: HashMap<Arc<str>, ProviderConfig>, // provider name => provider config
+}
+
+/// This is `Cow` without the `T: Clone` bound.
+/// Useful when we want a `Cow`, but don't want to (or can't) implement `Clone`
+pub enum CowNoClone<'a, T> {
+    Borrowed(&'a T),
+    Owned(T),
+}
+
+impl<T> Deref for CowNoClone<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            CowNoClone::Borrowed(t) => t,
+            CowNoClone::Owned(t) => t,
+        }
+    }
 }
 
 impl ModelConfig {
@@ -128,12 +146,12 @@ impl ModelConfig {
         }))
     }
 
-    pub async fn start_batch_inference<'a, 'request>(
-        &'a self,
+    pub async fn start_batch_inference<'request>(
+        &self,
         requests: &'request [ModelInferenceRequest<'request>],
         client: &'request Client,
         api_keys: &'request InferenceCredentials,
-    ) -> Result<StartBatchModelInferenceResponse<'a>, Error> {
+    ) -> Result<StartBatchModelInferenceResponse, Error> {
         let mut provider_errors: HashMap<String, Error> = HashMap::new();
         for provider_name in &self.routing {
             let provider_config = self.providers.get(provider_name).ok_or_else(|| {
@@ -153,7 +171,7 @@ impl ModelConfig {
                 Ok(response) => {
                     return Ok(StartBatchModelInferenceResponse::new(
                         response,
-                        provider_name,
+                        provider_name.clone(),
                     ));
                 }
                 Err(error) => {
@@ -1009,19 +1027,42 @@ impl TryFrom<HashMap<Arc<str>, ModelConfig>> for ModelTable {
     }
 }
 
-impl std::ops::Deref for ModelTable {
-    type Target = HashMap<Arc<str>, ModelConfig>;
+pub struct Shorthand<'a> {
+    pub provider_type: &'a str,
+    pub model_name: &'a str,
+}
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
+fn check_shorthand(key: &str) -> Option<Shorthand> {
+    for prefix in SHORTHAND_MODEL_PREFIXES {
+        if let Some(model_name) = key.strip_prefix(prefix) {
+            // Remove the last two characters of the prefix to get the provider type
+            let provider_type = &prefix[..prefix.len() - 2];
+            return Some(Shorthand {
+                provider_type,
+                model_name,
+            });
+        }
     }
+    None
 }
 
 impl ModelTable {
+    pub fn get(&self, key: &str) -> Result<Option<CowNoClone<'_, ModelConfig>>, Error> {
+        if let Some(model_config) = self.0.get(key) {
+            return Ok(Some(CowNoClone::Borrowed(model_config)));
+        }
+        if let Some(shorthand) = check_shorthand(key) {
+            // TODO - should we cache this?
+            return Ok(Some(CowNoClone::Owned(model_config_from_shorthand(
+                shorthand.provider_type,
+                shorthand.model_name,
+            )?)));
+        }
+        Ok(None)
+    }
     /// Check that a model name is valid
     /// This is either true because it's in the table, or because it's a valid shorthand name
-    /// In the latter case, we actually create a new model config in the table corresponding to the shorthand
-    pub fn validate_or_create(&mut self, key: &str) -> Result<(), Error> {
+    pub fn validate(&self, key: &str) -> Result<(), Error> {
         // Try direct lookup (if it's blacklisted, it's not in the table)
         // If it's shorthand and already in the table, it's valid
         if let Some(model_config) = self.0.get(key) {
@@ -1029,28 +1070,7 @@ impl ModelTable {
             return Ok(());
         }
 
-        // Try matching shorthand prefixes
-        if let Some(prefix) = SHORTHAND_MODEL_PREFIXES
-            .iter()
-            .find(|&&prefix| key.starts_with(prefix))
-        {
-            let model_name = match key.strip_prefix(prefix) {
-                Some(name) => name,
-                None => {
-                    return Err(ErrorDetails::Config {
-                        message: format!(
-                            "Failed to strip prefix '{}' from model name '{}' This should never happen. Please file a bug report at https://github.com/tensorzero/tensorzero/issues/new",
-                            prefix, key
-                        ),
-                    }
-                    .into());
-                }
-            };
-            // Remove the last two characters of the prefix to get the provider type
-            let provider_type = &prefix[..prefix.len() - 2];
-            let model_config = model_config_from_shorthand(provider_type, model_name)?;
-            model_config.validate(key)?;
-            self.0.insert(key.into(), model_config);
+        if check_shorthand(key).is_some() {
             return Ok(());
         }
 
@@ -1058,6 +1078,15 @@ impl ModelTable {
             message: format!("Model name '{}' not found in model table", key),
         }
         .into())
+    }
+
+    #[cfg(any(test, feature = "e2e_tests"))]
+    pub fn static_model_len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn iter_static_models(&self) -> impl Iterator<Item = (&Arc<str>, &ModelConfig)> {
+        self.0.iter()
     }
 }
 
@@ -1563,22 +1592,15 @@ mod tests {
 
     #[test]
     fn test_validate_or_create_model_config() {
-        let mut model_table = ModelTable::default();
+        let model_table = ModelTable::default();
         // Test that we can get or create a model config
-        model_table.validate_or_create("dummy::gpt-4o").unwrap();
-        assert_eq!(model_table.len(), 1);
-        let model_config = model_table.get("dummy::gpt-4o").unwrap();
-        assert_eq!(model_config.routing, vec!["dummy".into()]);
-        let provider_config = model_config.providers.get("dummy").unwrap();
-        match provider_config {
-            ProviderConfig::Dummy(provider) => assert_eq!(&*provider.model_name, "gpt-4o"),
-            _ => panic!("Expected Dummy provider"),
-        }
-
-        // Test that it is idempotent
-        model_table.validate_or_create("dummy::gpt-4o").unwrap();
-        assert_eq!(model_table.len(), 1);
-        let model_config = model_table.get("dummy::gpt-4o").unwrap();
+        model_table.validate("dummy::gpt-4o").unwrap();
+        // Shorthand models are not added to the model table
+        assert_eq!(model_table.static_model_len(), 0);
+        let model_config = model_table
+            .get("dummy::gpt-4o")
+            .unwrap()
+            .expect("Missing dummy model");
         assert_eq!(model_config.routing, vec!["dummy".into()]);
         let provider_config = model_config.providers.get("dummy").unwrap();
         match provider_config {
@@ -1587,7 +1609,7 @@ mod tests {
         }
 
         // Test that it fails if the model is not well-formed
-        let model_config = model_table.validate_or_create("foo::bar");
+        let model_config = model_table.validate("foo::bar");
         assert!(model_config.is_err());
         assert_eq!(
             model_config.unwrap_err(),
@@ -1603,12 +1625,11 @@ mod tests {
             routing: vec!["anthropic".into()],
             providers: HashMap::from([("anthropic".into(), anthropic_provider_config)]),
         };
-        let mut model_table: ModelTable =
-            HashMap::from([("claude".into(), anthropic_model_config)])
-                .try_into()
-                .unwrap();
+        let model_table: ModelTable = HashMap::from([("claude".into(), anthropic_model_config)])
+            .try_into()
+            .unwrap();
 
-        model_table.validate_or_create("dummy::claude").unwrap();
+        model_table.validate("dummy::claude").unwrap();
     }
 
     #[test]

--- a/tensorzero_internal/src/variant/chat_completion.rs
+++ b/tensorzero_internal/src/variant/chat_completion.rs
@@ -164,7 +164,7 @@ impl Variant for ChatCompletionConfig {
             false,
             &mut inference_params,
         )?;
-        let model_config = models.models.get(&self.model).ok_or_else(|| {
+        let model_config = models.models.get(&self.model)?.ok_or_else(|| {
             Error::new(ErrorDetails::UnknownModel {
                 name: self.model.to_string(),
             })
@@ -172,7 +172,7 @@ impl Variant for ChatCompletionConfig {
         let args = InferModelRequestArgs {
             request,
             model_name: self.model.clone(),
-            model_config,
+            model_config: &model_config,
             function,
             inference_config,
             clients,
@@ -199,7 +199,7 @@ impl Variant for ChatCompletionConfig {
             true,
             &mut inference_params,
         )?;
-        let model_config = models.models.get(&self.model).ok_or_else(|| {
+        let model_config = models.models.get(&self.model)?.ok_or_else(|| {
             Error::new(ErrorDetails::UnknownModel {
                 name: self.model.to_string(),
             })
@@ -207,7 +207,7 @@ impl Variant for ChatCompletionConfig {
         infer_model_request_stream(
             request,
             self.model.clone(),
-            model_config,
+            &model_config,
             function,
             clients,
             inference_params,
@@ -240,7 +240,7 @@ impl Variant for ChatCompletionConfig {
                 ),
             }.into());
         }
-        models.validate_or_create(&self.model)?;
+        models.validate(&self.model)?;
 
         // Validate the system template matches the system schema (best effort, we cannot check the variables comprehensively)
         validate_template_and_schema(
@@ -323,7 +323,7 @@ impl Variant for ChatCompletionConfig {
                 self.prepare_request(input, function, inference_config, false, inference_param)?;
             inference_requests.push(request);
         }
-        let model_config = models.models.get(&self.model).ok_or_else(|| {
+        let model_config = models.models.get(&self.model)?.ok_or_else(|| {
             Error::new(ErrorDetails::UnknownModel {
                 name: self.model.to_string(),
             })

--- a/tensorzero_internal/src/variant/dicl.rs
+++ b/tensorzero_internal/src/variant/dicl.rs
@@ -109,7 +109,7 @@ impl Variant for DiclConfig {
             &mut inference_params,
         )?;
 
-        let model_config = models.models.get(&self.model).ok_or_else(|| {
+        let model_config = models.models.get(&self.model)?.ok_or_else(|| {
             Error::new(ErrorDetails::UnknownModel {
                 name: self.model.to_string(),
             })
@@ -119,7 +119,7 @@ impl Variant for DiclConfig {
         let args = InferModelRequestArgs {
             request: model_inference_request,
             model_name: self.model.clone(),
-            model_config,
+            model_config: &model_config,
             function,
             inference_config,
             clients,
@@ -174,7 +174,7 @@ impl Variant for DiclConfig {
             &mut inference_params,
         )?;
 
-        let model_config = models.models.get(&self.model).ok_or_else(|| {
+        let model_config = models.models.get(&self.model)?.ok_or_else(|| {
             Error::new(ErrorDetails::UnknownModel {
                 name: self.model.to_string(),
             })
@@ -185,7 +185,7 @@ impl Variant for DiclConfig {
             infer_model_request_stream(
                 request,
                 self.model.clone(),
-                model_config,
+                &model_config,
                 function,
                 clients,
                 inference_params,
@@ -228,7 +228,7 @@ impl Variant for DiclConfig {
             .into());
         }
         // Validate that the generation model and embedding model are valid
-        models.validate_or_create(&self.model)?;
+        models.validate(&self.model)?;
         let embedding_model = embedding_models
             .get(&self.embedding_model)
             .ok_or_else(|| Error::new(ErrorDetails::Config {

--- a/tensorzero_internal/tests/e2e/inference.rs
+++ b/tensorzero_internal/tests/e2e/inference.rs
@@ -1714,3 +1714,183 @@ async fn test_inference_invalid_params() {
     // Should succeed with 200 OK
     assert_eq!(response.status(), StatusCode::OK);
 }
+
+#[tokio::test]
+async fn test_inference_invalid_default_function_arg() {
+    // We cannot provide both `function_name` and `model_name`
+    let func_and_model = json!({
+        "function_name": "basic_test",
+        "model_name": "dummy::my-model",
+        "input":
+            {
+               "system": {"assistant_name": "Dr. Mehta"},
+               "messages": [
+                {
+                    "role": "user",
+                    "content": "What is the capital city of Japan?"
+                }
+            ]},
+    });
+
+    let response = Client::new()
+        .post(get_gateway_endpoint("/inference"))
+        .json(&func_and_model)
+        .send()
+        .await
+        .unwrap();
+
+    // Should fail with 400 Bad Request
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_text = response.text().await.unwrap();
+    assert!(
+        response_text.contains("Only one of `function_name` or `model_name` can be provided"),
+        "Unexpected error message: {response_text}",
+    );
+
+    // We cannot provide both `function_name` and `model_name`
+    let func_and_model = json!({
+        "function_name": "basic_test",
+        "model_name": "dummy::my-model",
+        "input":
+            {
+               "system": {"assistant_name": "Dr. Mehta"},
+               "messages": [
+                {
+                    "role": "user",
+                    "content": "What is the capital city of Japan?"
+                }
+            ]},
+    });
+
+    let response = Client::new()
+        .post(get_gateway_endpoint("/inference"))
+        .json(&func_and_model)
+        .send()
+        .await
+        .unwrap();
+
+    // Should fail with 400 Bad Request
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_text = response.text().await.unwrap();
+    assert!(
+        response_text.contains("Only one of `function_name` or `model_name` can be provided"),
+        "Unexpected error message: {response_text}",
+    );
+
+    // We must provide `function_name` or `model_name`
+    let neither_nor = json!({
+        "input":
+            {
+               "system": {"assistant_name": "Dr. Mehta"},
+               "messages": [
+                {
+                    "role": "user",
+                    "content": "What is the capital city of Japan?"
+                }
+            ]},
+    });
+
+    let response = Client::new()
+        .post(get_gateway_endpoint("/inference"))
+        .json(&neither_nor)
+        .send()
+        .await
+        .unwrap();
+
+    // Should fail with 400 Bad Request
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_text = response.text().await.unwrap();
+    assert!(
+        response_text.contains("Either `function_name` or `model_name` must be provided"),
+        "Unexpected error message: {response_text}",
+    );
+
+    // We cannot specify both `model_name` and `variant_name`
+    let model_and_variant = json!({
+        "model_name": "dummy::my-model",
+        "variant_name": "test_variant",
+        "input":
+            {
+               "system": {"assistant_name": "Dr. Mehta"},
+               "messages": [
+                {
+                    "role": "user",
+                    "content": "What is the capital city of Japan?"
+                }
+            ]},
+    });
+
+    let response = Client::new()
+        .post(get_gateway_endpoint("/inference"))
+        .json(&model_and_variant)
+        .send()
+        .await
+        .unwrap();
+
+    // Should fail with 400 Bad Request
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_text = response.text().await.unwrap();
+    assert!(
+        response_text.contains("`variant_name` cannot be provided when using `model_name`"),
+        "Unexpected error message: {response_text}",
+    );
+
+    // We cannot specify a missing model name
+    let missing_model = json!({
+        "model_name": "missing_model",
+        "input":
+            {
+               "messages": [
+                {
+                    "role": "user",
+                    "content": "What is the capital city of Japan?"
+                }
+            ]},
+    });
+
+    let response = Client::new()
+        .post(get_gateway_endpoint("/inference"))
+        .json(&missing_model)
+        .send()
+        .await
+        .unwrap();
+
+    // Should fail with 400 Bad Request
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_text = response.text().await.unwrap();
+    assert!(
+        response_text.contains("Model name 'missing_model' not found in model table"),
+        "Unexpected error message: {response_text}",
+    );
+
+    // We cannot specify a system prompt
+    let bad_system_prompt = json!({
+        "model_name": "openai::tensorzero-invalid-model",
+        "input":
+            {
+               "system": {"assistant_name": "Dr. Mehta"},
+               "messages": [
+                {
+                    "role": "user",
+                    "content": "What is the capital city of Japan?"
+                }
+            ]},
+    });
+
+    let response = Client::new()
+        .post(get_gateway_endpoint("/inference"))
+        .json(&bad_system_prompt)
+        .send()
+        .await
+        .unwrap();
+
+    // Should fail with 400 Bad Request
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_text = response.text().await.unwrap();
+    assert!(
+        response_text.contains(
+            "Message has non-string content but there is no schema given for role system."
+        ),
+        "Unexpected error message: {response_text}",
+    );
+}

--- a/tensorzero_internal/tests/e2e/providers/common.rs
+++ b/tensorzero_internal/tests/e2e/providers/common.rs
@@ -5504,7 +5504,8 @@ pub async fn test_dynamic_tool_use_inference_request_with_provider(
     let episode_id = Uuid::now_v7();
 
     let response = client.inference(tensorzero::ClientInferenceParams {
-        function_name: "basic_test".to_string(),
+        function_name: Some("basic_test".to_string()),
+        model_name: None,
         variant_name: Some(provider.variant_name.clone()),
         episode_id: Some(episode_id),
         input: tensorzero::Input {
@@ -5804,7 +5805,8 @@ pub async fn test_dynamic_tool_use_streaming_inference_request_with_provider(
     let input_function_name = "basic_test";
 
     let stream = client.inference(tensorzero::ClientInferenceParams {
-        function_name: input_function_name.to_string(),
+        function_name: Some(input_function_name.to_string()),
+        model_name: None,
         variant_name: Some(provider.variant_name.clone()),
         episode_id: Some(episode_id),
         input: tensorzero::Input {

--- a/tensorzero_internal/tests/e2e/providers/openai.rs
+++ b/tensorzero_internal/tests/e2e/providers/openai.rs
@@ -90,6 +90,272 @@ async fn get_providers() -> E2ETestProviders {
     }
 }
 
+// Tests using 'model_name' with a shorthand model
+#[cfg(feature = "e2e_tests")]
+#[tokio::test]
+async fn test_default_function_model_name_shorthand() {
+    let client = Client::new();
+    let episode_id = Uuid::now_v7();
+
+    let payload = json!({
+        "model_name": "openai::o1-mini",
+        "episode_id": episode_id,
+        "input": {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "What is the capital of Japan?"
+                }
+            ]},
+        "stream": false,
+    });
+
+    let response = client
+        .post(get_gateway_endpoint("/inference"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    // Check Response is OK, then fields in order
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_json = response.json::<Value>().await.unwrap();
+    let content_blocks = response_json.get("content").unwrap().as_array().unwrap();
+    assert!(content_blocks.len() == 1);
+    let content_block = content_blocks.first().unwrap();
+    let content_block_type = content_block.get("type").unwrap().as_str().unwrap();
+    assert_eq!(content_block_type, "text");
+    let content = content_block.get("text").unwrap().as_str().unwrap();
+    // Assert that Tokyo is in the content
+    assert!(content.contains("Tokyo"), "Content should mention Tokyo");
+    // Check that inference_id is here
+    let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
+    let inference_id = Uuid::parse_str(inference_id).unwrap();
+
+    // Sleep for 1 second to allow time for data to be inserted into ClickHouse (trailing writes from API)
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    // Check ClickHouse
+    let clickhouse = get_clickhouse().await;
+
+    // First, check Inference table
+    let result = select_chat_inference_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+    let id = result.get("id").unwrap().as_str().unwrap();
+    let id_uuid = Uuid::parse_str(id).unwrap();
+    assert_eq!(id_uuid, inference_id);
+    let function_name = result.get("function_name").unwrap().as_str().unwrap();
+    assert_eq!(function_name, "tensorzero::default");
+    let input: Value =
+        serde_json::from_str(result.get("input").unwrap().as_str().unwrap()).unwrap();
+    let correct_input = json!({
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "value": "What is the capital of Japan?"}]
+            }
+        ]
+    });
+    assert_eq!(input, correct_input);
+    let content_blocks = result.get("output").unwrap().as_str().unwrap();
+    // Check that content_blocks is a list of blocks length 1
+    let content_blocks: Vec<Value> = serde_json::from_str(content_blocks).unwrap();
+    assert_eq!(content_blocks.len(), 1);
+    let content_block = content_blocks.first().unwrap();
+    // Check the type and content in the block
+    let content_block_type = content_block.get("type").unwrap().as_str().unwrap();
+    assert_eq!(content_block_type, "text");
+    let clickhouse_content = content_block.get("text").unwrap().as_str().unwrap();
+    assert_eq!(clickhouse_content, content);
+    // Check that episode_id is here and correct
+    let retrieved_episode_id = result.get("episode_id").unwrap().as_str().unwrap();
+    let retrieved_episode_id = Uuid::parse_str(retrieved_episode_id).unwrap();
+    assert_eq!(retrieved_episode_id, episode_id);
+    // Check the variant name
+    let variant_name = result.get("variant_name").unwrap().as_str().unwrap();
+    assert_eq!(variant_name, "openai::o1-mini");
+    // Check the processing time
+    let processing_time_ms = result.get("processing_time_ms").unwrap().as_u64().unwrap();
+    assert!(processing_time_ms > 0);
+
+    // Check the ModelInference Table
+    let result = select_model_inference_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+    let inference_id_result = result.get("inference_id").unwrap().as_str().unwrap();
+    let inference_id_result = Uuid::parse_str(inference_id_result).unwrap();
+    assert_eq!(inference_id_result, inference_id);
+    let model_name = result.get("model_name").unwrap().as_str().unwrap();
+    assert_eq!(model_name, "openai::o1-mini");
+    let model_provider_name = result.get("model_provider_name").unwrap().as_str().unwrap();
+    assert_eq!(model_provider_name, "openai");
+    let raw_request = result.get("raw_request").unwrap().as_str().unwrap();
+    assert!(raw_request.to_lowercase().contains("japan"));
+    // Check that raw_request is valid JSON
+    let _: Value = serde_json::from_str(raw_request).expect("raw_request should be valid JSON");
+    let input_tokens = result.get("input_tokens").unwrap().as_u64().unwrap();
+    assert!(input_tokens > 5);
+    let output_tokens = result.get("output_tokens").unwrap().as_u64().unwrap();
+    assert!(output_tokens > 5);
+    let response_time_ms = result.get("response_time_ms").unwrap().as_u64().unwrap();
+    assert!(response_time_ms > 0);
+    assert!(result.get("ttft_ms").unwrap().is_null());
+    let raw_response = result.get("raw_response").unwrap().as_str().unwrap();
+    let _raw_response_json: Value = serde_json::from_str(raw_response).unwrap();
+}
+
+// Tests using 'model_name' with a non-shorthand model
+#[cfg(feature = "e2e_tests")]
+#[tokio::test]
+async fn test_default_function_model_name_non_shorthand() {
+    let client = Client::new();
+    let episode_id = Uuid::now_v7();
+
+    let payload = json!({
+        "model_name": "o1-mini",
+        "episode_id": episode_id,
+        "input": {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "What is the capital of Japan?"
+                }
+            ]},
+        "stream": false,
+    });
+
+    let response = client
+        .post(get_gateway_endpoint("/inference"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    // Check Response is OK, then fields in order
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_json = response.json::<Value>().await.unwrap();
+    let content_blocks = response_json.get("content").unwrap().as_array().unwrap();
+    assert!(content_blocks.len() == 1);
+    let content_block = content_blocks.first().unwrap();
+    let content_block_type = content_block.get("type").unwrap().as_str().unwrap();
+    assert_eq!(content_block_type, "text");
+    let content = content_block.get("text").unwrap().as_str().unwrap();
+    // Assert that Tokyo is in the content
+    assert!(content.contains("Tokyo"), "Content should mention Tokyo");
+    // Check that inference_id is here
+    let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
+    let inference_id = Uuid::parse_str(inference_id).unwrap();
+
+    // Sleep for 1 second to allow time for data to be inserted into ClickHouse (trailing writes from API)
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    // Check ClickHouse
+    let clickhouse = get_clickhouse().await;
+
+    // First, check Inference table
+    let result = select_chat_inference_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+    let id = result.get("id").unwrap().as_str().unwrap();
+    let id_uuid = Uuid::parse_str(id).unwrap();
+    assert_eq!(id_uuid, inference_id);
+    let function_name = result.get("function_name").unwrap().as_str().unwrap();
+    assert_eq!(function_name, "tensorzero::default");
+    let input: Value =
+        serde_json::from_str(result.get("input").unwrap().as_str().unwrap()).unwrap();
+    let correct_input = json!({
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "value": "What is the capital of Japan?"}]
+            }
+        ]
+    });
+    assert_eq!(input, correct_input);
+    let content_blocks = result.get("output").unwrap().as_str().unwrap();
+    // Check that content_blocks is a list of blocks length 1
+    let content_blocks: Vec<Value> = serde_json::from_str(content_blocks).unwrap();
+    assert_eq!(content_blocks.len(), 1);
+    let content_block = content_blocks.first().unwrap();
+    // Check the type and content in the block
+    let content_block_type = content_block.get("type").unwrap().as_str().unwrap();
+    assert_eq!(content_block_type, "text");
+    let clickhouse_content = content_block.get("text").unwrap().as_str().unwrap();
+    assert_eq!(clickhouse_content, content);
+    // Check that episode_id is here and correct
+    let retrieved_episode_id = result.get("episode_id").unwrap().as_str().unwrap();
+    let retrieved_episode_id = Uuid::parse_str(retrieved_episode_id).unwrap();
+    assert_eq!(retrieved_episode_id, episode_id);
+    // Check the variant name
+    let variant_name = result.get("variant_name").unwrap().as_str().unwrap();
+    assert_eq!(variant_name, "o1-mini");
+    // Check the processing time
+    let processing_time_ms = result.get("processing_time_ms").unwrap().as_u64().unwrap();
+    assert!(processing_time_ms > 0);
+
+    // Check the ModelInference Table
+    let result = select_model_inference_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+    let inference_id_result = result.get("inference_id").unwrap().as_str().unwrap();
+    let inference_id_result = Uuid::parse_str(inference_id_result).unwrap();
+    assert_eq!(inference_id_result, inference_id);
+    let model_name = result.get("model_name").unwrap().as_str().unwrap();
+    assert_eq!(model_name, "o1-mini");
+    let model_provider_name = result.get("model_provider_name").unwrap().as_str().unwrap();
+    assert_eq!(model_provider_name, "openai");
+    let raw_request = result.get("raw_request").unwrap().as_str().unwrap();
+    assert!(raw_request.to_lowercase().contains("japan"));
+    // Check that raw_request is valid JSON
+    let _: Value = serde_json::from_str(raw_request).expect("raw_request should be valid JSON");
+    let input_tokens = result.get("input_tokens").unwrap().as_u64().unwrap();
+    assert!(input_tokens > 5);
+    let output_tokens = result.get("output_tokens").unwrap().as_u64().unwrap();
+    assert!(output_tokens > 5);
+    let response_time_ms = result.get("response_time_ms").unwrap().as_u64().unwrap();
+    assert!(response_time_ms > 0);
+    assert!(result.get("ttft_ms").unwrap().is_null());
+    let raw_response = result.get("raw_response").unwrap().as_str().unwrap();
+    let _raw_response_json: Value = serde_json::from_str(raw_response).unwrap();
+}
+
+// Tests using 'model_name' with a non-shorthand model
+#[cfg(feature = "e2e_tests")]
+#[tokio::test]
+async fn test_default_function_invalid_model_name() {
+    use reqwest::StatusCode;
+
+    let client = Client::new();
+    let episode_id = Uuid::now_v7();
+
+    let payload = json!({
+        "model_name": "openai::my-bad-model-name",
+        "episode_id": episode_id,
+        "input": {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "What is the capital of Japan?"
+                }
+            ]},
+        "stream": false,
+    });
+
+    let response = client
+        .post(get_gateway_endpoint("/inference"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    // Check Response is OK, then fields in order
+    let status = response.status();
+    let text = response.text().await.unwrap();
+    assert!(
+        text.contains("`my-bad-model-name` does not exist"),
+        "Unexpected error: {text}"
+    );
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+}
+
 #[cfg(feature = "e2e_tests")]
 #[tokio::test]
 async fn test_o1_mini_inference() {


### PR DESCRIPTION
Part of https://github.com/tensorzero/tensorzero/issues/818

This parameter can be used instead of `function_name`. When provided, we call a builtin "default" function, which simplify calls the provided model without any additional configuration. Only chat completions are supported, and templates/JSON schema are not allowed.

Internally, we no longer store shorthand models in `ModelTable`. `ModelTable.get` now creates shorthand models on-the-fly, which allows uses to pass in shorthands with arbitrary model names (e.g. `openai::gpt-9000`) to the model provider

All calls made using `model_name` are recorded in ClickHouse under the function name `tensorzero::default`, with the variant name set to the `model_name` provided by the user. This function does not exist in the config - we dynamically create a `FunctionConfig` for each request, with just a single variant for the `model_name`
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `model_name` parameter to `/inference` for direct model specification, with dynamic shorthand handling and ClickHouse logging.
> 
>   - **Behavior**:
>     - Add `model_name` parameter to `/inference` endpoint, allowing direct model specification.
>     - Calls with `model_name` use a default function and are logged under `tensorzero::default` in ClickHouse.
>     - Only supports chat completions; templates/JSON schema not allowed.
>   - **Model Handling**:
>     - `ModelTable.get` dynamically creates shorthand models, allowing arbitrary model names.
>     - Validates model names without storing them in `ModelTable`.
>   - **Testing**:
>     - Add tests for `model_name` with shorthand and non-shorthand models in `openai.rs`.
>     - Add error handling tests for invalid `model_name` usage.
>   - **Misc**:
>     - Update `ClientInferenceParams` to support `model_name` in `client_inference_params.rs`.
>     - Add `InvalidInferenceTarget` error in `error.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f55f3f872a796d63ccc16140047a362b751a7721. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->