### PR TITLE
Set debug/warn for tensorzero_internal as well as gateway

### DIFF
--- a/tensorzero_internal/src/observability.rs
+++ b/tensorzero_internal/src/observability.rs
@@ -7,7 +7,7 @@ use crate::error::{Error, ErrorDetails};
 pub fn setup_logs() {
     // Get the current log level from the environment variable `RUST_LOG`
     let log_level = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| "gateway=debug,warn".into());
+        .unwrap_or_else(|_| "gateway=debug,warn,tensorzero_internal=debug,warn".into());
 
     tracing_subscriber::registry()
         .with(log_level)


### PR DESCRIPTION
This was missed when I did the initial `tensorzero_internal` conversion
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update default log level in `setup_logs` to include `tensorzero_internal=debug,warn`.
> 
>   - **Logging Configuration**:
>     - Update default log level in `setup_logs` in `observability.rs` to include `tensorzero_internal=debug,warn` alongside `gateway=debug,warn`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d975a39fdc584b564e695e1c86c43a057ea0119a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->