### PR TITLE
Require `gateway_url` to be a kwarg in `build_http` python methods

### DIFF
--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -354,7 +354,7 @@ impl TensorZeroGateway {
     }
 
     #[classmethod]
-    #[pyo3(signature = (gateway_url, *, timeout=None))]
+    #[pyo3(signature = (*, gateway_url, timeout=None))]
     /// Initialize the TensorZero client, using the HTTP gateway.
     /// :param gateway_url: The base URL of the TensorZero gateway. Example: "http://localhost:3000"
     /// :param timeout: The timeout for the HTTP client in seconds. If not provided, no timeout will be set.
@@ -593,7 +593,7 @@ impl AsyncTensorZeroGateway {
     }
 
     #[classmethod]
-    #[pyo3(signature = (gateway_url, *, timeout=None))]
+    #[pyo3(signature = (*, gateway_url, timeout=None))]
     fn build_http<'a>(
         cls: &Bound<'a, PyType>,
         gateway_url: &str,

--- a/clients/python-pyo3/tensorzero/tensorzero.pyi
+++ b/clients/python-pyo3/tensorzero/tensorzero.pyi
@@ -32,7 +32,7 @@ class TensorZeroGateway(BaseTensorZeroGateway):
 
     @classmethod
     def build_http(
-        cls, gateway_url: str, *, timeout: Optional[float] = None
+        cls, *, gateway_url: str, timeout: Optional[float] = None
     ) -> "TensorZeroGateway":
         """
         Build a TensorZeroGateway instance.
@@ -155,7 +155,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
 
     @classmethod
     async def build_http(
-        cls, gateway_url: str, *, timeout: Optional[float] = None
+        cls, *, gateway_url: str, timeout: Optional[float] = None
     ) -> "AsyncTensorZeroGateway":
         """
         Build an AsyncTensorZeroGateway instance.


### PR DESCRIPTION
Fixes #1016

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
