### PR TITLE
added handling for new Any models for GCP Vertex Gemini

### DIFF
--- a/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
@@ -667,7 +667,7 @@ struct GCPVertexGeminiToolConfig<'a> {
 
 // Auto is the default mode where a tool could be called but it isn't required.
 // Any is a mode where a tool is required and if allowed_function_names is Some it has to be from that list.
-// See [the documentation](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/ToolConfig) for details.
+// See [the documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/function-calling) for details.
 const MODELS_SUPPORTING_ANY_MODE: &[&str] = &[
     "gemini-1.5-pro-001",
     "gemini-1.5-flash-001",


### PR DESCRIPTION
The list of models which support tool choice Any has been updated on GCP Vertex Gemini. This keeps us up to date!
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update GCP Vertex Gemini models supporting 'Any' tool choice mode and adjust related tests.
> 
>   - **Behavior**:
>     - Updated `MODELS_SUPPORTING_ANY_MODE` in `gcp_vertex_gemini.rs` to include `gemini-1.5-flash-001`, `gemini-1.5-pro-002`, and `gemini-1.5-flash-002`.
>   - **Tests**:
>     - Updated test cases in `gcp_vertex_gemini.rs` to use new model names `supports_any_model_name` and `no_any_model_name`.
>     - Adjusted assertions in `test_from_tool_choice()` and `test_prepare_tools()` to reflect updated model support.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 73483fdb53884964f7749d377657443108d52e5e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->