### PR TITLE
Explicitly specify '--config-file' in example docker-compose.yml

### DIFF
--- a/examples/babyai/docker-compose.yml
+++ b/examples/babyai/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero
       - OPENAI_API_KEY=${OPENAI_API_KEY:?Environment variable OPENAI_API_KEY must be set.}

--- a/examples/chess-puzzles/docker-compose.yml
+++ b/examples/chess-puzzles/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     volumes:
       - ./config:/app/config:ro
       - ${GCP_VERTEX_CREDENTIALS_PATH:-/dev/null}:/app/gcp-credentials.json:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - GCP_VERTEX_CREDENTIALS_PATH=${GCP_VERTEX_CREDENTIALS_PATH:+/app/gcp-credentials.json}
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero

--- a/examples/data-extraction-ner/docker-compose.yml
+++ b/examples/data-extraction-ner/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     volumes:
       - ./config:/app/config:ro
       - ${GCP_VERTEX_CREDENTIALS_PATH:-/dev/null}:/app/gcp-credentials.json:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero
       - GCP_VERTEX_CREDENTIALS_PATH=${GCP_VERTEX_CREDENTIALS_PATH:+/app/gcp-credentials.json}

--- a/examples/gsm8k-custom-recipe-dspy/docker-compose.yml
+++ b/examples/gsm8k-custom-recipe-dspy/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     volumes:
       - ./config:/app/config:ro
       - ${GCP_VERTEX_CREDENTIALS_PATH:-/dev/null}:/app/gcp-credentials.json:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero
       - GCP_VERTEX_CREDENTIALS_PATH=${GCP_VERTEX_CREDENTIALS_PATH:+/app/gcp-credentials.json}

--- a/examples/guides/batch-inference/docker-compose.yml
+++ b/examples/guides/batch-inference/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero
       - OPENAI_API_KEY=${OPENAI_API_KEY:?Environment variable OPENAI_API_KEY must be set.}

--- a/examples/guides/episodes/docker-compose.yml
+++ b/examples/guides/episodes/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero
       - OPENAI_API_KEY=${OPENAI_API_KEY:?Environment variable OPENAI_API_KEY must be set.}

--- a/examples/guides/metrics-feedback/docker-compose.yml
+++ b/examples/guides/metrics-feedback/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero
       - OPENAI_API_KEY=${OPENAI_API_KEY:?Environment variable OPENAI_API_KEY must be set.}

--- a/examples/guides/multimodal-inference/docker-compose.yml
+++ b/examples/guides/multimodal-inference/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY:?Environment variable OPENAI_API_KEY must be set.}
       - S3_ACCESS_KEY_ID=miniouser

--- a/examples/guides/prompts-templates-schemas/docker-compose.yml
+++ b/examples/guides/prompts-templates-schemas/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero
       - OPENAI_API_KEY=${OPENAI_API_KEY:?Environment variable OPENAI_API_KEY must be set.}

--- a/examples/guides/providers/anthropic/docker-compose.yml
+++ b/examples/guides/providers/anthropic/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: tensorzero/gateway
     volumes:
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:?Environment variable ANTHROPIC_API_KEY must be set.}
     ports:

--- a/examples/guides/providers/aws-bedrock/docker-compose.yml
+++ b/examples/guides/providers/aws-bedrock/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: tensorzero/gateway
     volumes:
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:?Environment variable AWS_ACCESS_KEY_ID must be set.}
       - AWS_REGION=${AWS_REGION:?Environment variable AWS_REGION must be set.}

--- a/examples/guides/providers/azure/docker-compose.yml
+++ b/examples/guides/providers/azure/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: tensorzero/gateway
     volumes:
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - AZURE_OPENAI_API_KEY=${AZURE_OPENAI_API_KEY:?Environment variable AZURE_OPENAI_API_KEY must be set.}
     ports:

--- a/examples/guides/providers/deepseek/docker-compose.yml
+++ b/examples/guides/providers/deepseek/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: tensorzero/gateway
     volumes:
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY:?Environment variable DEEPSEEK_API_KEY must be set.}
     ports:

--- a/examples/guides/providers/fireworks/docker-compose.yml
+++ b/examples/guides/providers/fireworks/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: tensorzero/gateway
     volumes:
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - FIREWORKS_API_KEY=${FIREWORKS_API_KEY:?Environment variable FIREWORKS_API_KEY must be set.}
     ports:

--- a/examples/guides/providers/gcp-vertex-ai-anthropic/docker-compose.yml
+++ b/examples/guides/providers/gcp-vertex-ai-anthropic/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - ./config:/app/config:ro
       - ${GCP_VERTEX_CREDENTIALS_PATH:-/dev/null}:/app/gcp-credentials.json:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - GCP_VERTEX_CREDENTIALS_PATH=${GCP_VERTEX_CREDENTIALS_PATH:+/app/gcp-credentials.json}
     ports:

--- a/examples/guides/providers/gcp-vertex-ai-gemini/docker-compose.yml
+++ b/examples/guides/providers/gcp-vertex-ai-gemini/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - ./config:/app/config:ro
       - ${GCP_VERTEX_CREDENTIALS_PATH:-/dev/null}:/app/gcp-credentials.json:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - GCP_VERTEX_CREDENTIALS_PATH=${GCP_VERTEX_CREDENTIALS_PATH:+/app/gcp-credentials.json}
     ports:

--- a/examples/guides/providers/google-ai-studio-gemini/docker-compose.yml
+++ b/examples/guides/providers/google-ai-studio-gemini/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: tensorzero/gateway
     volumes:
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - GOOGLE_AI_STUDIO_API_KEY=${GOOGLE_AI_STUDIO_API_KEY:?Environment variable GOOGLE_AI_STUDIO_API_KEY must be set.}
     ports:

--- a/examples/guides/providers/hyperbolic/docker-compose.yml
+++ b/examples/guides/providers/hyperbolic/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: tensorzero/gateway
     volumes:
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - HYPERBOLIC_API_KEY=${HYPERBOLIC_API_KEY:?Environment variable HYPERBOLIC_API_KEY must be set.}
     ports:

--- a/examples/guides/providers/mistral/docker-compose.yml
+++ b/examples/guides/providers/mistral/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: tensorzero/gateway
     volumes:
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - MISTRAL_API_KEY=${MISTRAL_API_KEY:?Environment variable MISTRAL_API_KEY must be set.}
     ports:

--- a/examples/guides/providers/openai-compatible/docker-compose.yml
+++ b/examples/guides/providers/openai-compatible/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: tensorzero/gateway
     volumes:
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     # environment:
     #   - OLLAMA_API_KEY=${OLLAMA_API_KEY:?Environment variable OLLAMA_API_KEY must be set.}
     ports:

--- a/examples/guides/providers/openai/docker-compose.yml
+++ b/examples/guides/providers/openai/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: tensorzero/gateway
     volumes:
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY:?Environment variable OPENAI_API_KEY must be set.}
     ports:

--- a/examples/guides/providers/sglang/docker-compose.yml
+++ b/examples/guides/providers/sglang/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: tensorzero/gateway
     volumes:
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     # environment:
     #   - SGLANG_API_KEY=${SGLANG_API_KEY:?Environment variable SGLANG_API_KEY must be set.}
     ports:

--- a/examples/guides/providers/tgi/docker-compose.yml
+++ b/examples/guides/providers/tgi/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: tensorzero/gateway
     volumes:
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     # environment:
     #   - TGI_API_KEY=${TGI_API_KEY:?Environment variable TGI_API_KEY must be set.}
     ports:

--- a/examples/guides/providers/together/docker-compose.yml
+++ b/examples/guides/providers/together/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: tensorzero/gateway
     volumes:
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - TOGETHER_API_KEY=${TOGETHER_API_KEY:?Environment variable TOGETHER_API_KEY must be set.}
     ports:

--- a/examples/guides/providers/vllm/docker-compose.yml
+++ b/examples/guides/providers/vllm/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: tensorzero/gateway
     volumes:
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     # environment:
     #   - VLLM_API_KEY=${VLLM_API_KEY:?Environment variable VLLM_API_KEY must be set.}
     ports:

--- a/examples/guides/providers/xai/docker-compose.yml
+++ b/examples/guides/providers/xai/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: tensorzero/gateway
     volumes:
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - XAI_API_KEY=${XAI_API_KEY:?Environment variable XAI_API_KEY must be set.}
     ports:

--- a/examples/guides/streaming-inference/docker-compose.yml
+++ b/examples/guides/streaming-inference/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY:?Environment variable OPENAI_API_KEY must be set.}
     ports:

--- a/examples/haiku-hidden-preferences/docker-compose.yml
+++ b/examples/haiku-hidden-preferences/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     volumes:
       - ./config:/app/config:ro
       - ${GCP_VERTEX_CREDENTIALS_PATH:-/dev/null}:/app/gcp-credentials.json:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero
       - GCP_VERTEX_CREDENTIALS_PATH=${GCP_VERTEX_CREDENTIALS_PATH:+/app/gcp-credentials.json}

--- a/examples/production-deployment/docker-compose.yml
+++ b/examples/production-deployment/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     volumes:
       - ./config:/app/config:ro
       - ${GCP_VERTEX_CREDENTIALS_PATH:-/dev/null}:/app/gcp-credentials.json:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - GCP_VERTEX_CREDENTIALS_PATH=${GCP_VERTEX_CREDENTIALS_PATH:+/app/gcp-credentials.json}
     env_file:

--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero
       - OPENAI_API_KEY=${OPENAI_API_KEY:?Environment variable OPENAI_API_KEY must be set.}

--- a/examples/readme/docker-compose.yml
+++ b/examples/readme/docker-compose.yml
@@ -19,9 +19,6 @@ services:
   gateway:
     image: tensorzero/gateway
     command: --default-config  # no `tensorzero.toml` configuration file provided
-    volumes:
-      # Mount our tensorzero.toml file into the container
-      - ./config:/app/config:ro
     environment:
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero
       - OPENAI_API_KEY=${OPENAI_API_KEY:?Environment variable OPENAI_API_KEY must be set.}

--- a/examples/tutorial/01-simple-chatbot/docker-compose.yml
+++ b/examples/tutorial/01-simple-chatbot/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero
       - OPENAI_API_KEY=${OPENAI_API_KEY:?Environment variable OPENAI_API_KEY must be set.}

--- a/examples/tutorial/02-email-copilot/docker-compose.yml
+++ b/examples/tutorial/02-email-copilot/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:?Environment variable ANTHROPIC_API_KEY must be set.}
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero

--- a/examples/tutorial/03-weather-rag/docker-compose.yml
+++ b/examples/tutorial/03-weather-rag/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero
       - OPENAI_API_KEY=${OPENAI_API_KEY:?Environment variable OPENAI_API_KEY must be set.}

--- a/examples/tutorial/04-email-data-extraction/docker-compose.yml
+++ b/examples/tutorial/04-email-data-extraction/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     volumes:
       # Mount our tensorzero.toml file into the container
       - ./config:/app/config:ro
+    command: --config-file /app/config/tensorzero.toml
     environment:
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero
       - OPENAI_API_KEY=${OPENAI_API_KEY:?Environment variable OPENAI_API_KEY must be set.}


### PR DESCRIPTION
This is preparation for removing the default 'config/tensorzero.toml' path from the gateway Dockerfile, and requiring either '--config-file' or '--default-config' when starting the gateway

The only example using '--default-config' is 'examples/readme' - I removed the (nonexistant) config file mount from the example

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds explicit `--config-file` specification to `gateway` service in `docker-compose.yml` files across examples, preparing for default config path removal.
> 
>   - **Behavior**:
>     - Adds `--config-file /app/config/tensorzero.toml` to `gateway` service in `docker-compose.yml` files across multiple examples, including `babyai`, `chess-puzzles`, and `data-extraction-ner`.
>     - `examples/readme/docker-compose.yml` uses `--default-config` and removes non-existent config file mount.
>   - **Purpose**:
>     - Prepares for removal of default config path from Dockerfile, requiring explicit config specification.
>   - **Misc**:
>     - Ensures consistent configuration handling across examples.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 01a2c9d7287b2da711ef7cbd8f2dee171d369f2b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->