### PR TITLE
Fix dependabot.yml configuration for Cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,20 +20,14 @@ updates:
       interval: "daily"
     labels: []
     open-pull-requests-limit: 0 # only send security updates
-
+    
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
-    labels: []
-    open-pull-requests-limit: 0 # only send security updates
-
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
+      # This schedule does not affect security updates: https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/customizing-dependabot-security-prs#about-customizing-pull-requests-for-security-updates
       interval: "weekly"
     groups:
       rust-dependencies:
         patterns:
           - "*"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 1 # This does not affect the security update pr limit


### PR DESCRIPTION
We need to use a single 'package-ecosystem: cargo' section - only some of the setttings will be applied to security update prs.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Consolidates `cargo` configuration in `dependabot.yml` to a single section with clarified update behavior.
> 
>   - **Configuration**:
>     - Consolidates `package-ecosystem: cargo` sections in `.github/dependabot.yml` to a single section.
>     - Sets `interval: weekly` for `cargo` updates, clarifying it does not affect security updates.
>     - Limits open pull requests for `cargo` to 1, specifying it does not affect security update limits.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for dee9915767dbc2a9e6d679684c16f2aa78a62b45. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->