### PR TITLE
Add 'POST /datasets/:dataset/datapoints' route to gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,15 +873,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
- "windows-targets",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -3772,6 +3774,7 @@ dependencies = [
  "base64 0.22.1",
  "blake3",
  "bytes",
+ "chrono",
  "derive_builder",
  "futures",
  "futures-core",
@@ -4526,6 +4529,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-registry"

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -104,6 +104,10 @@ async fn main() {
         .route("/status", get(endpoints::status::status_handler))
         .route("/health", get(endpoints::status::health_handler))
         .route(
+            "/datasets/:dataset/datapoints",
+            post(endpoints::datasets::create_datapoint_handler),
+        )
+        .route(
             "/metrics",
             get(move || std::future::ready(metrics_handle.render())),
         )

--- a/tensorzero-internal/Cargo.toml
+++ b/tensorzero-internal/Cargo.toml
@@ -42,6 +42,7 @@ axum = { workspace = true }
 backon = { version = "1.2.0", features = ["tokio-sleep"] }
 blake3 = "1.5.5"
 bytes = "1.6.1"
+chrono = { version = "0.4.40", features = ["serde"] }
 derive_builder = "0.20.0"
 futures = { workspace = true }
 futures-core = "0.3.30"

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0014.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0014.rs
@@ -3,7 +3,7 @@ use crate::clickhouse_migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
 use async_trait::async_trait;
 
-use super::{check_table_exists, get_column_type};
+use super::{check_table_exists, get_column_type, table_is_nonempty};
 
 /// This migration is used to set up the ClickHouse database for the datasets feature.
 /// It creates two tables: `ChatInferenceDataset` and `JsonInferenceDataset`
@@ -61,6 +61,25 @@ impl Migration for Migration0014<'_> {
     }
 
     async fn apply(&self) -> Result<(), Error> {
+        let chat_inference_dataset_has_data =
+            table_is_nonempty(self.clickhouse, "ChatInferenceDataset", "0014").await?;
+        if chat_inference_dataset_has_data {
+            return Err(Error::new(ErrorDetails::ClickHouseMigration {
+                id: "0014".to_string(),
+                message: "ChatInferenceDataset has data. Your database state is invalid."
+                    .to_string(),
+            }));
+        }
+        let json_inference_dataset_has_data =
+            table_is_nonempty(self.clickhouse, "JsonInferenceDataset", "0014").await?;
+        if json_inference_dataset_has_data {
+            return Err(Error::new(ErrorDetails::ClickHouseMigration {
+                id: "0014".to_string(),
+                message: "JsonInferenceDataset has data. Your database state is invalid."
+                    .to_string(),
+            }));
+        }
+
         // First, drop the tables if they were created in 0012
         let query = "DROP TABLE IF EXISTS ChatInferenceDataset";
         let _ = self.clickhouse.run_query(query.to_string(), None).await?;

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0014.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0014.rs
@@ -61,23 +61,28 @@ impl Migration for Migration0014<'_> {
     }
 
     async fn apply(&self) -> Result<(), Error> {
-        let chat_inference_dataset_has_data =
-            table_is_nonempty(self.clickhouse, "ChatInferenceDataset", "0014").await?;
-        if chat_inference_dataset_has_data {
-            return Err(Error::new(ErrorDetails::ClickHouseMigration {
-                id: "0014".to_string(),
-                message: "ChatInferenceDataset has data. Your database state is invalid."
-                    .to_string(),
-            }));
+        if check_table_exists(self.clickhouse, "ChatInferenceDataset", "0014").await? {
+            let chat_inference_dataset_has_data =
+                table_is_nonempty(self.clickhouse, "ChatInferenceDataset", "0014").await?;
+            if chat_inference_dataset_has_data {
+                return Err(Error::new(ErrorDetails::ClickHouseMigration {
+                    id: "0014".to_string(),
+                    message: "ChatInferenceDataset has data. Your database state is invalid."
+                        .to_string(),
+                }));
+            }
         }
-        let json_inference_dataset_has_data =
-            table_is_nonempty(self.clickhouse, "JsonInferenceDataset", "0014").await?;
-        if json_inference_dataset_has_data {
-            return Err(Error::new(ErrorDetails::ClickHouseMigration {
-                id: "0014".to_string(),
-                message: "JsonInferenceDataset has data. Your database state is invalid."
-                    .to_string(),
-            }));
+
+        if check_table_exists(self.clickhouse, "JsonInferenceDataset", "0014").await? {
+            let json_inference_dataset_has_data =
+                table_is_nonempty(self.clickhouse, "JsonInferenceDataset", "0014").await?;
+            if json_inference_dataset_has_data {
+                return Err(Error::new(ErrorDetails::ClickHouseMigration {
+                    id: "0014".to_string(),
+                    message: "JsonInferenceDataset has data. Your database state is invalid."
+                        .to_string(),
+                }));
+            }
         }
 
         // First, drop the tables if they were created in 0012

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0014.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0014.rs
@@ -3,7 +3,7 @@ use crate::clickhouse_migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
 use async_trait::async_trait;
 
-use super::{check_table_exists, get_column_type, table_is_nonempty};
+use super::{check_table_exists, get_column_type};
 
 /// This migration is used to set up the ClickHouse database for the datasets feature.
 /// It creates two tables: `ChatInferenceDataset` and `JsonInferenceDataset`
@@ -55,25 +55,6 @@ impl Migration for Migration0014<'_> {
             || json_inference_dataset_output_type != "Nullable(String)"
         {
             return Ok(true);
-        }
-
-        let chat_inference_dataset_has_data =
-            table_is_nonempty(self.clickhouse, "ChatInferenceDataset", "0014").await?;
-        if chat_inference_dataset_has_data {
-            return Err(Error::new(ErrorDetails::ClickHouseMigration {
-                id: "0014".to_string(),
-                message: "ChatInferenceDataset has data. Your database state is invalid."
-                    .to_string(),
-            }));
-        }
-        let json_inference_dataset_has_data =
-            table_is_nonempty(self.clickhouse, "JsonInferenceDataset", "0014").await?;
-        if json_inference_dataset_has_data {
-            return Err(Error::new(ErrorDetails::ClickHouseMigration {
-                id: "0014".to_string(),
-                message: "JsonInferenceDataset has data. Your database state is invalid."
-                    .to_string(),
-            }));
         }
 
         Ok(false)

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/mod.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/mod.rs
@@ -104,7 +104,6 @@ async fn get_column_type(
     }
 }
 
-#[allow(dead_code)]
 async fn table_is_nonempty(
     clickhouse: &ClickHouseConnectionInfo,
     table: &str,

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/mod.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/mod.rs
@@ -104,6 +104,7 @@ async fn get_column_type(
     }
 }
 
+#[allow(dead_code)]
 async fn table_is_nonempty(
     clickhouse: &ClickHouseConnectionInfo,
     table: &str,

--- a/tensorzero-internal/src/endpoints/datasets.rs
+++ b/tensorzero-internal/src/endpoints/datasets.rs
@@ -1,0 +1,305 @@
+use std::collections::HashMap;
+
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    clickhouse::ClickHouseConnectionInfo,
+    error::{Error, ErrorDetails},
+    gateway_util::{AppState, StructuredJson},
+    inference::types::{
+        ChatInferenceDatabaseInsert, ContentBlockChatOutput, JsonInferenceDatabaseInsert,
+        JsonInferenceOutput, ResolvedInput,
+    },
+    tool::ToolCallConfigDatabaseInsert,
+};
+use tracing::instrument;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputKind {
+    Inherit,
+    Demonstration,
+    None,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct Demonstration {
+    #[allow(dead_code)]
+    id: Uuid,
+    #[allow(dead_code)]
+    inference_id: Uuid,
+    value: String,
+}
+
+async fn query_demonstration(
+    clickhouse: &ClickHouseConnectionInfo,
+    inference_id: Uuid,
+    page_size: u32,
+) -> Result<Demonstration, Error> {
+    let result = clickhouse
+        .run_query(
+            r#"
+        SELECT
+          id,
+          inference_id,
+          value,
+          formatDateTime(UUIDv7ToDateTime(id), '%Y-%m-%dT%H:%i:%SZ') AS timestamp
+        FROM DemonstrationFeedbackByInferenceId
+        WHERE inference_id = {inference_id:String}
+        ORDER BY toUInt128(id) DESC
+        LIMIT {page_size:UInt32}
+        FORMAT JSONEachRow;"#
+                .to_string(),
+            Some(&HashMap::from([
+                ("inference_id", inference_id.to_string().as_str()),
+                ("page_size", page_size.to_string().as_str()),
+            ])),
+        )
+        .await?;
+    if result.is_empty() {
+        return Err(Error::new(ErrorDetails::InvalidRequest {
+            message: format!("No demonstration found for inference `{}`", inference_id),
+        }));
+    }
+    let demonstration: Demonstration = serde_json::from_str(&result).map_err(|e| {
+        Error::new(ErrorDetails::Serialization {
+            message: format!(
+                "Failed to deserialize demonstration ClickHouse response: {}",
+                e
+            ),
+        })
+    })?;
+    Ok(demonstration)
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, tag = "function_type", rename_all = "snake_case")]
+pub enum TaggedInferenceDatabaseInsert {
+    Chat(ChatInferenceDatabaseInsert),
+    Json(JsonInferenceDatabaseInsert),
+}
+
+async fn query_inference_for_datapoint(
+    clickhouse: &ClickHouseConnectionInfo,
+    inference_id: Uuid,
+) -> Result<TaggedInferenceDatabaseInsert, Error> {
+    let result: String = clickhouse
+        .run_query(
+            r#"
+            SELECT
+  uint_to_uuid(i.id_uint) AS id,
+
+  -- Common columns (pick via IF)
+  IF(i.function_type = 'chat', c.function_name, j.function_name) AS function_name,
+  IF(i.function_type = 'chat', c.variant_name,   j.variant_name)   AS variant_name,
+  IF(i.function_type = 'chat', c.episode_id,     j.episode_id)     AS episode_id,
+  IF(i.function_type = 'chat', c.input,          j.input)          AS input,
+  IF(i.function_type = 'chat', c.output,         j.output)         AS output,
+
+  -- Chat-specific columns
+  IF(i.function_type = 'chat', c.tool_params, '') AS tool_params,
+
+  -- Inference params (common name in the union)
+  IF(i.function_type = 'chat', c.inference_params, j.inference_params) AS inference_params,
+
+  -- Processing time
+  IF(i.function_type = 'chat', c.processing_time_ms, j.processing_time_ms) AS processing_time_ms,
+
+  -- JSON-specific column
+  IF(i.function_type = 'json', j.output_schema, '') AS output_schema,
+
+  -- Timestamps & tags
+  IF(i.function_type = 'chat',
+   formatDateTime(c.timestamp, '%Y-%m-%dT%H:%i:%SZ'),
+   formatDateTime(j.timestamp, '%Y-%m-%dT%H:%i:%SZ')
+) AS timestamp,
+  IF(i.function_type = 'chat', c.tags,      j.tags)      AS tags,
+
+  -- Discriminator itself
+  i.function_type
+
+FROM InferenceById i
+LEFT JOIN ChatInference c
+  ON i.id_uint = toUInt128(c.id)
+LEFT JOIN JsonInference j
+  ON i.id_uint = toUInt128(j.id)
+WHERE uint_to_uuid(i.id_uint) = {id:String}
+FORMAT JSONEachRow;"#
+                .to_string(),
+            Some(&HashMap::from([("id", inference_id.to_string().as_str())])),
+        )
+        .await?;
+
+    if result.is_empty() {
+        return Err(Error::new(ErrorDetails::InvalidRequest {
+            message: format!("Inference `{}` not found", inference_id),
+        }));
+    }
+
+    let inference_data: TaggedInferenceDatabaseInsert =
+        serde_json::from_str(&result).map_err(|e| {
+            Error::new(ErrorDetails::Serialization {
+                message: format!("Failed to deserialize inference data: {}", e),
+            })
+        })?;
+    Ok(inference_data)
+}
+
+/// A handler for the feedback endpoint
+#[instrument(name = "create_datapoint", skip_all)]
+pub async fn create_datapoint_handler(
+    State(app_state): AppState,
+    Path(path_params): Path<PathParams>,
+    StructuredJson(params): StructuredJson<CreateDatapointParams>,
+) -> Result<Json<CreateDatapointResponse>, Error> {
+    let inference_data =
+        query_inference_for_datapoint(&app_state.clickhouse_connection_info, params.inference_id)
+            .await?;
+    let datapoint_output = match params.output {
+        OutputKind::Inherit => match &inference_data {
+            TaggedInferenceDatabaseInsert::Json(inference) => {
+                Some(serde_json::to_string(&inference.output).map_err(|e| {
+                    Error::new(ErrorDetails::Serialization {
+                        message: format!("Failed to serialize JSON output: {}", e),
+                    })
+                })?)
+            }
+            TaggedInferenceDatabaseInsert::Chat(inference) => {
+                Some(serde_json::to_string(&inference.output).map_err(|e| {
+                    Error::new(ErrorDetails::Serialization {
+                        message: format!("Failed to serialize chat output: {}", e),
+                    })
+                })?)
+            }
+        },
+        OutputKind::Demonstration => {
+            let demonstration = query_demonstration(
+                &app_state.clickhouse_connection_info,
+                params.inference_id,
+                1,
+            )
+            .await?;
+            match &inference_data {
+                TaggedInferenceDatabaseInsert::Json(_) => {
+                    let _: JsonInferenceOutput = serde_json::from_str(&demonstration.value)
+                        .map_err(|e| {
+                            Error::new(ErrorDetails::Serialization {
+                                message: format!(
+                                    "Failed to deserialize JSON demonstration output: {}",
+                                    e
+                                ),
+                            })
+                        })?;
+                }
+                TaggedInferenceDatabaseInsert::Chat(_) => {
+                    let _: Vec<ContentBlockChatOutput> = serde_json::from_str(&demonstration.value)
+                        .map_err(|e| {
+                            Error::new(ErrorDetails::Serialization {
+                                message: format!(
+                                    "Failed to deserialize chat demonstration output: {}",
+                                    e
+                                ),
+                            })
+                        })?;
+                }
+            };
+            Some(demonstration.value)
+        }
+        OutputKind::None => None,
+    };
+
+    match inference_data {
+        TaggedInferenceDatabaseInsert::Json(inference) => {
+            let datapoint = JsonInferenceDatapoint {
+                dataset_name: path_params.dataset,
+                function_name: inference.function_name,
+                id: inference.id,
+                episode_id: inference.episode_id,
+                input: inference.input,
+                output: datapoint_output,
+                output_schema: inference.output_schema,
+                tags: Some(inference.tags),
+                auxiliary: "{}".to_string(),
+                is_deleted: false,
+            };
+            app_state
+                .clickhouse_connection_info
+                .write(&[datapoint], "JsonInferenceDataset")
+                .await?;
+        }
+        TaggedInferenceDatabaseInsert::Chat(inference) => {
+            let datapoint = ChatInferenceDatapoint {
+                dataset_name: path_params.dataset,
+                function_name: inference.function_name,
+                id: inference.id,
+                episode_id: inference.episode_id,
+                input: inference.input,
+                output: datapoint_output,
+                tool_params: inference.tool_params,
+                tags: Some(inference.tags),
+                auxiliary: "{}".to_string(),
+                is_deleted: false,
+            };
+            app_state
+                .clickhouse_connection_info
+                .write(&[datapoint], "ChatInferenceDataset")
+                .await?;
+        }
+    }
+    Ok(Json(CreateDatapointResponse {}))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PathParams {
+    pub dataset: String,
+}
+
+#[derive(Deserialize)]
+pub struct CreateDatapointParams {
+    pub output: OutputKind,
+    pub inference_id: Uuid,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreateDatapointResponse {}
+
+pub enum Datapoint {
+    ChatInference(ChatInferenceDatapoint),
+    JsonInference(JsonInferenceDatapoint),
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChatInferenceDatapoint {
+    pub dataset_name: String,
+    pub function_name: String,
+    pub id: Uuid,
+    pub episode_id: Uuid,
+    pub input: ResolvedInput,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_params: Option<ToolCallConfigDatabaseInsert>,
+    pub tags: Option<HashMap<String, String>>,
+    pub auxiliary: String,
+    pub is_deleted: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonInferenceDatapoint {
+    pub dataset_name: String,
+    pub function_name: String,
+    pub id: Uuid,
+    pub episode_id: Uuid,
+    pub input: ResolvedInput,
+    pub output: Option<String>,
+    pub output_schema: serde_json::Value,
+    pub tags: Option<HashMap<String, String>>,
+    pub auxiliary: String,
+    pub is_deleted: bool,
+}

--- a/tensorzero-internal/src/endpoints/mod.rs
+++ b/tensorzero-internal/src/endpoints/mod.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::error::{Error, ErrorDetails};
 
 pub mod batch_inference;
+pub mod datasets;
 pub mod fallback;
 pub mod feedback;
 pub mod inference;

--- a/tensorzero-internal/src/inference/types/mod.rs
+++ b/tensorzero-internal/src/inference/types/mod.rs
@@ -1,3 +1,5 @@
+use crate::inference::types::batch::deserialize_json_string;
+use crate::inference::types::batch::deserialize_optional_json_string;
 use derive_builder::Builder;
 use futures::stream::Peekable;
 use futures::Stream;
@@ -433,36 +435,43 @@ pub enum InferenceResultChunk {
 /// For this we convert the InferenceResult into a ChatInferenceDatabaseInsert or JsonInferenceDatabaseInsert and ModelInferenceDatabaseInserts,
 /// which are written to ClickHouse tables of the same name asynchronously.
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ChatInferenceDatabaseInsert {
     pub id: Uuid,
     pub function_name: String,
     pub variant_name: String,
     pub episode_id: Uuid,
+    #[serde(deserialize_with = "deserialize_json_string")]
     pub input: ResolvedInput,
+    #[serde(deserialize_with = "deserialize_json_string")]
     pub output: Vec<ContentBlockChatOutput>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(deserialize_with = "deserialize_optional_json_string")]
     pub tool_params: Option<ToolCallConfigDatabaseInsert>,
+    #[serde(deserialize_with = "deserialize_json_string")]
     pub inference_params: InferenceParams,
     pub processing_time_ms: Option<u32>,
     pub tags: HashMap<String, String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct JsonInferenceDatabaseInsert {
     pub id: Uuid,
     pub function_name: String,
     pub variant_name: String,
     pub episode_id: Uuid,
+    #[serde(deserialize_with = "deserialize_json_string")]
     pub input: ResolvedInput,
+    #[serde(deserialize_with = "deserialize_json_string")]
     pub output: JsonInferenceOutput,
+    #[serde(deserialize_with = "deserialize_json_string")]
     pub inference_params: InferenceParams,
     pub processing_time_ms: Option<u32>,
     pub output_schema: Value,
     pub tags: HashMap<String, String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum InferenceDatabaseInsert {
     Chat(ChatInferenceDatabaseInsert),

--- a/tensorzero-internal/tests/e2e/common.rs
+++ b/tensorzero-internal/tests/e2e/common.rs
@@ -31,6 +31,48 @@ pub async fn clickhouse_flush_async_insert(clickhouse: &ClickHouseConnectionInfo
         .unwrap();
 }
 
+#[allow(dead_code)]
+pub(crate) async fn select_chat_datapoint_clickhouse(
+    clickhouse_connection_info: &ClickHouseConnectionInfo,
+    inference_id: Uuid,
+) -> Option<Value> {
+    #[cfg(feature = "e2e_tests")]
+    clickhouse_flush_async_insert(clickhouse_connection_info).await;
+
+    let query = format!(
+        "SELECT * FROM ChatInferenceDataset WHERE id = '{}' LIMIT 1 FORMAT JSONEachRow",
+        inference_id
+    );
+
+    let text = clickhouse_connection_info
+        .run_query(query, None)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_str(&text).ok()?;
+    Some(json)
+}
+
+#[allow(dead_code)]
+pub(crate) async fn select_json_datapoint_clickhouse(
+    clickhouse_connection_info: &ClickHouseConnectionInfo,
+    inference_id: Uuid,
+) -> Option<Value> {
+    #[cfg(feature = "e2e_tests")]
+    clickhouse_flush_async_insert(clickhouse_connection_info).await;
+
+    let query = format!(
+        "SELECT * FROM JsonInferenceDataset WHERE id = '{}' LIMIT 1 FORMAT JSONEachRow",
+        inference_id
+    );
+
+    let text = clickhouse_connection_info
+        .run_query(query, None)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_str(&text).ok()?;
+    Some(json)
+}
+
 pub(crate) async fn select_chat_inference_clickhouse(
     clickhouse_connection_info: &ClickHouseConnectionInfo,
     inference_id: Uuid,

--- a/tensorzero-internal/tests/e2e/datasets.rs
+++ b/tensorzero-internal/tests/e2e/datasets.rs
@@ -1,0 +1,610 @@
+#![allow(clippy::print_stdout)]
+
+use reqwest::{Client, StatusCode};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::common::{
+    get_clickhouse, get_gateway_endpoint, select_chat_datapoint_clickhouse,
+    select_json_datapoint_clickhouse,
+};
+
+#[tokio::test]
+async fn test_datapoint_insert_output_inherit_chat() {
+    let clickhouse = get_clickhouse().await;
+    let client = Client::new();
+    // Run inference (standard, no dryrun) to get an episode_id.
+    let inference_payload = serde_json::json!({
+        "function_name": "basic_test",
+        "input": {
+            "system": {"assistant_name": "Alfred Pennyworth"},
+            "messages": [{"role": "user", "content": "Hello, world!"}]
+        },
+        "stream": false,
+    });
+
+    let response = client
+        .post(get_gateway_endpoint("/inference"))
+        .json(&inference_payload)
+        .send()
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+    let response_json = response.json::<Value>().await.unwrap();
+    let episode_id = response_json.get("episode_id").unwrap().as_str().unwrap();
+    let episode_id = Uuid::parse_str(episode_id).unwrap();
+    let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
+    let inference_id = Uuid::parse_str(inference_id).unwrap();
+
+    let dataset_name = format!("test-dataset-{}", Uuid::now_v7());
+
+    let resp = client
+        .post(get_gateway_endpoint(&format!(
+            "/datasets/{dataset_name}/datapoints"
+        )))
+        .json(&serde_json::json!({
+            "inference_id": inference_id,
+            "output": "inherit"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    if !resp.status().is_success() {
+        panic!("Bad request: {:?}", resp.text().await.unwrap());
+    }
+
+    let mut datapoint = select_chat_datapoint_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+
+    let updated_at = datapoint
+        .as_object_mut()
+        .unwrap()
+        .remove("updated_at")
+        .unwrap();
+    let updated_at =
+        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), "%Y-%m-%d %H:%M:%S")
+            .unwrap()
+            .and_utc();
+    assert!(
+        chrono::Utc::now()
+            .signed_duration_since(updated_at)
+            .num_seconds()
+            < 5,
+        "Unexpected updated_at: {updated_at:?}"
+    );
+
+    let expected = serde_json::json!({
+      "dataset_name": dataset_name,
+      "function_name": "basic_test",
+      "id": inference_id.to_string(),
+      "episode_id": episode_id.to_string(),
+      "input": "{\"system\":{\"assistant_name\":\"Alfred Pennyworth\"},\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"value\":\"Hello, world!\"}]}]}",
+      "output": "[{\"type\":\"text\",\"text\":\"Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake.\"}]",
+      "tool_params": "",
+      "tags": {},
+      "auxiliary": "{}",
+      "is_deleted": false
+    });
+    assert_eq!(datapoint, expected);
+}
+
+#[tokio::test]
+async fn test_datapoint_insert_output_none_chat() {
+    let clickhouse = get_clickhouse().await;
+    let client = Client::new();
+    // Run inference (standard, no dryrun) to get an episode_id.
+    let inference_payload = serde_json::json!({
+        "function_name": "basic_test",
+        "input": {
+            "system": {"assistant_name": "Alfred Pennyworth"},
+            "messages": [{"role": "user", "content": "Hello, world!"}]
+        },
+        "stream": false,
+    });
+
+    let response = client
+        .post(get_gateway_endpoint("/inference"))
+        .json(&inference_payload)
+        .send()
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+    let response_json = response.json::<Value>().await.unwrap();
+    let episode_id = response_json.get("episode_id").unwrap().as_str().unwrap();
+    let episode_id = Uuid::parse_str(episode_id).unwrap();
+    let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
+    let inference_id = Uuid::parse_str(inference_id).unwrap();
+
+    let dataset_name = format!("test-dataset-{}", Uuid::now_v7());
+
+    let resp = client
+        .post(get_gateway_endpoint(&format!(
+            "/datasets/{dataset_name}/datapoints"
+        )))
+        .json(&serde_json::json!({
+            "inference_id": inference_id,
+            "output": "none"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    if !resp.status().is_success() {
+        panic!("Bad request: {:?}", resp.text().await.unwrap());
+    }
+
+    let mut datapoint = select_chat_datapoint_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+
+    let updated_at = datapoint
+        .as_object_mut()
+        .unwrap()
+        .remove("updated_at")
+        .unwrap();
+    let updated_at =
+        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), "%Y-%m-%d %H:%M:%S")
+            .unwrap()
+            .and_utc();
+    assert!(
+        chrono::Utc::now()
+            .signed_duration_since(updated_at)
+            .num_seconds()
+            < 5,
+        "Unexpected updated_at: {updated_at:?}"
+    );
+
+    let expected = serde_json::json!({
+      "dataset_name": dataset_name,
+      "function_name": "basic_test",
+      "id": inference_id.to_string(),
+      "episode_id": episode_id.to_string(),
+      "input": "{\"system\":{\"assistant_name\":\"Alfred Pennyworth\"},\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"value\":\"Hello, world!\"}]}]}",
+      "output": null,
+      "tool_params": "",
+      "tags": {},
+      "auxiliary": "{}",
+      "is_deleted": false
+    });
+    assert_eq!(datapoint, expected);
+}
+
+#[tokio::test]
+async fn test_datapoint_insert_output_demonstration_chat() {
+    let clickhouse = get_clickhouse().await;
+    let client = Client::new();
+    // Run inference (standard, no dryrun) to get an episode_id.
+    let inference_payload = serde_json::json!({
+        "function_name": "basic_test",
+        "input": {
+            "system": {"assistant_name": "Alfred Pennyworth"},
+            "messages": [{"role": "user", "content": "Hello, world!"}]
+        },
+        "stream": false,
+    });
+
+    let response = client
+        .post(get_gateway_endpoint("/inference"))
+        .json(&inference_payload)
+        .send()
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+    let response_json = response.json::<Value>().await.unwrap();
+    let episode_id = response_json.get("episode_id").unwrap().as_str().unwrap();
+    let episode_id = Uuid::parse_str(episode_id).unwrap();
+    let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
+    let inference_id = Uuid::parse_str(inference_id).unwrap();
+
+    let dataset_name = format!("test-dataset-{}", Uuid::now_v7());
+
+    let response = client
+        .post(get_gateway_endpoint("/feedback"))
+        .json(&serde_json::json!({
+            "inference_id": inference_id,
+            "metric_name": "demonstration",
+            "value": [{"type": "text", "text": "My demonstration chat answer"}],
+        }))
+        .send()
+        .await
+        .unwrap();
+    if !response.status().is_success() {
+        panic!("Bad request: {:?}", response.text().await.unwrap());
+    }
+
+    // Sleep to allow writing demonstration before making datapoint
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let resp = client
+        .post(get_gateway_endpoint(&format!(
+            "/datasets/{dataset_name}/datapoints"
+        )))
+        .json(&serde_json::json!({
+            "inference_id": inference_id,
+            "output": "demonstration"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    if !resp.status().is_success() {
+        panic!("Bad request: {:?}", resp.text().await.unwrap());
+    }
+
+    let mut datapoint = select_chat_datapoint_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+
+    let updated_at = datapoint
+        .as_object_mut()
+        .unwrap()
+        .remove("updated_at")
+        .unwrap();
+    let updated_at =
+        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), "%Y-%m-%d %H:%M:%S")
+            .unwrap()
+            .and_utc();
+    assert!(
+        chrono::Utc::now()
+            .signed_duration_since(updated_at)
+            .num_seconds()
+            < 5,
+        "Unexpected updated_at: {updated_at:?}"
+    );
+
+    println!(
+        "Datapoint: {}",
+        serde_json::to_string_pretty(&datapoint).unwrap()
+    );
+
+    let expected = serde_json::json!({
+      "dataset_name": dataset_name,
+      "function_name": "basic_test",
+      "id": inference_id.to_string(),
+      "episode_id": episode_id.to_string(),
+      "input": "{\"system\":{\"assistant_name\":\"Alfred Pennyworth\"},\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"value\":\"Hello, world!\"}]}]}",
+      "output": "[{\"type\":\"text\",\"text\":\"My demonstration chat answer\"}]",
+      "tool_params": "",
+      "tags": {},
+      "auxiliary": "{}",
+      "is_deleted": false
+    });
+    assert_eq!(datapoint, expected);
+}
+
+#[tokio::test]
+async fn test_datapoint_insert_output_inherit_json() {
+    let clickhouse = get_clickhouse().await;
+    let client = Client::new();
+    // Run inference (standard, no dryrun) to get an episode_id.
+    let inference_payload = serde_json::json!({
+        "function_name": "json_success",
+        "input": {
+            "system": {"assistant_name": "Alfred Pennyworth"},
+            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+        },
+        "stream": false,
+    });
+
+    let response = client
+        .post(get_gateway_endpoint("/inference"))
+        .json(&inference_payload)
+        .send()
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+    let response_json = response.json::<Value>().await.unwrap();
+    let episode_id = response_json.get("episode_id").unwrap().as_str().unwrap();
+    let episode_id = Uuid::parse_str(episode_id).unwrap();
+    let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
+    let inference_id = Uuid::parse_str(inference_id).unwrap();
+
+    let dataset_name = format!("test-dataset-{}", Uuid::now_v7());
+
+    let resp = client
+        .post(get_gateway_endpoint(&format!(
+            "/datasets/{dataset_name}/datapoints"
+        )))
+        .json(&serde_json::json!({
+            "inference_id": inference_id,
+            "output": "inherit"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    if !resp.status().is_success() {
+        panic!("Bad request: {:?}", resp.text().await.unwrap());
+    }
+
+    let mut datapoint = select_json_datapoint_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+
+    let updated_at = datapoint
+        .as_object_mut()
+        .unwrap()
+        .remove("updated_at")
+        .unwrap();
+    let updated_at =
+        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), "%Y-%m-%d %H:%M:%S")
+            .unwrap()
+            .and_utc();
+    assert!(
+        chrono::Utc::now()
+            .signed_duration_since(updated_at)
+            .num_seconds()
+            < 5,
+        "Unexpected updated_at: {updated_at:?}"
+    );
+
+    let expected = serde_json::json!({
+      "dataset_name": dataset_name,
+      "function_name": "json_success",
+      "id": inference_id.to_string(),
+      "episode_id": episode_id.to_string(),
+      "input": "{\"system\":{\"assistant_name\":\"Alfred Pennyworth\"},\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"value\":{\"country\":\"Japan\"}}]}]}",
+      "output": "{\"raw\":\"{\\\"answer\\\":\\\"Hello\\\"}\",\"parsed\":{\"answer\":\"Hello\"}}",
+      "output_schema": "{\"type\":\"object\",\"properties\":{\"answer\":{\"type\":\"string\"}},\"required\":[\"answer\"],\"additionalProperties\":false}",
+      "tags": {},
+      "auxiliary": "{}",
+      "is_deleted": false,
+    });
+    assert_eq!(datapoint, expected);
+}
+
+#[tokio::test]
+async fn test_datapoint_insert_output_none_json() {
+    let clickhouse = get_clickhouse().await;
+    let client = Client::new();
+    // Run inference (standard, no dryrun) to get an episode_id.
+    let inference_payload = serde_json::json!({
+        "function_name": "json_success",
+        "input": {
+            "system": {"assistant_name": "Alfred Pennyworth"},
+            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+        },
+        "stream": false,
+    });
+
+    let response = client
+        .post(get_gateway_endpoint("/inference"))
+        .json(&inference_payload)
+        .send()
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+    let response_json = response.json::<Value>().await.unwrap();
+    let episode_id = response_json.get("episode_id").unwrap().as_str().unwrap();
+    let episode_id = Uuid::parse_str(episode_id).unwrap();
+    let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
+    let inference_id = Uuid::parse_str(inference_id).unwrap();
+
+    let dataset_name = format!("test-dataset-{}", Uuid::now_v7());
+
+    let resp = client
+        .post(get_gateway_endpoint(&format!(
+            "/datasets/{dataset_name}/datapoints"
+        )))
+        .json(&serde_json::json!({
+            "inference_id": inference_id,
+            "output": "none"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    if !resp.status().is_success() {
+        panic!("Bad request: {:?}", resp.text().await.unwrap());
+    }
+
+    let mut datapoint = select_json_datapoint_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+
+    let updated_at = datapoint
+        .as_object_mut()
+        .unwrap()
+        .remove("updated_at")
+        .unwrap();
+    let updated_at =
+        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), "%Y-%m-%d %H:%M:%S")
+            .unwrap()
+            .and_utc();
+    assert!(
+        chrono::Utc::now()
+            .signed_duration_since(updated_at)
+            .num_seconds()
+            < 5,
+        "Unexpected updated_at: {updated_at:?}"
+    );
+
+    let expected = serde_json::json!({
+      "dataset_name": dataset_name,
+      "function_name": "json_success",
+      "id": inference_id.to_string(),
+      "episode_id": episode_id.to_string(),
+      "input": "{\"system\":{\"assistant_name\":\"Alfred Pennyworth\"},\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"value\":{\"country\":\"Japan\"}}]}]}",
+      "output":null,
+      "output_schema": "{\"type\":\"object\",\"properties\":{\"answer\":{\"type\":\"string\"}},\"required\":[\"answer\"],\"additionalProperties\":false}",
+      "tags": {},
+      "auxiliary": "{}",
+      "is_deleted": false,
+    });
+    assert_eq!(datapoint, expected);
+}
+
+#[tokio::test]
+async fn test_datapoint_insert_output_demonstration_json() {
+    let clickhouse = get_clickhouse().await;
+    let client = Client::new();
+    // Run inference (standard, no dryrun) to get an episode_id.
+    let inference_payload = serde_json::json!({
+        "function_name": "json_success",
+        "input": {
+            "system": {"assistant_name": "Alfred Pennyworth"},
+            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+        },
+        "stream": false,
+    });
+
+    let response = client
+        .post(get_gateway_endpoint("/inference"))
+        .json(&inference_payload)
+        .send()
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+    let response_json = response.json::<Value>().await.unwrap();
+    let episode_id = response_json.get("episode_id").unwrap().as_str().unwrap();
+    let episode_id = Uuid::parse_str(episode_id).unwrap();
+    let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
+    let inference_id = Uuid::parse_str(inference_id).unwrap();
+
+    let dataset_name = format!("test-dataset-{}", Uuid::now_v7());
+
+    let response = client
+        .post(get_gateway_endpoint("/feedback"))
+        .json(&serde_json::json!({
+            "inference_id": inference_id,
+            "metric_name": "demonstration",
+            "value": {"answer": "My demonstration answer"},
+        }))
+        .send()
+        .await
+        .unwrap();
+    if !response.status().is_success() {
+        panic!("Bad request: {:?}", response.text().await.unwrap());
+    }
+
+    // Sleep to allow writing demonstration before making datapoint
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let resp = client
+        .post(get_gateway_endpoint(&format!(
+            "/datasets/{dataset_name}/datapoints"
+        )))
+        .json(&serde_json::json!({
+            "inference_id": inference_id,
+            "output": "demonstration"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    if !resp.status().is_success() {
+        panic!("Bad request: {:?}", resp.text().await.unwrap());
+    }
+
+    let mut datapoint = select_json_datapoint_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+
+    let updated_at = datapoint
+        .as_object_mut()
+        .unwrap()
+        .remove("updated_at")
+        .unwrap();
+    let updated_at =
+        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), "%Y-%m-%d %H:%M:%S")
+            .unwrap()
+            .and_utc();
+    assert!(
+        chrono::Utc::now()
+            .signed_duration_since(updated_at)
+            .num_seconds()
+            < 5,
+        "Unexpected updated_at: {updated_at:?}"
+    );
+
+    println!(
+        "Datapoint: {}",
+        serde_json::to_string_pretty(&datapoint).unwrap()
+    );
+
+    let expected = serde_json::json!({
+      "dataset_name": dataset_name,
+      "function_name": "json_success",
+      "id": inference_id.to_string(),
+      "episode_id": episode_id.to_string(),
+      "input": "{\"system\":{\"assistant_name\":\"Alfred Pennyworth\"},\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"value\":{\"country\":\"Japan\"}}]}]}",
+      "output": "{\"raw\":\"{\\\"answer\\\":\\\"My demonstration answer\\\"}\",\"parsed\":{\"answer\":\"My demonstration answer\"}}",
+      "output_schema": "{\"type\":\"object\",\"properties\":{\"answer\":{\"type\":\"string\"}},\"required\":[\"answer\"],\"additionalProperties\":false}",
+      "tags": {},
+      "auxiliary": "{}",
+      "is_deleted": false,
+    });
+    assert_eq!(datapoint, expected);
+}
+
+#[tokio::test]
+async fn test_missing_inference_id() {
+    let client = Client::new();
+    let fake_inference_id = Uuid::now_v7();
+    let resp = client
+        .post(get_gateway_endpoint("/datasets/dummy-dataset/datapoints"))
+        .json(&serde_json::json!({
+            "inference_id": fake_inference_id,
+            "output": "inherit"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains(&format!("Inference `{fake_inference_id}` not found")),
+        "Unexpected response: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_datapoint_missing_demonstration() {
+    let client = Client::new();
+    // Run inference (standard, no dryrun) to get an episode_id.
+    let inference_payload = serde_json::json!({
+        "function_name": "json_success",
+        "input": {
+            "system": {"assistant_name": "Alfred Pennyworth"},
+            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+        },
+        "stream": false,
+    });
+
+    let response = client
+        .post(get_gateway_endpoint("/inference"))
+        .json(&inference_payload)
+        .send()
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+    let response_json = response.json::<Value>().await.unwrap();
+    let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
+    let inference_id = Uuid::parse_str(inference_id).unwrap();
+
+    let dataset_name = format!("test-dataset-{}", Uuid::now_v7());
+
+    let resp = client
+        .post(get_gateway_endpoint(&format!(
+            "/datasets/{dataset_name}/datapoints"
+        )))
+        .json(&serde_json::json!({
+            "inference_id": inference_id,
+            "output": "demonstration"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains(&format!(
+            "No demonstration found for inference `{inference_id}`"
+        )),
+        "Unexpected response: {body}"
+    );
+}

--- a/tensorzero-internal/tests/e2e/tests.rs
+++ b/tensorzero-internal/tests/e2e/tests.rs
@@ -3,6 +3,7 @@ mod best_of_n;
 mod cache;
 mod clickhouse;
 mod common;
+mod datasets;
 mod dicl;
 mod fallback;
 mod feedback;


### PR DESCRIPTION
This is a port of the corresponding nodejs route in 'ui/app/routes/observability/inferences/$inference_id/route.tsx'

While implementing this route, I need to make a few other changes:
* 'Migration0014' no longer errors if 'ChatInferenceDataset' or 'JsonInferenceDataset' are non-empty (since we're now inserting data into these tables from the e2e tests)
* 'deserialize_optional_json_string' now treats empty strings as 'None'
* Several fields use 'deserialize_optional_json_string' or 'deserialize_json_string' so that we can read them back from ClickHouse in the new endpoint.

I've opted not to add in retrying logic when fetching the inference (or demonstration), under the assumption that users won't try to create a datapoint immediately after running an inference or providing a demonstration.

The tests are currently using 'chrono' to parse the 'updated_at' timestamp. I entirely avoided timestamp handling in the actual endpoint code, as we can just let ClickHouse fill in the current time for 'updated_at' when inserting a row.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `POST /datasets/:dataset/datapoints` route to insert datapoints into datasets with support for various output options and updates related deserialization and migration logic.
> 
>   - **Behavior**:
>     - Adds `POST /datasets/:dataset/datapoints` route in `main.rs` to insert datapoints into `ChatInferenceDataset` or `JsonInferenceDataset`.
>     - Supports `output` parameter with options: `inherit`, `demonstration`, or `none`.
>     - Handles missing inference or demonstration with appropriate error responses.
>   - **Migration**:
>     - Updates `Migration0014` to check for non-empty `ChatInferenceDataset` or `JsonInferenceDataset` before applying.
>   - **Deserialization**:
>     - `deserialize_optional_json_string` in `batch.rs` now treats empty strings as `None`.
>     - Applies `deserialize_optional_json_string` and `deserialize_json_string` to fields in `types/mod.rs`.
>   - **Testing**:
>     - Adds e2e tests in `datasets.rs` for datapoint insertion with different `output` options.
>     - Updates `common.rs` with helper functions for querying ClickHouse datasets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1dc43c5e9a01e63d6719fc4e28e92eea8662fa23. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->