### PR TITLE
Remove all 'feature = "e2e_tests"' cfgs from e2e test files

### DIFF
--- a/tensorzero-internal/tests/e2e/inference.rs
+++ b/tensorzero-internal/tests/e2e/inference.rs
@@ -2694,7 +2694,7 @@ async fn test_inference_invalid_default_function_arg() {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+
 async fn test_image_inference_without_object_store() {
     let client = make_embedded_gateway_no_config().await;
     let err_msg = client

--- a/tensorzero-internal/tests/e2e/openai_compatible.rs
+++ b/tensorzero-internal/tests/e2e/openai_compatible.rs
@@ -10,7 +10,6 @@ use tensorzero_internal::clickhouse::test_helpers::{
     select_model_inference_clickhouse,
 };
 
-#[cfg(feature = "e2e_tests")]
 #[tokio::test]
 async fn test_openai_compatible_route() {
     // Test that both the old and new formats work.
@@ -219,13 +218,11 @@ async fn test_openai_compatible_dryrun() {
     assert!(json_result.is_none());
 }
 
-#[cfg(feature = "e2e_tests")]
 #[tokio::test]
 async fn test_openai_compatible_route_model_name_shorthand() {
     test_openai_compatible_route_with_default_function("tensorzero::model_name::dummy::good", "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake.").await;
 }
 
-#[cfg(feature = "e2e_tests")]
 #[tokio::test]
 async fn test_openai_compatible_route_model_name_toml() {
     test_openai_compatible_route_with_default_function(
@@ -362,7 +359,6 @@ async fn test_openai_compatible_route_with_default_function(
     assert_eq!(finish_reason, "stop");
 }
 
-#[cfg(feature = "e2e_tests")]
 #[tokio::test]
 async fn test_openai_compatible_route_bad_model_name() {
     let client = Client::new();
@@ -400,7 +396,6 @@ async fn test_openai_compatible_route_bad_model_name() {
     )
 }
 
-#[cfg(feature = "e2e_tests")]
 #[tokio::test]
 async fn test_openai_compatible_route_with_json_mode_on() {
     let client = Client::new();
@@ -535,7 +530,6 @@ async fn test_openai_compatible_route_with_json_mode_on() {
     let _raw_response_json: Value = serde_json::from_str(raw_response).unwrap();
 }
 
-#[cfg(feature = "e2e_tests")]
 #[tokio::test]
 async fn test_openai_compatible_route_with_json_schema() {
     let client = Client::new();
@@ -673,7 +667,6 @@ async fn test_openai_compatible_route_with_json_schema() {
     let _raw_response_json: Value = serde_json::from_str(raw_response).unwrap();
 }
 
-#[cfg(feature = "e2e_tests")]
 #[tokio::test]
 async fn test_openai_compatible_streaming_tool_call() {
     use futures::StreamExt;

--- a/tensorzero-internal/tests/e2e/providers/anthropic.rs
+++ b/tensorzero-internal/tests/e2e/providers/anthropic.rs
@@ -13,7 +13,6 @@ use tensorzero_internal::clickhouse::test_helpers::{
     get_clickhouse, select_chat_inference_clickhouse, select_model_inference_clickhouse,
 };
 
-#[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
@@ -72,7 +71,6 @@ async fn get_providers() -> E2ETestProviders {
         },
     ];
 
-    #[cfg(feature = "e2e_tests")]
     let shorthand_providers = vec![E2ETestProvider {
         variant_name: "anthropic-shorthand".to_string(),
         model_name: "anthropic::claude-3-haiku-20240307".into(),
@@ -92,13 +90,12 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: standard_providers.clone(),
         json_mode_inference: json_providers.clone(),
         image_inference: image_providers,
-        #[cfg(feature = "e2e_tests")]
+
         shorthand_inference: shorthand_providers.clone(),
         supports_batch_inference: false,
     }
 }
 
-#[cfg_attr(not(feature = "e2e_tests"), ignore)]
 #[tokio::test]
 async fn test_thinking_signature() {
     let client = Client::new();
@@ -304,7 +301,6 @@ async fn test_thinking_signature() {
     );
 }
 
-#[cfg_attr(not(feature = "e2e_tests"), ignore)]
 #[tokio::test]
 async fn test_redacted_thinking() {
     let client = Client::new();

--- a/tensorzero-internal/tests/e2e/providers/aws_bedrock.rs
+++ b/tensorzero-internal/tests/e2e/providers/aws_bedrock.rs
@@ -1,22 +1,19 @@
-#[cfg(feature = "e2e_tests")]
 use reqwest::Client;
-#[cfg(feature = "e2e_tests")]
+
 use reqwest::StatusCode;
-#[cfg(feature = "e2e_tests")]
+
 use serde_json::{json, Value};
 use std::collections::HashMap;
-#[cfg(feature = "e2e_tests")]
+
 use uuid::Uuid;
 
-#[cfg(feature = "e2e_tests")]
 use crate::common::get_gateway_endpoint;
 use crate::providers::common::{E2ETestProvider, E2ETestProviders};
-#[cfg(feature = "e2e_tests")]
+
 use tensorzero_internal::clickhouse::test_helpers::{
     get_clickhouse, select_chat_inference_clickhouse, select_model_inference_clickhouse,
 };
 
-#[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
@@ -68,13 +65,12 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: vec![],
         json_mode_inference: json_providers.clone(),
         image_inference: vec![],
-        #[cfg(feature = "e2e_tests")]
+
         shorthand_inference: vec![],
         supports_batch_inference: false,
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 #[tokio::test]
 async fn test_inference_with_explicit_region() {
     let client = Client::new();
@@ -187,7 +183,6 @@ async fn test_inference_with_explicit_region() {
     let _ = raw_response_json.get("debug").unwrap().as_str().unwrap();
 }
 
-#[cfg(feature = "e2e_tests")]
 #[tokio::test]
 async fn test_inference_with_explicit_broken_region() {
     let client = Client::new();

--- a/tensorzero-internal/tests/e2e/providers/azure.rs
+++ b/tensorzero-internal/tests/e2e/providers/azure.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
-#[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
@@ -72,7 +71,7 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: vec![],
         json_mode_inference: json_providers.clone(),
         image_inference: vec![],
-        #[cfg(feature = "e2e_tests")]
+
         shorthand_inference: vec![],
         supports_batch_inference: false,
     }

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -1,19 +1,18 @@
 #![allow(clippy::print_stdout)]
 use std::{collections::HashMap, net::SocketAddr};
 
-#[cfg(feature = "e2e_tests")]
 use aws_config::Region;
-#[cfg(feature = "e2e_tests")]
+
 use aws_sdk_bedrockruntime::error::SdkError;
-#[cfg(feature = "e2e_tests")]
+
 use aws_sdk_s3::operation::get_object::GetObjectError;
-#[cfg(feature = "e2e_tests")]
+
 use axum::extract::{Query, State};
 use axum::{routing::get, Router};
 use base64::prelude::*;
 use futures::StreamExt;
 use object_store::path::Path;
-#[cfg(feature = "e2e_tests")]
+
 use rand::Rng;
 use reqwest::{Client, StatusCode};
 use reqwest_eventsource::{Event, RequestBuilderExt};
@@ -23,11 +22,11 @@ use tensorzero::{
     CacheParamsOptions, ClientInferenceParams, InferenceOutput, InferenceResponse, Input,
     InputMessage, InputMessageContent,
 };
-#[cfg(feature = "e2e_tests")]
+
 use tensorzero_internal::endpoints::object_storage::{
     get_object_handler, ObjectResponse, PathParams,
 };
-#[cfg(feature = "e2e_tests")]
+
 use tensorzero_internal::gateway_util::AppStateData;
 use tensorzero_internal::inference::types::TextKind;
 use tensorzero_internal::{
@@ -54,7 +53,7 @@ pub struct E2ETestProvider {
     pub variant_name: String,
     pub model_name: String,
     pub model_provider_name: String,
-    #[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+    
     pub credentials: HashMap<String, String>,
 }
 
@@ -67,27 +66,26 @@ pub struct E2ETestProvider {
 /// then the provider should return an empty vector for the corresponding test.
 pub struct E2ETestProviders {
     pub simple_inference: Vec<E2ETestProvider>,
-    #[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+    
     pub extra_body_inference: Vec<E2ETestProvider>,
-    #[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+    
     pub reasoning_inference: Vec<E2ETestProvider>,
-    #[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+    
     pub inference_params_dynamic_credentials: Vec<E2ETestProvider>,
-    #[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+    
     pub inference_params_inference: Vec<E2ETestProvider>,
     pub tool_use_inference: Vec<E2ETestProvider>,
     pub tool_multi_turn_inference: Vec<E2ETestProvider>,
     pub dynamic_tool_use_inference: Vec<E2ETestProvider>,
     pub parallel_tool_use_inference: Vec<E2ETestProvider>,
     pub json_mode_inference: Vec<E2ETestProvider>,
-    #[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+    
     pub image_inference: Vec<E2ETestProvider>,
-    #[cfg(feature = "e2e_tests")]
+
     pub shorthand_inference: Vec<E2ETestProvider>,
     pub supports_batch_inference: bool,
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn make_http_gateway() -> tensorzero::Client {
     tensorzero::ClientBuilder::new(tensorzero::ClientBuilderMode::HTTPGateway {
         url: get_gateway_endpoint("/"),
@@ -139,18 +137,18 @@ pub async fn make_embedded_gateway_with_config(config: &str) -> tensorzero::Clie
 
 // We use a multi-threaded runtime so that the embedded gateway can use 'block_on'.
 // For consistency, we also use a multi-threaded runtime for the http gateway test.
-#[cfg(feature = "e2e_tests")]
+
 #[macro_export]
 macro_rules! make_gateway_test_functions {
     ($prefix:ident) => {
         paste::paste! {
-            #[cfg(feature = "e2e_tests")]
+
             #[tokio::test(flavor = "multi_thread")]
             async fn [<$prefix _embedded_gateway>]() {
                 $prefix ($crate::providers::common::make_embedded_gateway().await).await;
             }
 
-            #[cfg(feature = "e2e_tests")]
+
             #[tokio::test(flavor = "multi_thread")]
             async fn [<$prefix _http_gateway>]() {
                 $prefix ($crate::providers::common::make_http_gateway().await).await;
@@ -159,7 +157,6 @@ macro_rules! make_gateway_test_functions {
     };
 }
 
-#[cfg(feature = "e2e_tests")]
 #[macro_export]
 macro_rules! generate_provider_tests {
     ($func:ident) => {
@@ -200,7 +197,7 @@ macro_rules! generate_provider_tests {
         use $crate::providers::common::test_multi_turn_parallel_tool_use_inference_request_with_provider;
         use $crate::providers::common::test_multi_turn_parallel_tool_use_streaming_inference_request_with_provider;
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_simple_inference_request() {
             let providers = $func().await.simple_inference;
@@ -209,7 +206,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_reasoning_inference_request_simple() {
             let providers = $func().await.reasoning_inference;
@@ -218,7 +215,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_streaming_reasoning_inference_request_simple() {
             let providers = $func().await.reasoning_inference;
@@ -227,7 +224,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_shorthand_inference_request() {
             let providers = $func().await.shorthand_inference;
@@ -244,7 +241,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_inference_params_inference_request() {
             let providers = $func().await.inference_params_dynamic_credentials;
@@ -253,7 +250,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_inference_params_streaming_inference_request() {
             let providers = $func().await.inference_params_dynamic_credentials;
@@ -262,7 +259,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_tool_use_tool_choice_auto_used_inference_request() {
             let providers = $func().await.tool_use_inference;
@@ -271,7 +268,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_tool_use_tool_choice_auto_used_streaming_inference_request() {
             let providers = $func().await.tool_use_inference;
@@ -280,7 +277,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_tool_use_tool_choice_auto_unused_inference_request() {
             let providers = $func().await.tool_use_inference;
@@ -289,7 +286,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_tool_use_tool_choice_auto_unused_streaming_inference_request() {
             let providers = $func().await.tool_use_inference;
@@ -298,7 +295,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_tool_use_tool_choice_required_inference_request() {
             let providers = $func().await.tool_use_inference;
@@ -307,7 +304,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_tool_use_tool_choice_required_streaming_inference_request() {
             let providers = $func().await.tool_use_inference;
@@ -316,7 +313,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_tool_use_tool_choice_none_inference_request() {
             let providers = $func().await.tool_use_inference;
@@ -325,7 +322,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_tool_use_tool_choice_none_streaming_inference_request() {
             let providers = $func().await.tool_use_inference;
@@ -334,7 +331,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_tool_use_tool_choice_specific_inference_request() {
             let providers = $func().await.tool_use_inference;
@@ -343,7 +340,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_tool_use_tool_choice_specific_streaming_inference_request() {
             let providers = $func().await.tool_use_inference;
@@ -352,7 +349,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_tool_use_allowed_tools_inference_request() {
             let providers = $func().await.tool_use_inference;
@@ -361,7 +358,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_tool_use_allowed_tools_streaming_inference_request() {
             let providers = $func().await.tool_use_inference;
@@ -370,7 +367,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_tool_multi_turn_inference_request() {
             let providers = $func().await.tool_multi_turn_inference;
@@ -379,7 +376,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_tool_multi_turn_streaming_inference_request() {
             let providers = $func().await.tool_multi_turn_inference;
@@ -404,7 +401,7 @@ macro_rules! generate_provider_tests {
         }
         $crate::make_gateway_test_functions!(test_dynamic_tool_use_streaming_inference_request);
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_parallel_tool_use_inference_request() {
             let providers = $func().await.parallel_tool_use_inference;
@@ -413,7 +410,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_parallel_tool_use_streaming_inference_request() {
             let providers = $func().await.parallel_tool_use_inference;
@@ -422,7 +419,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_json_mode_inference_request() {
             let providers = $func().await.json_mode_inference;
@@ -431,7 +428,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_reasoning_inference_request_json_mode() {
             let providers = $func().await.reasoning_inference;
@@ -440,7 +437,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_streaming_reasoning_inference_request_json_mode() {
             let providers = $func().await.reasoning_inference;
@@ -449,7 +446,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_dynamic_json_mode_inference_request() {
             let providers = $func().await.json_mode_inference;
@@ -458,7 +455,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_json_mode_streaming_inference_request() {
             let providers = $func().await.json_mode_inference;
@@ -467,7 +464,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_image_inference_store_filesystem() {
             let providers = $func().await.image_inference;
@@ -476,7 +473,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_image_url_inference_store_filesystem() {
             let providers = $func().await.image_inference;
@@ -485,7 +482,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_image_inference_store_amazon_s3() {
             let providers = $func().await.image_inference;
@@ -494,7 +491,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_extra_body() {
             let providers = $func().await.extra_body_inference;
@@ -503,7 +500,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_short_inference_request() {
             let providers = $func().await.simple_inference;
@@ -512,7 +509,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_multi_turn_parallel_tool_use_inference_request() {
             let providers = $func().await.parallel_tool_use_inference;
@@ -521,7 +518,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[cfg(feature = "e2e_tests")]
+
         #[tokio::test]
         async fn test_multi_turn_parallel_tool_use_streaming_inference_request() {
             let providers = $func().await.parallel_tool_use_inference;
@@ -532,7 +529,7 @@ macro_rules! generate_provider_tests {
     };
 }
 
-#[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+
 pub static FERRIS_PNG: &[u8] = include_bytes!("./ferris.png");
 
 pub const IMAGE_FUNCTION_CONFIG: &str = r#"
@@ -565,7 +562,7 @@ location = "us-central1"
 project_id = "tensorzero-public"
 "#;
 
-#[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+
 pub async fn test_image_url_inference_with_provider_filesystem(provider: E2ETestProvider) {
     let temp_dir = tempfile::tempdir().unwrap();
     println!("Temporary image dir: {}", temp_dir.path().to_string_lossy());
@@ -595,13 +592,11 @@ pub async fn test_image_url_inference_with_provider_filesystem(provider: E2ETest
     assert_eq!(result, FERRIS_PNG);
 }
 
-#[cfg(feature = "e2e_tests")]
 async fn check_object_fetch(data: AppStateData, storage_path: &StoragePath) {
     check_object_fetch_via_embedded(data.clone(), storage_path).await;
     check_object_fetch_via_gateway(storage_path).await;
 }
 
-#[cfg(feature = "e2e_tests")]
 async fn check_object_fetch_via_embedded(data: AppStateData, storage_path: &StoragePath) {
     let res = get_object_handler(
         State(data),
@@ -620,7 +615,6 @@ async fn check_object_fetch_via_embedded(data: AppStateData, storage_path: &Stor
     );
 }
 
-#[cfg(feature = "e2e_tests")]
 async fn check_object_fetch_via_gateway(storage_path: &StoragePath) {
     // Try using the running HTTP gateway (which is *not* configured with an object store)
     // to fetch the `StoragePath`
@@ -644,7 +638,6 @@ async fn check_object_fetch_via_gateway(storage_path: &StoragePath) {
     );
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_image_inference_with_provider_filesystem(provider: E2ETestProvider) {
     let temp_dir = tempfile::tempdir().unwrap();
     println!("Temporary image dir: {}", temp_dir.path().to_string_lossy());
@@ -676,7 +669,6 @@ pub async fn test_image_inference_with_provider_filesystem(provider: E2ETestProv
     check_object_fetch(client.get_app_state_data().unwrap().clone(), &storage_path).await;
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_image_inference_with_provider_amazon_s3(provider: E2ETestProvider) {
     let test_bucket = "tensorzero-e2e-test-images";
     let test_bucket_region = "us-east-1";
@@ -736,7 +728,6 @@ pub async fn test_image_inference_with_provider_amazon_s3(provider: E2ETestProvi
         .unwrap();
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_image_inference_with_provider_s3_compatible(
     provider: E2ETestProvider,
     storage_kind: &StorageKind,
@@ -807,7 +798,7 @@ async fn make_temp_image_server() -> (SocketAddr, tokio::sync::oneshot::Sender<(
     (real_addr, send)
 }
 
-#[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+
 pub async fn test_url_image_inference_with_provider_and_store(
     provider: E2ETestProvider,
     kind: StorageKind,
@@ -866,7 +857,7 @@ pub async fn test_url_image_inference_with_provider_and_store(
     }
 }
 
-#[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+
 pub async fn test_base64_image_inference_with_provider_and_store(
     provider: E2ETestProvider,
     kind: &StorageKind,
@@ -929,13 +920,13 @@ pub async fn test_base64_image_inference_with_provider_and_store(
     (client, storage_path.unwrap())
 }
 
-#[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+
 pub async fn test_extra_body_with_provider(provider: E2ETestProvider) {
     test_extra_body_with_provider_and_stream(&provider, false).await;
     test_extra_body_with_provider_and_stream(&provider, true).await;
 }
 
-#[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+
 pub async fn test_extra_body_with_provider_and_stream(provider: &E2ETestProvider, stream: bool) {
     let episode_id = Uuid::now_v7();
 
@@ -1059,7 +1050,6 @@ pub async fn test_extra_body_with_provider_and_stream(provider: &E2ETestProvider
     );
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_simple_inference_request_with_provider(provider: E2ETestProvider) {
     let episode_id = Uuid::now_v7();
 
@@ -1132,7 +1122,7 @@ pub async fn test_simple_inference_request_with_provider(provider: E2ETestProvid
     check_simple_inference_response(response_json, Some(episode_id), &provider, false, true).await;
 }
 
-#[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+
 pub async fn check_base64_image_response(
     response: InferenceResponse,
     episode_id: Option<Uuid>,
@@ -1289,7 +1279,7 @@ pub async fn check_base64_image_response(
     expected_storage_path
 }
 
-#[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+
 pub async fn check_url_image_response(
     response: InferenceResponse,
     episode_id: Option<Uuid>,
@@ -1855,7 +1845,6 @@ pub async fn check_simple_image_inference_response(
     );
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_simple_streaming_inference_request_with_provider(provider: E2ETestProvider) {
     let episode_id = Uuid::now_v7();
     let tag_value = Uuid::now_v7().to_string();
@@ -1874,7 +1863,6 @@ pub async fn test_simple_streaming_inference_request_with_provider(provider: E2E
     assert_eq!(original_content, cached_content);
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_simple_streaming_inference_request_with_provider_cache(
     provider: &E2ETestProvider,
     episode_id: Uuid,
@@ -2144,7 +2132,6 @@ pub async fn test_simple_streaming_inference_request_with_provider_cache(
     full_content
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_inference_params_inference_request_with_provider(provider: E2ETestProvider) {
     let episode_id = Uuid::now_v7();
 
@@ -2380,7 +2367,6 @@ pub async fn check_inference_params_response(
     assert_eq!(output.len(), 1);
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_inference_params_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
@@ -2641,7 +2627,6 @@ pub async fn test_inference_params_streaming_inference_request_with_provider(
     assert_eq!(output.len(), 1);
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_tool_use_tool_choice_auto_used_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
@@ -2923,7 +2908,6 @@ pub async fn check_tool_use_tool_choice_auto_used_inference_response(
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_tool_use_tool_choice_auto_used_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
@@ -3262,7 +3246,7 @@ pub async fn test_tool_use_tool_choice_auto_used_streaming_inference_request_wit
 
 /// This test is similar to `test_tool_use_tool_choice_auto_used_inference_request_with_provider`, but it steers the model to not use the tool.
 /// This ensures that ToolChoice::Auto is working as expected.
-#[cfg(feature = "e2e_tests")]
+
 pub async fn test_tool_use_tool_choice_auto_unused_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
@@ -3514,7 +3498,7 @@ pub async fn check_tool_use_tool_choice_auto_unused_inference_response(
 
 /// This test is similar to `test_tool_use_tool_choice_auto_used_streaming_inference_request_with_provider`, but it steers the model to not use the tool.
 /// This ensures that ToolChoice::Auto is working as expected.
-#[cfg(feature = "e2e_tests")]
+
 pub async fn test_tool_use_tool_choice_auto_unused_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
@@ -3800,7 +3784,6 @@ pub async fn test_tool_use_tool_choice_auto_unused_streaming_inference_request_w
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_tool_use_tool_choice_required_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
@@ -4080,7 +4063,6 @@ pub async fn check_tool_use_tool_choice_required_inference_response(
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_tool_use_tool_choice_required_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
@@ -4408,7 +4390,6 @@ pub async fn test_tool_use_tool_choice_required_streaming_inference_request_with
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_tool_use_tool_choice_none_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
@@ -4654,7 +4635,6 @@ pub async fn check_tool_use_tool_choice_none_inference_response(
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_tool_use_tool_choice_none_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
@@ -4951,7 +4931,6 @@ pub async fn test_tool_use_tool_choice_none_streaming_inference_request_with_pro
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_tool_use_tool_choice_specific_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
@@ -5284,7 +5263,6 @@ pub async fn check_tool_use_tool_choice_specific_inference_response(
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_tool_use_tool_choice_specific_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
@@ -5681,7 +5659,6 @@ pub async fn test_tool_use_tool_choice_specific_streaming_inference_request_with
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_tool_use_allowed_tools_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
@@ -5937,7 +5914,6 @@ pub async fn check_tool_use_tool_choice_allowed_tools_inference_response(
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_tool_use_allowed_tools_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
@@ -6258,7 +6234,6 @@ pub async fn test_tool_use_allowed_tools_streaming_inference_request_with_provid
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_tool_multi_turn_inference_request_with_provider(provider: E2ETestProvider) {
     // NOTE: The xAI API returns an error for multi-turn tool use when the assistant message only has tool_calls but no content.
     // The xAI team has acknowledged the issue and is working on a fix.
@@ -6543,7 +6518,6 @@ pub async fn check_tool_use_multi_turn_inference_response(
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_tool_multi_turn_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
@@ -6863,7 +6837,6 @@ pub async fn test_tool_multi_turn_streaming_inference_request_with_provider(
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_dynamic_tool_use_inference_request_with_provider(
     provider: E2ETestProvider,
     client: &tensorzero::Client,
@@ -7168,7 +7141,6 @@ pub async fn check_dynamic_tool_use_inference_response(
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_dynamic_tool_use_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
     client: &tensorzero::Client,
@@ -7510,7 +7482,6 @@ pub async fn test_dynamic_tool_use_streaming_inference_request_with_provider(
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_parallel_tool_use_inference_request_with_provider(provider: E2ETestProvider) {
     let episode_id = Uuid::now_v7();
 
@@ -7850,7 +7821,6 @@ pub async fn check_parallel_tool_use_inference_response(
     assert!(tool_call_names.contains(&"get_humidity".to_string()));
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_parallel_tool_use_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
@@ -8255,7 +8225,6 @@ pub async fn test_parallel_tool_use_streaming_inference_request_with_provider(
     assert!(tool_call_names.contains(&"get_humidity".to_string()));
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_json_mode_inference_request_with_provider(provider: E2ETestProvider) {
     let episode_id = Uuid::now_v7();
 
@@ -8487,7 +8456,6 @@ pub async fn check_json_mode_inference_response(
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_dynamic_json_mode_inference_request_with_provider(provider: E2ETestProvider) {
     let episode_id = Uuid::now_v7();
     let output_schema = json!({
@@ -8732,7 +8700,6 @@ pub async fn check_dynamic_json_mode_inference_response(
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_json_mode_streaming_inference_request_with_provider(provider: E2ETestProvider) {
     if provider.variant_name.contains("tgi") {
         // TGI does not support streaming in JSON mode (because it doesn't support streaming tools)
@@ -8999,7 +8966,6 @@ pub async fn test_json_mode_streaming_inference_request_with_provider(provider: 
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_short_inference_request_with_provider(provider: E2ETestProvider) {
     let episode_id = Uuid::now_v7();
 
@@ -9086,7 +9052,6 @@ pub async fn test_short_inference_request_with_provider(provider: E2ETestProvide
     check_short_inference_response(response_json, Some(episode_id), &provider, true).await;
 }
 
-#[cfg(feature = "e2e_tests")]
 async fn check_short_inference_response(
     response_json: Value,
     episode_id: Option<Uuid>,
@@ -9280,7 +9245,6 @@ async fn check_short_inference_response(
     );
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_multi_turn_parallel_tool_use_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
@@ -9556,7 +9520,6 @@ pub async fn check_multi_turn_parallel_tool_use_inference_response(
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 pub async fn test_multi_turn_parallel_tool_use_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -53,7 +53,7 @@ pub struct E2ETestProvider {
     pub variant_name: String,
     pub model_name: String,
     pub model_provider_name: String,
-    
+
     pub credentials: HashMap<String, String>,
 }
 
@@ -66,20 +66,20 @@ pub struct E2ETestProvider {
 /// then the provider should return an empty vector for the corresponding test.
 pub struct E2ETestProviders {
     pub simple_inference: Vec<E2ETestProvider>,
-    
+
     pub extra_body_inference: Vec<E2ETestProvider>,
-    
+
     pub reasoning_inference: Vec<E2ETestProvider>,
-    
+
     pub inference_params_dynamic_credentials: Vec<E2ETestProvider>,
-    
+
     pub inference_params_inference: Vec<E2ETestProvider>,
     pub tool_use_inference: Vec<E2ETestProvider>,
     pub tool_multi_turn_inference: Vec<E2ETestProvider>,
     pub dynamic_tool_use_inference: Vec<E2ETestProvider>,
     pub parallel_tool_use_inference: Vec<E2ETestProvider>,
     pub json_mode_inference: Vec<E2ETestProvider>,
-    
+
     pub image_inference: Vec<E2ETestProvider>,
 
     pub shorthand_inference: Vec<E2ETestProvider>,
@@ -529,7 +529,6 @@ macro_rules! generate_provider_tests {
     };
 }
 
-
 pub static FERRIS_PNG: &[u8] = include_bytes!("./ferris.png");
 
 pub const IMAGE_FUNCTION_CONFIG: &str = r#"
@@ -561,7 +560,6 @@ model_id = "gemini-1.5-pro-001"
 location = "us-central1"
 project_id = "tensorzero-public"
 "#;
-
 
 pub async fn test_image_url_inference_with_provider_filesystem(provider: E2ETestProvider) {
     let temp_dir = tempfile::tempdir().unwrap();
@@ -798,7 +796,6 @@ async fn make_temp_image_server() -> (SocketAddr, tokio::sync::oneshot::Sender<(
     (real_addr, send)
 }
 
-
 pub async fn test_url_image_inference_with_provider_and_store(
     provider: E2ETestProvider,
     kind: StorageKind,
@@ -856,7 +853,6 @@ pub async fn test_url_image_inference_with_provider_and_store(
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     }
 }
-
 
 pub async fn test_base64_image_inference_with_provider_and_store(
     provider: E2ETestProvider,
@@ -920,12 +916,10 @@ pub async fn test_base64_image_inference_with_provider_and_store(
     (client, storage_path.unwrap())
 }
 
-
 pub async fn test_extra_body_with_provider(provider: E2ETestProvider) {
     test_extra_body_with_provider_and_stream(&provider, false).await;
     test_extra_body_with_provider_and_stream(&provider, true).await;
 }
-
 
 pub async fn test_extra_body_with_provider_and_stream(provider: &E2ETestProvider, stream: bool) {
     let episode_id = Uuid::now_v7();
@@ -1122,7 +1116,6 @@ pub async fn test_simple_inference_request_with_provider(provider: E2ETestProvid
     check_simple_inference_response(response_json, Some(episode_id), &provider, false, true).await;
 }
 
-
 pub async fn check_base64_image_response(
     response: InferenceResponse,
     episode_id: Option<Uuid>,
@@ -1278,7 +1271,6 @@ pub async fn check_base64_image_response(
     );
     expected_storage_path
 }
-
 
 pub async fn check_url_image_response(
     response: InferenceResponse,

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -3238,7 +3238,6 @@ pub async fn test_tool_use_tool_choice_auto_used_streaming_inference_request_wit
 
 /// This test is similar to `test_tool_use_tool_choice_auto_used_inference_request_with_provider`, but it steers the model to not use the tool.
 /// This ensures that ToolChoice::Auto is working as expected.
-
 pub async fn test_tool_use_tool_choice_auto_unused_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
@@ -3490,7 +3489,6 @@ pub async fn check_tool_use_tool_choice_auto_unused_inference_response(
 
 /// This test is similar to `test_tool_use_tool_choice_auto_used_streaming_inference_request_with_provider`, but it steers the model to not use the tool.
 /// This ensures that ToolChoice::Auto is working as expected.
-
 pub async fn test_tool_use_tool_choice_auto_unused_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {

--- a/tensorzero-internal/tests/e2e/providers/deepseek.rs
+++ b/tensorzero-internal/tests/e2e/providers/deepseek.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
-#[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
@@ -53,7 +52,7 @@ async fn get_providers() -> E2ETestProviders {
             credentials: credentials.clone(),
         },
     ];
-    #[cfg(feature = "e2e_tests")]
+
     let shorthand_providers = vec![E2ETestProvider {
         variant_name: "deepseek-shorthand".to_string(),
         model_name: "deepseek::deepseek-chat".to_string(),
@@ -73,7 +72,7 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: vec![],
         json_mode_inference: json_providers.clone(),
         image_inference: vec![],
-        #[cfg(feature = "e2e_tests")]
+
         shorthand_inference: shorthand_providers.clone(),
         supports_batch_inference: false,
     }

--- a/tensorzero-internal/tests/e2e/providers/fireworks.rs
+++ b/tensorzero-internal/tests/e2e/providers/fireworks.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
-#[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
@@ -61,7 +60,6 @@ async fn get_providers() -> E2ETestProviders {
         },
     ];
 
-    #[cfg(feature = "e2e_tests")]
     let shorthand_providers = vec![E2ETestProvider {
         variant_name: "fireworks-shorthand".to_string(),
         model_name: "fireworks::accounts/fireworks/models/llama-v3p1-8b-instruct".into(),
@@ -81,7 +79,7 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: vec![],
         json_mode_inference: json_providers,
         image_inference: vec![],
-        #[cfg(feature = "e2e_tests")]
+
         shorthand_inference: shorthand_providers,
         supports_batch_inference: false,
     }

--- a/tensorzero-internal/tests/e2e/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/tests/e2e/providers/gcp_vertex_anthropic.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
-#[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
@@ -54,7 +53,7 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: vec![],
         json_mode_inference: json_providers.clone(),
         image_inference: vec![],
-        #[cfg(feature = "e2e_tests")]
+
         shorthand_inference: vec![],
         supports_batch_inference: false,
     }

--- a/tensorzero-internal/tests/e2e/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/tests/e2e/providers/gcp_vertex_gemini.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
-#[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
@@ -81,7 +80,7 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: vec![],
         json_mode_inference: json_providers.clone(),
         image_inference: image_providers,
-        #[cfg(feature = "e2e_tests")]
+
         shorthand_inference: vec![],
         supports_batch_inference: false,
     }

--- a/tensorzero-internal/tests/e2e/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-internal/tests/e2e/providers/google_ai_studio_gemini.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
-#[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
@@ -95,7 +94,6 @@ async fn get_providers() -> E2ETestProviders {
         },
     ];
 
-    #[cfg(feature = "e2e_tests")]
     let shorthand_providers = vec![E2ETestProvider {
         variant_name: "google-ai-studio-gemini-flash-8b-shorthand".to_string(),
         model_name: "google_ai_studio_gemini::gemini-2.0-flash-lite".into(),
@@ -115,7 +113,7 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: vec![],
         json_mode_inference: json_providers.clone(),
         image_inference: image_providers,
-        #[cfg(feature = "e2e_tests")]
+
         shorthand_inference: shorthand_providers.clone(),
         supports_batch_inference: false,
     }

--- a/tensorzero-internal/tests/e2e/providers/hyperbolic.rs
+++ b/tensorzero-internal/tests/e2e/providers/hyperbolic.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
-#[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
@@ -33,7 +32,6 @@ async fn get_providers() -> E2ETestProviders {
         credentials,
     }];
 
-    #[cfg(feature = "e2e_tests")]
     let shorthand_providers = vec![E2ETestProvider {
         variant_name: "hyperbolic-shorthand".to_string(),
         model_name: "hyperbolic::meta-llama/Meta-Llama-3-70B-Instruct".into(),
@@ -53,7 +51,7 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: vec![],
         json_mode_inference: vec![],
         image_inference: vec![],
-        #[cfg(feature = "e2e_tests")]
+
         shorthand_inference: shorthand_providers.clone(),
         supports_batch_inference: false,
     }

--- a/tensorzero-internal/tests/e2e/providers/mistral.rs
+++ b/tensorzero-internal/tests/e2e/providers/mistral.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
-#[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
@@ -48,7 +47,6 @@ async fn get_providers() -> E2ETestProviders {
         credentials,
     }];
 
-    #[cfg(feature = "e2e_tests")]
     let shorthand_providers = vec![E2ETestProvider {
         variant_name: "mistral-shorthand".to_string(),
         model_name: "mistral::open-mistral-nemo-2407".into(),
@@ -68,7 +66,7 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: vec![],
         json_mode_inference: json_providers.clone(),
         image_inference: vec![],
-        #[cfg(feature = "e2e_tests")]
+
         shorthand_inference: shorthand_providers.clone(),
         supports_batch_inference: false,
     }

--- a/tensorzero-internal/tests/e2e/providers/openai.rs
+++ b/tensorzero-internal/tests/e2e/providers/openai.rs
@@ -24,7 +24,6 @@ use tensorzero_internal::clickhouse::test_helpers::{
     get_clickhouse, select_chat_inference_clickhouse, select_model_inference_clickhouse,
 };
 
-#[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
@@ -117,7 +116,6 @@ async fn get_providers() -> E2ETestProviders {
         },
     ];
 
-    #[cfg(feature = "e2e_tests")]
     let shorthand_providers = vec![E2ETestProvider {
         variant_name: "openai-shorthand".to_string(),
         model_name: "openai::gpt-4o-mini-2024-07-18".into(),
@@ -137,13 +135,12 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: standard_without_o1.clone(),
         json_mode_inference: json_providers.clone(),
         image_inference: image_providers.clone(),
-        #[cfg(feature = "e2e_tests")]
+
         shorthand_inference: shorthand_providers.clone(),
         supports_batch_inference: true,
     }
 }
 
-#[cfg(feature = "e2e_tests")]
 #[tokio::test]
 pub async fn test_provider_config_extra_body() {
     let episode_id = Uuid::now_v7();
@@ -242,7 +239,7 @@ pub async fn test_provider_config_extra_body() {
 }
 
 // Tests using 'model_name' with a shorthand model
-#[cfg(feature = "e2e_tests")]
+
 #[tokio::test]
 async fn test_default_function_model_name_shorthand() {
     let client = Client::new();
@@ -356,7 +353,7 @@ async fn test_default_function_model_name_shorthand() {
 }
 
 // Tests using 'model_name' with a non-shorthand model
-#[cfg(feature = "e2e_tests")]
+
 #[tokio::test]
 async fn test_default_function_model_name_non_shorthand() {
     let client = Client::new();
@@ -470,7 +467,7 @@ async fn test_default_function_model_name_non_shorthand() {
 }
 
 // Tests using 'model_name' with a non-shorthand model
-#[cfg(feature = "e2e_tests")]
+
 #[tokio::test]
 async fn test_default_function_invalid_model_name() {
     use reqwest::StatusCode;
@@ -507,25 +504,21 @@ async fn test_default_function_invalid_model_name() {
     assert_eq!(status, StatusCode::BAD_GATEWAY);
 }
 
-#[cfg(feature = "e2e_tests")]
 #[tokio::test]
 async fn test_chat_function_json_override_with_mode_on() {
     test_chat_function_json_override_with_mode(ModelInferenceRequestJsonMode::On).await;
 }
 
-#[cfg(feature = "e2e_tests")]
 #[tokio::test]
 async fn test_chat_function_json_override_with_mode_off() {
     test_chat_function_json_override_with_mode(ModelInferenceRequestJsonMode::Off).await;
 }
 
-#[cfg(feature = "e2e_tests")]
 #[tokio::test]
 async fn test_chat_function_json_override_with_mode_strict() {
     test_chat_function_json_override_with_mode(ModelInferenceRequestJsonMode::Strict).await;
 }
 
-#[cfg(feature = "e2e_tests")]
 #[tokio::test]
 async fn test_chat_function_json_override_with_mode_implicit_tool() {
     let client = Client::new();
@@ -730,7 +723,6 @@ async fn test_chat_function_json_override_with_mode(json_mode: ModelInferenceReq
     let _raw_response_json: Value = serde_json::from_str(raw_response).unwrap();
 }
 
-#[cfg(feature = "e2e_tests")]
 #[tokio::test]
 async fn test_o1_mini_inference() {
     let client = Client::new();
@@ -960,7 +952,6 @@ async fn test_embedding_request() {
     assert_eq!(cached_response.usage.output_tokens, 0);
 }
 
-#[cfg(feature = "e2e_tests")]
 #[tokio::test]
 async fn test_embedding_sanity_check() {
     let provider_config_serialized = r#"
@@ -1012,7 +1003,6 @@ async fn test_embedding_sanity_check() {
     );
 }
 
-#[cfg(feature = "e2e_tests")]
 fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     let dot_product: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
     let magnitude_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
@@ -1022,7 +1012,7 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 
 // We already test Amazon S3 with all image providers, so let's test Cloudflare R2
 // (which is S3-compatible) with just OpenAI to save time and money.
-#[cfg(feature = "e2e_tests")]
+
 #[tokio::test]
 pub async fn test_image_inference_with_provider_cloudflare_r2() {
     use crate::providers::common::test_image_inference_with_provider_s3_compatible;
@@ -1213,7 +1203,7 @@ async fn test_content_block_text_field() {
 
 // We already test Amazon S3 with all image providers, so let's test Google Cloud Storage
 // (which is S3-compatible) with just OpenAI to save time and money.
-#[cfg(feature = "e2e_tests")]
+
 #[tokio::test]
 pub async fn test_image_inference_with_provider_gcp_storage() {
     use crate::providers::common::test_image_inference_with_provider_s3_compatible;
@@ -1288,7 +1278,7 @@ pub async fn test_image_inference_with_provider_gcp_storage() {
 
 // We already test Amazon S3 with all image providers, so let's test minio
 // (which is S3-compatible) with just OpenAI to save time and money.
-#[cfg(feature = "e2e_tests")]
+
 #[tokio::test]
 pub async fn test_image_inference_with_provider_docker_minio() {
     use crate::providers::common::test_image_inference_with_provider_s3_compatible;
@@ -1364,7 +1354,6 @@ pub async fn test_image_inference_with_provider_docker_minio() {
     .await;
 }
 
-#[cfg(feature = "e2e_tests")]
 #[tokio::test]
 pub async fn test_parallel_tool_use_default_true_inference_request() {
     use crate::providers::common::check_parallel_tool_use_inference_response;
@@ -1418,7 +1407,6 @@ pub async fn test_parallel_tool_use_default_true_inference_request() {
 }
 
 #[tokio::test]
-#[cfg(feature = "e2e_tests")]
 #[tracing_test::traced_test]
 async fn test_log_dropped_thought() {
     use tensorzero::{ClientInferenceParams, Input, InputMessage, InputMessageContent, Role};

--- a/tensorzero-internal/tests/e2e/providers/reasoning.rs
+++ b/tensorzero-internal/tests/e2e/providers/reasoning.rs
@@ -16,7 +16,7 @@ use tensorzero_internal::clickhouse::test_helpers::{
 use tensorzero_internal::inference::types::{ContentBlock, RequestMessage};
 use uuid::Uuid;
 
-#[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+
 pub async fn test_reasoning_inference_request_simple_with_provider(provider: E2ETestProvider) {
     let episode_id = Uuid::now_v7();
 
@@ -246,7 +246,7 @@ pub async fn test_reasoning_inference_request_simple_with_provider(provider: E2E
     assert_eq!(id, inference_id);
 }
 
-#[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+
 pub async fn test_streaming_reasoning_inference_request_simple_with_provider(
     provider: E2ETestProvider,
 ) {
@@ -525,7 +525,7 @@ pub async fn test_streaming_reasoning_inference_request_simple_with_provider(
     assert_eq!(id, inference_id);
 }
 
-#[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+
 pub async fn test_reasoning_inference_request_with_provider_json_mode(provider: E2ETestProvider) {
     let episode_id = Uuid::now_v7();
 
@@ -723,7 +723,7 @@ pub async fn test_reasoning_inference_request_with_provider_json_mode(provider: 
     assert_eq!(output.len(), 2);
 }
 
-#[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]
+
 pub async fn test_streaming_reasoning_inference_request_with_provider_json_mode(
     provider: E2ETestProvider,
 ) {

--- a/tensorzero-internal/tests/e2e/providers/reasoning.rs
+++ b/tensorzero-internal/tests/e2e/providers/reasoning.rs
@@ -16,7 +16,6 @@ use tensorzero_internal::clickhouse::test_helpers::{
 use tensorzero_internal::inference::types::{ContentBlock, RequestMessage};
 use uuid::Uuid;
 
-
 pub async fn test_reasoning_inference_request_simple_with_provider(provider: E2ETestProvider) {
     let episode_id = Uuid::now_v7();
 
@@ -245,7 +244,6 @@ pub async fn test_reasoning_inference_request_simple_with_provider(provider: E2E
     let id = Uuid::parse_str(id).unwrap();
     assert_eq!(id, inference_id);
 }
-
 
 pub async fn test_streaming_reasoning_inference_request_simple_with_provider(
     provider: E2ETestProvider,
@@ -525,7 +523,6 @@ pub async fn test_streaming_reasoning_inference_request_simple_with_provider(
     assert_eq!(id, inference_id);
 }
 
-
 pub async fn test_reasoning_inference_request_with_provider_json_mode(provider: E2ETestProvider) {
     let episode_id = Uuid::now_v7();
 
@@ -722,7 +719,6 @@ pub async fn test_reasoning_inference_request_with_provider_json_mode(provider: 
     let output: Vec<ContentBlock> = serde_json::from_str(output).unwrap();
     assert_eq!(output.len(), 2);
 }
-
 
 pub async fn test_streaming_reasoning_inference_request_with_provider_json_mode(
     provider: E2ETestProvider,

--- a/tensorzero-internal/tests/e2e/providers/sglang.rs
+++ b/tensorzero-internal/tests/e2e/providers/sglang.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
-#[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
@@ -49,7 +48,7 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: vec![],
         json_mode_inference: json_providers.clone(),
         image_inference: vec![],
-        #[cfg(feature = "e2e_tests")]
+
         shorthand_inference: vec![],
         supports_batch_inference: false,
     }

--- a/tensorzero-internal/tests/e2e/providers/tgi.rs
+++ b/tensorzero-internal/tests/e2e/providers/tgi.rs
@@ -1,6 +1,6 @@
 use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 use std::collections::HashMap;
-#[cfg(feature = "e2e_tests")]
+
 crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
@@ -39,7 +39,7 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: vec![],
         json_mode_inference: json_providers.clone(),
         image_inference: vec![],
-        #[cfg(feature = "e2e_tests")]
+
         shorthand_inference: vec![],
         supports_batch_inference: false,
     }

--- a/tensorzero-internal/tests/e2e/providers/together.rs
+++ b/tensorzero-internal/tests/e2e/providers/together.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
-#[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
@@ -62,7 +61,6 @@ async fn get_providers() -> E2ETestProviders {
         credentials: HashMap::new(),
     }];
 
-    #[cfg(feature = "e2e_tests")]
     let shorthand_providers = vec![E2ETestProvider {
         variant_name: "together-shorthand".to_string(),
         model_name: "together::meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo".into(),
@@ -82,7 +80,7 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: tool_providers.clone(),
         json_mode_inference: json_providers.clone(),
         image_inference: vec![],
-        #[cfg(feature = "e2e_tests")]
+
         shorthand_inference: shorthand_providers.clone(),
         supports_batch_inference: false,
     }

--- a/tensorzero-internal/tests/e2e/providers/vllm.rs
+++ b/tensorzero-internal/tests/e2e/providers/vllm.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
-#[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
@@ -61,7 +60,7 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: vec![],
         json_mode_inference: json_providers.clone(),
         image_inference: vec![],
-        #[cfg(feature = "e2e_tests")]
+
         shorthand_inference: vec![],
         supports_batch_inference: false,
     }

--- a/tensorzero-internal/tests/e2e/providers/xai.rs
+++ b/tensorzero-internal/tests/e2e/providers/xai.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use crate::providers::common::{E2ETestProvider, E2ETestProviders};
 
-#[cfg(feature = "e2e_tests")]
 crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
@@ -53,7 +52,6 @@ async fn get_providers() -> E2ETestProviders {
         credentials,
     }];
 
-    #[cfg(feature = "e2e_tests")]
     let shorthand_providers = vec![E2ETestProvider {
         variant_name: "xai-shorthand".to_string(),
         model_name: "xai::grok-2-1212".into(),
@@ -73,7 +71,7 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: vec![],
         json_mode_inference: json_providers,
         image_inference: vec![],
-        #[cfg(feature = "e2e_tests")]
+
         shorthand_inference: shorthand_providers.clone(),
         supports_batch_inference: false,
     }


### PR DESCRIPTION
Now that we no longer have the 'batch_tests' cargo feature, these test files will only ever be compiled with the 'e2e_tests' feature enabled, so these cfgs will always be true.

We still have 'feature = "e2e_tests"' inside the main tensorzero-internal code for things like the dummy provider.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove all `e2e_tests` feature `cfg` attributes from end-to-end test files as they are always compiled with this feature enabled.
> 
>   - **Behavior**:
>     - Remove all `#[cfg(feature = "e2e_tests")]` and `#[cfg_attr(not(feature = "e2e_tests"), allow(dead_code))]` from test functions in `inference.rs`, `openai_compatible.rs`, and `anthropic.rs`.
>     - Remove similar `cfg` attributes from `aws_bedrock.rs`, `azure.rs`, and `common.rs`.
>   - **Providers**:
>     - Remove `cfg` attributes from provider test files such as `deepseek.rs`, `fireworks.rs`, and `gcp_vertex_anthropic.rs`.
>     - Continue removal in `gcp_vertex_gemini.rs`, `google_ai_studio_gemini.rs`, and `hyperbolic.rs`.
>     - Further removal in `mistral.rs`, `openai.rs`, and `reasoning.rs`.
>     - Complete removal in `sglang.rs`, `tgi.rs`, `together.rs`, `vllm.rs`, and `xai.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 54e5925e097e6073480e2ca8fbaa617155f31d1d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->