### PR TITLE
Ban '::' in all config definition names

### DIFF
--- a/tensorzero-internal/src/endpoints/mod.rs
+++ b/tensorzero-internal/src/endpoints/mod.rs
@@ -18,7 +18,7 @@ fn validate_tags(tags: &HashMap<String, String>, internal: bool) -> Result<(), E
     for tag_name in tags.keys() {
         if tag_name.starts_with("tensorzero::") {
             return Err(Error::new(ErrorDetails::InvalidRequest {
-                message: format!("Tag name cannot start with 'tensorzero::': {tag_name}"),
+                message: format!("Tag name cannot contain '::' - {tag_name}"),
             }));
         }
     }

--- a/tensorzero-internal/src/function.rs
+++ b/tensorzero-internal/src/function.rs
@@ -276,9 +276,7 @@ impl FunctionConfig {
         for (variant_name, variant) in self.variants() {
             if variant_name.starts_with("tensorzero::") {
                 return Err(ErrorDetails::Config {
-                    message: format!(
-                        "Variant name cannot start with 'tensorzero::': {variant_name}"
-                    ),
+                    message: format!("Variant name cannot contain '::' - {variant_name}"),
                 }
                 .into());
             }

--- a/tensorzero-internal/src/model.rs
+++ b/tensorzero-internal/src/model.rs
@@ -1366,7 +1366,7 @@ impl ShorthandModelConfig for ModelConfig {
         for provider in &self.routing {
             if provider.starts_with("tensorzero::") {
                 return Err(ErrorDetails::Config {
-                    message: format!("`models.{model_name}.routing`: Provider name cannot start with 'tensorzero::': {provider}"),
+                    message: format!("`models.{model_name}.routing`: Provider name cannot contain '::' - {provider}"),
                 }
                 .into());
             }


### PR DESCRIPTION
This generalizing the existing 'tensorzero::' prefix check to ban '::' anywhere in the name

Fixes #1369

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
