### PR TITLE
Support tool calling with the OpenAI o1 model

### DIFF
--- a/tensorzero_internal/tests/e2e/providers/batch.rs
+++ b/tensorzero_internal/tests/e2e/providers/batch.rs
@@ -647,13 +647,18 @@ pub async fn test_start_simple_batch_inference_request_with_provider(provider: E
     let inference_params = inference_params.get("chat_completion").unwrap();
     assert!(inference_params.get("temperature").is_none());
     assert!(inference_params.get("seed").is_none());
+    let expected_max_tokens = if provider.model_name.starts_with("o1") {
+        400
+    } else {
+        100
+    };
     assert_eq!(
         inference_params
             .get("max_tokens")
             .unwrap()
             .as_u64()
             .unwrap(),
-        100
+        expected_max_tokens
     );
 
     let model_name = result.get("model_name").unwrap().as_str().unwrap();
@@ -1574,16 +1579,22 @@ pub async fn test_tool_use_batch_inference_request_with_provider(provider: E2ETe
         }),
     ];
 
+    let expected_max_tokens = if provider.model_name.starts_with("o1") {
+        400
+    } else {
+        100
+    };
+
     let expected_inference_params = vec![
         json!({
             "chat_completion": {
-                "max_tokens": 100,
+                "max_tokens": expected_max_tokens,
             }
         }),
-        json!({"chat_completion": {"max_tokens": 100}}),
-        json!({"chat_completion": {"max_tokens": 100}}),
-        json!({"chat_completion": {"max_tokens": 100}}),
-        json!({"chat_completion": {"max_tokens": 100}}),
+        json!({"chat_completion": {"max_tokens": expected_max_tokens}}),
+        json!({"chat_completion": {"max_tokens": expected_max_tokens}}),
+        json!({"chat_completion": {"max_tokens": expected_max_tokens}}),
+        json!({"chat_completion": {"max_tokens": expected_max_tokens}}),
     ];
 
     for inference_id in inference_ids {
@@ -2081,12 +2092,17 @@ pub async fn test_allowed_tools_batch_inference_request_with_provider(provider: 
     let inference_params = result.get("inference_params").unwrap().as_str().unwrap();
     let inference_params: Value = serde_json::from_str(inference_params).unwrap();
     let inference_params = inference_params.get("chat_completion").unwrap();
+    let expected_max_tokens = if provider.model_name.starts_with("o1") {
+        400
+    } else {
+        100
+    };
     let max_tokens = inference_params
         .get("max_tokens")
         .unwrap()
         .as_u64()
         .unwrap();
-    assert_eq!(max_tokens, 100);
+    assert_eq!(max_tokens, expected_max_tokens);
 
     let model_name = result.get("model_name").unwrap().as_str().unwrap();
     assert_eq!(model_name, provider.model_name);
@@ -2483,13 +2499,18 @@ pub async fn test_tool_multi_turn_batch_inference_request_with_provider(provider
     let inference_params = inference_params.get("chat_completion").unwrap();
     assert!(inference_params.get("temperature").is_none());
     assert!(inference_params.get("seed").is_none());
+    let expected_max_tokens = if provider.model_name.starts_with("o1") {
+        400
+    } else {
+        100
+    };
     assert_eq!(
         inference_params
             .get("max_tokens")
             .unwrap()
             .as_u64()
             .unwrap(),
-        100
+        expected_max_tokens
     );
 
     let model_name = result.get("model_name").unwrap().as_str().unwrap();
@@ -2864,12 +2885,17 @@ pub async fn test_dynamic_tool_use_batch_inference_request_with_provider(
     let inference_params = result.get("inference_params").unwrap().as_str().unwrap();
     let inference_params: Value = serde_json::from_str(inference_params).unwrap();
     let inference_params = inference_params.get("chat_completion").unwrap();
+    let expected_max_tokens = if provider.model_name.starts_with("o1") {
+        400
+    } else {
+        100
+    };
     let max_tokens = inference_params
         .get("max_tokens")
         .unwrap()
         .as_u64()
         .unwrap();
-    assert_eq!(max_tokens, 100);
+    assert_eq!(max_tokens, expected_max_tokens);
 
     let model_name = result.get("model_name").unwrap().as_str().unwrap();
     assert_eq!(model_name, provider.model_name);
@@ -3476,11 +3502,13 @@ pub async fn test_json_mode_batch_inference_request_with_provider(provider: E2ET
         .send()
         .await
         .unwrap();
-    // Check if the API response is fine
-    assert_eq!(response.status(), StatusCode::OK);
+    let response_status = response.status();
     let response_json = response.json::<Value>().await.unwrap();
 
     println!("API response: {response_json:#?}");
+    // Check if the API response is fine
+    assert_eq!(response_status, StatusCode::OK);
+
     let batch_id = response_json.get("batch_id").unwrap().as_str().unwrap();
     let batch_id = Uuid::parse_str(batch_id).unwrap();
 
@@ -3563,12 +3591,17 @@ pub async fn test_json_mode_batch_inference_request_with_provider(provider: E2ET
     let inference_params = result.get("inference_params").unwrap().as_str().unwrap();
     let inference_params: Value = serde_json::from_str(inference_params).unwrap();
     let inference_params = inference_params.get("chat_completion").unwrap();
+    let expected_max_tokens = if provider.model_name.starts_with("o1") {
+        400
+    } else {
+        100
+    };
     let max_tokens = inference_params
         .get("max_tokens")
         .unwrap()
         .as_u64()
         .unwrap();
-    assert_eq!(max_tokens, 100);
+    assert_eq!(max_tokens, expected_max_tokens);
 
     let model_name = result.get("model_name").unwrap().as_str().unwrap();
     assert_eq!(model_name, provider.model_name);
@@ -3911,7 +3944,12 @@ pub async fn test_dynamic_json_mode_batch_inference_request_with_provider(
         .unwrap()
         .as_u64()
         .unwrap();
-    assert_eq!(max_tokens, 100);
+    let expected_max_tokens = if provider.model_name.starts_with("o1") {
+        400
+    } else {
+        100
+    };
+    assert_eq!(max_tokens, expected_max_tokens);
 
     let model_name = result.get("model_name").unwrap().as_str().unwrap();
     assert_eq!(model_name, provider.model_name);

--- a/tensorzero_internal/tests/e2e/providers/common.rs
+++ b/tensorzero_internal/tests/e2e/providers/common.rs
@@ -488,13 +488,18 @@ pub async fn check_simple_inference_response(
     let inference_params = inference_params.get("chat_completion").unwrap();
     assert!(inference_params.get("temperature").is_none());
     assert!(inference_params.get("seed").is_none());
+    let max_tokens = if provider.model_name.starts_with("o1") {
+        400
+    } else {
+        100
+    };
     assert_eq!(
         inference_params
             .get("max_tokens")
             .unwrap()
             .as_u64()
             .unwrap(),
-        100
+        max_tokens
     );
 
     if !is_batch {
@@ -576,6 +581,11 @@ pub async fn check_simple_inference_response(
 
 #[cfg(feature = "e2e_tests")]
 pub async fn test_simple_streaming_inference_request_with_provider(provider: E2ETestProvider) {
+    // OpenAI O1 doesn't support streaming responses
+    if provider.model_provider_name.contains("openai") && provider.model_name.starts_with("o1") {
+        return;
+    }
+
     let episode_id = Uuid::now_v7();
     let tag_value = Uuid::now_v7().to_string();
 
@@ -1601,6 +1611,11 @@ pub async fn check_tool_use_tool_choice_auto_used_inference_response(
 pub async fn test_tool_use_tool_choice_auto_used_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    // OpenAI O1 doesn't support streaming responses
+    if provider.model_provider_name.contains("openai") && provider.model_name.starts_with("o1") {
+        return;
+    }
+
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -2183,6 +2198,10 @@ pub async fn check_tool_use_tool_choice_auto_unused_inference_response(
 pub async fn test_tool_use_tool_choice_auto_unused_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    // OpenAI O1 doesn't support streaming responses
+    if provider.model_provider_name.contains("openai") && provider.model_name.starts_with("o1") {
+        return;
+    }
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -2764,6 +2783,11 @@ pub async fn test_tool_use_tool_choice_required_streaming_inference_request_with
         return;
     }
 
+    // OpenAI O1 doesn't support streaming responses
+    if provider.model_provider_name.contains("openai") && provider.model_name.starts_with("o1") {
+        return;
+    }
+
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -3325,6 +3349,11 @@ pub async fn check_tool_use_tool_choice_none_inference_response(
 pub async fn test_tool_use_tool_choice_none_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    // OpenAI O1 doesn't support streaming responses
+    if provider.model_provider_name.contains("openai") && provider.model_name.starts_with("o1") {
+        return;
+    }
+
     // NOTE: The xAI API occasionally returns a tool call despite receiving the "tool_choice": "none" parameter.
     // We'll leave this test running for now, so some flakiness is expected.
     // The bug has been reported to the xAI team.
@@ -3620,6 +3649,11 @@ pub async fn test_tool_use_tool_choice_specific_inference_request_with_provider(
     if provider.model_provider_name == "mistral"
         || provider.model_provider_name.contains("gcp_vertex")
     {
+        return;
+    }
+
+    // OpenAI O1 doesn't support streaming responses
+    if provider.model_provider_name.contains("openai") && provider.model_name.starts_with("o1") {
         return;
     }
 
@@ -3946,6 +3980,11 @@ pub async fn test_tool_use_tool_choice_specific_streaming_inference_request_with
     if provider.model_provider_name == "mistral"
         || provider.model_provider_name.contains("gcp_vertex")
     {
+        return;
+    }
+
+    // OpenAI O1 doesn't support streaming responses
+    if provider.model_provider_name.contains("openai") && provider.model_name.starts_with("o1") {
         return;
     }
 
@@ -4600,6 +4639,11 @@ pub async fn test_tool_use_allowed_tools_streaming_inference_request_with_provid
         return;
     }
 
+    // OpenAI O1 doesn't support streaming responses
+    if provider.model_provider_name.contains("openai") && provider.model_name.starts_with("o1") {
+        return;
+    }
+
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -4916,6 +4960,11 @@ pub async fn test_tool_multi_turn_inference_request_with_provider(provider: E2ET
         return;
     }
 
+    // OpenAI O1 doesn't support streaming responses
+    if provider.model_provider_name.contains("openai") && provider.model_name.starts_with("o1") {
+        return;
+    }
+
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -4935,7 +4984,7 @@ pub async fn test_tool_multi_turn_inference_request_with_provider(provider: E2ET
                             "type": "tool_call",
                             "id": "123456789",
                             "name": "get_temperature",
-                            "arguments": "{\"location\": \"Tokyo\"}"
+                            "arguments": "{\"location\": \"Tokyo\", \"units\": \"celsius\"}"
                         }
                     ]
                 },
@@ -5041,7 +5090,7 @@ pub async fn check_tool_use_multi_turn_inference_response(
             },
             {
                 "role": "assistant",
-                "content": [{"type": "tool_call", "id": "123456789", "name": "get_temperature", "arguments": "{\"location\": \"Tokyo\"}"}]
+                "content": [{"type": "tool_call", "id": "123456789", "name": "get_temperature", "arguments": "{\"location\": \"Tokyo\", \"units\": \"celsius\"}"}]
             },
             {
                 "role": "user",
@@ -5080,13 +5129,18 @@ pub async fn check_tool_use_multi_turn_inference_response(
     let inference_params = inference_params.get("chat_completion").unwrap();
     assert!(inference_params.get("temperature").is_none());
     assert!(inference_params.get("seed").is_none());
+    let max_tokens = if provider.model_name.starts_with("o1") {
+        400
+    } else {
+        100
+    };
     assert_eq!(
         inference_params
             .get("max_tokens")
             .unwrap()
             .as_u64()
             .unwrap(),
-        100
+        max_tokens,
     );
 
     let processing_time_ms = result.get("processing_time_ms").unwrap().as_u64().unwrap();
@@ -5154,7 +5208,7 @@ pub async fn check_tool_use_multi_turn_inference_response(
             content: vec![ContentBlock::ToolCall(ToolCall {
                 id: "123456789".to_string(),
                 name: "get_temperature".to_string(),
-                arguments: "{\"location\": \"Tokyo\"}".to_string(),
+                arguments: "{\"location\": \"Tokyo\", \"units\": \"celsius\"}".to_string(),
             })],
         },
         RequestMessage {
@@ -5190,6 +5244,11 @@ pub async fn test_tool_multi_turn_streaming_inference_request_with_provider(
     // We skip this test for xAI until the fix is deployed.
     // https://gist.github.com/GabrielBianconi/47a4247cfd8b6689e7228f654806272d
     if provider.model_provider_name == "xai" {
+        return;
+    }
+
+    // OpenAI O1 doesn't support streaming responses
+    if provider.model_provider_name.contains("openai") && provider.model_name.starts_with("o1") {
         return;
     }
 
@@ -5800,6 +5859,11 @@ pub async fn test_dynamic_tool_use_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
     client: &tensorzero::Client,
 ) {
+    // OpenAI O1 doesn't support streaming responses
+    if provider.model_provider_name.contains("openai") && provider.model_name.starts_with("o1") {
+        return;
+    }
+
     let episode_id = Uuid::now_v7();
 
     let input_function_name = "basic_test";
@@ -6986,13 +7050,18 @@ pub async fn check_json_mode_inference_response(
     let inference_params = inference_params.get("chat_completion").unwrap();
     assert!(inference_params.get("temperature").is_none());
     assert!(inference_params.get("seed").is_none());
+    let max_tokens = if provider.model_name.starts_with("o1") {
+        400
+    } else {
+        100
+    };
     assert_eq!(
         inference_params
             .get("max_tokens")
             .unwrap()
             .as_u64()
             .unwrap(),
-        100
+        max_tokens
     );
 
     if !is_batch {
@@ -7235,13 +7304,18 @@ pub async fn check_dynamic_json_mode_inference_response(
     let inference_params = inference_params.get("chat_completion").unwrap();
     assert!(inference_params.get("temperature").is_none());
     assert!(inference_params.get("seed").is_none());
+    let max_tokens = if provider.model_name.starts_with("o1") {
+        400
+    } else {
+        100
+    };
     assert_eq!(
         inference_params
             .get("max_tokens")
             .unwrap()
             .as_u64()
             .unwrap(),
-        100
+        max_tokens
     );
 
     let processing_time_ms = result.get("processing_time_ms").unwrap().as_u64().unwrap();
@@ -7331,6 +7405,10 @@ pub async fn check_dynamic_json_mode_inference_response(
 pub async fn test_json_mode_streaming_inference_request_with_provider(provider: E2ETestProvider) {
     if provider.variant_name.contains("tgi") {
         // TGI does not support streaming in JSON mode (because it doesn't support streaming tools)
+        return;
+    }
+    // OpenAI O1 doesn't support streaming responses
+    if provider.model_provider_name.contains("openai") && provider.model_name.starts_with("o1") {
         return;
     }
     let episode_id = Uuid::now_v7();

--- a/tensorzero_internal/tests/e2e/tensorzero.toml
+++ b/tensorzero_internal/tests/e2e/tensorzero.toml
@@ -29,6 +29,13 @@ type = "openai"
 model_name = "gpt-4o-mini-2024-07-18"
 api_key_location = "dynamic::openai_api_key"
 
+[models."o1-2024-12-17"]
+routing = ["openai"]
+
+[models."o1-2024-12-17".providers.openai]
+type = "openai"
+model_name = "o1-2024-12-17"
+
 [models."gpt-4o-mini-azure"]
 routing = ["azure"]
 
@@ -574,6 +581,12 @@ model = "gpt-4o-mini-2024-07-18"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 
+[functions.basic_test.variants.openai-o1]
+type = "chat_completion"
+model = "o1-2024-12-17"
+system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
+max_tokens = 400
+
 [functions.basic_test.variants.openai-dynamic]
 type = "chat_completion"
 model = "gpt-4o-mini-2024-07-18-dynamic"
@@ -895,6 +908,14 @@ user_template = "../../fixtures/config/functions/json_success/prompt/user_templa
 json_mode = "on"
 max_tokens = 100
 
+[functions.json_success.variants.openai-o1]
+type = "chat_completion"
+model = "o1-2024-12-17"
+system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
+user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
+json_mode = "on"
+max_tokens = 400
+
 [functions.json_success.variants.openai-implicit]
 type = "chat_completion"
 model = "gpt-4o-mini-2024-07-18"
@@ -1141,6 +1162,15 @@ user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_templa
 json_mode = "on"
 max_tokens = 100
 
+[functions.dynamic_json.variants.openai-o1]
+type = "chat_completion"
+model = "o1-2024-12-17"
+system_template = "../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
+user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
+json_mode = "on"
+max_tokens = 400
+
+
 [functions.dynamic_json.variants.openai-implicit]
 type = "chat_completion"
 model = "gpt-4o-mini-2024-07-18"
@@ -1347,6 +1377,12 @@ model = "gpt-4o-mini-2024-07-18"
 system_template = "../../fixtures/config/functions/weather_helper/prompt/system_template.minijinja"
 max_tokens = 100
 
+[functions.weather_helper.variants.openai-o1]
+type = "chat_completion"
+model = "o1-2024-12-17"
+system_template = "../../fixtures/config/functions/weather_helper/prompt/system_template.minijinja"
+max_tokens = 400
+
 [functions.weather_helper.variants.together]
 type = "chat_completion"
 model = "mixtral-8x7b-instruct-v0.1"
@@ -1378,6 +1414,13 @@ weight = 1
 model = "gpt-4o-mini-2024-07-18"
 system_template = "../../fixtures/config/functions/weather_helper_parallel/prompt/system_template.minijinja"
 max_tokens = 100
+
+[functions.weather_helper_parallel.variants.openai-o1]
+type = "chat_completion"
+weight = 1
+model = "o1-2024-12-17"
+system_template = "../../fixtures/config/functions/weather_helper_parallel/prompt/system_template.minijinja"
+max_tokens = 400
 
 [functions.weather_helper_parallel.variants.anthropic]
 type = "chat_completion"


### PR DESCRIPTION
Fixes https://github.com/tensorzero/tensorzero/issues/548

This adjusts the e2e tests to run json and tool-calling tests against `o1-2024-12-17`. Openai doesn't currently support streaming for this model - however, to ensure that users can start using streaming as soon as it becomes available, I've removed the check on our end, and allow 'stream: true' to get passed to openai (which will currently produce an error).

In order to get the weather_helper tests to pass with o1, I needed to add an explicit `"units": "celcius"` to the tool call parameters (even though the json schema marks this parameter as optional). Without this, o1 will either generate a new tool call (instead of producing a human-readable response with the provided tool call response), or respond with a hallucinated temperature instead of using the temperature from the tool call response.

Supporing changes:
* OpenAI has deprecated the `max_tokens` parameter in favor of the `max_completion_tokens` parameter. The o1 models only support `max_completion_tokens`, so I've adjusted the openai provider to pass `max_tokens` as `max_completion_tokens` for all models.
* When we get an error status code back from openai in response to a streaming inference request, we now include the response body in the error message. This makes our errors much more useful when a user tries to use 'stream: true' with an unsupported model
* All of the streaming tests are manually disabled for o1 models. To ensure that we detect when OpenAI enables this, I've added a test that asserts that openai returns an error for the o1 model.
* The o1 model requires more token usage than other openai models, so I've set `max_tokens = 400` in the o1 variants in e2e tests.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds support for OpenAI o1 model, adjusts tests and configurations, and handles model-specific constraints like streaming and token usage.
> 
>   - **Behavior**:
>     - Adjusts e2e tests to run JSON and tool-calling tests against `o1-2024-12-17`.
>     - Removes streaming check for o1 models, allowing 'stream: true' to pass to OpenAI.
>     - Adds explicit `"units": "celsius"` to tool call parameters in `weather_helper` tests for o1.
>   - **Models**:
>     - Replaces `max_tokens` with `max_completion_tokens` for o1 models in `openai.rs`.
>     - Sets `max_tokens = 400` for o1 variants in e2e tests.
>   - **Tests**:
>     - Disables streaming tests for o1 models and adds a test to assert OpenAI returns an error for streaming with o1.
>     - Updates `tensorzero.toml` to include o1 model configurations.
>   - **Misc**:
>     - Includes response body in error message for streaming inference request errors in `openai.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 14c603bff1ae0dceb95b2477fcb909df4ceac980. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->