### PR TITLE
Allow `"role": "developer"` messages in openai-compatible endpoint

### DIFF
--- a/tensorzero-internal/src/endpoints/openai_compatible.rs
+++ b/tensorzero-internal/src/endpoints/openai_compatible.rs
@@ -113,6 +113,7 @@ struct OpenAICompatibleToolMessage {
 #[serde(tag = "role")]
 #[serde(rename_all = "lowercase")]
 enum OpenAICompatibleMessage {
+    #[serde(alias = "developer")]
     System(OpenAICompatibleSystemMessage),
     User(OpenAICompatibleUserMessage),
     Assistant(OpenAICompatibleAssistantMessage),


### PR DESCRIPTION
We treat this as an alias for "system", so all of the usual restrictions apply (e.g. at most one developer/system message can be used).

Fixes #1275

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allow `"role": "developer"` as an alias for `"system"` in OpenAI-compatible endpoint, with tests for correct handling and restrictions.
> 
>   - **Behavior**:
>     - Allow `"role": "developer"` as an alias for `"system"` in OpenAI-compatible endpoint.
>     - Enforce restriction: at most one `developer/system` message allowed.
>   - **Rust Code**:
>     - Update `OpenAICompatibleMessage` enum in `openai_compatible.rs` to include `#[serde(alias = "developer")]` for `System` variant.
>   - **Tests**:
>     - Add `test_reject_developer_and_system` in `test_openai_compatibility.py` to check error when both `developer` and `system` messages are present.
>     - Add `test_async_json_success_developer` in `test_openai_compatibility.py` to verify successful handling of `developer` messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3d636e255c790e95813057631c82e0136a303f6b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->