### PR TITLE
Accept 'raw_name' and 'raw_arguments' for tool call input

### DIFF
--- a/tensorzero-internal/src/inference/types/mod.rs
+++ b/tensorzero-internal/src/inference/types/mod.rs
@@ -2891,7 +2891,7 @@ mod tests {
             InputMessageContent::ToolCall(tool_call) => {
                 assert_eq!(tool_call.id, "123");
                 assert_eq!(tool_call.name, "test_tool");
-                assert_eq!(tool_call.arguments, "{}");
+                assert_eq!(tool_call.arguments, "\"{}\"");
             }
             _ => panic!("Expected ToolCall content"),
         }
@@ -2900,7 +2900,7 @@ mod tests {
             "role": "user",
             "content": [
                 {"type": "text", "value": {"complex": "json", "with": ["nested", "array"]}},
-                {"type": "tool_call", "id": "456", "name": "another_tool", "arguments": "{\"key\": \"value\"}"}
+                {"type": "tool_call", "id": "456", "name": "another_tool", "arguments": {"key": "value"}}
             ]
         });
         let message: InputMessage = serde_json::from_value(input).unwrap();
@@ -2919,7 +2919,7 @@ mod tests {
             InputMessageContent::ToolCall(tool_call) => {
                 assert_eq!(tool_call.id, "456");
                 assert_eq!(tool_call.name, "another_tool");
-                assert_eq!(tool_call.arguments, "{\"key\": \"value\"}");
+                assert_eq!(tool_call.arguments, "{\"key\":\"value\"}");
             }
             _ => panic!("Expected ToolCall content"),
         }

--- a/tensorzero-internal/src/inference/types/mod.rs
+++ b/tensorzero-internal/src/inference/types/mod.rs
@@ -2891,7 +2891,7 @@ mod tests {
             InputMessageContent::ToolCall(tool_call) => {
                 assert_eq!(tool_call.id, "123");
                 assert_eq!(tool_call.name, "test_tool");
-                assert_eq!(tool_call.arguments, "\"{}\"");
+                assert_eq!(tool_call.arguments, "{}");
             }
             _ => panic!("Expected ToolCall content"),
         }

--- a/tensorzero-internal/src/tool.rs
+++ b/tensorzero-internal/src/tool.rs
@@ -238,17 +238,29 @@ impl<'de> Deserialize<'de> for ToolCall {
             serde::de::Error::custom("ToolCall must have `name` or `raw_name` set")
         })?;
 
-        let arguments = if let Some(args) = helper.arguments {
-            serde_json::to_string(&args).map_err(|e| {
-                serde::de::Error::custom(format!("Failed to serialize arguments: {}", e))
-            })?
-        } else if let Some(args) = helper.raw_arguments {
-            args
+        let arguments = if let Some(arguments) = helper.arguments {
+            match arguments {
+                Value::String(s) => {
+                    tracing::warn!("Deprecation Warning: Treating string 'ToolCall.arguments' as a serialized JSON object. Please pass in a JSON object instead. Support for strings will be removed in a future release: https://github.com/tensorzero/tensorzero/issues/1410");
+                    s
+                }
+                Value::Object(obj) => {
+                    serde_json::to_string(&obj).map_err(serde::de::Error::custom)?
+                }
+                _ => {
+                    return Err(serde::de::Error::custom(
+                        "ToolCall arguments must be a string or an object",
+                    ))
+                }
+            }
+        } else if let Some(raw_arguments) = helper.raw_arguments {
+            raw_arguments
         } else {
             return Err(serde::de::Error::custom(
                 "ToolCall must have `arguments` or `raw_arguments` set",
             ));
         };
+
         Ok(ToolCall {
             name,
             arguments,
@@ -918,6 +930,90 @@ mod tests {
         assert_eq!(
             tool_call_output.arguments,
             Some(json!({"location": "Lucky Dog"}))
+        );
+    }
+
+    #[test]
+    fn test_tool_call_deserialize_plain_raw() {
+        let tool_call = serde_json::json!({
+            "name": "get_temperature",
+            "raw_name": "should have ignored raw name",
+            "arguments": "{\"location\": \"San Francisco\", \"unit\": \"celsius\"}",
+            "raw_arguments": "should have ignored raw arguments",
+            "id": "123"
+        });
+        let tool_call: ToolCall = serde_json::from_value(tool_call).unwrap();
+        assert_eq!(tool_call.name, "get_temperature");
+        assert_eq!(
+            tool_call.arguments,
+            "{\"location\": \"San Francisco\", \"unit\": \"celsius\"}"
+        );
+        assert_eq!(tool_call.id, "123");
+    }
+
+    #[test]
+    fn test_tool_call_deserialize_raw_only() {
+        let tool_call = serde_json::json!({
+            "raw_name": "get_temperature",
+            "raw_arguments": "my raw arguments",
+            "id": "123"
+        });
+        let tool_call: ToolCall = serde_json::from_value(tool_call).unwrap();
+        assert_eq!(tool_call.name, "get_temperature");
+        assert_eq!(tool_call.arguments, "my raw arguments");
+        assert_eq!(tool_call.id, "123");
+    }
+
+    #[test]
+    fn test_tool_call_deserialize_arguments_object() {
+        let tool_call = serde_json::json!({
+            "name": "get_temperature",
+            "arguments": {"my": "arguments"},
+            "id": "123"
+        });
+        let tool_call: ToolCall = serde_json::from_value(tool_call).unwrap();
+        assert_eq!(tool_call.name, "get_temperature");
+        assert_eq!(tool_call.arguments, "{\"my\":\"arguments\"}");
+        assert_eq!(tool_call.id, "123");
+    }
+
+    #[test]
+    fn test_tool_call_deserialize_arguments_string() {
+        let tool_call = serde_json::json!({
+            "name": "get_temperature",
+            "arguments": "{\"my\": \"arguments\"}",
+            "id": "123"
+        });
+        let tool_call: ToolCall = serde_json::from_value(tool_call).unwrap();
+        assert_eq!(tool_call.name, "get_temperature");
+        assert_eq!(tool_call.arguments, "{\"my\": \"arguments\"}");
+        assert_eq!(tool_call.id, "123");
+    }
+
+    #[test]
+    fn test_tool_call_deserialize_missing_name() {
+        let tool_call = serde_json::json!({
+            "arguments": "{\"my\": \"arguments\"}",
+            "id": "123"
+        });
+        let err_msg = serde_json::from_value::<ToolCall>(tool_call)
+            .unwrap_err()
+            .to_string();
+        assert_eq!(err_msg, "ToolCall must have `name` or `raw_name` set");
+    }
+
+    #[test]
+    fn test_tool_call_deserialize_missing_arguments() {
+        let tool_call = serde_json::json!({
+            "name": "get_temperature",
+            "id": "123"
+        });
+        let err_msg = serde_json::from_value::<ToolCall>(tool_call)
+            .unwrap_err()
+            .to_string();
+        assert_eq!(
+            err_msg,
+            "ToolCall must have `arguments` or `raw_arguments` set"
         );
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -9354,19 +9354,7 @@ pub async fn test_multi_turn_parallel_tool_use_inference_request_with_provider(
                 content_block.get("name").unwrap().as_str().unwrap()
             );
         }
-
-        let mut redacted_content_block = content_block.clone();
-        redacted_content_block
-            .as_object_mut()
-            .unwrap()
-            .remove("raw_name");
-        redacted_content_block
-            .as_object_mut()
-            .unwrap()
-            .remove("raw_arguments");
-        redacted_content_block["arguments"] =
-            Value::String(redacted_content_block.get("arguments").unwrap().to_string());
-        redacted_tool_calls.push(redacted_content_block);
+        redacted_tool_calls.push(content_block);
     }
 
     // Build the payload for the second inference request


### PR DESCRIPTION
This allows users to pass back a `ToolCall` content block in an assistant message, without needing to remove any fields.

We also now allow providing an arbitrary 'Value' for 'arguments', which matches 'ToolCallOutput'

Fixes #1366

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> `ToolCall` now accepts `raw_name` and `raw_arguments`, updating deserialization logic and tests for flexibility and issue #1366 fix.
> 
>   - **Behavior**:
>     - `ToolCall` struct in `tool.rs` now accepts `raw_name` and `raw_arguments` for input flexibility.
>     - Deserialization logic updated to handle `raw_name` and `raw_arguments`, with warnings for deprecated string usage.
>     - Fixes #1366.
>   - **Tests**:
>     - Added tests in `mod.rs` for `ToolCall` deserialization with `raw_name` and `raw_arguments`.
>     - Updated `common.rs` to remove redaction of `raw_name` and `raw_arguments`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 46959321f8af871cd949b49066afeeed2ece6408. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->