### PR TITLE
Make provider-proxy panic if we get data after running callback

### DIFF
--- a/provider-proxy/src/streaming_body_collector.rs
+++ b/provider-proxy/src/streaming_body_collector.rs
@@ -48,6 +48,9 @@ where
         let frame = ready!(frame);
         match &frame {
             Some(Ok(frame)) => {
+                if this.done_callback.is_none() {
+                    panic!("poll_frame got frame after done_callback was called");
+                }
                 if let Some(data) = frame.data_ref() {
                     this.buffer.extend(data);
                 } else {


### PR DESCRIPTION
This will guard against misbehavior from the wrapped `Body`

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add panic in `poll_frame` of `StreamingBodyCollector` to prevent data processing after `done_callback`.
> 
>   - **Behavior**:
>     - In `streaming_body_collector.rs`, `poll_frame` now panics if a frame is received after `done_callback` is called, ensuring no data is processed post-callback.
>   - **Misc**:
>     - Adds a panic message for unexpected frames in `poll_frame`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7a7d4bcd7d6d43cf8826af116b551eed16ae8699. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->