### PR TITLE
Fix Copy to clipboard button in SFT

### DIFF
--- a/ui/app/routes/optimization/supervised-fine-tuning/SFTResult.tsx
+++ b/ui/app/routes/optimization/supervised-fine-tuning/SFTResult.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { Button } from "~/components/ui/button";
 import { Textarea } from "~/components/ui/textarea";
 
@@ -8,26 +8,37 @@ interface SFTResultProps {
 
 export function SFTResult({ finalResult }: SFTResultProps) {
   const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
   if (!finalResult) return null;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(finalResult);
+      setCopied(true);
+      setError(null);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error(err);
+      setError("Failed to copy. Please copy manually.");
+      if (textAreaRef.current) {
+        textAreaRef.current.select();
+      }
+    }
+  };
 
   return (
     <div className="mt-4 rounded-lg bg-gray-100 p-4">
       <div className="mb-2 flex items-center justify-between font-medium">
         <span>Configuration</span>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => {
-            navigator.clipboard.writeText(finalResult);
-            setCopied(true);
-            setTimeout(() => setCopied(false), 2000);
-          }}
-        >
+        <Button variant="outline" size="sm" onClick={handleCopy}>
           {copied ? "Copied!" : "Copy to Clipboard"}
         </Button>
       </div>
+      {error && <p className="mb-2 text-sm text-red-500">{error}</p>}
       <Textarea
+        ref={textAreaRef}
         value={finalResult}
         className="h-48 w-full resize-none border-none bg-transparent focus:ring-0"
         readOnly

--- a/ui/app/routes/optimization/supervised-fine-tuning/SFTResult.tsx
+++ b/ui/app/routes/optimization/supervised-fine-tuning/SFTResult.tsx
@@ -4,12 +4,22 @@ import { Textarea } from "~/components/ui/textarea";
 
 interface SFTResultProps {
   finalResult: string | null;
+  forceShowCopyButton?: boolean;
 }
 
-export function SFTResult({ finalResult }: SFTResultProps) {
+export function SFTResult({
+  finalResult,
+  forceShowCopyButton = false,
+}: SFTResultProps) {
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
+
+  const isSecureContext =
+    typeof window !== "undefined" && window.isSecureContext;
+  const isClipboard = typeof navigator !== "undefined" && !!navigator.clipboard;
+  const shouldShowCopyButton =
+    (isSecureContext && isClipboard) || forceShowCopyButton;
 
   if (!finalResult) return null;
 
@@ -30,11 +40,13 @@ export function SFTResult({ finalResult }: SFTResultProps) {
 
   return (
     <div className="mt-4 rounded-lg bg-gray-100 p-4">
-      <div className="mb-2 flex items-center justify-between font-medium">
+      <div className="mb-2 flex min-h-8 items-center justify-between font-medium">
         <span>Configuration</span>
-        <Button variant="outline" size="sm" onClick={handleCopy}>
-          {copied ? "Copied!" : "Copy to Clipboard"}
-        </Button>
+        {shouldShowCopyButton ? (
+          <Button variant="outline" size="sm" onClick={handleCopy}>
+            {copied ? "Copied!" : "Copy to Clipboard"}
+          </Button>
+        ) : null}
       </div>
       {error && <p className="mb-2 text-sm text-red-500">{error}</p>}
       <Textarea


### PR DESCRIPTION
Issue #1137

Following implementations were added:
- Display an error message when clipboard copying fails.
- Automatically select the text after an error occurs.

This error was caused by Secure Contexts. The navigator.clipboard.writeText function can only be executed in environments such as HTTPS or localhost. Domains like http://example.local do not support clipboard copying.
https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts

document.execCommand('copy') could be used as an alternative, it was not added since it is deprecated.
The Final Result data in the screenshot was created by me for testing.

![20250301-003502@2x](https://github.com/user-attachments/assets/0ca71ff8-c0f5-4706-b090-ae65da927e96)


<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes clipboard copy error handling in `SFTResult.tsx`, displaying an error message and selecting text on failure.
> 
>   - **Behavior**:
>     - Adds error handling in `handleCopy` function in `SFTResult.tsx` for clipboard copy failures.
>     - Displays error message and selects text if clipboard copy fails.
>     - Uses `useRef` to manage text selection in `Textarea`.
>   - **UI**:
>     - Updates `Button` to use `handleCopy` for clipboard operations.
>     - Displays error message below `Button` if copy fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4fa895547e4a0a822e874eaa6aeb51cfa21886bd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->