### PR TITLE
Fixed missing output schema field in both Python clients

### DIFF
--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -19,7 +19,7 @@ use pyo3::{
     types::{PyDict, PyString, PyType},
 };
 use python_helpers::{
-    deserialize_from_json, parse_feedback_response, parse_inference_chunk,
+    deserialize_from_pydict, parse_feedback_response, parse_inference_chunk,
     parse_inference_response, parse_tool, python_uuid_to_uuid, serialize_to_dict,
 };
 use tensorzero_rust::{
@@ -238,7 +238,7 @@ impl BaseTensorZeroGateway {
     ) -> PyResult<FeedbackParams> {
         Ok(FeedbackParams {
             metric_name,
-            value: deserialize_from_json(py, &value)?,
+            value: deserialize_from_pydict(py, &value)?,
             episode_id: python_uuid_to_uuid("episode_id", episode_id)?,
             inference_id: python_uuid_to_uuid("inference_id", inference_id)?,
             dryrun,
@@ -269,7 +269,7 @@ impl BaseTensorZeroGateway {
         let episode_id = python_uuid_to_uuid("episode_id", episode_id)?;
 
         let params: Option<InferenceParams> = if let Some(params) = params {
-            deserialize_from_json(py, params)?
+            deserialize_from_pydict(py, params)?
         } else {
             None
         };
@@ -295,24 +295,24 @@ impl BaseTensorZeroGateway {
                     })?,
                 )
             } else {
-                Some(deserialize_from_json(py, &tool_choice)?)
+                Some(deserialize_from_pydict(py, &tool_choice)?)
             }
         } else {
             None
         };
 
         let cache_options: Option<CacheParamsOptions> = if let Some(cache_options) = cache_options {
-            Some(deserialize_from_json(py, cache_options)?)
+            Some(deserialize_from_pydict(py, cache_options)?)
         } else {
             None
         };
         let output_schema: Option<serde_json::Value> = if let Some(output_schema) = output_schema {
-            Some(deserialize_from_json(py, output_schema)?)
+            Some(deserialize_from_pydict(py, output_schema)?)
         } else {
             None
         };
 
-        let input: Input = deserialize_from_json(py, &input)?;
+        let input: Input = deserialize_from_pydict(py, &input)?;
 
         Ok(ClientInferenceParams {
             function_name,

--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -159,7 +159,7 @@ impl BaseTensorZeroGateway {
         })
     }
 
-    #[pyo3(signature = (*, input, function_name=None, model_name=None, episode_id=None, stream=None, params=None, variant_name=None, dryrun=None, allowed_tools=None, additional_tools=None, tool_choice=None, parallel_tool_calls=None, tags=None, credentials=None, cache_options=None))]
+    #[pyo3(signature = (*, input, function_name=None, model_name=None, episode_id=None, stream=None, params=None, variant_name=None, dryrun=None, output_schema=None, allowed_tools=None, additional_tools=None, tool_choice=None, parallel_tool_calls=None, tags=None, credentials=None, cache_options=None))]
     #[allow(clippy::too_many_arguments)]
     fn _prepare_inference_request(
         this: PyRef<'_, Self>,
@@ -171,6 +171,7 @@ impl BaseTensorZeroGateway {
         params: Option<&Bound<'_, PyDict>>,
         variant_name: Option<String>,
         dryrun: Option<bool>,
+        output_schema: Option<&Bound<'_, PyDict>>,
         allowed_tools: Option<Vec<String>>,
         additional_tools: Option<Vec<HashMap<String, Bound<'_, PyAny>>>>,
         tool_choice: Option<Bound<'_, PyAny>>,
@@ -189,6 +190,7 @@ impl BaseTensorZeroGateway {
             params,
             variant_name,
             dryrun,
+            output_schema,
             allowed_tools,
             additional_tools,
             tool_choice,
@@ -255,6 +257,7 @@ impl BaseTensorZeroGateway {
         params: Option<&Bound<'_, PyDict>>,
         variant_name: Option<String>,
         dryrun: Option<bool>,
+        output_schema: Option<&Bound<'_, PyDict>>,
         allowed_tools: Option<Vec<String>>,
         additional_tools: Option<Vec<HashMap<String, Bound<'_, PyAny>>>>,
         tool_choice: Option<Bound<'_, PyAny>>,
@@ -303,6 +306,11 @@ impl BaseTensorZeroGateway {
         } else {
             None
         };
+        let output_schema: Option<serde_json::Value> = if let Some(output_schema) = output_schema {
+            Some(deserialize_from_json(py, output_schema)?)
+        } else {
+            None
+        };
 
         let input: Input = deserialize_from_json(py, &input)?;
 
@@ -324,7 +332,7 @@ impl BaseTensorZeroGateway {
             input,
             credentials: credentials.unwrap_or_default(),
             cache_options: cache_options.unwrap_or_default(),
-            ..Default::default()
+            output_schema,
         })
     }
 }
@@ -444,7 +452,7 @@ impl TensorZeroGateway {
         }
     }
 
-    #[pyo3(signature = (*, input, function_name=None, model_name=None, episode_id=None, stream=None, params=None, variant_name=None, dryrun=None, allowed_tools=None, additional_tools=None, tool_choice=None, parallel_tool_calls=None, tags=None, credentials=None, cache_options=None))]
+    #[pyo3(signature = (*, input, function_name=None, model_name=None, episode_id=None, stream=None, params=None, variant_name=None, dryrun=None, output_schema=None, allowed_tools=None, additional_tools=None, tool_choice=None, parallel_tool_calls=None, tags=None, credentials=None, cache_options=None))]
     #[allow(clippy::too_many_arguments)]
     /// Make a request to the /inference endpoint.
     ///
@@ -462,6 +470,8 @@ impl TensorZeroGateway {
     ///                      Note: You should generally not do this, and instead let the TensorZero gateway assign a
     ///                      particular variant. This field is primarily used for testing or debugging purposes.
     /// :param dryrun: If true, the request will be executed but won't be stored to the database.
+    /// :param output_schema: If set, the JSON schema of a JSON function call will be validated against the given JSON Schema.
+    ///                       Overrides the output schema configured for the function.
     /// :param allowed_tools: If set, restricts the tools available during this inference request.
     ///                       The list of names should be a subset of the tools configured for the function.
     ///                       Tools provided at inference time in `additional_tools` (if any) are always available.
@@ -485,6 +495,7 @@ impl TensorZeroGateway {
         params: Option<&Bound<'_, PyDict>>,
         variant_name: Option<String>,
         dryrun: Option<bool>,
+        output_schema: Option<&Bound<'_, PyDict>>,
         allowed_tools: Option<Vec<String>>,
         additional_tools: Option<Vec<HashMap<String, Bound<'_, PyAny>>>>,
         tool_choice: Option<Bound<'_, PyAny>>,
@@ -506,6 +517,7 @@ impl TensorZeroGateway {
                     params,
                     variant_name,
                     dryrun,
+                    output_schema,
                     allowed_tools,
                     additional_tools,
                     tool_choice,
@@ -626,7 +638,7 @@ impl AsyncTensorZeroGateway {
         })
     }
 
-    #[pyo3(signature = (*, input, function_name=None, model_name=None, episode_id=None, stream=None, params=None, variant_name=None, dryrun=None, allowed_tools=None, additional_tools=None, tool_choice=None, parallel_tool_calls=None, tags=None, credentials=None, cache_options=None))]
+    #[pyo3(signature = (*, input, function_name=None, model_name=None, episode_id=None, stream=None, params=None, variant_name=None, dryrun=None, output_schema=None, allowed_tools=None, additional_tools=None, tool_choice=None, parallel_tool_calls=None, tags=None, credentials=None, cache_options=None))]
     #[allow(clippy::too_many_arguments)]
     /// Make a request to the /inference endpoint.
     ///
@@ -644,6 +656,8 @@ impl AsyncTensorZeroGateway {
     ///                      Note: You should generally not do this, and instead let the TensorZero gateway assign a
     ///                      particular variant. This field is primarily used for testing or debugging purposes.
     /// :param dryrun: If true, the request will be executed but won't be stored to the database.
+    /// :param output_schema: If set, the JSON schema of a JSON function call will be validated against the given JSON Schema.
+    ///                       Overrides the output schema configured for the function.
     /// :param allowed_tools: If set, restricts the tools available during this inference request.
     ///                       The list of names should be a subset of the tools configured for the function.
     ///                       Tools provided at inference time in `additional_tools` (if any) are always available.
@@ -667,6 +681,7 @@ impl AsyncTensorZeroGateway {
         params: Option<&Bound<'_, PyDict>>,
         variant_name: Option<String>,
         dryrun: Option<bool>,
+        output_schema: Option<&Bound<'_, PyDict>>,
         allowed_tools: Option<Vec<String>>,
         additional_tools: Option<Vec<HashMap<String, Bound<'_, PyAny>>>>,
         tool_choice: Option<Bound<'_, PyAny>>,
@@ -685,6 +700,7 @@ impl AsyncTensorZeroGateway {
             params,
             variant_name,
             dryrun,
+            output_schema,
             allowed_tools,
             additional_tools,
             tool_choice,

--- a/clients/python-pyo3/src/python_helpers.rs
+++ b/clients/python-pyo3/src/python_helpers.rs
@@ -69,7 +69,7 @@ pub fn serialize_to_dict<T: serde::ser::Serialize>(py: Python<'_>, val: T) -> Py
 
 // Converts a Python dictionary to json with `json.dumps`,
 /// then deserializes to a Rust type via serde
-pub fn deserialize_from_json<'a, T: serde::de::DeserializeOwned>(
+pub fn deserialize_from_pydict<'a, T: serde::de::DeserializeOwned>(
     py: Python<'a>,
     dict: &Bound<'a, PyAny>,
 ) -> PyResult<T> {
@@ -131,7 +131,7 @@ pub fn parse_tool(py: Python<'_>, key_vals: HashMap<String, Bound<'_, PyAny>>) -
     } else {
         false
     };
-    let tool_params: serde_json::Value = deserialize_from_json(py, params)?;
+    let tool_params: serde_json::Value = deserialize_from_pydict(py, params)?;
     Ok(Tool {
         name: name.extract()?,
         description: description.extract()?,

--- a/clients/python-pyo3/tensorzero/tensorzero.pyi
+++ b/clients/python-pyo3/tensorzero/tensorzero.pyi
@@ -30,6 +30,7 @@ class BaseTensorZeroGateway:
         params: Optional[Dict[str, Any]] = None,
         variant_name: Optional[str] = None,
         dryrun: Optional[bool] = None,
+        output_schema: Optional[Dict[str, Any]] = None,
         allowed_tools: Optional[List[str]] = None,
         additional_tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[
@@ -70,6 +71,7 @@ class TensorZeroGateway(BaseTensorZeroGateway):
         params: Optional[Dict[str, Any]] = None,
         variant_name: Optional[str] = None,
         dryrun: Optional[bool] = None,
+        output_schema: Optional[Dict[str, Any]] = None,
         allowed_tools: Optional[List[str]] = None,
         additional_tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[
@@ -97,6 +99,8 @@ class TensorZeroGateway(BaseTensorZeroGateway):
                              Note: You should generally not do this, and instead let the TensorZero gateway assign a
                              particular variant. This field is primarily used for testing or debugging purposes.
         :param dryrun: If true, the request will be executed but won't be stored to the database.
+        :param output_schema: If set, the JSON schema of a JSON function call will be validated against the given JSON Schema.
+                              Overrides the output schema configured for the function.
         :param allowed_tools: If set, restricts the tools available during this inference request.
                               The list of names should be a subset of the tools configured for the function.
                               Tools provided at inference time in `additional_tools` (if any) are always available.
@@ -179,6 +183,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         params: Optional[Dict[str, Any]] = None,
         variant_name: Optional[str] = None,
         dryrun: Optional[bool] = None,
+        output_schema: Optional[Dict[str, Any]] = None,
         allowed_tools: Optional[List[str]] = None,
         additional_tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[
@@ -206,6 +211,8 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
                              Note: You should generally not do this, and instead let the TensorZero gateway assign a
                              particular variant. This field is primarily used for testing or debugging purposes.
         :param dryrun: If true, the request will be executed but won't be stored to the database.
+        :param output_schema: If set, the JSON schema of a JSON function call will be validated against the given JSON Schema.
+                              Overrides the output schema configured for the function.
         :param allowed_tools: If set, restricts the tools available during this inference request.
                               The list of names should be a subset of the tools configured for the function.
                               Tools provided at inference time in `additional_tools` (if any) are always available.

--- a/clients/python-pyo3/tests/test_client.py
+++ b/clients/python-pyo3/tests/test_client.py
@@ -1138,6 +1138,7 @@ def test_prepare_inference_request(sync_client):
         stream=True,
         dryrun=False,
         episode_id=episode_id,
+        output_schema={"type": "object", "properties": {"answer": {"type": "string"}}},
         variant_name="baz",
         params={"chat_completion": {"temperature": 0.1}},
         tool_choice="auto",
@@ -1173,6 +1174,10 @@ def test_prepare_inference_request(sync_client):
     assert request["stream"]
     assert not request["dryrun"]
     assert request["episode_id"] == str(episode_id)
+    assert request["output_schema"] == {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+    }
     assert request["params"]["chat_completion"]["temperature"] == 0.1
     assert request["tool_choice"] == "auto"
     assert request["additional_tools"][0] == {

--- a/clients/python-pyo3/tests/test_client.py
+++ b/clients/python-pyo3/tests/test_client.py
@@ -484,6 +484,7 @@ async def test_async_json_success(async_client):
             "system": {"assistant_name": "Alfred Pennyworth"},
             "messages": [{"role": "user", "content": {"country": "Japan"}}],
         },
+        output_schema={"type": "object", "properties": {"answer": {"type": "string"}}},
         stream=False,
     )
     assert result.variant_name == "test"
@@ -956,6 +957,7 @@ def test_sync_json_success(sync_client):
             "system": {"assistant_name": "Alfred Pennyworth"},
             "messages": [{"role": "user", "content": {"country": "Japan"}}],
         },
+        output_schema={"type": "object", "properties": {"answer": {"type": "string"}}},
         stream=False,
     )
     assert result.variant_name == "test"

--- a/clients/python/src/tensorzero/client.py
+++ b/clients/python/src/tensorzero/client.py
@@ -76,6 +76,7 @@ class BaseTensorZeroGateway(ABC):
         params: Optional[Dict[str, Any]] = None,
         variant_name: Optional[str] = None,
         dryrun: Optional[bool] = None,
+        output_schema: Optional[Dict[str, Any]] = None,
         allowed_tools: Optional[List[str]] = None,
         additional_tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[
@@ -108,6 +109,8 @@ class BaseTensorZeroGateway(ABC):
             data["params"] = params
         if variant_name is not None:
             data["variant_name"] = variant_name
+        if output_schema is not None:
+            data["output_schema"] = output_schema
         if dryrun is not None:
             data["dryrun"] = dryrun
         if allowed_tools is not None:
@@ -164,6 +167,7 @@ class BaseTensorZeroGateway(ABC):
         params: Optional[Dict[str, Any]] = None,
         variant_name: Optional[str] = None,
         dryrun: Optional[bool] = None,
+        output_schema: Optional[Dict[str, Any]] = None,
         allowed_tools: Optional[List[str]] = None,
         additional_tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[
@@ -210,6 +214,7 @@ class TensorZeroGateway(BaseTensorZeroGateway):
         params: Optional[Dict[str, Any]] = None,
         variant_name: Optional[str] = None,
         dryrun: Optional[bool] = None,
+        output_schema: Optional[Dict[str, Any]] = None,
         allowed_tools: Optional[List[str]] = None,
         additional_tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[
@@ -236,6 +241,8 @@ class TensorZeroGateway(BaseTensorZeroGateway):
                              Note: You should generally not do this, and instead let the TensorZero gateway assign a
                              particular variant. This field is primarily used for testing or debugging purposes.
         :param dryrun: If true, the request will be executed but won't be stored to the database.
+        :param output_schema: If set, the JSON schema of a JSON function call will be validated against the given JSON Schema.
+                              Overrides the output schema configured for the function.
         :param allowed_tools: If set, restricts the tools available during this inference request.
                               The list of names should be a subset of the tools configured for the function.
                               Tools provided at inference time in `additional_tools` (if any) are always available.
@@ -257,6 +264,7 @@ class TensorZeroGateway(BaseTensorZeroGateway):
             params,
             variant_name,
             dryrun,
+            output_schema,
             allowed_tools,
             additional_tools,
             tool_choice,
@@ -380,6 +388,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         params: Optional[Dict[str, Any]] = None,
         variant_name: Optional[str] = None,
         dryrun: Optional[bool] = None,
+        output_schema: Optional[Dict[str, Any]] = None,
         allowed_tools: Optional[List[str]] = None,
         additional_tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[
@@ -406,6 +415,8 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
                              Note: You should generally not do this, and instead let the TensorZero gateway assign a
                              particular variant. This field is primarily used for testing or debugging purposes.
         :param dryrun: If true, the request will be executed but won't be stored to the database.
+        :param output_schema: If set, the JSON schema of a JSON function call will be validated against the given JSON Schema.
+                              Overrides the output schema configured for the function.
         :param allowed_tools: If set, restricts the tools available during this inference request.
                               The list of names should be a subset of the tools configured for the function.
                               Tools provided at inference time in `additional_tools` (if any) are always available.
@@ -427,6 +438,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
             params,
             variant_name,
             dryrun,
+            output_schema,
             allowed_tools,
             additional_tools,
             tool_choice,

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -372,6 +372,7 @@ async def test_async_json_success(async_client):
             "system": {"assistant_name": "Alfred Pennyworth"},
             "messages": [{"role": "user", "content": {"country": "Japan"}}],
         },
+        output_schema={"type": "object", "properties": {"answer": {"type": "string"}}},
         stream=False,
     )
     assert result.variant_name == "test"
@@ -818,6 +819,7 @@ def test_sync_json_success(sync_client):
             "system": {"assistant_name": "Alfred Pennyworth"},
             "messages": [{"role": "user", "content": {"country": "Japan"}}],
         },
+        output_schema={"type": "object", "properties": {"answer": {"type": "string"}}},
         stream=False,
     )
     assert result.variant_name == "test"
@@ -1000,6 +1002,7 @@ def test_prepare_inference_request(sync_client):
         },
         stream=True,
         dryrun=False,
+        output_schema={"type": "object", "properties": {"answer": {"type": "string"}}},
         episode_id=episode_id,
         variant_name="baz",
         params={"chat_completion": {"temperature": 0.1}},
@@ -1035,6 +1038,10 @@ def test_prepare_inference_request(sync_client):
     assert request["input"]["system"] == "you are the bad guy"
     assert request["stream"]
     assert not request["dryrun"]
+    assert request["output_schema"] == {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+    }
     assert request["episode_id"] == str(episode_id)
     assert request["params"]["chat_completion"]["temperature"] == 0.1
     assert request["tool_choice"] == "auto"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Added `output_schema` support for JSON schema validation in TensorZero Python clients, updating methods and tests accordingly.
> 
>   - **Behavior**:
>     - Added `output_schema` parameter to `_prepare_inference_request()` in `lib.rs` and `client.py` for JSON schema validation.
>     - Updated `inference()` methods in `TensorZeroGateway` and `AsyncTensorZeroGateway` to handle `output_schema`.
>   - **Functions**:
>     - Replaced `deserialize_from_json()` with `deserialize_from_pydict()` in `lib.rs` and `python_helpers.rs` for deserialization.
>   - **Tests**:
>     - Added `output_schema` to test cases in `test_client.py` and `tests/test_client.py` to verify JSON schema validation.
>   - **Misc**:
>     - Updated type hints in `tensorzero.pyi` to include `output_schema`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for cb54df5b6f1c060e89cc41a10abedc94dc1a29a4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->