### PR TITLE
Bump all crates except tensorzero-internal to edition 2024

### DIFF
--- a/clients/python-pyo3/Cargo.toml
+++ b/clients/python-pyo3/Cargo.toml
@@ -4,7 +4,7 @@
 # (which has a crate name of 'tensorzero')
 name = "tensorzero-python"
 version = "2025.3.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tensorzero"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 reqwest = { workspace = true }

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gateway"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 tensorzero-internal = { path = "../tensorzero-internal" }

--- a/provider-proxy/Cargo.toml
+++ b/provider-proxy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "provider-proxy"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [[test]]
 name = "e2e"

--- a/ui/app/utils/minijinja/Cargo.toml
+++ b/ui/app/utils/minijinja/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "minijinja-bindings"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
This raises our minimum Rust version to Rust 1.85.0 The full list of edition changes can be found here: https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html#rust-2024

The only things that might affect us are:
* Shorter temporary lifetimes, which will cause lock guards to be dropped earlier
* `std::env::set_var` is now unsafe - this blocks updating `tensorzero-internal`, as we use this in several tests. I'm hold off on the update until we decide how we want to deal with this.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump Rust edition to 2024 for multiple crates, raising minimum Rust version to 1.85.0, affecting lock guard lifetimes and blocking `tensorzero-internal` update due to `std::env::set_var` changes.
> 
>   - **Edition Update**:
>     - Bump Rust edition to 2024 in `clients/python-pyo3/Cargo.toml`, `clients/rust/Cargo.toml`, and `gateway/Cargo.toml`.
>     - Update `provider-proxy/Cargo.toml` and `ui/app/utils/minijinja/Cargo.toml` to edition 2024.
>   - **Rust Version**:
>     - Minimum Rust version raised to 1.85.0.
>   - **Behavioral Impact**:
>     - Shorter temporary lifetimes may cause lock guards to drop earlier.
>     - `std::env::set_var` is now unsafe, blocking `tensorzero-internal` update due to its usage in tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 248dcd8d4d49f45fb4689fd63bc023ce30d512b7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->