### PR TITLE
Only check that 'last_chunk_duration' is positive in tests

### DIFF
--- a/clients/python-pyo3/tests/test_client.py
+++ b/clients/python-pyo3/tests/test_client.py
@@ -379,7 +379,7 @@ async def test_async_reasoning_inference_streaming(async_client):
         previous_chunk_timestamp = time.time()
         chunks.append(chunk)
 
-    assert last_chunk_duration > 0.01
+    assert last_chunk_duration > 0
     expected_thinking = [
         "hmmm",
         "hmmm",
@@ -1179,7 +1179,7 @@ def test_sync_reasoning_inference_streaming(sync_client):
         previous_chunk_timestamp = time.time()
         chunks.append(chunk)
 
-    assert last_chunk_duration > 0.01
+    assert last_chunk_duration > 0
     expected_thinking = [
         "hmmm",
         "hmmm",

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -151,7 +151,7 @@ async def test_async_inference_streaming(async_client):
         previous_chunk_timestamp = time()
         chunks.append(chunk)
 
-    assert last_chunk_duration > 0.01
+    assert last_chunk_duration > 0
 
     expected_text = [
         "Wally,",
@@ -214,7 +214,7 @@ async def test_async_reasoning_inference_streaming(async_client):
         previous_chunk_timestamp = time()
         chunks.append(chunk)
 
-    assert last_chunk_duration > 0.01
+    assert last_chunk_duration > 0
     expected_thinking = [
         "hmmm",
         "hmmm",
@@ -741,7 +741,7 @@ def test_sync_inference_streaming(sync_client):
         previous_chunk_timestamp = time()
         chunks.append(chunk)
 
-    assert last_chunk_duration > 0.01
+    assert last_chunk_duration > 0
 
     expected_text = [
         "Wally,",
@@ -971,7 +971,7 @@ def test_sync_reasoning_inference_streaming(sync_client):
         previous_chunk_timestamp = time()
         chunks.append(chunk)
 
-    assert last_chunk_duration > 0.01
+    assert last_chunk_duration > 0
     expected_thinking = [
         "hmmm",
         "hmmm",


### PR DESCRIPTION
The duration is occasionally faster than 0.01 seconds, which causes the test to fail on ci.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update test assertions to check `last_chunk_duration > 0` in `test_client.py` files to prevent CI failures.
> 
>   - **Tests**:
>     - Change assertion in `test_async_reasoning_inference_streaming` and `test_sync_reasoning_inference_streaming` in `clients/python-pyo3/tests/test_client.py` to check `last_chunk_duration > 0`.
>     - Change assertion in `test_async_inference_streaming` and `test_sync_inference_streaming` in `clients/python/tests/test_client.py` to check `last_chunk_duration > 0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 79db72ae0896bc54771dbfa477ceca644d79adb6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->