### PR TITLE
Add '--no-fail-fast' when running batch tests on ci

### DIFF
--- a/.github/workflows/batch-test-cron.yml
+++ b/.github/workflows/batch-test-cron.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Run batch tests
         run: |
-          cargo test-batch
+          cargo test-batch --no-fail-fast
 
       - name: Print clickhouse wakeup logs
         if: always()


### PR DESCRIPTION
These tests are pretty flaky, so let's run all of them
to try to gather more data per run
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `--no-fail-fast` to `cargo test-batch` in `batch-test-cron.yml` to run all tests despite failures.
> 
>   - **Behavior**:
>     - Add `--no-fail-fast` flag to `cargo test-batch` command in `batch-test-cron.yml` to run all tests even if some fail.
>   - **Purpose**:
>     - Aims to gather more data from flaky tests by not stopping on first failure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7b6e016c2e0cc9f5c53a0ba40db0c8092cfd3a6f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->