### PR TITLE
Use TENSORZERO_E2E_PROXY in embedded gateway tests

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -99,9 +99,10 @@ jobs:
         run: |
           curl ${{ secrets.CLICKHOUSE_CLOUD_URL }} --data-binary 'SHOW DATABASES' > clickhouse_wakeup_logs.txt &
 
+      # We set 'TENSORZERO_E2E_PROXY' here so that embedded gateway tests can use it
       - name: Run all tests (including E2E tests)
         run: |
-          cargo test-all --profile ci ${{ vars.CARGO_NEXTEST_ARGS }}
+          TENSORZERO_E2E_PROXY="http://localhost:3003" cargo test-all --profile ci ${{ vars.CARGO_NEXTEST_ARGS }}
 
       - name: Print e2e logs
         if: always()

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use tensorzero_internal::{
     config_parser::Config,
     error::ErrorDetails,
-    gateway_util::{setup_clickhouse, AppStateData},
+    gateway_util::{setup_clickhouse, setup_http_client, AppStateData},
 };
 use thiserror::Error;
 use tokio_stream::StreamExt;
@@ -97,7 +97,7 @@ pub enum ClientBuilderError {
     #[error("Failed to parse config: {0}")]
     ConfigParsing(TensorZeroError),
     #[error("Failed to build HTTP client: {0}")]
-    HTTPClientBuild(reqwest::Error),
+    HTTPClientBuild(TensorZeroError),
 }
 
 /// Controls how a `Client` is run
@@ -152,11 +152,20 @@ impl ClientBuilder {
                     .map_err(|e| {
                         ClientBuilderError::Clickhouse(TensorZeroError::Other { source: e.into() })
                     })?;
+                let http_client = if let Some(http_client) = self.http_client {
+                    http_client
+                } else {
+                    setup_http_client().map_err(|e| {
+                        ClientBuilderError::HTTPClientBuild(TensorZeroError::Other {
+                            source: e.into(),
+                        })
+                    })?
+                };
                 Ok(Client {
                     mode: ClientMode::EmbeddedGateway(EmbeddedGateway {
                         state: AppStateData {
                             config,
-                            http_client: self.http_client.unwrap_or_default(),
+                            http_client,
                             clickhouse_connection_info,
                         },
                     }),


### PR DESCRIPTION
We were previously only setting (and reading) this when running the standalone gateway in e2e test mode, so embedded gateway tests were not making use of the provider-proxy cache.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `TENSORZERO_E2E_PROXY` for embedded gateway tests and update HTTP client setup in `lib.rs`.
> 
>   - **Behavior**:
>     - Set `TENSORZERO_E2E_PROXY` in `.github/workflows/merge-queue.yml` for embedded gateway tests to use the provider-proxy cache.
>     - Modify `ClientBuilder` in `lib.rs` to use `setup_http_client()` if no HTTP client is provided in embedded mode.
>   - **Functions**:
>     - Update `build()` in `ClientBuilder` to conditionally initialize `http_client` using `setup_http_client()` in `lib.rs`.
>   - **Misc**:
>     - Add `setup_http_client` to imports in `lib.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c106e4b8f71788f9c8dd4d4d515e54aad916e637. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->