### PR TITLE
Use `#[async_trait]` on `Migration`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3270,6 +3270,7 @@ name = "tensorzero-internal"
 version = "0.1.0"
 dependencies = [
  "async-stream",
+ "async-trait",
  "aws-config",
  "aws-sdk-bedrockruntime",
  "aws-smithy-types",

--- a/tensorzero-internal/Cargo.toml
+++ b/tensorzero-internal/Cargo.toml
@@ -28,6 +28,7 @@ workspace = true
 
 [dependencies]
 async-stream = { workspace = true }
+async-trait = "0.1.86"
 aws-config = { version = "1.5.11", features = ["behavior-version-latest"] }
 aws-sdk-bedrockruntime = { version = "1.65.0", features = [
     "behavior-version-latest",

--- a/tensorzero-internal/src/clickhouse_migration_manager/migration_trait.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migration_trait.rs
@@ -1,11 +1,11 @@
-use futures::Future;
-
 use crate::error::Error;
+use async_trait::async_trait;
 
+#[async_trait]
 pub trait Migration {
-    fn can_apply(&self) -> impl Future<Output = Result<(), Error>> + Send;
-    fn should_apply(&self) -> impl Future<Output = Result<bool, Error>> + Send;
-    fn apply(&self) -> impl Future<Output = Result<(), Error>> + Send;
+    async fn can_apply(&self) -> Result<(), Error>;
+    async fn should_apply(&self) -> Result<bool, Error>;
+    async fn apply(&self) -> Result<(), Error>;
     fn rollback_instructions(&self) -> String;
-    fn has_succeeded(&self) -> impl Future<Output = Result<bool, Error>> + Send;
+    async fn has_succeeded(&self) -> Result<bool, Error>;
 }

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0000.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0000.rs
@@ -1,6 +1,7 @@
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::clickhouse_migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
+use async_trait::async_trait;
 
 use super::check_table_exists;
 
@@ -18,6 +19,7 @@ pub struct Migration0000<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
+#[async_trait]
 impl Migration for Migration0000<'_> {
     /// Check if you can connect to the database
     async fn can_apply(&self) -> Result<(), Error> {

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0002.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0002.rs
@@ -1,3 +1,5 @@
+use async_trait::async_trait;
+
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::clickhouse_migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
@@ -10,6 +12,7 @@ pub struct Migration0002<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
+#[async_trait]
 impl Migration for Migration0002<'_> {
     /// Check if you can connect to the database
     async fn can_apply(&self) -> Result<(), Error> {

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0003.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0003.rs
@@ -1,6 +1,7 @@
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::clickhouse_migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
+use async_trait::async_trait;
 
 use super::check_table_exists;
 
@@ -18,6 +19,7 @@ pub struct Migration0003<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
+#[async_trait]
 impl Migration for Migration0003<'_> {
     /// Check if you can connect to the database
     /// Then check if the four feedback tables exist as the sources for the materialized views

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0004.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0004.rs
@@ -3,6 +3,7 @@ use crate::clickhouse_migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
 
 use super::check_table_exists;
+use async_trait::async_trait;
 
 /// This migration adds additional columns to the `ModelInference` table
 /// The goal of this is to improve observability of each model inference at an intermediate level of granularity.
@@ -17,6 +18,7 @@ pub struct Migration0004<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
+#[async_trait]
 impl Migration for Migration0004<'_> {
     /// Check if you can connect to the database and if the ModelInference table exists
     /// If all of this is OK, then we can apply the migration

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0005.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0005.rs
@@ -1,6 +1,7 @@
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::clickhouse_migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
+use async_trait::async_trait;
 
 use super::check_table_exists;
 
@@ -17,6 +18,7 @@ pub struct Migration0005<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
+#[async_trait]
 impl Migration for Migration0005<'_> {
     /// Check if you can connect to the database
     /// Then check if the two inference tables exist as the sources for the materialized views

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0006.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0006.rs
@@ -1,6 +1,7 @@
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::clickhouse_migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
+use async_trait::async_trait;
 
 use super::check_table_exists;
 
@@ -19,6 +20,7 @@ pub struct Migration0006<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
+#[async_trait]
 impl Migration for Migration0006<'_> {
     /// Check if you can connect to the database
     async fn can_apply(&self) -> Result<(), Error> {

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0008.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0008.rs
@@ -3,6 +3,7 @@ use crate::clickhouse_migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
 
 use super::{check_column_exists, check_table_exists, get_column_type};
+use async_trait::async_trait;
 
 /// This migration continues setting up the ClickHouse database for batch inference.
 ///
@@ -16,6 +17,7 @@ pub struct Migration0008<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
+#[async_trait]
 impl Migration for Migration0008<'_> {
     /// Check if you can connect to the database
     /// Also check that the tables that need altering already exist

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0009.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0009.rs
@@ -5,6 +5,7 @@ use crate::clickhouse_migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
 
 use super::check_table_exists;
+use async_trait::async_trait;
 
 /// This migration allows us to efficiently query feedback tables by their target IDs.
 pub struct Migration0009<'a> {
@@ -12,6 +13,7 @@ pub struct Migration0009<'a> {
     pub clean_start: bool,
 }
 
+#[async_trait]
 impl Migration for Migration0009<'_> {
     /// Check if you can connect to the database
     /// Then check if the four feedback tables exist

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0011.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0011.rs
@@ -1,6 +1,7 @@
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::clickhouse_migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
+use async_trait::async_trait;
 
 use super::{check_column_exists, check_table_exists};
 
@@ -15,6 +16,7 @@ pub struct Migration0011<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
+#[async_trait]
 impl Migration for Migration0011<'_> {
     /// Check if you can connect to the database
     /// Then check if the two inference tables exist as the sources for the materialized views

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0012.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0012.rs
@@ -3,6 +3,7 @@ use crate::clickhouse_migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
 
 use super::check_table_exists;
+use async_trait::async_trait;
 
 /// This migration is used to set up the ClickHouse database for the datasets feature.
 /// It creates two tables: `ChatInferenceDataset` and `JsonInferenceDataset`
@@ -13,6 +14,7 @@ pub struct Migration0012<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
+#[async_trait]
 impl Migration for Migration0012<'_> {
     /// Check if you can connect to the database
     async fn can_apply(&self) -> Result<(), Error> {

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0013.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0013.rs
@@ -5,6 +5,7 @@ use crate::clickhouse_migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
 
 use super::check_table_exists;
+use async_trait::async_trait;
 
 /// This migration reinitializes the `InferenceById` and `InferenceByEpisodeId` tables and
 /// their associated materialized views.
@@ -23,6 +24,7 @@ pub struct Migration0013<'a> {
     pub clean_start: bool,
 }
 
+#[async_trait]
 impl Migration for Migration0013<'_> {
     /// Check if you can connect to the database
     /// Then check if the two inference tables exist as the sources for the materialized views

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0014.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0014.rs
@@ -1,6 +1,7 @@
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::clickhouse_migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
+use async_trait::async_trait;
 
 use super::{check_table_exists, get_column_type, table_is_nonempty};
 
@@ -19,6 +20,7 @@ pub struct Migration0014<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
+#[async_trait]
 impl Migration for Migration0014<'_> {
     /// Check if you can connect to the database
     async fn can_apply(&self) -> Result<(), Error> {

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0015.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0015.rs
@@ -1,6 +1,7 @@
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::clickhouse_migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
+use async_trait::async_trait;
 
 use super::get_column_type;
 
@@ -9,6 +10,7 @@ pub struct Migration0015<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
+#[async_trait]
 impl Migration for Migration0015<'_> {
     /// Check if you can connect to the database
     async fn can_apply(&self) -> Result<(), Error> {

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/mod.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/mod.rs
@@ -4,18 +4,14 @@ use crate::{
 };
 
 pub mod migration_0000;
-// pub mod migration_0001;
 pub mod migration_0002;
 pub mod migration_0003;
 pub mod migration_0004;
 pub mod migration_0005;
 pub mod migration_0006;
-// pub mod migration_0007;
 pub mod migration_0008;
 pub mod migration_0009;
-// pub mod migration_0010;
 pub mod migration_0011;
-// pub mod migration_0012;
 pub mod migration_0013;
 pub mod migration_0014;
 

--- a/tensorzero-internal/src/clickhouse_migration_manager/mod.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/mod.rs
@@ -17,6 +17,8 @@ use migrations::migration_0011::Migration0011;
 use migrations::migration_0013::Migration0013;
 use migrations::migration_0014::Migration0014;
 
+use async_trait::async_trait;
+
 pub async fn run(clickhouse: &ClickHouseConnectionInfo) -> Result<(), Error> {
     // This is a no-op if the database already exists
     clickhouse.create_database().await?;
@@ -157,6 +159,7 @@ mod tests {
         }
     }
 
+    #[async_trait]
     impl Migration for MockMigration {
         async fn can_apply(&self) -> Result<(), Error> {
             self.called_can_apply


### PR DESCRIPTION
This is preparation for removing a large amount of duplication from test_clickhouse_migration_manager

I've also deleted several dead migrations (which had their 'mod' lines commented out) - they would have stopped compiling with this change. If we ever need the underlying clickhouse commands again, we can retrieve them from the git history

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Use `#[async_trait]` for `Migration` trait and implementations, remove dead migrations, and update `async-trait` dependency.
> 
>   - **Migration Trait**:
>     - Use `#[async_trait]` for `Migration` trait in `migration_trait.rs`.
>     - Convert `can_apply`, `should_apply`, `apply`, and `has_succeeded` to async functions.
>   - **Migrations**:
>     - Apply `#[async_trait]` to `Migration` implementations in `migration_0000.rs`, `migration_0002.rs`, and `migration_0003.rs`.
>     - Remove dead migrations `migration_0001`, `migration_0007`, `migration_0010`, and `migration_0012` from `mod.rs`.
>   - **Dependencies**:
>     - Update `async-trait` version to `0.1.86` in `Cargo.lock` and `Cargo.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a06de5f79ed6cb276ca8f0b830479056a60e64a3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->