### PR TITLE
Fix #1167

### DIFF
--- a/ui/app/routes/observability/functions/$function_name/variants/BasicInfo.tsx
+++ b/ui/app/routes/observability/functions/$function_name/variants/BasicInfo.tsx
@@ -197,15 +197,14 @@ export default function BasicVariantInfo({
                     seed={config.evaluator.seed}
                   />
                   <div>
-                    <dt className="text-lg font-semibold">Timeout (s)</dt>
-                    <dd>{config.timeout_s}</dd>
+                    <dt className="text-lg font-semibold">Timeout</dt>
+                    <dd>{config.timeout_s}s</dd>
                   </div>
                   <div className="col-span-2">
                     <dt className="text-lg font-semibold">Candidates</dt>
                     <dd>
-                      {config.candidates.map((candidate, i) => (
+                      {config.candidates.map((candidate) => (
                         <>
-                          {i > 0 && ", "}
                           <Link
                             to={`/observability/functions/${function_name}/variants/${candidate}`}
                             className="block no-underline"
@@ -277,15 +276,14 @@ export default function BasicVariantInfo({
                     seed={config.fuser.seed}
                   />
                   <div>
-                    <dt className="text-lg font-semibold">Timeout (s)</dt>
-                    <dd>{config.timeout_s}</dd>
+                    <dt className="text-lg font-semibold">Timeout</dt>
+                    <dd>{config.timeout_s}s</dd>
                   </div>
                   <div className="col-span-2">
                     <dt className="text-lg font-semibold">Candidates</dt>
                     <dd>
-                      {config.candidates.map((candidate, i) => (
+                      {config.candidates.map((candidate) => (
                         <>
-                          {i > 0 && ", "}
                           <Link
                             to={`/observability/functions/${function_name}/variants/${candidate}`}
                             className="block no-underline"


### PR DESCRIPTION
Fix #1167
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves `Timeout` display and simplifies `candidates` list rendering in `BasicVariantInfo.tsx`.
> 
>   - **Behavior**:
>     - In `BasicVariantInfo.tsx`, the `Timeout` label now displays the unit 's' directly after the value.
>     - Removed comma separator between `candidates` in the `map` function.
>   - **UI**:
>     - Updated `Timeout` display format in `BasicVariantInfo.tsx` for better clarity.
>     - Simplified `candidates` list rendering by removing unnecessary comma logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 605557f065eff9c2acac23ab459752cb52602f0e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->