### PR TITLE
Revert #908

### DIFF
--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -62,14 +62,14 @@ docker buildx create \
   --bootstrap
 ```
 
-Every time you want to build the Docker container, you need to run from the root of the repository:
+Every time you want to build the Docker container, you need to run from `ui/`:
 
 ```bash
 DOCKER_BUILDKIT=1 docker buildx build \
   --platform linux/amd64,linux/arm64 \
   -t tensorzero/ui:latest \
   -t tensorzero/ui:XXXX.XX.X \
-  -f ui/Dockerfile \
+  -f Dockerfile \
   --attest type=provenance,mode=max \
   --attest type=sbom \
   --push \


### PR DESCRIPTION
Revert #908
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts Docker build directory change in `RELEASE_GUIDE.md` to build from root instead of `ui/`.
> 
>   - **Behavior**:
>     - Reverts change in `RELEASE_GUIDE.md` to build Docker container from the root directory instead of `ui/`.
>     - Updates Docker build command to use `-f Dockerfile` instead of `-f ui/Dockerfile`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 19639f722458cf6502b389aff59403c782f69a32. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->