### PR TITLE
Remove '-p tensorzero_internal' from cargo nextest aliases

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,9 +9,9 @@ rustflags = [
 
 [alias]
 test-unit = "nextest run --lib --bins --profile unit"
-test-e2e = "nextest run -p tensorzero_internal --test e2e --features e2e_tests"
-test-all = "nextest run -p tensorzero_internal --features e2e_tests"
-test-batch = "nextest run -p tensorzero_internal --features batch_tests"
+test-e2e = "nextest run --test e2e --features e2e_tests"
+test-all = "nextest run --features e2e_tests"
+test-batch = "nextest run --features batch_tests"
 
 run-e2e = "run --bin gateway --features e2e_tests -- tensorzero_internal/tests/e2e/tensorzero.toml"
 watch-e2e = "watch -x run-e2e"


### PR DESCRIPTION
The wasm tests are now ignored on non-wasm platforms, so we can just let nextest run tests for all packages in the workspace

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `-p tensorzero_internal` from `cargo nextest` aliases in `.cargo/config.toml` to run tests for all packages.
> 
>   - **Aliases**:
>     - Remove `-p tensorzero_internal` from `test-e2e`, `test-all`, and `test-batch` in `.cargo/config.toml`.
>     - Allows `nextest` to run tests for all packages in the workspace.
>   - **Behavior**:
>     - Wasm tests are ignored on non-wasm platforms, enabling the above change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c5568976fd10b1b93f367c778ac6b8bdff79bf42. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->