### PR TITLE
Improve deserialization errors for `"type": "text"` blocks

### DIFF
--- a/tensorzero-internal/tests/e2e/providers/errors.rs
+++ b/tensorzero-internal/tests/e2e/providers/errors.rs
@@ -1,0 +1,127 @@
+use reqwest::{Client, StatusCode};
+use serde_json::{json, Value};
+
+use crate::common::get_gateway_endpoint;
+
+async fn test_payload_produces_error(payload: Value, expected_err: &str) {
+    let response = Client::new()
+        .post(get_gateway_endpoint("/inference"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let response_json = response.json::<Value>().await.unwrap();
+    let error_msg = response_json["error"].as_str().unwrap();
+    assert_eq!(expected_err, error_msg);
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_bad_text_input() {
+    test_payload_produces_error(
+        json!({
+            "function_name": "basic_test",
+            "input":
+                {
+                   "system": {"assistant_name": "Dr. Mehta"},
+                   "messages": [
+                    {
+                        "role": "user",
+                        "content": [{
+                            "type": "text",
+                            "bad_field": "Blah"
+                        }]
+                    }
+                ]},
+
+        }),
+        "input.messages[0].content[0]: Unknown key 'bad_field' in text content",
+    )
+    .await;
+
+    test_payload_produces_error(
+        json!({
+            "function_name": "basic_test",
+            "input":
+                {
+                   "system": {"assistant_name": "Dr. Mehta"},
+                   "messages": [
+                    {
+                        "role": "user",
+                        "content": [{
+                            "type": "text",
+                            "bad_field": "Blah",
+                            "bad_field_2": "Other",
+                        }]
+                    }
+                ]},
+
+        }),
+        "input.messages[0].content[0]: Expected exactly one other key in text content, found 2 other keys",
+    )
+    .await;
+
+    test_payload_produces_error(
+        json!({
+            "function_name": "basic_test",
+            "input":
+                {
+                   "system": {"assistant_name": "Dr. Mehta"},
+                   "messages": [
+                    {
+                        "role": "user",
+                        "content": [{
+                            "type": "text",
+                        }]
+                    }
+                ]},
+
+        }),
+        "input.messages[0].content[0]: Expected exactly one other key in text content, found 0 other keys",
+    )
+    .await;
+
+    test_payload_produces_error(
+        json!({
+            "function_name": "basic_test",
+            "input":
+                {
+                   "system": {"assistant_name": "Dr. Mehta"},
+                   "messages": [
+                    {
+                        "role": "user",
+                        "content": [{
+                            "type": "text",
+                            "text": ["Not", "a", "string"]
+                        }]
+                    }
+                ]},
+
+        }),
+        "input.messages[0].content[0]: Error deserializing 'text': invalid type: sequence, expected a string",
+    )
+    .await;
+
+    test_payload_produces_error(
+        json!({
+            "function_name": "basic_test",
+            "input":
+                {
+                   "system": {"assistant_name": "Dr. Mehta"},
+                   "messages": [
+                    {
+                        "role": "user",
+                        "content": [{
+                            "type": "text",
+                            "arguments": "Not an object"
+                        }]
+                    }
+                ]},
+
+        }),
+        "input.messages[0].content[0]: Error deserializing 'arguments': invalid type: string \"Not an object\", expected a map",
+    )
+    .await;
+}

--- a/tensorzero-internal/tests/e2e/providers/mod.rs
+++ b/tensorzero-internal/tests/e2e/providers/mod.rs
@@ -5,6 +5,7 @@ mod azure;
 mod batch;
 pub mod common;
 mod deepseek;
+mod errors;
 mod fireworks;
 mod gcp_vertex_anthropic;
 mod gcp_vertex_gemini;


### PR DESCRIPTION
Instead of using `#[serde(untagged)]`, we manually inspect the keys and emit more specific error messages.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve deserialization error handling for `TextKind` and add tests for specific error messages.
> 
>   - **Deserialization**:
>     - Remove `#[serde(untagged)]` from `TextKind` in `mod.rs`.
>     - Implement custom `Deserialize` for `TextKind` to provide specific error messages for unexpected keys and incorrect types.
>   - **Testing**:
>     - Add `errors.rs` to test deserialization errors for `TextKind` with various invalid inputs.
>     - Verify error messages for unknown keys, multiple keys, missing keys, and incorrect types.
>   - **Misc**:
>     - Remove `Deserialize` derive from `TextKind` in `mod.rs`.
>     - Add `errors` module to `mod.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 92d32bfada23dbc33f8e34dfdc1dd7f69d62f84b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->