### PR TITLE
Add 'endpoint' parameter to S3-compatible provider and test with R2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3762,6 +3762,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "aws-config",
+ "aws-credential-types",
  "aws-sdk-bedrockruntime",
  "aws-sdk-s3",
  "aws-smithy-types",

--- a/tensorzero-internal/Cargo.toml
+++ b/tensorzero-internal/Cargo.toml
@@ -93,3 +93,4 @@ tensorzero = { path = "../clients/rust"}
 paste = "1.0.15"
 base64 = "0.22.1"
 aws-sdk-s3 = "1.76.0"
+aws-credential-types = { version = "1.2.1", features = ["hardcoded-credentials"] }

--- a/tensorzero-internal/src/config_parser.rs
+++ b/tensorzero-internal/src/config_parser.rs
@@ -58,28 +58,60 @@ impl ObjectStoreInfo {
         };
 
         let object_store: Option<Arc<dyn ObjectStore>> = match &config {
-            StorageKind::Filesystem { path } => Some(Arc::new(LocalFileSystem::new_with_prefix(path).map_err(|e| Error::new(ErrorDetails::Config {
-                message: format!("Failed to create filesystem object store for path: {path}: {e}"),
-            }))?)),
+            StorageKind::Filesystem { path } => Some(Arc::new(
+                LocalFileSystem::new_with_prefix(path).map_err(|e| {
+                    Error::new(ErrorDetails::Config {
+                        message: format!(
+                            "Failed to create filesystem object store for path: {path}: {e}"
+                        ),
+                    })
+                })?,
+            )),
             StorageKind::S3Compatible {
                 bucket_name,
                 region,
+                endpoint,
                 #[cfg(feature = "e2e_tests")]
-                prefix: _,
-            } => Some(Arc::new(
-                AmazonS3Builder::from_env()
-                    .with_region(region)
-                    .with_bucket_name(bucket_name)
+                    prefix: _,
+            } => {
+                let mut builder = AmazonS3Builder::from_env()
                     // Uses the S3 'If-Match' and 'If-None-Match' headers to implement condition put
-                    .with_conditional_put(object_store::aws::S3ConditionalPut::ETagMatch)
-                    .build()
+                    .with_conditional_put(object_store::aws::S3ConditionalPut::ETagMatch);
+
+                // These env vars have the highest priority, overriding whatever was set from 'AmazonS3Builder::from_env()'
+                if let Ok(s3_access_key) = std::env::var("S3_ACCESS_KEY_ID") {
+                    let s3_secret_key = std::env::var("S3_SECRET_ACCESS_KEY").ok().ok_or_else(|| Error::new(ErrorDetails::Config {
+                        message: "S3_ACCESS_KEY_ID is set but S3_SECRET_ACCESS_KEY is not. Please set either both or none".to_string()
+                    }))?;
+                    builder = builder
+                        .with_access_key_id(s3_access_key)
+                        .with_secret_access_key(s3_secret_key);
+                }
+
+                if let Some(bucket_name) = bucket_name {
+                    builder = builder.with_bucket_name(bucket_name);
+                }
+                if let Some(region) = region {
+                    builder = builder.with_region(region);
+                }
+                if let Some(endpoint) = endpoint {
+                    builder = builder.with_endpoint(endpoint);
+                }
+
+                if let (Some(bucket_name), Some(endpoint)) = (bucket_name, endpoint) {
+                    if endpoint.ends_with(bucket_name) {
+                        tracing::warn!("S3-compatible object endpoint `{endpoint}` ends with configured bucket_name `{bucket_name}`. This may be incorrect - if the gateway fails to start, consider setting `bucket_name = null`");
+                    }
+                }
+
+                Some(Arc::new(
+                builder.build()
                     .map_err(|e| Error::new(ErrorDetails::Config {
-                        message: format!("Failed to create S3 object store for bucket: {bucket_name} in region: {region}: {e}"),
+                        message: format!("Failed to create S3-compatible object store with config `{config:?}`: {e}"),
                     }))?),
-            ),
-            StorageKind::Disabled => {
-                None
+            )
             }
+            StorageKind::Disabled => None,
         };
 
         Ok(Some(Self {

--- a/tensorzero-internal/src/inference/types/storage.rs
+++ b/tensorzero-internal/src/inference/types/storage.rs
@@ -9,8 +9,9 @@ use super::{Base64Image, ImageKind};
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum StorageKind {
     S3Compatible {
-        bucket_name: String,
-        region: String,
+        bucket_name: Option<String>,
+        region: Option<String>,
+        endpoint: Option<String>,
         /// An extra prefix to prepend to the object key.
         /// This is only enabled in e2e tests, to prevent clashes between concurrent test runs.
         #[cfg(feature = "e2e_tests")]

--- a/tensorzero-internal/tests/e2e/providers/openai.rs
+++ b/tensorzero-internal/tests/e2e/providers/openai.rs
@@ -862,3 +862,75 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     let magnitude_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
     dot_product / (magnitude_a * magnitude_b)
 }
+
+// We already test Amazon S3 with all image providers, so let's test Cloudflare R2
+// (which is S3-compatible) with just OpenAI to save time and money.
+#[cfg(feature = "e2e_tests")]
+#[tokio::test]
+pub async fn test_image_inference_with_provider_cloudflare_r2() {
+    use crate::providers::common::test_image_inference_with_provider_s3_compatible;
+    use aws_credential_types::Credentials;
+    use aws_sdk_s3::config::SharedCredentialsProvider;
+    use rand::distributions::Alphanumeric;
+    use rand::distributions::DistString;
+    use tensorzero_internal::inference::types::storage::StorageKind;
+
+    // We expect CI to provide our credentials in 'R2_' variables
+    // (to avoid conflicting with the normal AWS credentials for bedrock)
+    let r2_access_key_id = std::env::var("R2_ACCESS_KEY_ID").unwrap();
+    let r2_secret_access_key = std::env::var("R2_SECRET_ACCESS_KEY").unwrap();
+
+    let credentials = Credentials::from_keys(&r2_access_key_id, &r2_secret_access_key, None);
+
+    // Our S3-compatible object store checks for these variables, giving them
+    // higher priority than the normal 'AWS_ACCESS_KEY_ID'/'AWS_SECRET_ACCESS_KEY' vars
+    std::env::set_var("S3_ACCESS_KEY_ID", r2_access_key_id);
+    std::env::set_var("S3_SECRET_ACCESS_KEY", r2_secret_access_key);
+
+    let provider = E2ETestProvider {
+        variant_name: "openai".to_string(),
+        model_name: "openai::gpt-4o-mini-2024-07-18".into(),
+        model_provider_name: "openai".into(),
+        credentials: HashMap::new(),
+    };
+
+    let endpoint = "https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/tensorzero-e2e-test-images".to_string();
+
+    let test_bucket = "tensorzero-e2e-test-images";
+    let config = aws_config::load_from_env()
+        .await
+        .to_builder()
+        .credentials_provider(SharedCredentialsProvider::new(credentials))
+        .endpoint_url(&endpoint)
+        .build();
+
+    let client = aws_sdk_s3::Client::new(&config);
+
+    let mut prefix = Alphanumeric.sample_string(&mut rand::thread_rng(), 6);
+    prefix += "-";
+
+    test_image_inference_with_provider_s3_compatible(
+        provider,
+        &StorageKind::S3Compatible {
+            bucket_name: Some(test_bucket.to_string()),
+            region: None,
+            prefix: prefix.clone(),
+            endpoint: Some(endpoint.clone()),
+        },
+        &client,
+        &format!(
+            r#"
+    [object_storage]
+    type = "s3_compatible"
+    endpoint = "{endpoint}"
+    bucket_name = "{test_bucket}"
+    prefix = "{prefix}"
+    
+    [functions]
+    "#
+        ),
+        &test_bucket,
+        &prefix,
+    )
+    .await;
+}


### PR DESCRIPTION
This parameter is passed along to the object_store S3 client, and allows using an S3-compatible provider like Cloudflare R2. As a result, the 'region' and 'bucket_name' parameters are now optional (since these might come from the endpoint url).

The s3-compatible provider now checks for two new environment variables:
* S3_ACCESS_KEY_ID
* S3_SECRET_ACCESS_KEY

If set, these take priority over the normal 'AWS_ACCESS_KEY_ID' and 'AWS_SECRET_ACCESS_KEY' vars. This allows the gateway to use both AWS bedrock (with the normal AWS credentials) and a different S3-compatible provider for the object store.

I've added a test for Cloudflare R2 (only with the openai provider) verifying that an image inference request stores the image in the expected location.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
