### PR TITLE
Add sleep to test_datapoint_insert_synthetic_json to fix timestamp

### DIFF
--- a/tensorzero-internal/tests/e2e/datasets.rs
+++ b/tensorzero-internal/tests/e2e/datasets.rs
@@ -383,6 +383,9 @@ async fn test_datapoint_insert_synthetic_json() {
         "Error should mention the missing required property: {err_msg}"
     );
 
+    // Sleep to ensure that we get a different `updated_at` timestamp
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
     // Now try with the correct schema
     let new_resp = client
     .put(get_gateway_endpoint(&format!(


### PR DESCRIPTION
This test recently failed on CI due to both the old and new row being created during the same second.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add sleep in `test_datapoint_insert_synthetic_json()` to ensure distinct timestamps.
> 
>   - **Test Fix**:
>     - Adds `tokio::time::sleep(Duration::from_millis(1500)).await;` in `test_datapoint_insert_synthetic_json()` in `datasets.rs` to ensure distinct `updated_at` timestamps between row insertions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 23e03be62c995a0e5a9c271acea72f6394bea517. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->