### PR TITLE
Fix nightly clippy warnings

### DIFF
--- a/tensorzero-internal/src/inference/providers/anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/anthropic.rs
@@ -1056,7 +1056,7 @@ fn anthropic_to_tensorzero_stream_message(
                 Ok(None)
             }
         }
-        AnthropicStreamMessage::MessageStop | AnthropicStreamMessage::Ping {} => Ok(None),
+        AnthropicStreamMessage::MessageStop | AnthropicStreamMessage::Ping => Ok(None),
     }
 }
 

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
@@ -957,7 +957,7 @@ fn anthropic_to_tensorzero_stream_message(
                 Ok(None)
             }
         }
-        GCPVertexAnthropicStreamMessage::MessageStop | GCPVertexAnthropicStreamMessage::Ping {} => {
+        GCPVertexAnthropicStreamMessage::MessageStop | GCPVertexAnthropicStreamMessage::Ping => {
             Ok(None)
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix clippy warnings by removing unnecessary braces in match arms in `anthropic.rs` and `gcp_vertex_anthropic.rs`.
> 
>   - **Syntax Fixes**:
>     - Remove unnecessary braces in match arms for `AnthropicStreamMessage::Ping` in `anthropic.rs` and `GCPVertexAnthropicStreamMessage::Ping` in `gcp_vertex_anthropic.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b91ab1b799bf3394510c0842a8f5b10bf0d486d5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->