### PR TITLE
Use the response text for `raw_response` field in CH

### DIFF
--- a/tensorzero_internal/src/inference/providers/azure.rs
+++ b/tensorzero_internal/src/inference/providers/azure.rs
@@ -142,7 +142,7 @@ impl InferenceProvider for AzureProvider {
                 response_time: start_time.elapsed(),
             };
 
-            let response = res.text().await.map_err(|e| {
+            let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing text response: {e}"),
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -151,12 +151,12 @@ impl InferenceProvider for AzureProvider {
                 })
             })?;
 
-            let response = serde_json::from_str(&response).map_err(|e| {
+            let response = serde_json::from_str(&raw_response).map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing JSON response: {e}: {response}"),
+                    message: format!("Error parsing JSON response: {e}: {raw_response}"),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
-                    raw_response: Some(response.clone()),
+                    raw_response: Some(raw_response.clone()),
                 })
             })?;
 
@@ -165,6 +165,7 @@ impl InferenceProvider for AzureProvider {
                 latency,
                 request: request_body,
                 generic_request: request,
+                raw_response,
             }
             .try_into()?)
         } else {
@@ -386,6 +387,7 @@ impl<'a> AzureRequest<'a> {
 
 struct AzureResponseWithMetadata<'a> {
     response: OpenAIResponse,
+    raw_response: String,
     latency: Latency,
     request: AzureRequest<'a>,
     generic_request: &'a ModelInferenceRequest<'a>,
@@ -399,12 +401,9 @@ impl<'a> TryFrom<AzureResponseWithMetadata<'a>> for ProviderInferenceResponse {
             latency,
             request: request_body,
             generic_request,
+            raw_response,
         } = value;
-        let raw_response = serde_json::to_string(&response).map_err(|e| {
-            Error::new(ErrorDetails::Serialization {
-                message: format!("Error parsing response: {e}"),
-            })
-        })?;
+
         if response.choices.len() != 1 {
             return Err(ErrorDetails::InferenceServer {
                 message: format!(
@@ -462,13 +461,17 @@ impl<'a> TryFrom<AzureResponseWithMetadata<'a>> for ProviderInferenceResponse {
 #[cfg(test)]
 mod tests {
     use std::borrow::Cow;
+    use std::time::Duration;
 
     use uuid::Uuid;
 
     use super::*;
 
     use crate::inference::providers::common::{WEATHER_TOOL, WEATHER_TOOL_CONFIG};
-    use crate::inference::providers::openai::{OpenAIToolType, SpecificToolFunction};
+    use crate::inference::providers::openai::{
+        OpenAIResponseChoice, OpenAIResponseMessage, OpenAIToolType, OpenAIUsage,
+        SpecificToolFunction,
+    };
     use crate::inference::types::{
         FunctionType, ModelInferenceRequestJsonMode, RequestMessage, Role,
     };
@@ -643,5 +646,68 @@ mod tests {
             result.unwrap_err().get_owned_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
+    }
+
+    #[test]
+    fn test_azure_response_with_metadata_try_into() {
+        let valid_response = OpenAIResponse {
+            choices: vec![OpenAIResponseChoice {
+                index: 0,
+                message: OpenAIResponseMessage {
+                    content: Some("Hello, world!".to_string()),
+                    tool_calls: None,
+                },
+            }],
+            usage: OpenAIUsage {
+                prompt_tokens: 10,
+                completion_tokens: 20,
+                total_tokens: 30,
+            },
+        };
+        let generic_request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
+            messages: vec![RequestMessage {
+                role: Role::User,
+                content: vec!["test_user".to_string().into()],
+            }],
+            system: None,
+            temperature: Some(0.5),
+            top_p: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            max_tokens: Some(100),
+            stream: false,
+            seed: Some(69),
+            json_mode: ModelInferenceRequestJsonMode::Off,
+            tool_config: None,
+            function_type: FunctionType::Chat,
+            output_schema: None,
+        };
+        let azure_response_with_metadata = AzureResponseWithMetadata {
+            response: valid_response,
+            raw_response: "test_response".to_string(),
+            latency: Latency::NonStreaming {
+                response_time: Duration::from_secs(0),
+            },
+            request: AzureRequest::new(&generic_request),
+            generic_request: &generic_request,
+        };
+        let inference_response: ProviderInferenceResponse =
+            azure_response_with_metadata.try_into().unwrap();
+
+        assert_eq!(inference_response.output.len(), 1);
+        assert_eq!(
+            inference_response.output[0],
+            "Hello, world!".to_string().into()
+        );
+        assert_eq!(inference_response.raw_response, "test_response");
+        assert_eq!(inference_response.usage.input_tokens, 10);
+        assert_eq!(inference_response.usage.output_tokens, 20);
+        assert_eq!(
+            inference_response.latency,
+            Latency::NonStreaming {
+                response_time: Duration::from_secs(0)
+            }
+        );
     }
 }

--- a/tensorzero_internal/src/inference/providers/fireworks.rs
+++ b/tensorzero_internal/src/inference/providers/fireworks.rs
@@ -177,6 +177,7 @@ impl InferenceProvider for FireworksProvider {
                 latency,
                 request: request_body,
                 generic_request: request,
+                raw_response: response_text,
             }
             .try_into()?)
         } else {
@@ -394,6 +395,7 @@ impl<'a> From<OpenAITool<'a>> for FireworksTool<'a> {
 
 struct FireworksResponseWithMetadata<'a> {
     response: OpenAIResponse,
+    raw_response: String,
     latency: Latency,
     request: FireworksRequest<'a>,
     generic_request: &'a ModelInferenceRequest<'a>,
@@ -407,12 +409,8 @@ impl<'a> TryFrom<FireworksResponseWithMetadata<'a>> for ProviderInferenceRespons
             latency,
             request: request_body,
             generic_request,
+            raw_response,
         } = value;
-        let raw_response = serde_json::to_string(&response).map_err(|e| {
-            Error::new(ErrorDetails::Serialization {
-                message: format!("Error parsing response: {e}"),
-            })
-        })?;
         if response.choices.len() != 1 {
             return Err(ErrorDetails::InferenceServer {
                 message: format!(
@@ -468,13 +466,16 @@ impl<'a> TryFrom<FireworksResponseWithMetadata<'a>> for ProviderInferenceRespons
 #[cfg(test)]
 mod tests {
     use std::borrow::Cow;
+    use std::time::Duration;
 
     use uuid::Uuid;
 
     use super::*;
 
     use crate::inference::providers::common::{WEATHER_TOOL, WEATHER_TOOL_CONFIG};
-    use crate::inference::providers::openai::OpenAIToolType;
+    use crate::inference::providers::openai::{
+        OpenAIResponseChoice, OpenAIResponseMessage, OpenAIToolType, OpenAIUsage,
+    };
     use crate::inference::providers::openai::{SpecificToolChoice, SpecificToolFunction};
     use crate::inference::types::{FunctionType, RequestMessage, Role};
 
@@ -572,5 +573,68 @@ mod tests {
             result.unwrap_err().get_owned_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
+    }
+
+    #[test]
+    fn test_fireworks_response_with_metadata_try_into() {
+        let valid_response = OpenAIResponse {
+            choices: vec![OpenAIResponseChoice {
+                index: 0,
+                message: OpenAIResponseMessage {
+                    content: Some("Hello, world!".to_string()),
+                    tool_calls: None,
+                },
+            }],
+            usage: OpenAIUsage {
+                prompt_tokens: 10,
+                completion_tokens: 20,
+                total_tokens: 30,
+            },
+        };
+        let generic_request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
+            messages: vec![RequestMessage {
+                role: Role::User,
+                content: vec!["test_user".to_string().into()],
+            }],
+            system: None,
+            temperature: Some(0.5),
+            top_p: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            max_tokens: Some(100),
+            stream: false,
+            seed: Some(69),
+            json_mode: ModelInferenceRequestJsonMode::Off,
+            tool_config: None,
+            function_type: FunctionType::Chat,
+            output_schema: None,
+        };
+        let fireworks_response_with_metadata = FireworksResponseWithMetadata {
+            response: valid_response,
+            raw_response: "test_response".to_string(),
+            latency: Latency::NonStreaming {
+                response_time: Duration::from_secs(0),
+            },
+            request: FireworksRequest::new("test-model", &generic_request),
+            generic_request: &generic_request,
+        };
+        let inference_response: ProviderInferenceResponse =
+            fireworks_response_with_metadata.try_into().unwrap();
+
+        assert_eq!(inference_response.output.len(), 1);
+        assert_eq!(
+            inference_response.output[0],
+            "Hello, world!".to_string().into()
+        );
+        assert_eq!(inference_response.raw_response, "test_response");
+        assert_eq!(inference_response.usage.input_tokens, 10);
+        assert_eq!(inference_response.usage.output_tokens, 20);
+        assert_eq!(
+            inference_response.latency,
+            Latency::NonStreaming {
+                response_time: Duration::from_secs(0)
+            }
+        );
     }
 }

--- a/tensorzero_internal/src/inference/providers/gcp_vertex_gemini.rs
+++ b/tensorzero_internal/src/inference/providers/gcp_vertex_gemini.rs
@@ -285,7 +285,7 @@ impl InferenceProvider for GCPVertexGeminiProvider {
             response_time: start_time.elapsed(),
         };
         if res.status().is_success() {
-            let response = res.text().await.map_err(|e| {
+            let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing text response: {e}"),
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -294,12 +294,12 @@ impl InferenceProvider for GCPVertexGeminiProvider {
                 })
             })?;
 
-            let response = serde_json::from_str(&response).map_err(|e| {
+            let response = serde_json::from_str(&raw_response).map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing JSON response: {e}: {response}"),
+                    message: format!("Error parsing JSON response: {e}: {raw_response}"),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
-                    raw_response: Some(response),
+                    raw_response: Some(raw_response.clone()),
                 })
             })?;
             let response_with_latency = GCPVertexGeminiResponseWithMetadata {
@@ -307,6 +307,7 @@ impl InferenceProvider for GCPVertexGeminiProvider {
                 latency,
                 request: request_body,
                 generic_request: request,
+                raw_response,
             };
             Ok(response_with_latency.try_into()?)
         } else {
@@ -955,6 +956,7 @@ struct GCPVertexGeminiResponse {
 
 struct GCPVertexGeminiResponseWithMetadata<'a> {
     response: GCPVertexGeminiResponse,
+    raw_response: String,
     latency: Latency,
     request: GCPVertexGeminiRequest<'a>,
     generic_request: &'a ModelInferenceRequest<'a>,
@@ -965,15 +967,11 @@ impl<'a> TryFrom<GCPVertexGeminiResponseWithMetadata<'a>> for ProviderInferenceR
     fn try_from(response: GCPVertexGeminiResponseWithMetadata<'a>) -> Result<Self, Self::Error> {
         let GCPVertexGeminiResponseWithMetadata {
             response,
+            raw_response,
             latency,
             request: request_body,
             generic_request,
         } = response;
-        let raw_response = serde_json::to_string(&response).map_err(|e| {
-            Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing response from GCP Vertex Gemini: {e}"),
-            })
-        })?;
 
         // GCP Vertex Gemini response can contain multiple candidates and each of these can contain
         // multiple content parts. We will only use the first candidate but handle all parts of the response therein.
@@ -1602,11 +1600,13 @@ mod tests {
             system_instruction: None,
         };
         let raw_request = serde_json::to_string(&request_body).unwrap();
+        let raw_response = "test response".to_string();
         let response_with_latency = GCPVertexGeminiResponseWithMetadata {
             response,
             latency: latency.clone(),
             request: request_body,
             generic_request: &generic_request,
+            raw_response: raw_response.clone(),
         };
         let model_inference_response: ProviderInferenceResponse =
             response_with_latency.try_into().unwrap();
@@ -1623,6 +1623,7 @@ mod tests {
         );
         assert_eq!(model_inference_response.latency, latency);
         assert_eq!(model_inference_response.raw_request, raw_request);
+        assert_eq!(model_inference_response.raw_response, raw_response);
         assert_eq!(
             model_inference_response.system,
             Some("test_system".to_string())
@@ -1683,6 +1684,7 @@ mod tests {
             latency: latency.clone(),
             request: request_body,
             generic_request: &generic_request,
+            raw_response: raw_response.clone(),
         };
         let model_inference_response: ProviderInferenceResponse =
             response_with_latency.try_into().unwrap();
@@ -1709,6 +1711,7 @@ mod tests {
         );
         assert_eq!(model_inference_response.latency, latency);
         assert_eq!(model_inference_response.raw_request, raw_request);
+        assert_eq!(model_inference_response.raw_response, raw_response);
         assert_eq!(model_inference_response.system, None);
         assert_eq!(
             model_inference_response.input_messages,
@@ -1767,6 +1770,7 @@ mod tests {
             latency: latency.clone(),
             request: request_body,
             generic_request: &generic_request,
+            raw_response: raw_response.clone(),
         };
         let model_inference_response: ProviderInferenceResponse =
             response_with_latency.try_into().unwrap();
@@ -1802,6 +1806,8 @@ mod tests {
             }
         );
         assert_eq!(model_inference_response.latency, latency);
+        assert_eq!(model_inference_response.raw_request, raw_request);
+        assert_eq!(model_inference_response.raw_response, raw_response);
         assert_eq!(model_inference_response.system, None);
         assert_eq!(
             model_inference_response.input_messages,

--- a/tensorzero_internal/src/inference/providers/google_ai_studio_gemini.rs
+++ b/tensorzero_internal/src/inference/providers/google_ai_studio_gemini.rs
@@ -159,7 +159,7 @@ impl InferenceProvider for GoogleAIStudioGeminiProvider {
             response_time: start_time.elapsed(),
         };
         if res.status().is_success() {
-            let response = res.text().await.map_err(|e| {
+            let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing text response: {e}"),
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -168,17 +168,18 @@ impl InferenceProvider for GoogleAIStudioGeminiProvider {
                 })
             })?;
 
-            let response = serde_json::from_str(&response).map_err(|e| {
+            let response = serde_json::from_str(&raw_response).map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing JSON response: {e}: {response}"),
+                    message: format!("Error parsing JSON response: {e}"),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
-                    raw_response: Some(response.clone()),
+                    raw_response: Some(raw_response.clone()),
                 })
             })?;
             let response_with_latency = GeminiResponseWithMetadata {
                 response,
                 latency,
+                raw_response,
                 request: request_body,
                 generic_request: request,
             };
@@ -786,6 +787,7 @@ struct GeminiResponse {
 
 struct GeminiResponseWithMetadata<'a> {
     response: GeminiResponse,
+    raw_response: String,
     latency: Latency,
     request: GeminiRequest<'a>,
     generic_request: &'a ModelInferenceRequest<'a>,
@@ -796,15 +798,11 @@ impl<'a> TryFrom<GeminiResponseWithMetadata<'a>> for ProviderInferenceResponse {
     fn try_from(response: GeminiResponseWithMetadata<'a>) -> Result<Self, Self::Error> {
         let GeminiResponseWithMetadata {
             response,
+            raw_response,
             latency,
             request: request_body,
             generic_request,
         } = response;
-        let raw_response = serde_json::to_string(&response).map_err(|e| {
-            Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing response from Google AI Studio Gemini: {e}"),
-            })
-        })?;
 
         // Google AI Studio Gemini response can contain multiple candidates and each of these can contain
         // multiple content parts. We will only use the first candidate but handle all parts of the response therein.
@@ -1320,11 +1318,13 @@ mod tests {
             system_instruction: None,
         };
         let raw_request = serde_json::to_string(&request_body).unwrap();
+        let raw_response = "test response".to_string();
         let response_with_latency = GeminiResponseWithMetadata {
             response,
             latency: latency.clone(),
             request: request_body,
             generic_request: &generic_request,
+            raw_response: raw_response.clone(),
         };
         let model_inference_response: ProviderInferenceResponse =
             response_with_latency.try_into().unwrap();
@@ -1341,6 +1341,7 @@ mod tests {
         );
         assert_eq!(model_inference_response.latency, latency);
         assert_eq!(model_inference_response.raw_request, raw_request);
+        assert_eq!(model_inference_response.raw_response, raw_response);
         assert_eq!(model_inference_response.system, None);
         assert_eq!(
             model_inference_response.input_messages,
@@ -1404,6 +1405,7 @@ mod tests {
             latency: latency.clone(),
             request: request_body,
             generic_request: &generic_request,
+            raw_response: raw_response.clone(),
         };
         let model_inference_response: ProviderInferenceResponse =
             response_with_latency.try_into().unwrap();
@@ -1490,11 +1492,12 @@ mod tests {
             latency: latency.clone(),
             request: request_body,
             generic_request: &generic_request,
+            raw_response: raw_response.clone(),
         };
         let model_inference_response: ProviderInferenceResponse =
             response_with_latency.try_into().unwrap();
         assert_eq!(model_inference_response.raw_request, raw_request);
-
+        assert_eq!(model_inference_response.raw_response, raw_response);
         if let [ContentBlock::Text(Text { text: text1 }), ContentBlock::ToolCall(tool_call1), ContentBlock::Text(Text { text: text2 }), ContentBlock::ToolCall(tool_call2)] =
             &model_inference_response.output[..]
         {

--- a/tensorzero_internal/src/inference/providers/hyperbolic.rs
+++ b/tensorzero_internal/src/inference/providers/hyperbolic.rs
@@ -141,7 +141,7 @@ impl InferenceProvider for HyperbolicProvider {
             })?;
 
         if res.status().is_success() {
-            let response = res.text().await.map_err(|e| {
+            let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing text response: {e}"),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
@@ -150,12 +150,12 @@ impl InferenceProvider for HyperbolicProvider {
                 })
             })?;
 
-            let response = serde_json::from_str(&response).map_err(|e| {
+            let response = serde_json::from_str(&raw_response).map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing JSON response: {e}: {response}"),
+                    message: format!("Error parsing JSON response: {e}"),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
-                    raw_response: Some(response.clone()),
+                    raw_response: Some(raw_response.clone()),
                 })
             })?;
 
@@ -165,6 +165,7 @@ impl InferenceProvider for HyperbolicProvider {
             Ok(HyperbolicResponseWithMetadata {
                 response,
                 latency,
+                raw_response,
                 request: request_body,
                 generic_request: request,
             }
@@ -323,6 +324,7 @@ impl<'a> HyperbolicRequest<'a> {
 
 struct HyperbolicResponseWithMetadata<'a> {
     response: OpenAIResponse,
+    raw_response: String,
     latency: Latency,
     request: HyperbolicRequest<'a>,
     generic_request: &'a ModelInferenceRequest<'a>,
@@ -334,15 +336,10 @@ impl<'a> TryFrom<HyperbolicResponseWithMetadata<'a>> for ProviderInferenceRespon
         let HyperbolicResponseWithMetadata {
             mut response,
             latency,
+            raw_response,
             request: request_body,
             generic_request,
         } = value;
-
-        let raw_response = serde_json::to_string(&response).map_err(|e| {
-            Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing response: {e}"),
-            })
-        })?;
 
         if response.choices.len() != 1 {
             return Err(ErrorDetails::InferenceServer {
@@ -399,12 +396,16 @@ impl<'a> TryFrom<HyperbolicResponseWithMetadata<'a>> for ProviderInferenceRespon
 #[cfg(test)]
 mod tests {
     use std::borrow::Cow;
+    use std::time::Duration;
 
     use uuid::Uuid;
 
     use super::*;
 
     use crate::inference::providers::common::WEATHER_TOOL_CONFIG;
+    use crate::inference::providers::openai::{
+        OpenAIResponseChoice, OpenAIResponseMessage, OpenAIUsage,
+    };
     use crate::inference::types::{
         FunctionType, ModelInferenceRequestJsonMode, RequestMessage, Role,
     };
@@ -478,5 +479,67 @@ mod tests {
             result.unwrap_err().get_owned_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
+    }
+    #[test]
+    fn test_hyperbolic_response_with_metadata_try_into() {
+        let valid_response = OpenAIResponse {
+            choices: vec![OpenAIResponseChoice {
+                index: 0,
+                message: OpenAIResponseMessage {
+                    content: Some("Hello, world!".to_string()),
+                    tool_calls: None,
+                },
+            }],
+            usage: OpenAIUsage {
+                prompt_tokens: 10,
+                completion_tokens: 20,
+                total_tokens: 30,
+            },
+        };
+        let generic_request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
+            messages: vec![RequestMessage {
+                role: Role::User,
+                content: vec!["test_user".to_string().into()],
+            }],
+            system: None,
+            temperature: Some(0.5),
+            top_p: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            max_tokens: Some(100),
+            stream: false,
+            seed: Some(69),
+            json_mode: ModelInferenceRequestJsonMode::Off,
+            tool_config: None,
+            function_type: FunctionType::Chat,
+            output_schema: None,
+        };
+        let hyperbolic_response_with_metadata = HyperbolicResponseWithMetadata {
+            response: valid_response,
+            raw_response: "test_response".to_string(),
+            latency: Latency::NonStreaming {
+                response_time: Duration::from_secs(0),
+            },
+            request: HyperbolicRequest::new("test-model", &generic_request).unwrap(),
+            generic_request: &generic_request,
+        };
+        let inference_response: ProviderInferenceResponse =
+            hyperbolic_response_with_metadata.try_into().unwrap();
+
+        assert_eq!(inference_response.output.len(), 1);
+        assert_eq!(
+            inference_response.output[0],
+            "Hello, world!".to_string().into()
+        );
+        assert_eq!(inference_response.raw_response, "test_response");
+        assert_eq!(inference_response.usage.input_tokens, 10);
+        assert_eq!(inference_response.usage.output_tokens, 20);
+        assert_eq!(
+            inference_response.latency,
+            Latency::NonStreaming {
+                response_time: Duration::from_secs(0)
+            }
+        );
     }
 }

--- a/tensorzero_internal/src/inference/providers/openai.rs
+++ b/tensorzero_internal/src/inference/providers/openai.rs
@@ -1360,10 +1360,10 @@ impl<'a> OpenAIBatchRequest<'a> {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub(super) struct OpenAIUsage {
-    prompt_tokens: u32,
+    pub prompt_tokens: u32,
     #[serde(default)]
-    completion_tokens: u32,
-    total_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
 }
 
 impl From<OpenAIUsage> for Usage {

--- a/tensorzero_internal/src/inference/providers/sglang.rs
+++ b/tensorzero_internal/src/inference/providers/sglang.rs
@@ -137,7 +137,7 @@ impl InferenceProvider for SGLangProvider {
                 })
             })?;
         if res.status().is_success() {
-            let response = res.text().await.map_err(|e| {
+            let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing text response: {e}"),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
@@ -146,11 +146,11 @@ impl InferenceProvider for SGLangProvider {
                 })
             })?;
 
-            let response = serde_json::from_str(&response).map_err(|e| {
+            let response = serde_json::from_str(&raw_response).map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing JSON response: {e}: {response}"),
+                    message: format!("Error parsing JSON response: {e}"),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
-                    raw_response: Some(response.clone()),
+                    raw_response: Some(raw_response.clone()),
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
@@ -161,6 +161,7 @@ impl InferenceProvider for SGLangProvider {
             Ok(SGLangResponseWithMetadata {
                 response,
                 latency,
+                raw_response,
                 request: request_body,
                 generic_request: request,
             }
@@ -374,6 +375,7 @@ impl<'a> SGLangRequest<'a> {
 struct SGLangResponseWithMetadata<'a> {
     response: OpenAIResponse,
     latency: Latency,
+    raw_response: String,
     request: SGLangRequest<'a>,
     generic_request: &'a ModelInferenceRequest<'a>,
 }
@@ -384,14 +386,10 @@ impl<'a> TryFrom<SGLangResponseWithMetadata<'a>> for ProviderInferenceResponse {
         let SGLangResponseWithMetadata {
             mut response,
             latency,
+            raw_response,
             request: request_body,
             generic_request,
         } = value;
-        let raw_response = serde_json::to_string(&response).map_err(|e| {
-            Error::new(ErrorDetails::Serialization {
-                message: format!("Error parsing response: {e}"),
-            })
-        })?;
         if response.choices.len() != 1 {
             return Err(ErrorDetails::InferenceServer {
                 message: format!(
@@ -447,13 +445,16 @@ impl<'a> TryFrom<SGLangResponseWithMetadata<'a>> for ProviderInferenceResponse {
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Cow;
+    use std::{borrow::Cow, time::Duration};
 
     use serde_json::json;
     use uuid::Uuid;
 
     use crate::inference::{
-        providers::common::WEATHER_TOOL_CONFIG,
+        providers::{
+            common::WEATHER_TOOL_CONFIG,
+            openai::{OpenAIResponseChoice, OpenAIResponseMessage, OpenAIUsage},
+        },
         types::{FunctionType, ModelInferenceRequestJsonMode, RequestMessage, Role},
     };
 
@@ -579,5 +580,68 @@ mod tests {
         assert_eq!(sglang_request.top_p, None);
         assert_eq!(sglang_request.presence_penalty, None);
         assert_eq!(sglang_request.frequency_penalty, None);
+    }
+
+    #[test]
+    fn test_sglang_response_with_metadata_try_into() {
+        let valid_response = OpenAIResponse {
+            choices: vec![OpenAIResponseChoice {
+                index: 0,
+                message: OpenAIResponseMessage {
+                    content: Some("Hello, world!".to_string()),
+                    tool_calls: None,
+                },
+            }],
+            usage: OpenAIUsage {
+                prompt_tokens: 10,
+                completion_tokens: 20,
+                total_tokens: 30,
+            },
+        };
+        let generic_request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
+            messages: vec![RequestMessage {
+                role: Role::User,
+                content: vec!["test_user".to_string().into()],
+            }],
+            system: None,
+            temperature: Some(0.5),
+            top_p: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            max_tokens: Some(100),
+            stream: false,
+            seed: Some(69),
+            json_mode: ModelInferenceRequestJsonMode::Off,
+            tool_config: None,
+            function_type: FunctionType::Chat,
+            output_schema: None,
+        };
+        let sglang_response_with_metadata = SGLangResponseWithMetadata {
+            response: valid_response,
+            raw_response: "test_response".to_string(),
+            latency: Latency::NonStreaming {
+                response_time: Duration::from_secs(0),
+            },
+            request: SGLangRequest::new("test-model", &generic_request).unwrap(),
+            generic_request: &generic_request,
+        };
+        let inference_response: ProviderInferenceResponse =
+            sglang_response_with_metadata.try_into().unwrap();
+
+        assert_eq!(inference_response.output.len(), 1);
+        assert_eq!(
+            inference_response.output[0],
+            "Hello, world!".to_string().into()
+        );
+        assert_eq!(inference_response.raw_response, "test_response");
+        assert_eq!(inference_response.usage.input_tokens, 10);
+        assert_eq!(inference_response.usage.output_tokens, 20);
+        assert_eq!(
+            inference_response.latency,
+            Latency::NonStreaming {
+                response_time: Duration::from_secs(0)
+            }
+        );
     }
 }

--- a/tensorzero_internal/src/inference/providers/together.rs
+++ b/tensorzero_internal/src/inference/providers/together.rs
@@ -146,7 +146,7 @@ impl InferenceProvider for TogetherProvider {
                 })
             })?;
         if res.status().is_success() {
-            let response = res.text().await.map_err(|e| {
+            let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing text response: {e}"),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
@@ -155,17 +155,18 @@ impl InferenceProvider for TogetherProvider {
                 })
             })?;
 
-            let response = serde_json::from_str(&response).map_err(|e| {
+            let response = serde_json::from_str(&raw_response).map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing JSON response: {e}: {response}"),
+                    message: format!("Error parsing JSON response: {e}"),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
-                    raw_response: Some(response.clone()),
+                    raw_response: Some(raw_response.clone()),
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
 
             Ok(TogetherResponseWithMetadata {
                 response,
+                raw_response,
                 latency: Latency::NonStreaming {
                     response_time: start_time.elapsed(),
                 },
@@ -365,6 +366,7 @@ fn tensorzero_to_together_system_message(system: Option<&str>) -> Option<OpenAIR
 struct TogetherResponseWithMetadata<'a> {
     response: OpenAIResponse,
     latency: Latency,
+    raw_response: String,
     request: TogetherRequest<'a>,
     generic_request: &'a ModelInferenceRequest<'a>,
 }
@@ -375,17 +377,10 @@ impl<'a> TryFrom<TogetherResponseWithMetadata<'a>> for ProviderInferenceResponse
         let TogetherResponseWithMetadata {
             mut response,
             latency,
+            raw_response,
             request: request_body,
             generic_request,
         } = value;
-        let raw_response = serde_json::to_string(&response).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
-                message: format!("Error parsing response: {e}"),
-                raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
-                raw_response: None,
-                provider_type: PROVIDER_TYPE.to_string(),
-            })
-        })?;
         if response.choices.len() != 1 {
             return Err(ErrorDetails::InferenceServer {
                 message: format!(
@@ -443,6 +438,7 @@ impl<'a> TryFrom<TogetherResponseWithMetadata<'a>> for ProviderInferenceResponse
 #[cfg(test)]
 mod tests {
     use std::borrow::Cow;
+    use std::time::Duration;
 
     use uuid::Uuid;
 
@@ -450,7 +446,8 @@ mod tests {
 
     use crate::inference::providers::common::{WEATHER_TOOL, WEATHER_TOOL_CONFIG};
     use crate::inference::providers::openai::{
-        OpenAIToolType, SpecificToolChoice, SpecificToolFunction,
+        OpenAIResponseChoice, OpenAIResponseMessage, OpenAIToolType, OpenAIUsage,
+        SpecificToolChoice, SpecificToolFunction,
     };
     use crate::inference::types::{FunctionType, RequestMessage, Role};
 
@@ -536,5 +533,68 @@ mod tests {
             result.unwrap_err().get_owned_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
+    }
+
+    #[test]
+    fn test_together_response_with_metadata_try_into() {
+        let valid_response = OpenAIResponse {
+            choices: vec![OpenAIResponseChoice {
+                index: 0,
+                message: OpenAIResponseMessage {
+                    content: Some("Hello, world!".to_string()),
+                    tool_calls: None,
+                },
+            }],
+            usage: OpenAIUsage {
+                prompt_tokens: 10,
+                completion_tokens: 20,
+                total_tokens: 30,
+            },
+        };
+        let generic_request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
+            messages: vec![RequestMessage {
+                role: Role::User,
+                content: vec!["test_user".to_string().into()],
+            }],
+            system: None,
+            temperature: Some(0.5),
+            top_p: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            max_tokens: Some(100),
+            stream: false,
+            seed: Some(69),
+            json_mode: ModelInferenceRequestJsonMode::Off,
+            tool_config: None,
+            function_type: FunctionType::Chat,
+            output_schema: None,
+        };
+        let together_response_with_metadata = TogetherResponseWithMetadata {
+            response: valid_response,
+            raw_response: "test_response".to_string(),
+            latency: Latency::NonStreaming {
+                response_time: Duration::from_secs(0),
+            },
+            request: TogetherRequest::new("test-model", &generic_request),
+            generic_request: &generic_request,
+        };
+        let inference_response: ProviderInferenceResponse =
+            together_response_with_metadata.try_into().unwrap();
+
+        assert_eq!(inference_response.output.len(), 1);
+        assert_eq!(
+            inference_response.output[0],
+            "Hello, world!".to_string().into()
+        );
+        assert_eq!(inference_response.raw_response, "test_response");
+        assert_eq!(inference_response.usage.input_tokens, 10);
+        assert_eq!(inference_response.usage.output_tokens, 20);
+        assert_eq!(
+            inference_response.latency,
+            Latency::NonStreaming {
+                response_time: Duration::from_secs(0)
+            }
+        );
     }
 }

--- a/tensorzero_internal/src/inference/providers/vllm.rs
+++ b/tensorzero_internal/src/inference/providers/vllm.rs
@@ -160,6 +160,7 @@ impl InferenceProvider for VLLMProvider {
             Ok(VLLMResponseWithMetadata {
                 response: response_body,
                 latency,
+                raw_response,
                 request: request_body,
                 generic_request: request,
             }
@@ -338,6 +339,7 @@ impl<'a> VLLMRequest<'a> {
 struct VLLMResponseWithMetadata<'a> {
     response: OpenAIResponse,
     latency: Latency,
+    raw_response: String,
     request: VLLMRequest<'a>,
     generic_request: &'a ModelInferenceRequest<'a>,
 }
@@ -348,17 +350,11 @@ impl<'a> TryFrom<VLLMResponseWithMetadata<'a>> for ProviderInferenceResponse {
         let VLLMResponseWithMetadata {
             mut response,
             latency,
+            raw_response,
             request: request_body,
             generic_request,
         } = value;
-        let raw_response = serde_json::to_string(&response).map_err(|e| {
-            Error::new(ErrorDetails::InferenceServer {
-                message: format!("Error parsing response: {e}"),
-                raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
-                raw_response: None,
-                provider_type: PROVIDER_TYPE.to_string(),
-            })
-        })?;
+
         if response.choices.len() != 1 {
             return Err(ErrorDetails::InferenceServer {
                 message: format!(
@@ -437,7 +433,7 @@ fn tensorzero_to_vllm_system_message(system: Option<&str>) -> Option<OpenAIReque
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Cow;
+    use std::{borrow::Cow, time::Duration};
 
     use serde_json::json;
     use uuid::Uuid;
@@ -445,7 +441,10 @@ mod tests {
     use super::*;
 
     use crate::inference::{
-        providers::common::WEATHER_TOOL_CONFIG,
+        providers::{
+            common::WEATHER_TOOL_CONFIG,
+            openai::{OpenAIResponseChoice, OpenAIResponseMessage, OpenAIUsage},
+        },
         types::{FunctionType, RequestMessage, Role},
     };
 
@@ -548,5 +547,68 @@ mod tests {
             result.unwrap_err().get_owned_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
+    }
+
+    #[test]
+    fn test_vllm_response_with_metadata_try_into() {
+        let valid_response = OpenAIResponse {
+            choices: vec![OpenAIResponseChoice {
+                index: 0,
+                message: OpenAIResponseMessage {
+                    content: Some("Hello, world!".to_string()),
+                    tool_calls: None,
+                },
+            }],
+            usage: OpenAIUsage {
+                prompt_tokens: 10,
+                completion_tokens: 20,
+                total_tokens: 30,
+            },
+        };
+        let generic_request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
+            messages: vec![RequestMessage {
+                role: Role::User,
+                content: vec!["test_user".to_string().into()],
+            }],
+            system: None,
+            temperature: Some(0.5),
+            top_p: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            max_tokens: Some(100),
+            stream: false,
+            seed: Some(69),
+            json_mode: ModelInferenceRequestJsonMode::Off,
+            tool_config: None,
+            function_type: FunctionType::Chat,
+            output_schema: None,
+        };
+        let vllm_response_with_metadata = VLLMResponseWithMetadata {
+            response: valid_response,
+            raw_response: "test_response".to_string(),
+            latency: Latency::NonStreaming {
+                response_time: Duration::from_secs(0),
+            },
+            request: VLLMRequest::new("test-model", &generic_request).unwrap(),
+            generic_request: &generic_request,
+        };
+        let inference_response: ProviderInferenceResponse =
+            vllm_response_with_metadata.try_into().unwrap();
+
+        assert_eq!(inference_response.output.len(), 1);
+        assert_eq!(
+            inference_response.output[0],
+            "Hello, world!".to_string().into()
+        );
+        assert_eq!(inference_response.raw_response, "test_response");
+        assert_eq!(inference_response.usage.input_tokens, 10);
+        assert_eq!(inference_response.usage.output_tokens, 20);
+        assert_eq!(
+            inference_response.latency,
+            Latency::NonStreaming {
+                response_time: Duration::from_secs(0)
+            }
+        );
     }
 }

--- a/tensorzero_internal/src/inference/providers/xai.rs
+++ b/tensorzero_internal/src/inference/providers/xai.rs
@@ -142,7 +142,7 @@ impl InferenceProvider for XAIProvider {
             })?;
 
         if res.status().is_success() {
-            let response = res.text().await.map_err(|e| {
+            let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing text response: {e}"),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
@@ -151,11 +151,11 @@ impl InferenceProvider for XAIProvider {
                 })
             })?;
 
-            let response = serde_json::from_str(&response).map_err(|e| {
+            let response = serde_json::from_str(&raw_response).map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing JSON response: {e}: {response}"),
+                    message: format!("Error parsing JSON response: {e}"),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
-                    raw_response: Some(response.clone()),
+                    raw_response: Some(raw_response.clone()),
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
@@ -165,6 +165,7 @@ impl InferenceProvider for XAIProvider {
             };
             Ok(XAIResponseWithMetadata {
                 response,
+                raw_response,
                 latency,
                 request: request_body,
                 generic_request: request,
@@ -354,6 +355,7 @@ impl<'a> XAIRequest<'a> {
 
 struct XAIResponseWithMetadata<'a> {
     response: OpenAIResponse,
+    raw_response: String,
     latency: Latency,
     request: XAIRequest<'a>,
     generic_request: &'a ModelInferenceRequest<'a>,
@@ -367,13 +369,8 @@ impl<'a> TryFrom<XAIResponseWithMetadata<'a>> for ProviderInferenceResponse {
             latency,
             request: request_body,
             generic_request,
+            raw_response,
         } = value;
-
-        let raw_response = serde_json::to_string(&response).map_err(|e| {
-            Error::new(ErrorDetails::Serialization {
-                message: format!("Error parsing response: {e}"),
-            })
-        })?;
 
         if response.choices.len() != 1 {
             return Err(ErrorDetails::InferenceServer {
@@ -430,6 +427,7 @@ impl<'a> TryFrom<XAIResponseWithMetadata<'a>> for ProviderInferenceResponse {
 #[cfg(test)]
 mod tests {
     use std::borrow::Cow;
+    use std::time::Duration;
 
     use uuid::Uuid;
 
@@ -437,7 +435,8 @@ mod tests {
 
     use crate::inference::providers::common::{WEATHER_TOOL, WEATHER_TOOL_CONFIG};
     use crate::inference::providers::openai::{
-        OpenAIToolType, SpecificToolChoice, SpecificToolFunction,
+        OpenAIResponseChoice, OpenAIResponseMessage, OpenAIToolType, OpenAIUsage,
+        SpecificToolChoice, SpecificToolFunction,
     };
     use crate::inference::types::{
         FunctionType, ModelInferenceRequestJsonMode, RequestMessage, Role,
@@ -580,5 +579,67 @@ mod tests {
             result.unwrap_err().get_owned_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
+    }
+    #[test]
+    fn test_xai_response_with_metadata_try_into() {
+        let valid_response = OpenAIResponse {
+            choices: vec![OpenAIResponseChoice {
+                index: 0,
+                message: OpenAIResponseMessage {
+                    content: Some("Hello, world!".to_string()),
+                    tool_calls: None,
+                },
+            }],
+            usage: OpenAIUsage {
+                prompt_tokens: 10,
+                completion_tokens: 20,
+                total_tokens: 30,
+            },
+        };
+        let generic_request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
+            messages: vec![RequestMessage {
+                role: Role::User,
+                content: vec!["test_user".to_string().into()],
+            }],
+            system: None,
+            temperature: Some(0.5),
+            top_p: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            max_tokens: Some(100),
+            stream: false,
+            seed: Some(69),
+            json_mode: ModelInferenceRequestJsonMode::Off,
+            tool_config: None,
+            function_type: FunctionType::Chat,
+            output_schema: None,
+        };
+        let xai_response_with_metadata = XAIResponseWithMetadata {
+            response: valid_response,
+            raw_response: "test_response".to_string(),
+            latency: Latency::NonStreaming {
+                response_time: Duration::from_secs(0),
+            },
+            request: XAIRequest::new("grok-beta", &generic_request).unwrap(),
+            generic_request: &generic_request,
+        };
+        let inference_response: ProviderInferenceResponse =
+            xai_response_with_metadata.try_into().unwrap();
+
+        assert_eq!(inference_response.output.len(), 1);
+        assert_eq!(
+            inference_response.output[0],
+            "Hello, world!".to_string().into()
+        );
+        assert_eq!(inference_response.raw_response, "test_response");
+        assert_eq!(inference_response.usage.input_tokens, 10);
+        assert_eq!(inference_response.usage.output_tokens, 20);
+        assert_eq!(
+            inference_response.latency,
+            Latency::NonStreaming {
+                response_time: Duration::from_secs(0)
+            }
+        );
     }
 }


### PR DESCRIPTION
Also added unit tests everywhere to prevent this kind of regression in the future.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes response handling bug by using `raw_response` directly and adds unit tests to prevent regression across multiple inference providers.
> 
>   - **Behavior**:
>     - Fixes bug by directly using `raw_response` instead of serializing and deserializing responses in `anthropic.rs`, `azure.rs`, and `fireworks.rs`.
>     - Updates `raw_response` handling in `gcp_vertex_anthropic.rs`, `gcp_vertex_gemini.rs`, and `google_ai_studio_gemini.rs`.
>     - Refactors response handling in `hyperbolic.rs`, `mistral.rs`, and `openai.rs` to use `raw_response` directly.
>     - Adjusts `sglang.rs`, `tgi.rs`, and `together.rs` to maintain consistent `raw_response` usage.
>     - Ensures `vllm.rs` and `xai.rs` use `raw_response` without unnecessary serialization.
>   - **Testing**:
>     - Adds unit tests for `raw_response` handling in all modified files to prevent regression.
>     - Tests cover both successful and error response scenarios.
>   - **Misc**:
>     - Minor refactoring for clarity and maintainability across all affected files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6b0536d2b8dd7a7896620b4d3e3195c79f67a6cb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->