### PR TITLE
Unify structs used for model caching reads/writes

### DIFF
--- a/tensorzero_internal/src/inference/types/mod.rs
+++ b/tensorzero_internal/src/inference/types/mod.rs
@@ -12,7 +12,7 @@ use std::{
 };
 use uuid::Uuid;
 
-use crate::cache::CacheLookupResult;
+use crate::cache::CacheData;
 use crate::{endpoints::inference::InferenceParams, error::ErrorDetails};
 use crate::{
     endpoints::inference::{InferenceDatabaseInsertMetadata, InferenceIds},
@@ -473,7 +473,7 @@ impl ModelInferenceResponse {
     }
 
     pub fn from_cache(
-        cache_lookup: CacheLookupResult,
+        cache_lookup: CacheData,
         request: &ModelInferenceRequest<'_>,
         model_provider_name: &str,
     ) -> Self {


### PR DESCRIPTION
We now define a struct containing the fields we actually need to fetch for a read, and nest it (with `#[serde(flatten)]`) inside the full struct that we use when writing a new cache row.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Unify cache read/write structures by introducing `CacheData` and refactoring related code in `cache.rs` and `types/mod.rs`.
> 
>   - **Behavior**:
>     - Introduced `CacheData` struct in `cache.rs` to unify fields for cache reads and writes.
>     - `FullCacheRow` now nests `CacheData` using `#[serde(flatten)]` for ClickHouse writes.
>     - `cache_lookup()` now returns `CacheData` instead of `CacheLookupResult`.
>   - **Refactoring**:
>     - Removed `CacheLookupResult` struct from `cache.rs`.
>     - Updated `ModelInferenceResponse::from_cache()` in `types/mod.rs` to use `CacheData`.
>   - **Misc**:
>     - Updated imports in `types/mod.rs` to reflect struct changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b3e310bf7554bfbf8367956ade81a3178724f92c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->