### PR TITLE
Make episode_id nullable in ChatInferenceDataset/JsonInferenceDataset

### DIFF
--- a/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0016.rs
+++ b/tensorzero-internal/src/clickhouse_migration_manager/migrations/migration_0016.rs
@@ -58,6 +58,28 @@ impl Migration for Migration0016<'_> {
             return Ok(true);
         }
 
+        let chat_inference_dataset_episode_id_type = get_column_type(
+            self.clickhouse,
+            "ChatInferenceDataset",
+            "episode_id",
+            "0016",
+        )
+        .await?;
+
+        let json_inference_dataset_episode_id_type = get_column_type(
+            self.clickhouse,
+            "JsonInferenceDataset",
+            "episode_id",
+            "0016",
+        )
+        .await?;
+
+        if chat_inference_dataset_episode_id_type != "Nullable(UUID)"
+            || json_inference_dataset_episode_id_type != "Nullable(UUID)"
+        {
+            return Ok(true);
+        }
+
         Ok(false)
     }
 
@@ -103,7 +125,9 @@ impl Migration for Migration0016<'_> {
                         -- sort and sorting expected dataset sizes should be cheap
                         -- If this example is generated from an inference then this
                         -- should be the inference ID
-                episode_id UUID,
+                episode_id Nullable(UUID), -- If this is a synthetic datapoint
+                                           -- (not based on an existing inference),
+                                           -- then this will be null
                 input String,
                 output Nullable(String),
                 tool_params String,
@@ -125,7 +149,7 @@ impl Migration for Migration0016<'_> {
                 dataset_name LowCardinality(String),
                 function_name LowCardinality(String),
                 id UUID, -- same comment as above
-                episode_id UUID,
+                episode_id Nullable(UUID), -- same comment as above
                 input String,
                 output Nullable(String),
                 output_schema String,

--- a/tensorzero-internal/src/endpoints/datasets.rs
+++ b/tensorzero-internal/src/endpoints/datasets.rs
@@ -194,7 +194,7 @@ pub async fn create_datapoint_handler(
                 dataset_name: path_params.dataset,
                 function_name: inference.function_name,
                 id: inference.id,
-                episode_id: inference.episode_id,
+                episode_id: Some(inference.episode_id),
                 input: inference.input,
                 output,
                 output_schema: inference.output_schema,
@@ -232,7 +232,7 @@ pub async fn create_datapoint_handler(
                 dataset_name: path_params.dataset,
                 function_name: inference.function_name,
                 id: inference.id,
-                episode_id: inference.episode_id,
+                episode_id: Some(inference.episode_id),
                 input: inference.input,
                 output,
                 tool_params: inference.tool_params,
@@ -289,7 +289,7 @@ pub struct ChatInferenceDatapoint {
     pub dataset_name: String,
     pub function_name: String,
     pub id: Uuid,
-    pub episode_id: Uuid,
+    pub episode_id: Option<Uuid>,
     #[serde(deserialize_with = "deserialize_json_string")]
     pub input: ResolvedInput,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -308,7 +308,7 @@ pub struct JsonInferenceDatapoint {
     pub dataset_name: String,
     pub function_name: String,
     pub id: Uuid,
-    pub episode_id: Uuid,
+    pub episode_id: Option<Uuid>,
     #[serde(deserialize_with = "deserialize_json_string")]
     pub input: ResolvedInput,
     #[serde(deserialize_with = "deserialize_optional_json_string")]


### PR DESCRIPTION
We haven't made a release yet, so I edited the migration in-place.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `episode_id` nullable in `ChatInferenceDataset` and `JsonInferenceDataset` by updating database schema and data handling code.
> 
>   - **Database Schema**:
>     - In `migration_0016.rs`, change `episode_id` to `Nullable(UUID)` in `ChatInferenceDataset` and `JsonInferenceDataset` tables.
>     - Update `should_apply()` to check for `Nullable(UUID)` type for `episode_id`.
>   - **Data Handling**:
>     - In `datasets.rs`, update `ChatInferenceDatapoint` and `JsonInferenceDatapoint` structs to use `Option<Uuid>` for `episode_id`.
>     - Modify `create_datapoint_handler()` to wrap `episode_id` in `Some()` when creating datapoints.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c1bcd628031e6f1a39d3efb858c72c25873cb97b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->