### PR TITLE
Split inference-params and dynamic-credentials e2e tests

### DIFF
--- a/tensorzero-internal/tests/e2e/providers/anthropic.rs
+++ b/tensorzero-internal/tests/e2e/providers/anthropic.rs
@@ -44,7 +44,7 @@ async fn get_providers() -> E2ETestProviders {
         credentials: HashMap::new(),
     }];
 
-    let inference_params_providers = vec![E2ETestProvider {
+    let inference_params_dynamic_providers = vec![E2ETestProvider {
         variant_name: "anthropic-dynamic".to_string(),
         model_name: "claude-3-haiku-20240307-anthropic-dynamic".into(),
         model_provider_name: "anthropic".into(),
@@ -84,7 +84,8 @@ async fn get_providers() -> E2ETestProviders {
         simple_inference: standard_providers.clone(),
         extra_body_inference: extra_body_providers,
         reasoning_inference: vec![],
-        inference_params_inference: inference_params_providers,
+        inference_params_inference: standard_providers.clone(),
+        inference_params_dynamic_credentials: inference_params_dynamic_providers,
         tool_use_inference: standard_providers.clone(),
         tool_multi_turn_inference: standard_providers.clone(),
         dynamic_tool_use_inference: standard_providers.clone(),

--- a/tensorzero-internal/tests/e2e/providers/aws_bedrock.rs
+++ b/tensorzero-internal/tests/e2e/providers/aws_bedrock.rs
@@ -62,6 +62,7 @@ async fn get_providers() -> E2ETestProviders {
         extra_body_inference: extra_body_providers,
         reasoning_inference: vec![],
         inference_params_inference: standard_providers.clone(),
+        inference_params_dynamic_credentials: vec![],
         tool_use_inference: standard_providers.clone(),
         tool_multi_turn_inference: standard_providers.clone(),
         dynamic_tool_use_inference: standard_providers.clone(),

--- a/tensorzero-internal/tests/e2e/providers/azure.rs
+++ b/tensorzero-internal/tests/e2e/providers/azure.rs
@@ -27,7 +27,7 @@ async fn get_providers() -> E2ETestProviders {
         credentials: HashMap::new(),
     }];
 
-    let inference_params_providers = vec![E2ETestProvider {
+    let inference_params_dynamic_providers = vec![E2ETestProvider {
         variant_name: "azure-dynamic".to_string(),
         model_name: "gpt-4o-mini-azure-dynamic".into(),
         model_provider_name: "azure".into(),
@@ -65,7 +65,8 @@ async fn get_providers() -> E2ETestProviders {
         simple_inference: standard_providers.clone(),
         extra_body_inference: extra_body_providers,
         reasoning_inference: vec![],
-        inference_params_inference: inference_params_providers,
+        inference_params_inference: standard_providers.clone(),
+        inference_params_dynamic_credentials: inference_params_dynamic_providers,
         tool_use_inference: standard_providers.clone(),
         tool_multi_turn_inference: standard_providers.clone(),
         dynamic_tool_use_inference: standard_providers.clone(),

--- a/tensorzero-internal/tests/e2e/providers/batch.rs
+++ b/tensorzero-internal/tests/e2e/providers/batch.rs
@@ -899,7 +899,6 @@ pub async fn test_start_inference_params_batch_inference_request_with_provider(
         "tags": [{
             "test_type": "batch_inference_params"
         }],
-        "credentials": provider.credentials,
     });
 
     let response = Client::new()

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -46,6 +46,7 @@ pub struct E2ETestProvider {
     pub variant_name: String,
     pub model_name: String,
     pub model_provider_name: String,
+    #[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
     pub credentials: HashMap<String, String>,
 }
 
@@ -62,6 +63,7 @@ pub struct E2ETestProviders {
     pub extra_body_inference: Vec<E2ETestProvider>,
     #[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
     pub reasoning_inference: Vec<E2ETestProvider>,
+    #[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
     pub inference_params_dynamic_credentials: Vec<E2ETestProvider>,
     #[cfg_attr(not(feature = "batch_tests"), allow(dead_code))]
     pub inference_params_inference: Vec<E2ETestProvider>,

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -62,6 +62,8 @@ pub struct E2ETestProviders {
     pub extra_body_inference: Vec<E2ETestProvider>,
     #[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
     pub reasoning_inference: Vec<E2ETestProvider>,
+    pub inference_params_dynamic_credentials: Vec<E2ETestProvider>,
+    #[cfg_attr(not(feature = "batch_tests"), allow(dead_code))]
     pub inference_params_inference: Vec<E2ETestProvider>,
     pub tool_use_inference: Vec<E2ETestProvider>,
     pub tool_multi_turn_inference: Vec<E2ETestProvider>,
@@ -234,7 +236,7 @@ macro_rules! generate_provider_tests {
         #[cfg(feature = "e2e_tests")]
         #[tokio::test]
         async fn test_inference_params_inference_request() {
-            let providers = $func().await.inference_params_inference;
+            let providers = $func().await.inference_params_dynamic_credentials;
             for provider in providers {
                 test_inference_params_inference_request_with_provider(provider).await;
             }
@@ -243,7 +245,7 @@ macro_rules! generate_provider_tests {
         #[cfg(feature = "e2e_tests")]
         #[tokio::test]
         async fn test_inference_params_streaming_inference_request() {
-            let providers = $func().await.inference_params_inference;
+            let providers = $func().await.inference_params_dynamic_credentials;
             for provider in providers {
                 test_inference_params_streaming_inference_request_with_provider(provider).await;
             }

--- a/tensorzero-internal/tests/e2e/providers/deepseek.rs
+++ b/tensorzero-internal/tests/e2e/providers/deepseek.rs
@@ -33,7 +33,7 @@ async fn get_providers() -> E2ETestProviders {
         credentials: HashMap::new(),
     }];
 
-    let inference_params_providers = vec![E2ETestProvider {
+    let inference_params_dynamic_providers = vec![E2ETestProvider {
         variant_name: "deepseek-dynamic".to_string(),
         model_name: "deepseek-chat-dynamic".to_string(),
         model_provider_name: "deepseek".to_string(),
@@ -66,7 +66,8 @@ async fn get_providers() -> E2ETestProviders {
         simple_inference: standard_providers.clone(),
         extra_body_inference: extra_body_providers,
         reasoning_inference: reasoning_providers.clone(),
-        inference_params_inference: inference_params_providers,
+        inference_params_inference: standard_providers.clone(),
+        inference_params_dynamic_credentials: inference_params_dynamic_providers,
         tool_use_inference: vec![],
         tool_multi_turn_inference: vec![],
         dynamic_tool_use_inference: vec![],

--- a/tensorzero-internal/tests/e2e/providers/fireworks.rs
+++ b/tensorzero-internal/tests/e2e/providers/fireworks.rs
@@ -27,7 +27,7 @@ async fn get_providers() -> E2ETestProviders {
         credentials: HashMap::new(),
     }];
 
-    let inference_params_providers = vec![E2ETestProvider {
+    let inference_params_dynamic_providers = vec![E2ETestProvider {
         variant_name: "fireworks-dynamic".to_string(),
         model_name: "llama3.3-70b-instruct-fireworks-dynamic".into(),
         model_provider_name: "fireworks".into(),
@@ -71,10 +71,11 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     E2ETestProviders {
-        simple_inference: providers,
+        simple_inference: providers.clone(),
         extra_body_inference: extra_body_providers,
         reasoning_inference: vec![],
-        inference_params_inference: inference_params_providers,
+        inference_params_inference: providers.clone(),
+        inference_params_dynamic_credentials: inference_params_dynamic_providers,
         tool_use_inference: tool_providers.clone(),
         tool_multi_turn_inference: tool_providers.clone(),
         dynamic_tool_use_inference: tool_providers.clone(),

--- a/tensorzero-internal/tests/e2e/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/tests/e2e/providers/gcp_vertex_anthropic.rs
@@ -48,6 +48,7 @@ async fn get_providers() -> E2ETestProviders {
         extra_body_inference: extra_body_providers,
         reasoning_inference: vec![],
         inference_params_inference: standard_providers.clone(),
+        inference_params_dynamic_credentials: vec![],
         tool_use_inference: standard_providers.clone(),
         tool_multi_turn_inference: standard_providers.clone(),
         dynamic_tool_use_inference: standard_providers.clone(),

--- a/tensorzero-internal/tests/e2e/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/tests/e2e/providers/gcp_vertex_gemini.rs
@@ -68,6 +68,7 @@ async fn get_providers() -> E2ETestProviders {
         extra_body_inference: extra_body_providers,
         reasoning_inference: vec![],
         inference_params_inference: standard_providers.clone(),
+        inference_params_dynamic_credentials: vec![],
         tool_use_inference: standard_providers.clone(),
         tool_multi_turn_inference: standard_providers.clone(),
         dynamic_tool_use_inference: standard_providers.clone(),

--- a/tensorzero-internal/tests/e2e/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-internal/tests/e2e/providers/google_ai_studio_gemini.rs
@@ -41,7 +41,7 @@ async fn get_providers() -> E2ETestProviders {
         credentials: HashMap::new(),
     }];
 
-    let inference_params_providers = vec![
+    let inference_params_dynamic_providers = vec![
         E2ETestProvider {
             variant_name: "google-ai-studio-gemini-flash-8b-dynamic".to_string(),
             model_name: "gemini-1.5-flash-8b-dynamic".into(),
@@ -108,7 +108,8 @@ async fn get_providers() -> E2ETestProviders {
         simple_inference: standard_providers.clone(),
         extra_body_inference: extra_body_providers,
         reasoning_inference: vec![],
-        inference_params_inference: inference_params_providers,
+        inference_params_inference: standard_providers.clone(),
+        inference_params_dynamic_credentials: inference_params_dynamic_providers,
         tool_use_inference: tool_providers.clone(),
         tool_multi_turn_inference: tool_providers.clone(),
         dynamic_tool_use_inference: tool_providers.clone(),

--- a/tensorzero-internal/tests/e2e/providers/hyperbolic.rs
+++ b/tensorzero-internal/tests/e2e/providers/hyperbolic.rs
@@ -27,7 +27,7 @@ async fn get_providers() -> E2ETestProviders {
         credentials: HashMap::new(),
     }];
 
-    let inference_params_providers = vec![E2ETestProvider {
+    let inference_params_dynamic_providers = vec![E2ETestProvider {
         variant_name: "hyperbolic-dynamic".to_string(),
         model_name: "meta-llama/Meta-Llama-3-70B-Instruct-dynamic".into(),
         model_provider_name: "hyperbolic".into(),
@@ -43,10 +43,11 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     E2ETestProviders {
-        simple_inference: standard_providers,
+        simple_inference: standard_providers.clone(),
         reasoning_inference: vec![],
         extra_body_inference: extra_body_providers,
-        inference_params_inference: inference_params_providers,
+        inference_params_inference: standard_providers,
+        inference_params_dynamic_credentials: inference_params_dynamic_providers,
         tool_use_inference: vec![],
         tool_multi_turn_inference: vec![],
         dynamic_tool_use_inference: vec![],

--- a/tensorzero-internal/tests/e2e/providers/mistral.rs
+++ b/tensorzero-internal/tests/e2e/providers/mistral.rs
@@ -42,7 +42,7 @@ async fn get_providers() -> E2ETestProviders {
         },
     ];
 
-    let inference_params_providers = vec![E2ETestProvider {
+    let inference_params_dynamic_providers = vec![E2ETestProvider {
         variant_name: "mistral-dynamic".to_string(),
         model_name: "open-mistral-nemo-2407-dynamic".into(),
         model_provider_name: "mistral".into(),
@@ -61,7 +61,8 @@ async fn get_providers() -> E2ETestProviders {
         simple_inference: providers.clone(),
         extra_body_inference: extra_body_providers,
         reasoning_inference: vec![],
-        inference_params_inference: inference_params_providers,
+        inference_params_inference: providers.clone(),
+        inference_params_dynamic_credentials: inference_params_dynamic_providers,
         tool_use_inference: providers.clone(),
         tool_multi_turn_inference: providers.clone(),
         dynamic_tool_use_inference: providers.clone(),

--- a/tensorzero-internal/tests/e2e/providers/openai.rs
+++ b/tensorzero-internal/tests/e2e/providers/openai.rs
@@ -59,10 +59,17 @@ async fn get_providers() -> E2ETestProviders {
     ];
 
     let inference_params_providers = vec![E2ETestProvider {
-        variant_name: "openai-dynamic".to_string(),
-        model_name: "gpt-4o-mini-2024-07-18-dynamic".into(),
+        variant_name: "openai".to_string(),
+        model_name: "gpt-4o-mini-2024-07-18".into(),
         model_provider_name: "openai".into(),
         credentials,
+    }];
+
+    let inference_params_dynamic_providers = vec![E2ETestProvider {
+        variant_name: "openai-dynamic".to_string(),
+        model_name: "gpt-4o-mini-2024-07-18-dynamic".into(),
+        model_provider_name: "openfai".into(),
+        credentials: HashMap::new(),
     }];
 
     let image_providers = vec![E2ETestProvider {
@@ -118,6 +125,7 @@ async fn get_providers() -> E2ETestProviders {
         extra_body_inference: extra_body_providers,
         reasoning_inference: vec![],
         inference_params_inference: inference_params_providers,
+        inference_params_dynamic_credentials: inference_params_dynamic_providers,
         tool_use_inference: standard_providers.clone(),
         tool_multi_turn_inference: standard_providers.clone(),
         dynamic_tool_use_inference: standard_providers.clone(),

--- a/tensorzero-internal/tests/e2e/providers/openai.rs
+++ b/tensorzero-internal/tests/e2e/providers/openai.rs
@@ -62,14 +62,14 @@ async fn get_providers() -> E2ETestProviders {
         variant_name: "openai".to_string(),
         model_name: "gpt-4o-mini-2024-07-18".into(),
         model_provider_name: "openai".into(),
-        credentials,
+        credentials: credentials.clone(),
     }];
 
     let inference_params_dynamic_providers = vec![E2ETestProvider {
         variant_name: "openai-dynamic".to_string(),
         model_name: "gpt-4o-mini-2024-07-18-dynamic".into(),
-        model_provider_name: "openfai".into(),
-        credentials: HashMap::new(),
+        model_provider_name: "openai".into(),
+        credentials,
     }];
 
     let image_providers = vec![E2ETestProvider {

--- a/tensorzero-internal/tests/e2e/providers/sglang.rs
+++ b/tensorzero-internal/tests/e2e/providers/sglang.rs
@@ -42,6 +42,7 @@ async fn get_providers() -> E2ETestProviders {
         extra_body_inference: extra_body_providers,
         reasoning_inference: vec![],
         inference_params_inference: standard_providers.clone(),
+        inference_params_dynamic_credentials: vec![],
         // TODO: Support tool use once SGLang makes a releawe with https://github.com/sgl-project/sglang/pull/2544
         tool_use_inference: vec![],
         tool_multi_turn_inference: vec![],

--- a/tensorzero-internal/tests/e2e/providers/tgi.rs
+++ b/tensorzero-internal/tests/e2e/providers/tgi.rs
@@ -33,6 +33,7 @@ async fn get_providers() -> E2ETestProviders {
         extra_body_inference: extra_body_providers,
         reasoning_inference: vec![],
         inference_params_inference: standard_providers.clone(),
+        inference_params_dynamic_credentials: vec![],
         tool_use_inference: vec![],
         tool_multi_turn_inference: vec![],
         dynamic_tool_use_inference: vec![],

--- a/tensorzero-internal/tests/e2e/providers/together.rs
+++ b/tensorzero-internal/tests/e2e/providers/together.rs
@@ -27,7 +27,7 @@ async fn get_providers() -> E2ETestProviders {
         credentials: HashMap::new(),
     }];
 
-    let inference_params_providers = vec![E2ETestProvider {
+    let inference_params_dynamic_providers = vec![E2ETestProvider {
         variant_name: "together-dynamic".to_string(),
         model_name: "llama3.1-8b-instruct-together-dynamic".into(),
         model_provider_name: "together".into(),
@@ -75,7 +75,8 @@ async fn get_providers() -> E2ETestProviders {
         simple_inference: standard_providers.clone(),
         extra_body_inference: extra_body_providers,
         reasoning_inference: reasoning_providers.clone(),
-        inference_params_inference: inference_params_providers,
+        inference_params_inference: standard_providers,
+        inference_params_dynamic_credentials: inference_params_dynamic_providers,
         tool_use_inference: tool_providers.clone(),
         tool_multi_turn_inference: tool_providers.clone(),
         dynamic_tool_use_inference: tool_providers.clone(),

--- a/tensorzero-internal/tests/e2e/providers/vllm.rs
+++ b/tensorzero-internal/tests/e2e/providers/vllm.rs
@@ -42,7 +42,7 @@ async fn get_providers() -> E2ETestProviders {
         },
     ];
 
-    let inference_params_providers = vec![E2ETestProvider {
+    let inference_params_dynamic_providers = vec![E2ETestProvider {
         variant_name: "vllm-dynamic".to_string(),
         model_name: "microsoft/Phi-3.5-mini-instruct-dynamic".into(),
         model_provider_name: "vllm".into(),
@@ -54,7 +54,8 @@ async fn get_providers() -> E2ETestProviders {
         simple_inference: providers.clone(),
         extra_body_inference: extra_body_providers,
         reasoning_inference: vec![],
-        inference_params_inference: inference_params_providers,
+        inference_params_inference: providers.clone(),
+        inference_params_dynamic_credentials: inference_params_dynamic_providers,
         tool_use_inference: vec![],
         tool_multi_turn_inference: vec![],
         dynamic_tool_use_inference: vec![],

--- a/tensorzero-internal/tests/e2e/providers/xai.rs
+++ b/tensorzero-internal/tests/e2e/providers/xai.rs
@@ -67,6 +67,7 @@ async fn get_providers() -> E2ETestProviders {
         extra_body_inference: extra_body_providers,
         reasoning_inference: vec![],
         inference_params_inference: inference_params_providers,
+        inference_params_dynamic_credentials: vec![],
         tool_use_inference: standard_providers.clone(),
         tool_multi_turn_inference: standard_providers.clone(),
         dynamic_tool_use_inference: standard_providers.clone(),


### PR DESCRIPTION
We now have:
* `inference_params_inference` - supports inference params, does not use dynamic credentials. Used by batch tests
* `inference_params_dynamic_credentials` - supports inference params, requires dynamic credentials. Used in the two tests that explicitly set "credentials" in their inference requests.

This allows the batch tests to set 'temperature' when creating a batch request, without needing to have dynamic credentials available.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Split inference parameters and dynamic credentials tests to allow batch tests without dynamic credentials.
> 
>   - **Behavior**:
>     - Splits `inference_params_inference` and `inference_params_dynamic_credentials` in `E2ETestProviders` across multiple provider files.
>     - `inference_params_inference` supports inference params without dynamic credentials.
>     - `inference_params_dynamic_credentials` supports inference params with dynamic credentials.
>   - **Files**:
>     - Updates `anthropic.rs`, `aws_bedrock.rs`, `azure.rs` to use new test categories.
>     - Modifies `batch.rs` to remove credentials from batch inference requests.
>     - Changes `common.rs` to add `inference_params_dynamic_credentials` to `E2ETestProviders`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f2cc4a32977488a5767524bb4627868b51b1e4e0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->