### PR TITLE
Remove double layer of `PyErr` in `convert_error`

### DIFF
--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -92,12 +92,7 @@ impl AsyncStreamWrapper {
             // We need to interact with Python objects here (to build up a Python `InferenceChunk`),
             // so we need the GIL
             Python::with_gil(|py| {
-                let chunk = match chunk {
-                    Ok(chunk) => chunk,
-                    Err(e) => {
-                        return Err(convert_error(py, err_to_http(e))?);
-                    }
-                };
+                let chunk = chunk.map_err(|e| convert_error(py, err_to_http(e)))?;
                 parse_inference_chunk(py, chunk)
             })
         })
@@ -123,10 +118,7 @@ impl StreamWrapper {
         let Some(chunk) = chunk else {
             return Err(PyStopIteration::new_err(()));
         };
-        let chunk = match chunk {
-            Ok(chunk) => chunk,
-            Err(e) => return Err(convert_error(py, err_to_http(e))?),
-        };
+        let chunk = chunk.map_err(|e| convert_error(py, err_to_http(e)))?;
         parse_inference_chunk(py, chunk)
     }
 }
@@ -511,7 +503,7 @@ impl TensorZeroGateway {
         // and then return the result to the Python caller directly (not wrapped in a Python `Future`).
         match tokio_block_on_without_gil(py, fut) {
             Ok(resp) => Ok(parse_feedback_response(py, resp)?.into_any()),
-            Err(e) => Err(convert_error(py, e)?),
+            Err(e) => Err(convert_error(py, e)),
         }
     }
 
@@ -594,16 +586,15 @@ impl TensorZeroGateway {
 
         // We're in the synchronous `TensorZeroGateway` class, so we need to block on the Rust future,
         // and then return the result to the Python caller directly (not wrapped in a Python `Future`).
-        let resp = tokio_block_on_without_gil(py, fut);
+        let resp = tokio_block_on_without_gil(py, fut).map_err(|e| convert_error(py, e))?;
         match resp {
-            Ok(InferenceOutput::NonStreaming(data)) => parse_inference_response(py, data),
-            Ok(InferenceOutput::Streaming(stream)) => Ok(StreamWrapper {
+            InferenceOutput::NonStreaming(data) => parse_inference_response(py, data),
+            InferenceOutput::Streaming(stream) => Ok(StreamWrapper {
                 stream: Arc::new(Mutex::new(stream)),
             }
             .into_pyobject(py)?
             .into_any()
             .unbind()),
-            Err(e) => Err(convert_error(py, e)?),
         }
     }
 }
@@ -826,15 +817,17 @@ impl AsyncTensorZeroGateway {
             let res = client.inference(params).await;
             // We need to interact with Python objects here (to build up a Python inference response),
             // so we need the GIL
-            Python::with_gil(|py| match res {
-                Ok(InferenceOutput::NonStreaming(data)) => parse_inference_response(py, data),
-                Ok(InferenceOutput::Streaming(stream)) => Ok(AsyncStreamWrapper {
-                    stream: Arc::new(Mutex::new(stream)),
+            Python::with_gil(|py| {
+                let output = res.map_err(|e| convert_error(py, e))?;
+                match output {
+                    InferenceOutput::NonStreaming(data) => parse_inference_response(py, data),
+                    InferenceOutput::Streaming(stream) => Ok(AsyncStreamWrapper {
+                        stream: Arc::new(Mutex::new(stream)),
+                    }
+                    .into_pyobject(py)?
+                    .into_any()
+                    .unbind()),
                 }
-                .into_pyobject(py)?
-                .into_any()
-                .unbind()),
-                Err(e) => Err(convert_error(py, e)?),
             })
         })
     }
@@ -882,7 +875,7 @@ impl AsyncTensorZeroGateway {
             // so we need the GIL
             Python::with_gil(|py| match res {
                 Ok(resp) => Ok(parse_feedback_response(py, resp)?.into_any()),
-                Err(e) => Err(convert_error(py, e)?),
+                Err(e) => Err(convert_error(py, e)),
             })
         })
     }
@@ -892,15 +885,19 @@ impl AsyncTensorZeroGateway {
 // This lint currently does nothing on stable, but let's include it
 // so that it will start working automatically when it's stabilized
 #[deny(non_exhaustive_omitted_patterns)]
-fn convert_error(py: Python<'_>, e: TensorZeroError) -> PyResult<PyErr> {
+fn convert_error(py: Python<'_>, e: TensorZeroError) -> PyErr {
     match e {
         TensorZeroError::Http {
             status_code,
             text,
             source: _,
-        } => tensorzero_error(py, status_code, text),
-        TensorZeroError::Other { source } => tensorzero_internal_error(py, &source.to_string()),
-        TensorZeroError::RequestTimeout => tensorzero_internal_error(py, &e.to_string()),
+        } => tensorzero_error(py, status_code, text).unwrap_or_else(|e| e),
+        TensorZeroError::Other { source } => {
+            tensorzero_internal_error(py, &source.to_string()).unwrap_or_else(|e| e)
+        }
+        TensorZeroError::RequestTimeout => {
+            tensorzero_internal_error(py, &e.to_string()).unwrap_or_else(|e| e)
+        }
         // Required due to the `#[non_exhaustive]` attribute on `TensorZeroError` - we want to force
         // downstream consumers to handle all possible error types, but the compiler also requires us
         // to do this (since our python bindings are in a different crate from the Rust client.)


### PR DESCRIPTION
If calling `tensorzero_error` or `tensorzero_internal_error` fails with a `PyErr`, we can just use that as the `PyErr` produced by `convert_error`. This has the same overall behavior as before (since we were writin `convert_err(py, e)?`), but the caller code can be simplified in several places.`

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies error handling by removing double wrapping of `PyErr` in `convert_error`, affecting several methods across the codebase.
> 
>   - **Error Handling**:
>     - Simplifies error handling by removing double wrapping of `PyErr` in `convert_error`.
>     - `convert_error` now returns `PyErr` directly instead of `PyResult<PyErr>`.
>     - Updates error handling in `AsyncStreamWrapper::__anext__`, `StreamWrapper::__next__`, `TensorZeroGateway::feedback`, `TensorZeroGateway::inference`, `AsyncTensorZeroGateway::inference`, and `AsyncTensorZeroGateway::feedback` to use `convert_error` without `?`.
>   - **Functions**:
>     - Modifies `convert_error` to use `unwrap_or_else` for `tensorzero_error` and `tensorzero_internal_error` calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b4659a2d1a9ac68f630223e23ef14af685513398. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->