### PR TITLE
Use 'inference_params_inference' providers for batch inference params

### DIFF
--- a/tensorzero-internal/tests/e2e/providers/batch.rs
+++ b/tensorzero-internal/tests/e2e/providers/batch.rs
@@ -114,8 +114,7 @@ macro_rules! generate_batch_inference_tests {
         #[tokio::test]
         async fn test_start_inference_params_batch_inference_request() {
             let all_providers = $func().await;
-            // We use the simple inference providers for batch inference params inference because they do not require dynamic credentials
-            let providers = all_providers.simple_inference;
+            let providers = all_providers.inference_params_inference;
             if all_providers.supports_batch_inference {
                 for provider in providers {
                     test_start_inference_params_batch_inference_request_with_provider(provider).await;
@@ -126,8 +125,7 @@ macro_rules! generate_batch_inference_tests {
         #[tokio::test]
         async fn test_poll_existing_inference_params_batch_inference_request() {
             let all_providers = $func().await;
-            // We use the simple inference providers for batch inference params inference because they do not require dynamic credentials
-            let providers = all_providers.simple_inference;
+            let providers = all_providers.inference_params_inference;
             if all_providers.supports_batch_inference {
                 for provider in providers {
                     test_poll_existing_inference_params_batch_inference_request_with_provider(provider).await;


### PR DESCRIPTION
The 'simple_inference' models don't all support 'temperature', which causes the batch test to fail. The 'dynamic credentials' comment no longer seems to apply, since we're already using this provider for
'test_poll_completed_inference_params_batch_inference_request'

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch batch inference test provider to `inference_params_inference` in `batch.rs` for compatibility with `temperature` parameter.
> 
>   - **Behavior**:
>     - Change provider from `simple_inference` to `inference_params_inference` in `test_start_inference_params_batch_inference_request` and `test_poll_existing_inference_params_batch_inference_request` in `batch.rs`.
>     - Ensures compatibility with `temperature` parameter in batch inference tests.
>   - **Rationale**:
>     - Aligns with provider used in `test_poll_completed_inference_params_batch_inference_request`.
>     - Removes outdated comment about dynamic credentials.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 44f1a434864a038593deffb44fadf1a9b2c9463a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->