### PR TITLE
Add token usage display to inference details

### DIFF
--- a/ui/app/routes/observability/inferences/$inference_id/BasicInfo.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/BasicInfo.tsx
@@ -10,12 +10,14 @@ import {
 } from "~/components/inference/TryWithVariantButton";
 import { AddToDatasetButton } from "./AddToDatasetButton";
 import type { DatasetCountInfo } from "~/utils/clickhouse/datasets";
+import type { InferenceUsage } from "~/utils/clickhouse/helpers";
 
 const FF_ENABLE_DATASETS =
   import.meta.env.VITE_TENSORZERO_UI_FF_ENABLE_DATASETS === "1";
 
 interface BasicInfoProps {
   inference: ParsedInferenceRow;
+  inferenceUsage?: InferenceUsage;
   tryWithVariantProps: TryWithVariantButtonProps;
   dataset_counts: DatasetCountInfo[];
   onDatasetSelect: (
@@ -27,6 +29,7 @@ interface BasicInfoProps {
 
 export default function BasicInfo({
   inference,
+  inferenceUsage,
   tryWithVariantProps,
   dataset_counts,
   onDatasetSelect,
@@ -74,13 +77,21 @@ export default function BasicInfo({
               {variantType}
             </Badge>
           </div>
-          <div>
+          <div className="col-span-2">
             <dt className="text-lg font-semibold">Episode ID</dt>
             <dd>
               <Link to={`/observability/episodes/${inference.episode_id}`}>
                 <Code>{inference.episode_id}</Code>
               </Link>
             </dd>
+          </div>
+          <div>
+            <dt className="text-lg font-semibold">Input Tokens</dt>
+            <dd>{inferenceUsage?.input_tokens ?? ""}</dd>
+          </div>
+          <div>
+            <dt className="text-lg font-semibold">Output Tokens</dt>
+            <dd>{inferenceUsage?.output_tokens ?? ""}</dd>
           </div>
           <div>
             <dt className="text-lg font-semibold">Timestamp</dt>

--- a/ui/app/routes/observability/inferences/$inference_id/route.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/route.tsx
@@ -210,6 +210,7 @@ export default function InferencePage({ loaderData }: Route.ComponentProps) {
       <div className="space-y-6">
         <BasicInfo
           inference={inference}
+          inferenceUsage={getTotalInferenceUsage(model_inferences)}
           tryWithVariantProps={{
             variants,
             onVariantSelect,


### PR DESCRIPTION
Issue #1172

Display total input and output token counts in the inference details view.
Calculates totals from all associated model inferences using existing getTotalInferenceUsage helper.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add token usage display to inference details by calculating totals with `getTotalInferenceUsage` and displaying them in `BasicInfo`.
> 
>   - **Behavior**:
>     - Display input and output token counts in `BasicInfo` component in `BasicInfo.tsx`.
>     - Calculate token totals using `getTotalInferenceUsage` in `route.tsx`.
>   - **Props**:
>     - Add `inferenceUsage` prop to `BasicInfo` in `BasicInfo.tsx`.
>   - **Functions**:
>     - Use `getTotalInferenceUsage` to compute token usage in `InferencePage` in `route.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a6ab17004ed55e513d4ecd144192f910ad042475. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->