### PR TITLE
Don't use PyO3 manylinux docker container in general workflow

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           working-directory: clients/python-pyo3
           args: --find-interpreter
-          manylinux: auto
+          container: off
 
       - name: "Python: TensorZero Client: Install dependencies"
         working-directory: clients/python


### PR DESCRIPTION
We're not actually performing the release process here (since we're not building linux-arm/windows/mac wheels), so let's speed things up by building on the host and making use of the existing cargo cache.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disable PyO3 manylinux docker container in `general.yml` to speed up build by using host system.
> 
>   - **Workflow**:
>     - In `.github/workflows/general.yml`, change `manylinux: auto` to `container: off` for the PyO3 client build step.
>     - This change speeds up the build process by using the host system and existing cargo cache instead of the manylinux docker container.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 9323e26c378d408ad429031e5b17887e742eabcf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->