### PR TITLE
Run ClickHouse health check once at the start of migration manager

### DIFF
--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0000.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0000.rs
@@ -1,6 +1,6 @@
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::clickhouse_migration_manager::migration_trait::Migration;
-use crate::error::{Error, ErrorDetails};
+use crate::error::Error;
 use async_trait::async_trait;
 
 use super::check_table_exists;
@@ -21,14 +21,8 @@ pub struct Migration0000<'a> {
 
 #[async_trait]
 impl Migration for Migration0000<'_> {
-    /// Check if you can connect to the database
     async fn can_apply(&self) -> Result<(), Error> {
-        self.clickhouse.health().await.map_err(|e| {
-            Error::new(ErrorDetails::ClickHouseMigration {
-                id: "0000".to_string(),
-                message: e.to_string(),
-            })
-        })
+        Ok(())
     }
 
     /// Check if the tables exist

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0002.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0002.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::clickhouse_migration_manager::migration_trait::Migration;
-use crate::error::{Error, ErrorDetails};
+use crate::error::Error;
 
 use super::check_table_exists;
 
@@ -14,14 +14,8 @@ pub struct Migration0002<'a> {
 
 #[async_trait]
 impl Migration for Migration0002<'_> {
-    /// Check if you can connect to the database
     async fn can_apply(&self) -> Result<(), Error> {
-        self.clickhouse.health().await.map_err(|e| {
-            Error::new(ErrorDetails::ClickHouseMigration {
-                id: "0002".to_string(),
-                message: e.to_string(),
-            })
-        })
+        Ok(())
     }
 
     /// Check if the migration has already been applied

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0003.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0003.rs
@@ -21,17 +21,9 @@ pub struct Migration0003<'a> {
 
 #[async_trait]
 impl Migration for Migration0003<'_> {
-    /// Check if you can connect to the database
-    /// Then check if the four feedback tables exist as the sources for the materialized views
+    /// Check if the four feedback tables exist as the sources for the materialized views
     /// If all of this is OK, then we can apply the migration
     async fn can_apply(&self) -> Result<(), Error> {
-        self.clickhouse.health().await.map_err(|e| {
-            Error::new(ErrorDetails::ClickHouseMigration {
-                id: "0003".to_string(),
-                message: e.to_string(),
-            })
-        })?;
-
         let tables = vec![
             "BooleanMetricFeedback",
             "CommentFeedback",

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0004.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0004.rs
@@ -20,16 +20,9 @@ pub struct Migration0004<'a> {
 
 #[async_trait]
 impl Migration for Migration0004<'_> {
-    /// Check if you can connect to the database and if the ModelInference table exists
+    /// Check if the ModelInference table exists
     /// If all of this is OK, then we can apply the migration
     async fn can_apply(&self) -> Result<(), Error> {
-        self.clickhouse.health().await.map_err(|e| {
-            Error::new(ErrorDetails::ClickHouseMigration {
-                id: "0004".to_string(),
-                message: e.to_string(),
-            })
-        })?;
-
         if !check_table_exists(self.clickhouse, "ModelInference", "0004").await? {
             return Err(ErrorDetails::ClickHouseMigration {
                 id: "0004".to_string(),

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0005.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0005.rs
@@ -20,17 +20,9 @@ pub struct Migration0005<'a> {
 
 #[async_trait]
 impl Migration for Migration0005<'_> {
-    /// Check if you can connect to the database
-    /// Then check if the two inference tables exist as the sources for the materialized views
+    /// Check if the two inference tables exist as the sources for the materialized views
     /// If all of this is OK, then we can apply the migration
     async fn can_apply(&self) -> Result<(), Error> {
-        self.clickhouse.health().await.map_err(|e| {
-            Error::new(ErrorDetails::ClickHouseMigration {
-                id: "0005".to_string(),
-                message: e.to_string(),
-            })
-        })?;
-
         let tables = vec!["ChatInference", "JsonInference"];
         for table in tables {
             match check_table_exists(self.clickhouse, table, "0005").await {

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0006.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0006.rs
@@ -1,6 +1,6 @@
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::clickhouse_migration_manager::migration_trait::Migration;
-use crate::error::{Error, ErrorDetails};
+use crate::error::Error;
 use async_trait::async_trait;
 
 use super::check_table_exists;
@@ -22,14 +22,7 @@ pub struct Migration0006<'a> {
 
 #[async_trait]
 impl Migration for Migration0006<'_> {
-    /// Check if you can connect to the database
     async fn can_apply(&self) -> Result<(), Error> {
-        self.clickhouse.health().await.map_err(|e| {
-            Error::new(ErrorDetails::ClickHouseMigration {
-                id: "0006".to_string(),
-                message: e.to_string(),
-            })
-        })?;
         Ok(())
     }
 

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0008.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0008.rs
@@ -19,15 +19,8 @@ pub struct Migration0008<'a> {
 
 #[async_trait]
 impl Migration for Migration0008<'_> {
-    /// Check if you can connect to the database
-    /// Also check that the tables that need altering already exist
+    /// Ccheck that the tables that need altering already exist
     async fn can_apply(&self) -> Result<(), Error> {
-        self.clickhouse.health().await.map_err(|e| {
-            Error::new(ErrorDetails::ClickHouseMigration {
-                id: "0008".to_string(),
-                message: e.to_string(),
-            })
-        })?;
         let tables = [
             "ModelInference",
             "ChatInference",

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0009.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0009.rs
@@ -15,17 +15,9 @@ pub struct Migration0009<'a> {
 
 #[async_trait]
 impl Migration for Migration0009<'_> {
-    /// Check if you can connect to the database
-    /// Then check if the four feedback tables exist
+    /// Check if the four feedback tables exist
     /// If all of this is OK, then we can apply the migration
     async fn can_apply(&self) -> Result<(), Error> {
-        self.clickhouse.health().await.map_err(|e| {
-            Error::new(ErrorDetails::ClickHouseMigration {
-                id: "0009".to_string(),
-                message: e.to_string(),
-            })
-        })?;
-
         let tables = vec![
             "BooleanMetricFeedback",
             "CommentFeedback",

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0011.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0011.rs
@@ -1,6 +1,6 @@
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::clickhouse_migration_manager::migration_trait::Migration;
-use crate::error::{Error, ErrorDetails};
+use crate::error::Error;
 use async_trait::async_trait;
 
 use super::{check_column_exists, check_table_exists};
@@ -18,17 +18,7 @@ pub struct Migration0011<'a> {
 
 #[async_trait]
 impl Migration for Migration0011<'_> {
-    /// Check if you can connect to the database
-    /// Then check if the two inference tables exist as the sources for the materialized views
-    /// If all of this is OK, then we can apply the migration
     async fn can_apply(&self) -> Result<(), Error> {
-        self.clickhouse.health().await.map_err(|e| {
-            Error::new(ErrorDetails::ClickHouseMigration {
-                id: "0011".to_string(),
-                message: e.to_string(),
-            })
-        })?;
-
         Ok(())
     }
 

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0013.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0013.rs
@@ -26,17 +26,9 @@ pub struct Migration0013<'a> {
 
 #[async_trait]
 impl Migration for Migration0013<'_> {
-    /// Check if you can connect to the database
-    /// Then check if the two inference tables exist as the sources for the materialized views
+    /// Check if the two inference tables exist as the sources for the materialized views
     /// If all of this is OK, then we can apply the migration
     async fn can_apply(&self) -> Result<(), Error> {
-        self.clickhouse.health().await.map_err(|e| {
-            Error::new(ErrorDetails::ClickHouseMigration {
-                id: "0013".to_string(),
-                message: e.to_string(),
-            })
-        })?;
-
         let tables = vec!["ChatInference", "JsonInference"];
 
         for table in tables {

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0014.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0014.rs
@@ -22,15 +22,7 @@ pub struct Migration0014<'a> {
 
 #[async_trait]
 impl Migration for Migration0014<'_> {
-    /// Check if you can connect to the database
     async fn can_apply(&self) -> Result<(), Error> {
-        self.clickhouse.health().await.map_err(|e| {
-            Error::new(ErrorDetails::ClickHouseMigration {
-                id: "0014".to_string(),
-                message: e.to_string(),
-            })
-        })?;
-
         Ok(())
     }
 

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0015.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0015.rs
@@ -1,6 +1,6 @@
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::clickhouse_migration_manager::migration_trait::Migration;
-use crate::error::{Error, ErrorDetails};
+use crate::error::Error;
 use async_trait::async_trait;
 
 use super::get_column_type;
@@ -12,15 +12,7 @@ pub struct Migration0015<'a> {
 
 #[async_trait]
 impl Migration for Migration0015<'_> {
-    /// Check if you can connect to the database
     async fn can_apply(&self) -> Result<(), Error> {
-        self.clickhouse.health().await.map_err(|e| {
-            Error::new(ErrorDetails::ClickHouseMigration {
-                id: "0015".to_string(),
-                message: e.to_string(),
-            })
-        })?;
-
         Ok(())
     }
 

--- a/tensorzero-internal/src/clickhouse_migration_manager/mod.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/mod.rs
@@ -21,6 +21,7 @@ use migrations::migration_0015::Migration0015;
 use async_trait::async_trait;
 
 pub async fn run(clickhouse: &ClickHouseConnectionInfo) -> Result<(), Error> {
+    clickhouse.health().await?;
     // This is a no-op if the database already exists
     clickhouse.create_database().await?;
     // If the first migration needs to run, we are starting from scratch and don't need to wait for data to migrate


### PR DESCRIPTION
There's no need to run the health check at the start of each migration.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Optimize ClickHouse migration by running health check once at the start of migration manager instead of each migration.
> 
>   - **Behavior**:
>     - Run ClickHouse health check once at the start of `run()` in `mod.rs` instead of at the start of each migration.
>     - Removed health check from `can_apply()` in `Migration0000`, `Migration0002`, `Migration0003`, `Migration0004`, `Migration0005`, `Migration0006`, `Migration0008`, `Migration0009`, `Migration0011`, `Migration0013`, `Migration0014`, and `Migration0015`.
>   - **Error Handling**:
>     - Removed `ErrorDetails` usage in `migration_0000.rs`, `migration_0002.rs`, `migration_0006.rs`, and `migration_0011.rs`.
>   - **Documentation**:
>     - Updated comments in `migration_0003.rs`, `migration_0004.rs`, `migration_0005.rs`, `migration_0008.rs`, `migration_0009.rs`, `migration_0013.rs`, and `migration_0014.rs` to reflect the removal of health checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0c35a03f533b0e58102da0378faf81be4eb56a16. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->