### PR TITLE
Deprecate passing in arbitrary json objects to openai-compat api

### DIFF
--- a/clients/openai-python/tests/test_openai_compatibility.py
+++ b/clients/openai-python/tests/test_openai_compatibility.py
@@ -25,7 +25,7 @@ from uuid import UUID
 
 import pytest
 import pytest_asyncio
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, BadRequestError
 from pydantic import BaseModel, ValidationError
 from tensorzero.util import uuid7
 
@@ -441,6 +441,39 @@ async def test_async_json_streaming(async_client):
 
 
 @pytest.mark.asyncio
+async def test_async_json_success_non_deprecated(async_client):
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "tensorzero::arguments": {"assistant_name": "Alfred Pennyworth"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "tensorzero::arguments": {"country": "Japan"}}
+            ],
+        },
+    ]
+    episode_id = str(uuid7())
+    result = await async_client.chat.completions.create(
+        extra_headers={"episode_id": episode_id},
+        messages=messages,
+        model="tensorzero::function_name::json_success",
+    )
+    assert result.model == "test"
+    assert result.episode_id == episode_id
+    assert result.choices[0].message.content == '{"answer":"Hello"}'
+    assert result.choices[0].message.tool_calls is None
+    assert result.usage.prompt_tokens == 10
+    assert result.usage.completion_tokens == 10
+
+
+@pytest.mark.asyncio
 async def test_async_json_success(async_client):
     messages = [
         {"role": "system", "content": [{"assistant_name": "Alfred Pennyworth"}]},
@@ -458,6 +491,33 @@ async def test_async_json_success(async_client):
     assert result.choices[0].message.tool_calls is None
     assert result.usage.prompt_tokens == 10
     assert result.usage.completion_tokens == 10
+
+
+@pytest.mark.asyncio
+async def test_async_json_invalid_system(async_client):
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/image.jpg"},
+                }
+            ],
+        },
+        {"role": "user", "content": [{"country": "Japan"}]},
+    ]
+    episode_id = str(uuid7())
+    with pytest.raises(BadRequestError) as exc_info:
+        await async_client.chat.completions.create(
+            extra_headers={"episode_id": episode_id},
+            messages=messages,
+            model="tensorzero::function_name::json_success",
+        )
+    assert (
+        "Invalid request to OpenAI-compatible endpoint: `image_url` content blocks are not currently supported"
+        in str(exc_info.value)
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Previously, we supported invoking the openai-compatible inference endpoints with messages like:

```json
[
    {"role": "system", "content": [{"assistant_name": "Alfred Pennyworth"}]},
    {"role": "user", "content": [{"country": "Japan"}]},
]
```

However, the real OpenAI endpoints expects entries in the "content" array to be valid OpenAI content blocks, (e.g. "type": "text" or "type": "image_url"). This can clash with user-defined TensorZero function schemas (e.g. a json schema with a parameter named "type")

We now support parsing special content blocks that look like: `{"type": "text", "tensorzero::arguments", {"some": "arbitrary object"}}`

The "tensorzero::arguments" value is pasesd along to the TensorZero function as input, without any modifications.

To avoid breaking existing clients, we first try to parse each content block as either a valid OpenAI content block, or our special "tensorzero::arguments" block. If this fails, then we log a warning and fall back to the old behavior (creating an `InputMessageContent::Text` with `value` set to the entire 'content block' json object.

In the future, we'll want to change this in an error, and require that all content blocks have a valid "type" key.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Deprecates arbitrary JSON objects in OpenAI-compatible API, introducing a new content block format and updating parsing logic and tests.
> 
>   - **Behavior**:
>     - Deprecates arbitrary JSON objects in OpenAI-compatible API, requiring `{"type": "text", "tensorzero::arguments": {...}}` format.
>     - Logs warnings for deprecated usage and falls back to old behavior if parsing fails.
>     - Plans to enforce new format strictly in future.
>   - **Code Changes**:
>     - Updates `convert_openai_message_content` in `openai_compatible.rs` to handle new content block format.
>     - Adds `OpenAICompatibleContentBlock` and `TextContent` enums for parsing.
>   - **Tests**:
>     - Adds `test_async_json_success_non_deprecated` and `test_async_json_invalid_system` in `test_openai_compatibility.py`.
>     - Updates existing tests to cover new content block format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 89672173ddc29060300e345425fc0ce417a7164a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->