### PR TITLE
Pin pyright==1.1.394 on ci to unbreak build

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -118,7 +118,7 @@ jobs:
       - name: "Python: PyO3 Client: pyright"
         working-directory: clients/python-pyo3
         run: |
-          uv pip install pyright
+          uv pip install pyright==1.1.394
           uv run pyright
 
       - name: "Python: PyO3 Client: stubtest"
@@ -135,7 +135,7 @@ jobs:
       - name: "Python: TensorZero Client: pyright"
         working-directory: clients/python-deprecated
         run: |
-          uv pip install pyright
+          uv pip install pyright==1.1.394
           uv run pyright
 
       - name: "Python: OpenAI Client: Install dependencies"
@@ -147,7 +147,7 @@ jobs:
       - name: "Python: OpenAI Client: pyright"
         working-directory: clients/openai-python
         run: |
-          uv pip install pyright
+          uv pip install pyright==1.1.394
           uv run pyright
 
       - name: Setup Node.js

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -137,7 +137,7 @@ jobs:
       - name: "Python: TensorZero Client: pyright"
         working-directory: clients/python-deprecated
         run: |
-          uv pip install pyright
+          uv pip install pyright==1.1.394
           uv run pyright
 
       - name: "Python: TensorZero Client: pytest"
@@ -154,7 +154,7 @@ jobs:
       - name: "Python: PyO3 Client: pyright"
         working-directory: clients/python-pyo3
         run: |
-          uv pip install pyright
+          uv pip install pyright==1.1.394
           uv run pyright
 
       - name: "Python: PyO3 Client: stubtest"
@@ -176,7 +176,7 @@ jobs:
       - name: "Python: OpenAI Client: pyright"
         working-directory: clients/openai-python
         run: |
-          uv pip install pyright
+          uv pip install pyright==1.1.394
           uv run pyright
 
       - name: "Python: OpenAI Client: pytest"
@@ -193,7 +193,7 @@ jobs:
       - name: "Python: Recipes: pyright"
         working-directory: recipes/tests
         run: |
-          uv pip install pyright
+          uv pip install pyright==1.1.394
           uv run pyright
 
       - name: "Python: Recipes: pytest"


### PR DESCRIPTION
Pyright 1.1.395 started producing errors for our 'recipes', so let's pin it to the previous version for now

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Pin `pyright` to version `1.1.394` in CI workflows to prevent build errors from version `1.1.395`.
> 
>   - **CI Configuration**:
>     - Pin `pyright` version to `1.1.394` in `.github/workflows/general.yml` and `.github/workflows/merge-queue.yml`.
>     - Affects `Python: PyO3 Client: pyright`, `Python: TensorZero Client: pyright`, and `Python: OpenAI Client: pyright` steps.
>   - **Reason**:
>     - Pyright 1.1.395 introduced errors in 'recipes', necessitating the pinning to the previous version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3bae0f514e5cb29e0a206107a7969bff8bb183ca. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->