### PR TITLE
Add internal mode (new POST param) that bypasses tag validation

### DIFF
--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -173,7 +173,7 @@ impl BaseTensorZeroGateway {
         })
     }
 
-    #[pyo3(signature = (*, input, function_name=None, model_name=None, episode_id=None, stream=None, params=None, variant_name=None, dryrun=None, output_schema=None, allowed_tools=None, additional_tools=None, tool_choice=None, parallel_tool_calls=None, tags=None, credentials=None, cache_options=None))]
+    #[pyo3(signature = (*, input, function_name=None, model_name=None, episode_id=None, stream=None, params=None, variant_name=None, dryrun=None, output_schema=None, allowed_tools=None, additional_tools=None, tool_choice=None, parallel_tool_calls=None, internal=None, tags=None, credentials=None, cache_options=None))]
     #[allow(clippy::too_many_arguments)]
     fn _prepare_inference_request(
         this: PyRef<'_, Self>,
@@ -190,6 +190,7 @@ impl BaseTensorZeroGateway {
         additional_tools: Option<Vec<HashMap<String, Bound<'_, PyAny>>>>,
         tool_choice: Option<Bound<'_, PyAny>>,
         parallel_tool_calls: Option<bool>,
+        internal: Option<bool>,
         tags: Option<HashMap<String, String>>,
         credentials: Option<HashMap<String, ClientSecretString>>,
         cache_options: Option<&Bound<'_, PyDict>>,
@@ -209,6 +210,7 @@ impl BaseTensorZeroGateway {
             additional_tools,
             tool_choice,
             parallel_tool_calls,
+            internal.unwrap_or(false),
             tags,
             credentials,
             cache_options,
@@ -241,6 +243,7 @@ where
 }
 
 impl BaseTensorZeroGateway {
+    #[allow(clippy::too_many_arguments)]
     fn prepare_feedback_params(
         py: Python<'_>,
         metric_name: String,
@@ -248,6 +251,7 @@ impl BaseTensorZeroGateway {
         inference_id: Option<Bound<'_, PyAny>>,
         episode_id: Option<Bound<'_, PyAny>>,
         dryrun: Option<bool>,
+        internal: bool,
         tags: Option<HashMap<String, String>>,
     ) -> PyResult<FeedbackParams> {
         Ok(FeedbackParams {
@@ -257,6 +261,7 @@ impl BaseTensorZeroGateway {
             inference_id: python_uuid_to_uuid("inference_id", inference_id)?,
             dryrun,
             tags: tags.unwrap_or_default(),
+            internal,
         })
     }
 
@@ -276,6 +281,7 @@ impl BaseTensorZeroGateway {
         additional_tools: Option<Vec<HashMap<String, Bound<'_, PyAny>>>>,
         tool_choice: Option<Bound<'_, PyAny>>,
         parallel_tool_calls: Option<bool>,
+        internal: bool,
         tags: Option<HashMap<String, String>>,
         credentials: Option<HashMap<String, ClientSecretString>>,
         cache_options: Option<&Bound<'_, PyDict>>,
@@ -336,6 +342,7 @@ impl BaseTensorZeroGateway {
             variant_name,
             dryrun,
             tags: tags.unwrap_or_default(),
+            internal,
             params: params.unwrap_or_default(),
             dynamic_tool_params: DynamicToolParams {
                 allowed_tools,
@@ -461,7 +468,7 @@ impl TensorZeroGateway {
         Py::new(cls.py(), instance)
     }
 
-    #[pyo3(signature = (*, metric_name, value, inference_id=None, episode_id=None, dryrun=None, tags=None))]
+    #[pyo3(signature = (*, metric_name, value, inference_id=None, episode_id=None, dryrun=None, internal=None, tags=None))]
     /// Make a request to the /feedback endpoint of the gateway
     ///
     /// :param metric_name: The name of the metric to provide feedback for
@@ -484,6 +491,7 @@ impl TensorZeroGateway {
         inference_id: Option<Bound<'_, PyAny>>,
         episode_id: Option<Bound<'_, PyAny>>,
         dryrun: Option<bool>,
+        internal: Option<bool>,
         tags: Option<HashMap<String, String>>,
     ) -> PyResult<Py<PyAny>> {
         let fut = this
@@ -496,6 +504,7 @@ impl TensorZeroGateway {
                 inference_id,
                 episode_id,
                 dryrun,
+                internal.unwrap_or(false),
                 tags,
             )?);
         // We're in the synchronous `TensorZeroGateway` class, so we need to block on the Rust future,
@@ -506,7 +515,7 @@ impl TensorZeroGateway {
         }
     }
 
-    #[pyo3(signature = (*, input, function_name=None, model_name=None, episode_id=None, stream=None, params=None, variant_name=None, dryrun=None, output_schema=None, allowed_tools=None, additional_tools=None, tool_choice=None, parallel_tool_calls=None, tags=None, credentials=None, cache_options=None))]
+    #[pyo3(signature = (*, input, function_name=None, model_name=None, episode_id=None, stream=None, params=None, variant_name=None, dryrun=None, output_schema=None, allowed_tools=None, additional_tools=None, tool_choice=None, parallel_tool_calls=None, internal=None, tags=None, credentials=None, cache_options=None))]
     #[allow(clippy::too_many_arguments)]
     /// Make a request to the /inference endpoint.
     ///
@@ -554,6 +563,7 @@ impl TensorZeroGateway {
         additional_tools: Option<Vec<HashMap<String, Bound<'_, PyAny>>>>,
         tool_choice: Option<Bound<'_, PyAny>>,
         parallel_tool_calls: Option<bool>,
+        internal: Option<bool>,
         tags: Option<HashMap<String, String>>,
         credentials: Option<HashMap<String, ClientSecretString>>,
         cache_options: Option<&Bound<'_, PyDict>>,
@@ -576,6 +586,7 @@ impl TensorZeroGateway {
                     additional_tools,
                     tool_choice,
                     parallel_tool_calls,
+                    internal.unwrap_or(false),
                     tags,
                     credentials,
                     cache_options,
@@ -736,7 +747,7 @@ impl AsyncTensorZeroGateway {
         })
     }
 
-    #[pyo3(signature = (*, input, function_name=None, model_name=None, episode_id=None, stream=None, params=None, variant_name=None, dryrun=None, output_schema=None, allowed_tools=None, additional_tools=None, tool_choice=None, parallel_tool_calls=None, tags=None, credentials=None, cache_options=None))]
+    #[pyo3(signature = (*, input, function_name=None, model_name=None, episode_id=None, stream=None, params=None, variant_name=None, dryrun=None, output_schema=None, allowed_tools=None, additional_tools=None, tool_choice=None, parallel_tool_calls=None, internal=None,tags=None, credentials=None, cache_options=None))]
     #[allow(clippy::too_many_arguments)]
     /// Make a request to the /inference endpoint.
     ///
@@ -784,6 +795,7 @@ impl AsyncTensorZeroGateway {
         additional_tools: Option<Vec<HashMap<String, Bound<'_, PyAny>>>>,
         tool_choice: Option<Bound<'_, PyAny>>,
         parallel_tool_calls: Option<bool>,
+        internal: Option<bool>,
         tags: Option<HashMap<String, String>>,
         credentials: Option<HashMap<String, ClientSecretString>>,
         cache_options: Option<&Bound<'_, PyDict>>,
@@ -803,6 +815,7 @@ impl AsyncTensorZeroGateway {
             additional_tools,
             tool_choice,
             parallel_tool_calls,
+            internal.unwrap_or(false),
             tags,
             credentials,
             cache_options,
@@ -826,7 +839,7 @@ impl AsyncTensorZeroGateway {
         })
     }
 
-    #[pyo3(signature = (*, metric_name, value, inference_id=None, episode_id=None, dryrun=None, tags=None))]
+    #[pyo3(signature = (*, metric_name, value, inference_id=None, episode_id=None, dryrun=None, internal=None, tags=None))]
     /// Make a request to the /feedback endpoint.
     ///
     /// :param metric_name: The name of the metric to provide feedback for
@@ -840,6 +853,7 @@ impl AsyncTensorZeroGateway {
     /// :param dryrun: If true, the feedback request will be executed but won't be stored to the database (i.e. no-op).
     /// :param tags: If set, adds tags to the feedback request.
     /// :return: {"feedback_id": str}
+    #[allow(clippy::too_many_arguments)]
     fn feedback<'a>(
         this: PyRef<'a, Self>,
         metric_name: String,
@@ -847,6 +861,7 @@ impl AsyncTensorZeroGateway {
         inference_id: Option<Bound<'_, PyAny>>,
         episode_id: Option<Bound<'_, PyAny>>,
         dryrun: Option<bool>,
+        internal: Option<bool>,
         tags: Option<HashMap<String, String>>,
     ) -> PyResult<Bound<'a, PyAny>> {
         let client = this.as_super().client.clone();
@@ -857,6 +872,7 @@ impl AsyncTensorZeroGateway {
             inference_id,
             episode_id,
             dryrun,
+            internal.unwrap_or(false),
             tags,
         )?;
         // See `AsyncStreamWrapper::__anext__` for more details about `future_into_py`

--- a/clients/python-pyo3/tensorzero/tensorzero.pyi
+++ b/clients/python-pyo3/tensorzero/tensorzero.pyi
@@ -80,6 +80,7 @@ class TensorZeroGateway(BaseTensorZeroGateway):
             Union[Literal["auto", "required", "off"], Dict[Literal["specific"], str]]
         ] = None,
         parallel_tool_calls: Optional[bool] = None,
+        internal: Optional[bool] = None,
         tags: Optional[Dict[str, str]] = None,
         credentials: Optional[Dict[str, str]] = None,
         cache_options: Optional[Dict[str, Any]] = None,
@@ -110,6 +111,7 @@ class TensorZeroGateway(BaseTensorZeroGateway):
         :param tool_choice: If set, overrides the tool choice strategy for the request.
                             It should be one of: "auto", "required", "off", or {"specific": str}. The last option pins the request to a specific tool name.
         :param parallel_tool_calls: If true, the request will allow for multiple tool calls in a single inference request.
+        :param internal: Only set true if this is a request internal to TensorZero.
         :param tags: If set, adds tags to the inference request.
         :return: If stream is false, returns an InferenceResponse.
                  If stream is true, returns an async generator that yields InferenceChunks as they come in.
@@ -123,6 +125,7 @@ class TensorZeroGateway(BaseTensorZeroGateway):
         inference_id: Optional[UUID] = None,
         episode_id: Optional[UUID] = None,
         dryrun: Optional[bool] = None,
+        internal: Optional[bool] = None,
         tags: Optional[Dict[str, str]] = None,
     ) -> FeedbackResponse:
         """
@@ -137,6 +140,7 @@ class TensorZeroGateway(BaseTensorZeroGateway):
                            Only use episode IDs that were returned by the TensorZero gateway.
                            Note: You can assign feedback to either an episode or an inference, but not both.
         :param dryrun: If true, the feedback request will be executed but won't be stored to the database (i.e. no-op).
+        :param internal: Only set true if this is a request internal to TensorZero.
         :param tags: If set, adds tags to the feedback request.
         :return: {"feedback_id": str}
         """
@@ -213,6 +217,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
             Union[Literal["auto", "required", "off"], Dict[Literal["specific"], str]]
         ] = None,
         parallel_tool_calls: Optional[bool] = None,
+        internal: Optional[bool] = None,
         tags: Optional[Dict[str, str]] = None,
         credentials: Optional[Dict[str, str]] = None,
         cache_options: Optional[Dict[str, Any]] = None,
@@ -243,6 +248,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         :param tool_choice: If set, overrides the tool choice strategy for the request.
                             It should be one of: "auto", "required", "off", or {"specific": str}. The last option pins the request to a specific tool name.
         :param parallel_tool_calls: If true, the request will allow for multiple tool calls in a single inference request.
+        :param internal: Only set true if this is a request internal to TensorZero.
         :param tags: If set, adds tags to the inference request.
         :return: If stream is false, returns an InferenceResponse.
                  If stream is true, returns an async generator that yields InferenceChunks as they come in.
@@ -256,6 +262,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         inference_id: Optional[UUID] = None,
         episode_id: Optional[UUID] = None,
         dryrun: Optional[bool] = None,
+        internal: Optional[bool] = None,
         tags: Optional[Dict[str, str]] = None,
     ) -> FeedbackResponse:
         """
@@ -270,6 +277,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
                            Only use episode IDs that were returned by the TensorZero gateway.
                            Note: You can assign feedback to either an episode or an inference, but not both.
         :param dryrun: If true, the feedback request will be executed but won't be stored to the database (i.e. no-op).
+        :param internal: Only set true if this is a request internal to TensorZero.
         :param tags: If set, adds tags to the feedback request.
         :return: {"feedback_id": str}
         """

--- a/clients/python-pyo3/tensorzero/tensorzero.pyi
+++ b/clients/python-pyo3/tensorzero/tensorzero.pyi
@@ -111,7 +111,6 @@ class TensorZeroGateway(BaseTensorZeroGateway):
         :param tool_choice: If set, overrides the tool choice strategy for the request.
                             It should be one of: "auto", "required", "off", or {"specific": str}. The last option pins the request to a specific tool name.
         :param parallel_tool_calls: If true, the request will allow for multiple tool calls in a single inference request.
-        :param internal: Only set true if this is a request internal to TensorZero.
         :param tags: If set, adds tags to the inference request.
         :return: If stream is false, returns an InferenceResponse.
                  If stream is true, returns an async generator that yields InferenceChunks as they come in.
@@ -140,7 +139,6 @@ class TensorZeroGateway(BaseTensorZeroGateway):
                            Only use episode IDs that were returned by the TensorZero gateway.
                            Note: You can assign feedback to either an episode or an inference, but not both.
         :param dryrun: If true, the feedback request will be executed but won't be stored to the database (i.e. no-op).
-        :param internal: Only set true if this is a request internal to TensorZero.
         :param tags: If set, adds tags to the feedback request.
         :return: {"feedback_id": str}
         """
@@ -248,7 +246,6 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         :param tool_choice: If set, overrides the tool choice strategy for the request.
                             It should be one of: "auto", "required", "off", or {"specific": str}. The last option pins the request to a specific tool name.
         :param parallel_tool_calls: If true, the request will allow for multiple tool calls in a single inference request.
-        :param internal: Only set true if this is a request internal to TensorZero.
         :param tags: If set, adds tags to the inference request.
         :return: If stream is false, returns an InferenceResponse.
                  If stream is true, returns an async generator that yields InferenceChunks as they come in.
@@ -277,7 +274,6 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
                            Only use episode IDs that were returned by the TensorZero gateway.
                            Note: You can assign feedback to either an episode or an inference, but not both.
         :param dryrun: If true, the feedback request will be executed but won't be stored to the database (i.e. no-op).
-        :param internal: Only set true if this is a request internal to TensorZero.
         :param tags: If set, adds tags to the feedback request.
         :return: {"feedback_id": str}
         """

--- a/clients/rust/src/client_inference_params.rs
+++ b/clients/rust/src/client_inference_params.rs
@@ -35,6 +35,8 @@ pub struct ClientInferenceParams {
     pub variant_name: Option<String>,
     // if true, the inference will not be stored
     pub dryrun: Option<bool>,
+    // if true, the inference will be internal and validation of tags will be skipped
+    pub internal: bool,
     // the tags to add to the inference
     pub tags: HashMap<String, String>,
     // dynamic information about tool calling. Don't directly include `dynamic_tool_params` in `Params`.
@@ -73,6 +75,7 @@ impl From<ClientInferenceParams> for Params {
             variant_name: this.variant_name,
             dryrun: this.dryrun,
             tags: this.tags,
+            internal: this.internal,
             dynamic_tool_params: this.dynamic_tool_params,
             output_schema: this.output_schema,
             // TODO - can we avoid reconstructing the hashmap here?
@@ -102,6 +105,7 @@ fn assert_params_match(client_params: ClientInferenceParams) {
         variant_name,
         dryrun,
         tags,
+        internal,
         dynamic_tool_params,
         output_schema,
         credentials,
@@ -118,6 +122,7 @@ fn assert_params_match(client_params: ClientInferenceParams) {
         variant_name,
         dryrun,
         tags,
+        internal,
         dynamic_tool_params,
         output_schema,
         credentials: credentials.into_iter().map(|(k, v)| (k, v.0)).collect(),

--- a/tensorzero-internal/src/config_parser.rs
+++ b/tensorzero-internal/src/config_parser.rs
@@ -2342,7 +2342,7 @@ mod tests {
             "Unexpected error message: {err}"
         );
         assert!(
-            err.contains("failed to lookup address information: Name or service not known"),
+            err.contains("failed to lookup address information"),
             "Missing dns error in error: {err}"
         );
         assert!(logs_contain(
@@ -2382,7 +2382,7 @@ mod tests {
             "Unexpected error message: {err}"
         );
         assert!(
-            err.contains("failed to lookup address information: Name or service not known"),
+            err.contains("failed to lookup address information"),
             "Missing dns error in error: {err}"
         );
         assert!(!logs_contain("HTTPS"));

--- a/tensorzero-internal/src/endpoints/feedback.rs
+++ b/tensorzero-internal/src/endpoints/feedback.rs
@@ -48,6 +48,9 @@ pub struct Params {
     pub metric_name: String,
     // the value of the feedback being provided
     pub value: Value,
+    // if true, the feedback will be internal and validation of tags will be skipped
+    #[serde(default)]
+    pub internal: bool,
     // the tags to add to the feedback
     #[serde(default)]
     pub tags: HashMap<String, String>,
@@ -101,7 +104,7 @@ pub async fn feedback(
     }: AppStateData,
     params: Params,
 ) -> Result<Json<FeedbackResponse>, Error> {
-    validate_tags(&params.tags)?;
+    validate_tags(&params.tags, params.internal)?;
     // Get the metric config or return an error if it doesn't exist
     let feedback_metadata = get_feedback_metadata(
         &config,
@@ -797,6 +800,7 @@ mod tests {
             metric_name: "comment".to_string(),
             value: value.clone(),
             tags: HashMap::from([("foo".to_string(), "bar".to_string())]),
+            internal: false,
             dryrun: Some(false),
         };
         let response =
@@ -828,6 +832,7 @@ mod tests {
             value: value.clone(),
             tags: HashMap::from([("baz".to_string(), "bat".to_string())]),
             dryrun: Some(false),
+            internal: false,
         };
         let response = feedback_handler(State(app_state_data.clone()), StructuredJson(params))
             .await
@@ -850,6 +855,7 @@ mod tests {
             value: value.clone(),
             tags: HashMap::from([("bat".to_string(), "man".to_string())]),
             dryrun: Some(false),
+            internal: false,
         };
         let response =
             feedback_handler(State(app_state_data.clone()), StructuredJson(params)).await;
@@ -891,6 +897,7 @@ mod tests {
             value: value.clone(),
             tags: HashMap::from([("boo".to_string(), "far".to_string())]),
             dryrun: Some(false),
+            internal: false,
         };
         let response = feedback_handler(State(app_state_data.clone()), StructuredJson(params))
             .await
@@ -911,6 +918,7 @@ mod tests {
             value: value.clone(),
             tags: HashMap::from([("poo".to_string(), "bar".to_string())]),
             dryrun: Some(false),
+            internal: false,
         };
         let response =
             feedback_handler(State(app_state_data.clone()), StructuredJson(params)).await;
@@ -949,6 +957,7 @@ mod tests {
             value: value.clone(),
             tags: HashMap::from([("new".to_string(), "car".to_string())]),
             dryrun: None,
+            internal: false,
         };
         let response =
             feedback_handler(State(app_state_data.clone()), StructuredJson(params)).await;

--- a/tensorzero-internal/src/endpoints/inference.rs
+++ b/tensorzero-internal/src/endpoints/inference.rs
@@ -69,6 +69,9 @@ pub struct Params {
     pub variant_name: Option<String>,
     // if true, the inference will not be stored
     pub dryrun: Option<bool>,
+    // if true, the inference will be internal and validation of tags will be skipped
+    #[serde(default)]
+    pub internal: bool,
     // the tags to add to the inference
     #[serde(default)]
     pub tags: HashMap<String, String>,
@@ -207,7 +210,7 @@ pub async fn inference(
     validate_episode_id(episode_id)?;
     tracing::Span::current().record("episode_id", episode_id.to_string());
 
-    validate_tags(&params.tags)?;
+    validate_tags(&params.tags, params.internal)?;
     let (function, function_name) = find_function(&params, &config)?;
     // Collect the function variant names as a Vec<&str>
     let mut candidate_variant_names: Vec<&str> =

--- a/tensorzero-internal/src/endpoints/mod.rs
+++ b/tensorzero-internal/src/endpoints/mod.rs
@@ -10,7 +10,10 @@ pub mod inference;
 pub mod openai_compatible;
 pub mod status;
 
-fn validate_tags(tags: &HashMap<String, String>) -> Result<(), Error> {
+fn validate_tags(tags: &HashMap<String, String>, internal: bool) -> Result<(), Error> {
+    if internal {
+        return Ok(());
+    }
     for tag_name in tags.keys() {
         if tag_name.starts_with("tensorzero::") {
             return Err(Error::new(ErrorDetails::InvalidRequest {
@@ -28,8 +31,10 @@ mod tests {
     #[test]
     fn test_validate_tags() {
         let mut tags = HashMap::new();
-        assert!(validate_tags(&tags).is_ok());
+        assert!(validate_tags(&tags, false).is_ok());
         tags.insert("tensorzero::test".to_string(), "test".to_string());
-        assert!(validate_tags(&tags).is_err());
+        assert!(validate_tags(&tags, false).is_err());
+        // once we're in internal mode, we can have tags that start with "tensorzero::"
+        assert!(validate_tags(&tags, true).is_ok());
     }
 }

--- a/tensorzero-internal/src/endpoints/openai_compatible.rs
+++ b/tensorzero-internal/src/endpoints/openai_compatible.rs
@@ -420,6 +420,8 @@ impl TryFrom<(HeaderMap, OpenAICompatibleParams)> for Params {
             // OpenAI compatible endpoint does not support dynamic credentials
             credentials: InferenceCredentials::default(),
             cache_options: CacheParamsOptions::default(),
+            // For now, we don't support internal inference for OpenAI compatible endpoint
+            internal: false,
             tags: HashMap::new(),
             // OpenAI compatible endpoint does not support 'include_original_response'
             include_original_response: false,

--- a/tensorzero-internal/tests/e2e/feedback.rs
+++ b/tensorzero-internal/tests/e2e/feedback.rs
@@ -1013,12 +1013,14 @@ async fn test_fast_inference_then_feedback() {
                 let inference_id = response.inference_id;
 
                 // Prepare and send the feedback request.
+                // This also tests that the internal flag is correctly propagated.
                 let feedback_payload = tensorzero::FeedbackParams {
                     inference_id: Some(inference_id),
                     episode_id: None,
                     metric_name: "task_success".to_string(),
                     value: json!(true),
-                    tags: HashMap::new(),
+                    internal: true,
+                    tags: HashMap::from([("tensorzero::tag_key".to_string(), "tensorzero::tag_value".to_string())]),
                     dryrun: None,
                 };
                 client.feedback(feedback_payload).await.unwrap();

--- a/tensorzero-internal/tests/e2e/inference.rs
+++ b/tensorzero-internal/tests/e2e/inference.rs
@@ -97,6 +97,10 @@ async fn e2e_test_inference_chat_strip_unknown_block_non_stream() {
             ]
         },
         "stream": false,
+        "internal": true, // This also tests that the internal flag is correctly propagated.
+        "tags": {
+            "tensorzero::tag_key": "tensorzero::tag_value"
+        }
     });
 
     let response = Client::new()


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `internal` mode to bypass tag validation in TensorZero's inference and feedback processes.
> 
>   - **Behavior**:
>     - Adds `internal` parameter to bypass tag validation in `feedback.rs`, `inference.rs`, and `mod.rs`.
>     - Updates `validate_tags()` to skip validation if `internal` is true.
>   - **Functions**:
>     - Modifies `_prepare_inference_request()` and `feedback()` in `lib.rs` to include `internal` parameter.
>     - Updates `feedback_handler()` and `inference_handler()` to handle `internal` parameter.
>   - **Tests**:
>     - Adds tests in `feedback.rs` and `inference.rs` to verify `internal` mode functionality.
>     - Updates e2e tests to include scenarios with `internal` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 41521eb30c4f0eca7fd9776a14c67e800e20c9b1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->