### PR TITLE
Add '[gateway.enable_template_filesystem_access]'

### DIFF
--- a/tensorzero-internal/fixtures/config/functions/basic_test/prompt/system_template.minijinja
+++ b/tensorzero-internal/fixtures/config/functions/basic_test/prompt/system_template.minijinja
@@ -1,1 +1,1 @@
-You are a helpful and friendly assistant named {{ assistant_name }}
+You are a helpful and friendly {% include 'extra_templates/foo.minijinja' %} named {{ assistant_name }}

--- a/tensorzero-internal/src/gateway_util.rs
+++ b/tensorzero-internal/src/gateway_util.rs
@@ -173,6 +173,7 @@ mod tests {
             },
             bind_address: None,
             debug: false,
+            enable_template_filesystem_access: false,
         };
 
         let config = Box::leak(Box::new(Config {
@@ -222,6 +223,7 @@ mod tests {
             },
             bind_address: None,
             debug: false,
+            enable_template_filesystem_access: false,
         };
 
         let config = Box::leak(Box::new(Config {
@@ -242,6 +244,7 @@ mod tests {
             },
             bind_address: None,
             debug: false,
+            enable_template_filesystem_access: false,
         };
         let config = Box::leak(Box::new(Config {
             gateway: gateway_config,
@@ -264,6 +267,7 @@ mod tests {
             },
             bind_address: None,
             debug: false,
+            enable_template_filesystem_access: false,
         };
         let config = Config {
             gateway: gateway_config,

--- a/tensorzero-internal/src/minijinja_util.rs
+++ b/tensorzero-internal/src/minijinja_util.rs
@@ -1,6 +1,6 @@
 use minijinja::{Environment, UndefinedBehavior};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
 use crate::error::{Error, ErrorDetails};
 
@@ -18,7 +18,12 @@ impl TemplateConfig<'_> {
 
     /// Initializes the TemplateConfig with the given templates, given as a map from template names
     /// to template paths.
-    pub fn initialize(&mut self, template_paths: HashMap<String, String>) -> Result<(), Error> {
+    /// If `filesystem_path` is provided, we'll register a minijinja filesystem loader with the specified path
+    pub fn initialize(
+        &mut self,
+        template_paths: HashMap<String, String>,
+        filesystem_path: Option<PathBuf>,
+    ) -> Result<(), Error> {
         self.env.set_undefined_behavior(UndefinedBehavior::Strict);
 
         for (template_name, template_content) in template_paths {
@@ -32,6 +37,16 @@ impl TemplateConfig<'_> {
                 })?;
         }
         self.add_hardcoded_templates()?;
+        if let Some(path) = filesystem_path {
+            self.env.set_loader(minijinja::path_loader(path));
+        } else {
+            self.env.set_loader(|name| {
+                Err(minijinja::Error::new(
+                    minijinja::ErrorKind::InvalidOperation,
+                    format!("Could not load template '{name}' - if this a dynamic template included from the filesystem, please set [gateway.enable_template_filesystem_access] to `true`")
+                ))
+            });
+        }
         Ok(())
     }
 
@@ -226,7 +241,7 @@ pub(crate) mod tests {
             "malformed_template".to_string(),
             malformed_template.to_string(),
         )]);
-        let result = template_config.initialize(template_paths);
+        let result = template_config.initialize(template_paths, None);
         assert!(result
             .unwrap_err()
             .to_string()
@@ -307,14 +322,14 @@ pub(crate) mod tests {
 
         // Initialize templates
         let mut template_config = TemplateConfig::new();
-        let _ = template_config.initialize(templates);
+        let _ = template_config.initialize(templates, None);
         template_config
     }
 
     #[test]
     fn test_hardcoded_best_of_n_evaluator_system() {
         let mut config = TemplateConfig::new();
-        config.initialize(HashMap::new()).unwrap();
+        config.initialize(HashMap::new(), None).unwrap();
 
         // 1. Test with inner_system_message and max_index = 3
         let context_with_message = json!({
@@ -378,7 +393,7 @@ In the "answer_choice" block: you should output the index of the best response."
     #[test]
     fn test_hardcoded_best_of_n_evaluator_candidates() {
         let mut config = TemplateConfig::new();
-        config.initialize(HashMap::new()).unwrap();
+        config.initialize(HashMap::new(), None).unwrap();
 
         // Provide a list of candidates.
         let context = json!({
@@ -417,7 +432,7 @@ Please evaluate these candidates and provide the index of the best one."#;
     #[test]
     fn test_hardcoded_mixture_of_n_fuser_system() {
         let mut config = TemplateConfig::new();
-        config.initialize(HashMap::new()).unwrap();
+        config.initialize(HashMap::new(), None).unwrap();
 
         // 1. With inner_system_message
         let context_with_message = json!({ "inner_system_message": "some system message" });
@@ -455,7 +470,7 @@ Your task is to synthesize these responses into a single, high-quality response.
     #[test]
     fn test_hardcoded_mixture_of_n_fuser_candidates() {
         let mut config = TemplateConfig::new();
-        config.initialize(HashMap::new()).unwrap();
+        config.initialize(HashMap::new(), None).unwrap();
 
         let context = json!({
             "candidates": [

--- a/tensorzero-internal/tests/e2e/extra_templates/foo.minijinja
+++ b/tensorzero-internal/tests/e2e/extra_templates/foo.minijinja
@@ -1,0 +1,1 @@
+assistant

--- a/tensorzero-internal/tests/e2e/inference.rs
+++ b/tensorzero-internal/tests/e2e/inference.rs
@@ -1765,7 +1765,6 @@ model = "dummy::good"
                         .to_string(),
                 })],
             }],
-            ..Default::default()
         },
         include_original_response: true,
         ..Default::default()

--- a/tensorzero-internal/tests/e2e/inference.rs
+++ b/tensorzero-internal/tests/e2e/inference.rs
@@ -1736,6 +1736,54 @@ async fn e2e_test_inference_original_response_stream() {
 }
 
 #[tokio::test]
+async fn test_gateway_template_no_fs_access() {
+    // We use an embedded client so that we can control the number of
+    // requests to the flaky judge.
+    let gateway = make_embedded_gateway_with_config(&format!(
+        r#"
+[functions.my_test]
+type = "chat"
+system_schema = "{root}/fixtures/config/functions/basic_test/system_schema.json"
+
+[functions.my_test.variants.my_variant]
+type = "chat_completion"
+system_template = "{root}/fixtures/config/functions/basic_test/prompt/system_template.minijinja"
+model = "dummy::good"
+    "#,
+        root = env!("CARGO_MANIFEST_DIR")
+    ))
+    .await;
+
+    let params = ClientInferenceParams {
+        function_name: Some("my_test".to_string()),
+        input: Input {
+            system: Some(serde_json::json!({"assistant_name": "AskJeeves"})),
+            messages: vec![InputMessage {
+                role: Role::User,
+                content: vec![InputMessageContent::Text(TextKind::Text {
+                    text: "Please write me a sentence about Megumin making an explosion."
+                        .to_string(),
+                })],
+            }],
+            ..Default::default()
+        },
+        include_original_response: true,
+        ..Default::default()
+    };
+
+    // Request should fail due to template trying to include from fs
+    let err = gateway
+        .inference(params.clone())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("Could not load template 'extra_templates/foo.minijinja' - if this a dynamic template included from the filesystem, please set [gateway.enable_template_filesystem_access] to `true`"),
+        "Unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
 async fn test_original_response_best_of_n_flaky_judge() {
     // We use an embedded client so that we can control the number of
     // requests to the flaky judge.

--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -9,6 +9,7 @@
 [gateway]
 bind_address = "0.0.0.0:3000"
 debug = true
+enable_template_filesystem_access = true
 
 [object_storage]
 type = "disabled"


### PR DESCRIPTION
When enabled, this registers a filesystem loader with minijinja. (rooted at the config file parent).
This setting is off by default - since minijinja allows using variables in '{% include %}', a misconfigured template could allow reading arbitrary file from within the config file tree.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `enable_template_filesystem_access` to control filesystem access for templates, with tests to ensure correct behavior.
> 
>   - **Configuration**:
>     - Adds `enable_template_filesystem_access` to `GatewayConfig` in `config_parser.rs`, defaulting to `false`.
>     - Updates `tensorzero.toml` to set `enable_template_filesystem_access` to `true` for E2E tests.
>   - **Template Loading**:
>     - Modifies `initialize()` in `minijinja_util.rs` to conditionally register a filesystem loader based on `enable_template_filesystem_access`.
>   - **Tests**:
>     - Adds `test_gateway_template_no_fs_access()` in `inference.rs` to verify behavior when filesystem access is disabled.
>     - Updates existing tests in `gateway_util.rs` and `minijinja_util.rs` to include `enable_template_filesystem_access` in configurations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 653bfae8570b0217c5141bc11abe56545f4bdb97. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->