### PR TITLE
Set default env filter to 'warn' for other crates

### DIFF
--- a/tensorzero-internal/src/observability.rs
+++ b/tensorzero-internal/src/observability.rs
@@ -8,7 +8,7 @@ pub fn setup_logs(debug: bool) {
     let default_level = if debug { "debug,warn" } else { "warn" };
     // Get the current log level from the environment variable `RUST_LOG`
     let log_level = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-        format!("gateway={default_level},tensorzero_internal={default_level}").into()
+        format!("warn,gateway={default_level},tensorzero_internal={default_level}").into()
     });
 
     tracing_subscriber::registry()


### PR DESCRIPTION
This will ensure that we don't miss important information from other crates

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set default log level to include 'warn' for all crates in `setup_logs` in `observability.rs`.
> 
>   - **Behavior**:
>     - In `setup_logs` in `observability.rs`, default log level now includes a general `warn` for all crates, ensuring important warnings are captured.
>   - **Misc**:
>     - Adjusts log level format string in `setup_logs` to prepend `warn,` to existing configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for fcd1b3614deda0401c7d31f207323b947562a6a0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->