### PR TITLE
bumped version to 2025.03.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.3.0"
+version = "2025.3.1"
 dependencies = [
  "futures",
  "pyo3",

--- a/clients/python-pyo3/Cargo.toml
+++ b/clients/python-pyo3/Cargo.toml
@@ -3,7 +3,7 @@
 # It's named 'tensorzero-python' to avoid confusion with the Rust client
 # (which has a crate name of 'tensorzero')
 name = "tensorzero-python"
-version = "2025.3.0"
+version = "2025.3.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/tensorzero-internal/src/endpoints/status.rs
+++ b/tensorzero-internal/src/endpoints/status.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::response::Json;
 use serde_json::{json, Value};
 
-pub const TENSORZERO_VERSION: &str = "2025.03.0";
+pub const TENSORZERO_VERSION: &str = "2025.03.1";
 
 /// A handler for a simple liveness check
 #[debug_handler]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `tensorzero-python` version from `2025.3.0` to `2025.3.1`.
> 
>   - **Version Update**:
>     - Bump `tensorzero-python` version from `2025.3.0` to `2025.3.1` in `Cargo.lock`, `clients/python-pyo3/Cargo.toml`, and `tensorzero-internal/src/endpoints/status.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for af141b75c586181e108feba6dcd81d15639dc9a9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->