### PR TITLE
added a migration rebuilding dataset tables with nullable output

### DIFF
--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0014.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0014.rs
@@ -12,6 +12,9 @@ use super::{check_table_exists, get_column_type};
 ///
 /// This migration should subsume migration 0012.
 /// They should have been removed from the binary upon merging of this migration.
+///
+/// There were two changes made form 0014: changing created_at to updated_at and
+/// changing the output column to be Nullable(String) instead of String.
 pub struct Migration0014<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
@@ -82,8 +85,8 @@ impl Migration for Migration0014<'_> {
                 tags Map(String, String),
                 auxiliary String, -- a JSON (unstructured, for now)
                 is_deleted Bool DEFAULT false,
-                created_at DateTime DEFAULT now()
-            ) ENGINE = ReplacingMergeTree(created_at, is_deleted)
+                updated_at DateTime DEFAULT now()
+            ) ENGINE = ReplacingMergeTree(updated_at, is_deleted)
             ORDER BY (dataset_name, function_name, id)
         "#;
         let _ = self.clickhouse.run_query(query.to_string(), None).await?;
@@ -102,8 +105,8 @@ impl Migration for Migration0014<'_> {
                 tags Map(String, String),
                 auxiliary String, -- a JSON (unstructured, for now)
                 is_deleted Bool DEFAULT false,
-                created_at DateTime DEFAULT now()
-            ) ENGINE = ReplacingMergeTree(created_at, is_deleted)
+                updated_at DateTime DEFAULT now()
+            ) ENGINE = ReplacingMergeTree(updated_at, is_deleted)
             ORDER BY (dataset_name, function_name, id)
         "#;
         let _ = self.clickhouse.run_query(query.to_string(), None).await?;

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0014.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0014.rs
@@ -35,9 +35,9 @@ impl Migration for Migration0014<'_> {
     /// OR if they exist and either `output` column is not Nullable(String)
     async fn should_apply(&self) -> Result<bool, Error> {
         let chat_inference_dataset_table_exists =
-            check_table_exists(self.clickhouse, "ChatInferenceDataset", "0012").await?;
+            check_table_exists(self.clickhouse, "ChatInferenceDataset", "0014").await?;
         let json_inference_dataset_table_exists =
-            check_table_exists(self.clickhouse, "JsonInferenceDataset", "0012").await?;
+            check_table_exists(self.clickhouse, "JsonInferenceDataset", "0014").await?;
         if !chat_inference_dataset_table_exists || !json_inference_dataset_table_exists {
             return Ok(true);
         }

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0014.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0014.rs
@@ -1,0 +1,128 @@
+use crate::clickhouse::ClickHouseConnectionInfo;
+use crate::clickhouse_migration_manager::migration_trait::Migration;
+use crate::error::{Error, ErrorDetails};
+
+use super::{check_table_exists, get_column_type};
+
+/// This migration is used to set up the ClickHouse database for the datasets feature.
+/// It creates two tables: `ChatInferenceDataset` and `JsonInferenceDataset`
+/// These tables store the information required to do things like run evals,
+/// implement dynamic in-context learning, and run curated SFT jobs.
+/// We anticipate unpredictable future uses for datasets as well.
+///
+/// This migration should subsume migration 0012.
+/// They should have been removed from the binary upon merging of this migration.
+pub struct Migration0014<'a> {
+    pub clickhouse: &'a ClickHouseConnectionInfo,
+}
+
+impl Migration for Migration0014<'_> {
+    /// Check if you can connect to the database
+    async fn can_apply(&self) -> Result<(), Error> {
+        self.clickhouse.health().await.map_err(|e| {
+            Error::new(ErrorDetails::ClickHouseMigration {
+                id: "0014".to_string(),
+                message: e.to_string(),
+            })
+        })?;
+
+        Ok(())
+    }
+
+    /// Check if the migration needs to be applied
+    /// This should be equivalent to checking if `ChatInferenceDataset` is missing
+    /// or if `JsonInferenceDataset` is missing
+    /// OR if they exist and either `output` column is not Nullable(String)
+    async fn should_apply(&self) -> Result<bool, Error> {
+        let chat_inference_dataset_table_exists =
+            check_table_exists(self.clickhouse, "ChatInferenceDataset", "0012").await?;
+        let json_inference_dataset_table_exists =
+            check_table_exists(self.clickhouse, "JsonInferenceDataset", "0012").await?;
+        if !chat_inference_dataset_table_exists || !json_inference_dataset_table_exists {
+            return Ok(true);
+        }
+
+        let chat_inference_dataset_output_type =
+            get_column_type(self.clickhouse, "ChatInferenceDataset", "output", "0014").await?;
+        let json_inference_dataset_output_type =
+            get_column_type(self.clickhouse, "JsonInferenceDataset", "output", "0014").await?;
+        if chat_inference_dataset_output_type != "Nullable(String)"
+            || json_inference_dataset_output_type != "Nullable(String)"
+        {
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    async fn apply(&self) -> Result<(), Error> {
+        // First, drop the tables if they were created in 0012
+        let query = "DROP TABLE IF EXISTS ChatInferenceDataset";
+        let _ = self.clickhouse.run_query(query.to_string(), None).await?;
+
+        let query = "DROP TABLE IF EXISTS JsonInferenceDataset";
+        let _ = self.clickhouse.run_query(query.to_string(), None).await?;
+
+        // Create the `ChatInferenceDataset` table
+        let query = r#"
+            CREATE TABLE IF NOT EXISTS ChatInferenceDataset
+            (
+                dataset_name LowCardinality(String),
+                function_name LowCardinality(String),
+                id UUID, -- more important to join than to
+                        -- sort and sorting expected dataset sizes should be cheap
+                        -- If this example is generated from an inference then this
+                        -- should be the inference ID
+                episode_id UUID,
+                input String,
+                output Nullable(String),
+                tool_params String,
+                -- Don't think we need inference params, processing time,
+                -- timestamp, variant_name
+                tags Map(String, String),
+                auxiliary String, -- a JSON (unstructured, for now)
+                is_deleted Bool DEFAULT false,
+                created_at DateTime DEFAULT now()
+            ) ENGINE = ReplacingMergeTree(created_at, is_deleted)
+            ORDER BY (dataset_name, function_name, id)
+        "#;
+        let _ = self.clickhouse.run_query(query.to_string(), None).await?;
+
+        // Create the `JsonInferenceDataset` table
+        let query = r#"
+            CREATE TABLE IF NOT EXISTS JsonInferenceDataset
+            (
+                dataset_name LowCardinality(String),
+                function_name LowCardinality(String),
+                id UUID, -- same comment as above
+                episode_id UUID,
+                input String,
+                output Nullable(String),
+                output_schema String,
+                tags Map(String, String),
+                auxiliary String, -- a JSON (unstructured, for now)
+                is_deleted Bool DEFAULT false,
+                created_at DateTime DEFAULT now()
+            ) ENGINE = ReplacingMergeTree(created_at, is_deleted)
+            ORDER BY (dataset_name, function_name, id)
+        "#;
+        let _ = self.clickhouse.run_query(query.to_string(), None).await?;
+
+        Ok(())
+    }
+
+    fn rollback_instructions(&self) -> String {
+        "\
+            -- Drop the tables\n\
+            DROP TABLE IF EXISTS ChatInferenceDataset;\n\
+            DROP TABLE IF EXISTS JsonInferenceDataset;\n\
+            "
+        .to_string()
+    }
+
+    /// Check if the migration has succeeded (i.e. it should not be applied again)
+    async fn has_succeeded(&self) -> Result<bool, Error> {
+        let should_apply = self.should_apply().await?;
+        Ok(!should_apply)
+    }
+}

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/mod.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/mod.rs
@@ -15,8 +15,9 @@ pub mod migration_0008;
 pub mod migration_0009;
 // pub mod migration_0010;
 pub mod migration_0011;
-pub mod migration_0012;
+// pub mod migration_0012;
 pub mod migration_0013;
+pub mod migration_0014;
 
 /// Returns true if the table exists, false if it does not
 /// Errors if the query fails

--- a/tensorzero-internal/src/clickhouse_migration_manager/mod.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/mod.rs
@@ -13,8 +13,9 @@ use migrations::migration_0006::Migration0006;
 use migrations::migration_0008::Migration0008;
 use migrations::migration_0009::Migration0009;
 use migrations::migration_0011::Migration0011;
-use migrations::migration_0012::Migration0012;
+// use migrations::migration_0012::Migration0012;
 use migrations::migration_0013::Migration0013;
+use migrations::migration_0014::Migration0014;
 
 pub async fn run(clickhouse: &ClickHouseConnectionInfo) -> Result<(), Error> {
     // This is a no-op if the database already exists
@@ -51,12 +52,14 @@ pub async fn run(clickhouse: &ClickHouseConnectionInfo) -> Result<(), Error> {
     // })
     // .await?;
     run_migration(&Migration0011 { clickhouse }).await?;
-    run_migration(&Migration0012 { clickhouse }).await?;
+    // BANNED: This migration is no longer needed because it is deleted and replaced by migration 0014
+    // run_migration(&Migration0012 { clickhouse }).await?;
     run_migration(&Migration0013 {
         clickhouse,
         clean_start,
     })
     .await?;
+    run_migration(&Migration0014 { clickhouse }).await?;
     // NOTE:
     // When we add more migrations, we need to add a test that applies them in a cumulative (N^2) way.
     //

--- a/tensorzero-internal/tests/e2e/clickhouse.rs
+++ b/tensorzero-internal/tests/e2e/clickhouse.rs
@@ -16,8 +16,9 @@ use tensorzero_internal::clickhouse_migration_manager::migrations::migration_000
 use tensorzero_internal::clickhouse_migration_manager::migrations::migration_0008::Migration0008;
 use tensorzero_internal::clickhouse_migration_manager::migrations::migration_0009::Migration0009;
 use tensorzero_internal::clickhouse_migration_manager::migrations::migration_0011::Migration0011;
-use tensorzero_internal::clickhouse_migration_manager::migrations::migration_0012::Migration0012;
 use tensorzero_internal::clickhouse_migration_manager::migrations::migration_0013::Migration0013;
+use tensorzero_internal::clickhouse_migration_manager::migrations::migration_0014::Migration0014;
+
 fn get_clean_clickhouse() -> ClickHouseConnectionInfo {
     let database = format!(
         "tensorzero_e2e_tests_migration_manager_{}",
@@ -429,9 +430,13 @@ async fn test_clickhouse_migration_manager() {
         clickhouse_migration_manager::run_migration(&Migration0011 { clickhouse })
             .await
             .unwrap();
-        clickhouse_migration_manager::run_migration(&Migration0012 { clickhouse })
-            .await
-            .unwrap();
+        clickhouse_migration_manager::run_migration(&Migration0013 {
+            clickhouse,
+            clean_start: true,
+        })
+        .await
+        .unwrap();
+
         assert!(!logs_contain("Failed to apply migration"));
         assert!(!logs_contain("Failed migration success check"));
         assert!(!logs_contain("Failed to verify migration"));
@@ -454,8 +459,8 @@ async fn test_clickhouse_migration_manager() {
         assert!(!logs_contain("Migration succeeded: Migration0009"));
         assert!(!logs_contain("Applying migration: Migration0011"));
         assert!(!logs_contain("Migration succeeded: Migration0011"));
-        assert!(logs_contain("Applying migration: Migration0012"));
-        assert!(logs_contain("Migration succeeded: Migration0012"));
+        assert!(logs_contain("Applying migration: Migration0013"));
+        assert!(logs_contain("Migration succeeded: Migration0013"));
     }
 
     #[traced_test]
@@ -494,15 +499,15 @@ async fn test_clickhouse_migration_manager() {
         clickhouse_migration_manager::run_migration(&Migration0011 { clickhouse })
             .await
             .unwrap();
-        clickhouse_migration_manager::run_migration(&Migration0012 { clickhouse })
-            .await
-            .unwrap();
         clickhouse_migration_manager::run_migration(&Migration0013 {
             clickhouse,
             clean_start: true,
         })
         .await
         .unwrap();
+        clickhouse_migration_manager::run_migration(&Migration0014 { clickhouse })
+            .await
+            .unwrap();
 
         assert!(!logs_contain("Failed to apply migration"));
         assert!(!logs_contain("Failed migration success check"));
@@ -526,10 +531,10 @@ async fn test_clickhouse_migration_manager() {
         assert!(!logs_contain("Migration succeeded: Migration0009"));
         assert!(!logs_contain("Applying migration: Migration0011"));
         assert!(!logs_contain("Migration succeeded: Migration0011"));
-        assert!(!logs_contain("Applying migration: Migration0012"));
-        assert!(!logs_contain("Migration succeeded: Migration0012"));
-        assert!(logs_contain("Applying migration: Migration0013"));
-        assert!(logs_contain("Migration succeeded: Migration0013"));
+        assert!(!logs_contain("Applying migration: Migration0013"));
+        assert!(!logs_contain("Migration succeeded: Migration0013"));
+        assert!(logs_contain("Applying migration: Migration0014"));
+        assert!(logs_contain("Migration succeeded: Migration0014"));
     }
 
     #[traced_test]
@@ -568,15 +573,15 @@ async fn test_clickhouse_migration_manager() {
         clickhouse_migration_manager::run_migration(&Migration0011 { clickhouse })
             .await
             .unwrap();
-        clickhouse_migration_manager::run_migration(&Migration0012 { clickhouse })
-            .await
-            .unwrap();
         clickhouse_migration_manager::run_migration(&Migration0013 {
             clickhouse,
             clean_start: true,
         })
         .await
         .unwrap();
+        clickhouse_migration_manager::run_migration(&Migration0014 { clickhouse })
+            .await
+            .unwrap();
 
         assert!(!logs_contain("Failed to apply migration"));
         assert!(!logs_contain("Failed migration success check"));
@@ -600,10 +605,10 @@ async fn test_clickhouse_migration_manager() {
         assert!(!logs_contain("Migration succeeded: Migration0009"));
         assert!(!logs_contain("Applying migration: Migration0011"));
         assert!(!logs_contain("Migration succeeded: Migration0011"));
-        assert!(!logs_contain("Applying migration: Migration0012"));
-        assert!(!logs_contain("Migration succeeded: Migration0012"));
         assert!(!logs_contain("Applying migration: Migration0013"));
         assert!(!logs_contain("Migration succeeded: Migration0013"));
+        assert!(!logs_contain("Applying migration: Migration0014"));
+        assert!(!logs_contain("Migration succeeded: Migration0014"));
     }
 
     first(&clickhouse).await;


### PR DESCRIPTION
Adds migration 0014 which is a near-copy of migration 0012 but with the change that the output column is nullable.
* We deprecate migration 0012 
* we add a migration migration that defensively drops the tables from 0012 if it exists and then rebuilds the tables.
* Added e2e tests for the new migration
* Tables added are `ChatInferenceDataset` and `JsonInferenceDataset`

Important note: neither of the `ChatInferenceDataset` and `JsonInferenceDataset` tables was used. So we can safely drop and recreate.

I manually tested adding 0014 on top of the existing migrations before removing them from the codebase.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add migration 0014 to create dataset tables with nullable output, deprecating migration 0012, and add E2E tests.
> 
>   - **Migration 0014**:
>     - Adds `migration_0014.rs` to create `ChatInferenceDataset` and `JsonInferenceDataset` tables with nullable `output` column.
>     - Deprecates and removes `migration_0012`.
>     - Drops existing tables from `migration_0012` if they exist and recreates them.
>     - Ensures tables are empty before applying changes.
>   - **Testing**:
>     - Adds E2E tests in `clickhouse.rs` to verify `migration_0014`.
>   - **Misc**:
>     - Updates `mod.rs` to include `migration_0014` and exclude `migration_0012`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a895a080c1b0ffbe6614456a57952e3173d03ca0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->