### PR TITLE
Emit UserWarning when `build_embedded` is called without config path

### DIFF
--- a/clients/python-pyo3/tests/test_client.py
+++ b/clients/python-pyo3/tests/test_client.py
@@ -70,9 +70,10 @@ async def async_client(request):
 
 
 def test_sync_embedded_gateway_no_config():
+    with pytest.warns(UserWarning, match="No config file provided"):
+        client = TensorZeroGateway.build_embedded()
     with pytest.raises(TensorZeroError) as exc_info:
-        with TensorZeroGateway.build_embedded() as client:
-            client.inference(function_name="my_missing_func", input={})
+        client.inference(function_name="my_missing_func", input={})
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.text == '{"error":"Unknown function: my_missing_func"}'
@@ -80,9 +81,10 @@ def test_sync_embedded_gateway_no_config():
 
 @pytest.mark.asyncio
 async def test_async_embedded_gateway_no_config():
+    with pytest.warns(UserWarning, match="No config file provided"):
+        client = await AsyncTensorZeroGateway.build_embedded()
     with pytest.raises(TensorZeroError) as exc_info:
-        async with await AsyncTensorZeroGateway.build_embedded() as client:
-            await client.inference(function_name="my_missing_func", input={})
+        await client.inference(function_name="my_missing_func", input={})
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.text == '{"error":"Unknown function: my_missing_func"}'

--- a/clients/python-pyo3/uv.lock
+++ b/clients/python-pyo3/uv.lock
@@ -91,7 +91,6 @@ wheels = [
 
 [[package]]
 name = "tensorzero"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

Fixes #1073
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Emit `UserWarning` when `build_embedded` is called without a config path in `TensorZeroGateway` and `AsyncTensorZeroGateway`.
> 
>   - **Behavior**:
>     - Emit `UserWarning` in `warn_no_config()` in `lib.rs` when `build_embedded` is called without `config_path`.
>     - Affects `TensorZeroGateway.build_embedded()` and `AsyncTensorZeroGateway.build_embedded()`.
>   - **Tests**:
>     - Update `test_sync_embedded_gateway_no_config()` and `test_async_embedded_gateway_no_config()` in `test_client.py` to expect `UserWarning` when no config path is provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 01627901b384ce3975188f9dddb2a1227e1e87c7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->