### PR TITLE
Suppress newer clippy warning about format string args

### DIFF
--- a/tensorzero-internal/src/cache.rs
+++ b/tensorzero-internal/src/cache.rs
@@ -290,6 +290,7 @@ pub async fn cache_lookup_inner<T: CacheOutput + DeserializeOwned>(
     let long_cache_key = cache_key.get_long_key();
     // The clickhouse query args look like rust format string args, but they're not.
     #[allow(clippy::literal_string_with_formatting_args)]
+    #[allow(unknown_lints)]
     let query = if max_age_s.is_some() {
         r#"
             SELECT

--- a/tensorzero-internal/src/cache.rs
+++ b/tensorzero-internal/src/cache.rs
@@ -288,6 +288,8 @@ pub async fn cache_lookup_inner<T: CacheOutput + DeserializeOwned>(
     // but we always check against the long cache key before returning a result
     let short_cache_key = cache_key.get_short_key()?.to_string();
     let long_cache_key = cache_key.get_long_key();
+    // The clickhouse query args look like rust format string args, but they're not.
+    #[allow(clippy::literal_string_with_formatting_args)]
     let query = if max_age_s.is_some() {
         r#"
             SELECT

--- a/tensorzero-internal/src/cache.rs
+++ b/tensorzero-internal/src/cache.rs
@@ -289,8 +289,8 @@ pub async fn cache_lookup_inner<T: CacheOutput + DeserializeOwned>(
     let short_cache_key = cache_key.get_short_key()?.to_string();
     let long_cache_key = cache_key.get_long_key();
     // The clickhouse query args look like rust format string args, but they're not.
-    #[allow(clippy::literal_string_with_formatting_args)]
     #[allow(unknown_lints)]
+    #[allow(clippy::literal_string_with_formatting_args)]
     let query = if max_age_s.is_some() {
         r#"
             SELECT


### PR DESCRIPTION
Clippy is producing a false positive for the clickhouse query parameters.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Suppresses Clippy warning about format string arguments in `cache_lookup_inner()` in `cache.rs`.
> 
>   - **Lint Suppression**:
>     - Suppresses Clippy warning `literal_string_with_formatting_args` in `cache_lookup_inner()` in `cache.rs`.
>     - Adds `#[allow(unknown_lints)]` and `#[allow(clippy::literal_string_with_formatting_args)]` before the query definition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 290a5a7cd88bfd76ac10a04bde5e9fa04d3e36ed. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->