### PR TITLE
Apply 'unknown' content block filtering for streaming inference

### DIFF
--- a/tensorzero-internal/src/model.rs
+++ b/tensorzero-internal/src/model.rs
@@ -1653,12 +1653,15 @@ mod tests {
                 },
             )]),
         };
-        let StreamResponse {
-            mut stream,
-            raw_request,
-            model_provider_name,
-            cached: _,
-        } = model_config
+        let (
+            StreamResponse {
+                mut stream,
+                raw_request,
+                model_provider_name,
+                cached: _,
+            },
+            _input,
+        ) = model_config
             .infer_stream(
                 &request,
                 &InferenceClients {
@@ -1811,12 +1814,15 @@ mod tests {
                 ),
             ]),
         };
-        let StreamResponse {
-            mut stream,
-            raw_request,
-            model_provider_name,
-            cached: _,
-        } = model_config
+        let (
+            StreamResponse {
+                mut stream,
+                raw_request,
+                model_provider_name,
+                cached: _,
+            },
+            _input,
+        ) = model_config
             .infer_stream(
                 &request,
                 &InferenceClients {

--- a/tensorzero-internal/src/variant/mod.rs
+++ b/tensorzero-internal/src/variant/mod.rs
@@ -521,12 +521,15 @@ async fn infer_model_request_stream<'request>(
     inference_params: InferenceParams,
     retry_config: RetryConfig,
 ) -> Result<(InferenceResultStream, ModelUsedInfo), Error> {
-    let StreamResponse {
-        stream,
-        raw_request,
-        model_provider_name,
-        cached,
-    } = (|| async {
+    let (
+        StreamResponse {
+            stream,
+            raw_request,
+            model_provider_name,
+            cached,
+        },
+        input_messages,
+    ) = (|| async {
         model_config
             .infer_stream(&request, clients, &model_name)
             .await
@@ -534,7 +537,6 @@ async fn infer_model_request_stream<'request>(
     .retry(retry_config.get_backoff())
     .await?;
     let system = request.system.clone();
-    let input_messages = request.messages.clone();
     let model_used_info = ModelUsedInfo {
         model_name,
         model_provider_name,


### PR DESCRIPTION
We also need to use the filtered messages in 'ModelUsedInfo', so that we store the filtered messages in the ModelInference table after the stream is finished.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add content block filtering for streaming inference to store relevant messages in ModelInference table.
> 
>   - **Behavior**:
>     - `infer_stream` in `model.rs` now returns filtered messages alongside `StreamResponse`.
>     - `infer_model_request_stream` in `variant/mod.rs` updated to use filtered messages for `ModelUsedInfo`.
>   - **Functions**:
>     - `filter_content_blocks` in `ModelConfig` filters out irrelevant content blocks based on provider name.
>   - **Tests**:
>     - Added `e2e_test_inference_chat_strip_unknown_block_stream` in `inference.rs` to test streaming inference with unknown content blocks.
>     - Updated `e2e_test_inference_chat_strip_unknown_block_non_stream` in `inference.rs` for non-streaming cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 35924e4824e3dae35d09d2b5b0d672fe756ab33b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->