### PR TITLE
Publish gateway and ui docker images on release

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -1,0 +1,132 @@
+# This workflow builds and pushes the gateway and ui docker images to Docker Hub
+# when we tag a release.
+name: Publish docker images
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+env:
+  DOCKERHUB_USER: tensorzero
+
+jobs:
+  build:
+    name: Build and push Docker image to Docker Hub
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: ubuntu-24.04
+            target: linux/amd64
+          - runner: ubuntu-24.04-arm
+            target: linux/arm64
+        container:
+          - name: ui
+            context: ./ui
+          - name: gateway
+            context: .
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform.target }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: tensorzero-${{ matrix.container.name }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ matrix.platform.target }}
+          context: ${{ matrix.container.context }}
+          file: ./${{ matrix.container.name }}/Dockerfile
+          push: true
+          provenance: mode=max
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          tags: ${{ env.DOCKERHUB_USER }}/tensorzero-${{ matrix.container.name }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.push.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.container.name }}-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    strategy:
+      matrix:
+        container:
+          - name: ui
+            context: ./ui
+          - name: gateway
+            context: .
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-${{ matrix.container.name }}-*
+          merge-multiple: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKERHUB_USER }}/tensorzero-${{ matrix.container.name }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.DOCKERHUB_USER }}/tensorzero-${{ matrix.container.name }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.DOCKERHUB_USER }}/tensorzero-${{ matrix.container.name }}:${{ steps.meta.outputs.version }}

--- a/ui/.dockerignore
+++ b/ui/.dockerignore
@@ -2,3 +2,4 @@
 build
 node_modules
 README.md
+app/utils/minijinja/pkg/

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install -g pnpm
 
 FROM base AS development-dependencies-env
 
-COPY . /app
+COPY ./package.json pnpm-lock.yaml /app/
 
 WORKDIR /app
 
@@ -24,12 +24,22 @@ WORKDIR /app
 
 RUN pnpm install --frozen-lockfile --prod
 
+# ========== rust-build-env ==========
+
+FROM rust:latest AS rust-build-env
+
+COPY ./app/utils/minijinja /minijinja/
+
+WORKDIR /minijinja
+RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+RUN wasm-pack build --features console_error_panic_hook
+
 # ========== build-env ==========
 
 FROM base AS build-env
 
 COPY . /app/
-
+COPY --from=rust-build-env /minijinja/pkg /app/app/utils/minijinja/pkg
 COPY --from=development-dependencies-env /app/node_modules /app/node_modules
 
 WORKDIR /app


### PR DESCRIPTION
We build arm and x86 images for both (on separate runners), and use a final 'merge' step to tag the pushed images by digest.

As part of this change, I've started building the minijinja wasm bindings inside of the UI docker image (rather than relying on them already existing and getting copied over with the docker build context)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add GitHub Actions workflow to build and publish gateway and UI Docker images on release, and build minijinja wasm bindings within the UI Docker image.
> 
>   - **Docker Workflow**:
>     - New workflow `docker-hub-publish.yml` to build and push gateway and UI Docker images on release.
>     - Supports arm and x86 architectures using separate runners.
>     - Uses a merge step to tag images by digest.
>   - **UI Dockerfile**:
>     - Builds minijinja wasm bindings within the Docker image (`ui/Dockerfile`).
>     - Copies wasm bindings from `rust-build-env` to `/app/app/utils/minijinja/pkg`.
>   - **Misc**:
>     - Updates `.dockerignore` to exclude `app/utils/minijinja/pkg/`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 10df6051c535c3c9e0b5cfaed36026fcbfa37398. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->