### PR TITLE
bumped version to 2025.03.0 in just source code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3828,7 +3828,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.2.6"
+version = "2025.3.0"
 dependencies = [
  "futures",
  "pyo3",

--- a/clients/python-pyo3/Cargo.toml
+++ b/clients/python-pyo3/Cargo.toml
@@ -3,7 +3,7 @@
 # It's named 'tensorzero-python' to avoid confusion with the Rust client
 # (which has a crate name of 'tensorzero')
 name = "tensorzero-python"
-version = "2025.2.6"
+version = "2025.3.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/tensorzero-internal/src/endpoints/status.rs
+++ b/tensorzero-internal/src/endpoints/status.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::response::Json;
 use serde_json::{json, Value};
 
-pub const TENSORZERO_VERSION: &str = "2025.02.6";
+pub const TENSORZERO_VERSION: &str = "2025.03.0";
 
 /// A handler for a simple liveness check
 #[debug_handler]


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump version to `2025.3.0` in `Cargo.lock`, `clients/python-pyo3/Cargo.toml`, and `tensorzero-internal/src/endpoints/status.rs`.
> 
>   - **Version Update**:
>     - Bump version to `2025.3.0` in `Cargo.lock`, `clients/python-pyo3/Cargo.toml`, and `tensorzero-internal/src/endpoints/status.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 89b6951eaae7298b221d4c9cec6932d40478aa86. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->