### PR TITLE
forces updated_at columns in dataset tables to UTC

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -50,4 +50,4 @@ test-group = 'e2e_xai'
 # Settings for running unit tests
 filter = 'not binary(e2e)'
 retries = 0
-slow-timeout = { period = "10s", terminate-after = 1 }
+slow-timeout = { period = "5s", terminate-after = 1 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -50,4 +50,4 @@ test-group = 'e2e_xai'
 # Settings for running unit tests
 filter = 'not binary(e2e)'
 retries = 0
-slow-timeout = { period = "3s", terminate-after = 1 }
+slow-timeout = { period = "10s", terminate-after = 1 }

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -45,8 +45,7 @@ jobs:
           args: --find-interpreter
 
   validate:
-    # runs-on: namespace-profile-tensorzero-8x16
-    runs-on: macos-15
+    runs-on: namespace-profile-tensorzero-8x16
 
     timeout-minutes: 15
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -45,7 +45,8 @@ jobs:
           args: --find-interpreter
 
   validate:
-    runs-on: namespace-profile-tensorzero-8x16
+    # runs-on: namespace-profile-tensorzero-8x16
+    runs-on: macos-15
 
     timeout-minutes: 15
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -45,7 +45,9 @@ jobs:
           args: --find-interpreter
 
   validate:
-    runs-on: namespace-profile-tensorzero-8x16
+    # runs-on: namespace-profile-tensorzero-8x16
+    runs-on: macos-15
+    target: aarch64
 
     timeout-minutes: 15
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -45,9 +45,7 @@ jobs:
           args: --find-interpreter
 
   validate:
-    # runs-on: namespace-profile-tensorzero-8x16
-    runs-on: macos-15
-    target: aarch64
+    runs-on: namespace-profile-tensorzero-8x16
 
     timeout-minutes: 15
 

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0016.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0016.rs
@@ -1,0 +1,70 @@
+use crate::clickhouse::ClickHouseConnectionInfo;
+use crate::clickhouse_migration_manager::migration_trait::Migration;
+use crate::error::Error;
+use async_trait::async_trait;
+
+use super::{check_table_exists, get_column_type};
+
+/// This migration alters the updated_at column in the `ChatInferenceDataset` and `JsonInferenceDataset` tables.``
+/// so that times are explicitly stored in UTC
+pub struct Migration0016<'a> {
+    pub clickhouse: &'a ClickHouseConnectionInfo,
+}
+
+#[async_trait]
+impl Migration for Migration0016<'_> {
+    async fn can_apply(&self) -> Result<(), Error> {
+        check_table_exists(self.clickhouse, "ChatInferenceDataset", "0016").await?;
+        check_table_exists(self.clickhouse, "JsonInferenceDataset", "0016").await?;
+
+        Ok(())
+    }
+
+    async fn should_apply(&self) -> Result<bool, Error> {
+        let column_type = get_column_type(
+            self.clickhouse,
+            "ChatInferenceDataset",
+            "updated_at",
+            "0016",
+        )
+        .await?;
+        if column_type != "DateTime(\\'UTC\\')" {
+            return Ok(true);
+        }
+        let column_type = get_column_type(
+            self.clickhouse,
+            "JsonInferenceDataset",
+            "updated_at",
+            "0016",
+        )
+        .await?;
+        if column_type != "DateTime(\\'UTC\\')" {
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    async fn apply(&self) -> Result<(), Error> {
+        let query =
+            "ALTER TABLE ChatInferenceDataset MODIFY COLUMN updated_at DateTime('UTC')".to_string();
+        self.clickhouse.run_query(query, None).await?;
+
+        let query =
+            "ALTER TABLE JsonInferenceDataset MODIFY COLUMN updated_at DateTime('UTC')".to_string();
+        self.clickhouse.run_query(query, None).await?;
+
+        Ok(())
+    }
+
+    fn rollback_instructions(&self) -> String {
+        "ALTER TABLE ChatInferenceDataset MODIFY COLUMN updated_at DateTime;
+        ALTER TABLE JsonInferenceDataset MODIFY COLUMN updated_at DateTime;"
+            .to_string()
+    }
+
+    async fn has_succeeded(&self) -> Result<bool, Error> {
+        let should_apply = self.should_apply().await?;
+        Ok(!should_apply)
+    }
+}

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0016.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0016.rs
@@ -1,12 +1,20 @@
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::clickhouse_migration_manager::migration_trait::Migration;
-use crate::error::Error;
+use crate::error::{Error, ErrorDetails};
 use async_trait::async_trait;
 
-use super::{check_table_exists, get_column_type};
+use super::{check_table_exists, get_column_type, table_is_nonempty};
 
-/// This migration alters the updated_at column in the `ChatInferenceDataset` and `JsonInferenceDataset` tables.``
-/// so that times are explicitly stored in UTC
+/// This migration is used to set up the ClickHouse database for the datasets feature.
+/// It creates two tables: `ChatInferenceDataset` and `JsonInferenceDataset`
+/// These tables store the information required to do things like run evals,
+/// implement dynamic in-context learning, and run curated SFT jobs.
+/// We anticipate unpredictable future uses for datasets as well.
+///
+/// This migration should subsume migration 0014.
+/// They should have been removed from the binary upon merging of this migration.
+///
+/// This migration differs from 0014 in that it uses DateTime64(6, 'UTC') instead of DateTime('UTC')
 pub struct Migration0016<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
@@ -14,31 +22,47 @@ pub struct Migration0016<'a> {
 #[async_trait]
 impl Migration for Migration0016<'_> {
     async fn can_apply(&self) -> Result<(), Error> {
-        check_table_exists(self.clickhouse, "ChatInferenceDataset", "0016").await?;
-        check_table_exists(self.clickhouse, "JsonInferenceDataset", "0016").await?;
-
         Ok(())
     }
 
+    /// Check if the migration needs to be applied
+    /// This should be equivalent to checking if `ChatInferenceDataset` is missing
+    /// or if `JsonInferenceDataset` is missing
+    /// OR if they exist and either `output` column is not Nullable(String)
     async fn should_apply(&self) -> Result<bool, Error> {
-        let column_type = get_column_type(
+        let chat_inference_dataset_table_exists =
+            check_table_exists(self.clickhouse, "ChatInferenceDataset", "0016").await?;
+        let json_inference_dataset_table_exists =
+            check_table_exists(self.clickhouse, "JsonInferenceDataset", "0016").await?;
+        if !chat_inference_dataset_table_exists || !json_inference_dataset_table_exists {
+            return Ok(true);
+        }
+
+        let chat_inference_dataset_output_type = get_column_type(
             self.clickhouse,
             "ChatInferenceDataset",
             "updated_at",
             "0016",
         )
         .await?;
-        if column_type != "DateTime(\\'UTC\\')" {
-            return Ok(true);
-        }
-        let column_type = get_column_type(
+        let json_inference_dataset_output_type = get_column_type(
             self.clickhouse,
             "JsonInferenceDataset",
             "updated_at",
             "0016",
         )
         .await?;
-        if column_type != "DateTime(\\'UTC\\')" {
+        println!(
+            "chat_inference_dataset_output_type: {}",
+            chat_inference_dataset_output_type
+        );
+        println!(
+            "json_inference_dataset_output_type: {}",
+            json_inference_dataset_output_type
+        );
+        if chat_inference_dataset_output_type != "DateTime64(6, \\'UTC\\')"
+            || json_inference_dataset_output_type != "DateTime64(6, \\'UTC\\')"
+        {
             return Ok(true);
         }
 
@@ -46,23 +70,95 @@ impl Migration for Migration0016<'_> {
     }
 
     async fn apply(&self) -> Result<(), Error> {
-        let query =
-            "ALTER TABLE ChatInferenceDataset MODIFY COLUMN updated_at DateTime('UTC')".to_string();
-        self.clickhouse.run_query(query, None).await?;
+        if check_table_exists(self.clickhouse, "ChatInferenceDataset", "0016").await? {
+            let chat_inference_dataset_has_data =
+                table_is_nonempty(self.clickhouse, "ChatInferenceDataset", "0016").await?;
+            if chat_inference_dataset_has_data {
+                return Err(Error::new(ErrorDetails::ClickHouseMigration {
+                    id: "0016".to_string(),
+                    message: "ChatInferenceDataset has data. Your database state is invalid."
+                        .to_string(),
+                }));
+            }
+        }
 
-        let query =
-            "ALTER TABLE JsonInferenceDataset MODIFY COLUMN updated_at DateTime('UTC')".to_string();
-        self.clickhouse.run_query(query, None).await?;
+        if check_table_exists(self.clickhouse, "JsonInferenceDataset", "0016").await? {
+            let json_inference_dataset_has_data =
+                table_is_nonempty(self.clickhouse, "JsonInferenceDataset", "0016").await?;
+            if json_inference_dataset_has_data {
+                return Err(Error::new(ErrorDetails::ClickHouseMigration {
+                    id: "0016".to_string(),
+                    message: "JsonInferenceDataset has data. Your database state is invalid."
+                        .to_string(),
+                }));
+            }
+        }
+
+        // First, drop the tables if they were created in 0014
+        let query = "DROP TABLE IF EXISTS ChatInferenceDataset";
+        let _ = self.clickhouse.run_query(query.to_string(), None).await?;
+
+        let query = "DROP TABLE IF EXISTS JsonInferenceDataset";
+        let _ = self.clickhouse.run_query(query.to_string(), None).await?;
+
+        // Create the `ChatInferenceDataset` table
+        let query = r#"
+            CREATE TABLE IF NOT EXISTS ChatInferenceDataset
+            (
+                dataset_name LowCardinality(String),
+                function_name LowCardinality(String),
+                id UUID, -- more important to join than to
+                        -- sort and sorting expected dataset sizes should be cheap
+                        -- If this example is generated from an inference then this
+                        -- should be the inference ID
+                episode_id UUID,
+                input String,
+                output Nullable(String),
+                tool_params String,
+                -- Don't think we need inference params, processing time,
+                -- timestamp, variant_name
+                tags Map(String, String),
+                auxiliary String, -- a JSON (unstructured, for now)
+                is_deleted Bool DEFAULT false,
+                updated_at DateTime64(6, 'UTC') DEFAULT now()
+            ) ENGINE = ReplacingMergeTree(updated_at, is_deleted)
+            ORDER BY (dataset_name, function_name, id)
+        "#;
+        let _ = self.clickhouse.run_query(query.to_string(), None).await?;
+
+        // Create the `JsonInferenceDataset` table
+        let query = r#"
+            CREATE TABLE IF NOT EXISTS JsonInferenceDataset
+            (
+                dataset_name LowCardinality(String),
+                function_name LowCardinality(String),
+                id UUID, -- same comment as above
+                episode_id UUID,
+                input String,
+                output Nullable(String),
+                output_schema String,
+                tags Map(String, String),
+                auxiliary String, -- a JSON (unstructured, for now)
+                is_deleted Bool DEFAULT false,
+                updated_at DateTime64(6, 'UTC') DEFAULT now()
+            ) ENGINE = ReplacingMergeTree(updated_at, is_deleted)
+            ORDER BY (dataset_name, function_name, id)
+        "#;
+        let _ = self.clickhouse.run_query(query.to_string(), None).await?;
 
         Ok(())
     }
 
     fn rollback_instructions(&self) -> String {
-        "ALTER TABLE ChatInferenceDataset MODIFY COLUMN updated_at DateTime;
-        ALTER TABLE JsonInferenceDataset MODIFY COLUMN updated_at DateTime;"
-            .to_string()
+        "\
+            -- Drop the tables\n\
+            DROP TABLE IF EXISTS ChatInferenceDataset;\n\
+            DROP TABLE IF EXISTS JsonInferenceDataset;\n\
+            "
+        .to_string()
     }
 
+    /// Check if the migration has succeeded (i.e. it should not be applied again)
     async fn has_succeeded(&self) -> Result<bool, Error> {
         let should_apply = self.should_apply().await?;
         Ok(!should_apply)

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0016.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0016.rs
@@ -52,14 +52,6 @@ impl Migration for Migration0016<'_> {
             "0016",
         )
         .await?;
-        println!(
-            "chat_inference_dataset_output_type: {}",
-            chat_inference_dataset_output_type
-        );
-        println!(
-            "json_inference_dataset_output_type: {}",
-            json_inference_dataset_output_type
-        );
         if chat_inference_dataset_output_type != "DateTime64(6, \\'UTC\\')"
             || json_inference_dataset_output_type != "DateTime64(6, \\'UTC\\')"
         {

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/mod.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/mod.rs
@@ -15,6 +15,7 @@ pub mod migration_0011;
 pub mod migration_0013;
 pub mod migration_0014;
 pub mod migration_0015;
+pub mod migration_0016;
 
 /// Returns true if the table exists, false if it does not
 /// Errors if the query fails

--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/mod.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/mod.rs
@@ -13,7 +13,6 @@ pub mod migration_0008;
 pub mod migration_0009;
 pub mod migration_0011;
 pub mod migration_0013;
-pub mod migration_0014;
 pub mod migration_0015;
 pub mod migration_0016;
 

--- a/tensorzero-internal/src/clickhouse_migration_manager/mod.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/mod.rs
@@ -17,6 +17,7 @@ use migrations::migration_0011::Migration0011;
 use migrations::migration_0013::Migration0013;
 use migrations::migration_0014::Migration0014;
 use migrations::migration_0015::Migration0015;
+use migrations::migration_0016::Migration0016;
 
 use async_trait::async_trait;
 
@@ -65,6 +66,7 @@ pub async fn run(clickhouse: &ClickHouseConnectionInfo) -> Result<(), Error> {
     .await?;
     run_migration(&Migration0014 { clickhouse }).await?;
     run_migration(&Migration0015 { clickhouse }).await?;
+    run_migration(&Migration0016 { clickhouse }).await?;
     // NOTE:
     // When we add more migrations, we need to add a test that applies them in a cumulative (N^2) way.
     //

--- a/tensorzero-internal/src/clickhouse_migration_manager/mod.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/mod.rs
@@ -15,7 +15,6 @@ use migrations::migration_0009::Migration0009;
 use migrations::migration_0011::Migration0011;
 // use migrations::migration_0012::Migration0012;
 use migrations::migration_0013::Migration0013;
-use migrations::migration_0014::Migration0014;
 use migrations::migration_0015::Migration0015;
 use migrations::migration_0016::Migration0016;
 
@@ -64,7 +63,8 @@ pub async fn run(clickhouse: &ClickHouseConnectionInfo) -> Result<(), Error> {
         clean_start,
     })
     .await?;
-    run_migration(&Migration0014 { clickhouse }).await?;
+    // BANNED: This migration is no longer needed because it is deleted and replaced by migration 0016
+    // run_migration(&Migration0014 { clickhouse }).await?;
     run_migration(&Migration0015 { clickhouse }).await?;
     run_migration(&Migration0016 { clickhouse }).await?;
     // NOTE:

--- a/tensorzero-internal/tests/e2e/clickhouse.rs
+++ b/tensorzero-internal/tests/e2e/clickhouse.rs
@@ -20,7 +20,6 @@ use tensorzero_internal::clickhouse_migration_manager::migrations::migration_000
 use tensorzero_internal::clickhouse_migration_manager::migrations::migration_0009::Migration0009;
 use tensorzero_internal::clickhouse_migration_manager::migrations::migration_0011::Migration0011;
 use tensorzero_internal::clickhouse_migration_manager::migrations::migration_0013::Migration0013;
-use tensorzero_internal::clickhouse_migration_manager::migrations::migration_0014::Migration0014;
 use tensorzero_internal::clickhouse_migration_manager::migrations::migration_0015::Migration0015;
 use tensorzero_internal::clickhouse_migration_manager::migrations::migration_0016::Migration0016;
 use tensorzero_internal::clickhouse_migration_manager::{self};
@@ -79,7 +78,7 @@ async fn test_clickhouse_migration_manager() {
 
     // When creating a new migration, add it to the end of this array,
     // and adjust the call to `invoke_all!` to include the new array index.
-    let migrations: [Box<dyn Migration + '_>; 13] = [
+    let migrations: [Box<dyn Migration + '_>; 12] = [
         Box::new(Migration0000 {
             clickhouse: &clickhouse,
         }),
@@ -111,9 +110,6 @@ async fn test_clickhouse_migration_manager() {
         Box::new(Migration0013 {
             clickhouse: &clickhouse,
             clean_start: true,
-        }),
-        Box::new(Migration0014 {
-            clickhouse: &clickhouse,
         }),
         Box::new(Migration0015 {
             clickhouse: &clickhouse,
@@ -197,7 +193,7 @@ async fn test_clickhouse_migration_manager() {
         // will throw an error if it doesn't.
         // This must be an array literal, so that the macro can generate a function
         // for each element in the array.
-        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
     );
     run_all(&migrations).await;
 

--- a/tensorzero-internal/tests/e2e/clickhouse.rs
+++ b/tensorzero-internal/tests/e2e/clickhouse.rs
@@ -22,6 +22,7 @@ use tensorzero_internal::clickhouse_migration_manager::migrations::migration_001
 use tensorzero_internal::clickhouse_migration_manager::migrations::migration_0013::Migration0013;
 use tensorzero_internal::clickhouse_migration_manager::migrations::migration_0014::Migration0014;
 use tensorzero_internal::clickhouse_migration_manager::migrations::migration_0015::Migration0015;
+use tensorzero_internal::clickhouse_migration_manager::migrations::migration_0016::Migration0016;
 use tensorzero_internal::clickhouse_migration_manager::{self};
 
 fn get_clean_clickhouse() -> ClickHouseConnectionInfo {
@@ -78,7 +79,7 @@ async fn test_clickhouse_migration_manager() {
 
     // When creating a new migration, add it to the end of this array,
     // and adjust the call to `invoke_all!` to include the new array index.
-    let migrations: [Box<dyn Migration + '_>; 12] = [
+    let migrations: [Box<dyn Migration + '_>; 13] = [
         Box::new(Migration0000 {
             clickhouse: &clickhouse,
         }),
@@ -115,6 +116,9 @@ async fn test_clickhouse_migration_manager() {
             clickhouse: &clickhouse,
         }),
         Box::new(Migration0015 {
+            clickhouse: &clickhouse,
+        }),
+        Box::new(Migration0016 {
             clickhouse: &clickhouse,
         }),
     ];
@@ -193,7 +197,7 @@ async fn test_clickhouse_migration_manager() {
         // will throw an error if it doesn't.
         // This must be an array literal, so that the macro can generate a function
         // for each element in the array.
-        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     );
     run_all(&migrations).await;
 

--- a/tensorzero-internal/tests/e2e/datasets.rs
+++ b/tensorzero-internal/tests/e2e/datasets.rs
@@ -9,6 +9,8 @@ use crate::common::{
     select_json_datapoint_clickhouse,
 };
 
+const DATETIME_FORMAT: &str = "%Y-%m-%d %H:%M:%S.%f";
+
 #[tokio::test]
 async fn test_datapoint_insert_output_inherit_chat() {
     let clickhouse = get_clickhouse().await;
@@ -64,7 +66,7 @@ async fn test_datapoint_insert_output_inherit_chat() {
         .remove("updated_at")
         .unwrap();
     let updated_at =
-        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), "%Y-%m-%d %H:%M:%S")
+        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), DATETIME_FORMAT)
             .unwrap()
             .and_utc();
     assert!(
@@ -145,7 +147,7 @@ async fn test_datapoint_insert_output_none_chat() {
         .remove("updated_at")
         .unwrap();
     let updated_at =
-        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), "%Y-%m-%d %H:%M:%S")
+        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), DATETIME_FORMAT)
             .unwrap()
             .and_utc();
     assert!(
@@ -243,7 +245,7 @@ async fn test_datapoint_insert_output_demonstration_chat() {
         .remove("updated_at")
         .unwrap();
     let updated_at =
-        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), "%Y-%m-%d %H:%M:%S")
+        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), DATETIME_FORMAT)
             .unwrap()
             .and_utc();
     assert!(
@@ -329,7 +331,7 @@ async fn test_datapoint_insert_output_inherit_json() {
         .remove("updated_at")
         .unwrap();
     let updated_at =
-        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), "%Y-%m-%d %H:%M:%S")
+        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), DATETIME_FORMAT)
             .unwrap()
             .and_utc();
     assert!(
@@ -410,7 +412,7 @@ async fn test_datapoint_insert_output_none_json() {
         .remove("updated_at")
         .unwrap();
     let updated_at =
-        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), "%Y-%m-%d %H:%M:%S")
+        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), DATETIME_FORMAT)
             .unwrap()
             .and_utc();
     assert!(
@@ -508,7 +510,7 @@ async fn test_datapoint_insert_output_demonstration_json() {
         .remove("updated_at")
         .unwrap();
     let updated_at =
-        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), "%Y-%m-%d %H:%M:%S")
+        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), DATETIME_FORMAT)
             .unwrap()
             .and_utc();
     assert!(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds migration to enforce UTC `updated_at` columns in ClickHouse tables, replacing a previous migration and updating tests.
> 
>   - **Migration**:
>     - Adds `migration_0016.rs` to set `updated_at` columns in `ChatInferenceDataset` and `JsonInferenceDataset` tables to `DateTime64(6, 'UTC')`.
>     - Replaces `migration_0014` with `migration_0016` in `mod.rs` and `clickhouse.rs`.
>   - **Tests**:
>     - Updates `datasets.rs` to use `DateTime64(6, 'UTC')` format for `updated_at`.
>     - Adjusts `clickhouse.rs` to include `Migration0016` in migration tests.
>   - **Config**:
>     - Changes `slow-timeout` in `.config/nextest.toml` from `3s` to `5s`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4338c72ddb9cd130196a68ee083afc325088514f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->