### PR TITLE
Implement caching for embedding requests

### DIFF
--- a/tensorzero-internal/src/cache.rs
+++ b/tensorzero-internal/src/cache.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::clickhouse::ClickHouseConnectionInfo;
+use crate::embeddings::{EmbeddingRequest, EmbeddingResponse};
 use crate::error::{Error, ErrorDetails};
 use crate::inference::types::batch::deserialize_json_string;
 use crate::inference::types::{
@@ -64,12 +65,23 @@ pub struct CacheOptions {
     pub enabled: CacheEnabledMode,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct ModelProviderRequest<'request> {
-    pub request: &'request ModelInferenceRequest<'request>,
+#[derive(Debug)]
+pub struct BaseModelProviderRequest<'request, T> {
+    pub request: &'request T,
     pub model_name: &'request str,
     pub provider_name: &'request str,
 }
+
+// We need a manual impl to avoid adding a 'T: Copy' bound
+impl<T> Copy for BaseModelProviderRequest<'_, T> {}
+impl<T> Clone for BaseModelProviderRequest<'_, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+pub type ModelProviderRequest<'a> = BaseModelProviderRequest<'a, ModelInferenceRequest<'a>>;
+pub type EmbeddingModelProviderRequest<'a> = BaseModelProviderRequest<'a, EmbeddingRequest>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CacheKey([u8; 32]);
@@ -89,15 +101,48 @@ impl CacheKey {
     }
 }
 
+impl EmbeddingModelProviderRequest<'_> {
+    // Destructure EmbeddingModelProviderRequest so that we get a compiler error
+    // if we add any new fields
+    pub fn get_cache_key(&self) -> Result<CacheKey, Error> {
+        let EmbeddingModelProviderRequest {
+            model_name,
+            provider_name,
+            request,
+        } = self;
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(model_name.as_bytes());
+        hasher.update(&[0]); // null byte after model name to ensure data is prefix-free
+        hasher.update(provider_name.as_bytes());
+        hasher.update(&[0]); // null byte after provider name to ensure data is prefix-free
+
+        // Convert the request to a JSON Value, error if serialization fails
+        let request_json = serde_json::to_string(request).map_err(|e| {
+            Error::new(ErrorDetails::Serialization {
+                message: format!("Failed to serialize request: {e}"),
+            })
+        })?;
+        hasher.update(request_json.as_bytes());
+        Ok(CacheKey(hasher.finalize().into()))
+    }
+}
+
 impl ModelProviderRequest<'_> {
     pub fn get_cache_key(&self) -> Result<CacheKey, Error> {
+        // Destructure ModelProviderRequest so that we get a compiler error
+        // if we add any new fields
+        let ModelProviderRequest {
+            model_name,
+            provider_name,
+            request,
+        } = self;
         let mut hasher = blake3::Hasher::new();
-        hasher.update(self.model_name.as_bytes());
+        hasher.update(model_name.as_bytes());
         hasher.update(&[0]); // null byte after model name to ensure data is prefix-free
-        hasher.update(self.provider_name.as_bytes());
+        hasher.update(provider_name.as_bytes());
         hasher.update(&[0]); // null byte after provider name to ensure data is prefix-free
                              // Convert the request to a JSON Value, error if serialization fails
-        let mut request_value = serde_json::to_value(self.request).map_err(|e| {
+        let mut request_value = serde_json::to_value(request).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
                 message: format!("Failed to serialize request: {e}"),
             })
@@ -158,6 +203,14 @@ pub trait CacheOutput {}
 
 impl CacheOutput for StreamingCacheData {}
 impl CacheOutput for NonStreamingCacheData {}
+impl CacheOutput for EmbeddingCacheData {}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct EmbeddingCacheData {
+    #[serde(deserialize_with = "deserialize_json_string")]
+    pub embedding: Vec<f32>,
+}
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -174,19 +227,17 @@ pub struct StreamingCacheData {
 }
 
 // This doesn't block
-pub fn start_cache_write(
+pub fn start_cache_write<T: Serialize + CacheOutput + Send + Sync + 'static>(
     clickhouse_client: &ClickHouseConnectionInfo,
-    request: ModelProviderRequest<'_>,
-    output: &[ContentBlockOutput],
+    cache_key: CacheKey,
+    output: T,
     raw_request: &str,
     raw_response: &str,
     usage: &Usage,
     finish_reason: Option<&FinishReason>,
 ) -> Result<(), Error> {
-    let cache_key = request.get_cache_key()?;
     let short_cache_key = cache_key.get_short_key()?;
     let long_cache_key = cache_key.get_long_key();
-    let output = output.to_owned();
     let raw_request = raw_request.to_string();
     let raw_response = raw_response.to_string();
     let input_tokens = usage.input_tokens;
@@ -194,13 +245,13 @@ pub fn start_cache_write(
     let clickhouse_client = clickhouse_client.clone();
     let finish_reason = finish_reason.cloned();
     tokio::spawn(async move {
-        clickhouse_client
+        if let Err(e) = clickhouse_client
             .write(
                 &[FullCacheRow {
                     short_cache_key,
                     long_cache_key,
                     data: CacheData {
-                        output: NonStreamingCacheData { blocks: output },
+                        output,
                         raw_request,
                         raw_response,
                         input_tokens,
@@ -211,6 +262,9 @@ pub fn start_cache_write(
                 "ModelInferenceCache",
             )
             .await
+        {
+            tracing::warn!("Failed to write to cache: {e}");
+        }
     });
     Ok(())
 }
@@ -276,6 +330,20 @@ pub fn start_cache_write_streaming(
     Ok(())
 }
 
+pub async fn embedding_cache_lookup(
+    clickhouse_connection_info: &ClickHouseConnectionInfo,
+    request: &EmbeddingModelProviderRequest<'_>,
+    max_age_s: Option<u32>,
+) -> Result<Option<EmbeddingResponse>, Error> {
+    let result = cache_lookup_inner::<EmbeddingCacheData>(
+        clickhouse_connection_info,
+        request.get_cache_key()?,
+        max_age_s,
+    )
+    .await?;
+    Ok(result.map(|result| EmbeddingResponse::from_cache(result, request)))
+}
+
 pub async fn cache_lookup(
     clickhouse_connection_info: &ClickHouseConnectionInfo,
     request: ModelProviderRequest<'_>,
@@ -283,7 +351,7 @@ pub async fn cache_lookup(
 ) -> Result<Option<ModelInferenceResponse>, Error> {
     let result = cache_lookup_inner::<NonStreamingCacheData>(
         clickhouse_connection_info,
-        &request,
+        request.get_cache_key()?,
         max_age_s,
     )
     .await?;
@@ -297,16 +365,20 @@ pub async fn cache_lookup_streaming(
     request: ModelProviderRequest<'_>,
     max_age_s: Option<u32>,
 ) -> Result<Option<StreamResponse>, Error> {
-    let result = cache_lookup_inner(clickhouse_connection_info, &request, max_age_s).await?;
+    let result = cache_lookup_inner(
+        clickhouse_connection_info,
+        request.get_cache_key()?,
+        max_age_s,
+    )
+    .await?;
     Ok(result.map(|result| StreamResponse::from_cache(result, Arc::from(request.provider_name))))
 }
 
 pub async fn cache_lookup_inner<T: CacheOutput + DeserializeOwned>(
     clickhouse_connection_info: &ClickHouseConnectionInfo,
-    request: &ModelProviderRequest<'_>,
+    cache_key: CacheKey,
     max_age_s: Option<u32>,
 ) -> Result<Option<CacheData<T>>, Error> {
-    let cache_key = request.get_cache_key()?;
     // NOTE: the short cache key is just so the ClickHouse index can be as efficient as possible
     // but we always check against the long cache key before returning a result
     let short_cache_key = cache_key.get_short_key()?.to_string();

--- a/tensorzero-internal/src/embeddings.rs
+++ b/tensorzero-internal/src/embeddings.rs
@@ -1,6 +1,12 @@
 use std::future::Future;
+use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
 
+use crate::cache::{
+    embedding_cache_lookup, start_cache_write, CacheData, EmbeddingCacheData,
+    EmbeddingModelProviderRequest,
+};
+use crate::endpoints::inference::InferenceClients;
 use crate::model_table::BaseModelTable;
 use crate::model_table::ShorthandModelConfig;
 use crate::{
@@ -16,7 +22,7 @@ use crate::{
     model::ProviderConfig,
 };
 use reqwest::Client;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tracing::instrument;
 use uuid::Uuid;
 
@@ -67,8 +73,8 @@ impl EmbeddingModelConfig {
     pub async fn embed(
         &self,
         request: &EmbeddingRequest,
-        client: &Client,
-        dynamic_api_keys: &InferenceCredentials,
+        model_name: &str,
+        clients: &InferenceClients<'_>,
     ) -> Result<EmbeddingResponse, Error> {
         let mut provider_errors: HashMap<String, Error> = HashMap::new();
         for provider_name in &self.routing {
@@ -77,11 +83,43 @@ impl EmbeddingModelConfig {
                     provider_name: provider_name.to_string(),
                 })
             })?;
+            let provider_request = EmbeddingModelProviderRequest {
+                request,
+                provider_name,
+                model_name,
+            };
+            // TODO: think about how to best handle errors here
+            if clients.cache_options.enabled.read() {
+                let cache_lookup = embedding_cache_lookup(
+                    clients.clickhouse_connection_info,
+                    &provider_request,
+                    clients.cache_options.max_age_s,
+                )
+                .await
+                .ok()
+                .flatten();
+                if let Some(cache_lookup) = cache_lookup {
+                    return Ok(cache_lookup);
+                }
+            }
             let response = provider_config
-                .embed(request, client, dynamic_api_keys)
+                .embed(request, clients.http_client, clients.credentials)
                 .await;
             match response {
                 Ok(response) => {
+                    if clients.cache_options.enabled.write() {
+                        let _ = start_cache_write(
+                            clients.clickhouse_connection_info,
+                            provider_request.get_cache_key()?,
+                            EmbeddingCacheData {
+                                embedding: response.embedding.clone(),
+                            },
+                            &response.raw_request,
+                            &response.raw_response,
+                            &response.usage,
+                            None,
+                        );
+                    }
                     let embedding_response =
                         EmbeddingResponse::new(response, provider_name.clone());
                     return Ok(embedding_response);
@@ -95,9 +133,16 @@ impl EmbeddingModelConfig {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize)]
 pub struct EmbeddingRequest {
     pub input: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct EmbeddingProviderRequest<'request> {
+    pub request: &'request EmbeddingRequest,
+    pub model_name: &'request str,
+    pub provider_name: &'request str,
 }
 
 #[derive(Debug, PartialEq)]
@@ -123,6 +168,32 @@ pub struct EmbeddingResponse {
     pub usage: Usage,
     pub latency: Latency,
     pub embedding_provider_name: Arc<str>,
+    pub cached: bool,
+}
+
+impl EmbeddingResponse {
+    pub fn from_cache(
+        cache_lookup: CacheData<EmbeddingCacheData>,
+        request: &EmbeddingModelProviderRequest,
+    ) -> Self {
+        Self {
+            id: Uuid::now_v7(),
+            created: current_timestamp(),
+            input: request.request.input.clone(),
+            embedding: cache_lookup.output.embedding,
+            raw_request: cache_lookup.raw_request,
+            raw_response: cache_lookup.raw_response,
+            usage: Usage {
+                input_tokens: cache_lookup.input_tokens,
+                output_tokens: cache_lookup.output_tokens,
+            },
+            latency: Latency::NonStreaming {
+                response_time: Duration::from_secs(0),
+            },
+            embedding_provider_name: Arc::from(request.provider_name),
+            cached: true,
+        }
+    }
 }
 
 pub struct EmbeddingResponseWithMetadata {
@@ -153,6 +224,7 @@ impl EmbeddingResponse {
             usage: embedding_provider_response.usage,
             latency: embedding_provider_response.latency,
             embedding_provider_name,
+            cached: false,
         }
     }
 }
@@ -277,6 +349,11 @@ impl EmbeddingProviderResponse {
 mod tests {
     use tracing_test::traced_test;
 
+    use crate::{
+        cache::{CacheEnabledMode, CacheOptions},
+        clickhouse::ClickHouseConnectionInfo,
+    };
+
     use super::*;
 
     #[traced_test]
@@ -300,10 +377,20 @@ mod tests {
         let request = EmbeddingRequest {
             input: "Hello, world!".to_string(),
         };
-        let client = Client::new();
-        let inference_credentials = InferenceCredentials::default();
         let response = fallback_embedding_model
-            .embed(&request, &client, &inference_credentials)
+            .embed(
+                &request,
+                "fallback",
+                &InferenceClients {
+                    http_client: &Client::new(),
+                    credentials: &InferenceCredentials::default(),
+                    cache_options: &CacheOptions {
+                        max_age_s: None,
+                        enabled: CacheEnabledMode::Off,
+                    },
+                    clickhouse_connection_info: &ClickHouseConnectionInfo::new_disabled(),
+                },
+            )
             .await;
         assert!(response.is_ok());
         assert!(logs_contain(

--- a/tensorzero-internal/src/variant/dicl.rs
+++ b/tensorzero-internal/src/variant/dicl.rs
@@ -330,7 +330,7 @@ impl DiclConfig {
 
         // Embed the input via an API request
         let embedding_response = embedding_model
-            .embed(&embedding_request, clients.http_client, clients.credentials)
+            .embed(&embedding_request, &self.embedding_model, clients)
             .await?;
 
         // Wrap the embedding in a response with metadata

--- a/tensorzero-internal/tests/e2e/providers/openai.rs
+++ b/tensorzero-internal/tests/e2e/providers/openai.rs
@@ -8,9 +8,11 @@ use serde_json::Value;
 use tensorzero_internal::cache::CacheEnabledMode;
 use tensorzero_internal::cache::CacheOptions;
 use tensorzero_internal::embeddings::EmbeddingModelConfig;
+#[allow(unused)]
+use tensorzero_internal::embeddings::EmbeddingProvider;
 use tensorzero_internal::endpoints::inference::InferenceClients;
 use tensorzero_internal::{
-    embeddings::{EmbeddingProvider, EmbeddingProviderConfig, EmbeddingRequest},
+    embeddings::{EmbeddingProviderConfig, EmbeddingRequest},
     endpoints::inference::InferenceCredentials,
     inference::types::{Latency, ModelInferenceRequestJsonMode},
 };

--- a/tensorzero-internal/tests/e2e/providers/openai.rs
+++ b/tensorzero-internal/tests/e2e/providers/openai.rs
@@ -5,6 +5,10 @@ use reqwest::Client;
 use reqwest::StatusCode;
 use serde_json::json;
 use serde_json::Value;
+use tensorzero_internal::cache::CacheEnabledMode;
+use tensorzero_internal::cache::CacheOptions;
+use tensorzero_internal::embeddings::EmbeddingModelConfig;
+use tensorzero_internal::endpoints::inference::InferenceClients;
 use tensorzero_internal::{
     embeddings::{EmbeddingProvider, EmbeddingProviderConfig, EmbeddingRequest},
     endpoints::inference::InferenceCredentials,
@@ -835,6 +839,7 @@ async fn test_o1_mini_inference() {
 
 #[tokio::test]
 async fn test_embedding_request() {
+    let clickhouse = get_clickhouse().await;
     let provider_config_serialized = r#"
     type = "openai"
     model_name = "text-embedding-3-small"
@@ -846,16 +851,39 @@ async fn test_embedding_request() {
         EmbeddingProviderConfig::OpenAI(_)
     ));
 
-    let client = Client::new();
+    // Inject randomness into the model name to ensure that the first request
+    // is a cache miss
+    let model_name = format!("my-embedding-{}", Uuid::now_v7());
+
+    let model_config = EmbeddingModelConfig {
+        routing: vec![model_name.as_str().into()],
+        providers: [(model_name.as_str().into(), provider_config)]
+            .into_iter()
+            .collect(),
+    };
+
     let request = EmbeddingRequest {
         input: "This is a test input".to_string(),
     };
     let api_keys = InferenceCredentials::default();
-    let response = provider_config
-        .embed(&request, &client, &api_keys)
+    let response = model_config
+        .embed(
+            &request,
+            &model_name,
+            &InferenceClients {
+                http_client: &Default::default(),
+                credentials: &api_keys,
+                clickhouse_connection_info: &clickhouse,
+                cache_options: &CacheOptions {
+                    max_age_s: None,
+                    enabled: CacheEnabledMode::On,
+                },
+            },
+        )
         .await
         .unwrap();
     assert_eq!(response.embedding.len(), 1536);
+    assert!(!response.cached);
     // Calculate the L2 norm of the embedding
     let norm: f32 = response
         .embedding
@@ -900,6 +928,29 @@ async fn test_embedding_request() {
         }
         _ => panic!("Latency should be non-streaming"),
     }
+
+    // Wait for ClickHouse write
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    let cached_response = model_config
+        .embed(
+            &request,
+            &model_name,
+            &InferenceClients {
+                http_client: &Default::default(),
+                credentials: &api_keys,
+                clickhouse_connection_info: &clickhouse,
+                cache_options: &CacheOptions {
+                    max_age_s: None,
+                    enabled: CacheEnabledMode::On,
+                },
+            },
+        )
+        .await
+        .unwrap();
+    assert!(cached_response.cached);
+    assert_eq!(response.embedding, cached_response.embedding);
+    assert_eq!(cached_response.usage.input_tokens, 5);
+    assert_eq!(cached_response.usage.output_tokens, 0);
 }
 
 #[cfg(feature = "e2e_tests")]


### PR DESCRIPTION
This is very similar to the existing non-streaming cache code. The `EmbeddingModelConfig.embed` method now takes in `InferenceClients`, which gives us access to the cache settings.

For now, dicl is the only user of embeddings - the same cache settings will be used for both the normal model requests and the embedding request.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Implement caching for embedding requests, adding new types and functions to handle embedding-specific caching and updating tests to verify behavior.
> 
>   - **Behavior**:
>     - Implements caching for embedding requests in `cache.rs` using `EmbeddingModelProviderRequest` and `EmbeddingCacheData`.
>     - Updates `EmbeddingModelConfig.embed()` in `embeddings.rs` to utilize caching, checking cache before making requests and writing to cache after receiving responses.
>   - **Functions**:
>     - Adds `embedding_cache_lookup()` in `cache.rs` for retrieving cached embedding responses.
>     - Modifies `start_cache_write()` in `cache.rs` to support `EmbeddingCacheData`.
>   - **Types**:
>     - Introduces `EmbeddingModelProviderRequest` and `EmbeddingCacheData` in `cache.rs`.
>     - Updates `EmbeddingResponse` in `embeddings.rs` to include a `cached` flag.
>   - **Tests**:
>     - Adds tests in `cache.rs` and `openai.rs` to verify embedding caching behavior, ensuring cache hits and misses are handled correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3de6ad173c8412e6557d56370d90783ea8dd6db5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->