### PR TITLE
Add e2e RawText test

### DIFF
--- a/tensorzero-internal/src/endpoints/inference.rs
+++ b/tensorzero-internal/src/endpoints/inference.rs
@@ -673,10 +673,24 @@ impl InferenceResponse {
         }
     }
 
+    pub fn variant_name(&self) -> &str {
+        match self {
+            InferenceResponse::Chat(c) => &c.variant_name,
+            InferenceResponse::Json(j) => &j.variant_name,
+        }
+    }
+
     pub fn inference_id(&self) -> Uuid {
         match self {
             InferenceResponse::Chat(c) => c.inference_id,
             InferenceResponse::Json(j) => j.inference_id,
+        }
+    }
+
+    pub fn episode_id(&self) -> Uuid {
+        match self {
+            InferenceResponse::Chat(c) => c.episode_id,
+            InferenceResponse::Json(j) => j.episode_id,
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/tensorzero/tensorzero/issues/966

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add end-to-end tests for raw text inference and extend `InferenceResponse` with new methods.
> 
>   - **Tests**:
>     - Add `test_raw_text_http_gateway` and `test_raw_text_embedded_gateway` in `inference.rs` to test raw text inference.
>     - Add `test_raw_text()` function to handle raw text input and validate response.
>   - **InferenceResponse**:
>     - Add `variant_name()` and `episode_id()` methods to `InferenceResponse` in `inference.rs` to retrieve variant name and episode ID.
>   - **Misc**:
>     - Minor changes to `inference.rs` to support new test cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 11160aed1d4b058923c602688e134da1d87219b3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->