### PR TITLE
Build python-pyo3 client for Python ABI 3.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero_python"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ async-stream = "0.3.5"
 tokio-stream = "0.1.15"
 tokio = { version = "1.38.1", features = ["full"] }
 tracing = { version = "0.1.40", features = ["log"] }
-pyo3 = { version = "0.23.3", features = ["experimental-async"] }
+pyo3 = { version = "0.23.3", features = ["experimental-async", "abi3-py39"] }
 axum = { version = "0.7.5", features = ["macros"] }
 futures = "0.3.30"
 url = "2.5.4"

--- a/clients/python-pyo3/Cargo.toml
+++ b/clients/python-pyo3/Cargo.toml
@@ -3,7 +3,7 @@
 # It's named 'tensorzero_python' to avoid confusion with the Rust client
 # (which has a crate name of 'tensorzero')
 name = "tensorzero_python"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -292,7 +292,7 @@ impl BaseTensorZeroGateway {
         let tool_choice = if let Some(tool_choice) = tool_choice {
             if tool_choice.is_instance_of::<PyString>() {
                 Some(
-                    serde_json::from_value(tool_choice.str()?.to_str()?.into()).map_err(|e| {
+                    serde_json::from_value(tool_choice.str()?.to_cow()?.into()).map_err(|e| {
                         PyValueError::new_err(format!(
                             "Failed to parse tool_choice as valid JSON: {e:?}"
                         ))


### PR DESCRIPTION
This allows us to build a single wheel (per platform) which will work for Python 3.9 and above.

Some of the '&str'-based apis are not available on Python 3.9, so I switched to using 'Cow<'_, str'>' apis instead.

I've also bumped the python-pyo3 version, so that we can deploy to testpypi. This version will be replaced by a real version number when we deploy to the real pypi

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Build Python client with `pyo3` for Python ABI 3.9+, updating dependencies and code for compatibility.
> 
>   - **Build**:
>     - Add `abi3-py39` feature to `pyo3` in `Cargo.toml` to support Python 3.9+.
>     - Update `tensorzero_python` version to `0.2.0` in `Cargo.toml` and `Cargo.lock`.
>   - **Code Changes**:
>     - Replace `to_str()` with `to_cow()` in `lib.rs` and `python_helpers.rs` to handle `&str` APIs not available in Python 3.9.
>   - **Dependencies**:
>     - Bump `pyo3` version to `0.23.4` in `Cargo.lock` for deployment to testpypi.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8d2774d1716448e281cf80d7c29cd16c7d6f8a4b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->