### PR TITLE
added handling for dynamic validation of demonstrations and feedbacks

### DIFF
--- a/tensorzero-internal/src/endpoints/datasets.rs
+++ b/tensorzero-internal/src/endpoints/datasets.rs
@@ -344,7 +344,7 @@ pub async fn update_datapoint_handler(
             let json: SyntheticJsonInferenceDatapoint =
                 serde_json::from_value(params).map_err(|e| {
                     Error::new(ErrorDetails::InvalidRequest {
-                        message: format!("Failed to deserialize chat datapoint: {}", e),
+                        message: format!("Failed to deserialize JSON datapoint: {}", e),
                     })
                 })?;
             let resolved_input = json.input.clone().resolve(&fetch_context).await?;

--- a/tensorzero-internal/src/endpoints/datasets.rs
+++ b/tensorzero-internal/src/endpoints/datasets.rs
@@ -23,7 +23,9 @@ use crate::{
 use tracing::instrument;
 
 pub const CLICKHOUSE_DATETIME_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.6f";
-use super::feedback::{validate_parse_demonstration, DemonstrationOutput};
+use super::feedback::{
+    validate_parse_demonstration, DemonstrationOutput, DynamicDemonstrationInfo,
+};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -300,10 +302,18 @@ pub async fn update_datapoint_handler(
 
             let resolved_input = chat.input.clone().resolve(&fetch_context).await?;
             function_config.validate_input(&chat.input)?;
+            // If there are no tool params in the SyntheticChatInferenceDatapoint, we use the default tool params (empty tools).
+            // This is consistent with how they are serialized at inference time.
+            let dynamic_demonstration_info = DynamicDemonstrationInfo::Chat(
+                chat.tool_params
+                    .clone()
+                    .map(|x| x.into())
+                    .unwrap_or_default(),
+            );
             let validated_output = validate_parse_demonstration(
                 function_config,
-                &app_state.config.tools,
                 &chat.output,
+                dynamic_demonstration_info,
             )
             .await?;
 
@@ -339,10 +349,11 @@ pub async fn update_datapoint_handler(
                 })?;
             let resolved_input = json.input.clone().resolve(&fetch_context).await?;
             function_config.validate_input(&json.input)?;
+            let dynamic_demonstration_info = DynamicDemonstrationInfo::Json(json.output_schema);
             let validated_json = validate_parse_demonstration(
                 function_config,
-                &app_state.config.tools,
                 &json.output,
+                dynamic_demonstration_info,
             )
             .await?;
             let DemonstrationOutput::Json(json_out) = validated_json else {
@@ -638,6 +649,7 @@ pub struct SyntheticJsonInferenceDatapoint {
     pub function_name: String,
     pub input: Input,
     pub output: serde_json::Value,
+    pub output_schema: serde_json::Value,
     #[serde(default)]
     pub tags: Option<HashMap<String, String>>,
     #[serde(default)]

--- a/tensorzero-internal/src/endpoints/feedback.rs
+++ b/tensorzero-internal/src/endpoints/feedback.rs
@@ -1,6 +1,5 @@
 use std::cmp::max;
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::time::Duration;
 
 use axum::extract::State;
@@ -17,10 +16,12 @@ use crate::config_parser::{Config, MetricConfigLevel, MetricConfigType};
 use crate::error::{Error, ErrorDetails};
 use crate::function::FunctionConfig;
 use crate::gateway_util::{AppState, AppStateData, StructuredJson};
+use crate::inference::types::batch::deserialize_optional_json_string;
 use crate::inference::types::{
     parse_chat_output, ContentBlockChatOutput, ContentBlockOutput, Text,
 };
-use crate::tool::{DynamicToolParams, StaticToolConfig, ToolCall, ToolCallConfig};
+use crate::jsonschema_util::JSONSchemaFromPath;
+use crate::tool::{ToolCall, ToolCallConfig, ToolCallConfigDatabaseInsert};
 use crate::uuid_util::uuid_elapsed;
 
 use super::validate_tags;
@@ -286,7 +287,15 @@ async fn write_demonstration(
     )
     .await?;
     let function_config = config.get_function(&function_name)?;
-    let parsed_value = validate_parse_demonstration(function_config, &config.tools, value).await?;
+    let dynamic_demonstration_info = get_dynamic_demonstration_info(
+        &connection_info,
+        inference_id,
+        &function_name,
+        function_config,
+    )
+    .await?;
+    let parsed_value =
+        validate_parse_demonstration(function_config, value, dynamic_demonstration_info).await?;
     let string_value = serde_json::to_string(&parsed_value).map_err(|e| {
         Error::new(ErrorDetails::InvalidRequest {
             message: format!("Failed to serialize parsed value to json: {}", e),
@@ -511,11 +520,11 @@ pub enum DemonstrationOutput {
 // we construct the usual {"raw": str, "parsed": parsed_value} object, serialize it, and return it.
 pub async fn validate_parse_demonstration(
     function_config: &FunctionConfig,
-    tools: &HashMap<String, Arc<StaticToolConfig>>,
     value: &Value,
+    dynamic_demonstration_info: DynamicDemonstrationInfo,
 ) -> Result<DemonstrationOutput, Error> {
-    match function_config {
-        FunctionConfig::Chat(chat_config) => {
+    match (function_config, dynamic_demonstration_info) {
+        (FunctionConfig::Chat(_), DynamicDemonstrationInfo::Chat(tool_call_config)) => {
             // For chat functions, the value should either be a string or a list of valid content blocks.
             let content_blocks = match value {
                 Value::String(s) => {
@@ -543,24 +552,11 @@ pub async fn validate_parse_demonstration(
                     .into());
                 }
             };
-            let tool_config = ToolCallConfig::new(
-                &chat_config.tools,
-                &chat_config.tool_choice,
-                chat_config.parallel_tool_calls,
-                tools,
-                // TODO (#348): Eventually we should allow dynamic tools here as well.
-                DynamicToolParams {
-                    allowed_tools: None,
-                    additional_tools: None,
-                    tool_choice: None,
-                    parallel_tool_calls: None,
-                },
-            )?;
             let content_blocks: Vec<ContentBlockOutput> = content_blocks
                 .into_iter()
                 .map(|block| block.try_into())
                 .collect::<Result<Vec<ContentBlockOutput>, Error>>()?;
-            let parsed_value = parse_chat_output(content_blocks, tool_config.as_ref()).await;
+            let parsed_value = parse_chat_output(content_blocks, Some(&tool_call_config)).await;
             for block in &parsed_value {
                 if let ContentBlockChatOutput::ToolCall(tool_call) = block {
                     if tool_call.name.is_none() {
@@ -580,14 +576,18 @@ pub async fn validate_parse_demonstration(
             }
             Ok(DemonstrationOutput::Chat(parsed_value))
         }
-        FunctionConfig::Json(json_config) => {
+        (FunctionConfig::Json(_), DynamicDemonstrationInfo::Json(output_schema)) => {
             // For json functions, the value should be a valid json object.
-            // TODO (#348): Eventually we should allow dynamic output_schema here as well.
-            json_config.output_schema.validate(value).map_err(|e| {
-                Error::new(ErrorDetails::InvalidRequest {
-                    message: format!("Demonstration does not fit function output schema: {}", e),
-                })
-            })?;
+            JSONSchemaFromPath::from_value(&output_schema)?
+                .validate(value)
+                .map_err(|e| {
+                    Error::new(ErrorDetails::InvalidRequest {
+                        message: format!(
+                            "Demonstration does not fit function output schema: {}",
+                            e
+                        ),
+                    })
+                })?;
             let raw = serde_json::to_string(value).map_err(|e| {
                 Error::new(ErrorDetails::InvalidRequest {
                     message: format!("Failed to serialize demonstration to json: {}", e),
@@ -596,6 +596,98 @@ pub async fn validate_parse_demonstration(
             let json_inference_response = json!({"raw": raw, "parsed": value});
             Ok(DemonstrationOutput::Json(json_inference_response))
         }
+        _ => Err(ErrorDetails::Inference { message: "The DynamicDemonstrationInfo does not match the function type. This should never happen. Please file a bug report at https://github.com/tensorzero/tensorzero/discussions/new?category=bug-reports.".to_string()}.into())
+    }
+}
+
+/// Represents the different types of dynamic demonstration information that can be retrieved
+#[derive(Debug)]
+pub enum DynamicDemonstrationInfo {
+    Chat(ToolCallConfig),
+    Json(Value),
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolParamsResult {
+    #[serde(deserialize_with = "deserialize_optional_json_string")]
+    tool_params: Option<ToolCallConfigDatabaseInsert>,
+}
+
+/// In order to properly validate demonstration data we need to fetch the information that was
+/// passed to the inference at runtime.
+/// If we don't do this then we might allow some e.g. tool calls or output schemas that would not
+/// have been valid. Similarly, we might reject some tools or output schemas that were actually
+/// valid.
+/// This function grabs either the tool call or output schema information that was used at the
+/// time of the actual inference in order to validate the demonstration data.
+async fn get_dynamic_demonstration_info(
+    clickhouse_client: &ClickHouseConnectionInfo,
+    inference_id: Uuid,
+    function_name: &str,
+    function_config: &FunctionConfig,
+) -> Result<DynamicDemonstrationInfo, Error> {
+    match function_config {
+        FunctionConfig::Chat(..) => {
+            let parameterized_query = "SELECT tool_params FROM ChatInference WHERE function_name={function_name:String} and id={inference_id:String} FORMAT JSONEachRow".to_string();
+            let result = clickhouse_client
+                .run_query(
+                    parameterized_query,
+                    Some(&HashMap::from([
+                        ("function_name", function_name),
+                        ("inference_id", &inference_id.to_string()),
+                    ])),
+                )
+                .await?;
+
+            let tool_params_result =
+                serde_json::from_str::<ToolParamsResult>(&result).map_err(|e| {
+                    Error::new(ErrorDetails::ClickHouseQuery {
+                        message: format!("Failed to parse demonstration result: {}", e),
+                    })
+                })?;
+
+            Ok(DynamicDemonstrationInfo::Chat(
+                // If the tool params are not present in the database, we use the default tool params (empty tools).
+                // This is consistent with how they are serialized at inference time.
+                tool_params_result
+                    .tool_params
+                    .map(|x| x.into())
+                    .unwrap_or_default(),
+            ))
+        }
+        FunctionConfig::Json(..) => {
+            let parameterized_query = "SELECT output_schema FROM JsonInference WHERE function_name={function_name:String} and id={inference_id:String} FORMAT JSONEachRow".to_string();
+            let result = clickhouse_client
+                .run_query(
+                    parameterized_query,
+                    Some(&HashMap::from([
+                        ("function_name", function_name),
+                        ("inference_id", &inference_id.to_string()),
+                    ])),
+                )
+                .await?;
+            let result_value = serde_json::from_str::<Value>(&result).map_err(|e| {
+                Error::new(ErrorDetails::ClickHouseQuery {
+                    message: format!("Failed to parse demonstration result: {}", e),
+                })
+            })?;
+            let output_schema_str = result_value
+                .get("output_schema")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| {
+                    Error::new(ErrorDetails::ClickHouseQuery {
+                        message: "Failed to get output schema from demonstration result"
+                            .to_string(),
+                    })
+                })?;
+
+            let output_schema = serde_json::from_str::<Value>(output_schema_str).map_err(|e| {
+                Error::new(ErrorDetails::ClickHouseQuery {
+                    message: format!("Failed to parse output schema: {}", e),
+                })
+            })?;
+            Ok(DynamicDemonstrationInfo::Json(output_schema))
+        }
     }
 }
 
@@ -603,12 +695,13 @@ pub async fn validate_parse_demonstration(
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     use crate::config_parser::{Config, MetricConfig, MetricConfigOptimize};
     use crate::function::{FunctionConfigChat, FunctionConfigJson};
     use crate::jsonschema_util::JSONSchemaFromPath;
     use crate::testing::get_unit_test_app_state_data;
-    use crate::tool::{ToolCallOutput, ToolChoice};
+    use crate::tool::{StaticToolConfig, ToolCallOutput, ToolChoice, ToolConfig};
 
     #[tokio::test]
     async fn test_get_feedback_metadata() {
@@ -1000,10 +1093,19 @@ mod tests {
 
         // Case 1: a string passed to a chat function
         let value = json!("Hello, world!");
+        let dynamic_demonstration_info = DynamicDemonstrationInfo::Chat(ToolCallConfig {
+            tools_available: tools.values().cloned().map(ToolConfig::Static).collect(),
+            tool_choice: ToolChoice::Auto,
+            parallel_tool_calls: false,
+        });
         let parsed_value = serde_json::to_string(
-            &validate_parse_demonstration(function_config_chat_tools, &tools, &value)
-                .await
-                .unwrap(),
+            &validate_parse_demonstration(
+                function_config_chat_tools,
+                &value,
+                dynamic_demonstration_info,
+            )
+            .await
+            .unwrap(),
         )
         .unwrap();
         let expected_parsed_value = serde_json::to_string(&vec![ContentBlockOutput::Text(Text {
@@ -1015,10 +1117,19 @@ mod tests {
         // Case 2: a tool call to get_temperature, which exists
         let value = json!([{"type": "tool_call", "name": "get_temperature", "arguments": {"location": "London", "unit": "celsius"}}]
         );
+        let dynamic_demonstration_info = DynamicDemonstrationInfo::Chat(ToolCallConfig {
+            tools_available: tools.values().cloned().map(ToolConfig::Static).collect(),
+            tool_choice: ToolChoice::Auto,
+            parallel_tool_calls: false,
+        });
         let parsed_value = serde_json::to_string(
-            &validate_parse_demonstration(function_config_chat_tools, &tools, &value)
-                .await
-                .unwrap(),
+            &validate_parse_demonstration(
+                function_config_chat_tools,
+                &value,
+                dynamic_demonstration_info,
+            )
+            .await
+            .unwrap(),
         )
         .unwrap();
         let expected_parsed_value =
@@ -1038,9 +1149,18 @@ mod tests {
         // Case 3: a tool call to get_humidity, which does not exist
         let value = json!([{"type": "tool_call", "name": "get_humidity", "arguments": {"location": "London", "unit": "celsius"}}]
         );
-        let err = validate_parse_demonstration(function_config_chat_tools, &tools, &value)
-            .await
-            .unwrap_err();
+        let dynamic_demonstration_info = DynamicDemonstrationInfo::Chat(ToolCallConfig {
+            tools_available: tools.values().cloned().map(ToolConfig::Static).collect(),
+            tool_choice: ToolChoice::Auto,
+            parallel_tool_calls: false,
+        });
+        let err = validate_parse_demonstration(
+            function_config_chat_tools,
+            &value,
+            dynamic_demonstration_info,
+        )
+        .await
+        .unwrap_err();
         let details = err.get_owned_details();
         assert_eq!(
             details,
@@ -1052,9 +1172,18 @@ mod tests {
         // Case 4: a tool call to get_temperature, which exists but has bad arguments (place instead of location)
         let value = json!([{"type": "tool_call", "name": "get_temperature", "arguments": {"place": "London", "unit": "celsius"}}]
         );
-        let err = validate_parse_demonstration(function_config_chat_tools, &tools, &value)
-            .await
-            .unwrap_err();
+        let dynamic_demonstration_info = DynamicDemonstrationInfo::Chat(ToolCallConfig {
+            tools_available: tools.values().cloned().map(ToolConfig::Static).collect(),
+            tool_choice: ToolChoice::Auto,
+            parallel_tool_calls: false,
+        });
+        let err = validate_parse_demonstration(
+            function_config_chat_tools,
+            &value,
+            dynamic_demonstration_info,
+        )
+        .await
+        .unwrap_err();
         let details = err.get_owned_details();
         assert_eq!(
             details,
@@ -1080,13 +1209,12 @@ mod tests {
           "additionalProperties": false
         });
         let implicit_tool_call_config = ToolCallConfig::implicit_from_value(&output_schema);
-        let output_schema = JSONSchemaFromPath::from_value(&output_schema).unwrap();
         let function_config = Box::leak(Box::new(FunctionConfig::Json(FunctionConfigJson {
             variants: HashMap::new(),
             system_schema: None,
             user_schema: None,
             assistant_schema: None,
-            output_schema,
+            output_schema: JSONSchemaFromPath::from_value(&output_schema).unwrap(),
             implicit_tool_call_config,
         })));
 
@@ -1095,8 +1223,9 @@ mod tests {
             "name": "John",
             "age": 30
         });
+        let dynamic_demonstration_info = DynamicDemonstrationInfo::Json(output_schema.clone());
         let parsed_value = serde_json::to_string(
-            &validate_parse_demonstration(function_config, &tools, &value)
+            &validate_parse_demonstration(function_config, &value, dynamic_demonstration_info)
                 .await
                 .unwrap(),
         )
@@ -1107,11 +1236,53 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(expected_parsed_value, parsed_value);
-
         // Case 6: a JSON function with incorrect output
         let value = json!("Hello, world!");
-        validate_parse_demonstration(function_config, &tools, &value)
+        let dynamic_demonstration_info = DynamicDemonstrationInfo::Json(output_schema.clone());
+        let err = validate_parse_demonstration(function_config, &value, dynamic_demonstration_info)
             .await
             .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Demonstration does not fit function output schema"));
+
+        // Case 7: Mismatched function type - Chat function with JSON demonstration info
+        let value = json!("Hello, world!");
+        let dynamic_demonstration_info = DynamicDemonstrationInfo::Json(output_schema.clone());
+        let err = validate_parse_demonstration(
+            function_config_chat_tools,
+            &value,
+            dynamic_demonstration_info,
+        )
+        .await
+        .unwrap_err();
+        let details = err.get_owned_details();
+        assert_eq!(
+            details,
+            ErrorDetails::Inference {
+                message: "The DynamicDemonstrationInfo does not match the function type. This should never happen. Please file a bug report at https://github.com/tensorzero/tensorzero/discussions/new?category=bug-reports.".to_string()
+            }
+        );
+
+        // Case 8: Mismatched function type - JSON function with Chat demonstration info
+        let value = json!({
+            "name": "John",
+            "age": 30
+        });
+        let dynamic_demonstration_info = DynamicDemonstrationInfo::Chat(ToolCallConfig {
+            tools_available: tools.values().cloned().map(ToolConfig::Static).collect(),
+            tool_choice: ToolChoice::Auto,
+            parallel_tool_calls: false,
+        });
+        let err = validate_parse_demonstration(function_config, &value, dynamic_demonstration_info)
+            .await
+            .unwrap_err();
+        let details = err.get_owned_details();
+        assert_eq!(
+            details,
+            ErrorDetails::Inference {
+                message: "The DynamicDemonstrationInfo does not match the function type. This should never happen. Please file a bug report at https://github.com/tensorzero/tensorzero/discussions/new?category=bug-reports.".to_string()
+            }
+        );
     }
 }

--- a/tensorzero-internal/src/tool.rs
+++ b/tensorzero-internal/src/tool.rs
@@ -81,7 +81,7 @@ pub struct ToolCallConfig {
 
 /// ToolCallConfigDatabaseInsert is a lightweight version of ToolCallConfig that can be serialized and cloned.
 /// It is used to insert the ToolCallConfig into the database.
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ToolCallConfigDatabaseInsert {
     pub tools_available: Vec<Tool>,
     pub tool_choice: ToolChoice,

--- a/tensorzero-internal/tests/e2e/datasets.rs
+++ b/tensorzero-internal/tests/e2e/datasets.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use reqwest::{Client, StatusCode};
-use serde_json::Value;
+use serde_json::{json, Value};
 use tensorzero_internal::endpoints::datasets::CLICKHOUSE_DATETIME_FORMAT;
 use uuid::Uuid;
 
@@ -24,7 +24,7 @@ async fn test_datapoint_insert_synthetic_chat() {
         .put(get_gateway_endpoint(&format!(
             "/datasets/{dataset_name}/datapoints/{datapoint_id}",
         )))
-        .json(&serde_json::json!({
+        .json(&json!({
             "function_name": "basic_test",
             "input": {"system": {"assistant_name": "Dummy"}, "messages": [{"role": "user", "content": [{"type": "text", "value": "My synthetic input"}]}]},
             "output": [{"type": "text", "text": "My synthetic output"}],
@@ -73,7 +73,7 @@ async fn test_datapoint_insert_synthetic_chat() {
         "Unexpected updated_at: {updated_at:?}"
     );
 
-    let expected = serde_json::json!({
+    let expected = json!({
       "dataset_name": dataset_name,
       "function_name": "basic_test",
       "id": id.to_string(),
@@ -81,6 +81,197 @@ async fn test_datapoint_insert_synthetic_chat() {
       "input": "{\"system\":{\"assistant_name\":\"Dummy\"},\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"value\":\"My synthetic input\"}]}]}",
       "output": "[{\"type\":\"text\",\"text\":\"My synthetic output\"}]",
       "tool_params": "",
+      "tags": {},
+      "auxiliary": "",
+      "is_deleted": false
+    });
+    assert_eq!(datapoint, expected);
+}
+
+#[tokio::test]
+async fn test_datapoint_insert_synthetic_chat_with_tools() {
+    let clickhouse = get_clickhouse().await;
+    let client = Client::new();
+    let dataset_name = format!("test-dataset-{}", Uuid::now_v7());
+    let datapoint_id = Uuid::now_v7();
+
+    // Define the tool params once to avoid duplication
+    let tool_params = json!({
+        "tools_available": [
+            {
+                "description": "Get the current temperature in a given location",
+                "parameters": {
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "The location to get the temperature for (e.g. \"New York\")"
+                        },
+                        "units": {
+                            "type": "string",
+                            "description": "The units to get the temperature in (must be \"fahrenheit\" or \"celsius\")",
+                            "enum": ["fahrenheit", "celsius"]
+                        }
+                    },
+                    "required": ["location"],
+                    "additionalProperties": false
+                },
+                "name": "get_temperature",
+                "strict": false
+            }
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": false
+    });
+
+    let resp = client
+        .put(get_gateway_endpoint(&format!(
+            "/datasets/{dataset_name}/datapoints/{datapoint_id}",
+        )))
+        .json(&json!({
+            "function_name": "basic_test",
+            "input": {
+                "system": {"assistant_name": "Dummy"},
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "value": "My synthetic input"}
+                        ]
+                    }
+                ]
+            },
+            "output": [
+                {"type": "tool_call", "name": "get_humidity", "arguments": {"location": "New York", "units": "fahrenheit"}}
+            ],
+            "tool_params": tool_params,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let resp_json = resp.json::<Value>().await.unwrap();
+
+    // This should fail because the tool call is not in the tool_params
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let err_msg = resp_json.get("error").unwrap().as_str().unwrap();
+    println!("Error: {}", err_msg);
+    assert!(
+        err_msg.contains("Demonstration contains invalid tool name"),
+        "Unexpected error message: {err_msg}"
+    );
+
+    // Next we check invalid arguments
+    let resp = client
+        .put(get_gateway_endpoint(&format!(
+            "/datasets/{dataset_name}/datapoints/{datapoint_id}",
+        )))
+        .json(&json!({
+            "function_name": "basic_test",
+            "input": {
+                "system": {"assistant_name": "Dummy"},
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "value": "My synthetic input"}
+                        ]
+                    }
+                ]
+            },
+            "output": [
+                {"type": "tool_call", "name": "get_temperature", "arguments": {"city": "New York", "units": "fahrenheit"}}
+            ],
+            "tool_params": tool_params,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let resp_json = resp.json::<Value>().await.unwrap();
+
+    // This request is correct
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let err_msg = resp_json.get("error").unwrap().as_str().unwrap();
+    println!("Error: {}", err_msg);
+    assert!(
+        err_msg.contains("Demonstration contains invalid tool call arguments"),
+        "Unexpected error message: {err_msg}"
+    );
+
+    let resp = client
+    .put(get_gateway_endpoint(&format!(
+        "/datasets/{dataset_name}/datapoints/{datapoint_id}",
+    )))
+    .json(&json!({
+        "function_name": "basic_test",
+        "input": {
+            "system": {"assistant_name": "Dummy"},
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "value": "My synthetic input"}
+                    ]
+                }
+            ]
+        },
+        "output": [
+            {"type": "tool_call", "name": "get_temperature", "arguments": {"location": "New York", "units": "fahrenheit"}}
+        ],
+        "tool_params": tool_params,
+    }))
+    .send()
+    .await
+    .unwrap();
+
+    let status = resp.status();
+    assert!(status.is_success());
+    let resp_json = resp.json::<Value>().await.unwrap();
+
+    let id: Uuid = resp_json
+        .get("id")
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+
+    assert_eq!(id, datapoint_id);
+
+    let mut datapoint = select_chat_datapoint_clickhouse(&clickhouse, id)
+        .await
+        .unwrap();
+
+    let updated_at = datapoint
+        .as_object_mut()
+        .unwrap()
+        .remove("updated_at")
+        .unwrap();
+    let updated_at = chrono::NaiveDateTime::parse_from_str(
+        updated_at.as_str().unwrap(),
+        CLICKHOUSE_DATETIME_FORMAT,
+    )
+    .unwrap()
+    .and_utc();
+    assert!(
+        chrono::Utc::now()
+            .signed_duration_since(updated_at)
+            .num_seconds()
+            < 5,
+        "Unexpected updated_at: {updated_at:?}"
+    );
+    let expected = json!({
+      "dataset_name": dataset_name,
+      "function_name": "basic_test",
+      "id": id.to_string(),
+      "episode_id": null,
+      "input": "{\"system\":{\"assistant_name\":\"Dummy\"},\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"value\":\"My synthetic input\"}]}]}",
+      "output": "[{\"type\":\"tool_call\",\"arguments\":{\"location\":\"New York\",\"units\":\"fahrenheit\"},\"id\":\"\",\"name\":\"get_temperature\",\"raw_arguments\":\"{\\\"location\\\":\\\"New York\\\",\\\"units\\\":\\\"fahrenheit\\\"}\",\"raw_name\":\"get_temperature\"}]",
+      "tool_params": "{\"tools_available\":[{\"description\":\"Get the current temperature in a given location\",\"parameters\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"The location to get the temperature for (e.g. \\\"New York\\\")\"},\"units\":{\"type\":\"string\",\"description\":\"The units to get the temperature in (must be \\\"fahrenheit\\\" or \\\"celsius\\\")\",\"enum\":[\"fahrenheit\",\"celsius\"]}},\"required\":[\"location\"],\"additionalProperties\":false},\"name\":\"get_temperature\",\"strict\":false}],\"tool_choice\":\"auto\",\"parallel_tool_calls\":false}",
       "tags": {},
       "auxiliary": "",
       "is_deleted": false
@@ -99,10 +290,11 @@ async fn test_datapoint_insert_synthetic_json() {
         .put(get_gateway_endpoint(&format!(
             "/datasets/{dataset_name}/datapoints/{datapoint_id}",
         )))
-        .json(&serde_json::json!({
+        .json(&json!({
             "function_name": "json_success",
             "input": {"system": {"assistant_name": "Dummy"}, "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "US"}}]}]},
             "output": {"answer": "Hello"},
+            "output_schema": {},
         }))
         .send()
         .await
@@ -122,6 +314,7 @@ async fn test_datapoint_insert_synthetic_json() {
         .unwrap()
         .parse()
         .unwrap();
+    assert_eq!(id, datapoint_id);
 
     let mut datapoint = select_json_datapoint_clickhouse(&clickhouse, id)
         .await
@@ -146,7 +339,7 @@ async fn test_datapoint_insert_synthetic_json() {
         "Unexpected updated_at: {updated_at:?}"
     );
 
-    let expected = serde_json::json!({
+    let expected = json!({
       "dataset_name": dataset_name,
       "function_name": "json_success",
       "id": id,
@@ -161,17 +354,52 @@ async fn test_datapoint_insert_synthetic_json() {
     assert_eq!(datapoint, expected);
 
     // Sleep to ensure that we get a different `updated_at` timestamp
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::time::sleep(Duration::from_millis(1500)).await;
 
     // Now, update the existing datapoint and verify that it changes in clickhouse
+    // Test updating with a different output schema (this should fail)
     let new_resp = client
     .put(get_gateway_endpoint(&format!(
         "/datasets/{dataset_name}/datapoints/{datapoint_id}",
     )))
-    .json(&serde_json::json!({
+    .json(&json!({
         "function_name": "json_success",
         "input": {"system": {"assistant_name": "Dummy"}, "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "US"}}]}]},
         "output": {"answer": "New answer"},
+        "output_schema": {"type": "object", "properties": {"confidence": {"type": "number"}}, "required": ["confidence"]},
+    }))
+    .send()
+    .await
+    .unwrap();
+    assert_eq!(new_resp.status(), StatusCode::BAD_REQUEST);
+    let resp_json = new_resp.json::<Value>().await.unwrap();
+    let err_msg = resp_json.get("error").unwrap().as_str().unwrap();
+    assert!(
+        err_msg.contains("Demonstration does not fit function output schema"),
+        "Unexpected error message: {err_msg}"
+    );
+    assert!(
+        err_msg.contains("\"confidence\" is a required property"),
+        "Error should mention the missing required property: {err_msg}"
+    );
+
+    // Now try with the correct schema
+    let new_resp = client
+    .put(get_gateway_endpoint(&format!(
+        "/datasets/{dataset_name}/datapoints/{datapoint_id}",
+    )))
+    .json(&json!({
+        "function_name": "json_success",
+        "input": {"system": {"assistant_name": "Dummy"}, "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "US"}}]}]},
+        "output": {"answer": "New answer"},
+        "output_schema": {
+            "type": "object",
+            "properties": {
+                "answer": {"type": "string"}
+            },
+            "required": ["answer"],
+            "additionalProperties": false
+        },
     }))
     .send()
     .await
@@ -217,7 +445,7 @@ async fn test_datapoint_insert_synthetic_json() {
         "Expected updated_at to change: new_updated_at={new_updated_at:?} updated_at={updated_at:?}"
     );
 
-    let expected = serde_json::json!({
+    let expected = json!({
       "dataset_name": dataset_name,
       "function_name": "json_success",
       "id": id,
@@ -242,10 +470,11 @@ async fn test_datapoint_insert_invalid_input_synthetic_json() {
         .put(get_gateway_endpoint(&format!(
             "/datasets/{dataset_name}/datapoints/{datapoint_id}",
         )))
-        .json(&serde_json::json!({
+        .json(&json!({
             "function_name": "json_success",
             "input": {"system": {"assistant_name": "Ferris"}, "messages": [{"role": "user", "content": [{"type": "text", "value": "My synthetic input"}]}]},
             "output": "Not a json object",
+            "output_schema": {},
         }))
         .send()
         .await
@@ -276,7 +505,7 @@ async fn test_datapoint_insert_invalid_input_synthetic_chat() {
         .put(get_gateway_endpoint(&format!(
             "/datasets/{dataset_name}/datapoints/{datapoint_id}",
         )))
-        .json(&serde_json::json!({
+        .json(&json!({
             "function_name": "variant_failover",
             "input": {"system": {"assistant_name": "Ferris"}, "messages": [{"role": "user", "content": [{"type": "text", "value": "My synthetic input"}]}]},
             "output": "Not a json object",
@@ -310,10 +539,11 @@ async fn test_datapoint_insert_invalid_output_synthetic_json() {
         .put(get_gateway_endpoint(&format!(
             "/datasets/{dataset_name}/datapoints/{datapoint_id}",
         )))
-        .json(&serde_json::json!({
+        .json(&json!({
             "function_name": "json_success",
             "input": {"system": {"assistant_name": "Ferris"}, "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "US"}}]}]},
             "output": "Not a json object",
+            "output_schema": {"type": "object", "properties": {"answer": {"type": "string"}}, "required": ["answer"]},
         }))
         .send()
         .await
@@ -348,7 +578,7 @@ async fn test_datapoint_insert_synthetic_bad_uuid() {
         .put(get_gateway_endpoint(&format!(
             "/datasets/{dataset_name}/datapoints/{datapoint_uuid_v4}",
         )))
-        .json(&serde_json::json!({
+        .json(&json!({
             "function_name": "basic_test",
         }))
         .send()
@@ -360,7 +590,7 @@ async fn test_datapoint_insert_synthetic_bad_uuid() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(
         resp_json,
-        serde_json::json!({
+        json!({
             "error": "Invalid Datapoint ID: Version must be 7, got 4",
         })
     );
@@ -376,7 +606,7 @@ async fn test_datapoint_insert_synthetic_bad_params() {
         .put(get_gateway_endpoint(&format!(
             "/datasets/{dataset_name}/datapoints/{datapoint_id}",
         )))
-        .json(&serde_json::json!({
+        .json(&json!({
             "function_name": "basic_test",
         }))
         .send()
@@ -388,7 +618,7 @@ async fn test_datapoint_insert_synthetic_bad_params() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(
         resp_json,
-        serde_json::json!({
+        json!({
             "error": "Failed to deserialize chat datapoint: missing field `input`",
         })
     );
@@ -399,7 +629,7 @@ async fn test_datapoint_insert_output_inherit_chat() {
     let clickhouse = get_clickhouse().await;
     let client = Client::new();
     // Run inference (standard, no dryrun) to get an episode_id.
-    let inference_payload = serde_json::json!({
+    let inference_payload = json!({
         "function_name": "basic_test",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
@@ -427,7 +657,7 @@ async fn test_datapoint_insert_output_inherit_chat() {
         .post(get_gateway_endpoint(&format!(
             "/datasets/{dataset_name}/datapoints"
         )))
-        .json(&serde_json::json!({
+        .json(&json!({
             "inference_id": inference_id,
             "output": "inherit"
         }))
@@ -465,7 +695,7 @@ async fn test_datapoint_insert_output_inherit_chat() {
         "Unexpected updated_at: {updated_at:?}"
     );
 
-    let expected = serde_json::json!({
+    let expected = json!({
       "dataset_name": dataset_name,
       "function_name": "basic_test",
       "id": datapoint_id.to_string(),
@@ -520,7 +750,7 @@ async fn test_datapoint_insert_output_inherit_chat() {
         "Unexpected updated_at: {new_updated_at:?}"
     );
 
-    let expected = serde_json::json!({
+    let expected = json!({
       "dataset_name": dataset_name,
       "function_name": "basic_test",
       "id": datapoint_id.to_string(),
@@ -561,7 +791,7 @@ async fn test_bad_delete_datapoint() {
     );
     assert_eq!(
         resp,
-        serde_json::json!({
+        json!({
             "error": format!("Datapoint not found with params DeletePathParams {{ dataset: \"missing\", function: \"basic_test\", kind: Chat, id: {id} }}")
         })
     );
@@ -572,7 +802,7 @@ async fn test_datapoint_insert_output_none_chat() {
     let clickhouse = get_clickhouse().await;
     let client = Client::new();
     // Run inference (standard, no dryrun) to get an episode_id.
-    let inference_payload = serde_json::json!({
+    let inference_payload = json!({
         "function_name": "basic_test",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
@@ -600,7 +830,7 @@ async fn test_datapoint_insert_output_none_chat() {
         .post(get_gateway_endpoint(&format!(
             "/datasets/{dataset_name}/datapoints"
         )))
-        .json(&serde_json::json!({
+        .json(&json!({
             "inference_id": inference_id,
             "output": "none"
         }))
@@ -639,7 +869,7 @@ async fn test_datapoint_insert_output_none_chat() {
         "Unexpected updated_at: {updated_at:?}"
     );
 
-    let expected = serde_json::json!({
+    let expected = json!({
       "dataset_name": dataset_name,
       "function_name": "basic_test",
       "id": datapoint_id.to_string(),
@@ -659,7 +889,7 @@ async fn test_datapoint_insert_output_demonstration_chat() {
     let clickhouse = get_clickhouse().await;
     let client = Client::new();
     // Run inference (standard, no dryrun) to get an episode_id.
-    let inference_payload = serde_json::json!({
+    let inference_payload = json!({
         "function_name": "basic_test",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
@@ -685,7 +915,7 @@ async fn test_datapoint_insert_output_demonstration_chat() {
 
     let response = client
         .post(get_gateway_endpoint("/feedback"))
-        .json(&serde_json::json!({
+        .json(&json!({
             "inference_id": inference_id,
             "metric_name": "demonstration",
             "value": [{"type": "text", "text": "My demonstration chat answer"}],
@@ -704,7 +934,7 @@ async fn test_datapoint_insert_output_demonstration_chat() {
         .post(get_gateway_endpoint(&format!(
             "/datasets/{dataset_name}/datapoints"
         )))
-        .json(&serde_json::json!({
+        .json(&json!({
             "inference_id": inference_id,
             "output": "demonstration"
         }))
@@ -747,7 +977,7 @@ async fn test_datapoint_insert_output_demonstration_chat() {
         serde_json::to_string_pretty(&datapoint).unwrap()
     );
 
-    let expected = serde_json::json!({
+    let expected = json!({
       "dataset_name": dataset_name,
       "function_name": "basic_test",
       "id": datapoint_id.to_string(),
@@ -767,7 +997,7 @@ async fn test_datapoint_insert_output_inherit_json() {
     let clickhouse = get_clickhouse().await;
     let client = Client::new();
     // Run inference (standard, no dryrun) to get an episode_id.
-    let inference_payload = serde_json::json!({
+    let inference_payload = json!({
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
@@ -795,7 +1025,7 @@ async fn test_datapoint_insert_output_inherit_json() {
         .post(get_gateway_endpoint(&format!(
             "/datasets/{dataset_name}/datapoints"
         )))
-        .json(&serde_json::json!({
+        .json(&json!({
             "inference_id": inference_id,
             "output": "inherit"
         }))
@@ -833,7 +1063,7 @@ async fn test_datapoint_insert_output_inherit_json() {
         "Unexpected updated_at: {updated_at:?}"
     );
 
-    let expected = serde_json::json!({
+    let expected = json!({
       "dataset_name": dataset_name,
       "function_name": "json_success",
       "id": datapoint_id.to_string(),
@@ -888,7 +1118,7 @@ async fn test_datapoint_insert_output_inherit_json() {
         "Unexpected updated_at: {new_updated_at:?}"
     );
 
-    let expected = serde_json::json!({
+    let expected = json!({
       "dataset_name": dataset_name,
       "function_name": "json_success",
       "id": datapoint_id,
@@ -917,7 +1147,7 @@ async fn test_datapoint_insert_output_none_json() {
     let clickhouse = get_clickhouse().await;
     let client = Client::new();
     // Run inference (standard, no dryrun) to get an episode_id.
-    let inference_payload = serde_json::json!({
+    let inference_payload = json!({
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
@@ -945,7 +1175,7 @@ async fn test_datapoint_insert_output_none_json() {
         .post(get_gateway_endpoint(&format!(
             "/datasets/{dataset_name}/datapoints"
         )))
-        .json(&serde_json::json!({
+        .json(&json!({
             "inference_id": inference_id,
             "output": "none"
         }))
@@ -983,7 +1213,7 @@ async fn test_datapoint_insert_output_none_json() {
         "Unexpected updated_at: {updated_at:?}"
     );
 
-    let expected = serde_json::json!({
+    let expected = json!({
       "dataset_name": dataset_name,
       "function_name": "json_success",
       "id": datapoint_id.to_string(),
@@ -1003,7 +1233,7 @@ async fn test_datapoint_insert_output_demonstration_json() {
     let clickhouse = get_clickhouse().await;
     let client = Client::new();
     // Run inference (standard, no dryrun) to get an episode_id.
-    let inference_payload = serde_json::json!({
+    let inference_payload = json!({
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
@@ -1029,7 +1259,7 @@ async fn test_datapoint_insert_output_demonstration_json() {
 
     let response = client
         .post(get_gateway_endpoint("/feedback"))
-        .json(&serde_json::json!({
+        .json(&json!({
             "inference_id": inference_id,
             "metric_name": "demonstration",
             "value": {"answer": "My demonstration answer"},
@@ -1048,7 +1278,7 @@ async fn test_datapoint_insert_output_demonstration_json() {
         .post(get_gateway_endpoint(&format!(
             "/datasets/{dataset_name}/datapoints"
         )))
-        .json(&serde_json::json!({
+        .json(&json!({
             "inference_id": inference_id,
             "output": "demonstration"
         }))
@@ -1091,7 +1321,7 @@ async fn test_datapoint_insert_output_demonstration_json() {
         serde_json::to_string_pretty(&datapoint).unwrap()
     );
 
-    let expected = serde_json::json!({
+    let expected = json!({
       "dataset_name": dataset_name,
       "function_name": "json_success",
       "id": datapoint_id.to_string(),
@@ -1112,7 +1342,7 @@ async fn test_missing_inference_id() {
     let fake_inference_id = Uuid::now_v7();
     let resp = client
         .post(get_gateway_endpoint("/datasets/dummy-dataset/datapoints"))
-        .json(&serde_json::json!({
+        .json(&json!({
             "inference_id": fake_inference_id,
             "output": "inherit"
         }))
@@ -1132,7 +1362,7 @@ async fn test_missing_inference_id() {
 async fn test_datapoint_missing_demonstration() {
     let client = Client::new();
     // Run inference (standard, no dryrun) to get an episode_id.
-    let inference_payload = serde_json::json!({
+    let inference_payload = json!({
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
@@ -1158,7 +1388,7 @@ async fn test_datapoint_missing_demonstration() {
         .post(get_gateway_endpoint(&format!(
             "/datasets/{dataset_name}/datapoints"
         )))
-        .json(&serde_json::json!({
+        .json(&json!({
             "inference_id": inference_id,
             "output": "demonstration"
         }))
@@ -1175,3 +1405,165 @@ async fn test_datapoint_missing_demonstration() {
         "Unexpected response: {body}"
     );
 }
+
+/*
+#[tokio::test]
+async fn e2e_test_demonstration_feedback_dynamic_tool() {
+    let client = Client::new();
+
+    // Run inference (standard, no dryrun) to get an inference_id
+    let inference_payload = json!({
+        "function_name": "weather_helper",
+        "input": {
+            "system": {"assistant_name": "Alfred Pennyworth"},
+            "messages": [{"role": "user", "content": "What is the weather in Tokyo?"}]
+        },
+        "stream": false,
+        "additional_tools": [
+            {
+                "name": "get_humidity",
+                "description": "Get the current humidity in a given location",
+                "parameters": json!({
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string"}
+                    },
+                    "required": ["location"],
+                    "additionalProperties": false
+                })
+            }
+        ]
+    });
+
+    let response = client
+        .post(get_gateway_endpoint("/inference"))
+        .json(&inference_payload)
+        .send()
+        .await
+        .unwrap();
+
+    assert!(response.status().is_success());
+    let response_json = response.json::<Value>().await.unwrap();
+    let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
+    let inference_id = Uuid::parse_str(inference_id).unwrap();
+
+    // No sleeping, we should throttle in the gateway
+    // Test demonstration feedback on Inference (string shortcut)
+    let payload = json!({
+        "inference_id": inference_id,
+        "metric_name": "demonstration",
+        "value": "sunny",
+    });
+    let response = client
+        .post(get_gateway_endpoint("/feedback"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_json = response.json::<Value>().await.unwrap();
+    let feedback_id = response_json.get("feedback_id").unwrap();
+    assert!(feedback_id.is_string());
+    let feedback_id = Uuid::parse_str(feedback_id.as_str().unwrap()).unwrap();
+    sleep(Duration::from_millis(200)).await;
+
+    // Check ClickHouse
+    let clickhouse = get_clickhouse().await;
+    let result = select_feedback_clickhouse(&clickhouse, "DemonstrationFeedback", feedback_id)
+        .await
+        .unwrap();
+    let id = result.get("id").unwrap().as_str().unwrap();
+    let id_uuid = Uuid::parse_str(id).unwrap();
+    assert_eq!(id_uuid, feedback_id);
+    let retrieved_inference_id = result.get("inference_id").unwrap().as_str().unwrap();
+    let retrieved_inference_id_uuid = Uuid::parse_str(retrieved_inference_id).unwrap();
+    assert_eq!(retrieved_inference_id_uuid, inference_id);
+    let retrieved_value = result.get("value").unwrap().as_str().unwrap();
+    let expected_value =
+        serde_json::to_string(&json!([{"type": "text", "text": "sunny" }])).unwrap();
+    assert_eq!(retrieved_value, expected_value);
+
+    // Try it for an episode (should 400)
+    let episode_id = Uuid::now_v7();
+    let payload =
+        json!({"episode_id": episode_id, "metric_name": "demonstration", "value": "do this!"});
+    let response = client
+        .post(get_gateway_endpoint("/feedback"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_json = response.json::<Value>().await.unwrap();
+    let message = response_json.get("error").unwrap().as_str().unwrap();
+    assert_eq!(
+        message,
+        "Correct ID was not provided for feedback level \"inference\"."
+    );
+
+    // Try a tool call demonstration
+    // This should fail because the name is incorrect
+    let tool_call = json!({"type": "tool_call", "name": "tool_name", "arguments": "tool_input"});
+    let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
+    let response = client
+        .post(get_gateway_endpoint("/feedback"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_json = response.json::<Value>().await.unwrap();
+    let error_message = response_json.get("error").unwrap().as_str().unwrap();
+    assert_eq!(error_message, "Demonstration contains invalid tool name");
+
+    // Try a tool call demonstration with the dynamic tool name and incorrect args
+    let tool_call = json!({"type": "tool_call", "name": "get_humidity", "arguments": "tool_input"});
+    let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
+    let response = client
+        .post(get_gateway_endpoint("/feedback"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_json = response.json::<Value>().await.unwrap();
+    let error_message = response_json.get("error").unwrap().as_str().unwrap();
+    assert_eq!(
+        error_message,
+        "Demonstration contains invalid tool call arguments"
+    );
+
+    // Try a tool call demonstration with the dynamic tool name and correct args
+    let tool_call =
+        json!({"type": "tool_call", "name": "get_humidity", "arguments": {"location": "Tokyo"}});
+    let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
+    let response = client
+        .post(get_gateway_endpoint("/feedback"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    let response_json = response.json::<Value>().await.unwrap();
+    let feedback_id = response_json.get("feedback_id").unwrap();
+    assert!(feedback_id.is_string());
+    let feedback_id = Uuid::parse_str(feedback_id.as_str().unwrap()).unwrap();
+    sleep(Duration::from_millis(200)).await;
+
+    // Check ClickHouse
+    let clickhouse = get_clickhouse().await;
+    let result = select_feedback_clickhouse(&clickhouse, "DemonstrationFeedback", feedback_id)
+        .await
+        .unwrap();
+    let id = result.get("id").unwrap().as_str().unwrap();
+    let id_uuid = Uuid::parse_str(id).unwrap();
+    assert_eq!(id_uuid, feedback_id);
+    let retrieved_inference_id = result.get("inference_id").unwrap().as_str().unwrap();
+    let retrieved_inference_id_uuid = Uuid::parse_str(retrieved_inference_id).unwrap();
+    assert_eq!(retrieved_inference_id_uuid, inference_id);
+    let retrieved_value = result.get("value").unwrap().as_str().unwrap();
+    let retrieved_value = serde_json::from_str::<Value>(retrieved_value).unwrap();
+    let expected_value = json!([{"type": "tool_call", "name": "get_humidity", "arguments": {"location": "Tokyo"}, "raw_name": "get_humidity", "raw_arguments": "{\"location\":\"Tokyo\"}", "id": "" }]);
+    assert_eq!(retrieved_value, expected_value);
+}
+*/

--- a/tensorzero-internal/tests/e2e/feedback.rs
+++ b/tensorzero-internal/tests/e2e/feedback.rs
@@ -410,6 +410,145 @@ async fn e2e_test_demonstration_feedback_json() {
 }
 
 #[tokio::test]
+async fn e2e_test_demonstration_feedback_dynamic_json() {
+    let client = Client::new();
+    // Running without valid inference_id. Should fail.
+    let inference_id = Uuid::now_v7();
+    let payload = json!({
+        "inference_id": inference_id,
+        "metric_name": "demonstration",
+        "value": {"answer": "Tokyo"}
+    });
+    let response = client
+        .post(get_gateway_endpoint("/feedback"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    // Run inference (standard, no dryrun) to get an inference_id
+    let new_output_schema = json!({
+        "type": "object",
+        "properties": {
+            "answer": {
+                "type": "string"
+            },
+            "comment": {
+                "type": "string",
+            }
+        },
+        "required": ["answer"],
+        "additionalProperties": false
+    });
+    let inference_payload = serde_json::json!({
+        "function_name": "json_success",
+        "input": {
+            "system": {"assistant_name": "Alfred Pennyworth"},
+            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+        },
+        "stream": false,
+        "output_schema": new_output_schema,
+    });
+
+    let response = client
+        .post(get_gateway_endpoint("/inference"))
+        .json(&inference_payload)
+        .send()
+        .await
+        .unwrap();
+
+    assert!(response.status().is_success());
+    let response_json = response.json::<Value>().await.unwrap();
+    let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
+    let inference_id = Uuid::parse_str(inference_id).unwrap();
+
+    // No sleeping, we should throttle in the gateway
+    // Test demonstration feedback on an inference that requires the dynamic output schema
+    let payload = json!({
+        "inference_id": inference_id,
+        "metric_name": "demonstration",
+        "value": {"answer": "Tokyo", "comment": "This is a comment"}
+    });
+    let response = client
+        .post(get_gateway_endpoint("/feedback"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_json = response.json::<Value>().await.unwrap();
+    let feedback_id = response_json.get("feedback_id").unwrap();
+    assert!(feedback_id.is_string());
+    let feedback_id = Uuid::parse_str(feedback_id.as_str().unwrap()).unwrap();
+    sleep(Duration::from_millis(200)).await;
+
+    // Check ClickHouse
+    let clickhouse = get_clickhouse().await;
+    let result = select_feedback_clickhouse(&clickhouse, "DemonstrationFeedback", feedback_id)
+        .await
+        .unwrap();
+    let id = result.get("id").unwrap().as_str().unwrap();
+    let id_uuid = Uuid::parse_str(id).unwrap();
+    assert_eq!(id_uuid, feedback_id);
+    let retrieved_inference_id = result.get("inference_id").unwrap().as_str().unwrap();
+    let retrieved_inference_id_uuid = Uuid::parse_str(retrieved_inference_id).unwrap();
+    assert_eq!(retrieved_inference_id_uuid, inference_id);
+    let retrieved_value = result.get("value").unwrap().as_str().unwrap();
+    let retrieved_value = serde_json::from_str::<JsonInferenceOutput>(retrieved_value).unwrap();
+    let expected_value = JsonInferenceOutput {
+        parsed: Some(json!({"answer": "Tokyo", "comment": "This is a comment"})),
+        raw: "{\"answer\":\"Tokyo\",\"comment\":\"This is a comment\"}".to_string(),
+    };
+    assert_eq!(retrieved_value, expected_value);
+
+    // Try it for an episode (should 400)
+    let episode_id = Uuid::now_v7();
+    let payload =
+        json!({"episode_id": episode_id, "metric_name": "demonstration", "value": "do this!"});
+    let response = client
+        .post(get_gateway_endpoint("/feedback"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_json = response.json::<Value>().await.unwrap();
+    let message = response_json.get("error").unwrap().as_str().unwrap();
+    assert_eq!(
+        message,
+        "Correct ID was not provided for feedback level \"inference\"."
+    );
+
+    // Try a tool call demonstration
+    // This should fail because the inference was made for a function that doesn't support tool calls
+    let tool_call = json!({"type": "tool_call", "name": "tool_name", "arguments": "tool_input"});
+    let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
+    let response = client
+        .post(get_gateway_endpoint("/feedback"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_json = response.json::<Value>().await.unwrap();
+    let error_message = response_json.get("error").unwrap().as_str().unwrap();
+    assert!(error_message.starts_with("Demonstration does not fit function output schema:"));
+
+    // Try a demonstration with a value that doesn't match the output schema
+    let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": {"bad_key": "Tokyo"}});
+    let response = client
+        .post(get_gateway_endpoint("/feedback"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_json = response.json::<Value>().await.unwrap();
+    let error_message = response_json.get("error").unwrap().as_str().unwrap();
+    assert!(error_message.starts_with("Demonstration does not fit function output schema:"));
+}
+
+#[tokio::test]
 async fn e2e_test_demonstration_feedback_tool() {
     // Running without valid inference_id. Should fail.
     let client = Client::new();
@@ -564,6 +703,166 @@ async fn e2e_test_demonstration_feedback_tool() {
     let retrieved_value = result.get("value").unwrap().as_str().unwrap();
     let retrieved_value = serde_json::from_str::<Value>(retrieved_value).unwrap();
     let expected_value = json!([{"type": "tool_call", "name": "get_temperature", "arguments": {"location": "Tokyo", "units": "celsius"}, "raw_name": "get_temperature", "raw_arguments": "{\"location\":\"Tokyo\",\"units\":\"celsius\"}", "id": "" }]);
+    assert_eq!(retrieved_value, expected_value);
+}
+
+#[tokio::test]
+async fn e2e_test_demonstration_feedback_dynamic_tool() {
+    let client = Client::new();
+
+    // Run inference (standard, no dryrun) to get an inference_id
+    let inference_payload = serde_json::json!({
+        "function_name": "weather_helper",
+        "input": {
+            "system": {"assistant_name": "Alfred Pennyworth"},
+            "messages": [{"role": "user", "content": "What is the weather in Tokyo?"}]
+        },
+        "stream": false,
+        "additional_tools": [
+            {
+                "name": "get_humidity",
+                "description": "Get the current humidity in a given location",
+                "parameters": json!({
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string"}
+                    },
+                    "required": ["location"],
+                    "additionalProperties": false
+                })
+            }
+        ]
+    });
+
+    let response = client
+        .post(get_gateway_endpoint("/inference"))
+        .json(&inference_payload)
+        .send()
+        .await
+        .unwrap();
+
+    assert!(response.status().is_success());
+    let response_json = response.json::<Value>().await.unwrap();
+    let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
+    let inference_id = Uuid::parse_str(inference_id).unwrap();
+
+    // No sleeping, we should throttle in the gateway
+    // Test demonstration feedback on Inference (string shortcut)
+    let payload = json!({
+        "inference_id": inference_id,
+        "metric_name": "demonstration",
+        "value": "sunny",
+    });
+    let response = client
+        .post(get_gateway_endpoint("/feedback"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_json = response.json::<Value>().await.unwrap();
+    let feedback_id = response_json.get("feedback_id").unwrap();
+    assert!(feedback_id.is_string());
+    let feedback_id = Uuid::parse_str(feedback_id.as_str().unwrap()).unwrap();
+    sleep(Duration::from_millis(200)).await;
+
+    // Check ClickHouse
+    let clickhouse = get_clickhouse().await;
+    let result = select_feedback_clickhouse(&clickhouse, "DemonstrationFeedback", feedback_id)
+        .await
+        .unwrap();
+    let id = result.get("id").unwrap().as_str().unwrap();
+    let id_uuid = Uuid::parse_str(id).unwrap();
+    assert_eq!(id_uuid, feedback_id);
+    let retrieved_inference_id = result.get("inference_id").unwrap().as_str().unwrap();
+    let retrieved_inference_id_uuid = Uuid::parse_str(retrieved_inference_id).unwrap();
+    assert_eq!(retrieved_inference_id_uuid, inference_id);
+    let retrieved_value = result.get("value").unwrap().as_str().unwrap();
+    let expected_value =
+        serde_json::to_string(&json!([{"type": "text", "text": "sunny" }])).unwrap();
+    assert_eq!(retrieved_value, expected_value);
+
+    // Try it for an episode (should 400)
+    let episode_id = Uuid::now_v7();
+    let payload =
+        json!({"episode_id": episode_id, "metric_name": "demonstration", "value": "do this!"});
+    let response = client
+        .post(get_gateway_endpoint("/feedback"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_json = response.json::<Value>().await.unwrap();
+    let message = response_json.get("error").unwrap().as_str().unwrap();
+    assert_eq!(
+        message,
+        "Correct ID was not provided for feedback level \"inference\"."
+    );
+
+    // Try a tool call demonstration
+    // This should fail because the name is incorrect
+    let tool_call = json!({"type": "tool_call", "name": "tool_name", "arguments": "tool_input"});
+    let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
+    let response = client
+        .post(get_gateway_endpoint("/feedback"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_json = response.json::<Value>().await.unwrap();
+    let error_message = response_json.get("error").unwrap().as_str().unwrap();
+    assert_eq!(error_message, "Demonstration contains invalid tool name");
+
+    // Try a tool call demonstration with the dynamic tool name and incorrect args
+    let tool_call = json!({"type": "tool_call", "name": "get_humidity", "arguments": "tool_input"});
+    let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
+    let response = client
+        .post(get_gateway_endpoint("/feedback"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_json = response.json::<Value>().await.unwrap();
+    let error_message = response_json.get("error").unwrap().as_str().unwrap();
+    assert_eq!(
+        error_message,
+        "Demonstration contains invalid tool call arguments"
+    );
+
+    // Try a tool call demonstration with the dynamic tool name and correct args
+    let tool_call =
+        json!({"type": "tool_call", "name": "get_humidity", "arguments": {"location": "Tokyo"}});
+    let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
+    let response = client
+        .post(get_gateway_endpoint("/feedback"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    let response_json = response.json::<Value>().await.unwrap();
+    let feedback_id = response_json.get("feedback_id").unwrap();
+    assert!(feedback_id.is_string());
+    let feedback_id = Uuid::parse_str(feedback_id.as_str().unwrap()).unwrap();
+    sleep(Duration::from_millis(200)).await;
+
+    // Check ClickHouse
+    let clickhouse = get_clickhouse().await;
+    let result = select_feedback_clickhouse(&clickhouse, "DemonstrationFeedback", feedback_id)
+        .await
+        .unwrap();
+    let id = result.get("id").unwrap().as_str().unwrap();
+    let id_uuid = Uuid::parse_str(id).unwrap();
+    assert_eq!(id_uuid, feedback_id);
+    let retrieved_inference_id = result.get("inference_id").unwrap().as_str().unwrap();
+    let retrieved_inference_id_uuid = Uuid::parse_str(retrieved_inference_id).unwrap();
+    assert_eq!(retrieved_inference_id_uuid, inference_id);
+    let retrieved_value = result.get("value").unwrap().as_str().unwrap();
+    let retrieved_value = serde_json::from_str::<Value>(retrieved_value).unwrap();
+    let expected_value = json!([{"type": "tool_call", "name": "get_humidity", "arguments": {"location": "Tokyo"}, "raw_name": "get_humidity", "raw_arguments": "{\"location\":\"Tokyo\"}", "id": "" }]);
     assert_eq!(retrieved_value, expected_value);
 }
 


### PR DESCRIPTION
To do this:
  * added another dataset query to feedback route only for demonstration to get output schema / tool call info from DB
  * updated the PUT datapoint route to require output_schema for json requests and use that for validation (tools for chat)
  * added tests covering these cases to datasets and feedback tests
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add dynamic validation for demonstrations and feedbacks with new database queries and tests.
> 
>   - **Behavior**:
>     - Added dynamic validation for demonstrations and feedbacks in `datasets.rs` and `feedback.rs`.
>     - `update_datapoint_handler` in `datasets.rs` now requires `output_schema` for JSON requests and uses it for validation.
>     - `validate_parse_demonstration` in `feedback.rs` now handles dynamic demonstration info.
>   - **Database Queries**:
>     - Added queries in `feedback.rs` to fetch tool call or output schema info from the database for validation.
>   - **Tests**:
>     - Added tests in `datasets.rs` and `feedback.rs` to cover new validation logic and error cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4145912d3e25c5036f14926a65813b8d392e45b9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->