### PR TITLE
Publish to TestPyPI or real PyPI based on invocation type

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -183,6 +183,12 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: "wheels-*/*"
-      - name: Publish to PyPI
+
+      - name: Publish to real PyPI (only on GitHub release)
+        if: ${{ github.event_name == 'release' }}
         run: |
-          ./ci/upload-pyo3.sh
+          ./ci/upload-pyo3.sh pypi
+
+      - name: Publish to TestPyPI
+        run: |
+          ./ci/upload-pyo3.sh testpypi

--- a/ci/upload-pyo3.sh
+++ b/ci/upload-pyo3.sh
@@ -6,4 +6,4 @@ curl -LsSf https://astral.sh/uv/0.5.24/install.sh | sh
 cd ../clients/python-pyo3
 uv venv
 uv pip sync requirements.txt
-uv run maturin upload -v --repository testpypi --non-interactive --skip-existing ../../wheels-*/*
+uv run maturin upload -v --repository $1 --non-interactive --skip-existing ../../wheels-*/*


### PR DESCRIPTION
We always publish a release to TestPyPI in the workflow.
If the workflow was started from a Github release, we will also publish to the real PyPI

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Conditional publishing to real PyPI on GitHub release and dynamic repository selection in `upload-pyo3.sh`.
> 
>   - **Workflow Changes**:
>     - In `.github/workflows/pypi-publish.yml`, added conditional step to publish to real PyPI only if the event is a GitHub release.
>     - Always publish to TestPyPI regardless of event type.
>   - **Script Changes**:
>     - Modified `upload-pyo3.sh` to accept a repository argument, allowing dynamic selection of PyPI or TestPyPI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1e44bf1e39702c117a558d6b1696028249504ae3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->