### PR TITLE
added warnings on dropped content for openai compatible responses

### DIFF
--- a/tensorzero-internal/src/endpoints/openai_compatible.rs
+++ b/tensorzero-internal/src/endpoints/openai_compatible.rs
@@ -724,6 +724,9 @@ fn process_chat_content(
             ContentBlockChatOutput::Thought(_thought) => {
                 // OpenAI compatible endpoint does not support thought blocks
                 // Users of this endpoint will need to check observability to see them
+                tracing::warn!(
+                    "Ignoring 'thought' content block when constructing OpenAI-compatible response"
+                );
             }
             ContentBlockChatOutput::Unknown {
                 data: _,
@@ -863,6 +866,9 @@ fn process_chat_content_chunk(
             ContentBlockChunk::Thought(_thought) => {
                 // OpenAI compatible endpoint does not support thought blocks
                 // Users of this endpoint will need to check observability to see them
+                tracing::warn!(
+                    "Ignoring 'thought' content block chunk when constructing OpenAI-compatible response"
+                );
             }
         }
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add warnings for ignored 'thought' content blocks in OpenAI-compatible responses.
> 
>   - **Warnings**:
>     - Add warning for ignored `ContentBlockChatOutput::Thought` in `process_chat_content()`.
>     - Add warning for ignored `ContentBlockChunk::Thought` in `process_chat_content_chunk()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ed1c01b3ea8df3460a53b3de8e078b4223bb2e83. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->