### PR TITLE
Pin all Github actions to a commit instead of a tag

### DIFF
--- a/.github/workflows/batch-test.yml
+++ b/.github/workflows/batch-test.yml
@@ -38,22 +38,22 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Install Namespace CLI
-        uses: namespacelabs/nscloud-setup@v0
+        uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
 
       - name: Configure Namespace-powered Buildx
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
+        uses: namespacelabs/nscloud-setup-buildx-action@84ca8c58fdf372d6a4750476cd09b7b96ee778ca
 
       - name: Configure Namespace cache for Rust
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@2f50e7d0f70475e6f59a55ba0f05eec9108e77cc
         with:
           cache: |
             rust
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -63,7 +63,7 @@ jobs:
           curl ${{ secrets.CLICKHOUSE_CLOUD_URL }} --data-binary 'SHOW DATABASES'
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@37bdc826eaedac215f638a96472df572feab0f9b
         with:
           tool: cargo-nextest
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Check all docker-compose.yml files
         run: ./ci/check-all-docker-compose.sh
@@ -37,9 +37,9 @@ jobs:
           - runner: macos-14
             target: aarch64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: "TensorZero PyO3 Client: Build"
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
         with:
           working-directory: clients/python-pyo3
           args: --find-interpreter
@@ -50,16 +50,16 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Install Namespace CLI
-        uses: namespacelabs/nscloud-setup@v0
+        uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
 
       - name: Configure Namespace-powered Buildx
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
+        uses: namespacelabs/nscloud-setup-buildx-action@84ca8c58fdf372d6a4750476cd09b7b96ee778ca
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
         with:
           version: 10
 
@@ -67,7 +67,7 @@ jobs:
         run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
 
       - name: Configure Namespace cache for Rust, Python (pip), and pnpm
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@2f50e7d0f70475e6f59a55ba0f05eec9108e77cc
         with:
           cache: |
             pnpm
@@ -75,7 +75,7 @@ jobs:
             uv
 
       - name: Install cargo-nextest, cargo-deny, and cargo-hack
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@37bdc826eaedac215f638a96472df572feab0f9b
         with:
           tool: cargo-nextest,cargo-deny,cargo-hack
 
@@ -103,7 +103,7 @@ jobs:
           uvx ruff@0.9.0 format --check .
 
       - name: "TensorZero PyO3 Client: Build"
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
         with:
           working-directory: clients/python-pyo3
           args: --find-interpreter
@@ -177,7 +177,7 @@ jobs:
           pnpm run lint
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: "22.9.0"
 

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -40,24 +40,24 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Install Namespace CLI
-        uses: namespacelabs/nscloud-setup@v0
+        uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
 
       - name: Configure Namespace-powered Buildx
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
+        uses: namespacelabs/nscloud-setup-buildx-action@84ca8c58fdf372d6a4750476cd09b7b96ee778ca
 
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
         with:
           version: 10
 
       - name: Configure Namespace cache for Rust, Python (uv), and pnpm
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@2f50e7d0f70475e6f59a55ba0f05eec9108e77cc
         with:
           cache: |
             pnpm
@@ -65,13 +65,13 @@ jobs:
             uv
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@37bdc826eaedac215f638a96472df572feab0f9b
         with:
           tool: cargo-nextest
 
@@ -117,7 +117,7 @@ jobs:
 
       - name: Upload provider-proxy cache
         if: ${{ false }} # Change to `if: ${{ always() }}` to start uploading the cache
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: provider-proxy-cache
           path: ./ci/provider-proxy-cache/
@@ -228,7 +228,7 @@ jobs:
           kill $GATEWAY_PID
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: "22.9.0"
 

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -22,14 +22,14 @@ jobs:
           - runner: ubuntu-24.04-arm
             target: aarch64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: 3.x
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
         with:
           working-directory: ./clients/python-pyo3
           target: ${{ matrix.platform.target }}
@@ -37,7 +37,7 @@ jobs:
           sccache: "true"
           manylinux: auto
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: wheels-linux-${{ matrix.platform.target }}
           path: ./clients/python-pyo3/dist
@@ -55,14 +55,14 @@ jobs:
           - runner: ubuntu-24.04-arm
             target: aarch64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: 3.x
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
         with:
           working-directory: ./clients/python-pyo3
           target: ${{ matrix.platform.target }}
@@ -70,7 +70,7 @@ jobs:
           sccache: "true"
           manylinux: musllinux_1_2
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: wheels-musllinux-${{ matrix.platform.target }}
           path: ./clients/python-pyo3/dist
@@ -86,8 +86,8 @@ jobs:
           - runner: windows-latest
             target: x64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: 3.x
           architecture: ${{ matrix.platform.target }}
@@ -95,14 +95,14 @@ jobs:
         run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
         shell: bash
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
         with:
           working-directory: ./clients/python-pyo3
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: "true"
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: wheels-windows-${{ matrix.platform.target }}
           path: ./clients/python-pyo3/dist
@@ -121,8 +121,8 @@ jobs:
           - runner: macos-14
             target: aarch64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: 3.x
 
@@ -130,7 +130,7 @@ jobs:
         run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
         with:
           working-directory: ./clients/python-pyo3
           target: ${{ matrix.platform.target }}
@@ -138,7 +138,7 @@ jobs:
           sccache: "true"
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: wheels-macos-${{ matrix.platform.target }}
           path: ./clients/python-pyo3/dist
@@ -149,15 +149,15 @@ jobs:
   sdist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Build sdist
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
         with:
           working-directory: ./clients/python-pyo3
           command: sdist
           args: --out dist
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: wheels-sdist
           path: ./clients/python-pyo3/dist
@@ -182,10 +182,10 @@ jobs:
     # Download all of the wheel artifacts published by the other jobs,
     # and publish them to PyPi as a new release, using the `upload-pyo3.sh` script.
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@92c65d2898f1f53cfdc910b962cecff86e7f8fcc
         with:
           subject-path: "wheels-*/*"
 


### PR DESCRIPTION
This avoids relying on mutable tags, which can be
a security issue.

Fixes #1376

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Pin all GitHub Actions to specific commit hashes in workflows to enhance security by avoiding mutable tags.
> 
>   - **Security**:
>     - Pin all GitHub Actions to specific commit hashes instead of tags in `.github/workflows/batch-test.yml`, `.github/workflows/general.yml`, and `.github/workflows/merge-queue.yml`.
>   - **Affected Actions**:
>     - `actions/checkout` pinned to `11bd71901bbe5b1630ceea73d27597364c9af683`.
>     - `namespacelabs/nscloud-setup` pinned to `d1c625762f7c926a54bd39252efff0705fd11c64`.
>     - `namespacelabs/nscloud-setup-buildx-action` pinned to `84ca8c58fdf372d6a4750476cd09b7b96ee778ca`.
>     - `namespacelabs/nscloud-cache-action` pinned to `2f50e7d0f70475e6f59a55ba0f05eec9108e77cc`.
>     - `docker/login-action` pinned to `74a5d142397b4f367a81961eba4e8cd7edddf772`.
>     - `taiki-e/install-action` pinned to `37bdc826eaedac215f638a96472df572feab0f9b`.
>     - `PyO3/maturin-action` pinned to `b3709a81b3e175ce3ede866725776fee42465311`.
>     - `pnpm/action-setup` pinned to `a7487c7e89a18df4991f7f222e4898a00d66ddda`.
>     - `actions/setup-node` pinned to `cdca7365b2dadb8aad0a33bc7601856ffabcc48e`.
>     - `actions/upload-artifact` pinned to `ea165f8d65b6e75b540449e92b4886f43607fa02`.
>     - `actions/setup-python` pinned to `42375524e23c412d93fb67b49958b491fce71c38`.
>     - `actions/download-artifact` pinned to `95815c38cf2ff2164869cbab79da8d1f422bc89e`.
>     - `actions/attest-build-provenance` pinned to `92c65d2898f1f53cfdc910b962cecff86e7f8fcc`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 31009a270f1431e136fa5d29420c05dd5557d44a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->