### PR TITLE
fixed bug in dpo notebook and updated comment

### DIFF
--- a/recipes/dpo/openai/openai_dpo.ipynb
+++ b/recipes/dpo/openai/openai_dpo.ipynb
@@ -42,7 +42,8 @@
     "# Maximum number of samples to use for fine-tuning\n",
     "MAX_SAMPLES = 1000\n",
     "\n",
-    "#  model \"gpt-4o-2024-08-06\" is to our knowledge the only model supported for this method.\n",
+    "#  Model \"gpt-4o-2024-08-06\" is to our knowledge the only base model supported for this method.\n",
+    "#  You can can use the base model as below or fine-tunes derived from it for this recipe.\n",
     "MODEL_NAME = \"gpt-4o-2024-08-06\""
    ]
   },
@@ -224,6 +225,7 @@
     "query = f\"\"\"\n",
     "SELECT\n",
     "    i.variant_name AS variant,\n",
+    "    i.episode_id AS episode_id,\n",
     "    i.input AS input,\n",
     "    i.output AS non_preferred_output,\n",
     "    d.value AS preferred_output\n",


### PR DESCRIPTION
There was a bug where the episode_id was not being queried from ClickHouse for episode id splitting. Also updated the comment to clarify that this notebook works on SFT models as well. 