### PR TITLE
Bump tensorzero-python to 0.3.2 for testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "futures",
  "pyo3",

--- a/clients/python-pyo3/Cargo.toml
+++ b/clients/python-pyo3/Cargo.toml
@@ -3,7 +3,7 @@
 # It's named 'tensorzero-python' to avoid confusion with the Rust client
 # (which has a crate name of 'tensorzero')
 name = "tensorzero-python"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
This will just be published to testpypi

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `tensorzero-python` version to 0.3.2 for testing purposes, updating `Cargo.lock` and `clients/python-pyo3/Cargo.toml`.
> 
>   - **Version Update**:
>     - Bump `tensorzero-python` version from `0.3.1` to `0.3.2` in `Cargo.lock` and `clients/python-pyo3/Cargo.toml`.
>   - **Purpose**:
>     - Update intended for testing, to be published to testpypi.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d082ca5f73d20026b4826a0f7509d8fa8d3c34a3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->