### PR TITLE
Add missing metadata to python-pyo3/pyproject.toml

### DIFF
--- a/clients/python-pyo3/pyproject.toml
+++ b/clients/python-pyo3/pyproject.toml
@@ -4,9 +4,16 @@ build-backend = "maturin"
 
 [project]
 name = "tensorzero"
+description = "The Python client for TensorZero"
 license = "Apache-2.0"
+readme = "README.md"
 requires-python = ">=3.9"
 dependencies = ["httpx>=0.27.0", "uuid-utils>=0.9.0"]
+authors = [
+    { name = "Viraj Mehta", email = "viraj@tensorzero.com" },
+    { name = "Gabriel Bianconi", email = "gabriel@tensorzero.com" },
+    { name = "Aaron Hill", email = "aaron@tensorzero.com" },
+]
 dynamic = ["version"]
 
 [tool.maturin]


### PR DESCRIPTION
I forgot to copy this over from python/pyproject.toml

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add missing metadata (description, readme, authors) to `pyproject.toml` for `python-pyo3`.
> 
>   - **Metadata Additions**:
>     - Add `description` as "The Python client for TensorZero" in `pyproject.toml`.
>     - Add `readme` as "README.md" in `pyproject.toml`.
>     - Add `authors` list with names and emails in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2eff2e3f319458d19533f0fb9eabfc745a425c52. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->