### PR TITLE
Check security advisories with 'cargo deny' in CI

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -88,7 +88,7 @@ jobs:
           cargo hack clippy --all-targets --each-feature -- -D warnings
 
       - name: Run cargo-deny
-        run: cargo deny check bans
+        run: cargo deny check advisories bans
 
       - name: Test (Rust)
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
 
       - id: cargo-deny
         name: cargo deny
-        entry: cargo deny check bans
+        entry: cargo deny check advisories bans
         language: system
         types: [rust]
         pass_filenames: false

--- a/deny.toml
+++ b/deny.toml
@@ -3,4 +3,10 @@
 [bans]
 deny = [
     { name = "native-tls" },
+    { name = "openssl" },
+]
+
+[advisories]
+ignore = [
+    "RUSTSEC-2024-0436" # We don't care that 'paste' is unmaintained
 ]


### PR DESCRIPTION
I've ignored the 'crate is unmaintained' advisory for 'paste', since it's a relatively simple macro (and it's also a transitive dependency)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update CI and pre-commit to check security advisories with `cargo deny`, ignoring 'paste' crate advisory.
> 
>   - **CI Configuration**:
>     - Update `.github/workflows/general.yml` to run `cargo deny check advisories bans` instead of just `bans`.
>     - Update `.pre-commit-config.yaml` to use `cargo deny check advisories bans`.
>   - **Advisories**:
>     - Add `[advisories]` section in `deny.toml` to ignore advisory `RUSTSEC-2024-0436` for 'paste' crate.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1ed363fe84f7c4d2e0d1ec706f2e296f7accd38c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->