### PR TITLE
Pin container version in `docker-compose.yml`

### DIFF
--- a/examples/babyai/docker-compose.yml
+++ b/examples/babyai/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       timeout: 1s
 
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro
@@ -28,7 +28,7 @@ services:
         condition: service_healthy
 
   ui:
-    image: tensorzero/ui
+    image: tensorzero/ui:2025.02.2
     volumes:
       - ./config:/app/config:ro
     environment:

--- a/examples/chess-puzzles-best-of-n-sampling/docker-compose.yml
+++ b/examples/chess-puzzles-best-of-n-sampling/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       timeout: 1s
 
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
       - ${GCP_VERTEX_CREDENTIALS_PATH:-/dev/null}:/app/gcp-credentials.json:ro
@@ -34,7 +34,7 @@ services:
       clickhouse:
         condition: service_healthy
   ui:
-    image: tensorzero/ui
+    image: tensorzero/ui:2025.02.2
     volumes:
       - ./config:/app/config:ro
     environment:

--- a/examples/chess-puzzles-mixture-of-n-sampling/docker-compose.yml
+++ b/examples/chess-puzzles-mixture-of-n-sampling/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       timeout: 1s
 
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
       - ${GCP_VERTEX_CREDENTIALS_PATH:-/dev/null}:/app/gcp-credentials.json:ro
@@ -34,7 +34,7 @@ services:
       clickhouse:
         condition: service_healthy
   ui:
-    image: tensorzero/ui
+    image: tensorzero/ui:2025.02.2
     volumes:
       - ./config:/app/config:ro
     environment:

--- a/examples/data-extraction-ner/docker-compose.yml
+++ b/examples/data-extraction-ner/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       timeout: 1s
 
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
       - ${GCP_VERTEX_CREDENTIALS_PATH:-/dev/null}:/app/gcp-credentials.json:ro
@@ -35,7 +35,7 @@ services:
         condition: service_healthy
 
   ui:
-    image: tensorzero/ui
+    image: tensorzero/ui:2025.02.2
     volumes:
       - ./config:/app/config:ro
     environment:

--- a/examples/gsm8k-custom-recipe-dspy/docker-compose.yml
+++ b/examples/gsm8k-custom-recipe-dspy/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       timeout: 1s
 
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
       - ${GCP_VERTEX_CREDENTIALS_PATH:-/dev/null}:/app/gcp-credentials.json:ro
@@ -35,7 +35,7 @@ services:
         condition: service_healthy
 
   ui:
-    image: tensorzero/ui
+    image: tensorzero/ui:2025.02.2
     volumes:
       - ./config:/app/config:ro
     environment:

--- a/examples/guides/batch-inference/docker-compose.yml
+++ b/examples/guides/batch-inference/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       timeout: 1s
 
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro

--- a/examples/guides/episodes/docker-compose.yml
+++ b/examples/guides/episodes/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       timeout: 1s
 
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro

--- a/examples/guides/metrics-feedback/docker-compose.yml
+++ b/examples/guides/metrics-feedback/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       timeout: 1s
 
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro

--- a/examples/guides/prompts-templates-schemas/docker-compose.yml
+++ b/examples/guides/prompts-templates-schemas/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       timeout: 1s
 
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro

--- a/examples/guides/providers/anthropic/docker-compose.yml
+++ b/examples/guides/providers/anthropic/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
     environment:

--- a/examples/guides/providers/aws-bedrock/docker-compose.yml
+++ b/examples/guides/providers/aws-bedrock/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
     environment:

--- a/examples/guides/providers/azure/docker-compose.yml
+++ b/examples/guides/providers/azure/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
     environment:

--- a/examples/guides/providers/deepseek/docker-compose.yml
+++ b/examples/guides/providers/deepseek/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
     environment:

--- a/examples/guides/providers/fireworks/docker-compose.yml
+++ b/examples/guides/providers/fireworks/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
     environment:

--- a/examples/guides/providers/gcp-vertex-ai-anthropic/docker-compose.yml
+++ b/examples/guides/providers/gcp-vertex-ai-anthropic/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
       - ${GCP_VERTEX_CREDENTIALS_PATH:-/dev/null}:/app/gcp-credentials.json:ro

--- a/examples/guides/providers/gcp-vertex-ai-gemini/docker-compose.yml
+++ b/examples/guides/providers/gcp-vertex-ai-gemini/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
       - ${GCP_VERTEX_CREDENTIALS_PATH:-/dev/null}:/app/gcp-credentials.json:ro

--- a/examples/guides/providers/google-ai-studio-gemini/docker-compose.yml
+++ b/examples/guides/providers/google-ai-studio-gemini/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
     environment:

--- a/examples/guides/providers/hyperbolic/docker-compose.yml
+++ b/examples/guides/providers/hyperbolic/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
     environment:

--- a/examples/guides/providers/mistral/docker-compose.yml
+++ b/examples/guides/providers/mistral/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
     environment:

--- a/examples/guides/providers/openai-compatible/docker-compose.yml
+++ b/examples/guides/providers/openai-compatible/docker-compose.yml
@@ -3,10 +3,10 @@
 
 services:
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
     # environment:
-      # - OLLAMA_API_KEY=${OLLAMA_API_KEY:?Environment variable OLLAMA_API_KEY must be set.}
+    # - OLLAMA_API_KEY=${OLLAMA_API_KEY:?Environment variable OLLAMA_API_KEY must be set.}
     ports:
       - "3000:3000"

--- a/examples/guides/providers/openai/docker-compose.yml
+++ b/examples/guides/providers/openai/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
     environment:

--- a/examples/guides/providers/tgi/docker-compose.yml
+++ b/examples/guides/providers/tgi/docker-compose.yml
@@ -2,7 +2,7 @@
 # For production-ready deployments, see: https://www.tensorzero.com/docs/gateway/deployment
 services:
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
     # environment:

--- a/examples/guides/providers/together/docker-compose.yml
+++ b/examples/guides/providers/together/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
     environment:

--- a/examples/guides/providers/vllm/docker-compose.yml
+++ b/examples/guides/providers/vllm/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
     # environment:

--- a/examples/guides/providers/xai/docker-compose.yml
+++ b/examples/guides/providers/xai/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
     environment:

--- a/examples/guides/streaming-inference/docker-compose.yml
+++ b/examples/guides/streaming-inference/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro

--- a/examples/haiku-hidden-preferences/docker-compose.yml
+++ b/examples/haiku-hidden-preferences/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       timeout: 1s
 
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
       - ${GCP_VERTEX_CREDENTIALS_PATH:-/dev/null}:/app/gcp-credentials.json:ro
@@ -35,7 +35,7 @@ services:
         condition: service_healthy
 
   ui:
-    image: tensorzero/ui
+    image: tensorzero/ui:2025.02.2
     volumes:
       - ./config:/app/config:ro
     environment:

--- a/examples/production-deployment/docker-compose.yml
+++ b/examples/production-deployment/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       - ./config:/app/config:ro
       - ${GCP_VERTEX_CREDENTIALS_PATH:-/dev/null}:/app/gcp-credentials.json:ro

--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       timeout: 1s
 
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro
@@ -31,7 +31,7 @@ services:
         condition: service_healthy
 
   ui:
-    image: tensorzero/ui
+    image: tensorzero/ui:2025.02.2
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro

--- a/examples/readme/docker-compose.yml
+++ b/examples/readme/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       timeout: 1s
 
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     environment:
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero
       - OPENAI_API_KEY=${OPENAI_API_KEY:?Environment variable OPENAI_API_KEY must be set.}
@@ -28,7 +28,7 @@ services:
         condition: service_healthy
 
   ui:
-    image: tensorzero/ui
+    image: tensorzero/ui:2025.02.2
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY:?Environment variable OPENAI_API_KEY must be set.}
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero

--- a/examples/tutorial/01-simple-chatbot/docker-compose.yml
+++ b/examples/tutorial/01-simple-chatbot/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       timeout: 1s
 
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro

--- a/examples/tutorial/02-email-copilot/docker-compose.yml
+++ b/examples/tutorial/02-email-copilot/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       timeout: 1s
 
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro

--- a/examples/tutorial/03-weather-rag/docker-compose.yml
+++ b/examples/tutorial/03-weather-rag/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       timeout: 1s
 
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro

--- a/examples/tutorial/04-email-data-extraction/docker-compose.yml
+++ b/examples/tutorial/04-email-data-extraction/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       timeout: 1s
 
   gateway:
-    image: tensorzero/gateway
+    image: tensorzero/gateway:2025.02.2
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro

--- a/ui/docker-compose.yml
+++ b/ui/docker-compose.yml
@@ -1,6 +1,5 @@
 services:
   ui:
-    container_name: tensorzero-ui
     image: tensorzero/ui:2025.02.2
     volumes:
       - ./config:/app/config:ro

--- a/ui/docker-compose.yml
+++ b/ui/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   ui:
     container_name: tensorzero-ui
-    image: tensorzero/ui
+    image: tensorzero/ui:2025.02.2
     volumes:
       - ./config:/app/config:ro
     env_file:

--- a/ui/fixtures/docker-compose.ui.yml
+++ b/ui/fixtures/docker-compose.ui.yml
@@ -1,6 +1,5 @@
 services:
   ui:
-    container_name: tensorzero-ui
     image: tensorzero/ui:2025.02.2
     volumes:
       - ./config:/app/config:ro

--- a/ui/fixtures/docker-compose.ui.yml
+++ b/ui/fixtures/docker-compose.ui.yml
@@ -1,7 +1,7 @@
 services:
   ui:
     container_name: tensorzero-ui
-    image: tensorzero/ui
+    image: tensorzero/ui:2025.02.2
     volumes:
       - ./config:/app/config:ro
     env_file:


### PR DESCRIPTION
Fixes #998
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Pin `tensorzero/gateway` and `tensorzero/ui` images to version `2025.02.2` in multiple `docker-compose.yml` files for consistency.
> 
>   - **Behavior**:
>     - Pin `tensorzero/gateway` image to version `2025.02.2` in `docker-compose.yml` files across various examples and guides.
>     - Pin `tensorzero/ui` image to version `2025.02.2` in `docker-compose.yml` files across various examples and guides.
>   - **Files Affected**:
>     - `examples/babyai/docker-compose.yml`, `examples/chess-puzzles-best-of-n-sampling/docker-compose.yml`, `examples/chess-puzzles-mixture-of-n-sampling/docker-compose.yml` ... and 30 other files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8046d4e2002c7495965f7c565104989d8940e93d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->