### PR TITLE
Include a new '.cargo/config' file in 'maturin sdist'

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Try installing sdist
         run: |
           uv venv
-          uv pip install ./clients/python-pyo3/dist/tensorzero-*.tar.gz
+          uv pip install ./clients/python-pyo3/dist/tensorzero-*.tar.gz -v
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -165,7 +165,9 @@ jobs:
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/0.5.25/install.sh | sh
       - name: Try installing sdist
-        run: uv pip install ./clients/python-pyo3/dist/tensorzero-*.tar.gz
+        run: |
+          uv venv
+          uv pip install ./clients/python-pyo3/dist/tensorzero-*.tar.gz
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -164,10 +164,10 @@ jobs:
           path: ./clients/python-pyo3/dist
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/0.5.25/install.sh | sh
-      - name: Try installing sdist
+      - name: Check local sdist
         run: |
-          uv venv
-          uv pip install ./clients/python-pyo3/dist/tensorzero-*.tar.gz -v
+          ./ci/check-local-wheel.sh ./clients/python-pyo3/dist/tensorzero-*.tar.gz
+
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -162,7 +162,10 @@ jobs:
         with:
           name: wheels-sdist
           path: ./clients/python-pyo3/dist
-
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/0.5.25/install.sh | sh
+      - name: Try installing sdist
+        run: uv pip install ./clients/python-pyo3/dist/tensorzero-*.tar.gz
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/ci/check-local-wheel.sh
+++ b/ci/check-local-wheel.sh
@@ -2,5 +2,5 @@
 set -euxo pipefail
 
 uv venv
-uv pip install $1
+uv pip install $1 -v
 uv run python -c 'import tensorzero; print(tensorzero.tensorzero.__file__)'

--- a/clients/python-pyo3/.cargo/config.toml
+++ b/clients/python-pyo3/.cargo/config.toml
@@ -1,0 +1,11 @@
+# Note - this is a duplicate of the rustflags in the `.cargo/config.toml` file
+# in the root of the repository
+# We can't use `[tools.maturin.include]` with a file from parent directory,
+# so we need a .cargo/config inside `python-pyo3`
+# During a normal build, cargo will pick up both of these config.toml files -
+# that's fine, as we'll just end up passing the same cfg twice.
+[target.'cfg(not(target_arch = "wasm32"))']
+rustflags = [
+    "--cfg",
+    "aws_sdk_unstable",  # needed for aws-smithy-types + serde-(de)serialize
+]

--- a/clients/python-pyo3/pyproject.toml
+++ b/clients/python-pyo3/pyproject.toml
@@ -11,4 +11,5 @@ dynamic = ["version"]
 
 [tool.maturin]
 features = ["pyo3/extension-module"]
+include = [".cargo/*"]
 strip = true


### PR DESCRIPTION
This is needed to make the sdist useable, since we need our rustflags to include `--cfg aws_sdk_unstable`

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `.cargo/config.toml` to include Rust flags in `sdist` and update CI to verify `sdist`.
> 
>   - **Configuration**:
>     - Add `.cargo/config.toml` in `clients/python-pyo3` to include `rustflags` for `aws_sdk_unstable`.
>     - Update `pyproject.toml` to include `.cargo/*` in `sdist`.
>   - **CI/CD**:
>     - Update `pypi-publish.yml` to install `uv` and check local `sdist` with `check-local-wheel.sh`.
>     - Modify `check-local-wheel.sh` to install package with verbose output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2a46858d73469539343700438096b07bed2a02af. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->