### PR TITLE
Wake up Clickhouse before running batch tests

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -90,6 +90,10 @@ jobs:
           done
           echo "GATEWAY_PID=$!" >> $GITHUB_ENV
 
+      - name: Wake up ClickHouse cloud (for batch tests)
+        run: |
+          curl ${{ secrets.CLICKHOUSE_CLOUD_URL }}/ping &
+
       - name: Run all tests (including E2E tests)
         run: |
           cargo test-all --profile ci ${{ vars.CARGO_NEXTEST_ARGS }}


### PR DESCRIPTION
This should ensure that the ClickHouse db is awake by the time we reach the batch tests
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add a step to wake up ClickHouse before running batch tests in the GitHub Actions workflow.
> 
>   - **Workflow Update**:
>     - Adds a step in `.github/workflows/merge-queue.yml` to wake up ClickHouse before running batch tests using a `curl` command to `${{ secrets.CLICKHOUSE_CLOUD_URL }}/ping`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d8e22096cc95712803404291cb6a537cde8abf0d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->