### PR TITLE
Bump python-pyo3 version to 2025.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "0.3.3"
+version = "2025.2.3"
 dependencies = [
  "futures",
  "pyo3",

--- a/clients/python-pyo3/Cargo.toml
+++ b/clients/python-pyo3/Cargo.toml
@@ -3,7 +3,7 @@
 # It's named 'tensorzero-python' to avoid confusion with the Rust client
 # (which has a crate name of 'tensorzero')
 name = "tensorzero-python"
-version = "0.3.3"
+version = "2025.2.3"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `tensorzero-python` version from `0.3.3` to `2025.2.3`.
> 
>   - **Version Update**:
>     - Bump `tensorzero-python` version from `0.3.3` to `2025.2.3` in `Cargo.lock` and `Cargo.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ce8271b086a58ca2f057cd330d3ec7668635aa9d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->