### PR TITLE
Add 'TensorZeroError::RequestTimeout' and produce a better Python err

### DIFF
--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -845,6 +845,7 @@ fn convert_error(py: Python<'_>, e: TensorZeroError) -> PyResult<PyErr> {
             source: _,
         } => tensorzero_error(py, status_code, text),
         TensorZeroError::Other { source } => tensorzero_internal_error(py, &source.to_string()),
+        TensorZeroError::RequestTimeout => tensorzero_internal_error(py, &e.to_string()),
         // Required due to the `#[non_exhaustive]` attribute on `TensorZeroError` - we want to force
         // downstream consumers to handle all possible error types, but the compiler also requires us
         // to do this (since our python bindings are in a different crate from the Rust client.)

--- a/clients/python-pyo3/tests/test_client.py
+++ b/clients/python-pyo3/tests/test_client.py
@@ -29,8 +29,6 @@ from uuid import UUID
 
 import pytest
 import pytest_asyncio
-from uuid_utils import uuid7
-
 from tensorzero import (
     AsyncTensorZeroGateway,
     ChatInferenceResponse,
@@ -44,6 +42,7 @@ from tensorzero import (
     ToolCall,
     ToolResult,
 )
+from uuid_utils import uuid7
 
 PWD = os.path.dirname(os.path.abspath(__file__))
 TEST_CONFIG_FILE = os.path.join(


### PR DESCRIPTION
This makes a timeout error understandable even without `verbose_errors=True`

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `TensorZeroError::RequestTimeout` to handle HTTP request timeouts and update Python tests to expect `TensorZeroInternalError` for timeouts.
> 
>   - **Error Handling**:
>     - Add `TensorZeroError::RequestTimeout` to `clients/rust/src/lib.rs` for handling HTTP request timeouts.
>     - Update `convert_error()` in `clients/python-pyo3/src/lib.rs` to map `RequestTimeout` to `tensorzero_internal_error()`.
>   - **Testing**:
>     - Update `test_async_timeout()` and `test_sync_timeout()` in `test_client.py` to expect `TensorZeroInternalError` with "HTTP request timed out" message.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ca239188cd8d3609ca189312e3066dfcf1e71359. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->