### PR TITLE
Wait on ClickHouse wakeup in batch tests

### DIFF
--- a/.github/workflows/batch-test-cron.yml
+++ b/.github/workflows/batch-test-cron.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Wake up ClickHouse cloud (for batch tests)
         run: |
-          curl ${{ secrets.CLICKHOUSE_CLOUD_URL }} --data-binary 'SHOW DATABASES' > clickhouse_wakeup_logs.txt &
+          curl ${{ secrets.CLICKHOUSE_CLOUD_URL }} --data-binary 'SHOW DATABASES'
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
We don't need the batch test run to be fast, so let's just block the runner until clickhouse wakes up.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify ClickHouse wakeup step in `batch-test-cron.yml` to block until completion, ensuring readiness before batch tests.
> 
>   - **Workflow Change**:
>     - In `.github/workflows/batch-test-cron.yml`, modify ClickHouse wakeup step to block until completion by removing background execution (`&`).
>     - Ensures ClickHouse is fully awake before proceeding with batch tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4c35080bca72886074bdce4f773b13513acb6058. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->