### PR TITLE
Enable 'http2' feature for 'reqwest' crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,6 +2369,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2 0.4.7",
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ reqwest = { version = "0.12.10", features = [
     "json",
     "multipart",
     "rustls-tls",
+    "http2",
 ], default-features = false }
 serde = { version = "1.0.204", features = ["derive", "rc"] }
 uuid = { version = "1.10.0", features = ["serde", "v7"] }
 serde_json = { version = "1.0.134", features = ["preserve_order"] }
 secrecy = { version = "0.10.2", features = ["serde"] }
-#reqwest-eventsource = { path = "/home/aaron/repos/reqwest-eventsource" }
 reqwest-eventsource = "0.6.0"
 async-stream = "0.3.5"
 tokio-stream = "0.1.15"


### PR DESCRIPTION
This feature is enabled by default, but we have
'default-features = false' to avoid pulling in openssl.

This allows us to make outgoing http2 requests in the gateway (when supported by the target server).

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable `http2` feature for `reqwest` to support HTTP/2 requests in the gateway.
> 
>   - **Features**:
>     - Enable `http2` feature for `reqwest` in `Cargo.toml` to allow HTTP/2 requests.
>   - **Dependencies**:
>     - Add `h2 0.4.7` to `Cargo.lock` to support HTTP/2 functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for de708eda64ee4bb2fbe1e6ef5c49bf20287d7eda. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->