### PR TITLE
Add in `OpenAIUserContent` blocks (only `Text` for now)

### DIFF
--- a/tensorzero-internal/src/inference/providers/openai.rs
+++ b/tensorzero-internal/src/inference/providers/openai.rs
@@ -3137,4 +3137,33 @@ mod tests {
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
     }
+
+    #[test]
+    fn test_serialize_user_messages() {
+        // Test that a single message is serialized as 'content: string'
+        let message = OpenAIUserRequestMessage {
+            content: vec![OpenAIUserContent::Text {
+                text: "My single message".into(),
+            }],
+        };
+        let serialized = serde_json::to_string(&message).unwrap();
+        assert_eq!(serialized, r#"{"content":"My single message"}"#);
+
+        // Test that a multiple messages are serialized as an array of content blocks
+        let message = OpenAIUserRequestMessage {
+            content: vec![
+                OpenAIUserContent::Text {
+                    text: "My first message".into(),
+                },
+                OpenAIUserContent::Text {
+                    text: "My second message".into(),
+                },
+            ],
+        };
+        let serialized = serde_json::to_string(&message).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"content":[{"type":"text","text":"My first message"},{"type":"text","text":"My second message"}]}"#
+        );
+    }
 }


### PR DESCRIPTION
This is preperation for supporting multi-modal input. We now construct OpenAI user content as a vec of `OpenAIUserContent`, instead of a string. When implementing multi-modal support, we'll add and use `OpenAIUserContent::Image`.

We encode a single-element
vec (`vec![OpenAIUserContent::Text { text: "Some message".into() }]`) as a string ("Some Message") rather an array. This maintains compatibility with older openai-compatible providers which do not support a content block array within a user message.

The Deepseek api does support this, so I've modified our 'coalesce' logic to construct mutliple `OpenAIUserContent::Text` blocks, rather than performing string concatenation.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `OpenAIUserContent` enum for multi-modal input support, updating message handling and serialization logic.
> 
>   - **Behavior**:
>     - Introduces `OpenAIUserContent` enum in `openai.rs` to support multi-modal input, starting with `Text`.
>     - Updates `OpenAIUserRequestMessage` to use `Vec<OpenAIUserContent>` instead of `Cow<str>`.
>     - Serializes single `Text` block as string for compatibility with older providers.
>     - Modifies `coalesce_consecutive_messages` in `deepseek.rs` to handle multiple `OpenAIUserContent::Text` blocks.
>   - **Tests**:
>     - Adds tests in `openai.rs` and `deepseek.rs` to verify serialization of `OpenAIUserRequestMessage` and message coalescing logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for dbc578cba5e401adf50a9419b5108f5e9fc55674. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->