### PR TITLE
Enable 'strip' option for maturin

### DIFF
--- a/clients/python-pyo3/pyproject.toml
+++ b/clients/python-pyo3/pyproject.toml
@@ -11,3 +11,4 @@ dynamic = ["version"]
 
 [tool.maturin]
 features = ["pyo3/extension-module"]
+strip = true


### PR DESCRIPTION
This will further cut down on the size of the wheel

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable `strip` option in `pyproject.toml` to reduce wheel size.
> 
>   - **Configuration**:
>     - Enable `strip` option in `pyproject.toml` under `[tool.maturin]` to reduce wheel size.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a225c0241f386403faf0e94238a05dc53d0d4f8e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->