### PR TITLE
Bump uv to 0.5.24 in the merge queue workflow

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -43,7 +43,7 @@ jobs:
         uses: namespacelabs/nscloud-setup-buildx-action@v0
 
       - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.3.3/install.sh | sh
+        run: curl -LsSf https://astral.sh/uv/0.5.24/install.sh | sh
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
The older uv is unable to handle lockfiles produced by a newer uv (due to a missing `version` field for `tensorzero`), so let's bump it to the latest version.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `uv` version to `0.5.24` in `merge-queue.yml` to handle lockfiles from newer `uv` versions.
> 
>   - **Workflow Update**:
>     - Bump `uv` version from `0.3.3` to `0.5.24` in `.github/workflows/merge-queue.yml` to handle lockfiles from newer `uv` versions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 16e3a59dcc597482bbcf7f48651330e822fba5b0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->