### PR TITLE
Avoid apply nextest unit-test config to batch tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -53,6 +53,6 @@ slow-timeout = { period = "15s", terminate-after = 1 }
 
 [[profile.default.overrides]]
 # Settings for running unit tests
-filter = 'not binary(e2e)'
+filter = 'not binary(e2e) and not binary(batch)'
 retries = 0
 slow-timeout = { period = "5s", terminate-after = 1 }


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Exclude batch tests from unit tests in `nextest` configuration by updating the filter in `.config/nextest.toml`.
> 
>   - **Configuration**:
>     - Update `filter` in `.config/nextest.toml` to exclude batch tests from unit tests by changing `filter = 'not binary(e2e)'` to `filter = 'not binary(e2e) and not binary(batch)'`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a60cc1b1a4f151c225aa9910a954ccf294508d3a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->