### PR TITLE
Bump max tokens to 1000 for openai o1 tests

### DIFF
--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -1398,7 +1398,7 @@ pub async fn check_simple_inference_response(
     assert!(inference_params.get("temperature").is_none());
     assert!(inference_params.get("seed").is_none());
     let max_tokens = if provider.model_name.starts_with("o1") {
-        400
+        1000
     } else {
         100
     };
@@ -1672,7 +1672,7 @@ pub async fn test_simple_streaming_inference_request_with_provider_cache(
     assert!(inference_params.get("temperature").is_none());
     assert!(inference_params.get("seed").is_none());
     let expected_max_tokens = if provider.model_name.starts_with("o1") {
-        400
+        1000
     } else {
         100
     };
@@ -6104,7 +6104,7 @@ pub async fn check_tool_use_multi_turn_inference_response(
     assert!(inference_params.get("temperature").is_none());
     assert!(inference_params.get("seed").is_none());
     let max_tokens = if provider.model_name.starts_with("o1") {
-        400
+        1000
     } else {
         100
     };
@@ -8032,7 +8032,7 @@ pub async fn check_json_mode_inference_response(
     assert!(inference_params.get("temperature").is_none());
     assert!(inference_params.get("seed").is_none());
     let max_tokens = if provider.model_name.starts_with("o1") {
-        400
+        1000
     } else {
         100
     };
@@ -8287,7 +8287,7 @@ pub async fn check_dynamic_json_mode_inference_response(
     assert!(inference_params.get("temperature").is_none());
     assert!(inference_params.get("seed").is_none());
     let max_tokens = if provider.model_name.starts_with("o1") {
-        400
+        1000
     } else {
         100
     };

--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -727,7 +727,7 @@ extra_body = [{ pointer = "/temperature", value = 0.123 }, { pointer = "/max_com
 type = "chat_completion"
 model = "o1-2024-12-17"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
-max_tokens = 400
+max_tokens = 1000
 
 [functions.basic_test.variants.openai-dynamic]
 type = "chat_completion"
@@ -1261,7 +1261,7 @@ model = "o1-2024-12-17"
 system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "on"
-max_tokens = 400
+max_tokens = 1000
 
 [functions.json_success.variants.openai-implicit]
 type = "chat_completion"
@@ -1670,7 +1670,7 @@ model = "o1-2024-12-17"
 system_template = "../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 json_mode = "on"
-max_tokens = 400
+max_tokens = 1000
 
 
 [functions.dynamic_json.variants.openai-implicit]
@@ -1955,7 +1955,7 @@ max_tokens = 100
 type = "chat_completion"
 model = "o1-2024-12-17"
 system_template = "../../fixtures/config/functions/weather_helper/prompt/system_template.minijinja"
-max_tokens = 400
+max_tokens = 1000
 
 [functions.weather_helper.variants.together-tool]
 type = "chat_completion"
@@ -1988,7 +1988,7 @@ type = "chat_completion"
 weight = 1
 model = "o1-2024-12-17"
 system_template = "../../fixtures/config/functions/weather_helper_parallel/prompt/system_template.minijinja"
-max_tokens = 400
+max_tokens = 1000
 
 [functions.weather_helper_parallel.variants.anthropic]
 type = "chat_completion"


### PR DESCRIPTION
One of our o1 batch tests hit the 400 token output limit, and produced no output. Let's bump to 1000 to try to make our batch tests reliable

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase `max_tokens` to 1000 for `o1` model tests in `common.rs` and `tensorzero.toml` to prevent output limit issues.
> 
>   - **Behavior**:
>     - Increase `max_tokens` from 400 to 1000 for `o1` model tests in `common.rs` and `tensorzero.toml`.
>     - Affects functions: `check_simple_inference_response`, `test_simple_streaming_inference_request_with_provider_cache`, `check_tool_use_multi_turn_inference_response`, `check_json_mode_inference_response`, `check_dynamic_json_mode_inference_response`.
>   - **Configuration**:
>     - Update `max_tokens` to 1000 for `openai-o1` variants in `tensorzero.toml` for `basic_test`, `json_success`, `dynamic_json`, `weather_helper`, and `weather_helper_parallel`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 987a1b132babefc149128553463ff651f455346f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->