### PR TITLE
Test using MinIO as an S3-compatible object storage provider

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -84,6 +84,9 @@ jobs:
         run: |
           echo "TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@localhost:8123/tensorzero_e2e_tests" >> $GITHUB_ENV
 
+      - name: Launch MinIO container for E2E tests
+        run: docker compose -f ci/minio-docker-compose.yml up -d --wait
+
       - name: Launch ClickHouse container for E2E tests
         run: docker compose -f tensorzero-internal/tests/e2e/docker-compose.yml up -d --wait
 

--- a/ci/minio-docker-compose.yml
+++ b/ci/minio-docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  s3service:
+    image: quay.io/minio/minio
+    ports:
+      - "8000:9000"
+    environment:
+      - "MINIO_ROOT_USER=tensorzero-root"
+      - "MINIO_ROOT_PASSWORD=tensorzero-root"
+    command: server /data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 1s
+      timeout: 5s
+      retries: 5
+
+  createbuckets:
+    image: quay.io/minio/mc
+    depends_on:
+      s3service:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc alias set tensorzero-minio http://s3service:9000 tensorzero-root tensorzero-root;
+      /usr/bin/mc mb tensorzero-minio/tensorzero-e2e-tests;
+      /usr/bin/mc admin user add tensorzero-minio tensorzero tensorzero;
+      /usr/bin/mc admin policy attach tensorzero-minio readwrite --user tensorzero;
+      /usr/bin/mc policy set public tensorzero-minio/tensorzero-e2e-tests;
+      exit 0;
+      "

--- a/ci/run-minio.sh
+++ b/ci/run-minio.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+docker run \
+   -p 8000:9000 \
+   -p 8001:9001 \
+   -e "MINIO_ROOT_USER=tensorzero" \
+   -e "MINIO_ROOT_PASSWORD=tensorzero" \
+   quay.io/minio/minio server /data --console-address ":9001"

--- a/tensorzero-internal/tests/e2e/providers/openai.rs
+++ b/tensorzero-internal/tests/e2e/providers/openai.rs
@@ -1288,3 +1288,81 @@ pub async fn test_image_inference_with_provider_gcp_storage() {
     )
     .await;
 }
+
+// We already test Amazon S3 with all image providers, so let's test Google Cloud Storage
+// (which is S3-compatible) with just OpenAI to save time and money.
+#[cfg(feature = "e2e_tests")]
+#[tokio::test]
+pub async fn test_image_inference_with_provider_docker_minio() {
+    use crate::providers::common::test_image_inference_with_provider_s3_compatible;
+    use aws_credential_types::Credentials;
+    use aws_sdk_s3::config::SharedCredentialsProvider;
+    use rand::distributions::Alphanumeric;
+    use rand::distributions::DistString;
+    use tensorzero_internal::inference::types::storage::StorageKind;
+
+    // These are set in `ci/minio-docker-compose.yml`
+    let minio_access_key_id = "tensorzero".to_string();
+    let minio_secret_access_key = "tensorzero".to_string();
+
+    let credentials = Credentials::from_keys(&minio_access_key_id, &minio_secret_access_key, None);
+
+    // Our S3-compatible object store checks for these variables, giving them
+    // higher priority than the normal 'AWS_ACCESS_KEY_ID'/'AWS_SECRET_ACCESS_KEY' vars
+    std::env::set_var("S3_ACCESS_KEY_ID", minio_access_key_id);
+    std::env::set_var("S3_SECRET_ACCESS_KEY", minio_secret_access_key);
+
+    let provider = E2ETestProvider {
+        variant_name: "openai".to_string(),
+        model_name: "openai::gpt-4o-mini-2024-07-18".into(),
+        model_provider_name: "openai".into(),
+        credentials: HashMap::new(),
+    };
+
+    let endpoint = "http://127.0.0.1:8000/".to_string();
+
+    let test_bucket = "tensorzero-e2e-tests";
+    let config = aws_config::load_from_env()
+        .await
+        .to_builder()
+        .credentials_provider(SharedCredentialsProvider::new(credentials))
+        .endpoint_url(&endpoint)
+        .build();
+
+    let client = aws_sdk_s3::Client::new(&config);
+
+    let mut prefix = Alphanumeric.sample_string(&mut rand::thread_rng(), 6);
+    prefix += "-";
+
+    test_image_inference_with_provider_s3_compatible(
+        provider,
+        &StorageKind::S3Compatible {
+            bucket_name: Some(test_bucket.to_string()),
+            region: None,
+            prefix: prefix.clone(),
+            endpoint: Some(endpoint.clone()),
+            allow_http: Some(true),
+        },
+        &client,
+        &format!(
+            r#"
+    [object_storage]
+    type = "s3_compatible"
+    endpoint = "{endpoint}"
+    bucket_name = "{test_bucket}"
+    prefix = "{prefix}"
+    allow_http = true
+    
+    [functions.image_test]
+    type = "chat"
+
+    [functions.image_test.variants.openai]
+    type = "chat_completion"
+    model = "openai::gpt-4o-mini-2024-07-18"
+    "#
+        ),
+        test_bucket,
+        &prefix,
+    )
+    .await;
+}


### PR DESCRIPTION
I've added a
'ci/minio-docker-compose.yml' file which starts MinIO and creates a 'tensorzero-e2e-tests' bucket. This gets run in CI to allow us to test MinIO (only using OpenAI for image inference).

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
