### PR TITLE
Add timeout parameter to embedded gateway

### DIFF
--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -416,22 +416,29 @@ impl TensorZeroGateway {
     }
 
     #[classmethod]
-    #[pyo3(signature = (*, config_file=None, clickhouse_url=None))]
+    #[pyo3(signature = (*, config_file=None, clickhouse_url=None, timeout=None))]
     /// Initialize the TensorZero client, using an embedded gateway.
     /// This connects to ClickHouse (if provided) and runs DB migrations.
     ///
     /// :param config_file: The path to the TensorZero configuration file. Example: "tensorzero.toml"
     /// :param clickhouse_url: The URL of the ClickHouse instance to use for the gateway. If observability is disabled in the config, this can be `None`
+    /// :param timeout: The timeout for embedded gateway request processing, in seconds. If this timeout is hit, any in-progress LLM requests may be aborted. If not provided, no timeout will be set.
     /// :return: A `TensorZeroGateway` instance configured to use an embedded gateway.
     fn build_embedded(
         cls: &Bound<'_, PyType>,
         config_file: Option<&str>,
         clickhouse_url: Option<String>,
+        timeout: Option<f64>,
     ) -> PyResult<Py<TensorZeroGateway>> {
         warn_no_config(cls.py(), config_file)?;
+        let timeout = timeout
+            .map(Duration::try_from_secs_f64)
+            .transpose()
+            .map_err(|e| PyValueError::new_err(format!("Invalid timeout: {e}")))?;
         let client_fut = ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
             config_file: config_file.map(PathBuf::from),
             clickhouse_url,
+            timeout,
         })
         .build();
         let client = tokio_block_on_without_gil(cls.py(), client_fut);
@@ -674,23 +681,30 @@ impl AsyncTensorZeroGateway {
     // as `AsyncTensorZeroGateway` would be completely async *except* for this one method
     // (which potentially takes a very long time due to running DB migrations).
     #[classmethod]
-    #[pyo3(signature = (*, config_file=None, clickhouse_url=None))]
+    #[pyo3(signature = (*, config_file=None, clickhouse_url=None, timeout=None))]
     /// Initialize the TensorZero client, using an embedded gateway.
     /// This connects to ClickHouse (if provided) and runs DB migrations.
     ///
     /// :param config_file: The path to the TensorZero configuration file. Example: "tensorzero.toml"
     /// :param clickhouse_url: The URL of the ClickHouse instance to use for the gateway. If observability is disabled in the config, this can be `None`
+    /// :param timeout: The timeout for embedded gateway request processing, in seconds. If this timeout is hit, any in-progress LLM requests may be aborted. If not provided, no timeout will be set.
     /// :return: A `Future` that resolves to an `AsyncTensorZeroGateway` instance configured to use an embedded gateway.
     fn build_embedded<'a>(
         // This is a classmethod, so it receives the class object as a parameter.
         cls: &Bound<'a, PyType>,
         config_file: Option<&str>,
         clickhouse_url: Option<String>,
+        timeout: Option<f64>,
     ) -> PyResult<Bound<'a, PyAny>> {
         warn_no_config(cls.py(), config_file)?;
+        let timeout = timeout
+            .map(Duration::try_from_secs_f64)
+            .transpose()
+            .map_err(|e| PyValueError::new_err(format!("Invalid timeout: {e}")))?;
         let client_fut = ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
             config_file: config_file.map(PathBuf::from),
             clickhouse_url,
+            timeout,
         })
         .build();
 

--- a/clients/python-pyo3/tensorzero/tensorzero.pyi
+++ b/clients/python-pyo3/tensorzero/tensorzero.pyi
@@ -48,13 +48,18 @@ class TensorZeroGateway(BaseTensorZeroGateway):
 
     @classmethod
     def build_embedded(
-        cls, *, config_file: Optional[str] = None, clickhouse_url: Optional[str] = None
+        cls,
+        *,
+        config_file: Optional[str] = None,
+        clickhouse_url: Optional[str] = None,
+        timeout: Optional[float] = None,
     ) -> "TensorZeroGateway":
         """
         Build a TensorZeroGateway instance.
 
         :param config_file: (Optional) The path to the TensorZero configuration file.
         :param clickhouse_url: (Optional) The URL of the ClickHouse database.
+        :param timeout: The timeout for embedded gateway request processing, in seconds. If this timeout is hit, any in-progress LLM requests may be aborted. If not provided, no timeout will be set.
         """
 
     def inference(
@@ -176,13 +181,18 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
 
     @classmethod
     async def build_embedded(
-        cls, *, config_file: Optional[str] = None, clickhouse_url: Optional[str] = None
+        cls,
+        *,
+        config_file: Optional[str] = None,
+        clickhouse_url: Optional[str] = None,
+        timeout: Optional[float] = None,
     ) -> "AsyncTensorZeroGateway":
         """
         Build an AsyncTensorZeroGateway instance.
 
         :param config_file: (Optional) The path to the TensorZero configuration file.
         :param clickhouse_url: (Optional) The URL of the ClickHouse database.
+        :param timeout: The timeout for embedded gateway request processing, in seconds. If this timeout is hit, any in-progress LLM requests may be aborted. If not provided, no timeout will be set.
         """
 
     async def inference(  # type: ignore[override]

--- a/clients/python-pyo3/tests/test_client.py
+++ b/clients/python-pyo3/tests/test_client.py
@@ -1784,7 +1784,7 @@ async def test_async_err_in_stream(async_client):
 
 
 @pytest.mark.asyncio
-async def test_async_timeout_int():
+async def test_async_timeout_int_http():
     async with await AsyncTensorZeroGateway.build_http(
         gateway_url="http://localhost:3000",
         timeout=1,
@@ -1802,7 +1802,26 @@ async def test_async_timeout_int():
 
 
 @pytest.mark.asyncio
-async def test_async_timeout_float():
+async def test_async_timeout_int_embedded():
+    async with await AsyncTensorZeroGateway.build_embedded(
+        config_file=TEST_CONFIG_FILE,
+        clickhouse_url="http://chuser:chpassword@localhost:8123/tensorzero-python-e2e",
+        timeout=1,
+    ) as async_client:
+        with pytest.raises(TensorZeroInternalError) as exc_info:
+            await async_client.inference(
+                function_name="basic_test",
+                variant_name="slow",
+                input={
+                    "system": {"assistant_name": "TensorZero bot"},
+                    "messages": [{"role": "user", "content": "Hello"}],
+                },
+            )
+        assert "HTTP request timed out" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_async_timeout_float_http():
     async with await AsyncTensorZeroGateway.build_http(
         gateway_url="http://localhost:3000",
         timeout=0.1,
@@ -1819,7 +1838,26 @@ async def test_async_timeout_float():
         assert "HTTP request timed out" in str(exc_info.value)
 
 
-def test_sync_timeout_int():
+@pytest.mark.asyncio
+async def test_async_timeout_float_embedded():
+    async with await AsyncTensorZeroGateway.build_embedded(
+        config_file=TEST_CONFIG_FILE,
+        clickhouse_url="http://chuser:chpassword@localhost:8123/tensorzero-python-e2e",
+        timeout=0.1,
+    ) as async_client:
+        with pytest.raises(TensorZeroInternalError) as exc_info:
+            await async_client.inference(
+                function_name="basic_test",
+                variant_name="slow",
+                input={
+                    "system": {"assistant_name": "TensorZero bot"},
+                    "messages": [{"role": "user", "content": "Hello"}],
+                },
+            )
+        assert "HTTP request timed out" in str(exc_info.value)
+
+
+def test_sync_timeout_int_http():
     with TensorZeroGateway.build_http(
         gateway_url="http://localhost:3000", timeout=1
     ) as sync_client:
@@ -1835,9 +1873,45 @@ def test_sync_timeout_int():
         assert "HTTP request timed out" in str(exc_info.value)
 
 
-def test_sync_timeout_float():
+def test_sync_timeout_int_embedded():
+    with TensorZeroGateway.build_embedded(
+        config_file=TEST_CONFIG_FILE,
+        clickhouse_url="http://chuser:chpassword@localhost:8123/tensorzero-python-e2e",
+        timeout=1,
+    ) as sync_client:
+        with pytest.raises(TensorZeroInternalError) as exc_info:
+            sync_client.inference(
+                function_name="basic_test",
+                variant_name="slow",
+                input={
+                    "system": {"assistant_name": "TensorZero bot"},
+                    "messages": [{"role": "user", "content": "Hello"}],
+                },
+            )
+        assert "HTTP request timed out" in str(exc_info.value)
+
+
+def test_sync_timeout_float_http():
     with TensorZeroGateway.build_http(
         gateway_url="http://localhost:3000", timeout=0.1
+    ) as sync_client:
+        with pytest.raises(TensorZeroInternalError) as exc_info:
+            sync_client.inference(
+                function_name="basic_test",
+                variant_name="slow",
+                input={
+                    "system": {"assistant_name": "TensorZero bot"},
+                    "messages": [{"role": "user", "content": "Hello"}],
+                },
+            )
+        assert "HTTP request timed out" in str(exc_info.value)
+
+
+def test_sync_timeout_float_embedded():
+    with TensorZeroGateway.build_embedded(
+        config_file=TEST_CONFIG_FILE,
+        clickhouse_url="http://chuser:chpassword@localhost:8123/tensorzero-python-e2e",
+        timeout=0.1,
     ) as sync_client:
         with pytest.raises(TensorZeroInternalError) as exc_info:
             sync_client.inference(

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -17,6 +17,7 @@ url = { workspace = true }
 thiserror = "2.0.11"
 pyo3 = { workspace = true, optional = true }
 tracing = { workspace = true }
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/clients/rust/examples/inference_demo/main.rs
+++ b/clients/rust/examples/inference_demo/main.rs
@@ -49,6 +49,7 @@ async fn main() {
         (None, Some(config_file)) => ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
             config_file: Some(config_file),
             clickhouse_url: std::env::var("CLICKHOUSE_URL").ok(),
+            timeout: None,
         }),
         (Some(_), Some(_)) => {
             std::process::exit(1);

--- a/tensorzero-internal/tests/e2e/feedback.rs
+++ b/tensorzero-internal/tests/e2e/feedback.rs
@@ -19,6 +19,7 @@ async fn make_embedded_gateway() -> tensorzero::Client {
     tensorzero::ClientBuilder::new(tensorzero::ClientBuilderMode::EmbeddedGateway {
         config_file: Some(config_path),
         clickhouse_url: Some(CLICKHOUSE_URL.clone()),
+        timeout: None,
     })
     .build()
     .await

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -93,6 +93,7 @@ pub async fn make_embedded_gateway() -> tensorzero::Client {
     tensorzero::ClientBuilder::new(tensorzero::ClientBuilderMode::EmbeddedGateway {
         config_file: Some(config_path),
         clickhouse_url: Some(crate::common::CLICKHOUSE_URL.clone()),
+        timeout: None,
     })
     .build()
     .await
@@ -104,6 +105,7 @@ pub async fn make_embedded_gateway_no_config() -> tensorzero::Client {
     tensorzero::ClientBuilder::new(tensorzero::ClientBuilderMode::EmbeddedGateway {
         config_file: None,
         clickhouse_url: Some(crate::common::CLICKHOUSE_URL.clone()),
+        timeout: None,
     })
     .build()
     .await
@@ -117,6 +119,7 @@ pub async fn make_embedded_gateway_with_config(config: &str) -> tensorzero::Clie
     tensorzero::ClientBuilder::new(tensorzero::ClientBuilderMode::EmbeddedGateway {
         config_file: Some(tmp_config.path().to_owned()),
         clickhouse_url: Some(crate::common::CLICKHOUSE_URL.clone()),
+        timeout: None,
     })
     .build()
     .await


### PR DESCRIPTION
This uses a `tokio::time::timeout` to abort the reqest handler when the timeout is hit.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add timeout parameter to embedded gateway in TensorZero client, using `tokio::time::timeout` to abort requests if timeout is exceeded.
> 
>   - **Behavior**:
>     - Add `timeout` parameter to `build_embedded` methods in `TensorZeroGateway` and `AsyncTensorZeroGateway` in `lib.rs`.
>     - Use `tokio::time::timeout` to abort request processing if timeout is exceeded in `lib.rs`.
>   - **Tests**:
>     - Add tests for `timeout` parameter in `test_client.py` for both HTTP and embedded gateways.
>     - New tests include `test_async_timeout_int_embedded`, `test_async_timeout_float_embedded`, `test_sync_timeout_int_embedded`, and `test_sync_timeout_float_embedded`.
>   - **Misc**:
>     - Update `Cargo.toml` to include `tokio` dependency.
>     - Update type hints in `tensorzero.pyi` to include `timeout` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a57eb220bda85f54332fedb7b062bf9714440e3b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->