### PR TITLE
Fix clippy lint by using 'next_back' instead of 'last'

### DIFF
--- a/tensorzero-internal/src/inference/types/mod.rs
+++ b/tensorzero-internal/src/inference/types/mod.rs
@@ -974,7 +974,7 @@ fn get_finish_reason(
     model_inference_results
         .iter()
         .sorted_by_key(|r| r.created)
-        .last()
+        .next_back()
         .and_then(|r| r.finish_reason.clone())
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `get_finish_reason()` in `mod.rs` to use `next_back()` instead of `last()` to fix Clippy lint warning.
> 
>   - **Refactor**:
>     - Replace `last()` with `next_back()` in `get_finish_reason()` in `mod.rs` to fix Clippy lint warning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 40d217d152a32493f43d8033e71e48be098a06e7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->