### PR TITLE
Add more retries with higher delays for bedrock tests on ci

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,6 +15,10 @@ default-filter = "not test(no_aws_credentials)"
 retries = { backoff = "exponential", count = 4, delay = "5s", jitter = true, max-delay = "60s" }
 default-filter = "all()"
 
+[[profile.ci.overrides]]
+filter = 'binary(e2e) and test(providers::aws_bedrock::)'
+retries = { backoff = "exponential", count = 8, delay = "5s", jitter = true, max-delay = "120s" }
+
 # Note: use the following commands to debug test groups:
 # cargo nextest show-config test-groups
 # cargo nextest show-config test-groups --features e2e_tests


### PR DESCRIPTION
This should hopefully make at least one of the retries succeed when we have multiple merge queue jobs running in parallel (which can exhaust our bedrock rate limit)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase retries and delay for `providers::aws_bedrock::` tests in CI to handle rate limits better.
> 
>   - **CI Profile Changes**:
>     - In `.config/nextest.toml`, increased retries for `providers::aws_bedrock::` tests to 8 with exponential backoff, delay of 5s, and max-delay of 120s.
>   - **Purpose**:
>     - Aims to improve test success rates under high load by handling bedrock rate limits better.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8b40cb046ae021f61ea5f6921e2242efea975a5b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->