### PR TITLE
Enable 'unused_crate_dependencies' lint and remove some deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,7 +1067,6 @@ dependencies = [
  "tensorzero_internal",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2809,14 +2808,12 @@ dependencies = [
  "bytes",
  "derive_builder",
  "futures",
- "futures-core",
  "itertools",
  "jsonschema",
  "jsonwebtoken",
  "lazy_static",
  "metrics",
  "metrics-exporter-prometheus",
- "mimalloc",
  "minijinja",
  "paste",
  "rand",
@@ -2828,7 +2825,6 @@ dependencies = [
  "serde_path_to_error",
  "sha2",
  "strum",
- "strum_macros",
  "tempfile",
  "tensorzero",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { version = "1.38.1", features = ["full"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"
+unused_crate_dependencies = "deny"
 
 
 [workspace.lints.clippy]

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -7,11 +7,6 @@ edition = "2021"
 tensorzero_internal = { path = "../tensorzero_internal" }
 axum = { version = "0.7.5", features = ["macros"] }
 tracing = { version = "0.1.40", features = ["log", "release_max_level_debug"] }
-tracing-subscriber = { version = "0.3.18", features = [
-    "env-filter",
-    "fmt",
-    "json",
-] }
 tokio = { workspace = true }
 mimalloc = "0.1.43"
 

--- a/tensorzero_internal/Cargo.toml
+++ b/tensorzero_internal/Cargo.toml
@@ -42,7 +42,6 @@ backon = { version = "1.2.0", features = ["tokio-sleep"] }
 bytes = "1.6.1"
 derive_builder = "0.20.0"
 futures = "0.3.30"
-futures-core = "0.3.30"
 itertools = "0.13.0"
 jsonschema = "0.18.0"
 jsonwebtoken = "9.3.0"
@@ -51,7 +50,6 @@ metrics = "0.23.0"
 metrics-exporter-prometheus = { version = "0.15.3", features = [
     "http-listener",
 ], default-features = false }
-mimalloc = "0.1.43"
 minijinja = { version = "2.1.0", features = [
     "loader",
     "debug",
@@ -68,7 +66,6 @@ serde_json = { workspace = true }
 serde_path_to_error = "0.1.16"
 sha2 = "0.10.8"
 strum = { version = "0.26.3", features = ["derive"] }
-strum_macros = "0.26.3"
 tokio = { version = "1.38.1", features = ["full"] }
 tokio-stream = { workspace = true }
 toml = "0.8.15"


### PR DESCRIPTION
This lint can have false positives, which is why it's off-by-default. However, it's working correctly for our crates, and caught some unused dependencies left over from the `tensorzero_internal` split.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable `unused_crate_dependencies` lint and remove unused dependencies from the project.
> 
>   - **Lint**:
>     - Enable `unused_crate_dependencies` lint in `Cargo.toml` to catch unused dependencies.
>   - **Dependencies**:
>     - Remove `tracing-subscriber` from `Cargo.lock` and `gateway/Cargo.toml`.
>     - Remove `futures-core`, `mimalloc`, and `strum_macros` from `Cargo.lock` and `tensorzero_internal/Cargo.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4539daf07275f166fb04a40763f8beb306e88b8f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->