### PR TITLE
Align python-pyo3 stubs and implementation

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -75,6 +75,12 @@ jobs:
           args: --find-interpreter
           container: off
 
+      - name: "Python: Pyo3 Client: Install dependencies"
+        working-directory: clients/python-pyo3
+        run: |
+          uv venv
+          uv pip sync requirements.txt
+
       - name: "Python: PyO3 Client: pyright"
         working-directory: clients/python-pyo3
         run: |

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -75,6 +75,17 @@ jobs:
           args: --find-interpreter
           container: off
 
+      - name: "Python: PyO3 Client: pyright"
+        working-directory: clients/python-pyo3
+        run: |
+          uv pip install pyright
+          uv run pyright
+
+      - name: "Python: PyO3 Client: stubtest"
+        working-directory: clients/python-pyo3
+        run: |
+          uv run stubtest tensorzero.tensorzero
+
       - name: "Python: TensorZero Client: Install dependencies"
         working-directory: clients/python
         run: |

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -152,6 +152,7 @@ jobs:
       - name: "Python: PyO3 Client: pyright"
         working-directory: clients/python-pyo3
         run: |
+          uv venv
           uv pip install pyright
           uv run pyright
 

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -155,6 +155,11 @@ jobs:
           uv pip install pyright
           uv run pyright
 
+      - name: "Python: PyO3 Client: stubtest"
+        working-directory: clients/python-pyo3
+        run: |
+          uv run stubtest tensorzero.tensorzero
+
       - name: "Python: PyO3 Client: pytest"
         working-directory: clients/python-pyo3
         run: |

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -152,7 +152,6 @@ jobs:
       - name: "Python: PyO3 Client: pyright"
         working-directory: clients/python-pyo3
         run: |
-          uv venv
           uv pip install pyright
           uv run pyright
 

--- a/clients/python-pyo3/requirements.in
+++ b/clients/python-pyo3/requirements.in
@@ -3,3 +3,4 @@ pytest-asyncio
 maturin
 uuid_utils
 httpx
+mypy

--- a/clients/python-pyo3/requirements.txt
+++ b/clients/python-pyo3/requirements.txt
@@ -24,6 +24,10 @@ iniconfig==2.0.0
     # via pytest
 maturin==1.8.1
     # via -r requirements.in
+mypy==1.15.0
+    # via -r requirements.in
+mypy-extensions==1.0.0
+    # via mypy
 packaging==24.2
     # via pytest
 pluggy==1.5.0
@@ -39,8 +43,11 @@ sniffio==1.3.1
 tomli==2.2.1
     # via
     #   maturin
+    #   mypy
     #   pytest
 typing-extensions==4.12.2
-    # via anyio
+    # via
+    #   anyio
+    #   mypy
 uuid-utils==0.10.0
     # via -r requirements.in

--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -401,7 +401,7 @@ impl TensorZeroGateway {
     }
 
     #[classmethod]
-    #[pyo3(signature = (*, config_path, clickhouse_url=None))]
+    #[pyo3(signature = (*, config_path=None, clickhouse_url=None))]
     /// Initialize the TensorZero client, using an embedded gateway.
     /// This connects to ClickHouse (if provided) and runs DB migrations.
     ///
@@ -410,11 +410,11 @@ impl TensorZeroGateway {
     /// :return: A `TensorZeroGateway` instance configured to use an embedded gateway.
     fn build_embedded(
         cls: &Bound<'_, PyType>,
-        config_path: &str,
+        config_path: Option<&str>,
         clickhouse_url: Option<String>,
     ) -> PyResult<Py<TensorZeroGateway>> {
         let client_fut = ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
-            config_path: PathBuf::from(config_path),
+            config_path: config_path.map(PathBuf::from),
             clickhouse_url,
         })
         .build();
@@ -649,7 +649,7 @@ impl AsyncTensorZeroGateway {
     // as `AsyncTensorZeroGateway` would be completely async *except* for this one method
     // (which potentially takes a very long time due to running DB migrations).
     #[classmethod]
-    #[pyo3(signature = (*, config_path, clickhouse_url=None))]
+    #[pyo3(signature = (*, config_path=None, clickhouse_url=None))]
     /// Initialize the TensorZero client, using an embedded gateway.
     /// This connects to ClickHouse (if provided) and runs DB migrations.
     ///
@@ -659,11 +659,11 @@ impl AsyncTensorZeroGateway {
     fn build_embedded<'a>(
         // This is a classmethod, so it receives the class object as a parameter.
         cls: &Bound<'a, PyType>,
-        config_path: &str,
+        config_path: Option<&str>,
         clickhouse_url: Option<String>,
     ) -> PyResult<Bound<'a, PyAny>> {
         let client_fut = ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
-            config_path: PathBuf::from(config_path),
+            config_path: config_path.map(PathBuf::from),
             clickhouse_url,
         })
         .build();

--- a/clients/python-pyo3/tensorzero/tensorzero.pyi
+++ b/clients/python-pyo3/tensorzero/tensorzero.pyi
@@ -7,6 +7,7 @@ from typing import (
     Literal,
     Optional,
     Union,
+    final,
 )
 from uuid import UUID
 
@@ -18,40 +19,9 @@ from tensorzero import (
 )
 
 class BaseTensorZeroGateway:
-    def __init__(self, base_url: str, *, timeout: Optional[float] = None): ...
-    def inference(
-        self,
-        *,
-        input: InferenceInput,
-        function_name: Optional[str] = None,
-        model_name: Optional[str] = None,
-        episode_id: Optional[UUID] = None,
-        stream: Optional[bool] = None,
-        params: Optional[Dict[str, Any]] = None,
-        variant_name: Optional[str] = None,
-        dryrun: Optional[bool] = None,
-        output_schema: Optional[Dict[str, Any]] = None,
-        allowed_tools: Optional[List[str]] = None,
-        additional_tools: Optional[List[Dict[str, Any]]] = None,
-        tool_choice: Optional[
-            Union[Literal["auto", "required", "off"], Dict[Literal["specific"], str]]
-        ] = None,
-        parallel_tool_calls: Optional[bool] = None,
-        tags: Optional[Dict[str, str]] = None,
-        credentials: Optional[Dict[str, str]] = None,
-        cache_options: Optional[Dict[str, Any]] = None,
-    ) -> Union[InferenceResponse, Generator[InferenceChunk, None, None]]: ...
-    def feedback(
-        self,
-        *,
-        metric_name: str,
-        value: Any,
-        inference_id: Optional[UUID] = None,
-        episode_id: Optional[UUID] = None,
-        dryrun: Optional[bool] = None,
-        tags: Optional[Dict[str, str]] = None,
-    ) -> FeedbackResponse: ...
+    pass
 
+@final
 class TensorZeroGateway(BaseTensorZeroGateway):
     def __init__(self, base_url: str, *, timeout: Optional[float] = None):
         """
@@ -62,7 +32,7 @@ class TensorZeroGateway(BaseTensorZeroGateway):
 
     @classmethod
     def build_http(
-        self, gateway_url: str, *, timeout: Optional[float] = None
+        cls, gateway_url: str, *, timeout: Optional[float] = None
     ) -> "TensorZeroGateway":
         """
         Build a TensorZeroGateway instance.
@@ -73,7 +43,7 @@ class TensorZeroGateway(BaseTensorZeroGateway):
 
     @classmethod
     def build_embedded(
-        self, *, config_path: Optional[str] = None, clickhouse_url: Optional[str] = None
+        cls, *, config_path: Optional[str] = None, clickhouse_url: Optional[str] = None
     ) -> "TensorZeroGateway":
         """
         Build a TensorZeroGateway instance.
@@ -173,19 +143,8 @@ class TensorZeroGateway(BaseTensorZeroGateway):
         exc_val: Optional[BaseException],
         exc_tb: Optional[object],
     ) -> None: ...
-    def _stream_inference(
-        self, url: str, data: Dict[str, Any]
-    ) -> Generator[InferenceChunk, None, None]:
-        """
-        Parse the SSE stream from the response.
 
-        NOTE: The httpx client won't make a request until you start consuming the stream.
-
-        :param url: The URL to stream from
-        :param data: The request data to send
-        :yield: InferenceChunk objects containing partial results
-        """
-
+@final
 class AsyncTensorZeroGateway(BaseTensorZeroGateway):
     def __init__(self, base_url: str, *, timeout: Optional[float] = None):
         """
@@ -196,7 +155,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
 
     @classmethod
     async def build_http(
-        self, gateway_url: str, *, timeout: Optional[float] = None
+        cls, gateway_url: str, *, timeout: Optional[float] = None
     ) -> "AsyncTensorZeroGateway":
         """
         Build an AsyncTensorZeroGateway instance.
@@ -207,7 +166,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
 
     @classmethod
     async def build_embedded(
-        self, *, config_path: Optional[str] = None, clickhouse_url: Optional[str] = None
+        cls, *, config_path: Optional[str] = None, clickhouse_url: Optional[str] = None
     ) -> "AsyncTensorZeroGateway":
         """
         Build an AsyncTensorZeroGateway instance.
@@ -307,3 +266,9 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         exc_val: Optional[BaseException],
         exc_tb: Optional[object],
     ) -> None: ...
+
+__all__ = [
+    "AsyncTensorZeroGateway",
+    "BaseTensorZeroGateway",
+    "TensorZeroGateway",
+]

--- a/clients/python-pyo3/tests/test_client.py
+++ b/clients/python-pyo3/tests/test_client.py
@@ -68,6 +68,25 @@ async def async_client(request):
             yield client
 
 
+def test_sync_embedded_gateway_no_config():
+    with pytest.raises(TensorZeroError) as exc_info:
+        with TensorZeroGateway.build_embedded() as client:
+            client.inference(function_name="my_missing_func", input={})
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.text == '{"error":"Unknown function: my_missing_func"}'
+
+
+@pytest.mark.asyncio
+async def test_async_embedded_gateway_no_config():
+    with pytest.raises(TensorZeroError) as exc_info:
+        async with await AsyncTensorZeroGateway.build_embedded() as client:
+            await client.inference(function_name="my_missing_func", input={})
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.text == '{"error":"Unknown function: my_missing_func"}'
+
+
 @dataclass
 class CountData:
     count: int

--- a/clients/rust/examples/inference_demo/main.rs
+++ b/clients/rust/examples/inference_demo/main.rs
@@ -46,7 +46,7 @@ async fn main() {
             ClientBuilder::new(ClientBuilderMode::HTTPGateway { url: gateway_url })
         }
         (None, Some(config_path)) => ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
-            config_path,
+            config_path: Some(config_path),
             clickhouse_url: std::env::var("CLICKHOUSE_URL").ok(),
         }),
         (Some(_), Some(_)) => {

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -63,7 +63,7 @@ pub async fn make_embedded_gateway() -> tensorzero::Client {
     let mut config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     config_path.push("tests/e2e/tensorzero.toml");
     tensorzero::ClientBuilder::new(tensorzero::ClientBuilderMode::EmbeddedGateway {
-        config_path,
+        config_path: Some(config_path),
         clickhouse_url: Some(CLICKHOUSE_URL.clone()),
     })
     .build()


### PR DESCRIPTION
* We now support passing in `config=None` when building an embedded gateway
* The declared methods, types, and signatures in our tensorzero.pyi now match the actual runtime values
* We depend on 'mypy' (at dev time) for the 'stubtest' tool, which validates that our tensorzero.pyi matches the actual runtime signatures.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Align Python PyO3 stubs with implementation, support `config=None`, and add `mypy` for stub validation.
> 
>   - **Behavior**:
>     - Support `config=None` in `build_embedded` methods of `TensorZeroGateway` and `AsyncTensorZeroGateway` in `lib.rs`.
>     - Add tests `test_sync_embedded_gateway_no_config` and `test_async_embedded_gateway_no_config` in `test_client.py`.
>   - **Stubs**:
>     - Align `tensorzero.pyi` with runtime values, including method signatures and class definitions.
>     - Add `@final` to `TensorZeroGateway` and `AsyncTensorZeroGateway`.
>   - **Dependencies**:
>     - Add `mypy` to `requirements.in` and `requirements.txt` for stub validation.
>   - **CI/CD**:
>     - Add `stubtest` step in `general.yml` and `merge-queue.yml` for `tensorzero.tensorzero`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8d0400282a9d7544fb6b5a59a172aff2dcd98ff8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->