### PR TITLE
Generate inference UUIDs at the start of request processing

### DIFF
--- a/tensorzero_internal/src/endpoints/inference.rs
+++ b/tensorzero_internal/src/endpoints/inference.rs
@@ -90,6 +90,7 @@ struct InferenceMetadata {
     pub function_name: String,
     pub variant_name: String,
     pub episode_id: Uuid,
+    pub inference_id: Uuid,
     pub input: Input,
     pub dryrun: bool,
     pub start_time: Instant,
@@ -141,6 +142,12 @@ pub enum InferenceOutput {
 
 const DEFAULT_FUNCTION_NAME: &str = "tensorzero::default";
 
+#[derive(Copy, Clone, Debug)]
+pub struct InferenceIds {
+    pub inference_id: Uuid,
+    pub episode_id: Uuid,
+}
+
 #[instrument(
     name="inference",
     skip(config, http_client, clickhouse_connection_info, params),
@@ -148,6 +155,8 @@ const DEFAULT_FUNCTION_NAME: &str = "tensorzero::default";
         function_name = ?params.function_name,
         model_name = ?params.model_name,
         variant_name = ?params.variant_name,
+        inference_id,
+        episode_id,
     )
 )]
 pub async fn inference(
@@ -158,6 +167,14 @@ pub async fn inference(
 ) -> Result<InferenceOutput, Error> {
     // To be used for the Inference table processing_time measurements
     let start_time = Instant::now();
+    let inference_id = Uuid::now_v7();
+    tracing::Span::current().record("inference_id", inference_id.to_string());
+
+    // Retrieve or generate the episode ID
+    let episode_id = params.episode_id.unwrap_or(Uuid::now_v7());
+    validate_episode_id(episode_id)?;
+    tracing::Span::current().record("episode_id", episode_id.to_string());
+
     validate_tags(&params.tags)?;
     let (function, function_name) = find_function(&params, &config)?;
     let tool_config = function.prepare_tool_config(params.dynamic_tool_params, &config.tools)?;
@@ -189,10 +206,6 @@ pub async fn inference(
         }
     }
 
-    // Retrieve or generate the episode ID
-    let episode_id = params.episode_id.unwrap_or(Uuid::now_v7());
-    validate_episode_id(episode_id)?;
-
     // Should we store the results?
     let dryrun = params.dryrun.unwrap_or(false);
 
@@ -223,6 +236,10 @@ pub async fn inference(
         templates: &config.templates,
         tool_config: tool_config.as_ref(),
         dynamic_output_schema: output_schema.as_ref(),
+        ids: InferenceIds {
+            inference_id,
+            episode_id,
+        },
     };
 
     let inference_clients = InferenceClients {
@@ -277,6 +294,7 @@ pub async fn inference(
             let inference_metadata = InferenceMetadata {
                 function_name: function_name.to_string(),
                 variant_name: variant_name.to_string(),
+                inference_id,
                 episode_id,
                 input: params.input.clone(),
                 dryrun,
@@ -457,6 +475,7 @@ fn create_stream(
             let InferenceMetadata {
                 function_name,
                 variant_name,
+                inference_id,
                 episode_id,
                 input,
                 dryrun: _,
@@ -478,6 +497,8 @@ fn create_stream(
                 let templates = &config.templates;
                 let collect_chunks_args = CollectChunksArgs {
                     value: buffer,
+                    inference_id,
+                    episode_id,
                     system,
                     input_messages,
                     function,
@@ -524,7 +545,12 @@ fn prepare_response_chunk(
     metadata: &InferenceMetadata,
     chunk: InferenceResultChunk,
 ) -> InferenceResponseChunk {
-    InferenceResponseChunk::new(chunk, metadata.episode_id, metadata.variant_name.clone())
+    InferenceResponseChunk::new(
+        chunk,
+        metadata.inference_id,
+        metadata.episode_id,
+        metadata.variant_name.clone(),
+    )
 }
 
 // Prepares an Event for SSE on the way out of the gateway
@@ -677,11 +703,16 @@ pub struct JsonInferenceResponseChunk {
 }
 
 impl InferenceResponseChunk {
-    fn new(inference_result: InferenceResultChunk, episode_id: Uuid, variant_name: String) -> Self {
+    fn new(
+        inference_result: InferenceResultChunk,
+        inference_id: Uuid,
+        episode_id: Uuid,
+        variant_name: String,
+    ) -> Self {
         match inference_result {
             InferenceResultChunk::Chat(result) => {
                 InferenceResponseChunk::Chat(ChatInferenceResponseChunk {
-                    inference_id: result.inference_id,
+                    inference_id,
                     episode_id,
                     variant_name,
                     content: result.content,
@@ -690,7 +721,7 @@ impl InferenceResponseChunk {
             }
             InferenceResultChunk::Json(result) => {
                 InferenceResponseChunk::Json(JsonInferenceResponseChunk {
-                    inference_id: result.inference_id,
+                    inference_id,
                     episode_id,
                     variant_name,
                     raw: result.raw,
@@ -785,13 +816,11 @@ mod tests {
     #[tokio::test]
     async fn test_prepare_event() {
         // Test case 1: Valid Chat ProviderInferenceResponseChunk
-        let inference_id = Uuid::now_v7();
         let content = vec![ContentBlockChunk::Text(TextChunk {
             text: "Test content".to_string(),
             id: "0".to_string(),
         })];
         let chunk = InferenceResultChunk::Chat(ChatInferenceResultChunk {
-            inference_id,
             content: content.clone(),
             created: 0,
             usage: None,
@@ -803,6 +832,7 @@ mod tests {
             function_name: "test_function".to_string(),
             variant_name: "test_variant".to_string(),
             episode_id: Uuid::now_v7(),
+            inference_id: Uuid::now_v7(),
             input: Input {
                 messages: vec![],
                 system: None,
@@ -824,7 +854,7 @@ mod tests {
         let result = prepare_response_chunk(&inference_metadata, chunk);
         match result {
             InferenceResponseChunk::Chat(c) => {
-                assert_eq!(c.inference_id, inference_id);
+                assert_eq!(c.inference_id, inference_metadata.inference_id);
                 assert_eq!(c.episode_id, inference_metadata.episode_id);
                 assert_eq!(c.variant_name, inference_metadata.variant_name);
                 assert_eq!(c.content, content);
@@ -840,9 +870,7 @@ mod tests {
         // This test doesn't do much so consider deleting or doing more.
 
         // Test case 2: Valid JSON ProviderInferenceResponseChunk
-        let inference_id = Uuid::now_v7();
         let chunk = InferenceResultChunk::Json(JsonInferenceResultChunk {
-            inference_id,
             raw: "Test content".to_string(),
             created: 0,
             usage: None,
@@ -852,6 +880,7 @@ mod tests {
         let inference_metadata = InferenceMetadata {
             function_name: "test_function".to_string(),
             variant_name: "test_variant".to_string(),
+            inference_id: Uuid::now_v7(),
             episode_id: Uuid::now_v7(),
             input: Input {
                 messages: vec![],
@@ -874,7 +903,7 @@ mod tests {
         let result = prepare_response_chunk(&inference_metadata, chunk);
         match result {
             InferenceResponseChunk::Json(c) => {
-                assert_eq!(c.inference_id, inference_id);
+                assert_eq!(c.inference_id, inference_metadata.inference_id);
                 assert_eq!(c.episode_id, inference_metadata.episode_id);
                 assert_eq!(c.variant_name, inference_metadata.variant_name);
                 assert_eq!(c.raw, "Test content");

--- a/tensorzero_internal/src/function.rs
+++ b/tensorzero_internal/src/function.rs
@@ -464,6 +464,7 @@ fn get_uniform_value(function_name: &str, episode_id: &Uuid) -> f64 {
 
 #[cfg(test)]
 mod tests {
+    use crate::endpoints::inference::InferenceIds;
     use crate::inference::types::InputMessage;
     use crate::inference::types::Latency;
     use crate::jsonschema_util::DynamicJSONSchema;
@@ -1304,6 +1305,10 @@ mod tests {
         };
         let templates = TemplateConfig::default();
         let inference_config = InferenceConfig {
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
             tool_config: None,
             function_name: "",
             variant_name: Some(""),
@@ -1581,6 +1586,10 @@ mod tests {
             "required": ["answer"]
         }));
         let inference_config = InferenceConfig {
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
             tool_config: None,
             function_name: "",
             variant_name: Some(""),

--- a/tensorzero_internal/src/inference/providers/aws_bedrock.rs
+++ b/tensorzero_internal/src/inference/providers/aws_bedrock.rs
@@ -15,7 +15,6 @@ use futures::{Stream, StreamExt};
 use reqwest::StatusCode;
 use std::time::Duration;
 use tokio::time::Instant;
-use uuid::Uuid;
 
 use super::anthropic::{prefill_json_chunk_response, prefill_json_response};
 use crate::endpoints::inference::InferenceCredentials;
@@ -336,7 +335,6 @@ fn stream_bedrock(
     start_time: Instant,
 ) -> impl Stream<Item = Result<ProviderInferenceResponseChunk, Error>> {
     async_stream::stream! {
-        let inference_id = Uuid::now_v7();
         let mut current_tool_id : Option<String> = None;
         let mut current_tool_name: Option<String> = None;
 
@@ -359,7 +357,7 @@ fn stream_bedrock(
                         // NOTE: AWS Bedrock returns usage (ConverseStreamMetadataEvent) AFTER MessageStop.
 
                         // Convert the event to a tensorzero stream message
-                        let stream_message = bedrock_to_tensorzero_stream_message(output, inference_id, start_time.elapsed(), &mut current_tool_id, &mut current_tool_name);
+                        let stream_message = bedrock_to_tensorzero_stream_message(output, start_time.elapsed(), &mut current_tool_id, &mut current_tool_name);
 
                         match stream_message {
                             Ok(None) => {},
@@ -375,7 +373,6 @@ fn stream_bedrock(
 
 fn bedrock_to_tensorzero_stream_message(
     output: ConverseStreamOutputType,
-    inference_id: Uuid,
     message_latency: Duration,
     current_tool_id: &mut Option<String>,
     current_tool_name: &mut Option<String>,
@@ -387,7 +384,6 @@ fn bedrock_to_tensorzero_stream_message(
             match message.delta {
                 Some(delta) => match delta {
                     ContentBlockDelta::Text(text) => Ok(Some(ProviderInferenceResponseChunk::new(
-                        inference_id,
                         vec![ContentBlockChunk::Text(TextChunk {
                             text,
                             id: message.content_block_index.to_string(),
@@ -398,7 +394,6 @@ fn bedrock_to_tensorzero_stream_message(
                     ))),
                     ContentBlockDelta::ToolUse(tool_use) => {
                         Ok(Some(ProviderInferenceResponseChunk::new(
-                            inference_id,
                             // Take the current tool name and ID and use them to create a ToolCallChunk
                             // This is necessary because the ToolCallChunk must always contain the tool name and ID
                             // even though AWS Bedrock only sends the tool ID and name in the ToolUse chunk and not InputJSONDelta
@@ -443,7 +438,6 @@ fn bedrock_to_tensorzero_stream_message(
                     *current_tool_id = Some(tool_use.tool_use_id.clone());
                     *current_tool_name = Some(tool_use.name.clone());
                     Ok(Some(ProviderInferenceResponseChunk::new(
-                        inference_id,
                         vec![ContentBlockChunk::ToolCall(ToolCallChunk {
                             id: tool_use.tool_use_id,
                             raw_name: tool_use.name,
@@ -480,7 +474,6 @@ fn bedrock_to_tensorzero_stream_message(
                     });
 
                     Ok(Some(ProviderInferenceResponseChunk::new(
-                        inference_id,
                         vec![],
                         usage,
                         raw_message,

--- a/tensorzero_internal/src/inference/providers/azure.rs
+++ b/tensorzero_internal/src/inference/providers/azure.rs
@@ -463,6 +463,8 @@ impl<'a> TryFrom<AzureResponseWithMetadata<'a>> for ProviderInferenceResponse {
 mod tests {
     use std::borrow::Cow;
 
+    use uuid::Uuid;
+
     use super::*;
 
     use crate::inference::providers::common::{WEATHER_TOOL, WEATHER_TOOL_CONFIG};
@@ -474,6 +476,7 @@ mod tests {
     #[test]
     fn test_azure_request_new() {
         let request_with_tools = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: vec![RequestMessage {
                 role: Role::User,
                 content: vec!["What's the weather?".to_string().into()],
@@ -517,6 +520,7 @@ mod tests {
         );
 
         let request_with_tools = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: vec![RequestMessage {
                 role: Role::User,
                 content: vec!["What's the weather?".to_string().into()],

--- a/tensorzero_internal/src/inference/providers/dummy.rs
+++ b/tensorzero_internal/src/inference/providers/dummy.rs
@@ -318,7 +318,6 @@ impl InferenceProvider for DummyProvider {
             }
             .into());
         }
-        let id = Uuid::now_v7();
         let created = current_timestamp();
 
         let (content_chunks, is_tool_call) = if self.model_name == "tool" {
@@ -330,7 +329,6 @@ impl InferenceProvider for DummyProvider {
         let total_tokens = content_chunks.len() as u32;
 
         let initial_chunk = ProviderInferenceResponseChunk {
-            inference_id: id,
             created,
             content: vec![if is_tool_call {
                 ContentBlockChunk::ToolCall(ToolCallChunk {
@@ -352,7 +350,6 @@ impl InferenceProvider for DummyProvider {
         let stream = tokio_stream::iter(content_chunks.into_iter().skip(1).enumerate())
             .map(move |(i, chunk)| {
                 Ok(ProviderInferenceResponseChunk {
-                    inference_id: id,
                     created,
                     content: vec![if is_tool_call {
                         ContentBlockChunk::ToolCall(ToolCallChunk {
@@ -372,7 +369,6 @@ impl InferenceProvider for DummyProvider {
                 })
             })
             .chain(tokio_stream::once(Ok(ProviderInferenceResponseChunk {
-                inference_id: id,
                 created,
                 content: vec![],
                 usage: Some(crate::inference::types::Usage {
@@ -397,14 +393,12 @@ impl InferenceProvider for DummyProvider {
         _client: &'a reqwest::Client,
         _dynamic_api_keys: &'a InferenceCredentials,
     ) -> Result<StartBatchProviderInferenceResponse, Error> {
-        let inference_ids: Vec<Uuid> = requests.iter().map(|_| Uuid::now_v7()).collect();
         let file_id = Uuid::now_v7();
         let batch_id = Uuid::now_v7();
         let raw_requests: Vec<String> =
             requests.iter().map(|_| "raw_request".to_string()).collect();
         Ok(StartBatchProviderInferenceResponse {
             batch_id,
-            inference_ids,
             batch_params: json!({"file_id": file_id, "batch_id": batch_id}),
             status: BatchStatus::Pending,
             raw_requests,

--- a/tensorzero_internal/src/inference/providers/fireworks.rs
+++ b/tensorzero_internal/src/inference/providers/fireworks.rs
@@ -469,6 +469,8 @@ impl<'a> TryFrom<FireworksResponseWithMetadata<'a>> for ProviderInferenceRespons
 mod tests {
     use std::borrow::Cow;
 
+    use uuid::Uuid;
+
     use super::*;
 
     use crate::inference::providers::common::{WEATHER_TOOL, WEATHER_TOOL_CONFIG};
@@ -479,6 +481,7 @@ mod tests {
     #[test]
     fn test_fireworks_request_new() {
         let request_with_tools = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: vec![RequestMessage {
                 role: Role::User,
                 content: vec!["What's the weather?".to_string().into()],

--- a/tensorzero_internal/src/inference/providers/hyperbolic.rs
+++ b/tensorzero_internal/src/inference/providers/hyperbolic.rs
@@ -400,6 +400,8 @@ impl<'a> TryFrom<HyperbolicResponseWithMetadata<'a>> for ProviderInferenceRespon
 mod tests {
     use std::borrow::Cow;
 
+    use uuid::Uuid;
+
     use super::*;
 
     use crate::inference::providers::common::WEATHER_TOOL_CONFIG;
@@ -410,6 +412,7 @@ mod tests {
     #[test]
     fn test_hyperbolic_request_new() {
         let request_with_tools = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: vec![RequestMessage {
                 role: Role::User,
                 content: vec!["What's the weather?".to_string().into()],

--- a/tensorzero_internal/src/inference/providers/sglang.rs
+++ b/tensorzero_internal/src/inference/providers/sglang.rs
@@ -450,6 +450,7 @@ mod tests {
     use std::borrow::Cow;
 
     use serde_json::json;
+    use uuid::Uuid;
 
     use crate::inference::{
         providers::common::WEATHER_TOOL_CONFIG,
@@ -462,6 +463,7 @@ mod tests {
     fn test_sglang_request_new() {
         let model_name = PROVIDER_TYPE.to_string();
         let basic_request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: vec![
                 RequestMessage {
                     role: Role::User,
@@ -502,6 +504,7 @@ mod tests {
 
         // Test that non-strict JSON mode requires an output schema
         let request_with_tools = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: vec![RequestMessage {
                 role: Role::User,
                 content: vec!["What's the weather?".to_string().into()],
@@ -523,6 +526,7 @@ mod tests {
 
         // Test request with in strict JSON mode requires an no output schema
         let request_with_tools = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: vec![RequestMessage {
                 role: Role::User,
                 content: vec!["What's the weather?".to_string().into()],
@@ -545,6 +549,7 @@ mod tests {
         // Test request with strict JSON mode with an output schema
         let output_schema = json!({});
         let request_with_tools = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: vec![RequestMessage {
                 role: Role::User,
                 content: vec!["What's the weather?".to_string().into()],

--- a/tensorzero_internal/src/inference/providers/together.rs
+++ b/tensorzero_internal/src/inference/providers/together.rs
@@ -444,6 +444,8 @@ impl<'a> TryFrom<TogetherResponseWithMetadata<'a>> for ProviderInferenceResponse
 mod tests {
     use std::borrow::Cow;
 
+    use uuid::Uuid;
+
     use super::*;
 
     use crate::inference::providers::common::{WEATHER_TOOL, WEATHER_TOOL_CONFIG};
@@ -455,6 +457,7 @@ mod tests {
     #[test]
     fn test_together_request_new() {
         let request_with_tools = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: vec![RequestMessage {
                 role: Role::User,
                 content: vec!["What's the weather?".to_string().into()],

--- a/tensorzero_internal/src/inference/providers/vllm.rs
+++ b/tensorzero_internal/src/inference/providers/vllm.rs
@@ -440,6 +440,7 @@ mod tests {
     use std::borrow::Cow;
 
     use serde_json::json;
+    use uuid::Uuid;
 
     use super::*;
 
@@ -458,6 +459,7 @@ mod tests {
             }
         });
         let request_with_tools = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: vec![RequestMessage {
                 role: Role::User,
                 content: vec!["What's the weather?".to_string().into()],
@@ -493,6 +495,7 @@ mod tests {
             }
         });
         let request_with_tools = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: vec![RequestMessage {
                 role: Role::User,
                 content: vec!["What's the weather?".to_string().into()],

--- a/tensorzero_internal/src/inference/providers/xai.rs
+++ b/tensorzero_internal/src/inference/providers/xai.rs
@@ -431,6 +431,8 @@ impl<'a> TryFrom<XAIResponseWithMetadata<'a>> for ProviderInferenceResponse {
 mod tests {
     use std::borrow::Cow;
 
+    use uuid::Uuid;
+
     use super::*;
 
     use crate::inference::providers::common::{WEATHER_TOOL, WEATHER_TOOL_CONFIG};
@@ -444,6 +446,7 @@ mod tests {
     #[test]
     fn test_xai_request_new() {
         let request_with_tools = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: vec![RequestMessage {
                 role: Role::User,
                 content: vec!["What's the weather?".to_string().into()],
@@ -487,6 +490,7 @@ mod tests {
         );
 
         let request_with_tools = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: vec![RequestMessage {
                 role: Role::User,
                 content: vec!["What's the weather?".to_string().into()],
@@ -534,6 +538,7 @@ mod tests {
         );
 
         let request_with_tools = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             json_mode: ModelInferenceRequestJsonMode::Strict,
             ..request_with_tools
         };

--- a/tensorzero_internal/src/inference/types/batch.rs
+++ b/tensorzero_internal/src/inference/types/batch.rs
@@ -29,7 +29,6 @@ pub enum BatchStatus {
 /// through the call stack.
 pub struct StartBatchProviderInferenceResponse {
     pub batch_id: Uuid,
-    pub inference_ids: Vec<Uuid>,
     pub raw_requests: Vec<String>, // The raw text of each individual batch request
     pub batch_params: Value,
     pub raw_request: String,  // The raw text of the batch request body
@@ -42,7 +41,6 @@ pub struct StartBatchProviderInferenceResponse {
 /// Adds the model provider name to the response
 pub struct StartBatchModelInferenceResponse {
     pub batch_id: Uuid,
-    pub inference_ids: Vec<Uuid>,
     pub raw_requests: Vec<String>,
     pub batch_params: Value,
     pub raw_request: String,  // The raw text of the batch request body
@@ -59,7 +57,6 @@ impl StartBatchModelInferenceResponse {
     ) -> Self {
         Self {
             batch_id: provider_batch_response.batch_id,
-            inference_ids: provider_batch_response.inference_ids,
             raw_requests: provider_batch_response.raw_requests,
             batch_params: provider_batch_response.batch_params,
             raw_request: provider_batch_response.raw_request,
@@ -76,7 +73,6 @@ impl StartBatchModelInferenceResponse {
 /// systems, tool configs, inference params, model_name, and output schemas.
 pub struct StartBatchModelInferenceWithMetadata<'a> {
     pub batch_id: Uuid,
-    pub inference_ids: Vec<Uuid>,
     pub errors: Vec<Value>,
     pub input_messages: Vec<Vec<RequestMessage>>,
     pub systems: Vec<Option<String>>,
@@ -111,7 +107,6 @@ impl<'a> StartBatchModelInferenceWithMetadata<'a> {
         }
         Self {
             batch_id: model_batch_response.batch_id,
-            inference_ids: model_batch_response.inference_ids,
             input_messages,
             systems,
             tool_configs,

--- a/tensorzero_internal/src/model.rs
+++ b/tensorzero_internal/src/model.rs
@@ -1030,6 +1030,7 @@ mod tests {
     use secrecy::SecretString;
     use tokio_stream::StreamExt;
     use tracing_test::traced_test;
+    use uuid::Uuid;
 
     use super::*;
 
@@ -1056,6 +1057,7 @@ mod tests {
 
         // Try inferring the good model only
         let request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: vec![],
             system: None,
             tool_config: Some(Cow::Borrowed(&tool_config)),
@@ -1129,6 +1131,7 @@ mod tests {
         let api_keys = InferenceCredentials::default();
         // Try inferring the good model only
         let request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: vec![],
             system: None,
             tool_config: None,
@@ -1185,6 +1188,7 @@ mod tests {
         });
         let api_keys = InferenceCredentials::default();
         let request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: vec![],
             system: None,
             tool_config: None,
@@ -1287,6 +1291,7 @@ mod tests {
         });
         let api_keys = InferenceCredentials::default();
         let request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: vec![],
             system: None,
             tool_config: None,
@@ -1364,6 +1369,7 @@ mod tests {
         let api_keys = InferenceCredentials::default();
 
         let request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: vec![],
             system: None,
             tool_config: Some(Cow::Borrowed(&tool_config)),
@@ -1439,6 +1445,7 @@ mod tests {
 
         let request = ModelInferenceRequest {
             messages: vec![],
+            inference_id: Uuid::now_v7(),
             system: None,
             tool_config: Some(Cow::Borrowed(&tool_config)),
             temperature: None,

--- a/tensorzero_internal/src/variant/best_of_n_sampling.rs
+++ b/tensorzero_internal/src/variant/best_of_n_sampling.rs
@@ -606,6 +606,7 @@ impl EvaluatorConfig {
         };
         Ok((
             ModelInferenceRequest {
+                inference_id: inference_config.ids.inference_id,
                 messages,
                 system,
                 tool_config,
@@ -652,7 +653,7 @@ mod tests {
 
     use crate::{
         clickhouse::ClickHouseConnectionInfo,
-        endpoints::inference::InferenceCredentials,
+        endpoints::inference::{InferenceCredentials, InferenceIds},
         inference::{
             providers::dummy::DummyProvider,
             types::{ChatInferenceResult, JsonInferenceResult, Latency},
@@ -1122,6 +1123,10 @@ mod tests {
             messages: vec![],
         };
         let inference_config = InferenceConfig {
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
             templates: &templates,
             tool_config: None,
             dynamic_output_schema: None,

--- a/tensorzero_internal/src/variant/chat_completion.rs
+++ b/tensorzero_internal/src/variant/chat_completion.rs
@@ -380,10 +380,13 @@ mod tests {
     use futures::StreamExt;
     use reqwest::Client;
     use serde_json::{json, Value};
+    use uuid::Uuid;
 
     use crate::clickhouse::ClickHouseConnectionInfo;
     use crate::embeddings::EmbeddingModelTable;
-    use crate::endpoints::inference::{ChatCompletionInferenceParams, InferenceCredentials};
+    use crate::endpoints::inference::{
+        ChatCompletionInferenceParams, InferenceCredentials, InferenceIds,
+    };
     use crate::function::{FunctionConfigChat, FunctionConfigJson};
     use crate::inference::providers::common::get_temperature_tool_config;
     use crate::inference::providers::dummy::{DummyProvider, DUMMY_JSON_RESPONSE_RAW};
@@ -772,6 +775,10 @@ mod tests {
             function_name: "",
             variant_name: Some(""),
             dynamic_output_schema: None,
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
         };
         let models = ModelTable::default();
         let inference_models = InferenceModels {
@@ -820,6 +827,10 @@ mod tests {
             function_name: "",
             variant_name: Some(""),
             dynamic_output_schema: None,
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
         };
         let result = chat_completion_config
             .infer(
@@ -859,6 +870,10 @@ mod tests {
             function_name: "",
             variant_name: Some(""),
             dynamic_output_schema: None,
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
         };
         let err = chat_completion_config
             .infer(
@@ -918,6 +933,10 @@ mod tests {
             function_name: "",
             variant_name: Some(""),
             dynamic_output_schema: None,
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
         };
         let result = chat_completion_config
             .infer(
@@ -990,6 +1009,10 @@ mod tests {
             function_name: "",
             variant_name: Some(""),
             dynamic_output_schema: None,
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
         };
         let result = chat_completion_config
             .infer(
@@ -1070,6 +1093,10 @@ mod tests {
             function_name: "",
             variant_name: Some(""),
             dynamic_output_schema: None,
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
         };
         let inference_params = InferenceParams::default();
         let result = chat_completion_config
@@ -1120,6 +1147,10 @@ mod tests {
             embedding_models: &EmbeddingModelTable::default(),
         };
         let inference_config = InferenceConfig {
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
             templates: &templates,
             tool_config: None,
             function_name: "",
@@ -1212,6 +1243,10 @@ mod tests {
             "required": ["answer"]
         }));
         let inference_config = InferenceConfig {
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
             templates: &templates,
             tool_config: None,
             function_name: "",
@@ -1295,6 +1330,10 @@ mod tests {
             "required": ["response"]
         }));
         let inference_config = InferenceConfig {
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
             templates: &templates,
             tool_config: None,
             function_name: "",
@@ -1427,6 +1466,10 @@ mod tests {
             embedding_models,
         };
         let inference_config = InferenceConfig {
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
             templates,
             tool_config: None,
             dynamic_output_schema: None,
@@ -1479,6 +1522,10 @@ mod tests {
             embedding_models,
         };
         let inference_config = InferenceConfig {
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
             templates,
             tool_config: None,
             function_name: "",
@@ -1574,6 +1621,10 @@ mod tests {
         });
         let mut inference_params = InferenceParams::default();
         let inference_config = InferenceConfig {
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
             templates,
             tool_config: None,
             function_name: "",
@@ -1672,6 +1723,10 @@ mod tests {
             },
         });
         let inference_config = InferenceConfig {
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
             templates,
             tool_config: None,
             dynamic_output_schema: None,
@@ -1750,6 +1805,10 @@ mod tests {
             dynamic_output_schema: Some(&dynamic_output_schema),
             function_name: "",
             variant_name: Some(""),
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
         };
         let model_request = chat_completion_config
             .prepare_request(

--- a/tensorzero_internal/src/variant/mixture_of_n.rs
+++ b/tensorzero_internal/src/variant/mixture_of_n.rs
@@ -500,7 +500,7 @@ mod tests {
 
     use crate::{
         clickhouse::ClickHouseConnectionInfo,
-        endpoints::inference::InferenceCredentials,
+        endpoints::inference::{InferenceCredentials, InferenceIds},
         function::{FunctionConfigChat, FunctionConfigJson},
         inference::{
             providers::dummy::DummyProvider,
@@ -955,6 +955,10 @@ mod tests {
             messages: vec![],
         };
         let inference_config = InferenceConfig {
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
             templates: &templates,
             tool_config: None,
             dynamic_output_schema: None,

--- a/tensorzero_internal/src/variant/mod.rs
+++ b/tensorzero_internal/src/variant/mod.rs
@@ -11,6 +11,7 @@ use tracing::instrument;
 use uuid::Uuid;
 
 use crate::embeddings::EmbeddingModelTable;
+use crate::endpoints::inference::InferenceIds;
 use crate::endpoints::inference::{InferenceClients, InferenceModels, InferenceParams};
 use crate::error::Error;
 use crate::error::ErrorDetails;
@@ -53,7 +54,7 @@ pub enum JsonMode {
     ImplicitTool,
 }
 
-/// Maps to the subset of Config that applies to the current inference request.
+/// Configuration that applies to the current inference request.
 #[derive(Debug)]
 pub struct InferenceConfig<'a, 'request> {
     pub tool_config: Option<&'request ToolCallConfig>,
@@ -61,6 +62,7 @@ pub struct InferenceConfig<'a, 'request> {
     pub dynamic_output_schema: Option<&'request DynamicJSONSchema>,
     pub function_name: &'request str,
     pub variant_name: Option<&'request str>,
+    pub ids: InferenceIds,
 }
 
 /// Maps to the subset of Config that applies to the current inference request.
@@ -73,18 +75,30 @@ pub struct BatchInferenceConfig<'a> {
     pub variant_name: Option<&'a str>,
 }
 impl<'a> BatchInferenceConfig<'a> {
-    pub fn inference_configs(&'a self) -> Vec<InferenceConfig<'a, 'a>> {
+    pub fn inference_configs(
+        &'a self,
+        episode_ids: &[Uuid],
+        inference_ids: &[Uuid],
+    ) -> Vec<InferenceConfig<'a, 'a>> {
         izip!(
             self.tool_configs.iter().map(|x| x.as_ref()),
-            self.dynamic_output_schemas.iter().map(|x| x.as_ref())
+            self.dynamic_output_schemas.iter().map(|x| x.as_ref()),
+            episode_ids.iter(),
+            inference_ids.iter()
         )
-        .map(|(tool_config, dynamic_output_schema)| InferenceConfig {
-            templates: self.templates,
-            tool_config,
-            dynamic_output_schema,
-            function_name: self.function_name,
-            variant_name: self.variant_name,
-        })
+        .map(
+            |(tool_config, dynamic_output_schema, episode_id, inference_id)| InferenceConfig {
+                templates: self.templates,
+                tool_config,
+                dynamic_output_schema,
+                function_name: self.function_name,
+                variant_name: self.variant_name,
+                ids: InferenceIds {
+                    inference_id: *inference_id,
+                    episode_id: *episode_id,
+                },
+            },
+        )
         .collect()
     }
 }
@@ -388,6 +402,7 @@ where
         FunctionConfig::Chat(_) => ModelInferenceRequest {
             messages,
             system,
+            inference_id: inference_config.ids.inference_id,
             tool_config: inference_config.tool_config.map(Cow::Borrowed),
             temperature: inference_params.chat_completion.temperature,
             top_p: inference_params.chat_completion.top_p,
@@ -418,6 +433,7 @@ where
                 messages,
                 system,
                 tool_config,
+                inference_id: inference_config.ids.inference_id,
                 temperature: inference_params.chat_completion.temperature,
                 top_p: inference_params.chat_completion.top_p,
                 max_tokens: inference_params.chat_completion.max_tokens,
@@ -464,14 +480,13 @@ async fn infer_model_request<'a, 'request>(
 
     let model_inference_result =
         ModelInferenceResponseWithMetadata::new(model_inference_response, args.model_name);
-    let inference_id = Uuid::now_v7();
     let raw_content = model_inference_result.output.clone();
     let usage = model_inference_result.usage.clone();
     let model_inference_results = vec![model_inference_result];
 
     args.function
         .prepare_response(
-            inference_id,
+            args.inference_config.ids.inference_id,
             raw_content,
             usage,
             model_inference_results,
@@ -601,6 +616,10 @@ mod tests {
             function_name: "test_function",
             variant_name: Some("test_variant"),
             dynamic_output_schema: None,
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
         };
 
         // Define common inference parameters
@@ -719,6 +738,10 @@ mod tests {
         });
         let dynamic_output_schema = DynamicJSONSchema::new(dynamic_output_schema_value.clone());
         let inference_config_dynamic = InferenceConfig {
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
             templates: &templates,
             tool_config: Some(&tool_config),
             function_name: "test_function",
@@ -802,6 +825,10 @@ mod tests {
             function_name: "test_function",
             variant_name: Some("test_variant"),
             dynamic_output_schema: None,
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
         };
 
         // Test case 1: Successful inference with ChatCompletionConfig and FunctionConfigChat
@@ -822,6 +849,7 @@ mod tests {
         }];
 
         let model_request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: request_messages.clone(),
             system: None,
             temperature: Some(0.7),
@@ -917,6 +945,7 @@ mod tests {
         });
 
         let model_request_json = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: request_messages.clone(),
             system: None,
             temperature: Some(0.7),
@@ -1033,6 +1062,10 @@ mod tests {
             function_name: "test_function",
             variant_name: Some("test_variant"),
             dynamic_output_schema: None,
+            ids: InferenceIds {
+                inference_id: Uuid::now_v7(),
+                episode_id: Uuid::now_v7(),
+            },
         };
 
         let model_name = "dummy_chat_model";
@@ -1053,6 +1086,7 @@ mod tests {
         }];
 
         let model_request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: request_messages.clone(),
             system: None,
             temperature: Some(0.7),
@@ -1174,6 +1208,7 @@ mod tests {
 
         // Prepare the model inference request
         let request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages,
             system,
             temperature: Some(0.7),
@@ -1288,6 +1323,7 @@ mod tests {
         }];
 
         let model_request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
             messages: request_messages.clone(),
             system: None,
             temperature: Some(0.7),


### PR DESCRIPTION
Fixes https://github.com/tensorzero/tensorzero/issues/476

This will allow us to include these ids in early errors (and return them to the client even when the request failed).

The diff is unfortunately very large, but most of it is just creating uuids in tests.

The non-trivial changes are:
* We now pass in the episode id and inference id through `InferenceConfig` and `ModelInferenceRequest`
* In the openai `start_batch_inference`, we use the inference id from `ModelInferenceRequest` as the custom id in `OpenAIBatchFileInput`, rather than generating the ids within our openai provider code
* The anthropic provider now uses "0" for TextId.chunk when synthesizing a single chunk in `prefill_json_chunk_response`, rather than using the inference id.

Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Generate inference UUIDs at the start of request processing to improve error handling and pass them through `InferenceConfig` and `ModelInferenceRequest`.
> 
>   - **Behavior**:
>     - Generate inference UUIDs at the start of request processing to include in early errors.
>     - Pass `episode_id` and `inference_id` through `InferenceConfig` and `ModelInferenceRequest`.
>     - Use `inference_id` from `ModelInferenceRequest` in `OpenAIBatchFileInput` in `openai.rs`.
>     - Use "0" for `TextId.chunk` in `anthropic.rs` when synthesizing a single chunk.
>   - **Code Changes**:
>     - Add `InferenceIds` struct in `inference.rs` to encapsulate `inference_id` and `episode_id`.
>     - Modify `start_batch_inference_handler()` in `batch_inference.rs` to generate and use inference UUIDs.
>     - Update `InferenceConfig` and `BatchInferenceConfig` to handle UUIDs.
>   - **Tests**:
>     - Update tests across multiple files to create and use inference UUIDs.
>     - Ensure tests reflect changes in UUID handling and error logging.
>   - **Misc**:
>     - Remove redundant UUID generation in various provider files like `anthropic.rs`, `openai.rs`, etc.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6083f923a36a629e5e5254b07a8dd104bee1a106. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->