### PR TITLE
Add 5 minute timeout to all outgoing HTTP requests

### DIFF
--- a/tensorzero-internal/src/gateway_util.rs
+++ b/tensorzero-internal/src/gateway_util.rs
@@ -126,8 +126,12 @@ where
     }
 }
 
+// This is set high enough that it should never be hit for a normal model response.
+// In the future, we may want to allow overriding this at the model provider level.
+const DEFAULT_HTTP_CLIENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+
 pub fn setup_http_client() -> Result<Client, Error> {
-    let mut http_client_builder = Client::builder();
+    let mut http_client_builder = Client::builder().timeout(DEFAULT_HTTP_CLIENT_TIMEOUT);
 
     if cfg!(any(feature = "e2e_tests", feature = "batch_tests")) {
         if let Ok(proxy_url) = std::env::var("TENSORZERO_E2E_PROXY") {


### PR DESCRIPTION
This should be high enough to never interfere with real providers, which still catching problems like the Together api hanging.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a 5-minute timeout to all outgoing HTTP requests in `setup_http_client()` in `gateway_util.rs`.
> 
>   - **Behavior**:
>     - Adds a 5-minute timeout to all outgoing HTTP requests in `setup_http_client()` in `gateway_util.rs`.
>     - Timeout is set using `DEFAULT_HTTP_CLIENT_TIMEOUT` constant.
>   - **Constants**:
>     - Introduces `DEFAULT_HTTP_CLIENT_TIMEOUT` set to 5 minutes in `gateway_util.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for af9c060d66cbb78107ebc89b29a86cc2aef60f54. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->