### PR TITLE
Deprecate tensorzero headers and add openai-compatible body fields

### DIFF
--- a/clients/openai-python/uv.lock
+++ b/clients/openai-python/uv.lock
@@ -392,6 +392,7 @@ requires-dist = [
 dev = [
     { name = "maturin" },
     { name = "mypy" },
+    { name = "openai" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },

--- a/tensorzero-internal/src/endpoints/openai_compatible.rs
+++ b/tensorzero-internal/src/endpoints/openai_compatible.rs
@@ -1010,7 +1010,7 @@ mod tests {
         let messages = vec![OpenAICompatibleMessage::User(OpenAICompatibleUserMessage {
             content: Value::String("Hello, world!".to_string()),
         })];
-        let params: Params = (
+        let params = Params::try_from_openai(
             headers,
             OpenAICompatibleParams {
                 messages,
@@ -1027,10 +1027,12 @@ mod tests {
                 tool_choice: None,
                 top_p: Some(0.5),
                 parallel_tool_calls: None,
+                tensorzero_episode_id: None,
+                tensorzero_variant_name: None,
+                tensorzero_dryrun: None,
             },
         )
-            .try_into()
-            .unwrap();
+        .unwrap();
         assert_eq!(params.function_name, Some("test_function".to_string()));
         assert_eq!(params.episode_id, Some(episode_id));
         assert_eq!(params.variant_name, Some("test_variant".to_string()));

--- a/tensorzero-internal/src/endpoints/openai_compatible.rs
+++ b/tensorzero-internal/src/endpoints/openai_compatible.rs
@@ -55,7 +55,7 @@ pub async fn inference_handler(
     headers: HeaderMap,
     StructuredJson(openai_compatible_params): StructuredJson<OpenAICompatibleParams>,
 ) -> Result<Response<Body>, Error> {
-    let params: Params = (headers, openai_compatible_params).try_into()?;
+    let params = Params::try_from_openai(headers, openai_compatible_params)?;
 
     // The prefix for the response's `model` field depends on the inference target
     // (We run this disambiguation deep in the `inference` call below but we don't get the decision out, so we duplicate it here)
@@ -223,6 +223,12 @@ pub struct OpenAICompatibleParams {
     tool_choice: Option<ChatCompletionToolChoiceOption>,
     top_p: Option<f32>,
     parallel_tool_calls: Option<bool>,
+    #[serde(rename = "tensorzero::variant_name")]
+    tensorzero_variant_name: Option<String>,
+    #[serde(rename = "tensorzero::dryrun")]
+    tensorzero_dryrun: Option<bool>,
+    #[serde(rename = "tensorzero::episode_id")]
+    tensorzero_episode_id: Option<Uuid>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
@@ -283,11 +289,11 @@ struct OpenAICompatibleResponse {
 const TENSORZERO_FUNCTION_NAME_PREFIX: &str = "tensorzero::function_name::";
 const TENSORZERO_MODEL_NAME_PREFIX: &str = "tensorzero::model_name::";
 
-impl TryFrom<(HeaderMap, OpenAICompatibleParams)> for Params {
-    type Error = Error;
-    fn try_from(
-        (headers, openai_compatible_params): (HeaderMap, OpenAICompatibleParams),
-    ) -> Result<Self, Self::Error> {
+impl Params {
+    fn try_from_openai(
+        headers: HeaderMap,
+        openai_compatible_params: OpenAICompatibleParams,
+    ) -> Result<Self, Error> {
         let (function_name, model_name) = if let Some(function_name) = openai_compatible_params
             .model
             .strip_prefix(TENSORZERO_FUNCTION_NAME_PREFIX)
@@ -332,9 +338,10 @@ impl TryFrom<(HeaderMap, OpenAICompatibleParams)> for Params {
             }
         }
 
-        let episode_id = headers
+        let header_episode_id = headers
             .get("episode_id")
             .map(|h| {
+                tracing::warn!("Deprecation warning: Please use the `tensorzero::episode_id` field instead of the `episode_id` header. The header will be removed in a future release.");
                 h.to_str()
                     .map_err(|_| {
                         Error::new(ErrorDetails::InvalidOpenAICompatibleRequest {
@@ -385,9 +392,10 @@ impl TryFrom<(HeaderMap, OpenAICompatibleParams)> for Params {
         let inference_params = InferenceParams {
             chat_completion: chat_completion_inference_params,
         };
-        let variant_name = headers
+        let header_variant_name = headers
             .get("variant_name")
             .map(|h| {
+                tracing::warn!("Deprecation warning: Please use the `tensorzero::variant_name` field instead of the `variant_name` header. The header will be removed in a future release.");
                 h.to_str()
                     .map_err(|_| {
                         Error::new(ErrorDetails::InvalidOpenAICompatibleRequest {
@@ -397,9 +405,10 @@ impl TryFrom<(HeaderMap, OpenAICompatibleParams)> for Params {
                     .map(|s| s.to_string())
             })
             .transpose()?;
-        let dryrun = headers
+        let header_dryrun = headers
             .get("dryrun")
             .map(|h| {
+                tracing::warn!("Deprecation warning: Please use the `tensorzero::dryrun` field instead of the `dryrun` header. The header will be removed in a future release.");
                 h.to_str()
                     .map_err(|_| {
                         Error::new(ErrorDetails::InvalidOpenAICompatibleRequest {
@@ -432,12 +441,16 @@ impl TryFrom<(HeaderMap, OpenAICompatibleParams)> for Params {
         Ok(Params {
             function_name,
             model_name,
-            episode_id,
+            episode_id: openai_compatible_params
+                .tensorzero_episode_id
+                .or(header_episode_id),
             input,
             stream: openai_compatible_params.stream,
             params: inference_params,
-            variant_name,
-            dryrun,
+            variant_name: openai_compatible_params
+                .tensorzero_variant_name
+                .or(header_variant_name),
+            dryrun: openai_compatible_params.tensorzero_dryrun.or(header_dryrun),
             dynamic_tool_params,
             output_schema,
             // OpenAI compatible endpoint does not support dynamic credentials

--- a/tensorzero-internal/tests/e2e/openai_compatible.rs
+++ b/tensorzero-internal/tests/e2e/openai_compatible.rs
@@ -6,7 +6,8 @@ use uuid::Uuid;
 
 use crate::common::get_gateway_endpoint;
 use tensorzero_internal::clickhouse::test_helpers::{
-    get_clickhouse, select_chat_inference_clickhouse, select_model_inference_clickhouse,
+    get_clickhouse, select_chat_inference_clickhouse, select_json_inference_clickhouse,
+    select_model_inference_clickhouse,
 };
 
 #[cfg(feature = "e2e_tests")]
@@ -150,6 +151,72 @@ async fn test_openai_compatible_route_with_function_name_asmodel(model: &str) {
     let _raw_response_json: Value = serde_json::from_str(raw_response).unwrap();
     let finish_reason = result.get("finish_reason").unwrap().as_str().unwrap();
     assert_eq!(finish_reason, "stop");
+}
+
+#[tokio::test]
+async fn test_openai_compatible_dryrun() {
+    let client = Client::new();
+    let episode_id = Uuid::now_v7();
+
+    let payload = json!({
+        "model": "tensorzero::model_name::json",
+        "messages": [
+            {
+                "role": "system",
+                "content": "TensorBot"
+            },
+            {
+                "role": "user",
+                "content": "What is the capital of Japan?"
+            }
+        ],
+        "stream": false,
+        "tensorzero::episode_id": episode_id.to_string(),
+        "tensorzero::dryrun": true
+    });
+
+    let response = client
+        .post(get_gateway_endpoint("/openai/v1/chat/completions"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    // Check Response is OK, then fields in order
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_json = response.json::<Value>().await.unwrap();
+    println!("response_json: {:?}", response_json);
+    let choices = response_json.get("choices").unwrap().as_array().unwrap();
+    assert!(choices.len() == 1);
+    let choice = choices.first().unwrap();
+    assert_eq!(choice.get("index").unwrap().as_u64().unwrap(), 0);
+    let message = choice.get("message").unwrap();
+    assert_eq!(message.get("role").unwrap().as_str().unwrap(), "assistant");
+    let content = message.get("content").unwrap().as_str().unwrap();
+    assert_eq!(content, "{\"answer\":\"Hello\"}");
+    let finish_reason = choice.get("finish_reason").unwrap().as_str().unwrap();
+    assert_eq!(finish_reason, "stop");
+    let response_model = response_json.get("model").unwrap().as_str().unwrap();
+    assert_eq!(response_model, "tensorzero::model_name::json");
+
+    let inference_id: Uuid = response_json
+        .get("id")
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+
+    // Sleep for 1 second to allow time for data to be inserted into ClickHouse (trailing writes from API)
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    // Check ClickHouse
+    let clickhouse = get_clickhouse().await;
+
+    let chat_result = select_chat_inference_clickhouse(&clickhouse, inference_id).await;
+    let json_result = select_json_inference_clickhouse(&clickhouse, inference_id).await;
+    // No inference should be written to ClickHouse when dryrun is true
+    assert!(chat_result.is_none());
+    assert!(json_result.is_none());
 }
 
 #[cfg(feature = "e2e_tests")]


### PR DESCRIPTION
Instead of passing in 'episode_id', 'variant_name', and 'dryrun' as headers to the openai-compatible endpoints, these should now be passed as prefixed fields in the body:
`tensorzero::episode_id`, `tensorzero::variant_name`, and `tensorzero::dryrun`

Fixes https://github.com/tensorzero/tensorzero/issues/1346

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Deprecates certain headers in favor of new body fields for OpenAI-compatible endpoints, updating both backend and client tests.
> 
>   - **Behavior**:
>     - Deprecates `episode_id`, `variant_name`, and `dryrun` headers in favor of `tensorzero::episode_id`, `tensorzero::variant_name`, and `tensorzero::dryrun` body fields in `openai_compatible.rs`.
>     - Issues deprecation warnings for old headers in `Params::try_from_openai()`.
>   - **Tests**:
>     - Adds `test_dynamic_json_mode_inference_body_param_openai()` in `test_openai_compatibility.py` to test new body fields.
>     - Updates `test_async_multi_turn_parallel_tool_use()` in `test_openai_compatibility.py` to use new body fields.
>     - Adds `test_openai_compatible_dryrun()` in `openai_compatible.rs` to verify dryrun behavior.
>   - **Dependencies**:
>     - Adds `openai` to `dev` dependencies in `uv.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4abdf6d90365ac5f84d6d5ba700d3a1eb14e36cb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->