### PR TITLE
Peek first chunk from inference stream without consuming

### DIFF
--- a/tensorzero_internal/src/error.rs
+++ b/tensorzero_internal/src/error.rs
@@ -135,6 +135,9 @@ pub enum ErrorDetails {
         raw_request: Option<String>,
         raw_response: Option<String>,
     },
+    InternalError {
+        message: String,
+    },
     InferenceTimeout {
         variant_name: String,
     },
@@ -307,6 +310,7 @@ impl ErrorDetails {
             ErrorDetails::InferenceServer { .. } => tracing::Level::ERROR,
             ErrorDetails::InferenceTimeout { .. } => tracing::Level::WARN,
             ErrorDetails::InputValidation { .. } => tracing::Level::WARN,
+            ErrorDetails::InternalError { .. } => tracing::Level::ERROR,
             ErrorDetails::InvalidBaseUrl { .. } => tracing::Level::ERROR,
             ErrorDetails::InvalidBatchParams { .. } => tracing::Level::ERROR,
             ErrorDetails::InvalidCandidate { .. } => tracing::Level::ERROR,
@@ -383,6 +387,7 @@ impl ErrorDetails {
             ErrorDetails::InvalidEpisodeId { .. } => StatusCode::BAD_REQUEST,
             ErrorDetails::InvalidUuid { .. } => StatusCode::BAD_REQUEST,
             ErrorDetails::InputValidation { .. } => StatusCode::BAD_REQUEST,
+            ErrorDetails::InternalError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::InvalidBaseUrl { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::InvalidBatchParams { .. } => StatusCode::BAD_REQUEST,
             ErrorDetails::InvalidCandidate { .. } => StatusCode::INTERNAL_SERVER_ERROR,
@@ -573,6 +578,9 @@ impl std::fmt::Display for ErrorDetails {
             }
             ErrorDetails::InputValidation { source } => {
                 write!(f, "Input validation failed with messages: {}", source)
+            }
+            ErrorDetails::InternalError { message } => {
+                write!(f, "Internal error: {}", message)
             }
             ErrorDetails::InvalidBaseUrl { message } => write!(
                 f,

--- a/tensorzero_internal/src/inference/providers/anthropic.rs
+++ b/tensorzero_internal/src/inference/providers/anthropic.rs
@@ -26,6 +26,8 @@ use crate::inference::types::{
 use crate::model::{build_creds_caching_default, Credential, CredentialLocation};
 use crate::tool::{ToolCall, ToolCallChunk, ToolCallConfig, ToolChoice, ToolConfig};
 
+use super::helpers::peek_first_chunk;
+
 lazy_static! {
     static ref ANTHROPIC_BASE_URL: Url = {
         #[allow(clippy::expect_used)]
@@ -207,14 +209,7 @@ impl InferenceProvider for AnthropicProvider {
         request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         api_key: &'a InferenceCredentials,
-    ) -> Result<
-        (
-            ProviderInferenceResponseChunk,
-            ProviderInferenceResponseStream,
-            String,
-        ),
-        Error,
-    > {
+    ) -> Result<(ProviderInferenceResponseStream, String), Error> {
         let request_body = AnthropicRequestBody::new(&self.model_name, request)?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
@@ -239,27 +234,17 @@ impl InferenceProvider for AnthropicProvider {
                     raw_response: None,
                 })
             })?;
-        let mut stream = Box::pin(stream_anthropic(event_source, start_time));
-        let mut chunk = match stream.next().await {
-            Some(Ok(chunk)) => chunk,
-            Some(Err(e)) => return Err(e),
-            None => {
-                return Err(Error::new(ErrorDetails::InferenceServer {
-                    message: "Stream ended before first chunk".to_string(),
-                    provider_type: PROVIDER_TYPE.to_string(),
-                    raw_request: Some(raw_request.clone()),
-                    raw_response: None,
-                }))
-            }
-        };
+        let mut stream = Box::pin(stream_anthropic(event_source, start_time).peekable());
+        let mut stream_mut = stream.as_mut();
+        let chunk = peek_first_chunk(&mut stream_mut, &raw_request, PROVIDER_TYPE).await?;
         if matches!(
             request.json_mode,
             ModelInferenceRequestJsonMode::On | ModelInferenceRequestJsonMode::Strict
         ) && matches!(request.function_type, FunctionType::Json)
         {
-            chunk = prefill_json_chunk_response(chunk);
+            prefill_json_chunk_response(chunk);
         }
-        Ok((chunk, stream, raw_request))
+        Ok((stream, raw_request))
     }
 
     async fn start_batch_inference<'a>(
@@ -676,10 +661,7 @@ pub(crate) fn prefill_json_response(
     Ok(content)
 }
 
-pub(crate) fn prefill_json_chunk_response(
-    chunk: ProviderInferenceResponseChunk,
-) -> ProviderInferenceResponseChunk {
-    let mut chunk = chunk;
+pub(crate) fn prefill_json_chunk_response(chunk: &mut ProviderInferenceResponseChunk) {
     if chunk.content.is_empty() {
         chunk.content = vec![ContentBlockChunk::Text(TextChunk {
             text: "{".to_string(),
@@ -701,7 +683,6 @@ pub(crate) fn prefill_json_chunk_response(
             })).unwrap_or_default()
         });
     }
-    chunk
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
@@ -2324,7 +2305,8 @@ mod tests {
             raw_response: "".to_string(),
             latency: Duration::from_millis(0),
         };
-        let result = prefill_json_chunk_response(chunk);
+        let mut result = chunk.clone();
+        prefill_json_chunk_response(&mut result);
         assert_eq!(
             result.content,
             vec![ContentBlockChunk::Text(TextChunk {
@@ -2343,7 +2325,8 @@ mod tests {
                 id: "0".to_string(),
             })],
         };
-        let result = prefill_json_chunk_response(chunk);
+        let mut result = chunk.clone();
+        prefill_json_chunk_response(&mut result);
         assert_eq!(
             result.content,
             vec![ContentBlockChunk::Text(TextChunk {
@@ -2369,7 +2352,8 @@ mod tests {
                 }),
             ],
         };
-        let result = prefill_json_chunk_response(chunk.clone());
+        let mut result = chunk.clone();
+        prefill_json_chunk_response(&mut result);
         assert_eq!(result, chunk);
 
         // Test case 4: Non-text block (should remain unchanged)
@@ -2384,7 +2368,8 @@ mod tests {
                 raw_arguments: "{}".to_string(),
             })],
         };
-        let result = prefill_json_chunk_response(chunk.clone());
+        let mut result = chunk.clone();
+        prefill_json_chunk_response(&mut result);
         assert_eq!(result, chunk);
     }
 

--- a/tensorzero_internal/src/inference/providers/aws_bedrock.rs
+++ b/tensorzero_internal/src/inference/providers/aws_bedrock.rs
@@ -11,7 +11,7 @@ use aws_sdk_bedrockruntime::types::{
 };
 use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::region::Region;
-use futures::{Stream, StreamExt};
+use futures::StreamExt;
 use reqwest::StatusCode;
 use std::time::Duration;
 use tokio::time::Instant;
@@ -23,11 +23,12 @@ use crate::error::{Error, ErrorDetails};
 use crate::inference::providers::provider_trait::InferenceProvider;
 use crate::inference::types::batch::BatchRequestRow;
 use crate::inference::types::batch::PollBatchInferenceResponse;
+use crate::inference::types::ProviderInferenceResponseStreamInner;
 use crate::inference::types::{
     batch::StartBatchProviderInferenceResponse, ContentBlock, ContentBlockChunk, FunctionType,
-    Latency, ModelInferenceRequest, ModelInferenceRequestJsonMode, ProviderInferenceResponse,
-    ProviderInferenceResponseChunk, ProviderInferenceResponseStream, RequestMessage, Role, Text,
-    TextChunk, Usage,
+    Latency, ModelInferenceRequest, ModelInferenceRequestJsonMode,
+    PeekableProviderInferenceResponseStream, ProviderInferenceResponse,
+    ProviderInferenceResponseChunk, RequestMessage, Role, Text, TextChunk, Usage,
 };
 use crate::tool::{ToolCall, ToolCallChunk, ToolChoice, ToolConfig};
 
@@ -187,7 +188,7 @@ impl InferenceProvider for AWSBedrockProvider {
         request: &'a ModelInferenceRequest<'_>,
         _http_client: &'a reqwest::Client,
         _dynamic_api_keys: &'a InferenceCredentials,
-    ) -> Result<(ProviderInferenceResponseStream, String), Error> {
+    ) -> Result<(PeekableProviderInferenceResponseStream, String), Error> {
         // TODO (#55): add support for guardrails and additional fields
 
         let mut messages: Vec<Message> = request
@@ -271,9 +272,8 @@ impl InferenceProvider for AWSBedrockProvider {
             })
         })?;
 
-        let mut stream = Box::pin(stream_bedrock(stream, start_time).peekable());
-        let mut stream_mut = stream.as_mut();
-        let chunk = peek_first_chunk(&mut stream_mut, &raw_request, PROVIDER_TYPE).await?;
+        let mut stream = stream_bedrock(stream, start_time).peekable();
+        let chunk = peek_first_chunk(&mut stream, &raw_request, PROVIDER_TYPE).await?;
         if self.model_id.contains("claude")
             && matches!(
                 request.json_mode,
@@ -315,8 +315,8 @@ impl InferenceProvider for AWSBedrockProvider {
 fn stream_bedrock(
     mut stream: ConverseStreamOutput,
     start_time: Instant,
-) -> impl Stream<Item = Result<ProviderInferenceResponseChunk, Error>> {
-    async_stream::stream! {
+) -> ProviderInferenceResponseStreamInner {
+    Box::pin(async_stream::stream! {
         let mut current_tool_id : Option<String> = None;
         let mut current_tool_name: Option<String> = None;
 
@@ -350,7 +350,7 @@ fn stream_bedrock(
                 }
             }
         }
-    }
+    })
 }
 
 fn bedrock_to_tensorzero_stream_message(

--- a/tensorzero_internal/src/inference/providers/azure.rs
+++ b/tensorzero_internal/src/inference/providers/azure.rs
@@ -14,11 +14,11 @@ use crate::inference::types::batch::BatchRequestRow;
 use crate::inference::types::batch::PollBatchInferenceResponse;
 use crate::inference::types::{
     batch::StartBatchProviderInferenceResponse, ContentBlock, Latency, ModelInferenceRequest,
-    ModelInferenceRequestJsonMode, ProviderInferenceResponse, ProviderInferenceResponseChunk,
-    ProviderInferenceResponseStream,
+    ModelInferenceRequestJsonMode, ProviderInferenceResponse, ProviderInferenceResponseStream,
 };
 use crate::model::{build_creds_caching_default, Credential, CredentialLocation};
 
+use super::helpers::peek_first_chunk;
 use super::openai::{
     handle_openai_error, prepare_openai_messages, prepare_openai_tools, stream_openai,
     OpenAIRequestMessage, OpenAIResponse, OpenAITool, OpenAIToolChoice, OpenAIToolChoiceString,
@@ -187,14 +187,7 @@ impl InferenceProvider for AzureProvider {
         request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
-    ) -> Result<
-        (
-            ProviderInferenceResponseChunk,
-            ProviderInferenceResponseStream,
-            String,
-        ),
-        Error,
-    > {
+    ) -> Result<(ProviderInferenceResponseStream, String), Error> {
         let request_body = AzureRequest::new(request);
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
@@ -219,23 +212,11 @@ impl InferenceProvider for AzureProvider {
                     raw_response: None,
                 })
             })?;
-        let mut stream = Box::pin(stream_openai(event_source, start_time));
+        let mut stream = Box::pin(stream_openai(event_source, start_time).peekable());
         // Get a single chunk from the stream and make sure it is OK then send to client.
         // We want to do this here so that we can tell that the request is working.
-        let chunk = match stream.next().await {
-            Some(Ok(chunk)) => chunk,
-            Some(Err(e)) => return Err(e),
-            None => {
-                return Err(ErrorDetails::InferenceServer {
-                    message: "Stream ended before first chunk".to_string(),
-                    provider_type: PROVIDER_TYPE.to_string(),
-                    raw_request: Some(raw_request.clone()),
-                    raw_response: None,
-                }
-                .into())
-            }
-        };
-        Ok((chunk, stream, raw_request))
+        peek_first_chunk(&mut stream.as_mut(), &raw_request, PROVIDER_TYPE).await?;
+        Ok((stream, raw_request))
     }
 
     async fn start_batch_inference<'a>(

--- a/tensorzero_internal/src/inference/providers/fireworks.rs
+++ b/tensorzero_internal/src/inference/providers/fireworks.rs
@@ -15,12 +15,13 @@ use crate::{
     inference::types::{
         batch::{BatchRequestRow, PollBatchInferenceResponse, StartBatchProviderInferenceResponse},
         ContentBlock, Latency, ModelInferenceRequest, ModelInferenceRequestJsonMode,
-        ProviderInferenceResponse, ProviderInferenceResponseChunk, ProviderInferenceResponseStream,
+        ProviderInferenceResponse, ProviderInferenceResponseStream,
     },
     model::{build_creds_caching_default, Credential, CredentialLocation},
 };
 
 use super::{
+    helpers::peek_first_chunk,
     openai::{
         get_chat_url, handle_openai_error, prepare_openai_tools, stream_openai,
         tensorzero_to_openai_messages, OpenAIFunction, OpenAIRequestMessage, OpenAIResponse,
@@ -201,14 +202,7 @@ impl InferenceProvider for FireworksProvider {
         request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         api_key: &'a InferenceCredentials,
-    ) -> Result<
-        (
-            ProviderInferenceResponseChunk,
-            ProviderInferenceResponseStream,
-            String,
-        ),
-        Error,
-    > {
+    ) -> Result<(ProviderInferenceResponseStream, String), Error> {
         let request_body = FireworksRequest::new(&self.model_name, request);
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::InferenceServer {
@@ -236,23 +230,11 @@ impl InferenceProvider for FireworksProvider {
                     raw_response: None,
                 })
             })?;
-        let mut stream = Box::pin(stream_openai(event_source, start_time));
+        let mut stream = Box::pin(stream_openai(event_source, start_time).peekable());
         // Get a single chunk from the stream and make sure it is OK then send to client.
         // We want to do this here so that we can tell that the request is working.
-        let chunk = match stream.next().await {
-            Some(Ok(chunk)) => chunk,
-            Some(Err(e)) => return Err(e),
-            None => {
-                return Err(ErrorDetails::InferenceServer {
-                    message: "Stream ended before first chunk".to_string(),
-                    provider_type: PROVIDER_TYPE.to_string(),
-                    raw_request: Some(raw_request.clone()),
-                    raw_response: None,
-                }
-                .into())
-            }
-        };
-        Ok((chunk, stream, raw_request))
+        peek_first_chunk(&mut stream.as_mut(), &raw_request, PROVIDER_TYPE).await?;
+        Ok((stream, raw_request))
     }
 
     async fn start_batch_inference<'a>(

--- a/tensorzero_internal/src/inference/providers/gcp_vertex_gemini.rs
+++ b/tensorzero_internal/src/inference/providers/gcp_vertex_gemini.rs
@@ -27,6 +27,8 @@ use crate::inference::types::{
 use crate::model::{build_creds_caching_default_with_fn, Credential, CredentialLocation};
 use crate::tool::{ToolCall, ToolCallChunk, ToolChoice, ToolConfig};
 
+use super::helpers::peek_first_chunk;
+
 const PROVIDER_NAME: &str = "GCP Vertex Gemini";
 const PROVIDER_TYPE: &str = "gcp_vertex_gemini";
 
@@ -330,14 +332,7 @@ impl InferenceProvider for GCPVertexGeminiProvider {
         request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
-    ) -> Result<
-        (
-            ProviderInferenceResponseChunk,
-            ProviderInferenceResponseStream,
-            String,
-        ),
-        Error,
-    > {
+    ) -> Result<(ProviderInferenceResponseStream, String), Error> {
         let request_body: GCPVertexGeminiRequest =
             GCPVertexGeminiRequest::new(request, &self.model_id)?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
@@ -363,21 +358,12 @@ impl InferenceProvider for GCPVertexGeminiProvider {
                     raw_response: None,
                 })
             })?;
-        let mut stream = Box::pin(stream_gcp_vertex_gemini(event_source, start_time));
-        let chunk = match stream.next().await {
-            Some(Ok(chunk)) => chunk,
-            Some(Err(e)) => return Err(e),
-            None => {
-                return Err(ErrorDetails::InferenceServer {
-                    message: "Stream ended before first chunk".to_string(),
-                    provider_type: PROVIDER_TYPE.to_string(),
-                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
-                    raw_response: None,
-                }
-                .into())
-            }
-        };
-        Ok((chunk, stream, raw_request))
+        let mut stream = Box::pin(stream_gcp_vertex_gemini(event_source, start_time).peekable());
+        // Get a single chunk from the stream and make sure it is OK then send to client.
+        // We want to do this here so that we can tell that the request is working.
+        peek_first_chunk(&mut stream.as_mut(), &raw_request, PROVIDER_TYPE).await?;
+
+        Ok((stream, raw_request))
     }
 
     async fn start_batch_inference<'a>(

--- a/tensorzero_internal/src/inference/providers/helpers.rs
+++ b/tensorzero_internal/src/inference/providers/helpers.rs
@@ -1,0 +1,128 @@
+use std::pin::Pin;
+
+use futures::stream::Peekable;
+use futures::Stream;
+
+use crate::{
+    error::{Error, ErrorDetails},
+    inference::types::ProviderInferenceResponseChunk,
+};
+
+/// Gives mutable access to the first chunk of a stream, returning an error if the stream is empty
+pub async fn peek_first_chunk<
+    'a,
+    T: Stream<Item = Result<ProviderInferenceResponseChunk, Error>>,
+>(
+    stream: &'a mut Pin<&mut Peekable<T>>,
+    raw_request: &str,
+    provider_type: &str,
+) -> Result<&'a mut ProviderInferenceResponseChunk, Error> {
+    // If the next stream item is an error, consume and return it
+    if let Some(err) = stream.as_mut().next_if(Result::is_err).await {
+        match err {
+            Err(e) => {
+                return Err(e)
+            }
+            Ok(_) => {
+                return Err(Error::new(ErrorDetails::InternalError {
+                    message: "Stream `next_if` produced wrong value (this should never happen). Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new".to_string(),
+                 }))
+            }
+        }
+    }
+    // Peek at the same item - we already checked that it's not an error.
+    match stream.as_mut().peek_mut().await {
+        // Returning `chunk` extends the lifetime of 'stream.as_mut() to 'a,
+        // which blocks us from using 'stream' in the other branches of
+        // this match.
+        Some(Ok(chunk)) => Ok(chunk),
+        None => {
+            Err(Error::new(ErrorDetails::InferenceServer {
+                message: "Stream ended before first chunk".to_string(),
+                provider_type: provider_type.to_string(),
+                raw_request: Some(raw_request.to_string()),
+                raw_response: None,
+            }))
+        }
+        // Due to a borrow-checker limitation, we can't use 'stream' here
+        // (since returning `chunk` above will cause `stream` to still be borrowed here.)
+        // We check for an error before the `match` block, which makes this unreachable
+        Some(Err(_)) => {
+            Err(Error::new(ErrorDetails::InternalError {
+                message: "Stream produced error after we peeked non-error (this shoul dnever happen). Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new".to_string()
+             }))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use futures::{stream, StreamExt};
+
+    use crate::inference::types::{ContentBlockChunk, TextChunk};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_peek_empty() {
+        let mut stream = Box::pin(stream::empty().peekable());
+        let err = peek_first_chunk(&mut stream.as_mut(), "test", "test")
+            .await
+            .expect_err("Peeking empty stream should fail");
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains("Stream ended before first chunk"),
+            "Unexpected error message: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_peek_err() {
+        let mut stream = Box::pin(
+            stream::iter([Err(Error::new(ErrorDetails::InternalError {
+                message: "My test error".to_string(),
+            }))])
+            .peekable(),
+        );
+        let err = peek_first_chunk(&mut stream.as_mut(), "test", "test")
+            .await
+            .expect_err("Peeking errored stream should fail");
+        assert_eq!(
+            err,
+            Error::new(ErrorDetails::InternalError {
+                message: "My test error".to_string(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_peek_good() {
+        let chunk = ProviderInferenceResponseChunk {
+            content: vec![ContentBlockChunk::Text(TextChunk {
+                id: "0".to_string(),
+                text: "Hello, world!".to_string(),
+            })],
+            created: 0,
+            usage: None,
+            raw_response: "My raw response".to_string(),
+            latency: Duration::from_secs(0),
+        };
+        let mut stream = Box::pin(
+            stream::iter([
+                Ok(chunk.clone()),
+                Err(Error::new(ErrorDetails::InternalError {
+                    message: "My test error".to_string(),
+                })),
+            ])
+            .peekable(),
+        );
+        let mut stream_mut = stream.as_mut();
+        let peeked_chunk: &mut ProviderInferenceResponseChunk =
+            peek_first_chunk(&mut stream_mut, "test", "test")
+                .await
+                .expect("Peeking stream should succeed");
+        assert_eq!(&chunk, peeked_chunk);
+    }
+}

--- a/tensorzero_internal/src/inference/providers/hyperbolic.rs
+++ b/tensorzero_internal/src/inference/providers/hyperbolic.rs
@@ -5,7 +5,7 @@ use crate::error::{Error, ErrorDetails};
 use crate::inference::types::batch::{BatchRequestRow, PollBatchInferenceResponse};
 use crate::inference::types::{
     batch::StartBatchProviderInferenceResponse, ContentBlock, Latency, ModelInferenceRequest,
-    ProviderInferenceResponse, ProviderInferenceResponseChunk, ProviderInferenceResponseStream,
+    ProviderInferenceResponse, ProviderInferenceResponseStream,
 };
 use crate::model::{build_creds_caching_default, Credential, CredentialLocation};
 use futures::StreamExt;
@@ -16,6 +16,7 @@ use serde::Serialize;
 use tokio::time::Instant;
 use url::Url;
 
+use super::helpers::peek_first_chunk;
 use super::openai::{
     get_chat_url, handle_openai_error, prepare_openai_messages, stream_openai,
     OpenAIRequestMessage, OpenAIResponse,
@@ -191,14 +192,7 @@ impl InferenceProvider for HyperbolicProvider {
         request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
-    ) -> Result<
-        (
-            ProviderInferenceResponseChunk,
-            ProviderInferenceResponseStream,
-            String,
-        ),
-        Error,
-    > {
+    ) -> Result<(ProviderInferenceResponseStream, String), Error> {
         let request_body = HyperbolicRequest::new(&self.model_name, request)?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
@@ -224,23 +218,11 @@ impl InferenceProvider for HyperbolicProvider {
                 })
             })?;
 
-        let mut stream = Box::pin(stream_openai(event_source, start_time));
+        let mut stream = Box::pin(stream_openai(event_source, start_time).peekable());
         // Get a single chunk from the stream and make sure it is OK then send to client.
         // We want to do this here so that we can tell that the request is working.
-        let chunk = match stream.next().await {
-            Some(Ok(chunk)) => chunk,
-            Some(Err(e)) => return Err(e),
-            None => {
-                return Err(ErrorDetails::InferenceServer {
-                    message: "Stream ended before first chunk".to_string(),
-                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
-                    raw_response: None,
-                    provider_type: PROVIDER_TYPE.to_string(),
-                }
-                .into())
-            }
-        };
-        Ok((chunk, stream, raw_request))
+        peek_first_chunk(&mut stream.as_mut(), &raw_request, PROVIDER_TYPE).await?;
+        Ok((stream, raw_request))
     }
 
     async fn start_batch_inference<'a>(

--- a/tensorzero_internal/src/inference/providers/mistral.rs
+++ b/tensorzero_internal/src/inference/providers/mistral.rs
@@ -24,6 +24,7 @@ use crate::{
 };
 
 use super::{
+    helpers::peek_first_chunk,
     openai::{
         get_chat_url, tensorzero_to_openai_messages, OpenAIFunction, OpenAIRequestMessage,
         OpenAISystemRequestMessage, OpenAITool, OpenAIToolType,
@@ -196,14 +197,7 @@ impl InferenceProvider for MistralProvider {
         request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
-    ) -> Result<
-        (
-            ProviderInferenceResponseChunk,
-            ProviderInferenceResponseStream,
-            String,
-        ),
-        Error,
-    > {
+    ) -> Result<(ProviderInferenceResponseStream, String), Error> {
         let request_body = MistralRequest::new(&self.model_name, request)?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
@@ -228,22 +222,11 @@ impl InferenceProvider for MistralProvider {
                     raw_response: None,
                 })
             })?;
-        let mut stream = Box::pin(stream_mistral(event_source, start_time));
+        let mut stream = Box::pin(stream_mistral(event_source, start_time).peekable());
         // Get a single chunk from the stream and make sure it is OK then send to client.
         // We want to do this here so that we can tell that the request is working.
-        let chunk = match stream.next().await {
-            Some(Ok(chunk)) => chunk,
-            Some(Err(e)) => return Err(e),
-            None => {
-                return Err(Error::new(ErrorDetails::InferenceServer {
-                    message: "Stream ended before first chunk".to_string(),
-                    provider_type: PROVIDER_TYPE.to_string(),
-                    raw_request: Some(raw_request.clone()),
-                    raw_response: None,
-                }))
-            }
-        };
-        Ok((chunk, stream, raw_request))
+        peek_first_chunk(&mut stream.as_mut(), &raw_request, PROVIDER_TYPE).await?;
+        Ok((stream, raw_request))
     }
 
     async fn start_batch_inference<'a>(

--- a/tensorzero_internal/src/inference/providers/mod.rs
+++ b/tensorzero_internal/src/inference/providers/mod.rs
@@ -10,6 +10,7 @@ pub mod fireworks;
 pub mod gcp_vertex_anthropic;
 pub mod gcp_vertex_gemini;
 pub mod google_ai_studio_gemini;
+pub mod helpers;
 pub mod hyperbolic;
 pub mod mistral;
 pub mod openai;

--- a/tensorzero_internal/src/inference/providers/provider_trait.rs
+++ b/tensorzero_internal/src/inference/providers/provider_trait.rs
@@ -4,8 +4,8 @@ use crate::inference::types::batch::BatchRequestRow;
 use crate::inference::types::batch::PollBatchInferenceResponse;
 use crate::inference::types::batch::StartBatchProviderInferenceResponse;
 use crate::inference::types::ModelInferenceRequest;
+use crate::inference::types::PeekableProviderInferenceResponseStream;
 use crate::inference::types::ProviderInferenceResponse;
-use crate::inference::types::ProviderInferenceResponseStream;
 use futures::Future;
 use reqwest::Client;
 
@@ -22,7 +22,7 @@ pub trait InferenceProvider {
         request: &'a ModelInferenceRequest,
         client: &'a Client,
         dynamic_api_keys: &'a InferenceCredentials,
-    ) -> impl Future<Output = Result<(ProviderInferenceResponseStream, String), Error>> + Send + 'a;
+    ) -> impl Future<Output = Result<(PeekableProviderInferenceResponseStream, String), Error>> + Send + 'a;
 
     fn start_batch_inference<'a>(
         &'a self,

--- a/tensorzero_internal/src/inference/providers/provider_trait.rs
+++ b/tensorzero_internal/src/inference/providers/provider_trait.rs
@@ -5,7 +5,6 @@ use crate::inference::types::batch::PollBatchInferenceResponse;
 use crate::inference::types::batch::StartBatchProviderInferenceResponse;
 use crate::inference::types::ModelInferenceRequest;
 use crate::inference::types::ProviderInferenceResponse;
-use crate::inference::types::ProviderInferenceResponseChunk;
 use crate::inference::types::ProviderInferenceResponseStream;
 use futures::Future;
 use reqwest::Client;
@@ -23,17 +22,7 @@ pub trait InferenceProvider {
         request: &'a ModelInferenceRequest,
         client: &'a Client,
         dynamic_api_keys: &'a InferenceCredentials,
-    ) -> impl Future<
-        Output = Result<
-            (
-                ProviderInferenceResponseChunk,
-                ProviderInferenceResponseStream,
-                String,
-            ),
-            Error,
-        >,
-    > + Send
-           + 'a;
+    ) -> impl Future<Output = Result<(ProviderInferenceResponseStream, String), Error>> + Send + 'a;
 
     fn start_batch_inference<'a>(
         &'a self,

--- a/tensorzero_internal/src/inference/providers/sglang.rs
+++ b/tensorzero_internal/src/inference/providers/sglang.rs
@@ -14,11 +14,11 @@ use crate::inference::providers::provider_trait::InferenceProvider;
 use crate::inference::types::batch::{BatchRequestRow, PollBatchInferenceResponse};
 use crate::inference::types::{
     batch::StartBatchProviderInferenceResponse, ContentBlock, Latency, ModelInferenceRequest,
-    ModelInferenceRequestJsonMode, ProviderInferenceResponse, ProviderInferenceResponseStream,
+    ModelInferenceRequestJsonMode, PeekableProviderInferenceResponseStream,
+    ProviderInferenceResponse,
 };
 use crate::model::{build_creds_caching_default, Credential, CredentialLocation};
 
-use super::helpers::peek_first_chunk;
 use super::openai::{
     get_chat_url, handle_openai_error, prepare_openai_messages, prepare_openai_tools,
     stream_openai, OpenAIRequestMessage, OpenAIResponse, OpenAITool, OpenAIToolChoice,
@@ -187,7 +187,7 @@ impl InferenceProvider for SGLangProvider {
         request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
-    ) -> Result<(ProviderInferenceResponseStream, String), Error> {
+    ) -> Result<(PeekableProviderInferenceResponseStream, String), Error> {
         let request_body = SGLangRequest::new(&self.model_name, request)?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
@@ -216,10 +216,7 @@ impl InferenceProvider for SGLangProvider {
                 })
             })?;
 
-        let mut stream = Box::pin(stream_openai(event_source, start_time).peekable());
-        // Get a single chunk from the stream and make sure it is OK then send to client.
-        // We want to do this here so that we can tell that the request is working.
-        peek_first_chunk(&mut stream.as_mut(), &raw_request, PROVIDER_TYPE).await?;
+        let stream = stream_openai(event_source, start_time).peekable();
         Ok((stream, raw_request))
     }
 

--- a/tensorzero_internal/src/inference/providers/sglang.rs
+++ b/tensorzero_internal/src/inference/providers/sglang.rs
@@ -14,11 +14,11 @@ use crate::inference::providers::provider_trait::InferenceProvider;
 use crate::inference::types::batch::{BatchRequestRow, PollBatchInferenceResponse};
 use crate::inference::types::{
     batch::StartBatchProviderInferenceResponse, ContentBlock, Latency, ModelInferenceRequest,
-    ModelInferenceRequestJsonMode, ProviderInferenceResponse, ProviderInferenceResponseChunk,
-    ProviderInferenceResponseStream,
+    ModelInferenceRequestJsonMode, ProviderInferenceResponse, ProviderInferenceResponseStream,
 };
 use crate::model::{build_creds_caching_default, Credential, CredentialLocation};
 
+use super::helpers::peek_first_chunk;
 use super::openai::{
     get_chat_url, handle_openai_error, prepare_openai_messages, prepare_openai_tools,
     stream_openai, OpenAIRequestMessage, OpenAIResponse, OpenAITool, OpenAIToolChoice,
@@ -187,14 +187,7 @@ impl InferenceProvider for SGLangProvider {
         request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
-    ) -> Result<
-        (
-            ProviderInferenceResponseChunk,
-            ProviderInferenceResponseStream,
-            String,
-        ),
-        Error,
-    > {
+    ) -> Result<(ProviderInferenceResponseStream, String), Error> {
         let request_body = SGLangRequest::new(&self.model_name, request)?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
@@ -223,23 +216,11 @@ impl InferenceProvider for SGLangProvider {
                 })
             })?;
 
-        let mut stream = Box::pin(stream_openai(event_source, start_time));
+        let mut stream = Box::pin(stream_openai(event_source, start_time).peekable());
         // Get a single chunk from the stream and make sure it is OK then send to client.
         // We want to do this here so that we can tell that the request is working.
-        let chunk = match stream.next().await {
-            Some(Ok(chunk)) => chunk,
-            Some(Err(e)) => return Err(e),
-            None => {
-                return Err(ErrorDetails::InferenceServer {
-                    message: "Stream ended before first chunk".to_string(),
-                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
-                    raw_response: None,
-                    provider_type: PROVIDER_TYPE.to_string(),
-                }
-                .into())
-            }
-        };
-        Ok((chunk, stream, raw_request))
+        peek_first_chunk(&mut stream.as_mut(), &raw_request, PROVIDER_TYPE).await?;
+        Ok((stream, raw_request))
     }
 
     async fn start_batch_inference<'a>(

--- a/tensorzero_internal/src/inference/providers/vllm.rs
+++ b/tensorzero_internal/src/inference/providers/vllm.rs
@@ -9,7 +9,6 @@ use serde_json::Value;
 use tokio::time::Instant;
 use url::Url;
 
-use super::helpers::peek_first_chunk;
 use super::openai::{
     get_chat_url, handle_openai_error, stream_openai, tensorzero_to_openai_messages,
     OpenAIRequestMessage, OpenAIResponse, OpenAISystemRequestMessage, StreamOptions,
@@ -20,7 +19,8 @@ use crate::error::{Error, ErrorDetails};
 use crate::inference::types::batch::{BatchRequestRow, PollBatchInferenceResponse};
 use crate::inference::types::{
     batch::StartBatchProviderInferenceResponse, ContentBlock, Latency, ModelInferenceRequest,
-    ModelInferenceRequestJsonMode, ProviderInferenceResponse, ProviderInferenceResponseStream,
+    ModelInferenceRequestJsonMode, PeekableProviderInferenceResponseStream,
+    ProviderInferenceResponse,
 };
 use crate::model::{build_creds_caching_default, Credential, CredentialLocation};
 
@@ -184,7 +184,7 @@ impl InferenceProvider for VLLMProvider {
         request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
-    ) -> Result<(ProviderInferenceResponseStream, String), Error> {
+    ) -> Result<(PeekableProviderInferenceResponseStream, String), Error> {
         let request_body = VLLMRequest::new(&self.model_name, request)?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
@@ -212,10 +212,7 @@ impl InferenceProvider for VLLMProvider {
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
-        let mut stream = Box::pin(stream_openai(event_source, start_time).peekable());
-        // Get a single chunk from the stream and make sure it is OK then send to client.
-        // We want to do this here so that we can tell that the request is working.
-        peek_first_chunk(&mut stream.as_mut(), &raw_request, PROVIDER_TYPE).await?;
+        let stream = stream_openai(event_source, start_time).peekable();
         Ok((stream, raw_request))
     }
 

--- a/tensorzero_internal/src/inference/providers/vllm.rs
+++ b/tensorzero_internal/src/inference/providers/vllm.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 use tokio::time::Instant;
 use url::Url;
 
+use super::helpers::peek_first_chunk;
 use super::openai::{
     get_chat_url, handle_openai_error, stream_openai, tensorzero_to_openai_messages,
     OpenAIRequestMessage, OpenAIResponse, OpenAISystemRequestMessage, StreamOptions,
@@ -19,8 +20,7 @@ use crate::error::{Error, ErrorDetails};
 use crate::inference::types::batch::{BatchRequestRow, PollBatchInferenceResponse};
 use crate::inference::types::{
     batch::StartBatchProviderInferenceResponse, ContentBlock, Latency, ModelInferenceRequest,
-    ModelInferenceRequestJsonMode, ProviderInferenceResponse, ProviderInferenceResponseChunk,
-    ProviderInferenceResponseStream,
+    ModelInferenceRequestJsonMode, ProviderInferenceResponse, ProviderInferenceResponseStream,
 };
 use crate::model::{build_creds_caching_default, Credential, CredentialLocation};
 
@@ -184,14 +184,7 @@ impl InferenceProvider for VLLMProvider {
         request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
-    ) -> Result<
-        (
-            ProviderInferenceResponseChunk,
-            ProviderInferenceResponseStream,
-            String,
-        ),
-        Error,
-    > {
+    ) -> Result<(ProviderInferenceResponseStream, String), Error> {
         let request_body = VLLMRequest::new(&self.model_name, request)?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
@@ -219,23 +212,11 @@ impl InferenceProvider for VLLMProvider {
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
-        let mut stream = Box::pin(stream_openai(event_source, start_time));
+        let mut stream = Box::pin(stream_openai(event_source, start_time).peekable());
         // Get a single chunk from the stream and make sure it is OK then send to client.
         // We want to do this here so that we can tell that the request is working.
-        let chunk = match stream.next().await {
-            Some(Ok(chunk)) => chunk,
-            Some(Err(e)) => return Err(e),
-            None => {
-                return Err(ErrorDetails::InferenceServer {
-                    message: "Stream ended before first chunk".to_string(),
-                    raw_request: Some(raw_request.clone()),
-                    raw_response: None,
-                    provider_type: PROVIDER_TYPE.to_string(),
-                }
-                .into())
-            }
-        };
-        Ok((chunk, stream, raw_request))
+        peek_first_chunk(&mut stream.as_mut(), &raw_request, PROVIDER_TYPE).await?;
+        Ok((stream, raw_request))
     }
 
     async fn start_batch_inference<'a>(

--- a/tensorzero_internal/src/inference/providers/xai.rs
+++ b/tensorzero_internal/src/inference/providers/xai.rs
@@ -14,11 +14,11 @@ use crate::inference::providers::provider_trait::InferenceProvider;
 use crate::inference::types::batch::{BatchRequestRow, PollBatchInferenceResponse};
 use crate::inference::types::{
     batch::StartBatchProviderInferenceResponse, ContentBlock, Latency, ModelInferenceRequest,
-    ModelInferenceRequestJsonMode, ProviderInferenceResponse, ProviderInferenceResponseStream,
+    ModelInferenceRequestJsonMode, PeekableProviderInferenceResponseStream,
+    ProviderInferenceResponse,
 };
 use crate::model::{build_creds_caching_default, Credential, CredentialLocation};
 
-use super::helpers::peek_first_chunk;
 use super::openai::{
     get_chat_url, handle_openai_error, prepare_openai_messages, prepare_openai_tools,
     stream_openai, OpenAIRequestMessage, OpenAIResponse, OpenAITool, OpenAIToolChoice,
@@ -191,7 +191,7 @@ impl InferenceProvider for XAIProvider {
         request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
-    ) -> Result<(ProviderInferenceResponseStream, String), Error> {
+    ) -> Result<(PeekableProviderInferenceResponseStream, String), Error> {
         let request_body = XAIRequest::new(&self.model_name, request)?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::InferenceServer {
@@ -220,10 +220,7 @@ impl InferenceProvider for XAIProvider {
                 })
             })?;
 
-        let mut stream = Box::pin(stream_openai(event_source, start_time).peekable());
-        // Get a single chunk from the stream and make sure it is OK then send to client.
-        // We want to do this here so that we can tell that the request is working.
-        peek_first_chunk(&mut stream.as_mut(), &raw_request, PROVIDER_TYPE).await?;
+        let stream = stream_openai(event_source, start_time).peekable();
         Ok((stream, raw_request))
     }
 

--- a/tensorzero_internal/src/inference/providers/xai.rs
+++ b/tensorzero_internal/src/inference/providers/xai.rs
@@ -14,11 +14,11 @@ use crate::inference::providers::provider_trait::InferenceProvider;
 use crate::inference::types::batch::{BatchRequestRow, PollBatchInferenceResponse};
 use crate::inference::types::{
     batch::StartBatchProviderInferenceResponse, ContentBlock, Latency, ModelInferenceRequest,
-    ModelInferenceRequestJsonMode, ProviderInferenceResponse, ProviderInferenceResponseChunk,
-    ProviderInferenceResponseStream,
+    ModelInferenceRequestJsonMode, ProviderInferenceResponse, ProviderInferenceResponseStream,
 };
 use crate::model::{build_creds_caching_default, Credential, CredentialLocation};
 
+use super::helpers::peek_first_chunk;
 use super::openai::{
     get_chat_url, handle_openai_error, prepare_openai_messages, prepare_openai_tools,
     stream_openai, OpenAIRequestMessage, OpenAIResponse, OpenAITool, OpenAIToolChoice,
@@ -191,14 +191,7 @@ impl InferenceProvider for XAIProvider {
         request: &'a ModelInferenceRequest<'_>,
         http_client: &'a reqwest::Client,
         dynamic_api_keys: &'a InferenceCredentials,
-    ) -> Result<
-        (
-            ProviderInferenceResponseChunk,
-            ProviderInferenceResponseStream,
-            String,
-        ),
-        Error,
-    > {
+    ) -> Result<(ProviderInferenceResponseStream, String), Error> {
         let request_body = XAIRequest::new(&self.model_name, request)?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::InferenceServer {
@@ -227,23 +220,11 @@ impl InferenceProvider for XAIProvider {
                 })
             })?;
 
-        let mut stream = Box::pin(stream_openai(event_source, start_time));
+        let mut stream = Box::pin(stream_openai(event_source, start_time).peekable());
         // Get a single chunk from the stream and make sure it is OK then send to client.
         // We want to do this here so that we can tell that the request is working.
-        let chunk = match stream.next().await {
-            Some(Ok(chunk)) => chunk,
-            Some(Err(e)) => return Err(e),
-            None => {
-                return Err(ErrorDetails::InferenceServer {
-                    message: "Stream ended before first chunk".to_string(),
-                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
-                    raw_response: None,
-                    provider_type: PROVIDER_TYPE.to_string(),
-                }
-                .into())
-            }
-        };
-        Ok((chunk, stream, raw_request))
+        peek_first_chunk(&mut stream.as_mut(), &raw_request, PROVIDER_TYPE).await?;
+        Ok((stream, raw_request))
     }
 
     async fn start_batch_inference<'a>(

--- a/tensorzero_internal/src/variant/best_of_n_sampling.rs
+++ b/tensorzero_internal/src/variant/best_of_n_sampling.rs
@@ -23,7 +23,7 @@ use crate::{
     endpoints::inference::InferenceParams,
     error::Error,
     function::FunctionConfig,
-    inference::types::{InferenceResult, InferenceResultChunk, InferenceResultStream, Input},
+    inference::types::{InferenceResult, InferenceResultStream, Input},
     minijinja_util::TemplateConfig,
     variant::chat_completion::ChatCompletionConfig,
 };
@@ -106,7 +106,7 @@ impl Variant for BestOfNSamplingConfig {
         _inference_config: &'request InferenceConfig<'static, 'request>,
         _clients: &'request InferenceClients<'request>,
         _inference_params: InferenceParams,
-    ) -> Result<(InferenceResultChunk, InferenceResultStream, ModelUsedInfo), Error> {
+    ) -> Result<(InferenceResultStream, ModelUsedInfo), Error> {
         Err(ErrorDetails::InvalidRequest {
             message: "Best of n variants do not support streaming inference.".to_string(),
         }

--- a/tensorzero_internal/src/variant/dicl.rs
+++ b/tensorzero_internal/src/variant/dicl.rs
@@ -18,8 +18,8 @@ use crate::{
     error::{Error, ErrorDetails},
     function::FunctionConfig,
     inference::types::{
-        ContentBlock, ContentBlockOutput, InferenceResult, InferenceResultChunk,
-        InferenceResultStream, Input, JsonInferenceOutput,
+        ContentBlock, ContentBlockOutput, InferenceResult, InferenceResultStream, Input,
+        JsonInferenceOutput,
     },
     minijinja_util::TemplateConfig,
 };
@@ -146,7 +146,7 @@ impl Variant for DiclConfig {
         inference_config: &'request InferenceConfig<'static, 'request>,
         clients: &'request InferenceClients<'request>,
         inference_params: InferenceParams,
-    ) -> Result<(InferenceResultChunk, InferenceResultStream, ModelUsedInfo), Error> {
+    ) -> Result<(InferenceResultStream, ModelUsedInfo), Error> {
         // So this can be mutably borrowed by the prepare_request function
         let mut inference_params = inference_params;
 
@@ -182,27 +182,22 @@ impl Variant for DiclConfig {
         })?;
 
         // Actually run the inference
-        let (inference_result_chunk, inference_result_stream, mut model_used_info) =
-            infer_model_request_stream(
-                request,
-                self.model.clone(),
-                &model_config,
-                function,
-                clients,
-                inference_params,
-                self.retries,
-            )
-            .await?;
+        let (inference_result_stream, mut model_used_info) = infer_model_request_stream(
+            request,
+            self.model.clone(),
+            &model_config,
+            function,
+            clients,
+            inference_params,
+            self.retries,
+        )
+        .await?;
 
         // Add the embedding to the model inference results
         model_used_info
             .previous_model_inference_results
             .push(embedding_response.into());
-        Ok((
-            inference_result_chunk,
-            inference_result_stream,
-            model_used_info,
-        ))
+        Ok((inference_result_stream, model_used_info))
     }
 
     fn validate(

--- a/tensorzero_internal/src/variant/mixture_of_n.rs
+++ b/tensorzero_internal/src/variant/mixture_of_n.rs
@@ -16,7 +16,7 @@ use crate::{
     endpoints::inference::InferenceParams,
     error::{Error, ErrorDetails},
     function::FunctionConfig,
-    inference::types::{InferenceResult, InferenceResultChunk, InferenceResultStream, Input},
+    inference::types::{InferenceResult, InferenceResultStream, Input},
     minijinja_util::TemplateConfig,
     variant::chat_completion::ChatCompletionConfig,
 };
@@ -80,7 +80,7 @@ impl Variant for MixtureOfNConfig {
         _inference_config: &'request InferenceConfig<'static, 'request>,
         _clients: &'request InferenceClients<'request>,
         _inference_params: InferenceParams,
-    ) -> Result<(InferenceResultChunk, InferenceResultStream, ModelUsedInfo), Error> {
+    ) -> Result<(InferenceResultStream, ModelUsedInfo), Error> {
         Err(ErrorDetails::InvalidRequest {
             message: "Best of n variants do not support streaming inference.".to_string(),
         }


### PR DESCRIPTION
This lets us avoid passing around `first_chunk`. We still check that the provider produces at least one chunk before considering it to have succeededing.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor inference streaming to peek first chunk without consuming, ensuring provider success with at least one chunk.
> 
>   - **Behavior**:
>     - Refactor inference streaming to avoid passing `first_chunk` explicitly.
>     - Introduce `peek_first_chunk()` in `helpers.rs` to peek at the first chunk without consuming it.
>     - Ensure provider produces at least one chunk before success.
>   - **Functions**:
>     - Modify `infer_stream()` in `variant` modules to use `peek_first_chunk()`.
>     - Update `infer_model_request_stream()` to handle streams without `first_chunk`.
>   - **Types**:
>     - Change `ProviderInferenceResponseStream` to `PeekableProviderInferenceResponseStream`.
>     - Update `InferenceResultStream` handling in `variant` modules.
>   - **Misc**:
>     - Add `helpers.rs` for stream utility functions.
>     - Update error handling for empty or errored streams.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 305722d230ab86f888633b5e3bcf29d7f5ade9c6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->