### PR TITLE
Log an error if we fail to serialize ModelInferenceDatabaseInsert

### DIFF
--- a/tensorzero-internal/src/inference/types/mod.rs
+++ b/tensorzero-internal/src/inference/types/mod.rs
@@ -600,7 +600,18 @@ impl InferenceResult {
             .iter()
             .map(|r| {
                 let model_inference = ModelInferenceDatabaseInsert::new(r.clone(), inference_id);
-                serde_json::to_value(model_inference).unwrap_or_default()
+                match serde_json::to_value(model_inference) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        ErrorDetails::Serialization {
+                            message: format!(
+                                "Failed to serialize ModelInferenceDatabaseInsert: {e:?}"
+                            ),
+                        }
+                        .log();
+                        Default::default()
+                    }
+                }
             })
             .collect()
     }


### PR DESCRIPTION
We were silently ignoring any serde_json errors that occured during serialization.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Logs an error if serialization of `ModelInferenceDatabaseInsert` fails in `get_serialized_model_inferences()` of `InferenceResult`.
> 
>   - **Behavior**:
>     - Logs an error if `serde_json::to_value()` fails in `get_serialized_model_inferences()` in `InferenceResult`.
>     - Uses `ErrorDetails::Serialization` to log the error message.
>   - **Error Handling**:
>     - Returns `Default::default()` on serialization failure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e44492ccd4850821304659704ce94eeb39e6d194. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->