### PR TITLE
MIPRO Notebook: Was not writing `optimized_config` to `OUTPUT_DIR`

### DIFF
--- a/recipes/mipro/mipro.ipynb
+++ b/recipes/mipro/mipro.ipynb
@@ -833,7 +833,7 @@
     "    optimized_variant_name\n",
     "].name = optimized_variant_name\n",
     "# write the new config to a temporary directory\n",
-    "optimized_config_dir = optimized_config.write()"
+    "optimized_config_dir = optimized_config.write(base_dir=OUTPUT_DIR)"
    ]
   },
   {


### PR DESCRIPTION
Now passes `OUTPUT_DIR` to `optimized_config.write(base_dir=OUTPUT_DIR)`
