### PR TITLE
Fix path to python-pyo3 in upload-pyo3.sh

### DIFF
--- a/ci/upload-pyo3.sh
+++ b/ci/upload-pyo3.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 cd "$(dirname "$0")"
 curl -LsSf https://astral.sh/uv/0.5.24/install.sh | sh
-cd ../../clients/python-pyo3
+cd ../clients/python-pyo3
 uv venv
 uv pip sync requirements.txt
 uv run maturin upload -v --repository testpypi --non-interactive --skip-existing ../../wheels-*/*


### PR DESCRIPTION
I forgot to adjust this after moving it from
'scripts/ci/' to 'ci/'

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix path in `upload-pyo3.sh` to `../clients/python-pyo3` for correct directory structure.
> 
>   - **Script Fix**:
>     - Corrects path in `upload-pyo3.sh` from `../../clients/python-pyo3` to `../clients/python-pyo3` to reflect directory structure change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5c2783febf6318943db8923f0f6cf8b9ebc3abf1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->