### PR TITLE
Include tracing target in gateway log output

### DIFF
--- a/tensorzero-internal/src/observability.rs
+++ b/tensorzero-internal/src/observability.rs
@@ -16,9 +16,7 @@ pub fn setup_logs(debug: bool) {
         .with(
             tracing_subscriber::fmt::layer()
                 .json()
-                .flatten_event(true)
-                .with_current_span(false)
-                .with_target(false),
+                .with_current_span(false),
         )
         .init();
 }


### PR DESCRIPTION
Before:
```
{"timestamp":"2025-03-05T21:43:33.693689Z","level":"INFO","message":"TensorZero Gateway version 2025.02.6 is listening on 0.0.0.0:3000 with config file `tensorzero-internal/tests/e2e/tensorzero.toml` and observability enabled (database: tensorzero_e2e_tests)."}
```

After:
```
{"timestamp":"2025-03-05T21:44:08.214785Z","level":"INFO","fields":{"message":"TensorZero Gateway version 2025.02.6 is listening on 0.0.0.0:3000 with config file `tensorzero-internal/tests/e2e/tensorzero.toml` and observability enabled (database: tensorzero_e2e_tests)."},"target":"gateway"}
```

This should make it much easier for us to debug customer-provided logs, since we can tell what crate is logging a message. I've also turned off field flattenting, so that 'target' won't clash with a crate deciding to log a tracing field named 'target'

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
