### PR TITLE
Update type of system field in `InferenceInput` for dictionary support

### DIFF
--- a/clients/python-pyo3/tensorzero/types.py
+++ b/clients/python-pyo3/tensorzero/types.py
@@ -135,7 +135,7 @@ class Message(TypedDict):
 
 class InferenceInput(TypedDict):
     messages: List[Message]
-    system: Optional[str]
+    system: Optional[Union[str, Dict[str, Any]]]
 
 
 InferenceResponse = Union[ChatInferenceResponse, JsonInferenceResponse]


### PR DESCRIPTION
I am currently getting pyright errors when passing a dict to the system field in an `InferenceInput` object when using the python client.
This PR is trying to address that issue.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `system` field type in `InferenceInput` to support dictionaries, fixing pyright error.
> 
>   - **Type Update**:
>     - Update `system` field in `InferenceInput` to `Optional[Union[str, Dict[str, Any]]]` in `types.py` to support dictionaries.
>   - **Error Fix**:
>     - Fixes pyright error when passing a dictionary to `system` field in `InferenceInput`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 11acf1e190c094b2a96c6627379399cb6ca9553d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->