### PR TITLE
Don't assign `patch_openai_client` in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,13 +153,14 @@ You can access any provider using the OpenAI Python client with TensorZero.
 from openai import OpenAI
 from tensorzero import patch_openai_client
 
-client = patch_openai_client(
-    OpenAI(),
+client = OpenAI()
+
+patch_openai_client(
+    client,
     clickhouse_url="http://chuser:chpassword@localhost:8123/tensorzero",
     config_file="config/tensorzero.toml",
     async_setup=False,
 )
-
 
 response = client.chat.completions.create(
     model="tensorzero::model_name::openai::gpt-4o-mini",

--- a/clients/python-pyo3/tests/test_client.py
+++ b/clients/python-pyo3/tests/test_client.py
@@ -2012,7 +2012,7 @@ def test_uuid7_import():
 
 def test_patch_sync_openai_client_sync_setup():
     client = OpenAI()
-    client = tensorzero.patch_openai_client(
+    tensorzero.patch_openai_client(
         client,
         config_file="../../examples/readme/config/tensorzero.toml",
         clickhouse_url=None,
@@ -2052,7 +2052,7 @@ async def test_patch_sync_openai_client_async_setup():
 
 def test_patch_openai_client_no_config():
     client = OpenAI()
-    client = tensorzero.patch_openai_client(client, async_setup=False)
+    tensorzero.patch_openai_client(client, async_setup=False)
     response = client.chat.completions.create(
         model="tensorzero::model_name::dummy::json",
         messages=[
@@ -2067,7 +2067,7 @@ def test_patch_openai_client_no_config():
 
 def test_patch_openai_client_with_config():
     client = OpenAI()
-    client = tensorzero.patch_openai_client(
+    tensorzero.patch_openai_client(
         client,
         config_file="../../tensorzero-internal/tests/e2e/tensorzero.toml",
         async_setup=False,
@@ -2100,7 +2100,7 @@ def test_patch_openai_client_with_config():
 @pytest.mark.asyncio
 async def test_patch_async_openai_client_sync_setup():
     client = AsyncOpenAI()
-    client = tensorzero.patch_openai_client(
+    tensorzero.patch_openai_client(
         client,
         config_file="../../examples/readme/config/tensorzero.toml",
         clickhouse_url=None,

--- a/examples/readme/openai_client.py
+++ b/examples/readme/openai_client.py
@@ -1,8 +1,10 @@
 from openai import OpenAI
 from tensorzero import patch_openai_client
 
-client = patch_openai_client(
-    OpenAI(),
+client = OpenAI()
+
+patch_openai_client(
+    client,
     clickhouse_url="http://chuser:chpassword@localhost:8123/tensorzero",
     config_file="config/tensorzero.toml",
     async_setup=False,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove reassignment of `client` after `patch_openai_client()` in examples and tests for consistency and clarity.
> 
>   - **Behavior**:
>     - Modify `README.md` and `openai_client.py` to call `patch_openai_client()` without reassigning the `client` variable.
>     - Update `test_client.py` to remove reassignment of `client` after `patch_openai_client()` in `test_patch_sync_openai_client_sync_setup`, `test_patch_sync_openai_client_async_setup`, `test_patch_openai_client_no_config`, `test_patch_openai_client_with_config`, and `test_patch_async_openai_client_sync_setup`.
>   - **Misc**:
>     - Minor formatting adjustments in `README.md` and `openai_client.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for eea9647b4e2a0def631a0f70bb3fbff510f6e260. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->