### PR TITLE
Skip running certain AWS credential tests on developer machines

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,9 +1,17 @@
 [profile.default]
 retries = { backoff = "fixed", count = 2, delay = "5s", jitter = true }
 slow-timeout = { period = "10s", terminate-after = 3 }
+# We look for tests with names containing "no_aws_credentials"
+# These tests require that the surrounding environment has no AWS credentials
+# (including in places like `~/.aws`)
+# We don't have a good way of isolating these tests to ensure that they pass
+# on developer machines (with AWS credentials set up), so we exclude them by default.
+# On CI, we use the 'ci' profile, which runs all tests.
+default-filter = "not test(no_aws_credentials)"
 
 [profile.ci]
 retries = { backoff = "exponential", count = 4, delay = "5s", jitter = true, max-delay = "60s" }
+default-filter = "all()"
 
 [profile.unit]
 retries = 0

--- a/tensorzero-internal/src/config_parser.rs
+++ b/tensorzero-internal/src/config_parser.rs
@@ -1854,7 +1854,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_bedrock_err_auto_detect_region() {
+    async fn test_bedrock_err_auto_detect_region_no_aws_credentials() {
         // We want auto-detection to fail, so we clear this environment variable.
         // We use 'nextest' as our runner, so each test runs in its own process
         std::env::remove_var("AWS_REGION");

--- a/tensorzero-internal/src/inference/providers/aws_bedrock.rs
+++ b/tensorzero-internal/src/inference/providers/aws_bedrock.rs
@@ -805,7 +805,7 @@ mod tests {
     use tracing_test::traced_test;
 
     #[tokio::test]
-    async fn test_get_aws_bedrock_client() {
+    async fn test_get_aws_bedrock_client_no_aws_credentials() {
         #[traced_test]
         async fn first_run() {
             AWSBedrockProvider::new("test".to_string(), Some(Region::new("uk-hogwarts-1")))


### PR DESCRIPTION
We configure nextest to skip tests containing 'no_aws_credentials' by default. On ci, we ues the 'ci' profile, which includes all tests.

This will allow developers to run tests locally without getting failures due to AWS region detection incorrectly succeeding.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Configure `nextest` to skip AWS credential tests on developer machines and rename related test functions.
> 
>   - **Behavior**:
>     - Configure `nextest.toml` to skip tests with 'no_aws_credentials' by default on developer machines.
>     - On CI, use 'ci' profile to run all tests.
>   - **Tests**:
>     - Rename `test_bedrock_err_auto_detect_region` to `test_bedrock_err_auto_detect_region_no_aws_credentials` in `config_parser.rs`.
>     - Rename `test_get_aws_bedrock_client` to `test_get_aws_bedrock_client_no_aws_credentials` in `aws_bedrock.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5bc49dec04351f1b3db790bf60f3b632c02217da. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->