### PR TITLE
Remove 'batch_tests' cargo feature

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,7 +8,7 @@ rustflags = [
 [alias]
 test-unit = "nextest run --lib --bins"
 test-all = "nextest run --features e2e_tests"
-# Note - these two commands should only differ by the 'not' clausew wrapping 'test(batch)'
+# Note - these two commands should only differ by the 'not' clause wrapping 'test(batch)'
 # This ensures that running 'test-batch' and 'test-e2e' will cover all tests, and not miss any
 test-batch = ["nextest", "run", "--features", "e2e_tests", "-E",      "test(batch)"]
 test-e2e   = ["nextest", "run", "--features", "e2e_tests", "-E", "not (test(batch))"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,9 +7,11 @@ rustflags = [
 
 [alias]
 test-unit = "nextest run --lib --bins"
-test-e2e = "nextest run --test e2e --features e2e_tests"
 test-all = "nextest run --features e2e_tests"
-test-batch = "nextest run --test batch --features batch_tests"
+# Note - these two commands should only differ by the 'not' clausew wrapping 'test(batch)'
+# This ensures that running 'test-batch' and 'test-e2e' will cover all tests, and not miss any
+test-batch = ["nextest", "run", "--features", "e2e_tests", "-E",      "test(batch)"]
+test-e2e   = ["nextest", "run", "--features", "e2e_tests", "-E", "not (test(batch))"]
 
 run-e2e = "run --bin gateway --features e2e_tests -- --config-file tensorzero-internal/tests/e2e/tensorzero.toml"
 watch-e2e = "watch -x run-e2e"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -48,11 +48,11 @@ test-group = 'e2e_xai'
 
 [[profile.default.overrides]]
 # Settings for running batch tests
-filter = 'binary(batch)'
+filter = 'test(batch)'
 slow-timeout = { period = "15s", terminate-after = 1 }
 
 [[profile.default.overrides]]
 # Settings for running unit tests
-filter = 'not binary(e2e) and not binary(batch)'
+filter = 'not binary(e2e)'
 retries = 0
 slow-timeout = { period = "5s", terminate-after = 1 }

--- a/clients/python-pyo3/Cargo.toml
+++ b/clients/python-pyo3/Cargo.toml
@@ -36,4 +36,3 @@ uuid.workspace = true
 # We also set 'pyo3/extension-module' so that 'maturin develop --features e2e_tests'
 # will work correctly.
 e2e_tests = ["tensorzero_rust/e2e_tests", "pyo3/extension-module"]
-batch_tests = ["tensorzero_rust/batch_tests"]

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -30,9 +30,8 @@ tracing-subscriber = "0.3.19"
 tracing-test = { workspace = true }
 
 [features]
-# Forward these features to 'tensorzero-internal', so that our embedded
-# client can recognize things like the `dummy` provider
-e2e_tests = ["tensorzero-internal/e2e_tests"]
-batch_tests = ["tensorzero-internal/batch_tests"]
 pyo3 = ["dep:pyo3"]
 default = []
+# Forward this feature to 'tensorzero-internal', so that our embedded
+# client can recognize things like the `dummy` provider
+e2e_tests = ["tensorzero-internal/e2e_tests"]

--- a/evals/Cargo.toml
+++ b/evals/Cargo.toml
@@ -40,8 +40,7 @@ dbg_macro = "deny"
 
 
 [features]
-# Forward these features to 'evals', so that our
+default = []
+# Forward this feature to 'evals', so that our
 # tests can recognize things like the `dummy` provider
 e2e_tests = ["tensorzero/e2e_tests"]
-batch_tests = ["tensorzero/batch_tests"]
-default = []

--- a/tensorzero-internal/Cargo.toml
+++ b/tensorzero-internal/Cargo.toml
@@ -5,22 +5,14 @@ edition = "2021"
 
 
 [features]
-# Forward these features to the Rust client, so that the embedded gateway
+# Forward this feature to the Rust client, so that the embedded gateway
 # has the `e2e_tests` feature enabled when we run our e2e tests
 e2e_tests = ["tensorzero/e2e_tests"]
-batch_tests = ["tensorzero/batch_tests"]
-
 
 [[test]]
 name = "e2e"
 path = "tests/e2e/tests.rs"
 required-features = ["e2e_tests"]
-
-[[test]]
-name = "batch"
-path = "tests/e2e/batch.rs"
-required-features = ["batch_tests"]
-
 
 [lints]
 workspace = true

--- a/tensorzero-internal/src/clickhouse/mod.rs
+++ b/tensorzero-internal/src/clickhouse/mod.rs
@@ -8,7 +8,7 @@ use tokio::sync::RwLockWriteGuard;
 use url::Url;
 
 pub mod migration_manager;
-#[cfg(any(test, feature = "e2e_tests", feature = "batch_tests"))]
+#[cfg(any(test, feature = "e2e_tests"))]
 pub mod test_helpers;
 
 use crate::error::{Error, ErrorDetails};
@@ -49,7 +49,7 @@ impl ClickHouseConnectionInfo {
         let database = validate_clickhouse_url_get_db_name(&database_url)?
             .unwrap_or_else(|| "default".to_string());
 
-        #[cfg(any(feature = "e2e_tests", feature = "batch_tests"))]
+        #[cfg(feature = "e2e_tests")]
         let database = "tensorzero_e2e_tests".to_string();
 
         // Although we take the database name from the URL path,

--- a/tensorzero-internal/src/clickhouse/test_helpers.rs
+++ b/tensorzero-internal/src/clickhouse/test_helpers.rs
@@ -184,7 +184,6 @@ pub async fn select_inference_tags_clickhouse(
     Some(json)
 }
 
-#[cfg(feature = "batch_tests")]
 pub async fn select_batch_model_inference_clickhouse(
     clickhouse_connection_info: &ClickHouseConnectionInfo,
     inference_id: Uuid,
@@ -206,7 +205,6 @@ pub async fn select_batch_model_inference_clickhouse(
     Some(serde_json::from_str(&text).unwrap())
 }
 
-#[cfg(feature = "batch_tests")]
 pub async fn select_batch_model_inferences_clickhouse(
     clickhouse_connection_info: &ClickHouseConnectionInfo,
     batch_id: Uuid,
@@ -232,7 +230,6 @@ pub async fn select_batch_model_inferences_clickhouse(
     Some(json_rows)
 }
 
-#[cfg(feature = "batch_tests")]
 pub async fn select_latest_batch_request_clickhouse(
     clickhouse_connection_info: &ClickHouseConnectionInfo,
     batch_id: Uuid,

--- a/tensorzero-internal/src/gateway_util.rs
+++ b/tensorzero-internal/src/gateway_util.rs
@@ -146,7 +146,7 @@ const DEFAULT_HTTP_CLIENT_TIMEOUT: std::time::Duration = std::time::Duration::fr
 pub fn setup_http_client() -> Result<Client, Error> {
     let mut http_client_builder = Client::builder().timeout(DEFAULT_HTTP_CLIENT_TIMEOUT);
 
-    if cfg!(any(feature = "e2e_tests", feature = "batch_tests")) {
+    if cfg!(feature = "e2e_tests") {
         if let Ok(proxy_url) = std::env::var("TENSORZERO_E2E_PROXY") {
             tracing::info!("Using proxy URL from TENSORZERO_E2E_PROXY: {proxy_url}");
             http_client_builder = http_client_builder

--- a/tensorzero-internal/tests/e2e/batch/mod.rs
+++ b/tensorzero-internal/tests/e2e/batch/mod.rs
@@ -1,7 +1,4 @@
 #![allow(clippy::print_stdout)]
-#![cfg(test)]
-mod common;
-mod providers;
 
 use std::borrow::Cow;
 use std::collections::HashMap;

--- a/tensorzero-internal/tests/e2e/providers/anthropic.rs
+++ b/tensorzero-internal/tests/e2e/providers/anthropic.rs
@@ -15,7 +15,6 @@ use tensorzero_internal::clickhouse::test_helpers::{
 
 #[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
-#[cfg(feature = "batch_tests")]
 crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
@@ -95,7 +94,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: image_providers,
         #[cfg(feature = "e2e_tests")]
         shorthand_inference: shorthand_providers.clone(),
-        #[cfg(feature = "batch_tests")]
         supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/aws_bedrock.rs
+++ b/tensorzero-internal/tests/e2e/providers/aws_bedrock.rs
@@ -18,7 +18,6 @@ use tensorzero_internal::clickhouse::test_helpers::{
 
 #[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
-#[cfg(feature = "batch_tests")]
 crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
@@ -71,7 +70,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
         #[cfg(feature = "e2e_tests")]
         shorthand_inference: vec![],
-        #[cfg(feature = "batch_tests")]
         supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/azure.rs
+++ b/tensorzero-internal/tests/e2e/providers/azure.rs
@@ -4,7 +4,6 @@ use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
 #[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
-#[cfg(feature = "batch_tests")]
 crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
@@ -75,7 +74,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
         #[cfg(feature = "e2e_tests")]
         shorthand_inference: vec![],
-        #[cfg(feature = "batch_tests")]
         supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/batch.rs
+++ b/tensorzero-internal/tests/e2e/providers/batch.rs
@@ -217,7 +217,7 @@ macro_rules! generate_batch_inference_tests {
         }
 
         #[tokio::test]
-        async fn test_start_multi_turn_parallel_tool_use_inference_request() {
+        async fn test_start_multi_turn_parallel_tool_use_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.parallel_tool_use_inference;
             if all_providers.supports_batch_inference {
@@ -228,7 +228,7 @@ macro_rules! generate_batch_inference_tests {
         }
 
         #[tokio::test]
-        async fn test_poll_existing_multi_turn_parallel_tool_use_inference_request() {
+        async fn test_poll_existing_multi_turn_parallel_tool_use_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.parallel_tool_use_inference;
             if all_providers.supports_batch_inference {
@@ -239,7 +239,7 @@ macro_rules! generate_batch_inference_tests {
         }
 
         #[tokio::test]
-        async fn test_poll_completed_multi_turn_parallel_tool_use_inference_request() {
+        async fn test_poll_completed_multi_turn_parallel_tool_use_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.parallel_tool_use_inference;
             if all_providers.supports_batch_inference {

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -73,7 +73,7 @@ pub struct E2ETestProviders {
     pub reasoning_inference: Vec<E2ETestProvider>,
     #[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
     pub inference_params_dynamic_credentials: Vec<E2ETestProvider>,
-    #[cfg_attr(not(feature = "batch_tests"), allow(dead_code))]
+    #[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
     pub inference_params_inference: Vec<E2ETestProvider>,
     pub tool_use_inference: Vec<E2ETestProvider>,
     pub tool_multi_turn_inference: Vec<E2ETestProvider>,
@@ -84,7 +84,6 @@ pub struct E2ETestProviders {
     pub image_inference: Vec<E2ETestProvider>,
     #[cfg(feature = "e2e_tests")]
     pub shorthand_inference: Vec<E2ETestProvider>,
-    #[cfg(feature = "batch_tests")]
     pub supports_batch_inference: bool,
 }
 
@@ -1648,7 +1647,6 @@ pub async fn check_simple_inference_response(
     );
 }
 
-#[cfg_attr(not(feature = "batch_tests"), allow(dead_code))]
 pub async fn check_simple_image_inference_response(
     response_json: Value,
     episode_id: Option<Uuid>,

--- a/tensorzero-internal/tests/e2e/providers/deepseek.rs
+++ b/tensorzero-internal/tests/e2e/providers/deepseek.rs
@@ -4,7 +4,6 @@ use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
 #[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
-#[cfg(feature = "batch_tests")]
 crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
@@ -76,7 +75,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
         #[cfg(feature = "e2e_tests")]
         shorthand_inference: shorthand_providers.clone(),
-        #[cfg(feature = "batch_tests")]
         supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/fireworks.rs
+++ b/tensorzero-internal/tests/e2e/providers/fireworks.rs
@@ -4,7 +4,6 @@ use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
 #[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
-#[cfg(feature = "batch_tests")]
 crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
@@ -84,7 +83,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
         #[cfg(feature = "e2e_tests")]
         shorthand_inference: shorthand_providers,
-        #[cfg(feature = "batch_tests")]
         supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/tests/e2e/providers/gcp_vertex_anthropic.rs
@@ -4,7 +4,6 @@ use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
 #[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
-#[cfg(feature = "batch_tests")]
 crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
@@ -57,7 +56,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
         #[cfg(feature = "e2e_tests")]
         shorthand_inference: vec![],
-        #[cfg(feature = "batch_tests")]
         supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/tests/e2e/providers/gcp_vertex_gemini.rs
@@ -4,7 +4,6 @@ use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
 #[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
-#[cfg(feature = "batch_tests")]
 crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
@@ -84,7 +83,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: image_providers,
         #[cfg(feature = "e2e_tests")]
         shorthand_inference: vec![],
-        #[cfg(feature = "batch_tests")]
         supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-internal/tests/e2e/providers/google_ai_studio_gemini.rs
@@ -4,7 +4,6 @@ use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
 #[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
-#[cfg(feature = "batch_tests")]
 crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
@@ -118,7 +117,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: image_providers,
         #[cfg(feature = "e2e_tests")]
         shorthand_inference: shorthand_providers.clone(),
-        #[cfg(feature = "batch_tests")]
         supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/hyperbolic.rs
+++ b/tensorzero-internal/tests/e2e/providers/hyperbolic.rs
@@ -4,7 +4,6 @@ use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
 #[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
-#[cfg(feature = "batch_tests")]
 crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
@@ -56,7 +55,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
         #[cfg(feature = "e2e_tests")]
         shorthand_inference: shorthand_providers.clone(),
-        #[cfg(feature = "batch_tests")]
         supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/mistral.rs
+++ b/tensorzero-internal/tests/e2e/providers/mistral.rs
@@ -4,7 +4,6 @@ use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
 #[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
-#[cfg(feature = "batch_tests")]
 crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
@@ -71,7 +70,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
         #[cfg(feature = "e2e_tests")]
         shorthand_inference: shorthand_providers.clone(),
-        #[cfg(feature = "batch_tests")]
         supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/mod.rs
+++ b/tensorzero-internal/tests/e2e/providers/mod.rs
@@ -1,7 +1,6 @@
 mod anthropic;
 mod aws_bedrock;
 mod azure;
-#[cfg(feature = "batch_tests")]
 mod batch;
 pub mod common;
 mod deepseek;

--- a/tensorzero-internal/tests/e2e/providers/openai.rs
+++ b/tensorzero-internal/tests/e2e/providers/openai.rs
@@ -26,7 +26,6 @@ use tensorzero_internal::clickhouse::test_helpers::{
 
 #[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
-#[cfg(feature = "batch_tests")]
 crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
@@ -140,7 +139,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: image_providers.clone(),
         #[cfg(feature = "e2e_tests")]
         shorthand_inference: shorthand_providers.clone(),
-        #[cfg(feature = "batch_tests")]
         supports_batch_inference: true,
     }
 }
@@ -576,7 +574,6 @@ async fn test_chat_function_json_override_with_mode_implicit_tool() {
     );
 }
 
-#[cfg_attr(feature = "batch_tests", allow(unused))]
 async fn test_chat_function_json_override_with_mode(json_mode: ModelInferenceRequestJsonMode) {
     let client = Client::new();
     let episode_id = Uuid::now_v7();

--- a/tensorzero-internal/tests/e2e/providers/sglang.rs
+++ b/tensorzero-internal/tests/e2e/providers/sglang.rs
@@ -4,7 +4,6 @@ use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
 #[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
-#[cfg(feature = "batch_tests")]
 crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
@@ -52,7 +51,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
         #[cfg(feature = "e2e_tests")]
         shorthand_inference: vec![],
-        #[cfg(feature = "batch_tests")]
         supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/tgi.rs
+++ b/tensorzero-internal/tests/e2e/providers/tgi.rs
@@ -2,7 +2,6 @@ use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 use std::collections::HashMap;
 #[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
-#[cfg(feature = "batch_tests")]
 crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
@@ -42,7 +41,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
         #[cfg(feature = "e2e_tests")]
         shorthand_inference: vec![],
-        #[cfg(feature = "batch_tests")]
         supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/together.rs
+++ b/tensorzero-internal/tests/e2e/providers/together.rs
@@ -4,7 +4,6 @@ use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
 #[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
-#[cfg(feature = "batch_tests")]
 crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
@@ -85,7 +84,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
         #[cfg(feature = "e2e_tests")]
         shorthand_inference: shorthand_providers.clone(),
-        #[cfg(feature = "batch_tests")]
         supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/vllm.rs
+++ b/tensorzero-internal/tests/e2e/providers/vllm.rs
@@ -4,7 +4,6 @@ use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
 #[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
-#[cfg(feature = "batch_tests")]
 crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
@@ -64,7 +63,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
         #[cfg(feature = "e2e_tests")]
         shorthand_inference: vec![],
-        #[cfg(feature = "batch_tests")]
         supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/xai.rs
+++ b/tensorzero-internal/tests/e2e/providers/xai.rs
@@ -4,7 +4,6 @@ use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
 #[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
-#[cfg(feature = "batch_tests")]
 crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
@@ -76,7 +75,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
         #[cfg(feature = "e2e_tests")]
         shorthand_inference: shorthand_providers.clone(),
-        #[cfg(feature = "batch_tests")]
         supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/tests.rs
+++ b/tensorzero-internal/tests/e2e/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
 mod batch;
 mod best_of_n;
 mod cache;

--- a/tensorzero-internal/tests/e2e/tests.rs
+++ b/tensorzero-internal/tests/e2e/tests.rs
@@ -1,4 +1,4 @@
-#![cfg(test)]
+mod batch;
 mod best_of_n;
 mod cache;
 mod clickhouse;


### PR DESCRIPTION
We now gate all live tests under the 'e2e_tests' feature. The 'test-batch' alias now filters tests by the string 'batch', and the 'test-e2e' alias now excludes tests matching 'batch'

The preivous top-level 'tests/e2e/batch.rs' integration test is now a module underneath 'tests/e2e/tests.rs'. This avoids running tests from 'tests/e2e/providers/mod.rs' in two separate integration tests binaries (previous, both integration tests declared 'mod providers')

After this change, we should be able to remove lots of `#[cfg(feature = "e2e_tests")]` from our integration test code. This PR contains the minimal changes needed to keep everything compiling and running on CI.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove 'batch_tests' feature and consolidate batch tests under 'e2e_tests', updating test aliases and structure.
> 
>   - **Features**:
>     - Remove `batch_tests` feature from `Cargo.toml` in `clients/python-pyo3`, `clients/rust`, `evals`, and `tensorzero-internal`.
>     - Consolidate batch tests under `e2e_tests` feature.
>   - **Test Aliases**:
>     - Update `test-batch` alias to filter tests by 'batch' and `test-e2e` alias to exclude 'batch' in `.cargo/config.toml`.
>   - **Test Structure**:
>     - Move `tests/e2e/batch.rs` to `tests/e2e/batch/mod.rs`.
>     - Remove `#[cfg(feature = "batch_tests")]` from various test files, including `clickhouse/mod.rs`, `gateway_util.rs`, and multiple provider test files.
>   - **Miscellaneous**:
>     - Update `nextest.toml` to adjust test filters.
>     - Minor refactoring in `tests/e2e/tests.rs` to include `batch` module.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7e6aacf73b95cb99b98fb64f03ffaa3b4bd98dc2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->