### PR TITLE
MetricSelector now filters out comments and demonstrations

### DIFF
--- a/ui/app/components/function/variant/MetricSelector.tsx
+++ b/ui/app/components/function/variant/MetricSelector.tsx
@@ -37,14 +37,22 @@ export function MetricSelector({
           <SelectValue placeholder="Choose a metric" />
         </SelectTrigger>
         <SelectContent>
-          {metricsWithFeedback.metrics.map((metric) => (
-            <SelectItem key={metric.metric_name} value={metric.metric_name}>
-              <div className="flex items-center justify-between">
-                <span className="mr-2">{metric.metric_name}</span>
-                <MetricBadges metric={config.metrics[metric.metric_name]} />
-              </div>
-            </SelectItem>
-          ))}
+          {metricsWithFeedback.metrics
+            .filter((metric) => {
+              const metricConfig = config.metrics[metric.metric_name];
+              return (
+                metricConfig?.type !== "comment" &&
+                metricConfig?.type !== "demonstration"
+              );
+            })
+            .map((metric) => (
+              <SelectItem key={metric.metric_name} value={metric.metric_name}>
+                <div className="flex items-center justify-between">
+                  <span className="mr-2">{metric.metric_name}</span>
+                  <MetricBadges metric={config.metrics[metric.metric_name]} />
+                </div>
+              </SelectItem>
+            ))}
         </SelectContent>
       </Select>
     </div>


### PR DESCRIPTION
Closes #1232 
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `MetricSelector` now filters out 'comment' and 'demonstration' metrics in `MetricSelector.tsx`.
> 
>   - **Behavior**:
>     - `MetricSelector` in `MetricSelector.tsx` now filters out metrics of type `comment` and `demonstration`.
>     - Uses `.filter()` to exclude these types from `metricsWithFeedback.metrics`.
>   - **UI**:
>     - Only non-comment and non-demonstration metrics are displayed in the `SelectContent` dropdown.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for dc4eea9143566d9acb00860ad56bfdbcc7f34a05. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->