### PR TITLE
Add datapoint delete endpoint

### DIFF
--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -1,4 +1,4 @@
-use axum::routing::{get, post};
+use axum::routing::{delete, get, post};
 use axum::Router;
 use clap::Parser;
 use mimalloc::MiMalloc;
@@ -106,6 +106,10 @@ async fn main() {
         .route(
             "/datasets/:dataset/datapoints",
             post(endpoints::datasets::create_datapoint_handler),
+        )
+        .route(
+            "/datasets/:dataset/function/:function/kind/:kind/datapoint/:id",
+            delete(endpoints::datasets::delete_datapoint_handler),
         )
         .route(
             "/metrics",

--- a/tensorzero-internal/src/endpoints/datasets.rs
+++ b/tensorzero-internal/src/endpoints/datasets.rs
@@ -257,7 +257,7 @@ pub async fn delete_datapoint_handler(
     Path(path_params): Path<DeletePathParams>,
 ) -> Result<Json<DeleteDatapointResponse>, Error> {
     let datapoint = app_state.clickhouse_connection_info.run_query(
-        "SELECT * FROM {table_name:Identifier} WHERE dataset_name={dataset_name:String} AND function_name={function_name:String} AND id = {id:String} LIMIT 1 FORMAT JSONEachRow;".to_string(),
+        "SELECT * FROM {table_name:Identifier} WHERE dataset_name={dataset_name:String} AND function_name={function_name:String} AND id = {id:String} ORDER BY updated_at DESC LIMIT 1 FORMAT JSONEachRow;".to_string(),
         Some(&HashMap::from([
             ("table_name", path_params.kind.table_name()),
             ("function_name", path_params.function.as_str()),

--- a/tensorzero-internal/src/endpoints/datasets.rs
+++ b/tensorzero-internal/src/endpoints/datasets.rs
@@ -20,6 +20,8 @@ use crate::{
 };
 use tracing::instrument;
 
+pub const CLICKHOUSE_DATETIME_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.6f";
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OutputKind {
@@ -161,7 +163,7 @@ FORMAT JSONEachRow;"#
 #[instrument(name = "create_datapoint", skip(app_state))]
 pub async fn create_datapoint_handler(
     State(app_state): AppState,
-    Path(path_params): Path<PathParams>,
+    Path(path_params): Path<CreatePathParams>,
     StructuredJson(params): StructuredJson<CreateDatapointParams>,
 ) -> Result<Json<CreateDatapointResponse>, Error> {
     let inference_data =
@@ -249,15 +251,85 @@ pub async fn create_datapoint_handler(
     Ok(Json(CreateDatapointResponse {}))
 }
 
+#[instrument(name = "delete_datapoint", skip(app_state))]
+pub async fn delete_datapoint_handler(
+    State(app_state): AppState,
+    Path(path_params): Path<DeletePathParams>,
+) -> Result<Json<DeleteDatapointResponse>, Error> {
+    let datapoint = app_state.clickhouse_connection_info.run_query(
+        "SELECT * FROM {table_name:Identifier} WHERE dataset_name={dataset_name:String} and function_name={function_name:String} and id = {id:String} FORMAT JSONEachRow;".to_string(),
+        Some(&HashMap::from([
+            ("table_name", path_params.kind.table_name()),
+            ("function_name", path_params.function.as_str()),
+            ("dataset_name", path_params.dataset.as_str()),
+            ("id", path_params.id.to_string().as_str())
+        ]))).await?;
+
+    if datapoint.is_empty() {
+        return Err(Error::new(ErrorDetails::InvalidRequest {
+            message: format!("Datapoint not found with params {path_params:?}",),
+        }));
+    }
+
+    let mut datapoint_json: serde_json::Value = serde_json::from_str(&datapoint).map_err(|e| {
+        Error::new(ErrorDetails::Serialization {
+            message: format!("Failed to deserialize datapoint: {}", e),
+        })
+    })?;
+
+    // We delete datapoints by writing a new row (which ClickHouse will merge)
+    // with the 'is_deleted' and 'updated_at' fields modified.
+    datapoint_json["is_deleted"] = serde_json::Value::Bool(true);
+    datapoint_json["updated_at"] = dbg!(format!(
+        "{}",
+        chrono::Utc::now().format(CLICKHOUSE_DATETIME_FORMAT)
+    ))
+    .into();
+
+    app_state
+        .clickhouse_connection_info
+        .write(&[datapoint_json], path_params.kind.table_name())
+        .await?;
+
+    Ok(Json(DeleteDatapointResponse {}))
+}
+
+#[derive(Debug, Serialize)]
+pub struct DeleteDatapointResponse {}
+
 #[derive(Debug, Deserialize)]
-pub struct PathParams {
+pub struct CreatePathParams {
     pub dataset: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DeletePathParams {
+    pub dataset: String,
+    pub function: String,
+    pub kind: DatapointKind,
+    pub id: Uuid,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct CreateDatapointParams {
     pub output: OutputKind,
     pub inference_id: Uuid,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DatapointKind {
+    Chat,
+    Json,
+}
+
+impl DatapointKind {
+    fn table_name(&self) -> &'static str {
+        match self {
+            DatapointKind::Chat => "ChatInferenceDataset",
+            DatapointKind::Json => "JsonInferenceDataset",
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]

--- a/tensorzero-internal/tests/e2e/datasets.rs
+++ b/tensorzero-internal/tests/e2e/datasets.rs
@@ -2,14 +2,13 @@
 
 use reqwest::{Client, StatusCode};
 use serde_json::Value;
+use tensorzero_internal::endpoints::datasets::CLICKHOUSE_DATETIME_FORMAT;
 use uuid::Uuid;
 
 use crate::common::{
     get_clickhouse, get_gateway_endpoint, select_chat_datapoint_clickhouse,
     select_json_datapoint_clickhouse,
 };
-
-const DATETIME_FORMAT: &str = "%Y-%m-%d %H:%M:%S.%f";
 
 #[tokio::test]
 async fn test_datapoint_insert_output_inherit_chat() {
@@ -65,10 +64,12 @@ async fn test_datapoint_insert_output_inherit_chat() {
         .unwrap()
         .remove("updated_at")
         .unwrap();
-    let updated_at =
-        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), DATETIME_FORMAT)
-            .unwrap()
-            .and_utc();
+    let updated_at = chrono::NaiveDateTime::parse_from_str(
+        updated_at.as_str().unwrap(),
+        CLICKHOUSE_DATETIME_FORMAT,
+    )
+    .unwrap()
+    .and_utc();
     assert!(
         chrono::Utc::now()
             .signed_duration_since(updated_at)
@@ -90,6 +91,93 @@ async fn test_datapoint_insert_output_inherit_chat() {
       "is_deleted": false
     });
     assert_eq!(datapoint, expected);
+
+    let resp = client
+        .delete(get_gateway_endpoint(&format!(
+            "/datasets/{dataset_name}/function/basic_test/kind/chat/datapoint/{inference_id}",
+        )))
+        .send()
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let resp_text = resp.text().await.unwrap();
+    assert_eq!(status, StatusCode::OK, "Delete failed: {resp_text}");
+
+    // Force deduplication to run
+    clickhouse
+        .run_query("OPTIMIZE TABLE ChatInferenceDataset".to_string(), None)
+        .await
+        .unwrap();
+
+    let mut datapoint = select_chat_datapoint_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+
+    let new_updated_at = datapoint
+        .as_object_mut()
+        .unwrap()
+        .remove("updated_at")
+        .unwrap();
+    let new_updated_at = chrono::NaiveDateTime::parse_from_str(
+        new_updated_at.as_str().unwrap(),
+        CLICKHOUSE_DATETIME_FORMAT,
+    )
+    .unwrap()
+    .and_utc();
+    assert!(
+        chrono::Utc::now()
+            .signed_duration_since(new_updated_at)
+            .num_seconds()
+            < 5,
+        "Unexpected updated_at: {new_updated_at:?}"
+    );
+
+    let expected = serde_json::json!({
+      "dataset_name": dataset_name,
+      "function_name": "basic_test",
+      "id": inference_id.to_string(),
+      "episode_id": episode_id.to_string(),
+      "input": "{\"system\":{\"assistant_name\":\"Alfred Pennyworth\"},\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"value\":\"Hello, world!\"}]}]}",
+      "output": "[{\"type\":\"text\",\"text\":\"Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake.\"}]",
+      "tool_params": "",
+      "tags": {},
+      "auxiliary": "{}",
+      "is_deleted": true
+    });
+    assert_eq!(datapoint, expected);
+    assert_ne!(
+        updated_at, new_updated_at,
+        "Deleting datapoint should change updated_at"
+    );
+}
+
+#[tokio::test]
+async fn test_bad_delete_datapoint() {
+    let client = Client::new();
+
+    let id = Uuid::now_v7();
+    let resp = client
+        .delete(get_gateway_endpoint(&format!(
+            "/datasets/missing/function/basic_test/kind/chat/datapoint/{id}",
+        )))
+        .send()
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let resp: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "Delete should have failed: {resp}"
+    );
+    assert_eq!(
+        resp,
+        serde_json::json!({
+            "error": format!("Datapoint not found with params DeletePathParams {{ dataset: \"missing\", function: \"basic_test\", kind: Chat, id: {id} }}")
+        })
+    );
 }
 
 #[tokio::test]
@@ -146,10 +234,12 @@ async fn test_datapoint_insert_output_none_chat() {
         .unwrap()
         .remove("updated_at")
         .unwrap();
-    let updated_at =
-        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), DATETIME_FORMAT)
-            .unwrap()
-            .and_utc();
+    let updated_at = chrono::NaiveDateTime::parse_from_str(
+        updated_at.as_str().unwrap(),
+        CLICKHOUSE_DATETIME_FORMAT,
+    )
+    .unwrap()
+    .and_utc();
     assert!(
         chrono::Utc::now()
             .signed_duration_since(updated_at)
@@ -244,10 +334,12 @@ async fn test_datapoint_insert_output_demonstration_chat() {
         .unwrap()
         .remove("updated_at")
         .unwrap();
-    let updated_at =
-        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), DATETIME_FORMAT)
-            .unwrap()
-            .and_utc();
+    let updated_at = chrono::NaiveDateTime::parse_from_str(
+        updated_at.as_str().unwrap(),
+        CLICKHOUSE_DATETIME_FORMAT,
+    )
+    .unwrap()
+    .and_utc();
     assert!(
         chrono::Utc::now()
             .signed_duration_since(updated_at)
@@ -330,10 +422,12 @@ async fn test_datapoint_insert_output_inherit_json() {
         .unwrap()
         .remove("updated_at")
         .unwrap();
-    let updated_at =
-        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), DATETIME_FORMAT)
-            .unwrap()
-            .and_utc();
+    let updated_at = chrono::NaiveDateTime::parse_from_str(
+        updated_at.as_str().unwrap(),
+        CLICKHOUSE_DATETIME_FORMAT,
+    )
+    .unwrap()
+    .and_utc();
     assert!(
         chrono::Utc::now()
             .signed_duration_since(updated_at)
@@ -355,6 +449,70 @@ async fn test_datapoint_insert_output_inherit_json() {
       "is_deleted": false,
     });
     assert_eq!(datapoint, expected);
+
+    let resp = client
+        .delete(get_gateway_endpoint(&format!(
+            "/datasets/{dataset_name}/function/json_success/kind/json/datapoint/{inference_id}",
+        )))
+        .send()
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let resp_text = resp.text().await.unwrap();
+    assert_eq!(status, StatusCode::OK, "Delete failed: {resp_text}");
+
+    // Force deduplication to run
+    clickhouse
+        .run_query("OPTIMIZE TABLE JsonInferenceDataset".to_string(), None)
+        .await
+        .unwrap();
+
+    let mut datapoint = select_json_datapoint_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+
+    let new_updated_at = datapoint
+        .as_object_mut()
+        .unwrap()
+        .remove("updated_at")
+        .unwrap();
+    let new_updated_at = chrono::NaiveDateTime::parse_from_str(
+        new_updated_at.as_str().unwrap(),
+        CLICKHOUSE_DATETIME_FORMAT,
+    )
+    .unwrap()
+    .and_utc();
+    assert!(
+        chrono::Utc::now()
+            .signed_duration_since(new_updated_at)
+            .num_seconds()
+            < 5,
+        "Unexpected updated_at: {new_updated_at:?}"
+    );
+
+    let expected = serde_json::json!({
+      "dataset_name": dataset_name,
+      "function_name": "json_success",
+      "id": inference_id,
+      "episode_id": episode_id,
+      "input": "{\"system\":{\"assistant_name\":\"Alfred Pennyworth\"},\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"value\":{\"country\":\"Japan\"}}]}]}",
+      "output": "{\"raw\":\"{\\\"answer\\\":\\\"Hello\\\"}\",\"parsed\":{\"answer\":\"Hello\"}}",
+      "output_schema": "{\"type\":\"object\",\"properties\":{\"answer\":{\"type\":\"string\"}},\"required\":[\"answer\"],\"additionalProperties\":false}",
+      "tags": {},
+      "auxiliary": "{}",
+      "is_deleted": true
+    });
+    assert_eq!(
+        datapoint,
+        expected,
+        "Unexpected datapoint: {}",
+        serde_json::to_string_pretty(&datapoint).unwrap()
+    );
+    assert_ne!(
+        updated_at, new_updated_at,
+        "Deleting datapoint should change updated_at"
+    );
 }
 
 #[tokio::test]
@@ -411,10 +569,12 @@ async fn test_datapoint_insert_output_none_json() {
         .unwrap()
         .remove("updated_at")
         .unwrap();
-    let updated_at =
-        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), DATETIME_FORMAT)
-            .unwrap()
-            .and_utc();
+    let updated_at = chrono::NaiveDateTime::parse_from_str(
+        updated_at.as_str().unwrap(),
+        CLICKHOUSE_DATETIME_FORMAT,
+    )
+    .unwrap()
+    .and_utc();
     assert!(
         chrono::Utc::now()
             .signed_duration_since(updated_at)
@@ -509,10 +669,12 @@ async fn test_datapoint_insert_output_demonstration_json() {
         .unwrap()
         .remove("updated_at")
         .unwrap();
-    let updated_at =
-        chrono::NaiveDateTime::parse_from_str(updated_at.as_str().unwrap(), DATETIME_FORMAT)
-            .unwrap()
-            .and_utc();
+    let updated_at = chrono::NaiveDateTime::parse_from_str(
+        updated_at.as_str().unwrap(),
+        CLICKHOUSE_DATETIME_FORMAT,
+    )
+    .unwrap()
+    .and_utc();
     assert!(
         chrono::Utc::now()
             .signed_duration_since(updated_at)


### PR DESCRIPTION
The new endpoint is 'DELETE /datasets/:dataset/function/:function/kind/:kind/datapoint/:id' Since this is an internal endpoint that will only be called from the ui (for now), I've included all of the needed data as parameters, so that we can efficiently insert into the correct table.

Deletion is implemented by inserting a new row into the ClickHouse table with 'is_deleted' and 'updated_at' modified.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add DELETE endpoint for datapoints, marking them as deleted in ClickHouse, with tests for various scenarios.
> 
>   - **Endpoint**:
>     - Add `DELETE /datasets/:dataset/function/:function/kind/:kind/datapoint/:id` in `main.rs`.
>     - Implement `delete_datapoint_handler` in `datasets.rs` to mark datapoints as deleted in ClickHouse.
>   - **Behavior**:
>     - Deletion inserts a new row with `is_deleted` set to true and updates `updated_at`.
>     - Handles missing datapoints by returning a `BAD_REQUEST` error.
>   - **Tests**:
>     - Add tests in `datasets.rs` for successful deletion and error cases (e.g., missing datapoint).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4cbd508dec31c37b23de726731d751090fe729d2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->