### PR TITLE
Add '--default-config' flag to the gateway

### DIFF
--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -24,9 +24,13 @@ static GLOBAL: MiMalloc = MiMalloc;
 #[derive(Parser, Debug)]
 #[command(version, about)]
 struct Args {
-    /// Path to tensorzero.toml
+    /// Use the `tensorzero.toml` config file at the specified path. Incompatible with `--default-config`
     #[arg(long)]
     config_file: Option<PathBuf>,
+
+    /// Use a default config file. Incompatible with `--config-file`
+    #[arg(long)]
+    default_config: bool,
 
     /// Deprecated: use `--config-file` instead
     tensorzero_toml: Option<PathBuf>,
@@ -51,6 +55,11 @@ async fn main() {
     }
 
     let config_path = args.config_file.or(args.tensorzero_toml);
+
+    if config_path.is_some() && args.default_config {
+        tracing::error!("Cannot specify both `--config-file` and `--default-config`");
+        std::process::exit(1);
+    }
 
     let config = if let Some(path) = &config_path {
         Arc::new(


### PR DESCRIPTION
Right now, this does nothing. In the future, we're going to deprecate the no-arg invocation of the gateway, and require either '--default-config' or '--config-path'

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `--default-config` flag to gateway, mutually exclusive with `--config-file`, in preparation for future deprecation of no-arg invocation.
> 
>   - **Behavior**:
>     - Add `--default-config` flag to `Args` in `gateway/src/main.rs`, mutually exclusive with `--config-file`.
>     - Enforce mutual exclusivity between `--config-file` and `--default-config` in `main()`.
>   - **Misc**:
>     - Update comments and error messages to reflect new flag usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2817421b5182b6c0012ced79be66fd5a738d367f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->