### PR TITLE
Enable logging in python-pyo3 client

### DIFF
--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -39,6 +39,7 @@ pub(crate) static TENSORZERO_INTERNAL_ERROR: GILOnceCell<Py<PyAny>> = GILOnceCel
 
 #[pymodule]
 fn tensorzero(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    tensorzero_rust::observability::setup_logs(false);
     m.add_class::<BaseTensorZeroGateway>()?;
     m.add_class::<AsyncTensorZeroGateway>()?;
     m.add_class::<TensorZeroGateway>()?;

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -394,6 +394,9 @@ pub fn err_to_http(e: tensorzero_internal::error::Error) -> TensorZeroError {
     }
 }
 
+#[cfg(feature = "pyo3")]
+pub use tensorzero_internal::observability;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -20,7 +20,7 @@ static GLOBAL: MiMalloc = MiMalloc;
 #[tokio::main]
 async fn main() {
     // Set up logs and metrics
-    observability::setup_logs();
+    observability::setup_logs(true);
     let metrics_handle = observability::setup_metrics().expect_pretty("Failed to set up metrics");
 
     // Load config

--- a/tensorzero_internal/src/observability.rs
+++ b/tensorzero_internal/src/observability.rs
@@ -4,10 +4,12 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use crate::error::{Error, ErrorDetails};
 
 /// Set up logs
-pub fn setup_logs() {
+pub fn setup_logs(debug: bool) {
+    let default_level = if debug { "debug,warn" } else { "warn" };
     // Get the current log level from the environment variable `RUST_LOG`
-    let log_level = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| "gateway=debug,warn,tensorzero_internal=debug,warn".into());
+    let log_level = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        format!("gateway={default_level},tensorzero_internal={default_level}").into()
+    });
 
     tracing_subscriber::registry()
         .with(log_level)


### PR DESCRIPTION
Fixes https://github.com/tensorzero/tensorzero/issues/871

For now, this cannot be controlled directly from Python - it's configured via `RUST_LOG`. I've turned down the default verbosity for the python client (compared to the gateway binary)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable logging in Python client using Rust's logging setup with configurable verbosity.
> 
>   - **Logging Setup**:
>     - `setup_logs` in `observability.rs` now accepts a `debug` parameter to set verbosity level.
>     - Python client in `python-pyo3/src/lib.rs` initializes logging with `setup_logs(false)` for reduced verbosity.
>     - Gateway binary in `main.rs` uses `setup_logs(true)` for full verbosity.
>   - **Code Changes**:
>     - Expose `observability` module in `clients/rust/src/lib.rs` for use in Python client.
>     - Adjusted logging setup in `main.rs` to use new `setup_logs` signature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f3b8d951b095209f5bbb6a641bcdc8f09a932bdc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->