### PR TITLE
Deny 'clippy::dbg_macro' lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ todo = "deny"
 unimplemented = "deny"
 unreachable = "deny"
 unwrap_used = "deny"
+dbg_macro = "deny"
 
 
 [profile.performance]


### PR DESCRIPTION
This will error on uses of 'dbg!'

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Clippy lint to deny `dbg!` macro usage in `Cargo.toml`.
> 
>   - **Lint Configuration**:
>     - Add `dbg_macro = "deny"` to Clippy lints in `Cargo.toml` to error on `dbg!` macro usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2c8e4fbff7ebfb4573bb3782bb3ec12a46c8664e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->