### PR TITLE
Make 'parallel_tool_calls' an `Option` in config and params

### DIFF
--- a/evals/src/helpers.rs
+++ b/evals/src/helpers.rs
@@ -106,7 +106,7 @@ pub async fn get_tool_params_args(
                 allowed_tools: Some(allowed_tools),
                 additional_tools: Some(additional_tools),
                 tool_choice: Some(tool_params.tool_choice.clone()),
-                parallel_tool_calls: Some(tool_params.parallel_tool_calls),
+                parallel_tool_calls: tool_params.parallel_tool_calls,
             }
         }
         // This branch is actually unreachable
@@ -151,7 +151,7 @@ mod tests {
         // Dynamic tool params with tool_choice set to "tool_1"
         let tool_database_insert = ToolCallConfigDatabaseInsert {
             tool_choice: ToolChoice::Specific("tool_1".to_string()),
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
             tools_available: vec![Tool {
                 name: "tool_1".to_string(),
                 description: "Tool 1".to_string(),
@@ -166,14 +166,14 @@ mod tests {
             assistant_schema: None,
             tools: vec![],
             tool_choice: ToolChoice::Specific("tool_1".to_string()),
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         });
         let tool_params_args = get_tool_params_args(&tool_database_insert, &function_config).await;
         assert_eq!(
             tool_params_args,
             DynamicToolParams {
                 tool_choice: Some(ToolChoice::Specific("tool_1".to_string())),
-                parallel_tool_calls: Some(false),
+                parallel_tool_calls: None,
                 allowed_tools: Some(Vec::new()),
                 additional_tools: Some(vec![Tool {
                     name: "tool_1".to_string(),
@@ -187,7 +187,7 @@ mod tests {
         // Static tool params with a tool choice set to required
         let tool_database_insert = ToolCallConfigDatabaseInsert {
             tool_choice: ToolChoice::Required,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
             tools_available: vec![Tool {
                 name: "tool_1".to_string(),
                 description: "Tool 1".to_string(),
@@ -202,14 +202,14 @@ mod tests {
             assistant_schema: None,
             tools: vec!["tool_1".to_string()],
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         });
         let tool_params_args = get_tool_params_args(&tool_database_insert, &function_config).await;
         assert_eq!(
             tool_params_args,
             DynamicToolParams {
                 tool_choice: Some(ToolChoice::Required),
-                parallel_tool_calls: Some(false),
+                parallel_tool_calls: None,
                 allowed_tools: Some(vec!["tool_1".to_string()]),
                 additional_tools: Some(vec![]),
             }

--- a/tensorzero-internal/src/config_parser.rs
+++ b/tensorzero-internal/src/config_parser.rs
@@ -648,7 +648,7 @@ struct UninitializedFunctionConfigChat {
     #[serde(default)]
     tool_choice: ToolChoice,
     #[serde(default)]
-    parallel_tool_calls: bool,
+    parallel_tool_calls: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/tensorzero-internal/src/endpoints/feedback.rs
+++ b/tensorzero-internal/src/endpoints/feedback.rs
@@ -1088,7 +1088,7 @@ mod tests {
                 assistant_schema: None,
                 tools: vec!["get_temperature".to_string()],
                 tool_choice: ToolChoice::Auto,
-                parallel_tool_calls: false,
+                parallel_tool_calls: None,
             })));
 
         // Case 1: a string passed to a chat function
@@ -1096,7 +1096,7 @@ mod tests {
         let dynamic_demonstration_info = DynamicDemonstrationInfo::Chat(ToolCallConfig {
             tools_available: tools.values().cloned().map(ToolConfig::Static).collect(),
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         });
         let parsed_value = serde_json::to_string(
             &validate_parse_demonstration(
@@ -1120,7 +1120,7 @@ mod tests {
         let dynamic_demonstration_info = DynamicDemonstrationInfo::Chat(ToolCallConfig {
             tools_available: tools.values().cloned().map(ToolConfig::Static).collect(),
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         });
         let parsed_value = serde_json::to_string(
             &validate_parse_demonstration(
@@ -1152,7 +1152,7 @@ mod tests {
         let dynamic_demonstration_info = DynamicDemonstrationInfo::Chat(ToolCallConfig {
             tools_available: tools.values().cloned().map(ToolConfig::Static).collect(),
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         });
         let err = validate_parse_demonstration(
             function_config_chat_tools,
@@ -1175,7 +1175,7 @@ mod tests {
         let dynamic_demonstration_info = DynamicDemonstrationInfo::Chat(ToolCallConfig {
             tools_available: tools.values().cloned().map(ToolConfig::Static).collect(),
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         });
         let err = validate_parse_demonstration(
             function_config_chat_tools,
@@ -1272,7 +1272,7 @@ mod tests {
         let dynamic_demonstration_info = DynamicDemonstrationInfo::Chat(ToolCallConfig {
             tools_available: tools.values().cloned().map(ToolConfig::Static).collect(),
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         });
         let err = validate_parse_demonstration(function_config, &value, dynamic_demonstration_info)
             .await

--- a/tensorzero-internal/src/endpoints/inference.rs
+++ b/tensorzero-internal/src/endpoints/inference.rs
@@ -498,7 +498,7 @@ fn find_function(params: &Params, config: &Config) -> Result<(Arc<FunctionConfig
                     assistant_schema: None,
                     tools: vec![],
                     tool_choice: ToolChoice::None,
-                    parallel_tool_calls: false,
+                    parallel_tool_calls: None,
                 })),
                 DEFAULT_FUNCTION_NAME.to_string(),
             ))

--- a/tensorzero-internal/src/function.rs
+++ b/tensorzero-internal/src/function.rs
@@ -48,7 +48,7 @@ pub struct FunctionConfigChat {
     pub assistant_schema: Option<JSONSchemaFromPath>,
     pub tools: Vec<String>, // tool names
     pub tool_choice: ToolChoice,
-    pub parallel_tool_calls: bool,
+    pub parallel_tool_calls: Option<bool>,
 }
 
 #[derive(Debug, Default)]

--- a/tensorzero-internal/src/inference/providers/anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/anthropic.rs
@@ -410,7 +410,7 @@ impl<'a> TryFrom<&'a ToolCallConfig> for AnthropicToolChoice<'a> {
     type Error = Error;
 
     fn try_from(tool_call_config: &'a ToolCallConfig) -> Result<Self, Error> {
-        let disable_parallel_tool_use = Some(!tool_call_config.parallel_tool_calls);
+        let disable_parallel_tool_use = Some(tool_call_config.parallel_tool_calls == Some(false));
         let tool_choice = &tool_call_config.tool_choice;
 
         match tool_choice {
@@ -1214,7 +1214,7 @@ mod tests {
         // Need to cover all 4 cases
         let tool_call_config = ToolCallConfig {
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: Some(false),
             tools_available: vec![],
         };
         let anthropic_tool_choice = AnthropicToolChoice::try_from(&tool_call_config);
@@ -1227,7 +1227,7 @@ mod tests {
 
         let tool_call_config = ToolCallConfig {
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: true,
+            parallel_tool_calls: Some(true),
             tools_available: vec![],
         };
         let anthropic_tool_choice = AnthropicToolChoice::try_from(&tool_call_config);
@@ -1241,7 +1241,7 @@ mod tests {
 
         let tool_call_config = ToolCallConfig {
             tool_choice: ToolChoice::Required,
-            parallel_tool_calls: true,
+            parallel_tool_calls: Some(true),
             tools_available: vec![],
         };
         let anthropic_tool_choice = AnthropicToolChoice::try_from(&tool_call_config);
@@ -1255,7 +1255,7 @@ mod tests {
 
         let tool_call_config = ToolCallConfig {
             tool_choice: ToolChoice::Specific("test".to_string()),
-            parallel_tool_calls: false,
+            parallel_tool_calls: Some(false),
             tools_available: vec![],
         };
         let anthropic_tool_choice = AnthropicToolChoice::try_from(&tool_call_config);

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
@@ -1368,7 +1368,7 @@ mod tests {
         let tool_config = ToolCallConfig {
             tools_available: vec![],
             tool_choice: ToolChoice::None,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         };
         let inference_request = ModelInferenceRequest {
             inference_id: Uuid::now_v7(),

--- a/tensorzero-internal/src/inference/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/google_ai_studio_gemini.rs
@@ -1171,7 +1171,7 @@ mod tests {
         let tool_config = ToolCallConfig {
             tools_available: vec![],
             tool_choice: ToolChoice::None,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         };
         let inference_request = ModelInferenceRequest {
             inference_id: Uuid::now_v7(),

--- a/tensorzero-internal/src/inference/providers/openai.rs
+++ b/tensorzero-internal/src/inference/providers/openai.rs
@@ -1013,7 +1013,7 @@ pub(super) fn prepare_openai_tools<'a>(
                     .collect(),
             );
             let tool_choice = Some((&tool_config.tool_choice).into());
-            let parallel_tool_calls = Some(tool_config.parallel_tool_calls);
+            let parallel_tool_calls = tool_config.parallel_tool_calls;
             (tools, tool_choice, parallel_tool_calls)
         }
     }
@@ -2831,7 +2831,7 @@ mod tests {
         let tool_config = ToolCallConfig {
             tools_available: vec![],
             tool_choice: ToolChoice::Required,
-            parallel_tool_calls: true,
+            parallel_tool_calls: Some(true),
         };
 
         // Test no tools but a tool choice and make sure tool choice output is None

--- a/tensorzero-internal/src/inference/providers/test_helpers.rs
+++ b/tensorzero-internal/src/inference/providers/test_helpers.rs
@@ -25,7 +25,7 @@ lazy_static! {
     pub static ref WEATHER_TOOL_CONFIG: ToolCallConfig = ToolCallConfig {
         tools_available: vec![ToolConfig::Static(WEATHER_TOOL_CONFIG_STATIC.clone())],
         tool_choice: ToolChoice::Specific("get_temperature".to_string()),
-        parallel_tool_calls: false,
+        parallel_tool_calls: None,
     };
     pub static ref QUERY_TOOL_CONFIG_STATIC: Arc<StaticToolConfig> = Arc::new(StaticToolConfig {
         name: "query_articles".to_string(),
@@ -48,7 +48,7 @@ lazy_static! {
             ToolConfig::Static(QUERY_TOOL_CONFIG_STATIC.clone())
         ],
         tool_choice: ToolChoice::Required,
-        parallel_tool_calls: true,
+        parallel_tool_calls: Some(true),
     };
 }
 
@@ -58,6 +58,6 @@ pub fn get_temperature_tool_config() -> ToolCallConfig {
     ToolCallConfig {
         tools_available: vec![weather_tool],
         tool_choice: ToolChoice::Specific("get_temperature".to_string()),
-        parallel_tool_calls: false,
+        parallel_tool_calls: Some(false),
     }
 }

--- a/tensorzero-internal/src/inference/providers/together.rs
+++ b/tensorzero-internal/src/inference/providers/together.rs
@@ -932,7 +932,7 @@ mod tests {
                 }
             }))
         );
-        assert_eq!(together_request.parallel_tool_calls, Some(false));
+        assert_eq!(together_request.parallel_tool_calls, None);
     }
 
     #[test]

--- a/tensorzero-internal/src/inference/types/mod.rs
+++ b/tensorzero-internal/src/inference/types/mod.rs
@@ -2027,7 +2027,7 @@ mod tests {
                 strict: true,
             })],
             tool_choice: ToolChoice::None,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         };
 
         // Test valid arguments for additional tool
@@ -2151,7 +2151,7 @@ mod tests {
                 strict: true,
             })],
             tool_choice: ToolChoice::None,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         };
 
         // Test allowed tool call

--- a/tensorzero-internal/src/model.rs
+++ b/tensorzero-internal/src/model.rs
@@ -1451,7 +1451,7 @@ mod tests {
         let tool_config = ToolCallConfig {
             tools_available: vec![],
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         };
         let api_keys = InferenceCredentials::default();
         let http_client = Client::new();
@@ -1912,7 +1912,7 @@ mod tests {
         let tool_config = ToolCallConfig {
             tools_available: vec![],
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         };
         let api_keys = InferenceCredentials::default();
         let http_client = Client::new();
@@ -2017,7 +2017,7 @@ mod tests {
         let tool_config = ToolCallConfig {
             tools_available: vec![],
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         };
         let api_keys = InferenceCredentials::default();
         let http_client = Client::new();

--- a/tensorzero-internal/src/tool.rs
+++ b/tensorzero-internal/src/tool.rs
@@ -76,7 +76,7 @@ pub struct DynamicImplicitToolConfig {
 pub struct ToolCallConfig {
     pub tools_available: Vec<ToolConfig>,
     pub tool_choice: ToolChoice,
-    pub parallel_tool_calls: bool,
+    pub parallel_tool_calls: Option<bool>,
 }
 
 /// ToolCallConfigDatabaseInsert is a lightweight version of ToolCallConfig that can be serialized and cloned.
@@ -85,14 +85,14 @@ pub struct ToolCallConfig {
 pub struct ToolCallConfigDatabaseInsert {
     pub tools_available: Vec<Tool>,
     pub tool_choice: ToolChoice,
-    pub parallel_tool_calls: bool,
+    pub parallel_tool_calls: Option<bool>,
 }
 
 impl ToolCallConfig {
     pub fn new(
         function_tools: &[String],
         function_tool_choice: &ToolChoice,
-        function_parallel_tool_calls: bool,
+        function_parallel_tool_calls: Option<bool>,
         static_tools: &HashMap<String, Arc<StaticToolConfig>>,
         dynamic_tool_params: DynamicToolParams,
     ) -> Result<Option<Self>, Error> {
@@ -158,7 +158,7 @@ impl ToolCallConfig {
 
         let parallel_tool_calls = dynamic_tool_params
             .parallel_tool_calls
-            .unwrap_or(function_parallel_tool_calls);
+            .or(function_parallel_tool_calls);
 
         let tool_call_config_option = match tools_available.is_empty() {
             true => None,
@@ -271,7 +271,7 @@ impl ToolCallConfig {
         Self {
             tools_available: vec![implicit_tool_config],
             tool_choice: ToolChoice::Specific(IMPLICIT_TOOL_NAME.to_string()),
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         }
     }
 }
@@ -391,7 +391,7 @@ pub fn create_dynamic_implicit_tool_config(schema: Value) -> ToolCallConfig {
     ToolCallConfig {
         tools_available: vec![implicit_tool],
         tool_choice: ToolChoice::Specific(IMPLICIT_TOOL_NAME.to_string()),
-        parallel_tool_calls: false,
+        parallel_tool_calls: None,
     }
 }
 
@@ -526,7 +526,7 @@ pub fn create_implicit_tool_call_config(schema: JSONSchemaFromPath) -> ToolCallC
     ToolCallConfig {
         tools_available: vec![implicit_tool],
         tool_choice: ToolChoice::Specific(IMPLICIT_TOOL_NAME.to_string()),
-        parallel_tool_calls: false,
+        parallel_tool_calls: None,
     }
 }
 
@@ -594,7 +594,7 @@ mod tests {
         let tool_call_config = ToolCallConfig::new(
             &EMPTY_FUNCTION_TOOLS,
             &AUTO_TOOL_CHOICE,
-            true,
+            Some(true),
             &TOOLS,
             DynamicToolParams::default(),
         )
@@ -606,7 +606,7 @@ mod tests {
         let tool_call_config = ToolCallConfig::new(
             &ALL_FUNCTION_TOOLS,
             &AUTO_TOOL_CHOICE,
-            true,
+            Some(true),
             &TOOLS,
             DynamicToolParams::default(),
         )
@@ -614,7 +614,7 @@ mod tests {
         .unwrap();
         assert_eq!(tool_call_config.tools_available.len(), 2);
         assert_eq!(tool_call_config.tool_choice, ToolChoice::Auto);
-        assert!(tool_call_config.parallel_tool_calls);
+        assert_eq!(tool_call_config.parallel_tool_calls, Some(true));
         assert!(tool_call_config.tools_available[0].strict());
         assert!(!tool_call_config.tools_available[1].strict());
 
@@ -626,7 +626,7 @@ mod tests {
         let err = ToolCallConfig::new(
             &EMPTY_FUNCTION_TOOLS,
             &AUTO_TOOL_CHOICE,
-            true,
+            Some(true),
             &EMPTY_TOOLS,
             dynamic_tool_params,
         )
@@ -647,7 +647,7 @@ mod tests {
         let tool_call_config = ToolCallConfig::new(
             &ALL_FUNCTION_TOOLS,
             &AUTO_TOOL_CHOICE,
-            true,
+            Some(true),
             &TOOLS,
             dynamic_tool_params,
         )
@@ -658,7 +658,7 @@ mod tests {
             tool_call_config.tool_choice,
             ToolChoice::Specific("get_temperature".to_string())
         );
-        assert!(tool_call_config.parallel_tool_calls);
+        assert_eq!(tool_call_config.parallel_tool_calls, Some(true));
 
         // Dynamic tool config specifies a particular tool to call and it's not in the function tools list
         let dynamic_tool_params = DynamicToolParams {
@@ -668,7 +668,7 @@ mod tests {
         let err = ToolCallConfig::new(
             &ALL_FUNCTION_TOOLS,
             &AUTO_TOOL_CHOICE,
-            true,
+            Some(true),
             &TOOLS,
             dynamic_tool_params,
         )
@@ -696,7 +696,7 @@ mod tests {
         let tool_call_config = ToolCallConfig::new(
             &ALL_FUNCTION_TOOLS,
             &AUTO_TOOL_CHOICE,
-            true,
+            Some(true),
             &TOOLS,
             dynamic_tool_params,
         )
@@ -723,7 +723,7 @@ mod tests {
         let tool_call_config = ToolCallConfig::new(
             &ALL_FUNCTION_TOOLS,
             &AUTO_TOOL_CHOICE,
-            true,
+            Some(true),
             &TOOLS,
             dynamic_tool_params,
         )
@@ -740,7 +740,7 @@ mod tests {
             tool_call_config.tools_available[1].name(),
             "establish_campground"
         );
-        assert!(!tool_call_config.parallel_tool_calls);
+        assert_eq!(tool_call_config.parallel_tool_calls, Some(false));
 
         // We pass a list of no allowed tools and then configure a new tool
         // This should remove all configured tools and add the new tool
@@ -758,7 +758,7 @@ mod tests {
         let tool_call_config = ToolCallConfig::new(
             &ALL_FUNCTION_TOOLS,
             &AUTO_TOOL_CHOICE,
-            true,
+            Some(true),
             &TOOLS,
             dynamic_tool_params,
         )
@@ -769,7 +769,7 @@ mod tests {
             tool_call_config.tools_available[0].name(),
             "establish_campground"
         );
-        assert!(tool_call_config.parallel_tool_calls);
+        assert_eq!(tool_call_config.parallel_tool_calls, Some(true));
         assert_eq!(
             tool_call_config.tool_choice,
             ToolChoice::Specific("establish_campground".to_string())
@@ -787,7 +787,7 @@ mod tests {
         let tool_call_config = ToolCallConfig::new(
             &ALL_FUNCTION_TOOLS,
             &AUTO_TOOL_CHOICE,
-            true,
+            Some(true),
             &TOOLS,
             DynamicToolParams::default(),
         )
@@ -846,7 +846,7 @@ mod tests {
         let tool_call_config = ToolCallConfig::new(
             &ALL_FUNCTION_TOOLS,
             &AUTO_TOOL_CHOICE,
-            true,
+            Some(true),
             &TOOLS,
             DynamicToolParams {
                 additional_tools: Some(vec![Tool {

--- a/tensorzero-internal/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-internal/src/variant/best_of_n_sampling.rs
@@ -100,7 +100,7 @@ lazy_static! {
             parameters: EVALUATOR_OUTPUT_SCHEMA.clone(),
         })],
         tool_choice: ToolChoice::Specific("respond".to_string()),
-        parallel_tool_calls: false,
+        parallel_tool_calls: None,
     };
 }
 

--- a/tensorzero-internal/src/variant/chat_completion.rs
+++ b/tensorzero-internal/src/variant/chat_completion.rs
@@ -848,7 +848,7 @@ mod tests {
             assistant_schema: None,
             tools: vec![],
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         });
         let good_provider_config = ProviderConfig::Dummy(DummyProvider {
             model_name: "good".into(),
@@ -1623,7 +1623,7 @@ mod tests {
             assistant_schema: None,
             tools: vec![],
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         })));
         let system_template_name = "system";
         let user_template_name = "greeting_with_age";
@@ -1850,7 +1850,7 @@ mod tests {
             assistant_schema: None,
             tools: vec![],
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         });
         let mut inference_params = InferenceParams::default();
         let inference_config = InferenceConfig {
@@ -1954,7 +1954,7 @@ mod tests {
             implicit_tool_call_config: ToolCallConfig {
                 tools_available: vec![],
                 tool_choice: ToolChoice::Auto,
-                parallel_tool_calls: false,
+                parallel_tool_calls: None,
             },
         });
         let inference_config = InferenceConfig {

--- a/tensorzero-internal/src/variant/mixture_of_n.rs
+++ b/tensorzero-internal/src/variant/mixture_of_n.rs
@@ -1192,7 +1192,7 @@ mod tests {
             assistant_schema: None,
             tools: vec![],
             tool_choice: ToolChoice::None,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         });
 
         let result = mixture_of_n_variant

--- a/tensorzero-internal/src/variant/mod.rs
+++ b/tensorzero-internal/src/variant/mod.rs
@@ -639,7 +639,7 @@ mod tests {
         let tool_config = ToolCallConfig {
             tools_available: vec![],
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         };
 
         // Create a sample inference config
@@ -690,7 +690,7 @@ mod tests {
             assistant_schema: None,
             tools: vec![],
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         });
         let json_mode = JsonMode::Off;
 
@@ -886,7 +886,7 @@ mod tests {
             assistant_schema: None,
             tools: vec![],
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         });
 
         let request_messages = vec![RequestMessage {
@@ -988,7 +988,7 @@ mod tests {
             implicit_tool_call_config: crate::tool::ToolCallConfig {
                 tools_available: vec![],
                 tool_choice: ToolChoice::Auto,
-                parallel_tool_calls: false,
+                parallel_tool_calls: None,
             },
         });
         let output_schema = json!({
@@ -1153,7 +1153,7 @@ mod tests {
             assistant_schema: None,
             tools: vec![],
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         });
 
         let request_messages = vec![RequestMessage {
@@ -1281,7 +1281,7 @@ mod tests {
             assistant_schema: None,
             tools: vec![],
             tool_choice: crate::tool::ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         });
 
         // Create an input message
@@ -1423,7 +1423,7 @@ mod tests {
             assistant_schema: None,
             tools: vec![],
             tool_choice: ToolChoice::Auto,
-            parallel_tool_calls: false,
+            parallel_tool_calls: None,
         })));
 
         let request_messages = vec![RequestMessage {

--- a/tensorzero-internal/tests/e2e/best_of_n.rs
+++ b/tensorzero-internal/tests/e2e/best_of_n.rs
@@ -1000,7 +1000,7 @@ async fn e2e_test_best_of_n_json_real_judge_implicit_tool() {
                 "tool_choice": {
                     "type": "tool",
                     "name": "respond",
-                    "disable_parallel_tool_use": true
+                    "disable_parallel_tool_use": false,
                 },
                 "tools": [
                     {

--- a/tensorzero-internal/tests/e2e/inference.rs
+++ b/tensorzero-internal/tests/e2e/inference.rs
@@ -645,11 +645,10 @@ async fn e2e_test_tool_call() {
             == "get_temperature"
     );
     assert!(tool_params.get("tool_choice").unwrap().as_str().unwrap() == "auto");
-    assert!(!tool_params
-        .get("parallel_tool_calls")
-        .unwrap()
-        .as_bool()
-        .unwrap());
+    assert_eq!(
+        tool_params.get("parallel_tool_calls").unwrap(),
+        &Value::Null
+    );
     // Check the ModelInference Table
     let result = select_model_inference_clickhouse(&clickhouse, inference_id)
         .await
@@ -842,11 +841,10 @@ async fn e2e_test_tool_call_malformed() {
             == "get_temperature"
     );
     assert!(tool_params.get("tool_choice").unwrap().as_str().unwrap() == "auto");
-    assert!(!tool_params
-        .get("parallel_tool_calls")
-        .unwrap()
-        .as_bool()
-        .unwrap());
+    assert_eq!(
+        tool_params.get("parallel_tool_calls").unwrap(),
+        &Value::Null
+    );
     // Check the ModelInference Table
     let result = select_model_inference_clickhouse(&clickhouse, inference_id)
         .await
@@ -2092,11 +2090,10 @@ async fn e2e_test_tool_call_streaming() {
             == "get_temperature"
     );
     assert!(tool_params.get("tool_choice").unwrap().as_str().unwrap() == "auto");
-    assert!(!tool_params
-        .get("parallel_tool_calls")
-        .unwrap()
-        .as_bool()
-        .unwrap());
+    assert_eq!(
+        tool_params.get("parallel_tool_calls").unwrap(),
+        &Value::Null
+    );
     // Check the ModelInference Table
     let result = select_model_inference_clickhouse(&clickhouse, inference_id)
         .await

--- a/tensorzero-internal/tests/e2e/providers/batch.rs
+++ b/tensorzero-internal/tests/e2e/providers/batch.rs
@@ -1465,7 +1465,7 @@ pub async fn test_tool_use_batch_inference_request_with_provider(provider: E2ETe
     let expected_tool_params = [
         json!({
             "tool_choice": "auto",
-            "parallel_tool_calls": false,
+            "parallel_tool_calls": null,
             "tools_available": [{
                 "name": "get_temperature",
                 "description": "Get the current temperature in a given location",
@@ -1513,7 +1513,7 @@ pub async fn test_tool_use_batch_inference_request_with_provider(provider: E2ETe
                 "strict": false
             }],
             "tool_choice": "auto",
-            "parallel_tool_calls": false
+            "parallel_tool_calls": null
         }),
         json!({
             "tools_available": [{
@@ -1539,7 +1539,7 @@ pub async fn test_tool_use_batch_inference_request_with_provider(provider: E2ETe
                 "strict": false
             }],
             "tool_choice": "required",
-            "parallel_tool_calls": false
+            "parallel_tool_calls": null
         }),
         json!({
             "tools_available": [{
@@ -1565,7 +1565,7 @@ pub async fn test_tool_use_batch_inference_request_with_provider(provider: E2ETe
                 "strict": false
             }],
             "tool_choice": "none",
-            "parallel_tool_calls": false
+            "parallel_tool_calls": null
         }),
         json!({
             "tools_available": [{
@@ -1608,7 +1608,7 @@ pub async fn test_tool_use_batch_inference_request_with_provider(provider: E2ETe
             "tool_choice": {
                 "specific": "self_destruct"
             },
-            "parallel_tool_calls": false
+            "parallel_tool_calls": null
         }),
     ];
 
@@ -2118,7 +2118,7 @@ pub async fn test_allowed_tools_batch_inference_request_with_provider(provider: 
             "strict": false
         }],
         "tool_choice": "required",
-        "parallel_tool_calls": false
+        "parallel_tool_calls": null
     });
     assert_eq!(tool_params, expected_tool_params);
 
@@ -2524,7 +2524,7 @@ pub async fn test_tool_multi_turn_batch_inference_request_with_provider(provider
 
     let tool_params = result.get("tool_params").unwrap().as_str().unwrap();
     let tool_params: Value = serde_json::from_str(tool_params).unwrap();
-    let expected_tool_params = json!({"tools_available":[{"description":"Get the current temperature in a given location","parameters":{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"location":{"type":"string","description":"The location to get the temperature for (e.g. \"New York\")"},"units":{"type":"string","description":"The units to get the temperature in (must be \"fahrenheit\" or \"celsius\")","enum":["fahrenheit","celsius"]}},"required":["location"],"additionalProperties":false},"name":"get_temperature","strict":false}],"tool_choice":"auto","parallel_tool_calls":false});
+    let expected_tool_params = json!({"tools_available":[{"description":"Get the current temperature in a given location","parameters":{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"location":{"type":"string","description":"The location to get the temperature for (e.g. \"New York\")"},"units":{"type":"string","description":"The units to get the temperature in (must be \"fahrenheit\" or \"celsius\")","enum":["fahrenheit","celsius"]}},"required":["location"],"additionalProperties":false},"name":"get_temperature","strict":false}],"tool_choice":"auto","parallel_tool_calls":null});
     assert_eq!(tool_params, expected_tool_params);
 
     let inference_params = result.get("inference_params").unwrap().as_str().unwrap();
@@ -2911,7 +2911,7 @@ pub async fn test_dynamic_tool_use_batch_inference_request_with_provider(
             "strict": false
         }],
         "tool_choice": "auto",
-        "parallel_tool_calls": false
+        "parallel_tool_calls": null
     });
     assert_eq!(tool_params, expected_tool_params);
 
@@ -3398,8 +3398,14 @@ pub async fn test_poll_existing_parallel_tool_use_batch_inference_request_with_p
     let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
     // Check the response from polling by batch_id
-    check_parallel_tool_use_inference_response(inferences_json[0].clone(), &provider, None, true)
-        .await;
+    check_parallel_tool_use_inference_response(
+        inferences_json[0].clone(),
+        &provider,
+        None,
+        true,
+        true.into(),
+    )
+    .await;
 
     // Check the response from polling by inference_id
     let inference_id = inferences_json[0]
@@ -3425,8 +3431,14 @@ pub async fn test_poll_existing_parallel_tool_use_batch_inference_request_with_p
 
     let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
-    check_parallel_tool_use_inference_response(inferences_json[0].clone(), &provider, None, true)
-        .await;
+    check_parallel_tool_use_inference_response(
+        inferences_json[0].clone(),
+        &provider,
+        None,
+        true,
+        true.into(),
+    )
+    .await;
 }
 
 /// If there is a completed batch inference for the function, variant, and tags
@@ -3481,8 +3493,14 @@ pub async fn test_poll_completed_parallel_tool_use_batch_inference_request_with_
     let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
 
-    check_parallel_tool_use_inference_response(inferences_json[0].clone(), &provider, None, true)
-        .await;
+    check_parallel_tool_use_inference_response(
+        inferences_json[0].clone(),
+        &provider,
+        None,
+        true,
+        true.into(),
+    )
+    .await;
 
     // Poll by batch_id
     let url = get_poll_batch_inference_url(PollPathParams {
@@ -3507,8 +3525,14 @@ pub async fn test_poll_completed_parallel_tool_use_batch_inference_request_with_
     let inferences_json = response_json.get("inferences").unwrap().as_array().unwrap();
     assert_eq!(inferences_json.len(), 1);
 
-    check_parallel_tool_use_inference_response(inferences_json[0].clone(), &provider, None, true)
-        .await;
+    check_parallel_tool_use_inference_response(
+        inferences_json[0].clone(),
+        &provider,
+        None,
+        true,
+        true.into(),
+    )
+    .await;
 }
 
 pub async fn test_json_mode_batch_inference_request_with_provider(provider: E2ETestProvider) {

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -2799,7 +2799,7 @@ pub async fn check_tool_use_tool_choice_auto_used_inference_response(
     let tool_params: Value =
         serde_json::from_str(result.get("tool_params").unwrap().as_str().unwrap()).unwrap();
     assert_eq!(tool_params["tool_choice"], "auto");
-    assert_eq!(tool_params["parallel_tool_calls"], false);
+    assert_eq!(tool_params["parallel_tool_calls"], Value::Null);
 
     let tools_available = tool_params["tools_available"].as_array().unwrap();
     assert_eq!(tools_available.len(), 1);
@@ -3122,7 +3122,7 @@ pub async fn test_tool_use_tool_choice_auto_used_streaming_inference_request_wit
     let tool_params: Value =
         serde_json::from_str(result.get("tool_params").unwrap().as_str().unwrap()).unwrap();
     assert_eq!(tool_params["tool_choice"], "auto");
-    assert_eq!(tool_params["parallel_tool_calls"], false);
+    assert_eq!(tool_params["parallel_tool_calls"], Value::Null);
 
     let tools_available = tool_params["tools_available"].as_array().unwrap();
     assert_eq!(tools_available.len(), 1);
@@ -3392,7 +3392,7 @@ pub async fn check_tool_use_tool_choice_auto_unused_inference_response(
     let tool_params: Value =
         serde_json::from_str(result.get("tool_params").unwrap().as_str().unwrap()).unwrap();
     assert_eq!(tool_params["tool_choice"], "auto");
-    assert_eq!(tool_params["parallel_tool_calls"], false);
+    assert_eq!(tool_params["parallel_tool_calls"], Value::Null);
 
     let tools_available = tool_params["tools_available"].as_array().unwrap();
     assert_eq!(tools_available.len(), 1);
@@ -3685,7 +3685,7 @@ pub async fn test_tool_use_tool_choice_auto_unused_streaming_inference_request_w
     let tool_params: Value =
         serde_json::from_str(result.get("tool_params").unwrap().as_str().unwrap()).unwrap();
     assert_eq!(tool_params["tool_choice"], "auto");
-    assert_eq!(tool_params["parallel_tool_calls"], false);
+    assert_eq!(tool_params["parallel_tool_calls"], Value::Null);
 
     let tools_available = tool_params["tools_available"].as_array().unwrap();
     assert_eq!(tools_available.len(), 1);
@@ -3965,7 +3965,7 @@ pub async fn check_tool_use_tool_choice_required_inference_response(
     let tool_params: Value =
         serde_json::from_str(result.get("tool_params").unwrap().as_str().unwrap()).unwrap();
     assert_eq!(tool_params["tool_choice"], "required");
-    assert_eq!(tool_params["parallel_tool_calls"], false);
+    assert_eq!(tool_params["parallel_tool_calls"], Value::Null);
 
     let tools_available = tool_params["tools_available"].as_array().unwrap();
     assert_eq!(tools_available.len(), 1);
@@ -4283,7 +4283,7 @@ pub async fn test_tool_use_tool_choice_required_streaming_inference_request_with
     let tool_params: Value =
         serde_json::from_str(result.get("tool_params").unwrap().as_str().unwrap()).unwrap();
     assert_eq!(tool_params["tool_choice"], "required");
-    assert_eq!(tool_params["parallel_tool_calls"], false);
+    assert_eq!(tool_params["parallel_tool_calls"], Value::Null);
 
     let tools_available = tool_params["tools_available"].as_array().unwrap();
     assert_eq!(tools_available.len(), 1);
@@ -4547,7 +4547,7 @@ pub async fn check_tool_use_tool_choice_none_inference_response(
     let tool_params: Value =
         serde_json::from_str(result.get("tool_params").unwrap().as_str().unwrap()).unwrap();
     assert_eq!(tool_params["tool_choice"], "none");
-    assert_eq!(tool_params["parallel_tool_calls"], false);
+    assert_eq!(tool_params["parallel_tool_calls"], Value::Null);
 
     let tools_available = tool_params["tools_available"].as_array().unwrap();
     assert_eq!(tools_available.len(), 1);
@@ -4827,7 +4827,7 @@ pub async fn test_tool_use_tool_choice_none_streaming_inference_request_with_pro
     let tool_params: Value =
         serde_json::from_str(result.get("tool_params").unwrap().as_str().unwrap()).unwrap();
     assert_eq!(tool_params["tool_choice"], "none");
-    assert_eq!(tool_params["parallel_tool_calls"], false);
+    assert_eq!(tool_params["parallel_tool_calls"], Value::Null);
 
     let tools_available = tool_params["tools_available"].as_array().unwrap();
     assert_eq!(tools_available.len(), 1);
@@ -5139,7 +5139,7 @@ pub async fn check_tool_use_tool_choice_specific_inference_response(
         tool_params["tool_choice"],
         json!({"specific": "self_destruct"})
     );
-    assert_eq!(tool_params["parallel_tool_calls"], false);
+    assert_eq!(tool_params["parallel_tool_calls"], Value::Null);
 
     let tools_available = tool_params["tools_available"].as_array().unwrap();
     assert_eq!(tools_available.len(), 2);
@@ -5523,7 +5523,7 @@ pub async fn test_tool_use_tool_choice_specific_streaming_inference_request_with
         tool_params["tool_choice"],
         json!({"specific": "self_destruct"})
     );
-    assert_eq!(tool_params["parallel_tool_calls"], false);
+    assert_eq!(tool_params["parallel_tool_calls"], Value::Null);
 
     let tools_available = tool_params["tools_available"].as_array().unwrap();
     assert_eq!(tools_available.len(), 2);
@@ -5834,7 +5834,7 @@ pub async fn check_tool_use_tool_choice_allowed_tools_inference_response(
     let tool_params: Value =
         serde_json::from_str(result.get("tool_params").unwrap().as_str().unwrap()).unwrap();
     assert_eq!(tool_params["tool_choice"], "required");
-    assert_eq!(tool_params["parallel_tool_calls"], false);
+    assert_eq!(tool_params["parallel_tool_calls"], Value::Null);
 
     let tools_available = tool_params["tools_available"].as_array().unwrap();
     assert_eq!(tools_available.len(), 1);
@@ -6138,7 +6138,7 @@ pub async fn test_tool_use_allowed_tools_streaming_inference_request_with_provid
     let tool_params: Value =
         serde_json::from_str(result.get("tool_params").unwrap().as_str().unwrap()).unwrap();
     assert_eq!(tool_params["tool_choice"], "required");
-    assert_eq!(tool_params["parallel_tool_calls"], false);
+    assert_eq!(tool_params["parallel_tool_calls"], Value::Null);
 
     let tools_available = tool_params["tools_available"].as_array().unwrap();
     assert_eq!(tools_available.len(), 1);
@@ -6422,7 +6422,7 @@ pub async fn check_tool_use_multi_turn_inference_response(
     let tool_params: Value =
         serde_json::from_str(result.get("tool_params").unwrap().as_str().unwrap()).unwrap();
     assert_eq!(tool_params["tool_choice"], "auto");
-    assert_eq!(tool_params["parallel_tool_calls"], false);
+    assert_eq!(tool_params["parallel_tool_calls"], Value::Null);
 
     let tools_available = tool_params["tools_available"].as_array().unwrap();
     assert_eq!(tools_available.len(), 1);
@@ -6745,7 +6745,7 @@ pub async fn test_tool_multi_turn_streaming_inference_request_with_provider(
     let tool_params: Value =
         serde_json::from_str(result.get("tool_params").unwrap().as_str().unwrap()).unwrap();
     assert_eq!(tool_params["tool_choice"], "auto");
-    assert_eq!(tool_params["parallel_tool_calls"], false);
+    assert_eq!(tool_params["parallel_tool_calls"], Value::Null);
 
     let inference_params = result.get("inference_params").unwrap().as_str().unwrap();
     let inference_params: Value = serde_json::from_str(inference_params).unwrap();
@@ -7053,7 +7053,7 @@ pub async fn check_dynamic_tool_use_inference_response(
     let tool_params: Value =
         serde_json::from_str(result.get("tool_params").unwrap().as_str().unwrap()).unwrap();
     assert_eq!(tool_params["tool_choice"], "auto");
-    assert_eq!(tool_params["parallel_tool_calls"], false);
+    assert_eq!(tool_params["parallel_tool_calls"], Value::Null);
 
     let tools_available = tool_params["tools_available"].as_array().unwrap();
     assert_eq!(tools_available.len(), 1);
@@ -7381,7 +7381,7 @@ pub async fn test_dynamic_tool_use_streaming_inference_request_with_provider(
     let tool_params: Value =
         serde_json::from_str(result.get("tool_params").unwrap().as_str().unwrap()).unwrap();
     assert_eq!(tool_params["tool_choice"], "auto");
-    assert_eq!(tool_params["parallel_tool_calls"], false);
+    assert_eq!(tool_params["parallel_tool_calls"], Value::Null);
 
     let tools_available = tool_params["tools_available"].as_array().unwrap();
     assert_eq!(tools_available.len(), 1);
@@ -7544,8 +7544,14 @@ pub async fn test_parallel_tool_use_inference_request_with_provider(provider: E2
     let response_json = response.json::<Value>().await.unwrap();
 
     println!("API response: {response_json:#?}");
-    check_parallel_tool_use_inference_response(response_json, &provider, Some(episode_id), false)
-        .await;
+    check_parallel_tool_use_inference_response(
+        response_json,
+        &provider,
+        Some(episode_id),
+        false,
+        Value::Bool(true),
+    )
+    .await;
 }
 
 pub async fn check_parallel_tool_use_inference_response(
@@ -7553,6 +7559,7 @@ pub async fn check_parallel_tool_use_inference_response(
     provider: &E2ETestProvider,
     episode_id: Option<Uuid>,
     is_batch: bool,
+    parallel_param: Value,
 ) {
     let hardcoded_function_name = "weather_helper_parallel";
     let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
@@ -7696,7 +7703,7 @@ pub async fn check_parallel_tool_use_inference_response(
     let tool_params: Value =
         serde_json::from_str(result.get("tool_params").unwrap().as_str().unwrap()).unwrap();
     assert_eq!(tool_params["tool_choice"], "auto");
-    assert_eq!(tool_params["parallel_tool_calls"], true);
+    assert_eq!(tool_params["parallel_tool_calls"], parallel_param);
 
     let tools_available = tool_params["tools_available"].as_array().unwrap();
 


### PR DESCRIPTION
When this is `None`, we pass in `null` to the underlying provider, using its default value.
Fixes #1382

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `parallel_tool_calls` to `Option<bool>` to allow `None`, defaulting to provider's value when unspecified, with updated tests.
> 
>   - **Behavior**:
>     - Change `parallel_tool_calls` to `Option<bool>` in `config_parser.rs`, `function.rs`, and `tool.rs`.
>     - When `None`, pass `null` to providers, using their default value.
>   - **Tests**:
>     - Update tests in `helpers.rs`, `feedback.rs`, `inference.rs`, and `test_helpers.rs` to reflect `Option<bool>` change.
>     - Add test `test_parallel_tool_use_default_true_inference_request` in `openai.rs` to verify default behavior when `parallel_tool_calls` is `None`.
>   - **Misc**:
>     - Update e2e tests in `best_of_n.rs`, `inference.rs`, and `batch.rs` to check for `null` handling of `parallel_tool_calls`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d17ebce1311e4c929fd665a219fff3beb190dd7e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->