### PR TITLE
Warn if user doesn't provide a config file

### DIFF
--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -46,7 +46,7 @@ async fn main() {
 
     if args.tensorzero_toml.is_some() {
         tracing::warn!(
-            "`Specifying a positional path argument is deprecated. Use `--config-file` instead."
+            "`Specifying a positional path argument is deprecated. Use `--config-file path/to/tensorzero.toml` instead."
         );
     }
 
@@ -55,6 +55,7 @@ async fn main() {
     let config = if let Some(path) = &config_path {
         Arc::new(Config::load_from_path(Path::new(&path)).expect_pretty("Failed to load config"))
     } else {
+        tracing::warn!("No config file provided, so only default functions will be available. Use `--config-file path/to/tensorzero.toml` to specify a config file.");
         Arc::new(Config::default())
     };
 


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a warning in `main()` in `gateway/src/main.rs` if no config file is provided, indicating only default functions will be available.
> 
>   - **Behavior**:
>     - Adds a warning in `main()` in `gateway/src/main.rs` if no config file is provided, indicating only default functions will be available.
>     - Updates existing warning message for deprecated positional path argument to include full command syntax.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7fc29e5e54136df979ca13df540bc4363934558c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->