### PR TITLE
Wake up ClickHouse in batch tests, not merge queue

### DIFF
--- a/.github/workflows/batch-test-cron.yml
+++ b/.github/workflows/batch-test-cron.yml
@@ -51,12 +51,15 @@ jobs:
           cache: |
             rust
 
-
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Wake up ClickHouse cloud (for batch tests)
+        run: |
+          curl ${{ secrets.CLICKHOUSE_CLOUD_URL }} --data-binary 'SHOW DATABASES' > clickhouse_wakeup_logs.txt &
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
@@ -85,6 +88,10 @@ jobs:
       - name: Run batch tests
         run: |
           cargo test-batch
+
+      - name: Print clickhouse wakeup logs
+        if: always()
+        run: cat clickhouse_wakeup_logs.txt
 
       - name: Print batch logs
         if: always()

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -98,10 +98,6 @@ jobs:
           done
           echo "GATEWAY_PID=$!" >> $GITHUB_ENV
 
-      - name: Wake up ClickHouse cloud (for batch tests)
-        run: |
-          curl ${{ secrets.CLICKHOUSE_CLOUD_URL }} --data-binary 'SHOW DATABASES' > clickhouse_wakeup_logs.txt &
-
       # We set 'TENSORZERO_E2E_PROXY' here so that embedded gateway tests can use it
       - name: Run all tests (including E2E tests)
         run: |
@@ -275,7 +271,3 @@ jobs:
       - name: Take down ui tests
         working-directory: ui
         run: docker compose -f fixtures/docker-compose.yml down
-
-      - name: Print clickhouse wakeup logs
-        if: always()
-        run: cat clickhouse_wakeup_logs.txt


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move ClickHouse wake-up from merge queue to batch test cron job workflow for efficiency.
> 
>   - **Workflows**:
>     - Move ClickHouse wake-up step from `merge-queue.yml` to `batch-test-cron.yml`.
>     - Add `Wake up ClickHouse cloud` step in `batch-test-cron.yml` before running batch tests.
>     - Remove `Wake up ClickHouse cloud` and related log printing steps from `merge-queue.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for cc274c0b312335366c7069ee9e19daaff470f55b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->