### PR TITLE
Warn when starting gateway without `--config-file` or `--default-config`

### DIFF
--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -61,6 +61,10 @@ async fn main() {
         std::process::exit(1);
     }
 
+    if !args.default_config && config_path.is_none() {
+        tracing::warn!("Running the gateway without any config-related arguments is deprecated. Use `--default-config` to start the gateway with the default config.");
+    }
+
     let config = if let Some(path) = &config_path {
         Arc::new(
             Config::load_and_verify_from_path(Path::new(&path))


### PR DESCRIPTION
This is deprecated - eventually, we're going to require the user to specify `--config-file` or `--default-config`

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a warning in `main.rs` for starting the gateway without `--config-file` or `--default-config`, indicating deprecation.
> 
>   - **Behavior**:
>     - Adds a warning in `main.rs` when starting the gateway without `--config-file` or `--default-config`.
>     - Uses `tracing::warn` to log the deprecation warning.
>   - **Misc**:
>     - No changes to existing functionality, only adds a warning for deprecated behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 51f2b61a2240168b8eaaac4bf8ab5209e8258a07. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->