### PR TITLE
implemented eager template loading for all variant types

### DIFF
--- a/tensorzero-internal/src/config_parser.rs
+++ b/tensorzero-internal/src/config_parser.rs
@@ -19,10 +19,10 @@ use crate::tool::{
     ImplicitToolConfig, StaticToolConfig, ToolCallConfig, ToolChoice, ToolConfig,
     IMPLICIT_TOOL_NAME,
 };
-use crate::variant::best_of_n_sampling::BestOfNSamplingConfig;
-use crate::variant::chat_completion::ChatCompletionConfig;
+use crate::variant::best_of_n_sampling::UninitializedBestOfNSamplingConfig;
+use crate::variant::chat_completion::UninitializedChatCompletionConfig;
 use crate::variant::dicl::UninitializedDiclConfig;
-use crate::variant::mixture_of_n::MixtureOfNConfig;
+use crate::variant::mixture_of_n::UninitializedMixtureOfNConfig;
 use crate::variant::{Variant, VariantConfig};
 
 #[derive(Debug, Default)]
@@ -240,7 +240,7 @@ impl<'c> Config<'c> {
         };
 
         // Initialize the templates
-        let template_paths = config.get_templates(&base_path);
+        let template_paths = config.get_templates();
         config.templates.initialize(template_paths)?;
 
         // Validate the config
@@ -375,7 +375,7 @@ impl<'c> Config<'c> {
     /// The HashMap returned is a mapping from the path as given in the TOML file
     /// (relative to the directory containing the TOML file) to the path on the filesystem.
     /// The former path is used as the name of the template for retrieval by variants later.
-    pub fn get_templates<P: AsRef<Path>>(&self, base_path: P) -> HashMap<String, PathBuf> {
+    pub fn get_templates(&self) -> HashMap<String, String> {
         let mut templates = HashMap::new();
 
         for function in self.functions.values() {
@@ -383,14 +383,19 @@ impl<'c> Config<'c> {
                 let variant_template_paths = variant.get_all_template_paths();
                 for path in variant_template_paths {
                     templates.insert(
-                        path.to_string_lossy().to_string(),
-                        base_path.as_ref().join(path),
+                        path.path.to_string_lossy().to_string(),
+                        path.contents.clone(),
                     );
                 }
             }
         }
         templates
     }
+}
+
+/// A trait for loading configs with a base path
+pub trait LoadableConfig<T> {
+    fn load<P: AsRef<Path>>(self, base_path: P) -> Result<T, Error>;
 }
 
 /// This struct is used to deserialize the TOML config file
@@ -617,28 +622,30 @@ impl UninitializedFunctionConfig {
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 pub enum UninitializedVariantConfig {
-    ChatCompletion(ChatCompletionConfig),
+    ChatCompletion(UninitializedChatCompletionConfig),
     #[serde(rename = "experimental_best_of_n_sampling")]
-    BestOfNSampling(BestOfNSamplingConfig),
+    BestOfNSampling(UninitializedBestOfNSamplingConfig),
     #[serde(rename = "experimental_dynamic_in_context_learning")]
     Dicl(UninitializedDiclConfig),
     #[serde(rename = "experimental_mixture_of_n")]
-    MixtureOfN(MixtureOfNConfig),
+    MixtureOfN(UninitializedMixtureOfNConfig),
 }
 
 impl UninitializedVariantConfig {
     pub fn load<P: AsRef<Path>>(self, base_path: P) -> Result<VariantConfig, Error> {
         match self {
             UninitializedVariantConfig::ChatCompletion(params) => {
-                Ok(VariantConfig::ChatCompletion(params))
+                Ok(VariantConfig::ChatCompletion(params.load(base_path)?))
             }
             UninitializedVariantConfig::BestOfNSampling(params) => {
-                Ok(VariantConfig::BestOfNSampling(params))
+                Ok(VariantConfig::BestOfNSampling(params.load(base_path)?))
             }
             UninitializedVariantConfig::Dicl(params) => {
                 Ok(VariantConfig::Dicl(params.load(base_path)?))
             }
-            UninitializedVariantConfig::MixtureOfN(params) => Ok(VariantConfig::MixtureOfN(params)),
+            UninitializedVariantConfig::MixtureOfN(params) => {
+                Ok(VariantConfig::MixtureOfN(params.load(base_path)?))
+            }
         }
     }
 }
@@ -664,6 +671,32 @@ impl UninitializedToolConfig {
             parameters,
             strict: self.strict,
         })
+    }
+}
+
+#[derive(Debug)]
+pub struct PathWithContents {
+    pub path: PathBuf,
+    pub contents: String,
+}
+
+impl PathWithContents {
+    pub fn from_path<P: AsRef<Path>>(path: PathBuf, base_path: Option<P>) -> Result<Self, Error> {
+        let full_path = if let Some(base_path) = base_path.as_ref() {
+            &base_path.as_ref().join(&path)
+        } else {
+            &path
+        };
+        let contents = std::fs::read_to_string(full_path).map_err(|e| {
+            Error::new(ErrorDetails::Config {
+                message: format!(
+                    "Failed to read file at {}: {}",
+                    full_path.to_string_lossy(),
+                    e
+                ),
+            })
+        })?;
+        Ok(Self { path, contents })
     }
 }
 
@@ -1402,6 +1435,24 @@ mod tests {
         );
     }
 
+    /// Ensure that the config validation fails when a variant has a template that does not exist
+    #[test]
+    fn test_config_validate_variant_template_nonexistent() {
+        let mut config = get_sample_valid_config();
+        config["functions"]["generate_draft"]["variants"]["openai_promptA"]["system_template"] =
+            "nonexistent_template".into();
+        let base_path = PathBuf::new();
+        let result = Config::load_from_toml(config, base_path);
+
+        assert_eq!(
+            result.unwrap_err(),
+            ErrorDetails::Config {
+                message: "Failed to read file at nonexistent_template: No such file or directory (os error 2)".to_string()
+            }
+            .into()
+        );
+    }
+
     /// Ensure that the config validation fails when a function has a tool that does not exist in the tools section
     #[test]
     fn test_config_validate_function_nonexistent_tool() {
@@ -1651,74 +1702,92 @@ mod tests {
             Config::load_from_toml(config_table, PathBuf::new()).expect("Failed to load config");
 
         // Get all templates
-        let templates = config.get_templates(PathBuf::from("/base/path"));
+        let templates = config.get_templates();
 
         // Check if all expected templates are present
         assert_eq!(
             templates
                 .get("fixtures/config/functions/generate_draft/promptA/system_template.minijinja"),
-            Some(&PathBuf::from(
-                "/base/path/fixtures/config/functions/generate_draft/promptA/system_template.minijinja"
-            ))
+            Some(
+                &include_str!(
+                    "../fixtures/config/functions/generate_draft/promptA/system_template.minijinja"
+                )
+                .to_string()
+            )
         );
         assert_eq!(
             templates
                 .get("fixtures/config/functions/generate_draft/promptA/system_template.minijinja"),
-            Some(&PathBuf::from(
-                "/base/path/fixtures/config/functions/generate_draft/promptA/system_template.minijinja"
-            ))
+            Some(
+                &include_str!(
+                    "../fixtures/config/functions/generate_draft/promptA/system_template.minijinja"
+                )
+                .to_string()
+            )
         );
         assert_eq!(
             templates.get(
                 "fixtures/config/functions/json_with_schemas/promptA/system_template.minijinja"
             ),
-            Some(&PathBuf::from(
-                "/base/path/fixtures/config/functions/json_with_schemas/promptA/system_template.minijinja"
-            ))
+            Some(
+                &include_str!(
+                "../fixtures/config/functions/json_with_schemas/promptA/system_template.minijinja"
+            )
+                .to_string()
+            )
         );
         assert_eq!(
             templates.get(
                 "fixtures/config/functions/json_with_schemas/promptB/system_template.minijinja"
             ),
-            Some(&PathBuf::from(
-                "/base/path/fixtures/config/functions/json_with_schemas/promptB/system_template.minijinja"
-            ))
+            Some(
+                &include_str!(
+                "../fixtures/config/functions/json_with_schemas/promptB/system_template.minijinja"
+            )
+                .to_string()
+            )
         );
         assert_eq!(
             templates.get("fixtures/config/functions/templates_without_variables/variant_without_templates/system_template.minijinja"),
-            Some(&PathBuf::from(
-                "/base/path/fixtures/config/functions/templates_without_variables/variant_without_templates/system_template.minijinja"
-            ))
+            Some(&include_str!(
+                "../fixtures/config/functions/templates_without_variables/variant_without_templates/system_template.minijinja"
+            ).to_string()
+            )
         );
         assert_eq!(
             templates.get("fixtures/config/functions/templates_without_variables/variant_without_templates/user_template.minijinja"),
-            Some(&PathBuf::from(
-                "/base/path/fixtures/config/functions/templates_without_variables/variant_without_templates/user_template.minijinja"
-            ))
+            Some(&include_str!(
+                "../fixtures/config/functions/templates_without_variables/variant_without_templates/user_template.minijinja"
+            ).to_string()
+            )
         );
         assert_eq!(
             templates.get("fixtures/config/functions/templates_without_variables/variant_without_templates/assistant_template.minijinja"),
-            Some(&PathBuf::from(
-                "/base/path/fixtures/config/functions/templates_without_variables/variant_without_templates/assistant_template.minijinja"
-            ))
+            Some(&include_str!(
+                "../fixtures/config/functions/templates_without_variables/variant_without_templates/assistant_template.minijinja"
+            ).to_string()
+            )
         );
         assert_eq!(
             templates.get("fixtures/config/functions/templates_with_variables/variant_with_variables/assistant_template.minijinja"),
-            Some(&PathBuf::from(
-                "/base/path/fixtures/config/functions/templates_with_variables/variant_with_variables/assistant_template.minijinja"
-            ))
+            Some(&include_str!(
+                "../fixtures/config/functions/templates_with_variables/variant_with_variables/assistant_template.minijinja"
+            ).to_string()
+            )
         );
         assert_eq!(
             templates.get("fixtures/config/functions/templates_with_variables/variant_with_variables/user_template.minijinja"),
-            Some(&PathBuf::from(
-                "/base/path/fixtures/config/functions/templates_with_variables/variant_with_variables/user_template.minijinja"
-            ))
+            Some(&include_str!(
+                "../fixtures/config/functions/templates_with_variables/variant_with_variables/user_template.minijinja"
+            ).to_string()
+            )
         );
         assert_eq!(
             templates.get("fixtures/config/functions/templates_with_variables/variant_with_variables/system_template.minijinja"),
-            Some(&PathBuf::from(
-                "/base/path/fixtures/config/functions/templates_with_variables/variant_with_variables/system_template.minijinja"
-            ))
+            Some(&include_str!(
+                "../fixtures/config/functions/templates_with_variables/variant_with_variables/system_template.minijinja"
+            ).to_string()
+            )
         );
 
         // Check the total number of templates

--- a/tensorzero-internal/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-internal/src/variant/best_of_n_sampling.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::path::PathBuf;
+use std::path::Path;
 
 use backon::Retryable;
 use futures::future::join_all;
@@ -9,6 +9,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use tokio::time::{timeout, Duration};
 
+use crate::config_parser::{LoadableConfig, PathWithContents};
 use crate::embeddings::EmbeddingModelTable;
 use crate::endpoints::inference::{InferenceClients, InferenceModels};
 use crate::error::ErrorDetails;
@@ -29,28 +30,55 @@ use crate::{
     variant::chat_completion::ChatCompletionConfig,
 };
 
+use super::chat_completion::UninitializedChatCompletionConfig;
 use super::{InferenceConfig, JsonMode, ModelUsedInfo, Variant};
+
+#[derive(Debug)]
+pub struct BestOfNSamplingConfig {
+    pub weight: f64,
+    pub timeout_s: f64,
+    pub candidates: Vec<String>,
+    pub evaluator: EvaluatorConfig,
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct BestOfNSamplingConfig {
+pub struct UninitializedBestOfNSamplingConfig {
     #[serde(default)]
     pub weight: f64,
     #[serde(default = "default_timeout")]
     pub timeout_s: f64,
     pub candidates: Vec<String>,
-    pub evaluator: EvaluatorConfig,
+    pub evaluator: UninitializedEvaluatorConfig,
 }
 
 fn default_timeout() -> f64 {
     300.0
 }
 
+#[derive(Debug)]
+pub struct EvaluatorConfig {
+    pub inner: ChatCompletionConfig,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct EvaluatorConfig {
+pub struct UninitializedEvaluatorConfig {
     #[serde(flatten)]
-    pub inner: ChatCompletionConfig,
+    pub inner: UninitializedChatCompletionConfig,
+}
+
+impl LoadableConfig<BestOfNSamplingConfig> for UninitializedBestOfNSamplingConfig {
+    fn load<P: AsRef<Path>>(self, base_path: P) -> Result<BestOfNSamplingConfig, Error> {
+        Ok(BestOfNSamplingConfig {
+            weight: self.weight,
+            timeout_s: self.timeout_s,
+            candidates: self.candidates,
+            evaluator: EvaluatorConfig {
+                inner: self.evaluator.inner.load(base_path)?,
+            },
+        })
+    }
 }
 
 lazy_static! {
@@ -161,7 +189,7 @@ impl Variant for BestOfNSamplingConfig {
     // We do not return templates for the candidates, as they are required to be variants in the same function
     // and will therefore also have the same templates.
     // We only return templates for the evaluator variant.
-    fn get_all_template_paths(&self) -> Vec<&PathBuf> {
+    fn get_all_template_paths(&self) -> Vec<&PathWithContents> {
         self.evaluator.inner.get_all_template_paths()
     }
 
@@ -754,7 +782,10 @@ mod tests {
             inner: ChatCompletionConfig {
                 model: "dummy".into(),
                 weight: 1.0,
-                system_template: Some(system_template_name.into()),
+                system_template: Some(PathWithContents {
+                    path: system_template_name.into(),
+                    contents: "".to_string(),
+                }),
                 ..Default::default()
             },
         };
@@ -786,7 +817,10 @@ mod tests {
             inner: ChatCompletionConfig {
                 model: "dummy".into(),
                 weight: 1.0,
-                system_template: Some(system_template_name.into()),
+                system_template: Some(PathWithContents {
+                    path: system_template_name.into(),
+                    contents: "".to_string(),
+                }),
                 ..Default::default()
             },
         };

--- a/tensorzero-internal/src/variant/dicl.rs
+++ b/tensorzero-internal/src/variant/dicl.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 
 use serde::Deserialize;
 
+use crate::config_parser::LoadableConfig;
+use crate::config_parser::PathWithContents;
 use crate::embeddings::{EmbeddingModelTable, EmbeddingResponseWithMetadata};
 use crate::endpoints::inference::InferenceModels;
 use crate::inference::types::ContentBlock;
@@ -250,7 +252,7 @@ impl Variant for DiclConfig {
         Ok(())
     }
 
-    fn get_all_template_paths(&self) -> Vec<&PathBuf> {
+    fn get_all_template_paths(&self) -> Vec<&PathWithContents> {
         vec![]
     }
 
@@ -544,11 +546,11 @@ fn parse_raw_examples(
     Ok(examples)
 }
 
-impl UninitializedDiclConfig {
+impl LoadableConfig<DiclConfig> for UninitializedDiclConfig {
     /// Since the system instructions are optional and may be a path to a file,
     /// we need to load them here so that we can use the base_path to resolve
     /// any relative paths.
-    pub fn load<P: AsRef<Path>>(self, base_path: P) -> Result<DiclConfig, Error> {
+    fn load<P: AsRef<Path>>(self, base_path: P) -> Result<DiclConfig, Error> {
         let system_instructions = match self.system_instructions {
             Some(path) => {
                 let path = base_path.as_ref().join(path);

--- a/tensorzero-internal/src/variant/mod.rs
+++ b/tensorzero-internal/src/variant/mod.rs
@@ -6,12 +6,12 @@ use itertools::izip;
 use serde::Deserialize;
 use serde::Serialize;
 use std::borrow::Cow;
-use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::time::Duration;
 use tracing::instrument;
 use uuid::Uuid;
 
+use crate::config_parser::PathWithContents;
 use crate::embeddings::EmbeddingModelTable;
 use crate::endpoints::inference::InferenceIds;
 use crate::endpoints::inference::{InferenceClients, InferenceModels, InferenceParams};
@@ -149,7 +149,7 @@ pub trait Variant {
         variant_name: &str,
     ) -> Result<(), Error>;
 
-    fn get_all_template_paths(&self) -> Vec<&PathBuf>;
+    fn get_all_template_paths(&self) -> Vec<&PathWithContents>;
 
     async fn start_batch_inference<'a>(
         &'a self,
@@ -380,7 +380,7 @@ impl Variant for VariantConfig {
         }
     }
 
-    fn get_all_template_paths(&self) -> Vec<&PathBuf> {
+    fn get_all_template_paths(&self) -> Vec<&PathWithContents> {
         match self {
             VariantConfig::ChatCompletion(params) => params.get_all_template_paths(),
             VariantConfig::BestOfNSampling(params) => params.get_all_template_paths(),


### PR DESCRIPTION
As preparation for evals parsing I changed the variants so that they eagerly load the template files and pass the contents to the minijinja environment. There should be no behavior changes and IMO this simplifies code slightly.