### PR TITLE
Bump rand to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3746,7 +3746,7 @@ dependencies = [
  "minijinja",
  "object_store",
  "paste",
- "rand 0.8.5",
+ "rand 0.9.0",
  "reqwest",
  "reqwest-eventsource",
  "secrecy",

--- a/tensorzero-internal/Cargo.toml
+++ b/tensorzero-internal/Cargo.toml
@@ -66,7 +66,7 @@ minijinja = { version = "2.1.0", features = [
     "builtins",
 ] }
 object_store = { version = "0.11.2", features = ["serde", "aws"] }
-rand = "0.8.5"
+rand = "0.9.0"
 reqwest = { workspace = true }
 reqwest-eventsource = { workspace = true }
 secrecy = { workspace = true }

--- a/tensorzero-internal/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-internal/src/variant/best_of_n_sampling.rs
@@ -334,10 +334,10 @@ impl BestOfNSamplingConfig {
         .await
         {
             Ok((idx_opt, inf_result)) => (
-                idx_opt.unwrap_or_else(|| rand::thread_rng().gen_range(0..candidates.len())),
+                idx_opt.unwrap_or_else(|| rand::rng().random_range(0..candidates.len())),
                 inf_result,
             ),
-            Err(_) => (rand::thread_rng().gen_range(0..candidates.len()), None),
+            Err(_) => (rand::rng().random_range(0..candidates.len()), None),
         };
 
         // Safely remove the selected candidate without panicking

--- a/tensorzero-internal/src/variant/mixture_of_n.rs
+++ b/tensorzero-internal/src/variant/mixture_of_n.rs
@@ -310,7 +310,7 @@ impl MixtureOfNConfig {
         {
             Ok(inf_result) => inf_result,
             Err(_) => {
-                let random_index = rand::thread_rng().gen_range(0..candidates.len());
+                let random_index = rand::rng().random_range(0..candidates.len());
                 if random_index >= candidates.len() {
                     return Err(Error::new(ErrorDetails::Inference {
                         message: "Failed to get random candidate (should never happen). Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new".to_string(),

--- a/tensorzero-internal/tests/e2e/cache.rs
+++ b/tensorzero-internal/tests/e2e/cache.rs
@@ -283,7 +283,7 @@ async fn test_cache_stream_write_and_read() {
 pub async fn test_streaming_cache_with_err() {
     let episode_id = Uuid::now_v7();
     // Generate random u32
-    let seed = rand::thread_rng().gen_range(0..u32::MAX);
+    let seed = rand::rng().random_range(0..u32::MAX);
 
     // When the stream includes an error, we should not cache the response (we pass `expect_cached = false`
     // for both calls)
@@ -297,7 +297,7 @@ pub async fn test_streaming_cache_with_err() {
 pub async fn test_streaming_cache_without_err() {
     let episode_id = Uuid::now_v7();
     // Generate random u32
-    let seed = rand::thread_rng().gen_range(0..u32::MAX);
+    let seed = rand::rng().random_range(0..u32::MAX);
 
     // When the stream does not include an error, we should cache the response (we pass `expect_cached = true`
     // for the second call)

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -689,10 +689,10 @@ pub async fn test_image_inference_with_provider_amazon_s3(provider: E2ETestProvi
 
     let client = aws_sdk_s3::Client::new(&config);
 
-    use rand::distributions::Alphanumeric;
-    use rand::distributions::DistString;
+    use rand::distr::Alphanumeric;
+    use rand::distr::SampleString;
 
-    let mut prefix = Alphanumeric.sample_string(&mut rand::thread_rng(), 6);
+    let mut prefix = Alphanumeric.sample_string(&mut rand::rng(), 6);
     prefix += "-";
 
     let (tensorzero_client, expected_key, storage_path) =
@@ -1862,7 +1862,7 @@ pub async fn test_simple_streaming_inference_request_with_provider(provider: E2E
     let episode_id = Uuid::now_v7();
     let tag_value = Uuid::now_v7().to_string();
     // Generate random u32
-    let seed = rand::thread_rng().gen_range(0..u32::MAX);
+    let seed = rand::rng().random_range(0..u32::MAX);
 
     let original_content = test_simple_streaming_inference_request_with_provider_cache(
         &provider, episode_id, seed, &tag_value, false,

--- a/tensorzero-internal/tests/e2e/providers/openai.rs
+++ b/tensorzero-internal/tests/e2e/providers/openai.rs
@@ -1031,8 +1031,8 @@ pub async fn test_image_inference_with_provider_cloudflare_r2() {
     use crate::providers::common::test_image_inference_with_provider_s3_compatible;
     use aws_credential_types::Credentials;
     use aws_sdk_s3::config::SharedCredentialsProvider;
-    use rand::distributions::Alphanumeric;
-    use rand::distributions::DistString;
+    use rand::distr::Alphanumeric;
+    use rand::distr::SampleString;
     use tensorzero_internal::inference::types::storage::StorageKind;
 
     // We expect CI to provide our credentials in 'R2_' variables
@@ -1066,7 +1066,7 @@ pub async fn test_image_inference_with_provider_cloudflare_r2() {
 
     let client = aws_sdk_s3::Client::new(&config);
 
-    let mut prefix = Alphanumeric.sample_string(&mut rand::thread_rng(), 6);
+    let mut prefix = Alphanumeric.sample_string(&mut rand::rng(), 6);
     prefix += "-";
 
     test_image_inference_with_provider_s3_compatible(
@@ -1223,8 +1223,8 @@ pub async fn test_image_inference_with_provider_gcp_storage() {
     use crate::providers::common::IMAGE_FUNCTION_CONFIG;
     use aws_credential_types::Credentials;
     use aws_sdk_s3::config::SharedCredentialsProvider;
-    use rand::distributions::Alphanumeric;
-    use rand::distributions::DistString;
+    use rand::distr::Alphanumeric;
+    use rand::distr::SampleString;
     use tensorzero_internal::inference::types::storage::StorageKind;
 
     // We expect CI to provide our credentials in 'GCP_STORAGE_' variables
@@ -1259,7 +1259,7 @@ pub async fn test_image_inference_with_provider_gcp_storage() {
 
     let client = aws_sdk_s3::Client::new(&config);
 
-    let mut prefix = Alphanumeric.sample_string(&mut rand::thread_rng(), 6);
+    let mut prefix = Alphanumeric.sample_string(&mut rand::rng(), 6);
     prefix += "-";
 
     test_image_inference_with_provider_s3_compatible(
@@ -1297,8 +1297,8 @@ pub async fn test_image_inference_with_provider_docker_minio() {
     use crate::providers::common::test_image_inference_with_provider_s3_compatible;
     use aws_credential_types::Credentials;
     use aws_sdk_s3::config::SharedCredentialsProvider;
-    use rand::distributions::Alphanumeric;
-    use rand::distributions::DistString;
+    use rand::distr::Alphanumeric;
+    use rand::distr::SampleString;
     use tensorzero_internal::inference::types::storage::StorageKind;
 
     // These are set in `ci/minio-docker-compose.yml`
@@ -1331,7 +1331,7 @@ pub async fn test_image_inference_with_provider_docker_minio() {
 
     let client = aws_sdk_s3::Client::new(&config);
 
-    let mut prefix = Alphanumeric.sample_string(&mut rand::thread_rng(), 6);
+    let mut prefix = Alphanumeric.sample_string(&mut rand::rng(), 6);
     prefix += "-";
 
     test_image_inference_with_provider_s3_compatible(


### PR DESCRIPTION
Several types/modules were renamed, which is preventing Dependabot from updating 'rand' automatically

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `rand` crate to 0.9.0 and adjust code for API changes in random number generation and string sampling.
> 
>   - **Dependency Update**:
>     - Bump `rand` crate version from 0.8.5 to 0.9.0 in `Cargo.lock` and `Cargo.toml`.
>   - **Code Adjustments**:
>     - Replace `rand::thread_rng().gen_range()` with `rand::rng().random_range()` in `best_of_n_sampling.rs`, `mixture_of_n.rs`, and `cache.rs`.
>     - Update imports from `rand::distributions` to `rand::distr` and replace `DistString` with `SampleString` in `common.rs` and `openai.rs`.
>   - **Tests**:
>     - Adjust random string generation in `test_image_inference_with_provider_cloudflare_r2`, `test_image_inference_with_provider_gcp_storage`, and `test_image_inference_with_provider_docker_minio` to use `rand::rng()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3d997ee6bfd4c4d05b54c787ea4d5abe5f08340e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->