### PR TITLE
Add errors streamed back from evals binary via JSONL

### DIFF
--- a/evals/src/stats.rs
+++ b/evals/src/stats.rs
@@ -87,6 +87,11 @@ impl EvalStats {
     }
 }
 
+pub enum EvalUpdate {
+    Success(EvalInfo),
+    Error(EvalError),
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct EvalInfo {
     pub datapoint: Datapoint,

--- a/evals/tests/tests.rs
+++ b/evals/tests/tests.rs
@@ -248,7 +248,6 @@ async fn run_llm_judge_eval_chat() {
     let mut parsed_output = Vec::new();
     let mut total_topic_fs = 0;
     for line in output_str.lines() {
-        println!("line: {}", line);
         let parsed: EvalUpdate =
             serde_json::from_str(line).expect("Each line should be valid JSON");
         let parsed = match parsed {

--- a/evals/tests/tests.rs
+++ b/evals/tests/tests.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 use crate::common::write_json_fixture_to_dataset;
 use common::write_chat_fixture_to_dataset;
-use evals::{run_eval, stats::EvalInfo, Args, OutputFormat};
+use evals::{run_eval, stats::EvalUpdate, Args, OutputFormat};
 use tensorzero::InferenceResponse;
 use tensorzero_internal::{
     clickhouse::test_helpers::{
@@ -49,8 +49,17 @@ async fn run_evals_json() {
     let mut parsed_output = Vec::new();
     let mut total_the = 0;
     for line in output_str.lines() {
-        let parsed: EvalInfo = serde_json::from_str(line).expect("Each line should be valid JSON");
-        assert!(parsed.evaluator_errors.is_empty());
+        let parsed: EvalUpdate =
+            serde_json::from_str(line).expect("Each line should be valid JSON");
+        let parsed = match parsed {
+            EvalUpdate::Success(eval_info) => eval_info,
+            EvalUpdate::Error(eval_error) => {
+                panic!("Eval error: {}", eval_error.message);
+            }
+        };
+        assert_eq!(parsed.evaluator_errors.len(), 1);
+        let error = parsed.evaluator_errors.get("error").unwrap();
+        assert!(error.contains("Dummy error in inference"));
         let inference_id = parsed.response.inference_id();
         let clickhouse_inference = select_json_inference_clickhouse(&clickhouse, inference_id)
             .await
@@ -151,7 +160,14 @@ async fn run_exact_match_eval_chat() {
     let output_str = String::from_utf8(output).unwrap();
     let mut parsed_output = Vec::new();
     for line in output_str.lines() {
-        let parsed: EvalInfo = serde_json::from_str(line).expect("Each line should be valid JSON");
+        let parsed: EvalUpdate =
+            serde_json::from_str(line).expect("Each line should be valid JSON");
+        let parsed = match parsed {
+            EvalUpdate::Success(eval_info) => eval_info,
+            EvalUpdate::Error(eval_error) => {
+                panic!("Eval error: {}", eval_error.message);
+            }
+        };
         assert!(parsed.evaluator_errors.is_empty());
         let inference_id = parsed.response.inference_id();
         let clickhouse_inference = select_chat_inference_clickhouse(&clickhouse, inference_id)
@@ -232,7 +248,15 @@ async fn run_llm_judge_eval_chat() {
     let mut parsed_output = Vec::new();
     let mut total_topic_fs = 0;
     for line in output_str.lines() {
-        let parsed: EvalInfo = serde_json::from_str(line).expect("Each line should be valid JSON");
+        println!("line: {}", line);
+        let parsed: EvalUpdate =
+            serde_json::from_str(line).expect("Each line should be valid JSON");
+        let parsed = match parsed {
+            EvalUpdate::Success(eval_info) => eval_info,
+            EvalUpdate::Error(eval_error) => {
+                panic!("Eval error: {}", eval_error.message);
+            }
+        };
         assert!(parsed.evaluator_errors.is_empty());
         let inference_id = parsed.response.inference_id();
         let clickhouse_inference = select_chat_inference_clickhouse(&clickhouse, inference_id)
@@ -448,4 +472,46 @@ async fn test_run_eval_binary() {
     assert!(output_str.is_empty());
     let stderr_str = String::from_utf8(output.stderr).unwrap();
     assert!(stderr_str.contains("the following required arguments were not provided:"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn run_evals_errors() {
+    let clickhouse = get_clickhouse().await;
+    write_json_fixture_to_dataset(&PathBuf::from(&format!(
+        "{}/../tensorzero-internal/fixtures/datasets/json_datapoint_fixture.jsonl",
+        std::env::var("CARGO_MANIFEST_DIR").unwrap()
+    )))
+    .await;
+    let config_path = PathBuf::from(&format!(
+        "{}/../tensorzero-internal/tests/e2e/tensorzero.toml",
+        std::env::var("CARGO_MANIFEST_DIR").unwrap()
+    ));
+    let eval_run_id = Uuid::now_v7();
+    let args = Args {
+        config_file: config_path,
+        gateway_url: None,
+        name: "entity_extraction".to_string(),
+        variant: "dummy_error".to_string(),
+        concurrency: 10,
+        format: OutputFormat::Jsonl,
+    };
+
+    let mut output = Vec::new();
+    run_eval(args, eval_run_id, &mut output).await.unwrap();
+    clickhouse_flush_async_insert(&clickhouse).await;
+    let output_str = String::from_utf8(output).unwrap();
+    for line in output_str.lines() {
+        let parsed: EvalUpdate =
+            serde_json::from_str(line).expect("Each line should be valid JSON");
+        let error = match parsed {
+            EvalUpdate::Success(eval_info) => panic!(
+                "Eval success shouldn't happen: {}",
+                serde_json::to_string_pretty(&eval_info).unwrap()
+            ),
+            EvalUpdate::Error(eval_error) => eval_error,
+        };
+        assert!(error
+            .message
+            .contains("Error sending request to Dummy provider"));
+    }
 }

--- a/tensorzero-internal/src/endpoints/datasets.rs
+++ b/tensorzero-internal/src/endpoints/datasets.rs
@@ -501,6 +501,13 @@ impl Datapoint {
             Datapoint::JsonInference(datapoint) => Some(&datapoint.output_schema),
         }
     }
+
+    pub fn id(&self) -> Uuid {
+        match self {
+            Datapoint::ChatInference(datapoint) => datapoint.id,
+            Datapoint::JsonInference(datapoint) => datapoint.id,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/tensorzero-internal/src/inference/providers/dummy.rs
+++ b/tensorzero-internal/src/inference/providers/dummy.rs
@@ -308,6 +308,16 @@ impl InferenceProvider for DummyProvider {
             "llm_judge::one" => {
                 vec![r#"{"thinking": "hmmm", "score": 1}"#.to_string().into()]
             }
+            "llm_judge::error" => {
+                return Err(ErrorDetails::InferenceClient {
+                    message: "Dummy error in inference".to_string(),
+                    raw_request: Some("raw request".to_string()),
+                    raw_response: None,
+                    status_code: None,
+                    provider_type: PROVIDER_TYPE.to_string(),
+                }
+                .into());
+            }
             _ => vec![DUMMY_INFER_RESPONSE_CONTENT.to_string().into()],
         };
         let raw_request = DUMMY_RAW_REQUEST.to_string();

--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -2276,6 +2276,11 @@ type = "chat_completion"
 model = "openai::gpt-4o-mini-2024-07-18"
 system_template = "../../fixtures/config/functions/extract_entities/initial_prompt/system_template.minijinja"
 
+[functions.extract_entities.variants.dummy_error]
+type = "chat_completion"
+model = "dummy::error"
+system_template = "../../fixtures/config/functions/extract_entities/initial_prompt/system_template.minijinja"
+
 [functions.mixture_of_n_json_repeated]
 type = "json"
 system_schema = "../../fixtures/config/functions/basic_test/system_schema.json"
@@ -2469,6 +2474,7 @@ active = true
 system_instructions = "../../fixtures/config/evals/test_eval/llm_judge_bool/system_instructions.txt"
 json_mode = "on"
 
+
 [evals.entity_extraction]
 function_name = "extract_entities"
 dataset_name = "extract_entities_0.8"
@@ -2491,7 +2497,19 @@ model = "openai::gpt-4o-mini-2024-07-18"
 active = true
 system_instructions = "../../fixtures/config/evals/entity_extraction/count_sports/system_instructions.txt"
 json_mode = "strict"
-temperature=0.1
+temperature = 0.1
+
+[evals.entity_extraction.evaluators.error]
+type = "llm_judge"
+output_type = "float"
+optimize = "max"
+
+[evals.entity_extraction.evaluators.error.variants.dummy]
+type = "chat_completion"
+model = "dummy::llm_judge::error"
+active = true
+system_instructions = "../../fixtures/config/evals/test_eval/llm_judge_bool/system_instructions.txt"
+json_mode = "on"
 
 [evals.haiku_with_outputs]
 function_name = "write_haiku"


### PR DESCRIPTION
Closes #1341 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Stream errors as JSONL in evaluation process, updating `EvalStats` and adding tests for error handling.
> 
>   - **Behavior**:
>     - Errors during evaluation are now streamed back as JSONL in `run_eval()` in `lib.rs`.
>     - Maps task IDs to datapoint IDs to track errors.
>     - Updates `EvalStats` to store `eval_errors`.
>   - **Data Structures**:
>     - Introduces `EvalUpdate` enum in `stats.rs` to handle success and error cases.
>     - Adds `EvalError` struct to capture error details.
>   - **Tests**:
>     - Adds `run_evals_errors()` test in `tests.rs` to verify error handling.
>     - Updates existing tests to handle `EvalUpdate` enum changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c2bd3032cade266efd83ec6d0d0e108197d1af6f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->