### PR TITLE
Changed gateway to default to confirmed writes

### DIFF
--- a/tensorzero-internal/src/config_parser.rs
+++ b/tensorzero-internal/src/config_parser.rs
@@ -63,7 +63,7 @@ impl TryFrom<UninitializedGatewayConfig> for GatewayConfig {
                 }));
             }
             (true, None) => {
-                tracing::warn!("Deprecation Warning: The configuration flag `gateway.disable_observability.enabled` is deprecated in favor of `gateway.observability.enabled`. See https://github.com/tensorzero/tensorzero/issues/797 on GitHub for details.");
+                tracing::warn!("Deprecation Warning: The configuration flag `gateway.disable_observability` is deprecated in favor of `gateway.observability.enabled`. See https://github.com/tensorzero/tensorzero/issues/797 on GitHub for details.");
                 Some(false)
             }
             (false, Some(enabled)) => Some(enabled),
@@ -71,7 +71,10 @@ impl TryFrom<UninitializedGatewayConfig> for GatewayConfig {
         };
         Ok(Self {
             bind_address: config.bind_address,
-            observability: ObservabilityConfig { enabled },
+            observability: ObservabilityConfig {
+                enabled,
+                r#async: config.observability.r#async,
+            },
             debug: config.debug,
         })
     }
@@ -82,6 +85,8 @@ impl TryFrom<UninitializedGatewayConfig> for GatewayConfig {
 pub struct ObservabilityConfig {
     #[serde(default)]
     pub enabled: Option<bool>,
+    #[serde(default)]
+    pub r#async: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -660,6 +665,8 @@ mod tests {
             }
             _ => panic!("Expected a chat function"),
         }
+        // Check that the async flag is set to false by default
+        assert!(!config.gateway.observability.r#async);
 
         // To test that variant default weights work correctly,
         // We check `functions.templates_with_variables_json.variants.variant_with_variables.weight`

--- a/tensorzero-internal/src/config_parser.rs
+++ b/tensorzero-internal/src/config_parser.rs
@@ -73,7 +73,7 @@ impl TryFrom<UninitializedGatewayConfig> for GatewayConfig {
             bind_address: config.bind_address,
             observability: ObservabilityConfig {
                 enabled,
-                r#async: config.observability.r#async,
+                async_writes: config.observability.async_writes,
             },
             debug: config.debug,
         })
@@ -86,7 +86,7 @@ pub struct ObservabilityConfig {
     #[serde(default)]
     pub enabled: Option<bool>,
     #[serde(default)]
-    pub r#async: bool,
+    pub async_writes: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -666,7 +666,7 @@ mod tests {
             _ => panic!("Expected a chat function"),
         }
         // Check that the async flag is set to false by default
-        assert!(!config.gateway.observability.r#async);
+        assert!(!config.gateway.observability.async_writes);
 
         // To test that variant default weights work correctly,
         // We check `functions.templates_with_variables_json.variants.variant_with_variables.weight`

--- a/tensorzero-internal/src/endpoints/feedback.rs
+++ b/tensorzero-internal/src/endpoints/feedback.rs
@@ -1,3 +1,4 @@
+use std::cmp::max;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -7,6 +8,7 @@ use axum::{debug_handler, Json};
 use metrics::counter;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use tokio::time::Instant;
 use tracing::instrument;
 use uuid::Uuid;
 
@@ -27,6 +29,10 @@ use super::validate_tags;
 /// This is the amount of time we want to wait after the target was supposed to have been written
 /// before we decide that the target was actually not written because we can't find it in the database.
 const FEEDBACK_COOLDOWN_PERIOD: Duration = Duration::from_secs(5);
+/// Since we can't be sure that an inference actually completed when the ID says it was
+/// (the ID is generated at the start of the inference), we wait a minimum amount of time
+/// before we decide that the target was actually not written because we can't find it in the database.
+const FEEDBACK_MINIMUM_WAIT_TIME: Duration = Duration::from_millis(1200);
 
 /// The expected payload is a JSON object with the following fields:
 #[derive(Debug, Serialize, Deserialize)]
@@ -359,32 +365,35 @@ async fn write_boolean(
 /// This is to avoid a race condition where the id was created (e.g. an inference was made)
 /// but the feedback is received before the id is written to the database.
 ///
-/// The current behavior is to immediately check and return the result if the id was created
-/// more than FEEDBACK_COOLDOWN_PERIOD ago.
-///
-/// Otherwise, it will poll the database every second until the cooldown period has passed.
-/// Then, if the id has still not been created, it will return an error.
+/// We compute an amount of time to wait by max(FEEDBACK_COOLDOWN_PERIOD - elapsed_from_target_id, FEEDBACK_MINIMUM_WAIT_TIME)
+/// We then poll every 500ms until that time has passed.
+/// If the time has passed and the id is still not found, we return an error.
 async fn throttled_get_function_name(
     connection_info: &ClickHouseConnectionInfo,
     metric_config_level: &MetricConfigLevel,
     target_id: &Uuid,
 ) -> Result<String, Error> {
-    let mut elapsed = uuid_elapsed(target_id)?;
-    if elapsed > FEEDBACK_COOLDOWN_PERIOD {
-        return get_function_name(connection_info, metric_config_level, target_id).await;
-    }
+    // Compute how long ago the target_id was created.
+    let elapsed = uuid_elapsed(target_id)?;
 
+    // Calculate the remaining cooldown (which may be zero) and ensure we wait at least FEEDBACK_MINIMUM_WAIT_TIME.
+    let wait_time = max(
+        FEEDBACK_COOLDOWN_PERIOD.saturating_sub(elapsed),
+        FEEDBACK_MINIMUM_WAIT_TIME,
+    );
+    let deadline = Instant::now() + wait_time;
+
+    // Poll every 500ms until the deadline is reached.
     loop {
-        tokio::time::sleep(Duration::from_secs(1)).await;
-        elapsed = uuid_elapsed(target_id)?;
         match get_function_name(connection_info, metric_config_level, target_id).await {
             Ok(identifier) => return Ok(identifier),
-            Err(e) => {
-                if elapsed > FEEDBACK_COOLDOWN_PERIOD {
-                    return Err(e);
+            Err(err) => {
+                if Instant::now() >= deadline {
+                    return Err(err);
                 }
             }
         }
+        tokio::time::sleep(Duration::from_millis(500)).await;
     }
 }
 
@@ -789,10 +798,8 @@ mod tests {
             }
         );
     }
-
     #[tokio::test]
-    async fn test_feedback_handler() {
-        // Test a Comment Feedback
+    async fn test_feedback_handler_comment() {
         let config = Arc::new(Config {
             gateway: GatewayConfig::default(),
             models: ModelTable::default(),
@@ -823,11 +830,26 @@ mod tests {
                 message: format!("Episode ID: {episode_id} does not exist"),
             }
         );
+    }
 
-        // Test a Demonstration Feedback
+    #[tokio::test]
+    async fn test_feedback_handler_demonstration() {
+        let config = Arc::new(Config {
+            gateway: GatewayConfig::default(),
+            models: ModelTable::default(),
+            embedding_models: EmbeddingModelTable::default(),
+            metrics: HashMap::new(),
+            functions: HashMap::new(),
+            tools: HashMap::new(),
+            templates: TemplateConfig::new(),
+        });
+        let app_state_data = get_unit_test_app_state_data(config, true);
+        let timestamp = uuid::Timestamp::from_unix_time(1579751960, 0, 0, 0);
+        let episode_id = Uuid::new_v7(timestamp);
         let value = json!("test demonstration");
+
+        // Test with episode_id (should fail)
         let params = Params {
-            // Demonstrations shouldn't work with episode id
             episode_id: Some(episode_id),
             inference_id: None,
             metric_name: "demonstration".to_string(),
@@ -847,6 +869,7 @@ mod tests {
             }
         );
 
+        // Test with inference_id (should fail with non-existent ID)
         let inference_id = Uuid::new_v7(timestamp);
         let params = Params {
             episode_id: None,
@@ -865,8 +888,10 @@ mod tests {
                 message: format!("Inference ID: {inference_id} does not exist"),
             }
         );
+    }
 
-        // Test a Float Feedback (episode level)
+    #[tokio::test]
+    async fn test_feedback_handler_float_episode_level() {
         let mut metrics = HashMap::new();
         metrics.insert(
             "test_float".to_string(),
@@ -887,8 +912,11 @@ mod tests {
         });
         let app_state_data = get_unit_test_app_state_data(config.clone(), true);
         let value = json!(4.5);
+        let timestamp = uuid::Timestamp::from_unix_time(1579751960, 0, 0, 0);
         let inference_id = Uuid::new_v7(timestamp);
         let episode_id = Uuid::new_v7(timestamp);
+
+        // Test with inference_id (should fail)
         let params = Params {
             episode_id: None,
             inference_id: Some(inference_id),
@@ -908,6 +936,7 @@ mod tests {
             }
         );
 
+        // Test with episode_id (should fail with non-existent ID)
         let params = Params {
             episode_id: Some(episode_id),
             inference_id: None,
@@ -925,8 +954,10 @@ mod tests {
                 message: format!("Episode ID: {episode_id} does not exist"),
             }
         );
+    }
 
-        // Test Boolean feedback with invalid inference-level.
+    #[tokio::test]
+    async fn test_feedback_handler_boolean_inference_level() {
         let mut metrics = HashMap::new();
         metrics.insert(
             "test_boolean".to_string(),
@@ -947,6 +978,7 @@ mod tests {
         });
         let app_state_data = get_unit_test_app_state_data(config.clone(), true);
         let value = json!(true);
+        let timestamp = uuid::Timestamp::from_unix_time(1579751960, 0, 0, 0);
         let inference_id = Uuid::new_v7(timestamp);
         let params = Params {
             episode_id: None,

--- a/tensorzero-internal/src/endpoints/inference.rs
+++ b/tensorzero-internal/src/endpoints/inference.rs
@@ -374,7 +374,7 @@ pub async fn inference(
                     )
                     .await;
                 };
-                if config.gateway.observability.r#async {
+                if config.gateway.observability.async_writes {
                     tokio::spawn(write_future);
                 } else {
                     write_future.await;
@@ -500,7 +500,7 @@ fn create_stream(
             } = metadata;
 
             let config = config.clone();
-            let async_write = config.gateway.observability.r#async;
+            let async_write = config.gateway.observability.async_writes;
             let write_future = async move {
                 let templates = &config.templates;
                 let collect_chunks_args = CollectChunksArgs {

--- a/tensorzero-internal/src/gateway_util.rs
+++ b/tensorzero-internal/src/gateway_util.rs
@@ -159,6 +159,7 @@ mod tests {
         let gateway_config = GatewayConfig {
             observability: ObservabilityConfig {
                 enabled: Some(false),
+                r#async: false,
             },
             bind_address: None,
             debug: false,
@@ -180,7 +181,10 @@ mod tests {
 
         // Default observability and no ClickHouse URL
         let gateway_config = GatewayConfig {
-            observability: ObservabilityConfig { enabled: None },
+            observability: ObservabilityConfig {
+                enabled: None,
+                r#async: false,
+            },
             ..Default::default()
         };
         let config = Box::leak(Box::new(Config {
@@ -203,6 +207,7 @@ mod tests {
         let gateway_config = GatewayConfig {
             observability: ObservabilityConfig {
                 enabled: Some(true),
+                r#async: false,
             },
             bind_address: None,
             debug: false,
@@ -222,6 +227,7 @@ mod tests {
         let gateway_config = GatewayConfig {
             observability: ObservabilityConfig {
                 enabled: Some(true),
+                r#async: false,
             },
             bind_address: None,
             debug: false,
@@ -243,6 +249,7 @@ mod tests {
         let gateway_config = GatewayConfig {
             observability: ObservabilityConfig {
                 enabled: Some(true),
+                r#async: false,
             },
             bind_address: None,
             debug: false,

--- a/tensorzero-internal/src/gateway_util.rs
+++ b/tensorzero-internal/src/gateway_util.rs
@@ -159,7 +159,7 @@ mod tests {
         let gateway_config = GatewayConfig {
             observability: ObservabilityConfig {
                 enabled: Some(false),
-                r#async: false,
+                async_writes: false,
             },
             bind_address: None,
             debug: false,
@@ -183,7 +183,7 @@ mod tests {
         let gateway_config = GatewayConfig {
             observability: ObservabilityConfig {
                 enabled: None,
-                r#async: false,
+                async_writes: false,
             },
             ..Default::default()
         };
@@ -207,7 +207,7 @@ mod tests {
         let gateway_config = GatewayConfig {
             observability: ObservabilityConfig {
                 enabled: Some(true),
-                r#async: false,
+                async_writes: false,
             },
             bind_address: None,
             debug: false,
@@ -227,7 +227,7 @@ mod tests {
         let gateway_config = GatewayConfig {
             observability: ObservabilityConfig {
                 enabled: Some(true),
-                r#async: false,
+                async_writes: false,
             },
             bind_address: None,
             debug: false,
@@ -249,7 +249,7 @@ mod tests {
         let gateway_config = GatewayConfig {
             observability: ObservabilityConfig {
                 enabled: Some(true),
-                r#async: false,
+                async_writes: false,
             },
             bind_address: None,
             debug: false,

--- a/tensorzero-internal/tests/e2e/feedback.rs
+++ b/tensorzero-internal/tests/e2e/feedback.rs
@@ -1,13 +1,29 @@
+use std::path::PathBuf;
+
 use reqwest::{Client, StatusCode};
 use serde_json::{json, Value};
 use tensorzero_internal::{
     clickhouse::ClickHouseConnectionInfo,
-    inference::types::{ContentBlockOutput, JsonInferenceOutput, Text},
+    inference::types::{ContentBlockOutput, JsonInferenceOutput, Role, Text},
 };
 use tokio::time::{sleep, Duration};
 use uuid::Uuid;
 
-use crate::common::{clickhouse_flush_async_insert, get_clickhouse, get_gateway_endpoint};
+use crate::common::{
+    clickhouse_flush_async_insert, get_clickhouse, get_gateway_endpoint, CLICKHOUSE_URL,
+};
+
+async fn make_embedded_gateway() -> tensorzero::Client {
+    let mut config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    config_path.push("tests/e2e/tensorzero.toml");
+    tensorzero::ClientBuilder::new(tensorzero::ClientBuilderMode::EmbeddedGateway {
+        config_path: Some(config_path),
+        clickhouse_url: Some(CLICKHOUSE_URL.clone()),
+    })
+    .build()
+    .await
+    .unwrap()
+}
 
 #[tokio::test]
 async fn e2e_test_comment_feedback() {
@@ -946,4 +962,70 @@ async fn select_feedback_tags_clickhouse(
         .unwrap();
     let json: Value = serde_json::from_str(&text).ok()?;
     Some(json)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fast_inference_then_feedback() {
+    use serde_json::json;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    // Create the client and wrap it in an Arc for shared ownership.
+    let client = make_embedded_gateway().await;
+    let client = Arc::new(client);
+
+    // Create a collection of tasks, each making an inference then a feedback call.
+    let tasks: Vec<_> = (0..20)
+        .map(|_| {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move {
+                let inference_payload = tensorzero::ClientInferenceParams {
+                    function_name: Some("basic_test".to_string()),
+                    model_name: None,
+                    variant_name: None,
+                    episode_id: None,
+                    input: tensorzero::Input {
+                        system: Some(json!({"assistant_name": "Alfred Pennyworth"})),
+                        messages: vec![tensorzero::InputMessage {
+                            role: Role::User,
+                            content: vec![tensorzero::InputMessageContent::Text {
+                                value: "What is the weather like in Tokyo (in Celsius)? Use the provided `get_temperature` tool. Do not say anything else, just call the function."
+                                    .to_string()
+                                    .into(),
+                            }],
+                        }],
+                    },
+                    stream: Some(false),
+                    ..Default::default()
+                };
+
+                // Send the inference request.
+                let response = client.inference(inference_payload).await.unwrap();
+                let response = if let tensorzero::InferenceOutput::NonStreaming(response) = response {
+                    response
+                } else {
+                    panic!("Expected non-streaming response");
+                };
+                let response = if let tensorzero::InferenceResponse::Chat(response) = response {
+                    response
+                } else {
+                    panic!("Expected chat response");
+                };
+                let inference_id = response.inference_id;
+
+                // Prepare and send the feedback request.
+                let feedback_payload = tensorzero::FeedbackParams {
+                    inference_id: Some(inference_id),
+                    episode_id: None,
+                    metric_name: "task_success".to_string(),
+                    value: json!(true),
+                    tags: HashMap::new(),
+                    dryrun: None,
+                };
+                client.feedback(feedback_payload).await.unwrap();
+            })
+        })
+        .collect();
+
+    // Wait for all tasks to finish.
+    futures::future::join_all(tasks).await;
 }


### PR DESCRIPTION
Changes in this PR:
* add a flag in `gateway.observability.async: bool` to the config defaulting to `false`
* if `async` is false, inference writes now are performed in the request
* changed the behavior of feedback to check for the `inference_id` or `episode_id` immediately and then check every 500ms for max(1, 5 - (current_time - uuid_time)) seconds and then 404 if not found.
* added tests for this behavior
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add synchronous write option and immediate feedback checks with retries in gateway configuration.
> 
>   - **Configuration**:
>     - Add `async_writes: bool` to `ObservabilityConfig` in `config_parser.rs`, defaulting to `false`.
>   - **Behavior**:
>     - If `async_writes` is `false`, inference writes are performed synchronously in `inference.rs`.
>     - Feedback checks for `inference_id` or `episode_id` immediately, then every 500ms for up to 5 seconds in `feedback.rs`.
>   - **Tests**:
>     - Add tests for feedback behavior in `feedback.rs` and `e2e/feedback.rs`.
>     - Add test for fast inference and feedback in `e2e/feedback.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for bb3b41fdedb489ab7f057a4fe21df4e2d7582b08. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->