### PR TITLE
Print Rust version on CI

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Configure Namespace-powered Buildx
         uses: namespacelabs/nscloud-setup-buildx-action@84ca8c58fdf372d6a4750476cd09b7b96ee778ca
 
+      - name: Print Rust version
+        run: rustc --version
+
       - name: Install pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
         with:

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Configure Namespace-powered Buildx
         uses: namespacelabs/nscloud-setup-buildx-action@84ca8c58fdf372d6a4750476cd09b7b96ee778ca
 
+      - name: Print Rust version
+        run: rustc --version
+
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
 


### PR DESCRIPTION
This will help us debug any issues caused by Namespace updating Rust out from under us

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add step to print Rust version in CI workflows for debugging purposes.
> 
>   - **CI Workflows**:
>     - Add step to print Rust version using `rustc --version` in `general.yml` and `merge-queue.yml`.
>     - Helps debug issues from Namespace updating Rust version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 89853dd0af35f92ee0d4cfcbf8c48b60bc719051. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->