### PR TITLE
hide default function in sft form function selector

### DIFF
--- a/ui/app/components/function/FunctionSelector.tsx
+++ b/ui/app/components/function/FunctionSelector.tsx
@@ -16,6 +16,7 @@ type FunctionSelectorProps<T extends Record<string, unknown>> = {
   name: Path<T>;
   inferenceCount: number | null;
   config: Config;
+  hide_default_function?: boolean;
 };
 
 export function FunctionSelector<T extends Record<string, unknown>>({
@@ -23,6 +24,7 @@ export function FunctionSelector<T extends Record<string, unknown>>({
   name,
   inferenceCount,
   config,
+  hide_default_function = false,
 }: FunctionSelectorProps<T>) {
   return (
     <FormField
@@ -43,6 +45,9 @@ export function FunctionSelector<T extends Record<string, unknown>>({
               </SelectTrigger>
               <SelectContent>
                 {Object.entries(config.functions).map(([name, fn]) => {
+                  if (hide_default_function && name === "tensorzero::default") {
+                    return null;
+                  }
                   return (
                     <SelectItem key={name} value={name}>
                       <div className="flex w-full items-center justify-between">

--- a/ui/app/routes/optimization/supervised-fine-tuning/SFTForm.tsx
+++ b/ui/app/routes/optimization/supervised-fine-tuning/SFTForm.tsx
@@ -141,6 +141,7 @@ export function SFTForm({
                 name="function"
                 inferenceCount={counts.inferenceCount}
                 config={config}
+                hide_default_function={true}
               />
               {errors.function && (
                 <p className="text-xs text-red-500">


### PR DESCRIPTION
Closes #1294 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `hide_default_function` prop to `FunctionSelector` to optionally hide the default function, applied in `SFTForm`.
> 
>   - **FunctionSelector Component**:
>     - Adds `hide_default_function` prop to `FunctionSelector` in `FunctionSelector.tsx`.
>     - Hides `tensorzero::default` function when `hide_default_function` is `true`.
>   - **SFTForm Component**:
>     - Sets `hide_default_function` to `true` in `SFTForm.tsx` to hide default function in the form.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1deda5553e99dc69094d6781361686028c179659. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->