### PR TITLE
Remove `-C target-cpu=native` from our .cargo/config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,5 @@
 [target.'cfg(not(target_arch = "wasm32"))']
 rustflags = [
-    "-C",
-    "target-cpu=native",
     "--cfg",
     "aws_sdk_unstable",  # needed for aws-smithy-types + serde-(de)serialize
 ]


### PR DESCRIPTION
This was causing us to produce artifacts (docker images and python wheels) that were specialized to the cpu of the *build* machine, which may crash on older cpus.

Users can still set this manually when compiling tensorzero for their own machines, but we shouldn't turn it on ourselves.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `-C target-cpu=native` from `.cargo/config.toml` to ensure compatibility with older CPUs.
> 
>   - **Behavior**:
>     - Remove `-C target-cpu=native` from `.cargo/config.toml` to prevent producing CPU-specific artifacts.
>     - Ensures compatibility with older CPUs by not specializing artifacts to the build machine's CPU.
>   - **Configuration**:
>     - Users can manually set `-C target-cpu=native` if needed for personal builds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 39d6b78c81e2ae416c5ed52f4ab731ef0ed0efa9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->