### PR TITLE
Bump clickhouse ping timeout to 1000ms

### DIFF
--- a/tensorzero-internal/src/clickhouse.rs
+++ b/tensorzero-internal/src/clickhouse.rs
@@ -161,8 +161,8 @@ impl ClickHouseConnectionInfo {
 
                 match client
                     .get(ping_url)
-                    // If ClickHouse is healthy, it should respond within 500ms
-                    .timeout(std::time::Duration::from_millis(500))
+                    // If ClickHouse is healthy, it should respond within 1000ms
+                    .timeout(std::time::Duration::from_millis(1000))
                     .send()
                     .await
                 {


### PR DESCRIPTION
On CI, 500ms is sometimes too short. Let's bump the timeout in all cases to keep things simple.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase ClickHouse ping timeout to 1000ms in `clickhouse.rs` for better CI reliability.
> 
>   - **Behavior**:
>     - Increase ClickHouse ping timeout from 500ms to 1000ms in `health()` function in `clickhouse.rs` to improve reliability in CI environments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d6c1daeed80225d18c679e1ff94f461c5a172714. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->