### PR TITLE
Move default weight handling to VariantConfig.weight

### DIFF
--- a/tensorzero-internal/src/config_parser.rs
+++ b/tensorzero-internal/src/config_parser.rs
@@ -886,7 +886,7 @@ mod tests {
                 let variant = json_config.variants.get("variant_with_variables").unwrap();
                 match variant {
                     VariantConfig::ChatCompletion(chat_config) => {
-                        assert_eq!(chat_config.weight, 0.0); // Default weight should be 0
+                        assert_eq!(chat_config.weight, None); // Default weight should be None
                     }
                     _ => panic!("Expected a chat completion variant"),
                 }
@@ -917,7 +917,7 @@ mod tests {
                 match &json_config.variants["anthropic_promptA"] {
                     VariantConfig::ChatCompletion(chat_config) => {
                         assert_eq!(chat_config.model, "anthropic::claude-3.5-sonnet".into());
-                        assert_eq!(chat_config.weight, 1.0);
+                        assert_eq!(chat_config.weight, Some(1.0));
                         assert_eq!(
                             *chat_config.system_template.as_ref().unwrap(),
                             PathWithContents {

--- a/tensorzero-internal/src/evals/mod.rs
+++ b/tensorzero-internal/src/evals/mod.rs
@@ -351,7 +351,7 @@ impl UninitializedLLMJudgeVariantConfig {
                     contents: templated_system_instructions,
                 };
                 Ok(VariantConfig::ChatCompletion(ChatCompletionConfig {
-                    weight: if params.active { 1.0 } else { 0.0 },
+                    weight: Some(if params.active { 1.0 } else { 0.0 }),
                     model: params.model,
                     system_template: Some(system_template),
                     user_template: None,

--- a/tensorzero-internal/src/function.rs
+++ b/tensorzero-internal/src/function.rs
@@ -1350,7 +1350,7 @@ mod tests {
                     (
                         name.to_string(),
                         VariantConfig::ChatCompletion(ChatCompletionConfig {
-                            weight,
+                            weight: Some(weight),
                             model: "model-name".into(),
                             ..Default::default()
                         }),

--- a/tensorzero-internal/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-internal/src/variant/best_of_n_sampling.rs
@@ -35,7 +35,7 @@ use super::{InferenceConfig, JsonMode, ModelUsedInfo, Variant};
 
 #[derive(Debug)]
 pub struct BestOfNSamplingConfig {
-    pub weight: f64,
+    pub weight: Option<f64>,
     pub timeout_s: f64,
     pub candidates: Vec<String>,
     pub evaluator: EvaluatorConfig,
@@ -45,7 +45,7 @@ pub struct BestOfNSamplingConfig {
 #[serde(deny_unknown_fields)]
 pub struct UninitializedBestOfNSamplingConfig {
     #[serde(default)]
-    pub weight: f64,
+    pub weight: Option<f64>,
     #[serde(default = "default_timeout")]
     pub timeout_s: f64,
     pub candidates: Vec<String>,
@@ -719,7 +719,7 @@ mod tests {
         let evaluator_config = EvaluatorConfig {
             inner: ChatCompletionConfig {
                 model: "dummy".into(),
-                weight: 1.0,
+                weight: Some(1.0),
                 ..Default::default()
             },
         };
@@ -740,7 +740,7 @@ mod tests {
         let evaluator_config = EvaluatorConfig {
             inner: ChatCompletionConfig {
                 model: "dummy".into(),
-                weight: 1.0,
+                weight: Some(1.0),
                 ..Default::default()
             },
         };
@@ -759,7 +759,7 @@ mod tests {
         let evaluator_config = EvaluatorConfig {
             inner: ChatCompletionConfig {
                 model: "dummy".into(),
-                weight: 1.0,
+                weight: Some(1.0),
                 ..Default::default()
             },
         };
@@ -781,7 +781,7 @@ mod tests {
         let evaluator_config = EvaluatorConfig {
             inner: ChatCompletionConfig {
                 model: "dummy".into(),
-                weight: 1.0,
+                weight: Some(1.0),
                 system_template: Some(PathWithContents {
                     path: system_template_name.into(),
                     contents: "".to_string(),
@@ -816,7 +816,7 @@ mod tests {
         let evaluator_config = EvaluatorConfig {
             inner: ChatCompletionConfig {
                 model: "dummy".into(),
-                weight: 1.0,
+                weight: Some(1.0),
                 system_template: Some(PathWithContents {
                     path: system_template_name.into(),
                     contents: "".to_string(),
@@ -849,7 +849,7 @@ mod tests {
         let evaluator_config = EvaluatorConfig {
             inner: ChatCompletionConfig {
                 model: "dummy".into(),
-                weight: 1.0,
+                weight: Some(1.0),
                 ..Default::default()
             },
         };
@@ -953,7 +953,7 @@ mod tests {
         let evaluator_config = EvaluatorConfig {
             inner: ChatCompletionConfig {
                 model: "dummy_json".into(),
-                weight: 1.0,
+                weight: Some(1.0),
                 ..Default::default()
             },
         };
@@ -1060,7 +1060,7 @@ mod tests {
             },
         };
         let best_of_n_variant = BestOfNSamplingConfig {
-            weight: 1.0,
+            weight: Some(1.0),
             timeout_s: 10.0,
             candidates: vec![],
             evaluator: evaluator_config,
@@ -1228,7 +1228,7 @@ mod tests {
             },
         };
         let best_of_n_variant = BestOfNSamplingConfig {
-            weight: 1.0,
+            weight: Some(1.0),
             timeout_s: 10.0,
             candidates: vec![],
             evaluator: evaluator_config,
@@ -1291,7 +1291,7 @@ mod tests {
             },
         };
         let best_of_n_variant = BestOfNSamplingConfig {
-            weight: 1.0,
+            weight: Some(1.0),
             timeout_s: 10.0,
             candidates: vec![],
             evaluator: evaluator_config,
@@ -1366,13 +1366,13 @@ mod tests {
 
         // Test case: Index returned too large (should return an error)
         let best_of_n_big_variant = BestOfNSamplingConfig {
-            weight: 1.0,
+            weight: Some(1.0),
             timeout_s: 10.0,
             candidates: vec![],
             evaluator: EvaluatorConfig {
                 inner: ChatCompletionConfig {
                     model: "best_of_n_big".into(),
-                    weight: 1.0,
+                    weight: Some(1.0),
                     ..Default::default()
                 },
             },

--- a/tensorzero-internal/src/variant/chat_completion.rs
+++ b/tensorzero-internal/src/variant/chat_completion.rs
@@ -39,7 +39,7 @@ pub struct ExtraBodyReplacement {
 
 #[derive(Debug, Default)]
 pub struct ChatCompletionConfig {
-    pub weight: f64,
+    pub weight: Option<f64>,
     pub model: Arc<str>,
     pub system_template: Option<PathWithContents>,
     pub user_template: Option<PathWithContents>,
@@ -59,7 +59,7 @@ pub struct ChatCompletionConfig {
 #[serde(deny_unknown_fields)]
 pub struct UninitializedChatCompletionConfig {
     #[serde(default)]
-    pub weight: f64,
+    pub weight: Option<f64>,
     pub model: Arc<str>,
     pub system_template: Option<PathBuf>,
     pub user_template: Option<PathBuf>,
@@ -315,7 +315,7 @@ impl Variant for ChatCompletionConfig {
         variant_name: &str,
     ) -> Result<(), Error> {
         // Validate that weight is non-negative
-        if self.weight < 0.0 {
+        if self.weight.is_some_and(|w| w < 0.0) {
             return Err(ErrorDetails::Config {
                 message: format!(
                     "`functions.{function_name}.variants.{variant_name}`: `weight` must be non-negative"
@@ -494,7 +494,7 @@ mod tests {
         // Part 1: test without templates
         let chat_completion_config = ChatCompletionConfig {
             model: "dummy".into(),
-            weight: 1.0,
+            weight: Some(1.0),
             system_template: None,
             user_template: None,
             assistant_template: None,
@@ -564,7 +564,7 @@ mod tests {
 
         let chat_completion_config = ChatCompletionConfig {
             model: "dummy".into(),
-            weight: 1.0,
+            weight: Some(1.0),
             system_template: Some(PathWithContents {
                 path: system_template_name.into(),
                 contents: "".to_string(),
@@ -656,7 +656,7 @@ mod tests {
 
         let chat_completion_config = ChatCompletionConfig {
             model: "dummy".into(),
-            weight: 1.0,
+            weight: Some(1.0),
             system_template: Some(PathWithContents {
                 path: system_template_name.into(),
                 contents: "".to_string(),
@@ -723,7 +723,7 @@ mod tests {
         // Test without templates, string message
         let chat_completion_config = ChatCompletionConfig {
             model: "dummy".into(),
-            weight: 1.0,
+            weight: Some(1.0),
             ..Default::default()
         };
         let input_message = Value::String("You are a helpful assistant.".to_string());
@@ -739,7 +739,7 @@ mod tests {
         // Test without templates, object message
         let chat_completion_config = ChatCompletionConfig {
             model: "dummy".into(),
-            weight: 1.0,
+            weight: Some(1.0),
             ..Default::default()
         };
         let input_message = json!({"message": "You are a helpful assistant."});
@@ -755,7 +755,7 @@ mod tests {
         // Test without templates, no message
         let chat_completion_config = ChatCompletionConfig {
             model: "dummy".into(),
-            weight: 1.0,
+            weight: Some(1.0),
             ..Default::default()
         };
         let result = chat_completion_config.prepare_system_message(&templates, None);
@@ -768,7 +768,7 @@ mod tests {
 
         let chat_completion_config = ChatCompletionConfig {
             model: "dummy".into(),
-            weight: 1.0,
+            weight: Some(1.0),
             system_template: Some(PathWithContents {
                 path: system_template_name.into(),
                 contents: "".to_string(),
@@ -791,7 +791,7 @@ mod tests {
 
         let chat_completion_config = ChatCompletionConfig {
             model: "dummy".into(),
-            weight: 1.0,
+            weight: Some(1.0),
             system_template: Some(PathWithContents {
                 path: system_template_name.into(),
                 contents: "".to_string(),
@@ -827,7 +827,7 @@ mod tests {
         let user_template_name = "greeting_with_age";
         let chat_completion_config = ChatCompletionConfig {
             model: "good".into(),
-            weight: 1.0,
+            weight: Some(1.0),
             system_template: Some(PathWithContents {
                 path: system_template_name.into(),
                 contents: "".to_string(),
@@ -1000,7 +1000,7 @@ mod tests {
 
         let chat_completion_config = ChatCompletionConfig {
             model: "error".into(),
-            weight: 1.0,
+            weight: Some(1.0),
             system_template: Some(PathWithContents {
                 path: system_template_name.into(),
                 contents: "".to_string(),
@@ -1061,7 +1061,7 @@ mod tests {
         let inference_params = InferenceParams::default();
         let chat_completion_config = ChatCompletionConfig {
             model: "good".into(),
-            weight: 1.0,
+            weight: Some(1.0),
             system_template: Some(PathWithContents {
                 path: system_template_name.into(),
                 contents: "".to_string(),
@@ -1152,7 +1152,7 @@ mod tests {
         let inference_params = InferenceParams::default();
         let chat_completion_config = ChatCompletionConfig {
             model: "tool".into(),
-            weight: 1.0,
+            weight: Some(1.0),
             ..Default::default()
         };
         let input = ResolvedInput {
@@ -1326,7 +1326,7 @@ mod tests {
         };
         let chat_completion_config = ChatCompletionConfig {
             model: "json".into(),
-            weight: 1.0,
+            weight: Some(1.0),
             system_template: Some(PathWithContents {
                 path: system_template_name.into(),
                 contents: "".to_string(),
@@ -1429,7 +1429,7 @@ mod tests {
         };
         let chat_completion_config = ChatCompletionConfig {
             model: "json".into(),
-            weight: 1.0,
+            weight: Some(1.0),
             system_template: Some(PathWithContents {
                 path: system_template_name.into(),
                 contents: "".to_string(),
@@ -1522,7 +1522,7 @@ mod tests {
         };
         let chat_completion_config = ChatCompletionConfig {
             model: "json".into(),
-            weight: 1.0,
+            weight: Some(1.0),
             system_template: Some(PathWithContents {
                 path: system_template_name.into(),
                 contents: "".to_string(),
@@ -1655,7 +1655,7 @@ mod tests {
         };
         let chat_completion_config = Box::leak(Box::new(ChatCompletionConfig {
             model: "error".into(),
-            weight: 1.0,
+            weight: Some(1.0),
             system_template: Some(PathWithContents {
                 path: system_template_name.into(),
                 contents: "".to_string(),
@@ -1718,7 +1718,7 @@ mod tests {
         let inference_params = InferenceParams::default();
         let chat_completion_config = Box::leak(Box::new(ChatCompletionConfig {
             model: "good".into(),
-            weight: 1.0,
+            weight: Some(1.0),
             system_template: Some(PathWithContents {
                 path: system_template_name.into(),
                 contents: "".to_string(),

--- a/tensorzero-internal/src/variant/dicl.rs
+++ b/tensorzero-internal/src/variant/dicl.rs
@@ -40,7 +40,7 @@ use super::{
 /// load() step to get the fully qualified path.
 #[derive(Debug, Default)]
 pub struct DiclConfig {
-    pub weight: f64,
+    pub weight: Option<f64>,
     pub embedding_model: Arc<str>,
     pub k: u32, // k as in k-nearest neighbors
     pub model: Arc<str>,
@@ -60,7 +60,7 @@ pub struct DiclConfig {
 #[serde(deny_unknown_fields)]
 pub struct UninitializedDiclConfig {
     #[serde(default)]
-    pub weight: f64,
+    pub weight: Option<f64>,
     pub embedding_model: String,
     pub k: u32, // k as in k-nearest neighbors
     pub model: String,
@@ -222,7 +222,7 @@ impl Variant for DiclConfig {
         // Make sure that the count is positive
 
         // Validate that weight is non-negative
-        if self.weight < 0.0 {
+        if self.weight.is_some_and(|w| w < 0.0) {
             return Err(ErrorDetails::Config {
                 message: format!(
                 "`functions.{function_name}.variants.{variant_name}`: `weight` must be non-negative"

--- a/tensorzero-internal/src/variant/mixture_of_n.rs
+++ b/tensorzero-internal/src/variant/mixture_of_n.rs
@@ -33,7 +33,7 @@ use super::{
 
 #[derive(Debug)]
 pub struct MixtureOfNConfig {
-    pub weight: f64,
+    pub weight: Option<f64>,
     pub timeout_s: f64,
     pub candidates: Vec<String>,
     pub fuser: FuserConfig,
@@ -43,7 +43,7 @@ pub struct MixtureOfNConfig {
 #[serde(deny_unknown_fields)]
 pub struct UninitializedMixtureOfNConfig {
     #[serde(default)]
-    pub weight: f64,
+    pub weight: Option<f64>,
     #[serde(default = "default_timeout")]
     pub timeout_s: f64,
     pub candidates: Vec<String>,
@@ -558,7 +558,7 @@ mod tests {
         let fuser_config = FuserConfig {
             inner: ChatCompletionConfig {
                 model: "dummy".into(),
-                weight: 1.0,
+                weight: Some(1.0),
                 ..Default::default()
             },
         };
@@ -579,7 +579,7 @@ mod tests {
         let fuser_config = FuserConfig {
             inner: ChatCompletionConfig {
                 model: "dummy".into(),
-                weight: 1.0,
+                weight: Some(1.0),
                 ..Default::default()
             },
         };
@@ -598,7 +598,7 @@ mod tests {
         let fuser_config = FuserConfig {
             inner: ChatCompletionConfig {
                 model: "dummy".into(),
-                weight: 1.0,
+                weight: Some(1.0),
                 ..Default::default()
             },
         };
@@ -620,7 +620,7 @@ mod tests {
         let fuser_config = FuserConfig {
             inner: ChatCompletionConfig {
                 model: "dummy".into(),
-                weight: 1.0,
+                weight: Some(1.0),
                 system_template: Some(PathWithContents {
                     path: system_template_name.into(),
                     contents: "".to_string(),
@@ -655,7 +655,7 @@ mod tests {
         let fuser_config = FuserConfig {
             inner: ChatCompletionConfig {
                 model: "dummy".into(),
-                weight: 1.0,
+                weight: Some(1.0),
                 system_template: Some(PathWithContents {
                     path: system_template_name.into(),
                     contents: "".to_string(),
@@ -688,7 +688,7 @@ mod tests {
         let fuser_config = FuserConfig {
             inner: ChatCompletionConfig {
                 model: "dummy".into(),
-                weight: 1.0,
+                weight: Some(1.0),
                 ..Default::default()
             },
         };
@@ -786,7 +786,7 @@ mod tests {
         let fuser_config = FuserConfig {
             inner: ChatCompletionConfig {
                 model: "dummy_json".into(),
-                weight: 1.0,
+                weight: Some(1.0),
                 ..Default::default()
             },
         };
@@ -887,7 +887,7 @@ mod tests {
             },
         };
         let mixture_of_n_variant = MixtureOfNConfig {
-            weight: 1.0,
+            weight: Some(1.0),
             timeout_s: 10.0,
             candidates: vec![],
             fuser: fuser_config,
@@ -1057,7 +1057,7 @@ mod tests {
             },
         };
         let mixture_of_n_variant = MixtureOfNConfig {
-            weight: 1.0,
+            weight: Some(1.0),
             timeout_s: 10.0,
             candidates: vec![],
             fuser: fuser_config,
@@ -1121,7 +1121,7 @@ mod tests {
             },
         };
         let mixture_of_n_variant = MixtureOfNConfig {
-            weight: 1.0,
+            weight: Some(1.0),
             timeout_s: 10.0,
             candidates: vec![],
             fuser: fuser_config,

--- a/tensorzero-internal/src/variant/mod.rs
+++ b/tensorzero-internal/src/variant/mod.rs
@@ -165,10 +165,10 @@ pub trait Variant {
 impl VariantConfig {
     pub fn weight(&self) -> f64 {
         match self {
-            VariantConfig::ChatCompletion(params) => params.weight,
-            VariantConfig::BestOfNSampling(params) => params.weight,
-            VariantConfig::Dicl(params) => params.weight,
-            VariantConfig::MixtureOfN(params) => params.weight,
+            VariantConfig::ChatCompletion(params) => params.weight.unwrap_or(0.0),
+            VariantConfig::BestOfNSampling(params) => params.weight.unwrap_or(0.0),
+            VariantConfig::Dicl(params) => params.weight.unwrap_or(0.0),
+            VariantConfig::MixtureOfN(params) => params.weight.unwrap_or(0.0),
         }
     }
 }


### PR DESCRIPTION
We now parse weights from the config as `Option<f64>`. The `VariantConfig.weight` function unwraps these with a default of `0.0` for now, which preserves the current behavior. As a result, this PR is a pure refactoring.

In a follow-up pr, I'm going change `weight` to return an `Option<f64>`, and implement the new fallback behavior (don't fall back to variants with zero weight)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor weight handling in `VariantConfig` to use `Option<f64>` with a default of `0.0`.
> 
>   - **Behavior**:
>     - `VariantConfig.weight` now returns `Option<f64>` instead of `f64`, defaulting to `0.0` if `None`.
>     - Updates weight handling in `BestOfNSamplingConfig`, `ChatCompletionConfig`, `DiclConfig`, and `MixtureOfNConfig` to use `Option<f64>`.
>   - **Tests**:
>     - Adjusts tests in `config_parser.rs`, `best_of_n_sampling.rs`, `chat_completion.rs`, `dicl.rs`, and `mixture_of_n.rs` to reflect the new weight handling.
>   - **Misc**:
>     - Updates `weight()` function in `variant/mod.rs` to handle `Option<f64>` and default to `0.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3f04516431598e6527e90a0480a66e77be129323. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->