### PR TITLE
Make 'Input::resolve' take 'self' by value

### DIFF
--- a/tensorzero-internal/src/endpoints/batch_inference.rs
+++ b/tensorzero-internal/src/endpoints/batch_inference.rs
@@ -224,9 +224,13 @@ pub async fn start_batch_inference_handler(
         object_store_info: &config.object_store_info,
     };
 
-    let resolved_inputs =
-        futures::future::try_join_all(params.inputs.iter().map(|input| input.resolve(&context)))
-            .await?;
+    let resolved_inputs = futures::future::try_join_all(
+        params
+            .inputs
+            .into_iter()
+            .map(|input| input.resolve(&context)),
+    )
+    .await?;
 
     // Keep sampling variants until one succeeds
     // We already guarantee there is at least one inference


### PR DESCRIPTION
This lets us avoid cloning the input fields

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `Input::resolve` to take `self` by value, optimizing input handling by avoiding unnecessary cloning.
> 
>   - **Behavior**:
>     - `Input::resolve` now takes `self` by value, avoiding cloning of input fields.
>     - Updated `start_batch_inference_handler` in `batch_inference.rs` to use `into_iter()` for `params.inputs`.
>   - **Functions**:
>     - Modified `resolve` in `Input`, `InputMessage`, and `InputMessageContent` to take `self` by value in `mod.rs`.
>   - **Misc**:
>     - Removed unnecessary cloning of `system` and `image` in `resolve` methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 326210f60b2ca7bc6a42da4999cd384c54678e7d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->