### PR TITLE
Support OpenAI 'image_url' content blocks in openai-compat

### DIFF
--- a/clients/openai-python/tests/test_openai_compatibility.py
+++ b/clients/openai-python/tests/test_openai_compatibility.py
@@ -517,7 +517,7 @@ async def test_async_json_invalid_system(async_client):
             model="tensorzero::function_name::json_success",
         )
     assert (
-        "Invalid request to OpenAI-compatible endpoint: `image_url` content blocks are not currently supported"
+        "Invalid request to OpenAI-compatible endpoint: System message must be a text content block"
         in str(exc_info.value)
     )
 


### PR DESCRIPTION
This also removes the restriction on only passing in one content block through the openai-compatible api.
We support both base64 'data:' urls, as well as normal remote urls.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for 'image_url' content blocks in OpenAI-compatible API, allowing both base64 and remote URLs, and remove single content block restriction.
> 
>   - **Behavior**:
>     - Support for `image_url` content blocks in OpenAI-compatible API, allowing both base64 and remote URLs in `openai_compatible.rs`.
>     - Removes restriction on passing only one content block in `openai_compatible.rs`.
>   - **Functions**:
>     - `convert_openai_message_content()` in `openai_compatible.rs` now returns a `Vec` of `InputMessageContent` to handle multiple content blocks.
>     - `parse_base64_image_data_url()` added to handle base64 image URLs in `openai_compatible.rs`.
>   - **Tests**:
>     - Added `test_async_multi_block_image_url` and `test_async_multi_block_image_base64` in `test_openai_compatibility.py` to verify handling of image URLs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1b4338a2e4e41aa7dc5b3db0840d90f57f528d16. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->