### PR TITLE
Support shorthand model names for embedding models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,9 +2238,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "7fe060fe50f524be480214aba758c71f99f90ee8c83c5a36b5e9e1d568eb4eb3"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/tensorzero_internal/src/endpoints/feedback.rs
+++ b/tensorzero_internal/src/endpoints/feedback.rs
@@ -577,6 +577,7 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::config_parser::{Config, GatewayConfig, MetricConfig, MetricConfigOptimize};
+    use crate::embeddings::EmbeddingModelTable;
     use crate::function::{FunctionConfigChat, FunctionConfigJson};
     use crate::jsonschema_util::JSONSchemaFromPath;
     use crate::minijinja_util::TemplateConfig;
@@ -599,7 +600,7 @@ mod tests {
         let config = Config {
             gateway: GatewayConfig::default(),
             models: ModelTable::default(),
-            embedding_models: HashMap::new(),
+            embedding_models: EmbeddingModelTable::default(),
             metrics,
             functions: HashMap::new(),
             tools: HashMap::new(),
@@ -721,7 +722,7 @@ mod tests {
         let config = Config {
             gateway: GatewayConfig::default(),
             models: ModelTable::default(),
-            embedding_models: HashMap::new(),
+            embedding_models: EmbeddingModelTable::default(),
             metrics,
             functions: HashMap::new(),
             tools: HashMap::new(),
@@ -753,7 +754,7 @@ mod tests {
         let config = Config {
             gateway: GatewayConfig::default(),
             models: ModelTable::default(),
-            embedding_models: HashMap::new(),
+            embedding_models: EmbeddingModelTable::default(),
             metrics,
             functions: HashMap::new(),
             tools: HashMap::new(),
@@ -778,7 +779,7 @@ mod tests {
         let config = Arc::new(Config {
             gateway: GatewayConfig::default(),
             models: ModelTable::default(),
-            embedding_models: HashMap::new(),
+            embedding_models: EmbeddingModelTable::default(),
             metrics: HashMap::new(),
             functions: HashMap::new(),
             tools: HashMap::new(),
@@ -861,7 +862,7 @@ mod tests {
         let config = Arc::new(Config {
             gateway: GatewayConfig::default(),
             models: ModelTable::default(),
-            embedding_models: HashMap::new(),
+            embedding_models: EmbeddingModelTable::default(),
             metrics,
             functions: HashMap::new(),
             tools: HashMap::new(),
@@ -921,7 +922,7 @@ mod tests {
         let config = Arc::new(Config {
             gateway: GatewayConfig::default(),
             models: ModelTable::default(),
-            embedding_models: HashMap::new(),
+            embedding_models: EmbeddingModelTable::default(),
             metrics,
             functions: HashMap::new(),
             tools: HashMap::new(),

--- a/tensorzero_internal/src/endpoints/inference.rs
+++ b/tensorzero_internal/src/endpoints/inference.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::config_parser::Config;
-use crate::embeddings::EmbeddingModelConfig;
+use crate::embeddings::EmbeddingModelTable;
 use crate::error::{Error, ErrorDetails};
 use crate::function::FunctionConfig;
 use crate::function::{sample_variant, FunctionConfigChat};
@@ -712,7 +712,7 @@ pub struct InferenceClients<'a> {
 #[derive(Debug)]
 pub struct InferenceModels<'a> {
     pub models: &'a ModelTable,
-    pub embedding_models: &'a HashMap<Arc<str>, EmbeddingModelConfig>,
+    pub embedding_models: &'a EmbeddingModelTable,
 }
 
 /// InferenceParams is the top-level struct for inference parameters.

--- a/tensorzero_internal/src/function.rs
+++ b/tensorzero_internal/src/function.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tracing::instrument;
 use uuid::Uuid;
 
-use crate::embeddings::EmbeddingModelConfig;
+use crate::embeddings::EmbeddingModelTable;
 use crate::endpoints::inference::InferenceParams;
 use crate::error::{Error, ErrorDetails};
 use crate::inference::types::{
@@ -248,7 +248,7 @@ impl FunctionConfig {
         &self,
         static_tools: &HashMap<String, Arc<StaticToolConfig>>,
         models: &mut ModelTable,
-        embedding_models: &HashMap<Arc<str>, EmbeddingModelConfig>,
+        embedding_models: &EmbeddingModelTable,
         templates: &TemplateConfig,
         function_name: &str,
     ) -> Result<(), Error> {

--- a/tensorzero_internal/src/lib.rs
+++ b/tensorzero_internal/src/lib.rs
@@ -10,6 +10,7 @@ pub mod inference; // model inference
 pub mod jsonschema_util; // utilities for working with JSON schemas
 mod minijinja_util; // utilities for working with MiniJinja templates
 pub mod model; // types and methods for working with TensorZero-supported models
+pub mod model_table;
 pub mod observability; // utilities for observability (logs, metrics, etc.)
 mod testing;
 pub mod tool; // types and methods for working with TensorZero tools

--- a/tensorzero_internal/src/model_table.rs
+++ b/tensorzero_internal/src/model_table.rs
@@ -110,7 +110,6 @@ impl<T: ShorthandModelConfig> BaseModelTable<T> {
             return Ok(Some(CowNoClone::Borrowed(model_config)));
         }
         if let Some(shorthand) = check_shorthand(T::SHORTHAND_MODEL_PREFIXES, key) {
-            // TODO - should we cache this?
             return Ok(Some(CowNoClone::Owned(T::from_shorthand(
                 shorthand.provider_type,
                 shorthand.model_name,

--- a/tensorzero_internal/src/model_table.rs
+++ b/tensorzero_internal/src/model_table.rs
@@ -1,0 +1,149 @@
+use std::{collections::HashMap, ops::Deref, sync::Arc};
+
+use serde::Deserialize;
+
+use crate::{
+    error::{Error, ErrorDetails},
+    model::ProviderConfigHelper,
+};
+use lazy_static::lazy_static;
+use strum::VariantNames;
+
+// Reserve prefixes for all supported providers, regardless of whether or not a particular `BaseModelTable`
+// currently supports them.
+lazy_static! {
+    pub static ref RESERVED_MODEL_PREFIXES: Vec<String> = {
+        let mut prefixes: Vec<String> = ProviderConfigHelper::VARIANTS
+            .iter()
+            .map(|&v| format!("{}::", v))
+            .collect();
+        prefixes.push("tensorzero::".to_string());
+        prefixes
+    };
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(try_from = "HashMap<Arc<str>, T>")]
+pub struct BaseModelTable<T: ShorthandModelConfig>(HashMap<Arc<str>, T>);
+
+impl<T: ShorthandModelConfig> Default for BaseModelTable<T> {
+    fn default() -> Self {
+        BaseModelTable(HashMap::new())
+    }
+}
+
+pub trait ShorthandModelConfig: Sized {
+    const SHORTHAND_MODEL_PREFIXES: &[&str];
+    /// Used in error messages (e.g. 'Model' or 'Embedding model')
+    const MODEL_TYPE: &str;
+    fn from_shorthand(provider_type: &str, model_name: &str) -> Result<Self, Error>;
+    fn validate(&self, key: &str) -> Result<(), Error>;
+}
+
+impl<T: ShorthandModelConfig> TryFrom<HashMap<Arc<str>, T>> for BaseModelTable<T> {
+    type Error = String;
+
+    fn try_from(map: HashMap<Arc<str>, T>) -> Result<Self, Self::Error> {
+        for key in map.keys() {
+            if RESERVED_MODEL_PREFIXES
+                .iter()
+                .any(|name| key.starts_with(name))
+            {
+                return Err(format!(
+                    "{} name '{}' contains a reserved prefix",
+                    T::MODEL_TYPE,
+                    key
+                ));
+            }
+        }
+        Ok(BaseModelTable(map))
+    }
+}
+
+impl<T: ShorthandModelConfig> std::ops::Deref for BaseModelTable<T> {
+    type Target = HashMap<Arc<str>, T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// This is `Cow` without the `T: Clone` bound.
+/// Useful when we want a `Cow`, but don't want to (or can't) implement `Clone`
+pub enum CowNoClone<'a, T> {
+    Borrowed(&'a T),
+    Owned(T),
+}
+
+impl<T> Deref for CowNoClone<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            CowNoClone::Borrowed(t) => t,
+            CowNoClone::Owned(t) => t,
+        }
+    }
+}
+
+pub struct Shorthand<'a> {
+    pub provider_type: &'a str,
+    pub model_name: &'a str,
+}
+
+fn check_shorthand<'a>(prefixes: &[&'a str], key: &'a str) -> Option<Shorthand<'a>> {
+    for prefix in prefixes {
+        if let Some(model_name) = key.strip_prefix(prefix) {
+            // Remove the last two characters of the prefix to get the provider type
+            let provider_type = &prefix[..prefix.len() - 2];
+            return Some(Shorthand {
+                provider_type,
+                model_name,
+            });
+        }
+    }
+    None
+}
+
+impl<T: ShorthandModelConfig> BaseModelTable<T> {
+    pub fn get(&self, key: &str) -> Result<Option<CowNoClone<'_, T>>, Error> {
+        if let Some(model_config) = self.0.get(key) {
+            return Ok(Some(CowNoClone::Borrowed(model_config)));
+        }
+        if let Some(shorthand) = check_shorthand(T::SHORTHAND_MODEL_PREFIXES, key) {
+            // TODO - should we cache this?
+            return Ok(Some(CowNoClone::Owned(T::from_shorthand(
+                shorthand.provider_type,
+                shorthand.model_name,
+            )?)));
+        }
+        Ok(None)
+    }
+    /// Check that a model name is valid
+    /// This is either true because it's in the table, or because it's a valid shorthand name
+    pub fn validate(&self, key: &str) -> Result<(), Error> {
+        // Try direct lookup (if it's blacklisted, it's not in the table)
+        // If it's shorthand and already in the table, it's valid
+        if let Some(model_config) = self.0.get(key) {
+            model_config.validate(key)?;
+            return Ok(());
+        }
+
+        if check_shorthand(T::SHORTHAND_MODEL_PREFIXES, key).is_some() {
+            return Ok(());
+        }
+
+        Err(ErrorDetails::Config {
+            message: format!("Model name '{}' not found in model table", key),
+        }
+        .into())
+    }
+
+    #[cfg(any(test, feature = "e2e_tests"))]
+    pub fn static_model_len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn iter_static_models(&self) -> impl Iterator<Item = (&Arc<str>, &T)> {
+        self.0.iter()
+    }
+}

--- a/tensorzero_internal/src/variant/best_of_n_sampling.rs
+++ b/tensorzero_internal/src/variant/best_of_n_sampling.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
-use std::sync::Arc;
-use std::{collections::HashMap, path::PathBuf};
+use std::path::PathBuf;
 
 use backon::Retryable;
 use futures::future::join_all;
@@ -10,7 +9,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use tokio::time::{timeout, Duration};
 
-use crate::embeddings::EmbeddingModelConfig;
+use crate::embeddings::EmbeddingModelTable;
 use crate::endpoints::inference::{InferenceClients, InferenceModels};
 use crate::error::ErrorDetails;
 use crate::inference::types::{
@@ -118,7 +117,7 @@ impl Variant for BestOfNSamplingConfig {
         &self,
         function: &FunctionConfig,
         models: &mut ModelTable,
-        embedding_models: &HashMap<Arc<str>, EmbeddingModelConfig>,
+        embedding_models: &EmbeddingModelTable,
         templates: &TemplateConfig,
         function_name: &str,
         variant_name: &str,
@@ -646,6 +645,8 @@ fn map_evaluator_to_actual_index(evaluator_idx: usize, skipped_indices: &[usize]
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use reqwest::Client;
     use uuid::Uuid;
 

--- a/tensorzero_internal/src/variant/chat_completion.rs
+++ b/tensorzero_internal/src/variant/chat_completion.rs
@@ -1,9 +1,9 @@
 use serde::Deserialize;
 use serde_json::Value;
+use std::path::PathBuf;
 use std::sync::Arc;
-use std::{collections::HashMap, path::PathBuf};
 
-use crate::embeddings::EmbeddingModelConfig;
+use crate::embeddings::EmbeddingModelTable;
 use crate::endpoints::inference::{InferenceClients, InferenceModels, InferenceParams};
 use crate::error::{Error, ErrorDetails};
 use crate::function::FunctionConfig;
@@ -227,7 +227,7 @@ impl Variant for ChatCompletionConfig {
         &self,
         function: &FunctionConfig,
         models: &mut ModelTable,
-        _embedding_models: &HashMap<Arc<str>, EmbeddingModelConfig>,
+        _embedding_models: &EmbeddingModelTable,
         templates: &TemplateConfig,
         function_name: &str,
         variant_name: &str,
@@ -373,6 +373,8 @@ pub fn validate_template_and_schema(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
 
     use futures::StreamExt;
@@ -380,6 +382,7 @@ mod tests {
     use serde_json::{json, Value};
 
     use crate::clickhouse::ClickHouseConnectionInfo;
+    use crate::embeddings::EmbeddingModelTable;
     use crate::endpoints::inference::{ChatCompletionInferenceParams, InferenceCredentials};
     use crate::function::{FunctionConfigChat, FunctionConfigJson};
     use crate::inference::providers::common::get_temperature_tool_config;
@@ -773,7 +776,7 @@ mod tests {
         let models = ModelTable::default();
         let inference_models = InferenceModels {
             models: &models,
-            embedding_models: &HashMap::new(),
+            embedding_models: &EmbeddingModelTable::default(),
         };
         let result = chat_completion_config
             .infer(
@@ -809,7 +812,7 @@ mod tests {
             .unwrap();
         let inference_models = InferenceModels {
             models: &models,
-            embedding_models: &HashMap::new(),
+            embedding_models: &EmbeddingModelTable::default(),
         };
         let inference_config = InferenceConfig {
             templates: &templates,
@@ -848,7 +851,7 @@ mod tests {
         let models = models.try_into().unwrap();
         let inference_models = InferenceModels {
             models: &models,
-            embedding_models: &HashMap::new(),
+            embedding_models: &EmbeddingModelTable::try_from(HashMap::new()).unwrap(),
         };
         let inference_config = InferenceConfig {
             templates: &templates,
@@ -907,7 +910,7 @@ mod tests {
             .unwrap();
         let inference_models = InferenceModels {
             models: &models,
-            embedding_models: &HashMap::new(),
+            embedding_models: &EmbeddingModelTable::default(),
         };
         let inference_config = InferenceConfig {
             templates: &templates,
@@ -978,7 +981,7 @@ mod tests {
             .unwrap();
         let inference_models = InferenceModels {
             models: &models,
-            embedding_models: &HashMap::new(),
+            embedding_models: &EmbeddingModelTable::default(),
         };
         let weather_tool_config = get_temperature_tool_config();
         let inference_config = InferenceConfig {
@@ -1114,7 +1117,7 @@ mod tests {
             .unwrap();
         let inference_models = InferenceModels {
             models: &models,
-            embedding_models: &HashMap::new(),
+            embedding_models: &EmbeddingModelTable::default(),
         };
         let inference_config = InferenceConfig {
             templates: &templates,
@@ -1418,7 +1421,7 @@ mod tests {
                 .try_into()
                 .unwrap(),
         ));
-        let embedding_models = Box::leak(Box::new(HashMap::new()));
+        let embedding_models = &EmbeddingModelTable::try_from(HashMap::new()).unwrap();
         let inference_models = InferenceModels {
             models,
             embedding_models,

--- a/tensorzero_internal/src/variant/mixture_of_n.rs
+++ b/tensorzero_internal/src/variant/mixture_of_n.rs
@@ -1,5 +1,4 @@
-use std::sync::Arc;
-use std::{collections::HashMap, path::PathBuf};
+use std::path::PathBuf;
 
 use futures::future::join_all;
 use rand::Rng;
@@ -7,7 +6,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use tokio::time::{timeout, Duration};
 
-use crate::embeddings::EmbeddingModelConfig;
+use crate::embeddings::EmbeddingModelTable;
 use crate::endpoints::inference::{InferenceClients, InferenceModels};
 use crate::inference::types::{
     batch::StartBatchModelInferenceWithMetadata, ModelInferenceRequest, RequestMessage, Role, Usage,
@@ -92,7 +91,7 @@ impl Variant for MixtureOfNConfig {
         &self,
         function: &FunctionConfig,
         models: &mut ModelTable,
-        embedding_models: &HashMap<Arc<str>, EmbeddingModelConfig>,
+        embedding_models: &EmbeddingModelTable,
         templates: &TemplateConfig,
         function_name: &str,
         variant_name: &str,
@@ -494,6 +493,8 @@ impl FuserConfig {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use reqwest::Client;
     use uuid::Uuid;
 

--- a/tensorzero_internal/src/variant/mod.rs
+++ b/tensorzero_internal/src/variant/mod.rs
@@ -4,14 +4,13 @@ use futures::StreamExt;
 use itertools::izip;
 use serde::Deserialize;
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::time::Duration;
 use tracing::instrument;
 use uuid::Uuid;
 
-use crate::embeddings::EmbeddingModelConfig;
+use crate::embeddings::EmbeddingModelTable;
 use crate::endpoints::inference::{InferenceClients, InferenceModels, InferenceParams};
 use crate::error::Error;
 use crate::error::ErrorDetails;
@@ -126,7 +125,7 @@ pub trait Variant {
         &self,
         function: &FunctionConfig,
         models: &mut ModelTable,
-        embedding_models: &HashMap<Arc<str>, EmbeddingModelConfig>,
+        embedding_models: &EmbeddingModelTable,
         templates: &TemplateConfig,
         function_name: &str,
         variant_name: &str,
@@ -322,7 +321,7 @@ impl Variant for VariantConfig {
         &self,
         function: &FunctionConfig,
         models: &mut ModelTable,
-        embedding_models: &HashMap<Arc<str>, EmbeddingModelConfig>,
+        embedding_models: &EmbeddingModelTable,
         templates: &TemplateConfig,
         function_name: &str,
         variant_name: &str,

--- a/tensorzero_internal/tests/e2e/dicl.rs
+++ b/tensorzero_internal/tests/e2e/dicl.rs
@@ -23,12 +23,23 @@ use crate::common::{
 };
 
 #[tokio::test]
-pub async fn test_dicl_inference_request_no_examples() {
+pub async fn test_dicl_inference_request_no_examples_empty_dicl() {
+    test_dicl_inference_request_no_examples("empty_dicl").await;
+}
+
+// This model is identical to `empty_dicl`, but it specified the embedding model
+// using shorthand
+#[tokio::test]
+pub async fn test_dicl_inference_request_no_examples_empty_dicl_shorthand() {
+    test_dicl_inference_request_no_examples("empty_dicl_shorthand").await;
+}
+
+pub async fn test_dicl_inference_request_no_examples(dicl_variant_name: &str) {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
         "function_name": "basic_test",
-        "variant_name": "empty_dicl",
+        "variant_name": dicl_variant_name,
         "episode_id": episode_id,
         "input":
             {
@@ -63,7 +74,7 @@ pub async fn test_dicl_inference_request_no_examples() {
     assert_eq!(episode_id_response, episode_id);
 
     let variant_name = response_json.get("variant_name").unwrap().as_str().unwrap();
-    assert_eq!(variant_name, "empty_dicl");
+    assert_eq!(variant_name, dicl_variant_name);
 
     let content = response_json.get("content").unwrap().as_array().unwrap();
     assert_eq!(content.len(), 1);
@@ -98,7 +109,7 @@ pub async fn test_dicl_inference_request_no_examples() {
     assert_eq!(function_name, payload["function_name"]);
 
     let variant_name = result.get("variant_name").unwrap().as_str().unwrap();
-    assert_eq!(variant_name, "empty_dicl");
+    assert_eq!(variant_name, dicl_variant_name);
 
     let retrieved_episode_id = result.get("episode_id").unwrap().as_str().unwrap();
     let retrieved_episode_id = Uuid::parse_str(retrieved_episode_id).unwrap();
@@ -173,7 +184,7 @@ pub async fn test_dicl_inference_request_no_examples() {
                     .unwrap();
                 assert!(raw_response.to_lowercase().contains("tokyo"));
             }
-            "text-embedding-3-small" => {
+            "openai::text-embedding-3-small" | "text-embedding-3-small" => {
                 // The embedding call should not generate any output tokens
                 assert_eq!(
                     model_inference

--- a/tensorzero_internal/tests/e2e/tensorzero.toml
+++ b/tensorzero_internal/tests/e2e/tensorzero.toml
@@ -690,6 +690,13 @@ embedding_model = "text-embedding-3-small"
 k = 3
 max_tokens = 100
 
+[functions.basic_test.variants.empty_dicl_shorthand]
+type = "experimental_dynamic_in_context_learning"
+model = "gpt-4o-mini-2024-07-18"
+embedding_model = "openai::text-embedding-3-small"
+k = 3
+max_tokens = 100
+
 [functions.model_fallback_test]
 type = "chat"
 system_schema = "../../fixtures/config/functions/basic_test/system_schema.json"


### PR DESCRIPTION
Depends on https://github.com/tensorzero/tensorzero/pull/863

This allows using model names like `openai::some-model-name` when
specifying any embedding model. This behaves in the same way as
shorthands for normal models - we'll create a model with the default
settings for the specified provider and model name.

Currently, this is only usable with `dicl` - you can now set
`embedding_model = "openai::text-embedding-3-small"` for a dicl
function.

Internally, we now have a generic `BaseModelTable` struct,
which handles the shorthand logic for both standard and
embedding models (with the model-specific behavior controlled through
a new `ShorthandModelConfig`).

We treat all provider names as reserved for both standard and embedding
models (e.g. you cannot declare an embedding model named
`vllm::fake_model`). However, the only embedding shorthand that works
in `embedding_model` is `openai::*` and `dummy::*` (since these are
the only two embedding providers that we currently support).
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Support shorthand model names for embedding models using `BaseModelTable` and `ShorthandModelConfig` for `openai::*` and `dummy::*` providers.
> 
>   - **Behavior**:
>     - Support shorthand model names for embedding models, e.g., `openai::some-model-name`.
>     - Implemented in `config_parser.rs`, `embeddings.rs`, and `model.rs`.
>     - Only `openai::*` and `dummy::*` shorthands are supported for embedding models.
>   - **Structure**:
>     - Introduced `BaseModelTable` struct and `ShorthandModelConfig` trait for handling shorthand logic.
>     - Refactored model handling to use `BaseModelTable` for both standard and embedding models.
>   - **Testing**:
>     - Updated tests in `dicl.rs` and `tensorzero.toml` to include shorthand model names.
>     - Added tests for embedding model shorthand in `dicl.rs`.
>   - **Misc**:
>     - Minor version change in `Cargo.lock` for `reqwest` dependency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 40c61b605d9fce7f0b85503abb769fd5df5a5e2c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->