### PR TITLE
Move evals EmbeddedGateway tests to e2e test file

### DIFF
--- a/evals/Cargo.toml
+++ b/evals/Cargo.toml
@@ -24,7 +24,7 @@ futures = { workspace = true }
 indicatif = "0.17.11"
 
 [dev-dependencies]
-tensorzero = { path = "../clients/rust", features = ["e2e_tests"] }
+tensorzero = { path = "../clients/rust" }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/evals/src/evaluators/llm_judge.rs
+++ b/evals/src/evaluators/llm_judge.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 
 use crate::ThrottledTensorZeroClient;
 
-pub(super) async fn run_llm_judge_evaluator(
+pub async fn run_llm_judge_evaluator(
     inference_response: &InferenceResponse,
     datapoint: &Datapoint,
     tensorzero_client: &ThrottledTensorZeroClient,
@@ -173,27 +173,21 @@ fn handle_reference_output(
 
 #[cfg(test)]
 mod tests {
-    use std::{path::PathBuf, sync::Arc};
 
     use super::*;
 
     use serde_json::json;
-    use tensorzero::{ClientBuilder, ClientBuilderMode, Role};
+    use tensorzero::Role;
     use tensorzero_internal::{
-        endpoints::{
-            datasets::{ChatInferenceDatapoint, JsonInferenceDatapoint},
-            inference::{ChatInferenceResponse, JsonInferenceResponse},
-        },
-        evals::{LLMJudgeIncludeConfig, LLMJudgeOptimize},
         inference::types::{
             resolved_input::ImageWithPath,
             storage::{StorageKind, StoragePath},
             Base64Image, ContentBlockChatOutput, ImageKind, ResolvedInput, ResolvedInputMessage,
-            ResolvedInputMessageContent, Text, Usage,
+            ResolvedInputMessageContent, Text,
         },
         tool::{ToolCallOutput, ToolResult},
     };
-    use tokio::sync::Semaphore;
+
     use url::Url;
 
     #[test]
@@ -306,305 +300,5 @@ mod tests {
             serialized_output,
             r#"[{"type":"tool_call","arguments":{"foo":"bar"},"id":"foooo","name":"tool","raw_arguments":"{\"foo\": \"bar\"}","raw_name":"tool"},{"type":"text","text":"Hello, world!"}]"#
         );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_run_llm_judge_evaluator_chat() {
-        let tensorzero_client = ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
-            config_file: Some(PathBuf::from(&format!(
-                "{}/../tensorzero-internal/tests/e2e/tensorzero.toml",
-                std::env::var("CARGO_MANIFEST_DIR").unwrap()
-            ))),
-            clickhouse_url: None,
-            timeout: None,
-        })
-        .build()
-        .await
-        .unwrap();
-        let tensorzero_client = Arc::new(ThrottledTensorZeroClient::new(
-            tensorzero_client,
-            Semaphore::new(1),
-        ));
-        let inference_response = InferenceResponse::Chat(ChatInferenceResponse {
-            content: vec![ContentBlockChatOutput::Text(Text {
-                text: "Hello, world!".to_string(),
-            })],
-            original_response: None,
-            finish_reason: None,
-            episode_id: Uuid::now_v7(),
-            inference_id: Uuid::now_v7(),
-            usage: Usage {
-                input_tokens: 0,
-                output_tokens: 0,
-            },
-            variant_name: "test_variant".to_string(),
-        });
-        let datapoint = Datapoint::ChatInference(ChatInferenceDatapoint {
-            input: ResolvedInput {
-                system: None,
-                messages: vec![ResolvedInputMessage {
-                    role: Role::User,
-                    content: vec![ResolvedInputMessageContent::Text {
-                        value: json!("Hello, world!"),
-                    }],
-                }],
-            },
-            auxiliary: "".to_string(),
-            dataset_name: "test_dataset".to_string(),
-            episode_id: Some(Uuid::now_v7()),
-            id: Uuid::now_v7(),
-            is_deleted: false,
-            function_name: "test_function".to_string(),
-            output: Some(vec![ContentBlockChatOutput::Text(Text {
-                text: "Hello, world!".to_string(),
-            })]),
-            tags: None,
-            tool_params: None,
-        });
-        let llm_judge_config = LLMJudgeConfig {
-            include: LLMJudgeIncludeConfig {
-                reference_output: true,
-            },
-            optimize: LLMJudgeOptimize::Max,
-            output_type: LLMJudgeOutputType::Boolean,
-            cutoff: None,
-        };
-        let result = run_llm_judge_evaluator(
-            &inference_response,
-            &datapoint,
-            &tensorzero_client,
-            &llm_judge_config,
-            "test_eval",
-            "happy_bool",
-            Uuid::now_v7(),
-        )
-        .await
-        .unwrap();
-        assert_eq!(result, Some(json!(true)));
-
-        let result = run_llm_judge_evaluator(
-            &inference_response,
-            &datapoint,
-            &tensorzero_client,
-            &llm_judge_config,
-            "test_eval",
-            "sad_bool",
-            Uuid::now_v7(),
-        )
-        .await
-        .unwrap();
-        assert_eq!(result, Some(json!(false)));
-
-        let result = run_llm_judge_evaluator(
-            &inference_response,
-            &datapoint,
-            &tensorzero_client,
-            &llm_judge_config,
-            "test_eval",
-            "zero",
-            Uuid::now_v7(),
-        )
-        .await
-        .unwrap();
-        assert_eq!(result, Some(json!(0)));
-
-        let result = run_llm_judge_evaluator(
-            &inference_response,
-            &datapoint,
-            &tensorzero_client,
-            &llm_judge_config,
-            "test_eval",
-            "one",
-            Uuid::now_v7(),
-        )
-        .await
-        .unwrap();
-        assert_eq!(result, Some(json!(1)));
-
-        // Try without output
-        let datapoint = Datapoint::ChatInference(ChatInferenceDatapoint {
-            input: ResolvedInput {
-                system: None,
-                messages: vec![ResolvedInputMessage {
-                    role: Role::User,
-                    content: vec![ResolvedInputMessageContent::Text {
-                        value: json!("Hello, world!"),
-                    }],
-                }],
-            },
-            auxiliary: "".to_string(),
-            dataset_name: "test_dataset".to_string(),
-            episode_id: Some(Uuid::now_v7()),
-            id: Uuid::now_v7(),
-            is_deleted: false,
-            function_name: "test_function".to_string(),
-            output: None,
-            tags: None,
-            tool_params: None,
-        });
-
-        let result = run_llm_judge_evaluator(
-            &inference_response,
-            &datapoint,
-            &tensorzero_client,
-            &llm_judge_config,
-            "test_eval",
-            "happy_bool",
-            Uuid::now_v7(),
-        )
-        .await
-        .unwrap();
-        assert_eq!(result, None);
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_run_llm_judge_evaluator_json() {
-        let tensorzero_client = ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
-            config_file: Some(PathBuf::from(&format!(
-                "{}/../tensorzero-internal/tests/e2e/tensorzero.toml",
-                std::env::var("CARGO_MANIFEST_DIR").unwrap()
-            ))),
-            clickhouse_url: None,
-            timeout: None,
-        })
-        .build()
-        .await
-        .unwrap();
-        let tensorzero_client = Arc::new(ThrottledTensorZeroClient::new(
-            tensorzero_client,
-            Semaphore::new(1),
-        ));
-        let inference_response = InferenceResponse::Json(JsonInferenceResponse {
-            output: JsonInferenceOutput {
-                parsed: Some(json!({"answer": "LeBron James"})),
-                raw: "{\"answer\": \"LeBron James\"}".to_string(),
-            },
-            original_response: None,
-            finish_reason: None,
-            episode_id: Uuid::now_v7(),
-            inference_id: Uuid::now_v7(),
-            usage: Usage {
-                input_tokens: 0,
-                output_tokens: 0,
-            },
-            variant_name: "test_variant".to_string(),
-        });
-        let datapoint = Datapoint::JsonInference(JsonInferenceDatapoint {
-            input: ResolvedInput {
-                system: None,
-                messages: vec![ResolvedInputMessage {
-                    role: Role::User,
-                    content: vec![ResolvedInputMessageContent::Text {
-                        value: json!("Hello, world!"),
-                    }],
-                }],
-            },
-            auxiliary: "".to_string(),
-            dataset_name: "test_dataset".to_string(),
-            episode_id: Some(Uuid::now_v7()),
-            id: Uuid::now_v7(),
-            is_deleted: false,
-            function_name: "test_function".to_string(),
-            output: Some(JsonInferenceOutput {
-                parsed: Some(json!({"answer": "LeBron James"})),
-                raw: "{\"answer\": \"LeBron James\"}".to_string(),
-            }),
-            output_schema: json!({"answer": "string"}),
-            tags: None,
-        });
-        let llm_judge_config = LLMJudgeConfig {
-            include: LLMJudgeIncludeConfig {
-                reference_output: true,
-            },
-            optimize: LLMJudgeOptimize::Max,
-            output_type: LLMJudgeOutputType::Boolean,
-            cutoff: None,
-        };
-        let result = run_llm_judge_evaluator(
-            &inference_response,
-            &datapoint,
-            &tensorzero_client,
-            &llm_judge_config,
-            "test_eval",
-            "happy_bool",
-            Uuid::now_v7(),
-        )
-        .await
-        .unwrap();
-        assert_eq!(result, Some(json!(true)));
-
-        let result = run_llm_judge_evaluator(
-            &inference_response,
-            &datapoint,
-            &tensorzero_client,
-            &llm_judge_config,
-            "test_eval",
-            "sad_bool",
-            Uuid::now_v7(),
-        )
-        .await
-        .unwrap();
-        assert_eq!(result, Some(json!(false)));
-
-        let result = run_llm_judge_evaluator(
-            &inference_response,
-            &datapoint,
-            &tensorzero_client,
-            &llm_judge_config,
-            "test_eval",
-            "zero",
-            Uuid::now_v7(),
-        )
-        .await
-        .unwrap();
-        assert_eq!(result, Some(json!(0)));
-
-        let result = run_llm_judge_evaluator(
-            &inference_response,
-            &datapoint,
-            &tensorzero_client,
-            &llm_judge_config,
-            "test_eval",
-            "one",
-            Uuid::now_v7(),
-        )
-        .await
-        .unwrap();
-        assert_eq!(result, Some(json!(1)));
-
-        // Try without output
-        let datapoint = Datapoint::ChatInference(ChatInferenceDatapoint {
-            input: ResolvedInput {
-                system: None,
-                messages: vec![ResolvedInputMessage {
-                    role: Role::User,
-                    content: vec![ResolvedInputMessageContent::Text {
-                        value: json!("Hello, world!"),
-                    }],
-                }],
-            },
-            auxiliary: "".to_string(),
-            dataset_name: "test_dataset".to_string(),
-            episode_id: Some(Uuid::now_v7()),
-            id: Uuid::now_v7(),
-            is_deleted: false,
-            function_name: "test_function".to_string(),
-            output: None,
-            tags: None,
-            tool_params: None,
-        });
-
-        let result = run_llm_judge_evaluator(
-            &inference_response,
-            &datapoint,
-            &tensorzero_client,
-            &llm_judge_config,
-            "test_eval",
-            "happy_bool",
-            Uuid::now_v7(),
-        )
-        .await
-        .unwrap();
-        assert_eq!(result, None);
     }
 }

--- a/evals/src/evaluators/mod.rs
+++ b/evals/src/evaluators/mod.rs
@@ -9,7 +9,7 @@ use tensorzero_internal::evals::{get_evaluator_metric_name, EvalConfig, Evaluato
 
 mod exact_match;
 use exact_match::run_exact_match_evaluator;
-mod llm_judge;
+pub mod llm_judge;
 use futures::stream::{FuturesUnordered, StreamExt};
 use llm_judge::run_llm_judge_evaluator;
 use uuid::Uuid;

--- a/evals/src/lib.rs
+++ b/evals/src/lib.rs
@@ -318,13 +318,13 @@ async fn infer_datapoint(
     }
 }
 
-struct ThrottledTensorZeroClient {
+pub struct ThrottledTensorZeroClient {
     client: Client,
     semaphore: Semaphore,
 }
 
 impl ThrottledTensorZeroClient {
-    fn new(client: Client, semaphore: Semaphore) -> Self {
+    pub fn new(client: Client, semaphore: Semaphore) -> Self {
         Self { client, semaphore }
     }
 


### PR DESCRIPTION
This lets us remove the 'e2e_tests' feature from the dev-dependency, which was forcing this feature on when running tests at the workspace level

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move `EmbeddedGateway` tests to `tests.rs` and remove `e2e_tests` feature from `dev-dependencies`.
> 
>   - **Tests**:
>     - Move `EmbeddedGateway` tests from `llm_judge.rs` to `tests.rs`.
>     - Remove `e2e_tests` feature from `dev-dependencies` in `Cargo.toml`.
>   - **Code Changes**:
>     - Make `run_llm_judge_evaluator` and `ThrottledTensorZeroClient` public in `llm_judge.rs` and `lib.rs` respectively.
>     - Update imports in `tests.rs` to reflect moved tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 73d4fcea19e1616e3a1bd246ac88ef8f47f59bba. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->