### PR TITLE
Add 'GET /internal/object_storage?storage_path={}' endpoint

### DIFF
--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -518,6 +518,14 @@ impl Client {
             }
         }))
     }
+
+    #[cfg(feature = "e2e_tests")]
+    pub fn get_app_state_data(&self) -> Option<&AppStateData> {
+        match &self.mode {
+            ClientMode::EmbeddedGateway { gateway, .. } => Some(&gateway.state),
+            _ => None,
+        }
+    }
 }
 
 async fn with_embedded_timeout<R, F: Future<Output = Result<R, TensorZeroError>>>(

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -121,6 +121,10 @@ async fn main() {
             delete(endpoints::datasets::delete_datapoint_handler),
         )
         .route(
+            "/internal/object_storage",
+            get(endpoints::object_storage::get_object_handler),
+        )
+        .route(
             "/metrics",
             get(move || std::future::ready(metrics_handle.render())),
         )

--- a/tensorzero-internal/src/config_parser.rs
+++ b/tensorzero-internal/src/config_parser.rs
@@ -52,7 +52,7 @@ pub struct ObjectStoreInfo {
 }
 
 impl ObjectStoreInfo {
-    fn new(config: Option<StorageKind>) -> Result<Option<Self>, Error> {
+    pub fn new(config: Option<StorageKind>) -> Result<Option<Self>, Error> {
         let Some(config) = config else {
             return Ok(None);
         };

--- a/tensorzero-internal/src/endpoints/mod.rs
+++ b/tensorzero-internal/src/endpoints/mod.rs
@@ -7,6 +7,7 @@ pub mod datasets;
 pub mod fallback;
 pub mod feedback;
 pub mod inference;
+pub mod object_storage;
 pub mod openai_compatible;
 pub mod status;
 

--- a/tensorzero-internal/src/endpoints/object_storage.rs
+++ b/tensorzero-internal/src/endpoints/object_storage.rs
@@ -1,0 +1,62 @@
+use axum::{
+    extract::{Query, State},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    config_parser::ObjectStoreInfo,
+    error::{Error, ErrorDetails},
+    gateway_util::{AppState, AppStateData},
+    inference::types::storage::StoragePath,
+};
+use aws_smithy_types::base64;
+
+#[derive(Debug, Serialize)]
+pub struct ObjectResponse {
+    data: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PathParams {
+    storage_path: String,
+}
+
+pub async fn get_object_handler(
+    State(AppStateData { .. }): AppState,
+    Query(params): Query<PathParams>,
+) -> Result<Json<ObjectResponse>, Error> {
+    // TODO - should we re-use the config object store if it matches?
+    let storage_path: StoragePath = serde_json::from_str(&params.storage_path).map_err(|e| {
+        Error::new(ErrorDetails::InvalidRequest {
+            message: format!("Error parsing storage path: {}", e),
+        })
+    })?;
+    let store = ObjectStoreInfo::new(Some(storage_path.kind))?.ok_or_else(|| {
+        Error::new(ErrorDetails::InvalidRequest {
+            message: "Could not create ObjectStoreInfo from provided `kind`".to_string(),
+        })
+    })?;
+    let object = store
+        .object_store
+        .ok_or_else(|| {
+            Error::new(ErrorDetails::InvalidRequest {
+                message: "Object store was disabled".to_string(),
+            })
+        })?
+        .get(&storage_path.path)
+        .await
+        .map_err(|e| {
+            Error::new(ErrorDetails::InternalError {
+                message: format!("Error getting object: {}", e),
+            })
+        })?;
+    let bytes = object.bytes().await.map_err(|e| {
+        Error::new(ErrorDetails::InternalError {
+            message: format!("Error getting object bytes: {}", e),
+        })
+    })?;
+    Ok(Json(ObjectResponse {
+        data: base64::encode(&bytes),
+    }))
+}

--- a/tensorzero-internal/src/endpoints/object_storage.rs
+++ b/tensorzero-internal/src/endpoints/object_storage.rs
@@ -40,7 +40,6 @@ pub async fn get_object_handler(
     State(AppStateData { config, .. }): AppState,
     Query(params): Query<PathParams>,
 ) -> Result<Json<ObjectResponse>, Error> {
-    // TODO - should we re-use the config object store if it matches?
     let storage_path: StoragePath = serde_json::from_str(&params.storage_path).map_err(|e| {
         Error::new(ErrorDetails::InvalidRequest {
             message: format!("Error parsing storage path: {}", e),

--- a/tensorzero-internal/src/endpoints/object_storage.rs
+++ b/tensorzero-internal/src/endpoints/object_storage.rs
@@ -15,13 +15,15 @@ use crate::{
 use aws_smithy_types::base64;
 
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "e2e_tests", derive(PartialEq))]
 pub struct ObjectResponse {
-    data: String,
+    pub data: String,
+    pub reused_object_store: bool,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct PathParams {
-    storage_path: String,
+    pub storage_path: String,
 }
 
 /// Fetches an object using the object store and path specified by the encoded `StoragePath`.
@@ -78,5 +80,6 @@ pub async fn get_object_handler(
     })?;
     Ok(Json(ObjectResponse {
         data: base64::encode(&bytes),
+        reused_object_store: matches!(store, Cow::Borrowed(_)),
     }))
 }

--- a/tensorzero-internal/src/endpoints/object_storage.rs
+++ b/tensorzero-internal/src/endpoints/object_storage.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use axum::{
     extract::{Query, State},
     Json,
@@ -22,8 +24,18 @@ pub struct PathParams {
     storage_path: String,
 }
 
+/// Fetches an object using the object store and path specified by the encoded `StoragePath`.
+/// This does not need to match the gateway's current object store (e.g. a `StorageKind::Filesystem`)
+/// could be provided even if the gateway is configured with `StorageKind::S3Compatible`.
+/// However, if the provider requires authentication, the gateway must have the correct credentials
+/// set as environment variables.
+///
+/// This is invoked as `GET /internal/object_storage?storage_path=<urlencoded_storagepath>`.
+/// The `<urlencoded_storagepath>` value constructed by serializing `StoragePath` to JSON,
+/// and the urlencoding the resulting string.
+/// For example, `GET /internal/object_storage?storage_path={%22kind%22:{%22type%22:%22filesystem%22,%22path%22:%22/tmp%22},%22path%22:%22fake-tensorzero-file%22}`
 pub async fn get_object_handler(
-    State(AppStateData { .. }): AppState,
+    State(AppStateData { config, .. }): AppState,
     Query(params): Query<PathParams>,
 ) -> Result<Json<ObjectResponse>, Error> {
     // TODO - should we re-use the config object store if it matches?
@@ -32,13 +44,21 @@ pub async fn get_object_handler(
             message: format!("Error parsing storage path: {}", e),
         })
     })?;
-    let store = ObjectStoreInfo::new(Some(storage_path.kind))?.ok_or_else(|| {
-        Error::new(ErrorDetails::InvalidRequest {
-            message: "Could not create ObjectStoreInfo from provided `kind`".to_string(),
-        })
-    })?;
+    // Use the existing object store if it matches the requested kind, so
+    // that we can re-use our connection pool.
+    let store = match &config.object_store_info {
+        Some(store) if store.kind == storage_path.kind => Cow::Borrowed(store),
+        _ => Cow::Owned(
+            ObjectStoreInfo::new(Some(storage_path.kind))?.ok_or_else(|| {
+                Error::new(ErrorDetails::InvalidRequest {
+                    message: "Could not create ObjectStoreInfo from provided `kind`".to_string(),
+                })
+            })?,
+        ),
+    };
     let object = store
         .object_store
+        .as_ref()
         .ok_or_else(|| {
             Error::new(ErrorDetails::InvalidRequest {
                 message: "Object store was disabled".to_string(),

--- a/tensorzero-internal/tests/e2e/object_storage.rs
+++ b/tensorzero-internal/tests/e2e/object_storage.rs
@@ -4,7 +4,8 @@ use tensorzero_internal::inference::types::storage::{StorageKind, StoragePath};
 
 use crate::common::get_gateway_endpoint;
 
-// We test a successful fetch in `test_image_inference_with_provider_amazon_s3`
+// We test a successful fetch in `test_image_inference_with_provider_amazon_s3`m
+// so we only need to test an invalid fetch here.
 #[tokio::test]
 async fn test_object_store_fetch_missing() {
     let client = reqwest::Client::new();

--- a/tensorzero-internal/tests/e2e/object_storage.rs
+++ b/tensorzero-internal/tests/e2e/object_storage.rs
@@ -1,0 +1,36 @@
+use reqwest::StatusCode;
+use serde_json::Value;
+use tensorzero_internal::inference::types::storage::{StorageKind, StoragePath};
+
+use crate::common::get_gateway_endpoint;
+
+// We test a successful fetch in `test_image_inference_with_provider_amazon_s3`
+#[tokio::test]
+async fn test_object_store_fetch_missing() {
+    let client = reqwest::Client::new();
+    let res = client
+        .get(get_gateway_endpoint(&format!(
+            "/internal/object_storage?storage_path={}",
+            serde_json::to_string(&StoragePath {
+                kind: StorageKind::Filesystem {
+                    path: "/tmp".to_string()
+                },
+                path: object_store::path::Path::parse("fake-tensorzero-file").unwrap()
+            })
+            .unwrap()
+        )))
+        .send()
+        .await
+        .unwrap();
+
+    let status = res.status();
+    let res = res.json::<Value>().await.unwrap();
+    assert!(
+        res["error"]
+            .as_str()
+            .unwrap()
+            .contains("Internal error: Error getting object:"),
+        "Unexpected response: {res}"
+    );
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+}

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -7,6 +7,7 @@ use aws_config::Region;
 use aws_sdk_bedrockruntime::error::SdkError;
 #[cfg(feature = "e2e_tests")]
 use aws_sdk_s3::operation::get_object::GetObjectError;
+#[cfg(feature = "e2e_tests")]
 use axum::extract::{Query, State};
 use axum::{routing::get, Router};
 use base64::prelude::*;
@@ -22,9 +23,11 @@ use tensorzero::{
     CacheParamsOptions, ClientInferenceParams, InferenceOutput, InferenceResponse, Input,
     InputMessage, InputMessageContent,
 };
+#[cfg(feature = "e2e_tests")]
 use tensorzero_internal::endpoints::object_storage::{
     get_object_handler, ObjectResponse, PathParams,
 };
+#[cfg(feature = "e2e_tests")]
 use tensorzero_internal::gateway_util::AppStateData;
 use tensorzero_internal::inference::types::TextKind;
 use tensorzero_internal::{

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -569,11 +569,31 @@ pub async fn test_image_url_inference_with_provider_filesystem(provider: E2ETest
     assert_eq!(result, FERRIS_PNG);
 }
 
+async fn check_object_fetch_via_gateway(storage_path: &StoragePath) {
+    // Try using the running HTTP gateway (which is *not* configured with an object store)
+    // to fetch the `StoragePath`
+    let client = reqwest::Client::new();
+    let res = client
+        .get(get_gateway_endpoint(&format!(
+            "/internal/object_storage?storage_path={}",
+            serde_json::to_string(storage_path).unwrap()
+        )))
+        .send()
+        .await
+        .unwrap();
+
+    let response_json = res.json::<Value>().await.unwrap();
+    assert_eq!(
+        response_json["data"].as_str().unwrap(),
+        BASE64_STANDARD.encode(FERRIS_PNG)
+    );
+}
+
 #[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
 pub async fn test_image_inference_with_provider_filesystem(provider: E2ETestProvider) {
     let temp_dir = tempfile::tempdir().unwrap();
     println!("Temporary image dir: {}", temp_dir.path().to_string_lossy());
-    test_base64_image_inference_with_provider_and_store(
+    let storage_path = test_base64_image_inference_with_provider_and_store(
         provider,
         &StorageKind::Filesystem {
             path: temp_dir.path().to_string_lossy().to_string(),
@@ -598,6 +618,7 @@ pub async fn test_image_inference_with_provider_filesystem(provider: E2ETestProv
     ))
     .unwrap();
     assert_eq!(result, FERRIS_PNG);
+    check_object_fetch_via_gateway(&storage_path).await;
 }
 
 #[cfg(feature = "e2e_tests")]
@@ -618,7 +639,7 @@ pub async fn test_image_inference_with_provider_amazon_s3(provider: E2ETestProvi
     let mut prefix = Alphanumeric.sample_string(&mut rand::thread_rng(), 6);
     prefix += "-";
 
-    test_image_inference_with_provider_s3_compatible(
+    let (expected_key, storage_path) = test_image_inference_with_provider_s3_compatible(
         provider,
         &StorageKind::S3Compatible {
             bucket_name: Some(test_bucket.to_string()),
@@ -643,6 +664,16 @@ pub async fn test_image_inference_with_provider_amazon_s3(provider: E2ETestProvi
         &prefix,
     )
     .await;
+
+    check_object_fetch_via_gateway(&storage_path).await;
+
+    client
+        .delete_object()
+        .key(&expected_key)
+        .bucket(test_bucket)
+        .send()
+        .await
+        .unwrap();
 }
 
 #[cfg(feature = "e2e_tests")]
@@ -653,7 +684,7 @@ pub async fn test_image_inference_with_provider_s3_compatible(
     toml: &str,
     bucket_name: &str,
     prefix: &str,
-) {
+) -> (String, StoragePath) {
     let expected_key =
         format!("{prefix}observability/images/08bfa764c6dc25e658bab2b8039ddb494546c3bc5523296804efc4cab604df5d.png");
 
@@ -676,7 +707,9 @@ pub async fn test_image_inference_with_provider_s3_compatible(
         panic!("Expected ServiceError: {err:?}");
     }
 
-    test_base64_image_inference_with_provider_and_store(provider, storage_kind, toml, prefix).await;
+    let storage_path =
+        test_base64_image_inference_with_provider_and_store(provider, storage_kind, toml, prefix)
+            .await;
 
     let result = client
         .get_object()
@@ -688,13 +721,7 @@ pub async fn test_image_inference_with_provider_s3_compatible(
 
     assert_eq!(result.body.collect().await.unwrap().to_vec(), FERRIS_PNG);
 
-    client
-        .delete_object()
-        .key(&expected_key)
-        .bucket(bucket_name)
-        .send()
-        .await
-        .unwrap();
+    (expected_key, storage_path)
 }
 
 async fn make_temp_image_server() -> (SocketAddr, tokio::sync::oneshot::Sender<()>) {
@@ -785,12 +812,13 @@ pub async fn test_base64_image_inference_with_provider_and_store(
     kind: &StorageKind,
     config_toml: &str,
     prefix: &str,
-) {
+) -> StoragePath {
     let episode_id = Uuid::now_v7();
 
     let image_data = BASE64_STANDARD.encode(FERRIS_PNG);
 
     let client = make_embedded_gateway_with_config(config_toml).await;
+    let mut storage_path = None;
 
     for should_be_cached in [false, true] {
         let response = client
@@ -826,7 +854,7 @@ pub async fn test_base64_image_inference_with_provider_and_store(
             panic!("Expected non-streaming inference response");
         };
 
-        check_base64_image_response(
+        let latest_storage_path = check_base64_image_response(
             response,
             Some(episode_id),
             &provider,
@@ -836,7 +864,9 @@ pub async fn test_base64_image_inference_with_provider_and_store(
         )
         .await;
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        storage_path = Some(latest_storage_path);
     }
+    storage_path.unwrap()
 }
 
 #[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
@@ -1050,7 +1080,7 @@ pub async fn check_base64_image_response(
     should_be_cached: bool,
     kind: &StorageKind,
     prefix: &str,
-) {
+) -> StoragePath {
     let inference_id = response.inference_id();
 
     let episode_id_response = response.episode_id();
@@ -1147,28 +1177,31 @@ pub async fn check_base64_image_response(
     let model_inference_id = result.get("id").unwrap().as_str().unwrap();
     assert!(Uuid::parse_str(model_inference_id).is_ok());
 
+    let expected_storage_path = StoragePath {
+        kind: kind.clone(),
+        path: Path::parse(format!("{prefix}observability/images/08bfa764c6dc25e658bab2b8039ddb494546c3bc5523296804efc4cab604df5d.png")).unwrap(),
+    };
+
     let input_messages = result.get("input_messages").unwrap().as_str().unwrap();
     let input_messages: Vec<RequestMessage> = serde_json::from_str(input_messages).unwrap();
     assert_eq!(
         input_messages,
-        vec![
-            RequestMessage {
-                role: Role::User,
-                content: vec![ContentBlock::Text(Text {
+        vec![RequestMessage {
+            role: Role::User,
+            content: vec![
+                ContentBlock::Text(Text {
                     text: "Describe the contents of the image".to_string(),
-                }), ContentBlock::Image(ImageWithPath {
+                }),
+                ContentBlock::Image(ImageWithPath {
                     image: Base64Image {
                         url: None,
                         data: None,
                         mime_type: ImageKind::Png,
                     },
-                    storage_path: StoragePath {
-                        kind: kind.clone(),
-                        path: Path::parse(format!("{prefix}observability/images/08bfa764c6dc25e658bab2b8039ddb494546c3bc5523296804efc4cab604df5d.png")).unwrap(),
-                    }
-                })]
-            },
-        ]
+                    storage_path: expected_storage_path.clone(),
+                })
+            ]
+        },]
     );
 
     let inference_id_result = result.get("inference_id").unwrap().as_str().unwrap();
@@ -1193,6 +1226,7 @@ pub async fn check_base64_image_response(
         result.get("cached").unwrap().as_bool().unwrap(),
         should_be_cached
     );
+    expected_storage_path
 }
 
 #[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]

--- a/tensorzero-internal/tests/e2e/tests.rs
+++ b/tensorzero-internal/tests/e2e/tests.rs
@@ -10,6 +10,7 @@ mod feedback;
 mod health;
 mod inference;
 mod mixture_of_n;
+mod object_storage;
 mod openai_compatible;
 mod prometheus;
 mod providers;


### PR DESCRIPTION
This allows fetching an object from *any* object store (assuming the credentials are available in the gateway environment)

The `storage_path` parameter is a JSON-serialized `StoragePath`, which contains both the object store information (e.g. S3 bucket/region) and the path within the object store.

Fixes https://github.com/tensorzero/tensorzero/issues/1288

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `GET /internal/object_storage` endpoint to fetch objects from any object store, with handler and tests.
> 
>   - **Endpoint Addition**:
>     - Adds `GET /internal/object_storage?storage_path={}` endpoint in `main.rs` to fetch objects from any object store.
>   - **Handler Implementation**:
>     - Implements `get_object_handler` in `object_storage.rs` to process requests using `StoragePath`.
>     - Utilizes `ObjectStoreInfo::new` to create object store connections.
>   - **Testing**:
>     - Adds `test_object_store_fetch_missing` in `object_storage.rs` to test invalid fetch scenarios.
>     - Updates `common.rs` and `providers/common.rs` to include tests for object fetching via embedded and gateway modes.
>   - **Miscellaneous**:
>     - Makes `ObjectStoreInfo::new` public in `config_parser.rs`.
>     - Adds `object_storage` module to `endpoints/mod.rs` and `tests/e2e/tests.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for bb84cd3777a82655a096c3c1cde168ce124dbf92. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->