### PR TITLE
Consistently use same "capital of Japan" prompt in batch/common tests

### DIFF
--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -896,7 +896,7 @@ pub async fn test_inference_params_inference_request_with_provider(provider: E2E
                "messages": [
                 {
                     "role": "user",
-                    "content": [{"type": "raw_text", "value": "What is the name of the capital city of Japan?"}],
+                    "content": [{"type": "raw_text", "value": "What is the capital city of Japan?"}],
                 }
             ]},
         "params": {
@@ -930,6 +930,9 @@ pub async fn test_inference_params_inference_request_with_provider(provider: E2E
     check_inference_params_response(response_json, &provider, Some(episode_id), false).await;
 }
 
+// This function is also used by batch tests. If you adjust the prompt checked by this function
+// ("What is the capital city of Japan?"), make sure to update the batch tests to start batch
+// jobs with the correct prompt.
 pub async fn check_inference_params_response(
     response_json: Value,
     provider: &E2ETestProvider,
@@ -997,7 +1000,7 @@ pub async fn check_inference_params_response(
         "messages": [
             {
                 "role": "user",
-                "content": [{"type": "raw_text", "value": "What is the name of the capital city of Japan?"}]
+                "content": [{"type": "raw_text", "value": "What is the capital city of Japan?"}]
             }
         ]
     });
@@ -1105,9 +1108,7 @@ pub async fn check_inference_params_response(
     let input_messages: Vec<RequestMessage> = serde_json::from_str(input_messages).unwrap();
     let expected_input_messages = vec![RequestMessage {
         role: Role::User,
-        content: vec!["What is the name of the capital city of Japan?"
-            .to_string()
-            .into()],
+        content: vec!["What is the capital city of Japan?".to_string().into()],
     }];
     assert_eq!(input_messages, expected_input_messages);
     let output = result.get("output").unwrap().as_str().unwrap();
@@ -1131,7 +1132,7 @@ pub async fn test_inference_params_streaming_inference_request_with_provider(
                "messages": [
                 {
                     "role": "user",
-                    "content": "What is the name of the capital city of Japan?"
+                    "content": "What is the capital city of Japan?"
                 }
             ]},
         "params": {
@@ -1252,7 +1253,7 @@ pub async fn test_inference_params_streaming_inference_request_with_provider(
         "messages": [
             {
                 "role": "user",
-                "content": [{"type": "text", "value": "What is the name of the capital city of Japan?"}]
+                "content": [{"type": "text", "value": "What is the capital city of Japan?"}]
             }
         ]
     });
@@ -1366,9 +1367,7 @@ pub async fn test_inference_params_streaming_inference_request_with_provider(
     let input_messages: Vec<RequestMessage> = serde_json::from_str(input_messages).unwrap();
     let expected_input_messages = vec![RequestMessage {
         role: Role::User,
-        content: vec!["What is the name of the capital city of Japan?"
-            .to_string()
-            .into()],
+        content: vec!["What is the capital city of Japan?".to_string().into()],
     }];
     assert_eq!(input_messages, expected_input_messages);
     let output = result.get("output").unwrap().as_str().unwrap();


### PR DESCRIPTION
Our batch tests start new jobs with the prompt
"What is the capital city of Japan?", and check existing batch jobs with `check_inference_params_response`. However, this function was checking for a different prompt:
"What is the name of the capital city of Japan?"
which caused the batch tests to fail whenever an existing job was polled.

We now use the prompt "What is the capital city of Japan?" everywhere.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Standardizes the prompt to "What is the capital city of Japan?" across batch and common tests to fix test failures.
> 
>   - **Behavior**:
>     - Standardizes prompt to "What is the capital city of Japan?" in `check_inference_params_response()` and related functions.
>   - **Tests**:
>     - Updates prompt in `test_inference_params_inference_request_with_provider()` and `test_inference_params_streaming_inference_request_with_provider()`.
>     - Ensures consistency in prompt usage across batch and common tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4e1f3538de5985cd24dc49be05894222fc2f15a6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->