### PR TITLE
Install pytest-xdist and use 'pytest -n auto' for python-pyo3

### DIFF
--- a/clients/python-pyo3/requirements.in
+++ b/clients/python-pyo3/requirements.in
@@ -1,5 +1,6 @@
 pytest
 pytest-asyncio
+pytest-xdist
 maturin
 uuid_utils
 httpx

--- a/clients/python-pyo3/requirements.txt
+++ b/clients/python-pyo3/requirements.txt
@@ -10,6 +10,8 @@ exceptiongroup==1.2.2
     # via
     #   anyio
     #   pytest
+execnet==2.1.1
+    # via pytest-xdist
 h11==0.14.0
     # via httpcore
 httpcore==1.0.7
@@ -36,7 +38,10 @@ pytest==8.3.4
     # via
     #   -r requirements.in
     #   pytest-asyncio
+    #   pytest-xdist
 pytest-asyncio==0.25.3
+    # via -r requirements.in
+pytest-xdist==3.6.1
     # via -r requirements.in
 sniffio==1.3.1
     # via anyio

--- a/clients/python-pyo3/test.sh
+++ b/clients/python-pyo3/test.sh
@@ -2,4 +2,4 @@
 
 set -euxo pipefail
 uv run maturin develop --uv --features e2e_tests
-uv run pytest $@
+uv run pytest -n auto $@

--- a/clients/python-pyo3/uv.lock
+++ b/clients/python-pyo3/uv.lock
@@ -91,7 +91,6 @@ wheels = [
 
 [[package]]
 name = "tensorzero"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
This will run our tests in parallel

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `pytest-xdist` for parallel test execution in `python-pyo3` client and update test script accordingly.
> 
>   - **Testing**:
>     - Install `pytest-xdist` in `requirements.in` and `requirements.txt` for parallel test execution.
>     - Modify `test.sh` to use `pytest -n auto` for running tests in parallel.
>   - **Dependencies**:
>     - Add `execnet` as a dependency in `requirements.txt` via `pytest-xdist`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for dde741a1e4b528b65bdc0c48542c6b2c3cf89f91. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->