### PR TITLE
Add 'include_original_response' to inference request

### DIFF
--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -347,6 +347,8 @@ impl BaseTensorZeroGateway {
             credentials: credentials.unwrap_or_default(),
             cache_options: cache_options.unwrap_or_default(),
             output_schema,
+            // This is currently unsupported in the Python client
+            include_original_response: false,
         })
     }
 }

--- a/tensorzero-internal/src/cache.rs
+++ b/tensorzero-internal/src/cache.rs
@@ -33,7 +33,7 @@ impl CacheEnabledMode {
     }
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct CacheParamsOptions {
     #[serde(default)]
     pub max_age_s: Option<u32>,

--- a/tensorzero-internal/src/endpoints/batch_inference.rs
+++ b/tensorzero-internal/src/endpoints/batch_inference.rs
@@ -870,6 +870,7 @@ pub async fn write_completed_batch_inference<'a>(
                 vec![model_inference_response],
                 &inference_config,
                 inference_params.into_owned(),
+                None,
             )
             .await?;
         let inference_response = InferenceResponse::new(
@@ -1175,6 +1176,8 @@ impl TryFrom<ChatInferenceResponseDatabaseRead> for ChatInferenceResponse {
             variant_name: value.variant_name,
             content: output,
             usage,
+            // This is currently unsupported in the batch API
+            original_response: None,
         })
     }
 }
@@ -1208,6 +1211,8 @@ impl TryFrom<JsonInferenceResponseDatabaseRead> for JsonInferenceResponse {
             variant_name: value.variant_name,
             output,
             usage,
+            // This is currently unsupported in the batch API
+            original_response: None,
         })
     }
 }

--- a/tensorzero-internal/src/endpoints/inference.rs
+++ b/tensorzero-internal/src/endpoints/inference.rs
@@ -91,6 +91,11 @@ pub struct Params {
     pub cache_options: CacheParamsOptions,
     #[serde(default)]
     pub credentials: InferenceCredentials,
+    /// If `true`, add an `original_response` field to the response, containing the raw string response from the model.
+    /// Note that for complex variants (e.g. `experimental_best_of_n_sampling`), the response may not contain `original_response`
+    /// if the fuser/judge model failed
+    #[serde(default)]
+    pub include_original_response: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -188,6 +193,14 @@ pub async fn inference(
     let start_time = Instant::now();
     let inference_id = Uuid::now_v7();
     tracing::Span::current().record("inference_id", inference_id.to_string());
+
+    if params.include_original_response && params.stream.unwrap_or(false) {
+        return Err(ErrorDetails::InvalidRequest {
+            message: "Cannot set both `include_original_response` and `stream` to `true`"
+                .to_string(),
+        }
+        .into());
+    }
 
     // Retrieve or generate the episode ID
     let episode_id = params.episode_id.unwrap_or(Uuid::now_v7());
@@ -361,7 +374,7 @@ pub async fn inference(
                 )
                 .await;
 
-            let result = match result {
+            let mut result = match result {
                 Ok(result) => result,
                 Err(e) => {
                     tracing::warn!(
@@ -409,6 +422,10 @@ pub async fn inference(
                         })
                     })?;
                 }
+            }
+
+            if !params.include_original_response {
+                result.set_original_response(None);
             }
 
             let response = InferenceResponse::new(result, episode_id, variant_name.to_string());
@@ -760,6 +777,8 @@ pub struct ChatInferenceResponse {
     pub variant_name: String,
     pub content: Vec<ContentBlockChatOutput>,
     pub usage: Usage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original_response: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -769,6 +788,8 @@ pub struct JsonInferenceResponse {
     pub variant_name: String,
     pub output: JsonInferenceOutput,
     pub usage: Usage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original_response: Option<String>,
 }
 
 impl InferenceResponse {
@@ -780,6 +801,7 @@ impl InferenceResponse {
                 variant_name,
                 content: result.content,
                 usage: result.usage,
+                original_response: result.original_response,
             }),
             InferenceResult::Json(result) => InferenceResponse::Json(JsonInferenceResponse {
                 inference_id: result.inference_id,
@@ -787,6 +809,7 @@ impl InferenceResponse {
                 variant_name,
                 output: result.output,
                 usage: result.usage,
+                original_response: result.original_response,
             }),
         }
     }

--- a/tensorzero-internal/src/endpoints/openai_compatible.rs
+++ b/tensorzero-internal/src/endpoints/openai_compatible.rs
@@ -386,6 +386,8 @@ impl TryFrom<(HeaderMap, OpenAICompatibleParams)> for Params {
             credentials: InferenceCredentials::default(),
             cache_options: CacheParamsOptions::default(),
             tags: HashMap::new(),
+            // OpenAI compatible endpoint does not support 'include_original_response'
+            include_original_response: false,
         })
     }
 }

--- a/tensorzero-internal/src/function.rs
+++ b/tensorzero-internal/src/function.rs
@@ -162,6 +162,7 @@ impl FunctionConfig {
     }
 
     #[instrument(skip_all, fields(inference_id))]
+    #[allow(clippy::too_many_arguments)]
     pub async fn prepare_response<'a, 'request>(
         &self,
         inference_id: Uuid,
@@ -170,6 +171,7 @@ impl FunctionConfig {
         model_inference_results: Vec<ModelInferenceResponseWithMetadata>,
         inference_config: &'request InferenceConfig<'a, 'request>,
         inference_params: InferenceParams,
+        original_response: Option<String>,
     ) -> Result<InferenceResult, Error> {
         match self {
             FunctionConfig::Chat(..) => Ok(InferenceResult::Chat(
@@ -180,6 +182,7 @@ impl FunctionConfig {
                     model_inference_results,
                     inference_config.tool_config,
                     inference_params,
+                    original_response,
                 )
                 .await,
             )),
@@ -233,6 +236,7 @@ impl FunctionConfig {
                     model_inference_results,
                     output_schema.value().clone(),
                     inference_params,
+                    original_response,
                 )))
             }
         }
@@ -1544,6 +1548,7 @@ mod tests {
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
+                None,
             )
             .await
             .unwrap();
@@ -1593,6 +1598,7 @@ mod tests {
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
+                None,
             )
             .await
             .unwrap();
@@ -1642,6 +1648,7 @@ mod tests {
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
+                None,
             )
             .await
             .unwrap();
@@ -1692,6 +1699,7 @@ mod tests {
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
+                None,
             )
             .await
             .unwrap();
@@ -1743,6 +1751,7 @@ mod tests {
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
+                None,
             )
             .await
             .unwrap();
@@ -1791,6 +1800,7 @@ mod tests {
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
+                None,
             )
             .await
             .unwrap_err();
@@ -1854,6 +1864,7 @@ mod tests {
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
+                None,
             )
             .await
             .unwrap();
@@ -1900,6 +1911,7 @@ mod tests {
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
+                None,
             )
             .await
             .unwrap();
@@ -1950,6 +1962,7 @@ mod tests {
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
+                None,
             )
             .await
             .unwrap();
@@ -2001,6 +2014,7 @@ mod tests {
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
+                None,
             )
             .await
             .unwrap();
@@ -2058,6 +2072,7 @@ mod tests {
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
+                None,
             )
             .await
             .unwrap();

--- a/tensorzero-internal/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-internal/src/variant/best_of_n_sampling.rs
@@ -338,6 +338,11 @@ impl BestOfNSamplingConfig {
         if let Some(inference_result) = &inference_result {
             total_usage.input_tokens += inference_result.usage.input_tokens;
             total_usage.output_tokens += inference_result.usage.output_tokens;
+            // Pass the evaluator response back to the user as 'original_response'
+            selected_candidate.set_original_response(Some(inference_result.raw_response.clone()));
+        } else {
+            // If the evaluator failed, don't provide an 'original_response' to the uesr
+            selected_candidate.set_original_response(None);
         }
         selected_candidate.set_usage(total_usage);
         for candidate in candidates {
@@ -889,6 +894,7 @@ mod tests {
                 vec![model_inference_response],
                 None,
                 InferenceParams::default(),
+                None,
             )
             .await,
         );
@@ -927,6 +933,7 @@ mod tests {
                 vec![model_inference_response2],
                 None,
                 InferenceParams::default(),
+                None,
             )
             .await,
         );
@@ -993,6 +1000,7 @@ mod tests {
             vec![model_inference_response_valid],
             json!({"type": "object", "properties": {"response": {"type": "string"}}}),
             InferenceParams::default(),
+            None,
         ));
 
         let model_inference_response_malformed = ModelInferenceResponseWithMetadata {
@@ -1031,6 +1039,7 @@ mod tests {
             vec![model_inference_response_malformed],
             json!({"type": "object", "properties": {"response": {"type": "string"}}}),
             InferenceParams::default(),
+            None,
         ));
 
         let candidates = vec![candidate1, candidate2];
@@ -1102,6 +1111,7 @@ mod tests {
                 vec![model_inference_response0],
                 None,
                 InferenceParams::default(),
+                None,
             )
             .await,
         );
@@ -1140,6 +1150,7 @@ mod tests {
                 vec![model_inference_response1],
                 None,
                 InferenceParams::default(),
+                None,
             )
             .await,
         );

--- a/tensorzero-internal/src/variant/mixture_of_n.rs
+++ b/tensorzero-internal/src/variant/mixture_of_n.rs
@@ -299,7 +299,10 @@ impl MixtureOfNConfig {
                         message: "Failed to get random candidate (should never happen). Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new".to_string(),
                     }));
                 }
-                candidates.swap_remove(random_index)
+                // If the fuser fails, don't provide any 'original_response' to the user
+                let mut candidate = candidates.swap_remove(random_index);
+                candidate.set_original_response(None);
+                candidate
             }
         };
 
@@ -725,6 +728,7 @@ mod tests {
                 vec![model_inference_response],
                 None,
                 InferenceParams::default(),
+                None,
             )
             .await,
         );
@@ -760,6 +764,7 @@ mod tests {
                 vec![model_inference_response2],
                 None,
                 InferenceParams::default(),
+                None,
             )
             .await,
         );
@@ -823,6 +828,7 @@ mod tests {
             vec![model_inference_response_valid],
             json!({"type": "object", "properties": {"response": {"type": "string"}}}),
             InferenceParams::default(),
+            None,
         ));
 
         let model_inference_response_malformed = ModelInferenceResponseWithMetadata {
@@ -858,6 +864,7 @@ mod tests {
             vec![model_inference_response_malformed],
             json!({"type": "object", "properties": {"response": {"type": "string"}}}),
             InferenceParams::default(),
+            None,
         ));
 
         let candidates = vec![candidate1, candidate2];
@@ -934,6 +941,7 @@ mod tests {
                 vec![model_inference_response0],
                 None,
                 InferenceParams::default(),
+                None,
             )
             .await,
         );
@@ -969,6 +977,7 @@ mod tests {
                 vec![model_inference_response1],
                 None,
                 InferenceParams::default(),
+                None,
             )
             .await,
         );

--- a/tensorzero-internal/src/variant/mod.rs
+++ b/tensorzero-internal/src/variant/mod.rs
@@ -493,6 +493,7 @@ async fn infer_model_request<'a, 'request>(
     .retry(args.retry_config.get_backoff())
     .await?;
 
+    let original_response = model_inference_response.raw_response.clone();
     let model_inference_result =
         ModelInferenceResponseWithMetadata::new(model_inference_response, args.model_name);
     let raw_content = model_inference_result.output.clone();
@@ -507,6 +508,7 @@ async fn infer_model_request<'a, 'request>(
             model_inference_results,
             args.inference_config,
             args.inference_params,
+            Some(original_response),
         )
         .await
 }

--- a/tensorzero-internal/tests/e2e/dicl.rs
+++ b/tensorzero-internal/tests/e2e/dicl.rs
@@ -425,6 +425,7 @@ pub async fn test_dicl_inference_request() {
                 }
             ]},
         "stream": false,
+        "include_original_response": true,
     });
 
     let response = Client::new()
@@ -464,6 +465,15 @@ pub async fn test_dicl_inference_request() {
     assert!(input_tokens > 0);
     let output_tokens = usage.get("output_tokens").unwrap().as_u64().unwrap();
     assert!(output_tokens > 0);
+
+    let original_response = response_json.get("original_response").unwrap();
+    let original_response_json: serde_json::Value =
+        serde_json::from_str(original_response.as_str().unwrap()).unwrap();
+    assert_eq!(original_response_json["model"], "gpt-4o-mini-2024-07-18");
+    assert!(
+        original_response_json.get("choices").is_some(),
+        "Unexpected original_response: {original_response}"
+    );
 
     // Sleep to allow time for data to be inserted into ClickHouse (trailing writes from API)
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;

--- a/tensorzero-internal/tests/e2e/inference.rs
+++ b/tensorzero-internal/tests/e2e/inference.rs
@@ -1,4 +1,4 @@
-use crate::providers::common::FERRIS_PNG;
+use crate::providers::common::{make_embedded_gateway_with_config, FERRIS_PNG};
 use base64::prelude::*;
 use futures::StreamExt;
 use reqwest::{Client, StatusCode};
@@ -71,6 +71,248 @@ async fn e2e_test_inference_dryrun() {
     let clickhouse = get_clickhouse().await;
     let result = select_chat_inference_clickhouse(&clickhouse, inference_id).await;
     assert!(result.is_none()); // No inference should be written to ClickHouse when dryrun is true
+}
+
+#[tokio::test]
+async fn e2e_test_inference_original_response_non_stream() {
+    let payload = json!({
+        "function_name": "basic_test",
+        "episode_id": Uuid::now_v7(),
+        "input": {
+            "system": {"assistant_name": "AskJeeves"},
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Hello, world!"
+                }
+            ]
+        },
+        "stream": false,
+        "include_original_response": true,
+    });
+
+    let response = Client::new()
+        .post(get_gateway_endpoint("/inference"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+
+    // Check Response is OK, then fields in order
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_json = response.json::<Value>().await.unwrap();
+
+    let original = &response_json["original_response"];
+    assert_eq!(original, DUMMY_INFER_RESPONSE_RAW);
+    // Don't both checking ClickHouse, as we do that in lots of other tests.
+}
+
+#[tokio::test]
+async fn e2e_test_inference_original_response_stream() {
+    let payload = json!({
+        "function_name": "basic_test",
+        "episode_id": Uuid::now_v7(),
+        "input": {
+            "system": {"assistant_name": "AskJeeves"},
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Hello, world!"
+                }
+            ]
+        },
+        "stream": true,
+        "include_original_response": true,
+    });
+
+    let response = Client::new()
+        .post(get_gateway_endpoint("/inference"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let response_json = response.json::<Value>().await.unwrap();
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "Expected bad request: {response_json}"
+    );
+
+    assert_eq!(
+        response_json,
+        serde_json::json!({
+            "error": "Cannot set both `include_original_response` and `stream` to `true`",
+        })
+    );
+    // Don't both checking ClickHouse, as we do that in lots of other tests.
+}
+
+#[tokio::test]
+async fn test_original_response_best_of_n_flaky_judge() {
+    // We use an embedded client so that we can control the number of
+    // requests to the flaky judge.
+    let gateway = make_embedded_gateway_with_config(
+        r#"
+
+[functions.best_of_n]
+type = "chat"
+
+[functions.best_of_n.variants.variant0]
+type = "chat_completion"
+weight = 0
+model = "test"
+
+[functions.best_of_n.variants.variant1]
+type = "chat_completion"
+weight = 0
+model = "json"
+
+[functions.best_of_n.variants.flaky_best_of_n_variant]
+type = "experimental_best_of_n_sampling"
+weight = 1
+candidates = ["variant0", "variant1"]
+
+[functions.best_of_n.variants.flaky_best_of_n_variant.evaluator]
+model = "flaky_best_of_n_judge"
+retries = { num_retries = 0, max_delay_s = 0 }
+
+[models.flaky_best_of_n_judge]
+routing = ["dummy"]
+
+[models.flaky_best_of_n_judge.providers.dummy]
+type = "dummy"
+model_name = "flaky_best_of_n_judge"
+
+[models.test]
+routing = ["good"]
+
+[models.test.providers.good]
+type = "dummy"
+model_name = "good"
+
+[models.json]
+routing = ["json"]
+
+[models.json.providers.json]
+type = "dummy"
+model_name = "json"
+    "#,
+    )
+    .await;
+
+    let params = ClientInferenceParams {
+        function_name: Some("best_of_n".to_string()),
+        input: Input {
+            messages: vec![InputMessage {
+                role: Role::User,
+                content: vec![InputMessageContent::Text(TextKind::Text {
+                    text: "Please write me a sentence about Megumin making an explosion."
+                        .to_string(),
+                })],
+            }],
+            ..Default::default()
+        },
+        include_original_response: true,
+        ..Default::default()
+    };
+
+    // First request to the flaky judge should succeed
+    let good_response = gateway.inference(params.clone()).await.unwrap();
+    let InferenceOutput::NonStreaming(InferenceResponse::Chat(good_response)) = good_response
+    else {
+        panic!("Expected non-streaming response, got {:?}", good_response);
+    };
+
+    assert_eq!(
+        good_response.original_response.unwrap(),
+        DUMMY_INFER_RESPONSE_RAW,
+    );
+
+    // Second request to the flaky judge should fail
+    let bad_response = gateway.inference(params).await.unwrap();
+    let InferenceOutput::NonStreaming(InferenceResponse::Chat(bad_response)) = bad_response else {
+        panic!("Expected non-streaming response, got {:?}", bad_response);
+    };
+
+    assert!(
+        bad_response.original_response.is_none(),
+        "Expected no original response"
+    );
+}
+
+#[tokio::test]
+async fn test_original_response_mixture_of_n_flaky_fuser() {
+    // We use an embedded client so that we can control the number of
+    // requests to the flaky judge.
+    let gateway = make_embedded_gateway_with_config(
+        r#"
+
+[functions.mixture_of_n]
+type = "chat"
+
+[functions.mixture_of_n.variants.variant0]
+type = "chat_completion"
+weight = 0
+model = "dummy::test"
+
+[functions.mixture_of_n.variants.variant1]
+type = "chat_completion"
+weight = 0
+model = "dummy::alternate"
+
+[functions.mixture_of_n.variants.mixture_of_n_variant]
+type = "experimental_mixture_of_n"
+weight = 1
+candidates = ["variant0", "variant1"]
+
+[functions.mixture_of_n.variants.mixture_of_n_variant.fuser]
+model = "dummy::flaky_model"
+    "#,
+    )
+    .await;
+
+    let params = ClientInferenceParams {
+        function_name: Some("mixture_of_n".to_string()),
+        input: Input {
+            messages: vec![InputMessage {
+                role: Role::User,
+                content: vec![InputMessageContent::Text(TextKind::Text {
+                    text: "Please write me a sentence about Megumin making an explosion."
+                        .to_string(),
+                })],
+            }],
+            ..Default::default()
+        },
+        include_original_response: true,
+        ..Default::default()
+    };
+
+    // First request to the flaky judge should succeed
+    let good_response = gateway.inference(params.clone()).await.unwrap();
+    let InferenceOutput::NonStreaming(InferenceResponse::Chat(good_response)) = good_response
+    else {
+        panic!("Expected non-streaming response, got {:?}", good_response);
+    };
+
+    assert_eq!(
+        good_response.original_response.unwrap(),
+        DUMMY_INFER_RESPONSE_RAW,
+    );
+
+    // Second request to the flaky judge should fail
+    let bad_response = gateway.inference(params).await.unwrap();
+    let InferenceOutput::NonStreaming(InferenceResponse::Chat(bad_response)) = bad_response else {
+        panic!("Expected non-streaming response, got {:?}", bad_response);
+    };
+
+    assert!(
+        bad_response.original_response.is_none(),
+        "Expected no original response"
+    );
+
+    // Don't check ClickHouse, as we do that in lots of other tests.
 }
 
 /// This test calls a function which calls a model where the first provider is broken but


### PR DESCRIPTION
When set, this adds an 'original_response' field to the top-level response, containing the raw string from the model provider.

For best_of_n/mixture_of_n, 'original_response' will be unset if the fuser/judge failed (we'll still return a successful overall response from a random candidate)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
