### PR TITLE
Avoid creating proxy-proxy-cache file for non-string body

### DIFF
--- a/provider-proxy/src/mitm_server.rs
+++ b/provider-proxy/src/mitm_server.rs
@@ -82,7 +82,7 @@ where
                         .with_upgrades()
                         .await
                     {
-                        tracing::error!("Error in proxy: {}", err);
+                        tracing::error!("Error in proxy: {err:?}");
                     }
                 });
             }

--- a/tensorzero-internal/src/inference/types/image.rs
+++ b/tensorzero-internal/src/inference/types/image.rs
@@ -72,7 +72,7 @@ impl Image {
                 let response = client.get(url.clone()).send().await.map_err(|e| {
                     Error::new(ErrorDetails::BadImageFetch {
                         url: url.clone(),
-                        message: format!("Error fetching image: {e}"),
+                        message: format!("Error fetching image: {e:?}"),
                     })
                 })?;
                 let bytes = response.bytes().await.map_err(|e| {


### PR DESCRIPTION
When attempting to cache a non-string response in proxy-provider, we would first create an empty file, and then skip writing to it when we failed to process the server response. This broke some of the image tests when running the provider-proxy in write mode, since we run a small HTTP server which serves an image.

We now only open the proxy-proxy-cache file after successfully serializing the response to a string, to reduce the chance that we end up with an empty file.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
