### PR TITLE
Ignore variants with zero weight unless pinned

### DIFF
--- a/tensorzero-internal/src/embeddings.rs
+++ b/tensorzero-internal/src/embeddings.rs
@@ -305,6 +305,8 @@ mod tests {
             .embed(&request, &client, &inference_credentials)
             .await;
         assert!(response.is_ok());
-        assert!(logs_contain("Error sending request to Dummy provider."))
+        assert!(logs_contain(
+            "Error sending request to Dummy provider for model 'error'"
+        ))
     }
 }

--- a/tensorzero-internal/src/endpoints/inference.rs
+++ b/tensorzero-internal/src/endpoints/inference.rs
@@ -224,6 +224,17 @@ pub async fn inference(
             }
             .into());
         }
+    } else {
+        // Remove all zero-weight variants - these can only be used if explicitly pinned above
+        candidate_variant_names.retain(|name| {
+            if let Some(variant) = function.variants().get(*name) {
+                // Retain 'None' and positive-weight variants, discarding zero-weight variants
+                variant.weight().is_none_or(|w| w > 0.0)
+            } else {
+                // Keep missing variants - later code will error if we try to use them
+                true
+            }
+        });
     }
 
     // Should we store the results?

--- a/tensorzero-internal/src/evals/mod.rs
+++ b/tensorzero-internal/src/evals/mod.rs
@@ -241,7 +241,8 @@ impl UninitializedEvaluatorConfig {
                     .collect::<Result<HashMap<_, _>, Error>>()?;
                 let nonzero_weights = variants
                     .iter()
-                    .filter(|(_, variant)| variant.weight() > 0.0)
+                    // Treat a None weight as 0.0 for this check - we only care if we have multiple variants with an explicit positive weight
+                    .filter(|(_, variant)| variant.weight().unwrap_or(0.0) > 0.0)
                     .count();
                 if nonzero_weights != 1 {
                     return Err(ErrorDetails::Config {

--- a/tensorzero-internal/src/function.rs
+++ b/tensorzero-internal/src/function.rs
@@ -414,7 +414,7 @@ pub fn sample_variant<'a>(
     let total_weight = candidate_variant_names
         .iter()
         .filter_map(|name| variants.get(*name))
-        .map(|variant| variant.weight())
+        .map(|variant| variant.weight().unwrap_or(0.0))
         .sum::<f64>();
 
     // If the total weight is non-positive, perform uniform sampling
@@ -468,7 +468,7 @@ pub fn sample_variant<'a>(
                 message: format!("Function `{function_name}` has no variant `{variant_name}`"),
             })
         })?;
-        cumulative_weight += variant.weight();
+        cumulative_weight += variant.weight().unwrap_or(0.0);
         if cumulative_weight > random_threshold {
             sampled_variant_name = candidate_variant_names.swap_remove(i);
             break;
@@ -1366,7 +1366,7 @@ mod tests {
             sample_size: usize,
             tolerance: f64,
         ) {
-            let total_weight: f64 = variants.values().map(|v| v.weight()).sum();
+            let total_weight: f64 = variants.values().map(|v| v.weight().unwrap_or(0.0)).sum();
             let mut counts: HashMap<String, usize> = HashMap::new();
 
             for _ in 0..sample_size {
@@ -1382,7 +1382,7 @@ mod tests {
             }
 
             for (variant_name, variant) in variants {
-                let expected_prob = variant.weight() / total_weight;
+                let expected_prob = variant.weight().unwrap_or(0.0) / total_weight;
                 let actual_prob =
                     *counts.get(variant_name).unwrap_or(&0) as f64 / sample_size as f64;
                 let diff = (expected_prob - actual_prob).abs();

--- a/tensorzero-internal/src/inference/providers/dummy.rs
+++ b/tensorzero-internal/src/inference/providers/dummy.rs
@@ -193,9 +193,12 @@ impl InferenceProvider for DummyProvider {
             }
         }
 
-        if self.model_name == "error" {
+        if self.model_name.starts_with("error") {
             return Err(ErrorDetails::InferenceClient {
-                message: "Error sending request to Dummy provider.".to_string(),
+                message: format!(
+                    "Error sending request to Dummy provider for model '{}'.",
+                    self.model_name
+                ),
                 raw_request: Some("raw request".to_string()),
                 raw_response: None,
                 status_code: None,
@@ -388,9 +391,12 @@ impl InferenceProvider for DummyProvider {
             .await;
         }
 
-        if self.model_name == "error" {
+        if self.model_name.starts_with("error") {
             return Err(ErrorDetails::InferenceClient {
-                message: "Error sending request to Dummy provider.".to_string(),
+                message: format!(
+                    "Error sending request to Dummy provider for model '{}'.",
+                    self.model_name
+                ),
                 raw_request: Some("raw request".to_string()),
                 raw_response: None,
                 status_code: None,
@@ -507,9 +513,12 @@ impl EmbeddingProvider for DummyProvider {
         _http_client: &reqwest::Client,
         _dynamic_api_keys: &InferenceCredentials,
     ) -> Result<EmbeddingProviderResponse, Error> {
-        if self.model_name == "error" {
+        if self.model_name.starts_with("error") {
             return Err(ErrorDetails::InferenceClient {
-                message: "Error sending request to Dummy provider.".to_string(),
+                message: format!(
+                    "Error sending request to Dummy provider for model '{}'.",
+                    self.model_name
+                ),
                 raw_request: Some("raw request".to_string()),
                 raw_response: None,
                 status_code: None,

--- a/tensorzero-internal/src/model.rs
+++ b/tensorzero-internal/src/model.rs
@@ -1506,7 +1506,8 @@ mod tests {
                 provider_errors: HashMap::from([(
                     "error".to_string(),
                     ErrorDetails::InferenceClient {
-                        message: "Error sending request to Dummy provider.".to_string(),
+                        message: "Error sending request to Dummy provider for model 'error'"
+                            .to_string(),
                         status_code: None,
                         provider_type: "dummy".to_string(),
                         raw_request: Some("raw request".to_string()),
@@ -1594,7 +1595,9 @@ mod tests {
             .await
             .unwrap();
         // Ensure that the error for the bad provider was logged, but the request worked nonetheless
-        assert!(logs_contain("Error sending request to Dummy provider"));
+        assert!(logs_contain(
+            "Error sending request to Dummy provider for model 'error'."
+        ));
         let content = response.output;
         assert_eq!(
             content,
@@ -1739,7 +1742,8 @@ mod tests {
                 provider_errors: HashMap::from([(
                     "error".to_string(),
                     ErrorDetails::InferenceClient {
-                        message: "Error sending request to Dummy provider.".to_string(),
+                        message: "Error sending request to Dummy provider for model 'error'."
+                            .to_string(),
                         status_code: None,
                         provider_type: "dummy".to_string(),
                         raw_request: Some("raw request".to_string()),
@@ -1830,7 +1834,9 @@ mod tests {
         let initial_chunk = stream.next().await.unwrap().unwrap();
         assert_eq!(&*model_provider_name, "good_provider");
         // Ensure that the error for the bad provider was logged, but the request worked nonetheless
-        assert!(logs_contain("Error sending request to Dummy provider"));
+        assert!(logs_contain(
+            "Error sending request to Dummy provider for model 'error'"
+        ));
         assert_eq!(raw_request, "raw request");
 
         assert_eq!(

--- a/tensorzero-internal/src/model.rs
+++ b/tensorzero-internal/src/model.rs
@@ -1506,7 +1506,7 @@ mod tests {
                 provider_errors: HashMap::from([(
                     "error".to_string(),
                     ErrorDetails::InferenceClient {
-                        message: "Error sending request to Dummy provider for model 'error'"
+                        message: "Error sending request to Dummy provider for model 'error'."
                             .to_string(),
                         status_code: None,
                         provider_type: "dummy".to_string(),

--- a/tensorzero-internal/src/variant/chat_completion.rs
+++ b/tensorzero-internal/src/variant/chat_completion.rs
@@ -1047,7 +1047,8 @@ mod tests {
                 provider_errors: HashMap::from([(
                     "error".to_string(),
                     Error::new(ErrorDetails::InferenceClient {
-                        message: "Error sending request to Dummy provider.".to_string(),
+                        message: "Error sending request to Dummy provider for model 'error'."
+                            .to_string(),
                         status_code: None,
                         raw_request: Some("raw request".to_string()),
                         raw_response: None,

--- a/tensorzero-internal/src/variant/mod.rs
+++ b/tensorzero-internal/src/variant/mod.rs
@@ -163,12 +163,12 @@ pub trait Variant {
 }
 
 impl VariantConfig {
-    pub fn weight(&self) -> f64 {
+    pub fn weight(&self) -> Option<f64> {
         match self {
-            VariantConfig::ChatCompletion(params) => params.weight.unwrap_or(0.0),
-            VariantConfig::BestOfNSampling(params) => params.weight.unwrap_or(0.0),
-            VariantConfig::Dicl(params) => params.weight.unwrap_or(0.0),
-            VariantConfig::MixtureOfN(params) => params.weight.unwrap_or(0.0),
+            VariantConfig::ChatCompletion(params) => params.weight,
+            VariantConfig::BestOfNSampling(params) => params.weight,
+            VariantConfig::Dicl(params) => params.weight,
+            VariantConfig::MixtureOfN(params) => params.weight,
         }
     }
 }
@@ -1234,7 +1234,7 @@ mod tests {
             _ => panic!("Expected Chat inference result"),
         }
         assert!(logs_contain(
-            r#"ERROR test_infer_model_request_errors:infer_model_request{model_name=dummy_chat_model}:infer{provider_name="error"}: tensorzero_internal::error: Error from dummy client: Error sending request to Dummy provider."#
+            r#"ERROR test_infer_model_request_errors:infer_model_request{model_name=dummy_chat_model}:infer{provider_name="error"}: tensorzero_internal::error: Error from dummy client: Error sending request to Dummy provider for model 'error'."#
         ));
     }
 
@@ -1529,7 +1529,7 @@ mod tests {
         assert_eq!(full_response, expected_response);
 
         assert!(logs_contain(
-            r#"ERROR test_infer_model_request_errors_stream:infer_model_request_stream{model_name=dummy_chat_model}:infer_stream{provider_name="error"}: tensorzero_internal::error: Error from dummy client: Error sending request to Dummy provider."#
+            r#"ERROR test_infer_model_request_errors_stream:infer_model_request_stream{model_name=dummy_chat_model}:infer_stream{provider_name="error"}: tensorzero_internal::error: Error from dummy client: Error sending request to Dummy provider for model 'error'."#
         ));
     }
 }

--- a/tensorzero-internal/tests/e2e/inference.rs
+++ b/tensorzero-internal/tests/e2e/inference.rs
@@ -1171,6 +1171,86 @@ async fn e2e_test_variant_failover() {
     assert_eq!(output, vec!["Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake.".to_string().into()]);
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn e2e_test_variant_zero_weight_skip_zero() {
+    let client = make_embedded_gateway().await;
+    let error = client
+        .inference(ClientInferenceParams {
+            function_name: Some("variant_failover_zero_weight".to_string()),
+            input: Input {
+                system: Some(serde_json::json!({"assistant_name": "AskJeeves"})),
+                messages: vec![InputMessage {
+                    role: Role::User,
+                    content: vec![InputMessageContent::Text(TextKind::Arguments {
+                        arguments: serde_json::json!({"type": "tacos", "quantity": 13})
+                            .as_object()
+                            .unwrap()
+                            .clone(),
+                    })],
+                }],
+            },
+            ..Default::default()
+        })
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        error.contains("Error sending request to Dummy provider for model 'error_1'"),
+        "Missing 'error_1' in `{error}`"
+    );
+    assert!(
+        error.contains("Error sending request to Dummy provider for model 'error_2'"),
+        "Missing 'error_2' in `{error}`"
+    );
+    assert!(
+        error.contains("Error sending request to Dummy provider for model 'error_no_weight'"),
+        "Missing 'error_3' in `{error}`"
+    );
+    assert!(
+        !error.contains("error_zero_weight"),
+        "error_zero_weight should not have been called: `{error}`"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn e2e_test_variant_zero_weight_pin_zero() {
+    let client = make_embedded_gateway().await;
+    let error = client
+        .inference(ClientInferenceParams {
+            function_name: Some("variant_failover_zero_weight".to_string()),
+            variant_name: Some("zero_weight".to_string()),
+            input: Input {
+                system: Some(serde_json::json!({"assistant_name": "AskJeeves"})),
+                messages: vec![InputMessage {
+                    role: Role::User,
+                    content: vec![InputMessageContent::Text(TextKind::Arguments {
+                        arguments: serde_json::json!({"type": "tacos", "quantity": 13})
+                            .as_object()
+                            .unwrap()
+                            .clone(),
+                    })],
+                }],
+            },
+            ..Default::default()
+        })
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        error.contains("Error sending request to Dummy provider for model 'error_zero_weight'"),
+        "Missing 'error_zero_weight' in `{error}`"
+    );
+
+    assert!(!error.contains("error_1"), "Found 'error_1' in `{error}`");
+    assert!(!error.contains("error_2"), "Found 'error_2' in `{error}`");
+    assert!(
+        !error.contains("error_no_weight"),
+        "Found 'error_no_weight' in `{error}`"
+    );
+}
+
 /// This test checks that streaming inference works as expected.
 #[tokio::test]
 async fn e2e_test_streaming() {

--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -1837,6 +1837,42 @@ system_template = "../../fixtures/config/functions/basic_test/prompt/system_temp
 user_template = "../../fixtures/config/functions/variant_failover/prompt/user_template.minijinja"
 max_tokens = 100
 
+[functions.variant_failover_zero_weight]
+type = "chat"
+system_schema = "../../fixtures/config/functions/basic_test/system_schema.json"
+user_schema = "../../fixtures/config/functions/variant_failover/user_schema.json"
+
+[functions.variant_failover_zero_weight.variants.first_error]
+type = "chat_completion"
+weight = 0.5
+model = "dummy::error_1"
+system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
+user_template = "../../fixtures/config/functions/variant_failover/prompt/user_template.minijinja"
+max_tokens = 100
+
+[functions.variant_failover_zero_weight.variants.second_error]
+type = "chat_completion"
+weight = 0.5
+model = "dummy::error_2"
+system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
+user_template = "../../fixtures/config/functions/variant_failover/prompt/user_template.minijinja"
+max_tokens = 100
+
+[functions.variant_failover_zero_weight.variants.no_weight]
+type = "chat_completion"
+model = "dummy::error_no_weight"
+system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
+user_template = "../../fixtures/config/functions/variant_failover/prompt/user_template.minijinja"
+max_tokens = 100
+
+[functions.variant_failover_zero_weight.variants.zero_weight]
+type = "chat_completion"
+weight = 0
+model = "dummy::error_zero_weight"
+system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
+user_template = "../../fixtures/config/functions/variant_failover/prompt/user_template.minijinja"
+max_tokens = 100
+
 [functions.prometheus_test1]
 type = "chat"
 


### PR DESCRIPTION
We first sample variants with positive weight,
then a `None` (unspecified in config) weight.

Variants with zero weight are normally ignored - they can only be used if the 'varian_namet' parameter is explicitly set.

Fixes https://github.com/tensorzero/tensorzero/issues/1142

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Variants with zero weight are ignored unless explicitly pinned, with tests added to verify this behavior.
> 
>   - **Behavior**:
>     - Variants with zero weight are ignored unless explicitly pinned, as implemented in `inference.rs`.
>     - `weight()` in `variant/mod.rs` now returns `Option<f64>` to handle `None` as zero weight.
>   - **Tests**:
>     - Added `e2e_test_variant_zero_weight_skip_zero` and `e2e_test_variant_zero_weight_pin_zero` in `inference.rs` to verify behavior.
>   - **Logging**:
>     - Enhanced error logging in `dummy.rs` to include model names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 52ac2dff26617b846fb2ba9c1f2af2300850ae28. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->