### PR TITLE
Add `ModelProvider` struct to wrap `ProviderConfig` enum

### DIFF
--- a/tensorzero-internal/src/endpoints/batch_inference.rs
+++ b/tensorzero-internal/src/endpoints/batch_inference.rs
@@ -525,6 +525,7 @@ async fn poll_batch_inference(
             })
         })?;
     model_provider
+        .config
         .poll_batch_inference(batch_request, &http_client, credentials)
         .await
 }

--- a/tensorzero-internal/src/model.rs
+++ b/tensorzero-internal/src/model.rs
@@ -328,9 +328,8 @@ async fn stream_with_cache_write(
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(transparent)]
 pub struct ModelProvider {
-    #[serde(flatten)]
     pub config: ProviderConfig,
 }
 

--- a/tensorzero-internal/src/model.rs
+++ b/tensorzero-internal/src/model.rs
@@ -54,7 +54,7 @@ use serde::Deserialize;
 #[serde(deny_unknown_fields)]
 pub struct ModelConfig {
     pub routing: Vec<Arc<str>>, // [provider name A, provider name B, ...]
-    pub providers: HashMap<Arc<str>, ProviderConfig>, // provider name => provider config
+    pub providers: HashMap<Arc<str>, ModelProvider>, // provider name => provider config
 }
 
 pub struct StreamResponse {
@@ -124,11 +124,12 @@ impl ModelConfig {
                     return Ok(cache_lookup);
                 }
             }
-            let provider_config = self.providers.get(provider_name).ok_or_else(|| {
+            let provider = self.providers.get(provider_name).ok_or_else(|| {
                 Error::new(ErrorDetails::ProviderNotFound {
                     provider_name: provider_name.to_string(),
                 })
             })?;
+            let provider_config = &provider.config;
             let response = provider_config
                 .infer(request, clients.http_client, clients.credentials)
                 .instrument(span!(
@@ -195,11 +196,12 @@ impl ModelConfig {
                 }
             }
 
-            let provider_config = self.providers.get(provider_name).ok_or_else(|| {
+            let provider = self.providers.get(provider_name).ok_or_else(|| {
                 Error::new(ErrorDetails::ProviderNotFound {
                     provider_name: provider_name.to_string(),
                 })
             })?;
+            let provider_config = &provider.config;
             let response = provider_config
                 .infer_stream(request, clients.http_client, clients.credentials)
                 .instrument(span!(
@@ -257,11 +259,12 @@ impl ModelConfig {
     ) -> Result<StartBatchModelInferenceResponse, Error> {
         let mut provider_errors: HashMap<String, Error> = HashMap::new();
         for provider_name in &self.routing {
-            let provider_config = self.providers.get(provider_name).ok_or_else(|| {
+            let provider = self.providers.get(provider_name).ok_or_else(|| {
                 Error::new(ErrorDetails::ProviderNotFound {
                     provider_name: provider_name.to_string(),
                 })
             })?;
+            let provider_config = &provider.config;
             let response = provider_config
                 .start_batch_inference(requests, client, api_keys)
                 .instrument(span!(
@@ -323,6 +326,14 @@ async fn stream_with_cache_write(
         }
     }) as ProviderInferenceResponseStreamInner).peekable())
 }
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ModelProvider {
+    #[serde(flatten)]
+    pub config: ProviderConfig,
+}
+
 #[derive(Debug)]
 pub enum ProviderConfig {
     Anthropic(AnthropicProvider),
@@ -1152,7 +1163,12 @@ impl ShorthandModelConfig for ModelConfig {
         };
         Ok(ModelConfig {
             routing: vec![provider_type.to_string().into()],
-            providers: HashMap::from([(provider_type.to_string().into(), provider_config)]),
+            providers: HashMap::from([(
+                provider_type.to_string().into(),
+                ModelProvider {
+                    config: provider_config,
+                },
+            )]),
         })
     }
 
@@ -1243,7 +1259,12 @@ mod tests {
         });
         let model_config = ModelConfig {
             routing: vec!["good_provider".into()],
-            providers: HashMap::from([("good_provider".into(), good_provider_config)]),
+            providers: HashMap::from([(
+                "good_provider".into(),
+                ModelProvider {
+                    config: good_provider_config,
+                },
+            )]),
         };
         let tool_config = ToolCallConfig {
             tools_available: vec![],
@@ -1299,7 +1320,12 @@ mod tests {
         // Try inferring the bad model
         let model_config = ModelConfig {
             routing: vec!["error".into()],
-            providers: HashMap::from([("error".into(), bad_provider_config)]),
+            providers: HashMap::from([(
+                "error".into(),
+                ModelProvider {
+                    config: bad_provider_config,
+                },
+            )]),
         };
         let response = model_config
             .infer(&request, &clients, model_name)
@@ -1373,8 +1399,18 @@ mod tests {
                 "good_provider".to_string().into(),
             ],
             providers: HashMap::from([
-                ("error_provider".to_string().into(), bad_provider_config),
-                ("good_provider".to_string().into(), good_provider_config),
+                (
+                    "error_provider".to_string().into(),
+                    ModelProvider {
+                        config: bad_provider_config,
+                    },
+                ),
+                (
+                    "good_provider".to_string().into(),
+                    ModelProvider {
+                        config: good_provider_config,
+                    },
+                ),
             ]),
         };
 
@@ -1428,7 +1464,12 @@ mod tests {
         // Test good model
         let model_config = ModelConfig {
             routing: vec!["good_provider".to_string().into()],
-            providers: HashMap::from([("good_provider".to_string().into(), good_provider_config)]),
+            providers: HashMap::from([(
+                "good_provider".to_string().into(),
+                ModelProvider {
+                    config: good_provider_config,
+                },
+            )]),
         };
         let StreamResponse {
             mut stream,
@@ -1486,7 +1527,12 @@ mod tests {
         // Test bad model
         let model_config = ModelConfig {
             routing: vec!["error".to_string().into()],
-            providers: HashMap::from([("error".to_string().into(), bad_provider_config)]),
+            providers: HashMap::from([(
+                "error".to_string().into(),
+                ModelProvider {
+                    config: bad_provider_config,
+                },
+            )]),
         };
         let response = model_config
             .infer_stream(
@@ -1562,8 +1608,18 @@ mod tests {
         let model_config = ModelConfig {
             routing: vec!["error_provider".into(), "good_provider".into()],
             providers: HashMap::from([
-                ("error_provider".to_string().into(), bad_provider_config),
-                ("good_provider".to_string().into(), good_provider_config),
+                (
+                    "error_provider".to_string().into(),
+                    ModelProvider {
+                        config: bad_provider_config,
+                    },
+                ),
+                (
+                    "good_provider".to_string().into(),
+                    ModelProvider {
+                        config: good_provider_config,
+                    },
+                ),
             ]),
         };
         let StreamResponse {
@@ -1628,7 +1684,12 @@ mod tests {
         });
         let model_config = ModelConfig {
             routing: vec!["model".into()],
-            providers: HashMap::from([("model".into(), provider_config)]),
+            providers: HashMap::from([(
+                "model".into(),
+                ModelProvider {
+                    config: provider_config,
+                },
+            )]),
         };
         let tool_config = ToolCallConfig {
             tools_available: vec![],
@@ -1724,7 +1785,12 @@ mod tests {
         });
         let model_config = ModelConfig {
             routing: vec!["model".to_string().into()],
-            providers: HashMap::from([("model".to_string().into(), provider_config)]),
+            providers: HashMap::from([(
+                "model".to_string().into(),
+                ModelProvider {
+                    config: provider_config,
+                },
+            )]),
         };
         let tool_config = ToolCallConfig {
             tools_available: vec![],
@@ -1813,7 +1879,7 @@ mod tests {
             .unwrap()
             .expect("Missing dummy model");
         assert_eq!(model_config.routing, vec!["dummy".into()]);
-        let provider_config = model_config.providers.get("dummy").unwrap();
+        let provider_config = &model_config.providers.get("dummy").unwrap().config;
         match provider_config {
             ProviderConfig::Dummy(provider) => assert_eq!(&*provider.model_name, "gpt-4o"),
             _ => panic!("Expected Dummy provider"),
@@ -1834,7 +1900,12 @@ mod tests {
             ProviderConfig::Anthropic(AnthropicProvider::new("claude".to_string(), None).unwrap());
         let anthropic_model_config = ModelConfig {
             routing: vec!["anthropic".into()],
-            providers: HashMap::from([("anthropic".into(), anthropic_provider_config)]),
+            providers: HashMap::from([(
+                "anthropic".into(),
+                ModelProvider {
+                    config: anthropic_provider_config,
+                },
+            )]),
         };
         let model_table: ModelTable = HashMap::from([("claude".into(), anthropic_model_config)])
             .try_into()

--- a/tensorzero-internal/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-internal/src/variant/best_of_n_sampling.rs
@@ -666,7 +666,7 @@ mod tests {
             types::{ChatInferenceResult, JsonInferenceResult, Latency},
         },
         minijinja_util::tests::get_test_template_config,
-        model::{ModelConfig, ProviderConfig},
+        model::{ModelConfig, ModelProvider, ProviderConfig},
     };
 
     use super::*;
@@ -1115,10 +1115,12 @@ mod tests {
                 routing: vec!["best_of_n_1".into()],
                 providers: HashMap::from([(
                     "best_of_n_1".into(),
-                    ProviderConfig::Dummy(DummyProvider {
-                        model_name: "best_of_n_1".into(),
-                        ..Default::default()
-                    }),
+                    ModelProvider {
+                        config: ProviderConfig::Dummy(DummyProvider {
+                            model_name: "best_of_n_1".into(),
+                            ..Default::default()
+                        }),
+                    },
                 )]),
             },
         )]))
@@ -1203,10 +1205,12 @@ mod tests {
                     routing: vec!["error".into()],
                     providers: HashMap::from([(
                         "error".into(),
-                        ProviderConfig::Dummy(DummyProvider {
-                            model_name: "error".into(),
-                            ..Default::default()
-                        }),
+                        ModelProvider {
+                            config: ProviderConfig::Dummy(DummyProvider {
+                                model_name: "error".into(),
+                                ..Default::default()
+                            }),
+                        },
                     )]),
                 },
             );
@@ -1262,10 +1266,12 @@ mod tests {
                     routing: vec!["regular".into()],
                     providers: HashMap::from([(
                         "regular".into(),
-                        ProviderConfig::Dummy(DummyProvider {
-                            model_name: "regular".into(),
-                            ..Default::default()
-                        }),
+                        ModelProvider {
+                            config: ProviderConfig::Dummy(DummyProvider {
+                                model_name: "regular".into(),
+                                ..Default::default()
+                            }),
+                        },
                     )]),
                 },
             );
@@ -1338,10 +1344,12 @@ mod tests {
                 routing: vec!["best_of_n_big".into()],
                 providers: HashMap::from([(
                     "best_of_n_big".into(),
-                    ProviderConfig::Dummy(DummyProvider {
-                        model_name: "best_of_n_big".into(),
-                        ..Default::default()
-                    }),
+                    ModelProvider {
+                        config: ProviderConfig::Dummy(DummyProvider {
+                            model_name: "best_of_n_big".into(),
+                            ..Default::default()
+                        }),
+                    },
                 )]),
             },
         );

--- a/tensorzero-internal/src/variant/chat_completion.rs
+++ b/tensorzero-internal/src/variant/chat_completion.rs
@@ -399,7 +399,7 @@ mod tests {
     };
     use crate::jsonschema_util::{DynamicJSONSchema, JSONSchemaFromPath};
     use crate::minijinja_util::tests::get_test_template_config;
-    use crate::model::{ModelConfig, ProviderConfig};
+    use crate::model::{ModelConfig, ModelProvider, ProviderConfig};
     use crate::tool::{ToolCallConfig, ToolChoice};
     use crate::{
         error::Error,
@@ -751,11 +751,21 @@ mod tests {
         });
         let text_model_config = ModelConfig {
             routing: vec!["good".into()],
-            providers: HashMap::from([("good".into(), good_provider_config)]),
+            providers: HashMap::from([(
+                "good".into(),
+                ModelProvider {
+                    config: good_provider_config,
+                },
+            )]),
         };
         let json_model_config = ModelConfig {
             routing: vec!["json_provider".into()],
-            providers: HashMap::from([("json_provider".into(), json_provider_config)]),
+            providers: HashMap::from([(
+                "json_provider".into(),
+                ModelProvider {
+                    config: json_provider_config,
+                },
+            )]),
         };
         let tool_provider_config = ProviderConfig::Dummy(DummyProvider {
             model_name: "tool".into(),
@@ -763,11 +773,21 @@ mod tests {
         });
         let tool_model_config = ModelConfig {
             routing: vec!["tool_provider".into()],
-            providers: HashMap::from([("tool_provider".into(), tool_provider_config)]),
+            providers: HashMap::from([(
+                "tool_provider".into(),
+                ModelProvider {
+                    config: tool_provider_config,
+                },
+            )]),
         };
         let error_model_config = ModelConfig {
             routing: vec!["error".into()],
-            providers: HashMap::from([("error".into(), error_provider_config)]),
+            providers: HashMap::from([(
+                "error".into(),
+                ModelProvider {
+                    config: error_provider_config,
+                },
+            )]),
         };
         // Test case 1: invalid message (String passed when template required)
         let messages = vec![InputMessage {
@@ -928,7 +948,12 @@ mod tests {
         });
         let text_model_config = ModelConfig {
             routing: vec!["good_provider".into()],
-            providers: HashMap::from([("good_provider".into(), good_provider_config)]),
+            providers: HashMap::from([(
+                "good_provider".into(),
+                ModelProvider {
+                    config: good_provider_config,
+                },
+            )]),
         };
         let models = HashMap::from([("good".into(), text_model_config)])
             .try_into()
@@ -1448,11 +1473,21 @@ mod tests {
         });
         let text_model_config = ModelConfig {
             routing: vec!["good_provider".into()],
-            providers: HashMap::from([("good_provider".into(), good_provider_config)]),
+            providers: HashMap::from([(
+                "good_provider".into(),
+                ModelProvider {
+                    config: good_provider_config,
+                },
+            )]),
         };
         let error_model_config = ModelConfig {
             routing: vec!["error_provider".into()],
-            providers: HashMap::from([("error_provider".into(), error_provider_config)]),
+            providers: HashMap::from([(
+                "error_provider".into(),
+                ModelProvider {
+                    config: error_provider_config,
+                },
+            )]),
         };
         // Test case 1: Model inference fails because of model issues
         let inference_params = InferenceParams::default();

--- a/tensorzero-internal/src/variant/mixture_of_n.rs
+++ b/tensorzero-internal/src/variant/mixture_of_n.rs
@@ -995,7 +995,7 @@ mod tests {
             input_tokens: 35,
             output_tokens: 55,
         };
-        let expected_content: JsonInferenceOutput = JsonInferenceOutput {
+        let expected_content = JsonInferenceOutput {
             raw: "{\"answer\":\"Hello\"}".to_string(),
             parsed: Some(json!({"answer": "Hello"})),
         };

--- a/tensorzero-internal/src/variant/mixture_of_n.rs
+++ b/tensorzero-internal/src/variant/mixture_of_n.rs
@@ -512,7 +512,7 @@ mod tests {
         },
         jsonschema_util::JSONSchemaFromPath,
         minijinja_util::tests::get_test_template_config,
-        model::{ModelConfig, ProviderConfig},
+        model::{ModelConfig, ModelProvider, ProviderConfig},
         tool::{ToolCallConfig, ToolChoice},
     };
 
@@ -941,10 +941,12 @@ mod tests {
                 routing: vec!["json".into()],
                 providers: HashMap::from([(
                     "json".into(),
-                    ProviderConfig::Dummy(DummyProvider {
-                        model_name: "json".into(),
-                        ..Default::default()
-                    }),
+                    ModelProvider {
+                        config: ProviderConfig::Dummy(DummyProvider {
+                            model_name: "json".into(),
+                            ..Default::default()
+                        }),
+                    },
                 )]),
             },
         )]))
@@ -993,7 +995,7 @@ mod tests {
             input_tokens: 35,
             output_tokens: 55,
         };
-        let expected_content = JsonInferenceOutput {
+        let expected_content: JsonInferenceOutput = JsonInferenceOutput {
             raw: "{\"answer\":\"Hello\"}".to_string(),
             parsed: Some(json!({"answer": "Hello"})),
         };
@@ -1029,10 +1031,12 @@ mod tests {
                     routing: vec!["error".into()],
                     providers: HashMap::from([(
                         "error".into(),
-                        ProviderConfig::Dummy(DummyProvider {
-                            model_name: "error".into(),
-                            ..Default::default()
-                        }),
+                        ModelProvider {
+                            config: ProviderConfig::Dummy(DummyProvider {
+                                model_name: "error".into(),
+                                ..Default::default()
+                            }),
+                        },
                     )]),
                 },
             );
@@ -1089,10 +1093,12 @@ mod tests {
                     routing: vec!["regular".into()],
                     providers: HashMap::from([(
                         "regular".into(),
-                        ProviderConfig::Dummy(DummyProvider {
-                            model_name: "regular".into(),
-                            ..Default::default()
-                        }),
+                        ModelProvider {
+                            config: ProviderConfig::Dummy(DummyProvider {
+                                model_name: "regular".into(),
+                                ..Default::default()
+                            }),
+                        },
                     )]),
                 },
             );

--- a/tensorzero-internal/src/variant/mod.rs
+++ b/tensorzero-internal/src/variant/mod.rs
@@ -604,7 +604,7 @@ mod tests {
     };
     use crate::jsonschema_util::JSONSchemaFromPath;
     use crate::minijinja_util::tests::get_test_template_config;
-    use crate::model::ProviderConfig;
+    use crate::model::{ModelProvider, ProviderConfig};
     use crate::tool::{ToolCallConfig, ToolChoice};
     use reqwest::Client;
     use serde_json::json;
@@ -894,7 +894,12 @@ mod tests {
         // Create a model config with the dummy provider
         let model_config = ModelConfig {
             routing: vec![model_name.into()],
-            providers: HashMap::from([(model_name.into(), dummy_provider_config)]),
+            providers: HashMap::from([(
+                model_name.into(),
+                ModelProvider {
+                    config: dummy_provider_config,
+                },
+            )]),
         };
         let retry_config = Box::leak(Box::new(RetryConfig::default()));
 
@@ -989,7 +994,12 @@ mod tests {
 
         let model_config_json = ModelConfig {
             routing: vec![model_name_json.into()],
-            providers: HashMap::from([(model_name_json.into(), dummy_provider_config_json)]),
+            providers: HashMap::from([(
+                model_name_json.into(),
+                ModelProvider {
+                    config: dummy_provider_config_json,
+                },
+            )]),
         };
 
         // Create the arguments struct
@@ -1036,7 +1046,12 @@ mod tests {
 
         let error_model_config = ModelConfig {
             routing: vec![error_model_name.into()],
-            providers: HashMap::from([(error_model_name.into(), error_provider_config)]),
+            providers: HashMap::from([(
+                error_model_name.into(),
+                ModelProvider {
+                    config: error_provider_config,
+                },
+            )]),
         };
 
         // Create the arguments struct
@@ -1142,8 +1157,18 @@ mod tests {
         let model_config = ModelConfig {
             routing: vec![error_model_name.into(), model_name.into()],
             providers: HashMap::from([
-                (error_model_name.into(), error_provider_config),
-                (model_name.into(), dummy_provider_config),
+                (
+                    error_model_name.into(),
+                    ModelProvider {
+                        config: error_provider_config,
+                    },
+                ),
+                (
+                    model_name.into(),
+                    ModelProvider {
+                        config: dummy_provider_config,
+                    },
+                ),
             ]),
         };
         let retry_config = Box::leak(Box::new(RetryConfig::default()));
@@ -1231,7 +1256,12 @@ mod tests {
 
         let model_config = Box::leak(Box::new(ModelConfig {
             routing: vec!["good_provider".into()],
-            providers: HashMap::from([("good_provider".into(), dummy_provider_config)]),
+            providers: HashMap::from([(
+                "good_provider".into(),
+                ModelProvider {
+                    config: dummy_provider_config,
+                },
+            )]),
         }));
 
         // Prepare the model inference request
@@ -1387,8 +1417,18 @@ mod tests {
         let model_config = Box::leak(Box::new(ModelConfig {
             routing: vec![error_model_name.into(), model_name.into()],
             providers: HashMap::from([
-                (error_model_name.into(), error_provider_config),
-                (model_name.into(), dummy_provider_config),
+                (
+                    error_model_name.into(),
+                    ModelProvider {
+                        config: error_provider_config,
+                    },
+                ),
+                (
+                    model_name.into(),
+                    ModelProvider {
+                        config: dummy_provider_config,
+                    },
+                ),
             ]),
         }));
         let retry_config = RetryConfig::default();


### PR DESCRIPTION
This will be used to hold generic model provider configuration fields used by all provder implementations (e.g. an `extra_body` field).

This PR is a pure refactoring, with no behavioral changes.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor to encapsulate `ProviderConfig` within a new `ModelProvider` struct, updating relevant code and tests across multiple files.
> 
>   - **Refactoring**:
>     - Introduce `ModelProvider` struct in `model.rs` to encapsulate `ProviderConfig`.
>     - Update `ModelConfig` to use `ModelProvider` instead of `ProviderConfig` directly.
>     - Modify functions in `model.rs` to access `ProviderConfig` through `ModelProvider`.
>   - **Affected Files**:
>     - `batch_inference.rs`: Adjust function calls to use `ModelProvider`.
>     - `best_of_n_sampling.rs`, `chat_completion.rs`, `mixture_of_n.rs`: Update test cases to use `ModelProvider`.
>     - `mod.rs`: Update imports and references to `ProviderConfig` to use `ModelProvider`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 143a2499c24310039eae73f765a0e02a4afe79fd. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->