### PR TITLE
bumped version to 2025.02.6

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -50,4 +50,4 @@ test-group = 'e2e_xai'
 # Settings for running unit tests
 filter = 'not binary(e2e)'
 retries = 0
-slow-timeout = { period = "2s", terminate-after = 1 }
+slow-timeout = { period = "3s", terminate-after = 1 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.2.5"
+version = "2025.2.6"
 dependencies = [
  "futures",
  "pyo3",

--- a/clients/python-deprecated/pyproject.toml
+++ b/clients/python-deprecated/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorzero"
-version = "2025.02.5"
+version = "2025.02.6"
 description = "The Python client for TensorZero"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/clients/python-deprecated/uv.lock
+++ b/clients/python-deprecated/uv.lock
@@ -156,7 +156,7 @@ wheels = [
 
 [[package]]
 name = "tensorzero"
-version = "2025.2.5"
+version = "2025.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/clients/python-pyo3/Cargo.toml
+++ b/clients/python-pyo3/Cargo.toml
@@ -3,7 +3,7 @@
 # It's named 'tensorzero-python' to avoid confusion with the Rust client
 # (which has a crate name of 'tensorzero')
 name = "tensorzero-python"
-version = "2025.2.5"
+version = "2025.2.6"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/babyai/requirements.txt
+++ b/examples/babyai/requirements.txt
@@ -417,7 +417,7 @@ stack-data==0.6.3
     # via ipython
 tatsu==5.8.3
     # via textworld
-tensorzero==2025.2.5
+tensorzero==2025.2.6
     # via -r requirements.in
 termcolor==2.5.0
     # via

--- a/examples/chess-puzzles-best-of-n-sampling/requirements.txt
+++ b/examples/chess-puzzles-best-of-n-sampling/requirements.txt
@@ -119,7 +119,7 @@ sniffio==1.3.1
     #   httpx
 stack-data==0.6.3
     # via ipython
-tensorzero==2025.2.5
+tensorzero==2025.2.6
     # via -r requirements.in
 tornado==6.4.2
     # via

--- a/examples/chess-puzzles-mixture-of-n-sampling/requirements.txt
+++ b/examples/chess-puzzles-mixture-of-n-sampling/requirements.txt
@@ -119,7 +119,7 @@ sniffio==1.3.1
     #   httpx
 stack-data==0.6.3
     # via ipython
-tensorzero==2025.2.5
+tensorzero==2025.2.6
     # via -r requirements.in
 tornado==6.4.2
     # via

--- a/examples/data-extraction-ner/requirements.txt
+++ b/examples/data-extraction-ner/requirements.txt
@@ -247,7 +247,7 @@ soupsieve==2.6
     # via beautifulsoup4
 stack-data==0.6.3
     # via ipython
-tensorzero==2025.2.5
+tensorzero==2025.2.6
     # via -r requirements.in
 terminado==0.18.1
     # via

--- a/examples/gsm8k-custom-recipe-dspy/requirements.txt
+++ b/examples/gsm8k-custom-recipe-dspy/requirements.txt
@@ -447,7 +447,7 @@ starlette==0.45.3
     # via fastapi
 tenacity==9.0.0
     # via dspy
-tensorzero==2025.2.5
+tensorzero==2025.2.6
     # via -r requirements.in
 terminado==0.18.1
     # via

--- a/examples/guides/episodes/requirements.txt
+++ b/examples/guides/episodes/requirements.txt
@@ -20,7 +20,7 @@ idna==3.10
     #   httpx
 sniffio==1.3.1
     # via anyio
-tensorzero==2025.2.5
+tensorzero==2025.2.6
     # via -r requirements.in
 typing-extensions==4.12.2
     # via anyio

--- a/examples/guides/metrics-feedback/requirements.txt
+++ b/examples/guides/metrics-feedback/requirements.txt
@@ -20,7 +20,7 @@ idna==3.10
     #   httpx
 sniffio==1.3.1
     # via anyio
-tensorzero==2025.2.5
+tensorzero==2025.2.6
     # via -r requirements.in
 typing-extensions==4.12.2
     # via anyio

--- a/examples/haiku-hidden-preferences/requirements.txt
+++ b/examples/haiku-hidden-preferences/requirements.txt
@@ -255,7 +255,7 @@ soupsieve==2.6
     # via beautifulsoup4
 stack-data==0.6.3
     # via ipython
-tensorzero==2025.2.5
+tensorzero==2025.2.6
     # via -r requirements.in
 terminado==0.18.1
     # via

--- a/examples/quickstart/requirements.txt
+++ b/examples/quickstart/requirements.txt
@@ -38,7 +38,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   openai
-tensorzero==2025.2.5
+tensorzero==2025.2.6
     # via -r requirements.in
 tqdm==4.67.1
     # via openai

--- a/examples/readme/requirements.txt
+++ b/examples/readme/requirements.txt
@@ -38,7 +38,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   openai
-tensorzero==2025.2.5
+tensorzero==2025.2.6
     # via -r requirements.in
 tqdm==4.67.1
     # via openai

--- a/examples/tutorial/01-simple-chatbot/requirements.txt
+++ b/examples/tutorial/01-simple-chatbot/requirements.txt
@@ -38,7 +38,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   openai
-tensorzero==2025.2.5
+tensorzero==2025.2.6
     # via -r requirements.in
 tqdm==4.67.1
     # via openai

--- a/examples/tutorial/02-email-copilot/requirements.txt
+++ b/examples/tutorial/02-email-copilot/requirements.txt
@@ -38,7 +38,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   openai
-tensorzero==2025.2.5
+tensorzero==2025.2.6
     # via -r requirements.in
 tqdm==4.67.1
     # via openai

--- a/examples/tutorial/03-weather-rag/requirements.txt
+++ b/examples/tutorial/03-weather-rag/requirements.txt
@@ -38,7 +38,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   openai
-tensorzero==2025.2.5
+tensorzero==2025.2.6
     # via -r requirements.in
 tqdm==4.67.1
     # via openai

--- a/examples/tutorial/04-email-data-extraction/requirements.txt
+++ b/examples/tutorial/04-email-data-extraction/requirements.txt
@@ -38,7 +38,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   openai
-tensorzero==2025.2.5
+tensorzero==2025.2.6
     # via -r requirements.in
 tqdm==4.67.1
     # via openai

--- a/recipes/dicl/requirements.txt
+++ b/recipes/dicl/requirements.txt
@@ -116,7 +116,7 @@ sniffio==1.3.1
     #   openai
 stack-data==0.6.3
     # via ipython
-tensorzero==2025.2.5
+tensorzero==2025.2.6
     # via -r requirements.in
 toml==0.10.2
     # via -r requirements.in

--- a/recipes/supervised_fine_tuning/demonstrations/fireworks/requirements.txt
+++ b/recipes/supervised_fine_tuning/demonstrations/fireworks/requirements.txt
@@ -253,7 +253,7 @@ soupsieve==2.6
     # via beautifulsoup4
 stack-data==0.6.3
     # via ipython
-tensorzero==2025.2.5
+tensorzero==2025.2.6
     # via -r requirements.in
 terminado==0.18.1
     # via

--- a/recipes/supervised_fine_tuning/metrics/fireworks/requirements.txt
+++ b/recipes/supervised_fine_tuning/metrics/fireworks/requirements.txt
@@ -257,7 +257,7 @@ soupsieve==2.6
     # via beautifulsoup4
 stack-data==0.6.3
     # via ipython
-tensorzero==2025.2.5
+tensorzero==2025.2.6
     # via -r requirements.in
 terminado==0.18.1
     # via

--- a/tensorzero-internal/src/endpoints/status.rs
+++ b/tensorzero-internal/src/endpoints/status.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::response::Json;
 use serde_json::{json, Value};
 
-pub const TENSORZERO_VERSION: &str = "2025.02.5";
+pub const TENSORZERO_VERSION: &str = "2025.02.6";
 
 /// A handler for a simple liveness check
 #[debug_handler]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `tensorzero` version to `2025.2.6` and update `slow-timeout` in `.config/nextest.toml`.
> 
>   - **Version Bump**:
>     - Update `tensorzero` version from `2025.2.5` to `2025.2.6` in `Cargo.lock`, `pyproject.toml`, `uv.lock`, `Cargo.toml`, and `status.rs`.
>     - Update `tensorzero` version in `requirements.txt` files across multiple example and recipe directories.
>   - **Configuration**:
>     - Change `slow-timeout` period from `2s` to `3s` in `.config/nextest.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2003bb85db1e830777ece6de7856a8c553b46daf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->