### PR TITLE
Add '--write' option to provider-proxy to control cache writes

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Launch the provider-proxy cache for E2E tests
         run: |
-          ./ci/run-provider-proxy.sh detach
+          ./ci/run-provider-proxy.sh ci
 
       - name: Launch the gateway for E2E tests
         run: |

--- a/ci/run-provider-proxy.sh
+++ b/ci/run-provider-proxy.sh
@@ -3,8 +3,8 @@ set -euxo pipefail
 
 
 cargo build --bin provider-proxy
-if [[ "${1:-}" = "detach" ]]; then
-  cargo run --bin provider-proxy -- --cache-path ./ci/provider-proxy-cache > provider_proxy_logs.txt 2>&1 &
+if [[ "${1:-}" = "ci" ]]; then
+  cargo run --bin provider-proxy -- --cache-path ./ci/provider-proxy-cache --write false > provider_proxy_logs.txt 2>&1 &
 else
   cargo run --bin provider-proxy -- --cache-path ./ci/provider-proxy-cache
 fi

--- a/provider-proxy/src/lib.rs
+++ b/provider-proxy/src/lib.rs
@@ -10,11 +10,12 @@ mod tls;
 use std::io::Write;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::{fs::OpenOptions, future::Future};
 
 use anyhow::Context as _;
 use bytes::{Bytes, BytesMut};
-use clap::Parser;
+use clap::{ArgAction, Parser};
 use http::HeaderValue;
 use http_body_util::{combinators::BoxBody, BodyExt, Full};
 use hyper::service::service_fn;
@@ -102,7 +103,7 @@ async fn check_cache<
     T: Future<Output = Result<hyper::Response<BoxBody<Bytes, E>>, anyhow::Error>>,
     F: FnOnce() -> T,
 >(
-    cache_path: PathBuf,
+    args: &Args,
     request: &hyper::Request<Bytes>,
     missing: F,
 ) -> Result<hyper::Response<BoxBody<Bytes, E>>, anyhow::Error> {
@@ -117,7 +118,7 @@ async fn check_cache<
         hash
     );
 
-    let path = cache_path.join(filename);
+    let path = args.cache_path.join(filename);
     let path_str = path.to_string_lossy().into_owned();
     let (mut resp, cache_hit) = if path.exists() {
         tracing::info!("Cache hit: {}", path_str);
@@ -159,21 +160,27 @@ async fn check_cache<
             // We need to clear the extensions in order to be able to serialize the response
             hyper_response.extensions_mut().clear();
 
+            let write = args.write;
+
             // Start streaming the response to the client, running the provided callback once the whole body has been received
             // This lets us forward streaming responses without needing to wait for the entire response, while
             // still caching the entire response to disk.
+            // Note that we make a `StreamingBodyCollector` even when `write` is false, so that
+            // the HTTP behavior is consistent regardless of whether `write` is enabled.
             let body_collector = hyper_response.map(|b| {
                 StreamingBodyCollector::new(
                     b,
                     Box::new(move |body| {
-                        tokio::task::spawn_blocking(move || {
-                            if let Err(e) = save_cache_body(path, parts, body) {
-                                tracing::error!(
-                                    err = e.as_ref() as &dyn std::error::Error,
-                                    "Failed to save cache body"
-                                );
-                            }
-                        });
+                        if write {
+                            tokio::task::spawn_blocking(move || {
+                                if let Err(e) = save_cache_body(path, parts, body) {
+                                    tracing::error!(
+                                        err = e.as_ref() as &dyn std::error::Error,
+                                        "Failed to save cache body"
+                                    );
+                                }
+                            });
+                        }
                     }),
                 )
             });
@@ -199,6 +206,10 @@ pub struct Args {
     /// Port to listen on
     #[arg(long, default_value = "3003")]
     pub port: u16,
+    /// Whether to write to the cache when a cache miss occurs.
+    /// If false, the proxy will still read existing entries from the cache, but not write new ones.
+    #[arg(long, action = ArgAction::Set, default_value_t = true, num_args = 1)]
+    pub write: bool,
 }
 
 pub async fn run_server(args: Args, server_started: oneshot::Sender<SocketAddr>) {
@@ -212,6 +223,8 @@ pub async fn run_server(args: Args, server_started: oneshot::Sender<SocketAddr>)
         )
         .try_init()
         .unwrap();
+
+    let args = Arc::new(args);
 
     std::fs::create_dir_all(&args.cache_path).expect("Failed to create cache directory");
 
@@ -228,12 +241,13 @@ pub async fn run_server(args: Args, server_started: oneshot::Sender<SocketAddr>)
     );
 
     let client = reqwest::Client::new();
+    let args_clone = args.clone();
     let (server_addr, server) = proxy
         .bind(
             ("127.0.0.1", args.port),
             service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
                 let client = client.clone();
-                let cache_path = args.cache_path.clone();
+                let args = args_clone.clone();
                 async move {
                     let (parts, body) = req.into_parts();
                     let body_bytes = body
@@ -242,7 +256,7 @@ pub async fn run_server(args: Args, server_started: oneshot::Sender<SocketAddr>)
                         .with_context(|| "Failed to collect body")?
                         .to_bytes();
                     let bytes_request = hyper::Request::from_parts(parts, body_bytes);
-                    let response = check_cache(cache_path, &bytes_request, || async {
+                    let response = check_cache(&args, &bytes_request, || async {
                         let request: reqwest::Request =
                             bytes_request.clone().try_into().with_context(|| {
                                 "Failed to convert Request from `hyper` to `reqwest`"
@@ -258,7 +272,7 @@ pub async fn run_server(args: Args, server_started: oneshot::Sender<SocketAddr>)
         .await
         .unwrap();
 
-    tracing::info!("HTTP Proxy is listening on http://{server_addr}");
+    tracing::info!(?args, "HTTP Proxy is listening on http://{server_addr}");
     server_started
         .send(server_addr)
         .expect("Failed to send server started signal");

--- a/provider-proxy/tests/e2e/tests.rs
+++ b/provider-proxy/tests/e2e/tests.rs
@@ -62,6 +62,7 @@ async fn test_provider_proxy() {
         Args {
             cache_path: temp_dir.path().to_path_buf(),
             port: 0,
+            write: true,
         },
         server_started_tx,
     ));


### PR DESCRIPTION
On ci, we run provider-proxy with '--write false'. This stops the provider proxy from caching potentially incorrect responses (e.g. an inference result that happens to be missing the expected tool calls), which breaks our retry logic.

Developers can leave '--write' enabled (the default), and run e2e tests to generate new cache entries.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
