### PR TITLE
Add 'extra_cache_key' field and use it for *_of_n variants

### DIFF
--- a/tensorzero-internal/src/cache.rs
+++ b/tensorzero-internal/src/cache.rs
@@ -472,6 +472,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            extra_cache_key: None,
         };
         let model_provider_request = ModelProviderRequest {
             request: &model_inference_request,
@@ -495,6 +496,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            extra_cache_key: None,
         };
         let model_provider_request = ModelProviderRequest {
             request: &model_inference_request,
@@ -520,6 +522,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            extra_cache_key: None,
         };
         let model_provider_request = ModelProviderRequest {
             request: &streaming_model_inference_request,

--- a/tensorzero-internal/src/endpoints/batch_inference.rs
+++ b/tensorzero-internal/src/endpoints/batch_inference.rs
@@ -863,6 +863,7 @@ pub async fn write_completed_batch_inference<'a>(
                 inference_id,
                 episode_id,
             },
+            extra_cache_key: None,
         };
         let inference_result = function
             .prepare_response(

--- a/tensorzero-internal/src/endpoints/inference.rs
+++ b/tensorzero-internal/src/endpoints/inference.rs
@@ -287,6 +287,7 @@ pub async fn inference(
             inference_id,
             episode_id,
         },
+        extra_cache_key: None,
     };
     let inference_clients = InferenceClients {
         http_client,

--- a/tensorzero-internal/src/function.rs
+++ b/tensorzero-internal/src/function.rs
@@ -1541,6 +1541,7 @@ mod tests {
             variant_name: Some(""),
             templates: &templates,
             dynamic_output_schema: None,
+            extra_cache_key: None,
         };
         let response = function_config
             .prepare_response(
@@ -1842,6 +1843,7 @@ mod tests {
             variant_name: Some(""),
             templates: &templates,
             dynamic_output_schema: Some(&dynamic_output_schema),
+            extra_cache_key: None,
         };
         // Test with a correct content block
         let inference_id = Uuid::now_v7();

--- a/tensorzero-internal/src/inference/providers/anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/anthropic.rs
@@ -1398,6 +1398,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let anthropic_request_body = AnthropicRequestBody::new(&model, &inference_request);
         let details = anthropic_request_body.unwrap_err().get_owned_details();
@@ -1429,6 +1430,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let anthropic_request_body = AnthropicRequestBody::new(&model, &inference_request);
         assert!(anthropic_request_body.is_ok());
@@ -1478,6 +1480,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let anthropic_request_body = AnthropicRequestBody::new(&model, &inference_request);
         assert!(anthropic_request_body.is_ok());
@@ -1531,6 +1534,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let anthropic_request_body = AnthropicRequestBody::new(&model, &inference_request);
         assert!(anthropic_request_body.is_ok());
@@ -1584,6 +1588,7 @@ mod tests {
             function_type: FunctionType::Json,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let anthropic_request_body = AnthropicRequestBody::new(&model, &inference_request);
         assert!(anthropic_request_body.is_ok());

--- a/tensorzero-internal/src/inference/providers/azure.rs
+++ b/tensorzero-internal/src/inference/providers/azure.rs
@@ -519,6 +519,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let azure_request = AzureRequest::new(&request_with_tools).unwrap();
@@ -564,6 +565,7 @@ mod tests {
             function_type: FunctionType::Json,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let azure_request = AzureRequest::new(&request_with_tools).unwrap();
@@ -708,6 +710,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let azure_response_with_metadata = AzureResponseWithMetadata {
             response: valid_response,

--- a/tensorzero-internal/src/inference/providers/deepseek.rs
+++ b/tensorzero-internal/src/inference/providers/deepseek.rs
@@ -800,6 +800,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let deepseek_request = DeepSeekRequest::new("deepseek-chat", &request_with_tools)
@@ -845,6 +846,7 @@ mod tests {
             function_type: FunctionType::Json,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let deepseek_request = DeepSeekRequest::new("deepseek-chat", &request_with_tools)
@@ -963,6 +965,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let deepseek_response_with_metadata = DeepSeekResponseWithMetadata {
             response: valid_response,
@@ -1025,6 +1028,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let messages = prepare_deepseek_messages(&request, "deepseek-chat").unwrap();
@@ -1072,6 +1076,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let messages = prepare_deepseek_messages(&request_no_system, "deepseek-chat").unwrap();
@@ -1108,6 +1113,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let messages = prepare_deepseek_messages(&request_multiple, "deepseek-chat").unwrap();

--- a/tensorzero-internal/src/inference/providers/dummy.rs
+++ b/tensorzero-internal/src/inference/providers/dummy.rs
@@ -269,6 +269,14 @@ impl InferenceProvider for DummyProvider {
             "flaky_best_of_n_judge" => {
                 vec![r#"{"thinking": "hmmm", "answer_choice": 0}"#.to_string().into()]
             }
+            "random_answer" => {
+                vec![ContentBlockOutput::Text(Text {
+                    text: serde_json::json!({
+                        "answer": Uuid::now_v7().to_string()
+                    })
+                    .to_string(),
+                })]
+            }
             "alternate" => vec![ALTERNATE_INFER_RESPONSE_CONTENT.to_string().into()],
             "extract_images" => {
                 let images: Vec<_> = request

--- a/tensorzero-internal/src/inference/providers/fireworks.rs
+++ b/tensorzero-internal/src/inference/providers/fireworks.rs
@@ -517,6 +517,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let fireworks_request =
@@ -630,6 +631,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let fireworks_response_with_metadata = FireworksResponseWithMetadata {
             response: valid_response,

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
@@ -1226,6 +1226,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let anthropic_request_body = GCPVertexAnthropicRequestBody::new(&inference_request);
         let details = anthropic_request_body.unwrap_err().get_owned_details();
@@ -1263,6 +1264,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let anthropic_request_body = GCPVertexAnthropicRequestBody::new(&inference_request);
         assert!(anthropic_request_body.is_ok());
@@ -1317,6 +1319,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let anthropic_request_body = GCPVertexAnthropicRequestBody::new(&inference_request);
         assert!(anthropic_request_body.is_ok());
@@ -1385,6 +1388,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let anthropic_request_body = GCPVertexAnthropicRequestBody::new(&inference_request);
@@ -1797,6 +1801,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let request_body = GCPVertexAnthropicRequestBody {
             anthropic_version: "1.0",
@@ -1877,6 +1882,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let request_body = GCPVertexAnthropicRequestBody {
             anthropic_version: "1.0",
@@ -1966,6 +1972,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let request_body = GCPVertexAnthropicRequestBody {
             anthropic_version: "1.0",

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
@@ -1386,6 +1386,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let result = GCPVertexGeminiRequest::new(&inference_request, "gemini-pro");
         let details = result.unwrap_err().get_owned_details();
@@ -1423,6 +1424,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let result = GCPVertexGeminiRequest::new(&inference_request, "gemini-pro");
         let request = result.unwrap();
@@ -1473,6 +1475,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: Some(&output_schema),
             extra_body: None,
+            ..Default::default()
         };
         // JSON schema should be supported for Gemini Pro models
         let result = GCPVertexGeminiRequest::new(&inference_request, "gemini-1.5-pro-001");
@@ -1540,6 +1543,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: Some(&output_schema),
             extra_body: None,
+            ..Default::default()
         };
         // JSON mode should be supported for Gemini Flash models but without a schema
         let result = GCPVertexGeminiRequest::new(&inference_request, "gemini-flash");
@@ -1639,6 +1643,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let request_body = GCPVertexGeminiRequest {
             contents: vec![],
@@ -1724,6 +1729,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let request_body = GCPVertexGeminiRequest {
             contents: vec![],
@@ -1898,6 +1904,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let (tools, tool_choice) = prepare_tools(&request_with_tools, "gemini-1.5-pro-001");
         let tools = tools.unwrap();
@@ -1941,6 +1948,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let (tools, tool_choice) = prepare_tools(&request_with_tools, "gemini-2.0-flash-lite");
         let tools = tools.unwrap();

--- a/tensorzero-internal/src/inference/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/google_ai_studio_gemini.rs
@@ -1189,6 +1189,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let result = GeminiRequest::new(&inference_request);
         let details = result.unwrap_err().get_owned_details();
@@ -1226,6 +1227,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let result = GeminiRequest::new(&inference_request);
         let request = result.unwrap();
@@ -1276,6 +1278,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: Some(&output_schema),
             extra_body: None,
+            ..Default::default()
         };
         // JSON schema should be supported for Gemini Pro models
         let result = GeminiRequest::new(&inference_request);
@@ -1378,6 +1381,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let request_body = GeminiRequest {
             contents: vec![],
@@ -1466,6 +1470,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let request_body = GeminiRequest {
             contents: vec![],
@@ -1643,6 +1648,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let (tools, tool_choice) = prepare_tools(&request_with_tools);
         let tools = tools.unwrap();
@@ -1685,6 +1691,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let (tools, tool_choice) = prepare_tools(&request_with_tools);
         let tools = tools.unwrap();

--- a/tensorzero-internal/src/inference/providers/hyperbolic.rs
+++ b/tensorzero-internal/src/inference/providers/hyperbolic.rs
@@ -444,6 +444,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let hyperbolic_request =
@@ -530,6 +531,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let hyperbolic_response_with_metadata = HyperbolicResponseWithMetadata {
             response: valid_response,

--- a/tensorzero-internal/src/inference/providers/mistral.rs
+++ b/tensorzero-internal/src/inference/providers/mistral.rs
@@ -792,6 +792,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let mistral_request =
@@ -852,6 +853,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let request_body = MistralRequest {
@@ -946,6 +948,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let request_body = MistralRequest {
             messages: vec![],

--- a/tensorzero-internal/src/inference/providers/openai.rs
+++ b/tensorzero-internal/src/inference/providers/openai.rs
@@ -2150,6 +2150,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let openai_request = OpenAIRequest::new("gpt-3.5-turbo", &basic_request).unwrap();
@@ -2191,6 +2192,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let openai_request = OpenAIRequest::new("gpt-4", &request_with_tools).unwrap();
@@ -2242,6 +2244,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let openai_request = OpenAIRequest::new("gpt-4", &request_with_tools).unwrap();
@@ -2282,6 +2285,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: Some(&output_schema),
             extra_body: None,
+            ..Default::default()
         };
 
         let openai_request = OpenAIRequest::new("gpt-4", &request_with_tools).unwrap();
@@ -2325,6 +2329,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let openai_request = OpenAIRequest::new("o1-preview", &request).unwrap();
@@ -2364,6 +2369,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let openai_request_with_system =
@@ -2432,6 +2438,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let request_body = OpenAIRequest {
@@ -2528,6 +2535,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let request_body = OpenAIRequest {
@@ -2706,6 +2714,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let (tools, tool_choice, parallel_tool_calls) = prepare_openai_tools(&request_with_tools);
         let tools = tools.unwrap();
@@ -2747,6 +2756,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let (tools, tool_choice, parallel_tool_calls) =
             prepare_openai_tools(&request_without_tools);

--- a/tensorzero-internal/src/inference/providers/sglang.rs
+++ b/tensorzero-internal/src/inference/providers/sglang.rs
@@ -499,6 +499,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let sglang_request = SGLangRequest::new(&model_name, &basic_request).unwrap();
 
@@ -535,6 +536,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         SGLangRequest::new(&model_name, &request_with_tools).expect_err("requires a schema");
 
@@ -558,6 +560,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         SGLangRequest::new(&model_name, &request_with_tools).expect_err("requires a schema");
 
@@ -582,6 +585,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: Some(&output_schema),
             extra_body: None,
+            ..Default::default()
         };
 
         let sglang_request = SGLangRequest::new(&model_name, &request_with_tools).unwrap();
@@ -633,6 +637,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let sglang_response_with_metadata = SGLangResponseWithMetadata {
             response: valid_response,

--- a/tensorzero-internal/src/inference/providers/tgi.rs
+++ b/tensorzero-internal/src/inference/providers/tgi.rs
@@ -753,6 +753,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let tgi_request = TGIRequest::new(&model_name, &basic_request).unwrap();
 
@@ -789,6 +790,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let tgi_request = TGIRequest::new(&model_name, &request_with_tools).unwrap();
@@ -836,6 +838,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let tgi_request = TGIRequest::new(&model_name, &request_with_tools).unwrap();
@@ -871,6 +874,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: Some(&output_schema),
             extra_body: None,
+            ..Default::default()
         };
 
         let tgi_request = TGIRequest::new(&model_name, &request_with_tools).unwrap();
@@ -944,6 +948,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let tgi_response_with_metadata = TGIResponseWithMetadata {
             response: valid_response,

--- a/tensorzero-internal/src/inference/providers/together.rs
+++ b/tensorzero-internal/src/inference/providers/together.rs
@@ -901,6 +901,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let together_request =
@@ -1001,6 +1002,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let together_response_with_metadata = TogetherResponseWithMetadata {
             response: valid_response,

--- a/tensorzero-internal/src/inference/providers/vllm.rs
+++ b/tensorzero-internal/src/inference/providers/vllm.rs
@@ -483,6 +483,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: Some(&output_schema),
             extra_body: None,
+            ..Default::default()
         };
 
         let vllm_request = VLLMRequest::new("llama-v3-8b", &request_with_tools).unwrap();
@@ -520,6 +521,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: Some(&output_schema),
             extra_body: None,
+            ..Default::default()
         };
 
         let err = VLLMRequest::new("llama-v3-8b", &request_with_tools).unwrap_err();
@@ -594,6 +596,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let vllm_response_with_metadata = VLLMResponseWithMetadata {
             response: valid_response,

--- a/tensorzero-internal/src/inference/providers/xai.rs
+++ b/tensorzero-internal/src/inference/providers/xai.rs
@@ -501,6 +501,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let xai_request = XAIRequest::new("grok-beta", &request_with_tools)
@@ -546,6 +547,7 @@ mod tests {
             function_type: FunctionType::Json,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let xai_request = XAIRequest::new("grok-beta", &request_with_tools)
@@ -647,6 +649,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let xai_response_with_metadata = XAIResponseWithMetadata {
             response: valid_response,

--- a/tensorzero-internal/src/inference/types/mod.rs
+++ b/tensorzero-internal/src/inference/types/mod.rs
@@ -375,6 +375,10 @@ pub struct ModelInferenceRequest<'a> {
     pub function_type: FunctionType,
     pub output_schema: Option<&'a Value>,
     pub extra_body: Option<&'a ExtraBodyConfig>,
+    /// Optional arbitrary data, only used when constructing the cache key.
+    /// This is used by best_of_n/mixture_of_n to force different sub-variants
+    /// to have different cache keys.
+    pub extra_cache_key: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -1462,6 +1466,7 @@ pub async fn collect_chunks(args: CollectChunksArgs<'_, '_>) -> Result<Inference
         tool_config,
         templates,
         dynamic_output_schema: dynamic_output_schema.as_ref(),
+        extra_cache_key: None,
     };
     function
         .prepare_response(

--- a/tensorzero-internal/src/model.rs
+++ b/tensorzero-internal/src/model.rs
@@ -1483,6 +1483,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let model_name = "test model";
         let response = model_config
@@ -1578,6 +1579,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         let model_config = ModelConfig {
@@ -1653,6 +1655,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         // Test good model
@@ -1805,6 +1808,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
 
         // Test fallback
@@ -1939,6 +1943,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let model_name = "test model";
         let error = model_config
@@ -2043,6 +2048,7 @@ mod tests {
             function_type: FunctionType::Chat,
             output_schema: None,
             extra_body: None,
+            ..Default::default()
         };
         let error = model_config
             .infer(&request, &clients, model_name)

--- a/tensorzero-internal/src/variant/chat_completion.rs
+++ b/tensorzero-internal/src/variant/chat_completion.rs
@@ -927,6 +927,7 @@ mod tests {
                 inference_id: Uuid::now_v7(),
                 episode_id: Uuid::now_v7(),
             },
+            extra_cache_key: None,
         };
         let models = ModelTable::default();
         let inference_models = InferenceModels {
@@ -979,6 +980,7 @@ mod tests {
                 inference_id: Uuid::now_v7(),
                 episode_id: Uuid::now_v7(),
             },
+            extra_cache_key: None,
         };
         let result = chat_completion_config
             .infer(
@@ -1028,6 +1030,7 @@ mod tests {
                 inference_id: Uuid::now_v7(),
                 episode_id: Uuid::now_v7(),
             },
+            extra_cache_key: None,
         };
         let err = chat_completion_config
             .infer(
@@ -1105,6 +1108,7 @@ mod tests {
                 inference_id: Uuid::now_v7(),
                 episode_id: Uuid::now_v7(),
             },
+            extra_cache_key: None,
         };
         let result = chat_completion_config
             .infer(
@@ -1181,6 +1185,7 @@ mod tests {
                 inference_id: Uuid::now_v7(),
                 episode_id: Uuid::now_v7(),
             },
+            extra_cache_key: None,
         };
         let result = chat_completion_config
             .infer(
@@ -1265,6 +1270,7 @@ mod tests {
                 inference_id: Uuid::now_v7(),
                 episode_id: Uuid::now_v7(),
             },
+            extra_cache_key: None,
         };
         let inference_params = InferenceParams::default();
         let result = chat_completion_config
@@ -1324,6 +1330,7 @@ mod tests {
             function_name: "",
             variant_name: Some(""),
             dynamic_output_schema: None,
+            extra_cache_key: None,
         };
         let chat_completion_config = ChatCompletionConfig {
             model: "json".into(),
@@ -1336,6 +1343,7 @@ mod tests {
                 path: user_template_name.into(),
                 contents: "".to_string(),
             }),
+            extra_body: None,
             ..Default::default()
         };
         let result = chat_completion_config
@@ -1427,6 +1435,7 @@ mod tests {
             function_name: "",
             variant_name: Some(""),
             dynamic_output_schema: Some(&output_schema),
+            extra_cache_key: None,
         };
         let chat_completion_config = ChatCompletionConfig {
             model: "json".into(),
@@ -1520,6 +1529,7 @@ mod tests {
             function_name: "",
             variant_name: Some(""),
             dynamic_output_schema: Some(&output_schema),
+            extra_cache_key: None,
         };
         let chat_completion_config = ChatCompletionConfig {
             model: "json".into(),
@@ -1687,6 +1697,7 @@ mod tests {
             dynamic_output_schema: None,
             function_name: "",
             variant_name: Some(""),
+            extra_cache_key: None,
         };
         let result = chat_completion_config
             .infer_stream(
@@ -1749,6 +1760,7 @@ mod tests {
             function_name: "",
             variant_name: Some(""),
             dynamic_output_schema: None,
+            extra_cache_key: None,
         };
         let (mut stream, models_used) = chat_completion_config
             .infer_stream(
@@ -1848,6 +1860,7 @@ mod tests {
             function_name: "",
             variant_name: Some(""),
             dynamic_output_schema: None,
+            extra_cache_key: None,
         };
         let model_request = chat_completion_config
             .prepare_request(
@@ -1951,6 +1964,7 @@ mod tests {
             dynamic_output_schema: None,
             function_name: "",
             variant_name: Some(""),
+            extra_cache_key: None,
         };
         let mut inference_params = InferenceParams::default();
         let model_request = chat_completion_config
@@ -2028,6 +2042,7 @@ mod tests {
                 inference_id: Uuid::now_v7(),
                 episode_id: Uuid::now_v7(),
             },
+            extra_cache_key: None,
         };
         let model_request = chat_completion_config
             .prepare_request(

--- a/tensorzero-internal/src/variant/mixture_of_n.rs
+++ b/tensorzero-internal/src/variant/mixture_of_n.rs
@@ -196,19 +196,36 @@ impl MixtureOfNConfig {
         let candidate_variants = self
             .candidates
             .iter()
-            .map(|candidate| {
+            .enumerate()
+            .map(|(i, candidate)| {
                 let variant = function.variants().get(candidate).ok_or_else(|| {
                     Error::new(ErrorDetails::UnknownCandidate {
                         name: candidate.to_string(),
                     })
                 })?;
-                Ok((candidate.to_string(), variant))
+                // Inject the candidate index into the cache key. This prevents us from using the same cache entry
+                // for identical candidates, allowing users to evaluate the same candidate multiple times
+                // to generate (potentially) different responses.
+                // Note - we intentionally *only* inject the index, and not any other variant/model name
+                // information. This means that multiple top-level 'best_of_n' variants will be able to share
+                // the same cache entries. For example, consider two top-level best-of-n variants with
+                // sub variants:
+                // [A, B, A, C]
+                // [A, B, C, D]
+                //
+                // The first two evaluations (A and B) will share the same cache key, since
+                // the sub-variant will make the same request (and have the same injected index)
+                // However, the 'A, C' and 'C, D' evaluations will all have distinct cache keys:
+                // (A, 2), (C, 3), (C, 2), (D, 4)
+                let mut config = inference_config.clone();
+                config.extra_cache_key = Some(format!("candidate_{i}"));
+                Ok((candidate.to_string(), variant, config))
             })
             .collect::<Result<Vec<_>, Error>>()?;
 
         // Start the inference tasks (we keep the names around for logging)
         let mut inference_futures = Vec::new();
-        for (candidate_name, candidate_variant) in &candidate_variants {
+        for (candidate_name, candidate_variant, config) in &candidate_variants {
             inference_futures.push((
                 candidate_name.clone(),
                 timeout(
@@ -217,7 +234,7 @@ impl MixtureOfNConfig {
                         input,
                         models,
                         function,
-                        inference_config,
+                        config,
                         clients,
                         InferenceParams::default(),
                     ),
@@ -1032,6 +1049,7 @@ mod tests {
             dynamic_output_schema: None,
             function_name: "",
             variant_name: Some(""),
+            extra_cache_key: None,
         };
 
         let fused = mixture_of_n_variant

--- a/tensorzero-internal/tests/e2e/best_of_n.rs
+++ b/tensorzero-internal/tests/e2e/best_of_n.rs
@@ -12,6 +12,145 @@ use tensorzero_internal::clickhouse::test_helpers::{
     select_model_inferences_clickhouse,
 };
 
+#[tokio::test]
+async fn e2e_test_best_of_n_dummy_candidates_dummy_judge() {
+    // Include randomness in put to make sure that the first request is a cache miss
+    let random_input = Uuid::now_v7();
+    e2e_test_best_of_n_dummy_candidates_dummy_judge_inner(random_input, false).await;
+    e2e_test_best_of_n_dummy_candidates_dummy_judge_inner(random_input, true).await;
+}
+
+async fn e2e_test_best_of_n_dummy_candidates_dummy_judge_inner(
+    random_input: Uuid,
+    should_be_cached: bool,
+) {
+    let episode_id = Uuid::now_v7();
+
+    let payload = json!({
+        "function_name": "best_of_n_json_repeated",
+        "variant_name": "best_of_n_variant",
+        "episode_id": episode_id,
+        "input": {
+            "system": {"assistant_name": "AskJeeves"},
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "value": format!("Please write me a sentence about Megumin making an explosion: {random_input}")},
+                    ]
+                }
+            ]},
+        "stream": false,
+        "cache_options": {"enabled": "on", "lookback_s": 10}
+    });
+
+    let response = Client::new()
+        .post(get_gateway_endpoint("/inference"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    // Check Response is OK, then fields in order
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_json = response.json::<Value>().await.unwrap();
+    // Check that inference_id is here
+    let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
+    let inference_id = Uuid::parse_str(inference_id).unwrap();
+
+    // Sleep for 1 second to allow time for data to be inserted into ClickHouse (trailing writes from API)
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    // Check ClickHouse
+    let clickhouse = get_clickhouse().await;
+    let result = select_json_inference_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+    let id = result.get("id").unwrap().as_str().unwrap();
+    let id_uuid = Uuid::parse_str(id).unwrap();
+    assert_eq!(id_uuid, inference_id);
+    let input: Value =
+        serde_json::from_str(result.get("input").unwrap().as_str().unwrap()).unwrap();
+    let correct_input: Value = json!(
+        {
+            "system": {
+                "assistant_name": "AskJeeves"
+            },
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "value": format!("Please write me a sentence about Megumin making an explosion: {random_input}")},
+                    ]
+                }
+            ]
+        }
+    );
+    assert_eq!(input, correct_input);
+
+    // Check the ModelInference Table
+    let results: Vec<Value> = select_model_inferences_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 4);
+
+    // Collect model names
+    let mut model_names = std::collections::HashSet::new();
+    let mut dummy_uuids = vec![];
+
+    for result in results {
+        let id = result.get("id").unwrap().as_str().unwrap();
+        let _ = Uuid::parse_str(id).unwrap();
+        let inference_id_result = result.get("inference_id").unwrap().as_str().unwrap();
+        let inference_id_result = Uuid::parse_str(inference_id_result).unwrap();
+        assert_eq!(inference_id_result, inference_id);
+
+        // Collect model_name
+        let model_name = result.get("model_name").unwrap().as_str().unwrap();
+        model_names.insert(model_name.to_string());
+
+        // Check that all expected fields are present
+        assert!(result.get("model_provider_name").is_some());
+        assert!(result.get("raw_request").is_some());
+        assert!(result.get("raw_response").is_some());
+        assert!(result.get("input_tokens").is_some());
+        assert!(result.get("output_tokens").is_some());
+        assert!(result.get("response_time_ms").is_some());
+        assert!(result.get("ttft_ms").is_some());
+
+        // We just check the output here, since we already have several tests covering the other fields
+        // for best_of_n
+        if model_name == "dummy::random_answer" {
+            let cached = result.get("cached").unwrap().as_bool().unwrap();
+            assert_eq!(cached, should_be_cached);
+            let output = result.get("output").unwrap().as_str().unwrap();
+            let output: Vec<ContentBlock> = serde_json::from_str(output).unwrap();
+            assert_eq!(output.len(), 1);
+            match &output[0] {
+                ContentBlock::Text(text) => {
+                    let parsed: Value = serde_json::from_str(&text.text).unwrap();
+                    let uuid = parsed.get("answer").unwrap().as_str().unwrap();
+                    dummy_uuids.push(uuid.to_string());
+                }
+                _ => {
+                    panic!("Expected a text block, got {:?}", output[0]);
+                }
+            }
+        }
+    }
+
+    // Check that all expected model names are present
+    let expected_model_names: std::collections::HashSet<String> =
+        ["dummy::random_answer", "dummy::best_of_n_0", "json"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+    assert_eq!(model_names, expected_model_names);
+
+    // Test that the model was actually invoked twice (producing a different UUID each time)
+    assert_eq!(dummy_uuids.len(), 2);
+    assert_ne!(dummy_uuids[0], dummy_uuids[1]);
+}
+
 /// This test calls a function which currently uses best of n.
 /// We call 2 models, one that gives the usual good response, one that
 /// gives a JSON response, and then use Gemini to select the best one.

--- a/tensorzero-internal/tests/e2e/cache.rs
+++ b/tensorzero-internal/tests/e2e/cache.rs
@@ -66,6 +66,7 @@ async fn test_cache_write_and_read() {
         function_type: FunctionType::Chat,
         output_schema: None,
         extra_body: None,
+        ..Default::default()
     };
     let model_provider_request = ModelProviderRequest {
         request: &model_inference_request,
@@ -189,6 +190,7 @@ async fn test_cache_stream_write_and_read() {
         function_type: FunctionType::Chat,
         output_schema: None,
         extra_body: None,
+        ..Default::default()
     };
     let model_provider_request = ModelProviderRequest {
         request: &model_inference_request,

--- a/tensorzero-internal/tests/e2e/mixture_of_n.rs
+++ b/tensorzero-internal/tests/e2e/mixture_of_n.rs
@@ -9,6 +9,144 @@ use tensorzero_internal::clickhouse::test_helpers::{
     select_model_inferences_clickhouse,
 };
 
+#[tokio::test]
+async fn e2e_test_mixture_of_n_dummy_candidates_dummy_judge() {
+    // Include randomness in put to make sure that the first request is a cache miss
+    let random_input = Uuid::now_v7();
+    e2e_test_mixture_of_n_dummy_candidates_dummy_judge_inner(random_input, false).await;
+    e2e_test_mixture_of_n_dummy_candidates_dummy_judge_inner(random_input, true).await;
+}
+
+async fn e2e_test_mixture_of_n_dummy_candidates_dummy_judge_inner(
+    random_input: Uuid,
+    should_be_cached: bool,
+) {
+    let episode_id = Uuid::now_v7();
+
+    let payload = json!({
+        "function_name": "mixture_of_n_json_repeated",
+        "variant_name": "mixture_of_n_variant",
+        "episode_id": episode_id,
+        "input": {
+            "system": {"assistant_name": "AskJeeves"},
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "value": format!("Please write me a sentence about Megumin making an explosion: {random_input}")},
+                    ]
+                }
+            ]},
+        "stream": false,
+        "cache_options": {"enabled": "on", "lookback_s": 10}
+    });
+
+    let response = Client::new()
+        .post(get_gateway_endpoint("/inference"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    // Check Response is OK, then fields in order
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_json = response.json::<Value>().await.unwrap();
+    // Check that inference_id is here
+    let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
+    let inference_id = Uuid::parse_str(inference_id).unwrap();
+
+    // Sleep for 1 second to allow time for data to be inserted into ClickHouse (trailing writes from API)
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    // Check ClickHouse
+    let clickhouse = get_clickhouse().await;
+    let result = select_json_inference_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+    let id = result.get("id").unwrap().as_str().unwrap();
+    let id_uuid = Uuid::parse_str(id).unwrap();
+    assert_eq!(id_uuid, inference_id);
+    let input: Value =
+        serde_json::from_str(result.get("input").unwrap().as_str().unwrap()).unwrap();
+    let correct_input: Value = json!(
+        {
+            "system": {
+                "assistant_name": "AskJeeves"
+            },
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "value": format!("Please write me a sentence about Megumin making an explosion: {random_input}")},
+                    ]
+                }
+            ]
+        }
+    );
+    assert_eq!(input, correct_input);
+
+    // Check the ModelInference Table
+    let results: Vec<Value> = select_model_inferences_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 4);
+
+    // Collect model names
+    let mut model_names = std::collections::HashSet::new();
+    let mut dummy_uuids = vec![];
+
+    for result in results {
+        let id = result.get("id").unwrap().as_str().unwrap();
+        let _ = Uuid::parse_str(id).unwrap();
+        let inference_id_result = result.get("inference_id").unwrap().as_str().unwrap();
+        let inference_id_result = Uuid::parse_str(inference_id_result).unwrap();
+        assert_eq!(inference_id_result, inference_id);
+
+        // Collect model_name
+        let model_name = result.get("model_name").unwrap().as_str().unwrap();
+        model_names.insert(model_name.to_string());
+
+        // Check that all expected fields are present
+        assert!(result.get("model_provider_name").is_some());
+        assert!(result.get("raw_request").is_some());
+        assert!(result.get("raw_response").is_some());
+        assert!(result.get("input_tokens").is_some());
+        assert!(result.get("output_tokens").is_some());
+        assert!(result.get("response_time_ms").is_some());
+        assert!(result.get("ttft_ms").is_some());
+
+        // We just check the output here, since we already have several tests covering the other fields
+        // for mixture_of_n
+        if model_name == "dummy::random_answer" {
+            let cached = result.get("cached").unwrap().as_bool().unwrap();
+            assert_eq!(cached, should_be_cached);
+            let output = result.get("output").unwrap().as_str().unwrap();
+            let output: Vec<ContentBlock> = serde_json::from_str(output).unwrap();
+            assert_eq!(output.len(), 1);
+            match &output[0] {
+                ContentBlock::Text(text) => {
+                    let parsed: Value = serde_json::from_str(&text.text).unwrap();
+                    let uuid = parsed.get("answer").unwrap().as_str().unwrap();
+                    dummy_uuids.push(uuid.to_string());
+                }
+                _ => {
+                    panic!("Expected a text block, got {:?}", output[0]);
+                }
+            }
+        }
+    }
+
+    // Check that all expected model names are present
+    let expected_model_names: std::collections::HashSet<String> = ["dummy::random_answer", "json"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    assert_eq!(model_names, expected_model_names);
+
+    // Test that the model was actually invoked twice (producing a different UUID each time)
+    assert_eq!(dummy_uuids.len(), 2);
+    assert_ne!(dummy_uuids[0], dummy_uuids[1]);
+}
+
 /// This test calls a function which currently uses mixture of n.
 /// We call 2 models that each give a different response, and then use GPT4o-mini to fuse them.
 /// Besides checking that the response is well-formed and everything is stored correctly,

--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -2136,6 +2136,35 @@ model = "claude-3-haiku-20240307-anthropic"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 json_mode = "implicit_tool"
 
+[functions.best_of_n_json_repeated]
+type = "json"
+system_schema = "../../fixtures/config/functions/basic_test/system_schema.json"
+output_schema = "../../fixtures/config/functions/best_of_n_json/output_schema.json"
+
+[functions.best_of_n_json_repeated.variants.variant0]
+type = "chat_completion"
+weight = 0
+model = "dummy::random_answer"
+system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
+json_mode = "strict"
+
+[functions.best_of_n_json_repeated.variants.variant1]
+type = "chat_completion"
+weight = 0
+model = "json"
+system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
+json_mode = "strict"
+
+[functions.best_of_n_json_repeated.variants.best_of_n_variant]
+type = "experimental_best_of_n_sampling"
+weight = 1
+candidates = ["variant0", "variant0", "variant1"]
+
+[functions.best_of_n_json_repeated.variants.best_of_n_variant.evaluator]
+model = "dummy::best_of_n_0"
+system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
+json_mode = "strict"
+
 [functions.mixture_of_n]
 type = "chat"
 system_schema = "../../fixtures/config/functions/basic_test/system_schema.json"
@@ -2218,6 +2247,33 @@ model = "gpt-4o-mini-2024-07-18"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 json_mode = "strict"
 
+[functions.mixture_of_n_json_repeated]
+type = "json"
+system_schema = "../../fixtures/config/functions/basic_test/system_schema.json"
+
+[functions.mixture_of_n_json_repeated.variants.variant0]
+type = "chat_completion"
+weight = 0
+model = "dummy::random_answer"
+system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
+json_mode = "strict"
+
+[functions.mixture_of_n_json_repeated.variants.variant1]
+type = "chat_completion"
+weight = 0
+model = "json"
+system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
+json_mode = "strict"
+
+[functions.mixture_of_n_json_repeated.variants.mixture_of_n_variant]
+type = "experimental_mixture_of_n"
+weight = 1
+candidates = ["variant0", "variant0", "variant1"]
+
+[functions.mixture_of_n_json_repeated.variants.mixture_of_n_variant.fuser]
+model = "json"
+system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
+json_mode = "strict"
 
 # ┌────────────────────────────────────────────────────────────────────────────┐
 # │                                  METRICS                                   │


### PR DESCRIPTION
This allows caching to be used while duplicating a variant name (or using two identical variants) in the
best_of_n/mixture_of_n config:

For example, the following config:

```
[functions.mixture_of_n_json_repeated.variants.mixture_of_n_variant]
type = "experimental_mixture_of_n"
weight = 1
candidates = ["variant0", "variant0", "variant1"]
```

will use distinct cache keys for the two "variant0" invocations. This allows mixture_of_n/best_of_n to judge/fuse results from multiple invocations of the same variant, even when caching is enabled.

Fixes https://github.com/tensorzero/tensorzero/issues/1168

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `extra_cache_key` to handle caching for repeated variants in `best_of_n` and `mixture_of_n` configurations, with corresponding tests and configuration updates.
> 
>   - **Behavior**:
>     - Adds `extra_cache_key` field to `ModelInferenceRequest` in `types/mod.rs` to differentiate cache keys for repeated or identical variants in `best_of_n` and `mixture_of_n`.
>     - Updates `best_of_n_sampling.rs` and `mixture_of_n.rs` to use `extra_cache_key` for cache differentiation.
>   - **Tests**:
>     - Adds tests in `best_of_n.rs` and `mixture_of_n.rs` to verify caching behavior with repeated variants.
>     - Updates `cache.rs` to test cache read/write with `extra_cache_key`.
>   - **Misc**:
>     - Minor updates to `tensorzero.toml` to include new test configurations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 62c4ce4ffe41fa0f9b312501f980f3b60fd086f0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->