### PR TITLE
Use 'name of capital city' in all test prompts

### DIFF
--- a/tensorzero-internal/fixtures/config/functions/dynamic_json/prompt/user_template.minijinja
+++ b/tensorzero-internal/fixtures/config/functions/dynamic_json/prompt/user_template.minijinja
@@ -1,1 +1,1 @@
-What is the capital city of {{ country }}?
+What is the name of the capital city of {{ country }}?

--- a/tensorzero-internal/fixtures/config/functions/json_success/prompt/user_template.minijinja
+++ b/tensorzero-internal/fixtures/config/functions/json_success/prompt/user_template.minijinja
@@ -1,1 +1,1 @@
-What is the capital city of {{ country }}?
+What is the name of the capital city of {{ country }}?

--- a/tensorzero-internal/src/variant/dicl.rs
+++ b/tensorzero-internal/src/variant/dicl.rs
@@ -756,7 +756,7 @@ mod tests {
                     messages: vec![InputMessage {
                         role: Role::User,
                         content: vec![InputMessageContent::Text {
-                            value: json!("What is the capital city of Japan?"),
+                            value: json!("What is the name of the capital city of Japan?"),
                         }],
                     }],
                 })

--- a/tensorzero-internal/tests/e2e/dicl.rs
+++ b/tensorzero-internal/tests/e2e/dicl.rs
@@ -47,7 +47,7 @@ pub async fn test_dicl_inference_request_no_examples(dicl_variant_name: &str) {
                "messages": [
                 {
                     "role": "user",
-                    "content": "What is the capital city of Japan?"
+                    "content": "What is the name of the capital city of Japan?"
                 }
             ]},
         "stream": false,
@@ -122,7 +122,7 @@ pub async fn test_dicl_inference_request_no_examples(dicl_variant_name: &str) {
         "messages": [
             {
                 "role": "user",
-                "content": [{"type": "text", "value": "What is the capital city of Japan?"}]
+                "content": [{"type": "text", "value": "What is the name of the capital city of Japan?"}]
             }
         ]
     });

--- a/tensorzero-internal/tests/e2e/inference.rs
+++ b/tensorzero-internal/tests/e2e/inference.rs
@@ -848,7 +848,9 @@ async fn e2e_test_inference_json_success() {
         input_messages[0],
         RequestMessage {
             role: Role::User,
-            content: vec!["What is the capital city of Japan?".to_string().into()],
+            content: vec!["What is the name of the capital city of Japan?"
+                .to_string()
+                .into()],
         }
     );
     let output = result.get("output").unwrap().as_str().unwrap();
@@ -1504,7 +1506,7 @@ pub async fn e2e_test_dynamic_api_key() {
                "messages": [
                 {
                     "role": "user",
-                    "content": "What is the capital city of Japan?"
+                    "content": "What is the name of the capital city of Japan?"
                 }
             ]},
         "stream": false,
@@ -1532,7 +1534,7 @@ pub async fn e2e_test_dynamic_api_key() {
                "messages": [
                 {
                     "role": "user",
-                    "content": "What is the capital city of Japan?"
+                    "content": "What is the name of the capital city of Japan?"
                 }
             ]},
         "stream": false,
@@ -1606,7 +1608,7 @@ pub async fn e2e_test_dynamic_api_key() {
         "messages": [
             {
                 "role": "user",
-                "content": [{"type": "text", "value": "What is the capital city of Japan?"}]
+                "content": [{"type": "text", "value": "What is the name of the capital city of Japan?"}]
             }
         ]
     });
@@ -1661,7 +1663,7 @@ async fn test_inference_invalid_params() {
                "messages": [
                 {
                     "role": "user",
-                    "content": "What is the capital city of Japan?"
+                    "content": "What is the name of the capital city of Japan?"
                 }
             ]},
         "params": {
@@ -1726,7 +1728,7 @@ async fn test_inference_invalid_default_function_arg() {
                "messages": [
                 {
                     "role": "user",
-                    "content": "What is the capital city of Japan?"
+                    "content": "What is the name of the capital city of Japan?"
                 }
             ]},
     });
@@ -1756,7 +1758,7 @@ async fn test_inference_invalid_default_function_arg() {
                "messages": [
                 {
                     "role": "user",
-                    "content": "What is the capital city of Japan?"
+                    "content": "What is the name of the capital city of Japan?"
                 }
             ]},
     });
@@ -1784,7 +1786,7 @@ async fn test_inference_invalid_default_function_arg() {
                "messages": [
                 {
                     "role": "user",
-                    "content": "What is the capital city of Japan?"
+                    "content": "What is the name of the capital city of Japan?"
                 }
             ]},
     });
@@ -1814,7 +1816,7 @@ async fn test_inference_invalid_default_function_arg() {
                "messages": [
                 {
                     "role": "user",
-                    "content": "What is the capital city of Japan?"
+                    "content": "What is the name of the capital city of Japan?"
                 }
             ]},
     });
@@ -1842,7 +1844,7 @@ async fn test_inference_invalid_default_function_arg() {
                "messages": [
                 {
                     "role": "user",
-                    "content": "What is the capital city of Japan?"
+                    "content": "What is the name of the capital city of Japan?"
                 }
             ]},
     });
@@ -1871,7 +1873,7 @@ async fn test_inference_invalid_default_function_arg() {
                "messages": [
                 {
                     "role": "user",
-                    "content": "What is the capital city of Japan?"
+                    "content": "What is the name of the capital city of Japan?"
                 }
             ]},
     });

--- a/tensorzero-internal/tests/e2e/providers/batch.rs
+++ b/tensorzero-internal/tests/e2e/providers/batch.rs
@@ -543,7 +543,7 @@ pub async fn test_start_simple_batch_inference_request_with_provider(provider: E
                "messages": [
                 {
                     "role": "user",
-                    "content": "What is the capital city of Japan?"
+                    "content": "What is the name of the capital city of Japan?"
                 }
             ]}],
         "tags": [{"foo": "bar", "test_type": "batch_simple", "variant_name": provider.variant_name}],
@@ -619,7 +619,7 @@ pub async fn test_start_simple_batch_inference_request_with_provider(provider: E
         "messages": [
             {
                 "role": "user",
-                "content": [{"type": "text", "value": "What is the capital city of Japan?"}]
+                "content": [{"type": "text", "value": "What is the name of the capital city of Japan?"}]
             }
         ]
     });
@@ -629,7 +629,9 @@ pub async fn test_start_simple_batch_inference_request_with_provider(provider: E
     let input_messages: Vec<RequestMessage> = serde_json::from_str(input_messages).unwrap();
     let expected_input_messages = vec![RequestMessage {
         role: Role::User,
-        content: vec!["What is the capital city of Japan?".to_string().into()],
+        content: vec!["What is the name of the capital city of Japan?"
+            .to_string()
+            .into()],
     }];
     assert_eq!(input_messages, expected_input_messages);
 
@@ -878,7 +880,7 @@ pub async fn test_start_inference_params_batch_inference_request_with_provider(
                "messages": [
                 {
                     "role": "user",
-                    "content": [{"type": "raw_text", "value": "What is the capital city of Japan?"}]
+                    "content": [{"type": "raw_text", "value": "What is the name of the capital city of Japan?"}]
                 }
             ]}],
         "params": {
@@ -973,7 +975,7 @@ pub async fn test_start_inference_params_batch_inference_request_with_provider(
         "messages": [
             {
                 "role": "user",
-                "content": [{"type": "raw_text", "value": "What is the capital city of Japan?"}]
+                "content": [{"type": "raw_text", "value": "What is the name of the capital city of Japan?"}]
             }
         ]
     });
@@ -983,7 +985,9 @@ pub async fn test_start_inference_params_batch_inference_request_with_provider(
     let input_messages: Vec<RequestMessage> = serde_json::from_str(input_messages).unwrap();
     let expected_input_messages = vec![RequestMessage {
         role: Role::User,
-        content: vec!["What is the capital city of Japan?".to_string().into()],
+        content: vec!["What is the name of the capital city of Japan?"
+            .to_string()
+            .into()],
     }];
     assert_eq!(input_messages, expected_input_messages);
 
@@ -3577,7 +3581,9 @@ pub async fn test_json_mode_batch_inference_request_with_provider(provider: E2ET
     let input_messages: Vec<RequestMessage> = serde_json::from_str(input_messages).unwrap();
     let expected_input_messages = vec![RequestMessage {
         role: Role::User,
-        content: vec!["What is the capital city of Japan?".to_string().into()],
+        content: vec!["What is the name of the capital city of Japan?"
+            .to_string()
+            .into()],
     }];
     assert_eq!(input_messages, expected_input_messages);
 
@@ -3925,7 +3931,9 @@ pub async fn test_dynamic_json_mode_batch_inference_request_with_provider(
     let input_messages: Vec<RequestMessage> = serde_json::from_str(input_messages).unwrap();
     let expected_input_messages = vec![RequestMessage {
         role: Role::User,
-        content: vec!["What is the capital city of Japan?".to_string().into()],
+        content: vec!["What is the name of the capital city of Japan?"
+            .to_string()
+            .into()],
     }];
     assert_eq!(input_messages, expected_input_messages);
 

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -370,7 +370,7 @@ pub async fn test_simple_inference_request_with_provider(provider: E2ETestProvid
                "messages": [
                 {
                     "role": "user",
-                    "content": "What is the capital city of Japan?"
+                    "content": "What is the name of the capital city of Japan?"
                 }
             ]},
         "stream": false,
@@ -405,7 +405,7 @@ pub async fn test_simple_inference_request_with_provider(provider: E2ETestProvid
                "messages": [
                 {
                     "role": "user",
-                    "content": "What is the capital city of Japan?"
+                    "content": "What is the name of the capital city of Japan?"
                 }
             ]},
         "stream": false,
@@ -502,7 +502,7 @@ pub async fn check_simple_inference_response(
         "messages": [
             {
                 "role": "user",
-                "content": [{"type": "text", "value": "What is the capital city of Japan?"}]
+                "content": [{"type": "text", "value": "What is the name of the capital city of Japan?"}]
             }
         ]
     });
@@ -602,7 +602,9 @@ pub async fn check_simple_inference_response(
     let input_messages: Vec<RequestMessage> = serde_json::from_str(input_messages).unwrap();
     let expected_input_messages = vec![RequestMessage {
         role: Role::User,
-        content: vec!["What is the capital city of Japan?".to_string().into()],
+        content: vec!["What is the name of the capital city of Japan?"
+            .to_string()
+            .into()],
     }];
     assert_eq!(input_messages, expected_input_messages);
     let output = result.get("output").unwrap().as_str().unwrap();
@@ -650,7 +652,7 @@ pub async fn test_simple_streaming_inference_request_with_provider(provider: E2E
                "messages": [
                 {
                     "role": "user",
-                    "content": "What is the capital city of Japan?"
+                    "content": "What is the name of the capital city of Japan?"
                 }
             ]},
         "stream": true,
@@ -761,7 +763,7 @@ pub async fn test_simple_streaming_inference_request_with_provider(provider: E2E
         "messages": [
             {
                 "role": "user",
-                "content": [{"type": "text", "value": "What is the capital city of Japan?"}]
+                "content": [{"type": "text", "value": "What is the name of the capital city of Japan?"}]
             }
         ]
     });
@@ -861,7 +863,9 @@ pub async fn test_simple_streaming_inference_request_with_provider(provider: E2E
     let input_messages: Vec<RequestMessage> = serde_json::from_str(input_messages).unwrap();
     let expected_input_messages = vec![RequestMessage {
         role: Role::User,
-        content: vec!["What is the capital city of Japan?".to_string().into()],
+        content: vec!["What is the name of the capital city of Japan?"
+            .to_string()
+            .into()],
     }];
     assert_eq!(input_messages, expected_input_messages);
     let output = result.get("output").unwrap().as_str().unwrap();
@@ -896,7 +900,7 @@ pub async fn test_inference_params_inference_request_with_provider(provider: E2E
                "messages": [
                 {
                     "role": "user",
-                    "content": [{"type": "raw_text", "value": "What is the capital city of Japan?"}],
+                    "content": [{"type": "raw_text", "value": "What is the name of the capital city of Japan?"}],
                 }
             ]},
         "params": {
@@ -931,7 +935,7 @@ pub async fn test_inference_params_inference_request_with_provider(provider: E2E
 }
 
 // This function is also used by batch tests. If you adjust the prompt checked by this function
-// ("What is the capital city of Japan?"), make sure to update the batch tests to start batch
+// ("What is the name of the capital city of Japan?"), make sure to update the batch tests to start batch
 // jobs with the correct prompt.
 pub async fn check_inference_params_response(
     response_json: Value,
@@ -1000,7 +1004,7 @@ pub async fn check_inference_params_response(
         "messages": [
             {
                 "role": "user",
-                "content": [{"type": "raw_text", "value": "What is the capital city of Japan?"}]
+                "content": [{"type": "raw_text", "value": "What is the name of the capital city of Japan?"}]
             }
         ]
     });
@@ -1108,7 +1112,9 @@ pub async fn check_inference_params_response(
     let input_messages: Vec<RequestMessage> = serde_json::from_str(input_messages).unwrap();
     let expected_input_messages = vec![RequestMessage {
         role: Role::User,
-        content: vec!["What is the capital city of Japan?".to_string().into()],
+        content: vec!["What is the name of the capital city of Japan?"
+            .to_string()
+            .into()],
     }];
     assert_eq!(input_messages, expected_input_messages);
     let output = result.get("output").unwrap().as_str().unwrap();
@@ -1132,7 +1138,7 @@ pub async fn test_inference_params_streaming_inference_request_with_provider(
                "messages": [
                 {
                     "role": "user",
-                    "content": "What is the capital city of Japan?"
+                    "content": "What is the name of the capital city of Japan?"
                 }
             ]},
         "params": {
@@ -1253,7 +1259,7 @@ pub async fn test_inference_params_streaming_inference_request_with_provider(
         "messages": [
             {
                 "role": "user",
-                "content": [{"type": "text", "value": "What is the capital city of Japan?"}]
+                "content": [{"type": "text", "value": "What is the name of the capital city of Japan?"}]
             }
         ]
     });
@@ -1367,7 +1373,9 @@ pub async fn test_inference_params_streaming_inference_request_with_provider(
     let input_messages: Vec<RequestMessage> = serde_json::from_str(input_messages).unwrap();
     let expected_input_messages = vec![RequestMessage {
         role: Role::User,
-        content: vec!["What is the capital city of Japan?".to_string().into()],
+        content: vec!["What is the name of the capital city of Japan?"
+            .to_string()
+            .into()],
     }];
     assert_eq!(input_messages, expected_input_messages);
     let output = result.get("output").unwrap().as_str().unwrap();
@@ -7182,7 +7190,9 @@ pub async fn check_json_mode_inference_response(
     let input_messages: Vec<RequestMessage> = serde_json::from_str(input_messages).unwrap();
     let expected_input_messages = vec![RequestMessage {
         role: Role::User,
-        content: vec!["What is the capital city of Japan?".to_string().into()],
+        content: vec!["What is the name of the capital city of Japan?"
+            .to_string()
+            .into()],
     }];
     assert_eq!(input_messages, expected_input_messages);
     let output = result.get("output").unwrap().as_str().unwrap();
@@ -7426,7 +7436,9 @@ pub async fn check_dynamic_json_mode_inference_response(
     let input_messages: Vec<RequestMessage> = serde_json::from_str(input_messages).unwrap();
     let expected_input_messages = vec![RequestMessage {
         role: Role::User,
-        content: vec!["What is the capital city of Japan?".to_string().into()],
+        content: vec!["What is the name of the capital city of Japan?"
+            .to_string()
+            .into()],
     }];
     assert_eq!(input_messages, expected_input_messages);
     let output = result.get("output").unwrap().as_str().unwrap();
@@ -7691,7 +7703,9 @@ pub async fn test_json_mode_streaming_inference_request_with_provider(provider: 
     let input_messages: Vec<RequestMessage> = serde_json::from_str(input_messages).unwrap();
     let expected_input_messages = vec![RequestMessage {
         role: Role::User,
-        content: vec!["What is the capital city of Japan?".to_string().into()],
+        content: vec!["What is the name of the capital city of Japan?"
+            .to_string()
+            .into()],
     }];
     assert_eq!(input_messages, expected_input_messages);
     let output = result.get("output").unwrap().as_str().unwrap();


### PR DESCRIPTION
Some of the TGI models intermittently fail when we just ask for "the capital city"

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update test prompts to explicitly ask for "the name of the capital city" to improve TGI model reliability.
> 
>   - **Behavior**:
>     - Change test prompts to "What is the name of the capital city of {{ country }}?" in `user_template.minijinja` files.
>     - Update test prompts to "What is the name of the capital city of Japan?" in `dicl.rs`, `inference.rs`, and `batch.rs`.
>   - **Files Affected**:
>     - `user_template.minijinja` in `dynamic_json` and `json_success`.
>     - `dicl.rs` in `src/variant` and `tests/e2e`.
>     - `inference.rs` and `batch.rs` in `tests/e2e/providers`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 10394766238b16b50ae8ace9005e781daf89896a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->