### PR TITLE
Remove 'cat clickhouse_wakeup_logs.txt' from batch cron

### DIFF
--- a/.github/workflows/batch-test-cron.yml
+++ b/.github/workflows/batch-test-cron.yml
@@ -89,10 +89,6 @@ jobs:
         run: |
           cargo test-batch --no-fail-fast
 
-      - name: Print clickhouse wakeup logs
-        if: always()
-        run: cat clickhouse_wakeup_logs.txt
-
       - name: Print batch logs
         if: always()
         run: cat batch_logs.txt


### PR DESCRIPTION
We now wait for clickhouse to wake up, and print the logs inline, so this file no longer exists

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
