### PR TITLE
Make Dependabot bump our Rust deps every week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,13 @@ updates:
       interval: "daily"
     labels: []
     open-pull-requests-limit: 0 # only send security updates
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 1


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds weekly update schedule for Rust dependencies in Dependabot configuration with a limit of one open pull request.
> 
>   - **Dependabot Configuration**:
>     - Adds a weekly update schedule for Rust dependencies using Cargo in `.github/dependabot.yml`.
>     - Sets `open-pull-requests-limit` to 1 for Rust dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 019f03b4a9d33965d7ca7d23cadbe0188a92a58f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->