### PR TITLE
Cleanup some rust dependency usages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3287,7 +3287,6 @@ dependencies = [
  "lazy_static",
  "metrics",
  "metrics-exporter-prometheus",
- "mimalloc",
  "minijinja",
  "paste",
  "rand 0.8.5",

--- a/tensorzero-internal/Cargo.toml
+++ b/tensorzero-internal/Cargo.toml
@@ -53,7 +53,6 @@ metrics = "0.23.0"
 metrics-exporter-prometheus = { version = "0.15.3", features = [
     "http-listener",
 ], default-features = false }
-mimalloc = "0.1.43"
 minijinja = { version = "2.1.0", features = [
     "loader",
     "debug",

--- a/tensorzero-internal/tests/mock-inference-provider/Cargo.toml
+++ b/tensorzero-internal/tests/mock-inference-provider/Cargo.toml
@@ -6,11 +6,13 @@ edition = "2021"
 [dependencies]
 async-stream = { workspace = true }
 axum = { workspace = true }
-eventsource-stream = "0.2.3"
 futures = { workspace = true }
 mimalloc = "0.1.43"
-reqwest = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
-tokio-stream = { workspace = true }
 tower = { version = "0.5.2", features = ["util"] }
+
+[dev-dependencies]
+eventsource-stream = "0.2.3"
+reqwest = { workspace = true }
+tokio-stream = { workspace = true }

--- a/ui/app/utils/minijinja/Cargo.toml
+++ b/ui/app/utils/minijinja/Cargo.toml
@@ -24,4 +24,6 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 serde_json = { version = "1.0.134", features = ["preserve_order"] }
 serde-wasm-bindgen = "0.6.5"
 serde = { version = "1.0.204", features = ["derive"] }
+
+[dev-dependencies]
 wasm-bindgen-test = "0.3.45"


### PR DESCRIPTION
`tensorzero-internal` doesn't need `mimalloc` at all (only the gateway binary uses it), while some other deps can be `[dev-dependencies]`

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Clean up Rust dependencies by removing `mimalloc` from `tensorzero-internal` and adjusting dev-dependencies in `mock-inference-provider` and `minijinja-bindings`.
> 
>   - **Dependencies**:
>     - Remove `mimalloc` from `tensorzero-internal/Cargo.toml` as it's not needed.
>     - Move `eventsource-stream`, `reqwest`, and `tokio-stream` to `[dev-dependencies]` in `mock-inference-provider/Cargo.toml`.
>   - **Misc**:
>     - Add `wasm-bindgen-test` to `[dev-dependencies]` in `minijinja-bindings/Cargo.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ebb96128e10fc3ccb9f3cae25b667dd0b5d3f158. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->