### PR TITLE
Place PR template text inside a comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!--
 Thank you for contributing to TensorZero!
 
 Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.
@@ -5,3 +6,4 @@ Before submitting your PR, make sure you've read **[Contributing to TensorZero](
 In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).
 
 By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
+-->


### PR DESCRIPTION
This will still display it to the user in the PR creation view, but will hide it from the rendered PR. This lets users press 'submit' on Github without first needing to delete this text.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Wrap PR template text in a comment to hide it from the rendered view.
> 
>   - **Template Update**:
>     - Wraps PR template text in `.github/PULL_REQUEST_TEMPLATE.md` with HTML comment tags to hide it from the rendered PR view.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 19b75147c7f765c923716b03bf300ba4f9222e3a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->