### PR TITLE
Remove extra margin in inference detail page

### DIFF
--- a/ui/app/routes/observability/inference/BasicInfo.tsx
+++ b/ui/app/routes/observability/inference/BasicInfo.tsx
@@ -38,7 +38,7 @@ export default function BasicInfo({ inference }: BasicInfoProps) {
                 <Code>{inference.variant_name}</Code>
               </Link>
             </dd>
-            <Badge variant="outline" className="ml-2 bg-blue-200">
+            <Badge variant="outline" className="bg-blue-200">
               {variantType}
             </Badge>
           </div>


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

This PR fixes #890.

Verified through ui/fixtures:

<img width="1234" alt="Screenshot 2025-02-01 at 3 00 55 PM" src="https://github.com/user-attachments/assets/27a826c0-175b-42e9-9c37-e3623a13742f" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `ml-2` class from `Badge` in `BasicInfo.tsx` to adjust margin-left styling.
> 
>   - **UI Change**:
>     - Removed `ml-2` class from `Badge` component in `BasicInfo.tsx`, affecting margin-left styling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6628b8534fed69af5d1544720c68bc8f14913245. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->