### PR TITLE
Update Gemini examples to use 2.0 models

### DIFF
--- a/examples/guides/providers/gcp-vertex-ai-gemini/config/tensorzero.toml
+++ b/examples/guides/providers/gcp-vertex-ai-gemini/config/tensorzero.toml
@@ -1,9 +1,9 @@
-[models.gemini_1_5_flash_001]
+[models.gemini_2_0_flash]
 routing = ["gcp_vertex_gemini"]
 
-[models.gemini_1_5_flash_001.providers.gcp_vertex_gemini]
+[models.gemini_2_0_flash.providers.gcp_vertex_gemini]
 type = "gcp_vertex_gemini"
-model_id = "gemini-1.5-flash-001"
+model_id = "gemini-2.0-flash"
 location = "us-central1"
 project_id = "your-project-id"  # change this
 
@@ -12,4 +12,4 @@ type = "chat"
 
 [functions.my_function_name.variants.my_variant_name]
 type = "chat_completion"
-model = "gemini_1_5_flash_001"
+model = "gemini_2_0_flash"

--- a/examples/guides/providers/google-ai-studio-gemini/config/tensorzero.toml
+++ b/examples/guides/providers/google-ai-studio-gemini/config/tensorzero.toml
@@ -1,13 +1,13 @@
-[models.gemini_1_5_flash_8b]
+[models.gemini_2_0_flash_lite]
 routing = ["google_ai_studio_gemini"]
 
-[models.gemini_1_5_flash_8b.providers.google_ai_studio_gemini]
+[models.gemini_2_0_flash_lite.providers.google_ai_studio_gemini]
 type = "google_ai_studio_gemini"
-model_name = "gemini-1.5-flash-8b"
+model_name = "gemini-2.0-flash-lite"
 
 [functions.my_function_name]
 type = "chat"
 
 [functions.my_function_name.variants.my_variant_name]
 type = "chat_completion"
-model = "gemini_1_5_flash_8b"
+model = "gemini_2_0_flash_lite"


### PR DESCRIPTION
I've left off the '001' suffix, since we don't care about using a particular stable version in the example

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Gemini model configurations to use version 2.0 in example files.
> 
>   - **Configuration Updates**:
>     - Update `tensorzero.toml` in `gcp-vertex-ai-gemini` to use `gemini_2_0_flash` instead of `gemini_1_5_flash_001`.
>     - Update `tensorzero.toml` in `google-ai-studio-gemini` to use `gemini_2_0_flash_lite` instead of `gemini_1_5_flash_8b`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for dbd98c1c57d77c115d53ceda04b9205367b96ca3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->