### PR TITLE
Added UI handling for default functions and variants

### DIFF
--- a/ui/app/utils/clickhouse/function.test.ts
+++ b/ui/app/utils/clickhouse/function.test.ts
@@ -1,5 +1,9 @@
 import { expect, test, describe } from "vitest";
-import { getVariantCounts, getVariantPerformances } from "./function";
+import {
+  getUsedVariants,
+  getVariantCounts,
+  getVariantPerformances,
+} from "./function";
 import type { FunctionConfig } from "../config/function";
 import type { MetricConfig } from "../config/metric";
 
@@ -530,5 +534,24 @@ describe("getVariantCounts", () => {
         variant_name: "initial_prompt_gpt4o_mini",
       },
     ]);
+  });
+});
+
+describe("getUsedVariants", () => {
+  test("getUsedVariants for extract_entities", async () => {
+    const function_name = "extract_entities";
+    const result = await getUsedVariants(function_name);
+    console.log(result);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        "baseline",
+        "dicl",
+        "llama_8b_initial_prompt",
+        "gpt4o_mini_initial_prompt",
+        "gpt4o_initial_prompt",
+        "turbo",
+      ]),
+    );
+    expect(result.length).toBe(6);
   });
 });

--- a/ui/app/utils/config/index.server.ts
+++ b/ui/app/utils/config/index.server.ts
@@ -16,6 +16,30 @@ const DEFAULT_CONFIG_PATH = "config/tensorzero.toml";
 const ENV_CONFIG_PATH = process.env.TENSORZERO_UI_CONFIG_PATH;
 const CACHE_TTL_MS = 1000 * 60; // 1 minute
 
+/*
+Config Context provider:
+
+In general, the config tree for TensorZero is static and can be loaded at startup and then used by any component.
+This is good so that we can avoid reading the config from the file system on every request.
+Since it is required for a very large number of components, it is also great to avoid drilling it down through nearly all components.
+
+So we implement a context provider that loads the config at the root of the app and makes it available to all components
+via the ConfigProvider and the useConfig hook.
+
+However, there is one exception to this static behavior: the default function `tensorzero::default`.
+Since the default function can be called with any model and since doing so with essentially creates a new variant,
+we must check what variants have been used in the past for this function.
+
+In order to avoid drilling the config through the entire application, we implement a caching mechanism here that is used for context.
+We only reload the config (file + database query) if the config is needed (via the hook or a backend helper function getConfig)
+and it has not been loaded in the past CACHE_TTL_MS.
+
+This introduces a small liveness issue where the list of variants for the default function is not updated for up toCACHE_TTL_MS
+after a new variant is used.
+
+We will likely address this with some form of query library down the line.
+*/
+
 export async function loadConfig(config_path?: string): Promise<Config> {
   // If the config_path was provided (via the env var)
   if (config_path) {


### PR DESCRIPTION
This ended up being a bit more complicated than I would have liked, but it does some work that we probably would have wanted anyway.

Important changes: 
* added a function `getUsedVariants` in `clickhouse/function.ts` that gets the names of all variants actually used for a particular function in the DB. Also tested. 
* Changed the config context loading to be a cache instead of a constant. This means that the config is actually rehydrated every minute from disk (lazily, when a page is actually loaded)
* As part of that config loaded, we call the `getUsedVariants` on `tensorzero::default` and construct variant configs for each default variant that was used. That way, we can be ~up to date on what's going on with it. 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Added `getUsedVariants` function and modified config loading to handle default function variants dynamically, with tests included.
> 
>   - **Behavior**:
>     - Added `getUsedVariants` in `function.ts` to fetch used variants for a function from the database.
>     - Modified config context loading in `index.server.ts` to cache and refresh every minute, ensuring up-to-date default function variants.
>   - **Functions**:
>     - `getUsedVariants` queries `ChatInference` and `JsonInference` tables for distinct variant names.
>     - `getDefaultFunctionWithVariants` in `function.server.ts` constructs variant configs for used default variants.
>   - **Tests**:
>     - Added tests for `getUsedVariants` in `function.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b6319ff999b91d560501d4dae78042581f567adb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->