### PR TITLE
removed assertion over exact match value

### DIFF
--- a/evals/tests/tests.rs
+++ b/evals/tests/tests.rs
@@ -353,10 +353,11 @@ async fn run_llm_judge_eval_json_human_readable() {
     let err = run_eval(args, eval_run_id, &mut output).await.unwrap_err();
     let output_str = String::from_utf8(output).unwrap();
     assert!(output_str.contains("count_sports: 0.50 ± 0.20"));
-    assert!(output_str.contains("exact_match: 0.33 ± 0.19"));
+    // We don't assert the exact value here because it's not deterministic
+    assert!(output_str.contains("exact_match: "));
     let err = err.to_string();
     assert!(err.contains("Failed cutoffs for evaluators:"));
-    assert!(err.contains("exact_match (cutoff: 0.60, got: 0.33)"));
+    assert!(err.contains("exact_match (cutoff: 0.60, got: "));
 }
 
 #[tokio::test]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removed non-deterministic exact match value assertion in `run_llm_judge_eval_json_human_readable` test in `tests.rs`.
> 
>   - **Tests**:
>     - In `run_llm_judge_eval_json_human_readable` in `tests.rs`, removed assertion on exact match value due to non-determinism.
>     - Updated assertion to check for presence of "exact_match: " instead of specific value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4c09c514085d4287d814f9a57944dc5c7932acd1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->