### PR TITLE
Add image support to GCP Vertex Gemini

### DIFF
--- a/tensorzero-internal/tests/e2e/providers/anthropic.rs
+++ b/tensorzero-internal/tests/e2e/providers/anthropic.rs
@@ -31,7 +31,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let image_providers = vec![E2ETestProvider {
-        variant_name: "anthropic-image".to_string(),
+        variant_name: "anthropic".to_string(),
         model_name: "anthropic::claude-3-haiku-20240307".into(),
         model_provider_name: "anthropic".into(),
         credentials: HashMap::new(),

--- a/tensorzero-internal/tests/e2e/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/tests/e2e/providers/gcp_vertex_gemini.rs
@@ -23,6 +23,13 @@ async fn get_providers() -> E2ETestProviders {
         },
     ];
 
+    let image_providers = vec![E2ETestProvider {
+        variant_name: "gcp_vertex".to_string(),
+        model_name: "gemini-1.5-pro-001".into(),
+        model_provider_name: "gcp_vertex_gemini".into(),
+        credentials: HashMap::new(),
+    }];
+
     let extra_body_providers = vec![E2ETestProvider {
         variant_name: "gcp-vertex-gemini-flash-extra-body".to_string(),
         model_name: "gemini-1.5-flash-001".into(),
@@ -73,7 +80,7 @@ async fn get_providers() -> E2ETestProviders {
         dynamic_tool_use_inference: standard_providers.clone(),
         parallel_tool_use_inference: vec![],
         json_mode_inference: json_providers.clone(),
-        image_inference: vec![],
+        image_inference: image_providers,
         #[cfg(feature = "e2e_tests")]
         shorthand_inference: vec![],
         #[cfg(feature = "batch_tests")]

--- a/tensorzero-internal/tests/e2e/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-internal/tests/e2e/providers/google_ai_studio_gemini.rs
@@ -29,7 +29,7 @@ async fn get_providers() -> E2ETestProviders {
     ];
 
     let image_providers = vec![E2ETestProvider {
-        variant_name: "google-ai-studio-gemini-flash-8b".to_string(),
+        variant_name: "google_ai_studio".to_string(),
         model_name: "google_ai_studio_gemini::gemini-1.5-flash-8b".into(),
         model_provider_name: "google_ai_studio_gemini".into(),
         credentials: HashMap::new(),

--- a/tensorzero-internal/tests/e2e/providers/openai.rs
+++ b/tensorzero-internal/tests/e2e/providers/openai.rs
@@ -1026,7 +1026,12 @@ pub async fn test_image_inference_with_provider_cloudflare_r2() {
     bucket_name = "{test_bucket}"
     prefix = "{prefix}"
 
-    [functions]
+    [functions.image_test]
+    type = "chat"
+
+    [functions.image_test.variants.openai]
+    type = "chat_completion"
+    model = "openai::gpt-4o-mini-2024-07-18"
     "#
         ),
         test_bucket,
@@ -1154,6 +1159,7 @@ async fn test_content_block_text_field() {
 #[tokio::test]
 pub async fn test_image_inference_with_provider_gcp_storage() {
     use crate::providers::common::test_image_inference_with_provider_s3_compatible;
+    use crate::providers::common::IMAGE_FUNCTION_CONFIG;
     use aws_credential_types::Credentials;
     use aws_sdk_s3::config::SharedCredentialsProvider;
     use rand::distributions::Alphanumeric;
@@ -1213,7 +1219,7 @@ pub async fn test_image_inference_with_provider_gcp_storage() {
     bucket_name = "{test_bucket}"
     prefix = "{prefix}"
 
-    [functions]
+    {IMAGE_FUNCTION_CONFIG}
     "#
         ),
         test_bucket,


### PR DESCRIPTION
Since we can't support shorthand models with GCP Vertex, I added some function/model definitions to the embedded gateway configs.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add image support to GCP Vertex Gemini by introducing new data structures and updating tests for image handling.
> 
>   - **Behavior**:
>     - Adds `GCPVertexInlineData` struct in `gcp_vertex_gemini.rs` to handle image data with `mime_type` and `data` fields.
>     - Modifies `GCPVertexGeminiContentPart` enum to include `InlineData` variant for image support.
>     - Updates `TryFrom<&ContentBlock>` implementation to handle `ContentBlock::Image` by converting it to `InlineData`.
>   - **Tests**:
>     - Adds `IMAGE_FUNCTION_CONFIG` constant in `common.rs` for image function configuration.
>     - Updates `gcp_vertex_gemini.rs`, `google_ai_studio_gemini.rs`, and `openai.rs` to include image providers in `get_providers()`.
>     - Modifies test functions in `openai.rs` to use `IMAGE_FUNCTION_CONFIG` for image inference tests.
>   - **Misc**:
>     - Renames `variant_name` from `anthropic-image` to `anthropic` in `anthropic.rs`.
>     - Renames `variant_name` from `google-ai-studio-gemini-flash-8b` to `google_ai_studio` in `google_ai_studio_gemini.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 41372bade026c8c827a2686d1765a9d5353ffeb5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->