### PR TITLE
Add missing 'json_mode' field to e2e tensorzero.toml

### DIFF
--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -2289,6 +2289,7 @@ json_mode = "strict"
 type = "chat_completion"
 model = "dummy::error"
 system_template = "../../fixtures/config/functions/extract_entities/initial_prompt/system_template.minijinja"
+json_mode = "strict"
 
 [functions.mixture_of_n_json_repeated]
 type = "json"


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add missing `json_mode` field to `[functions.mixture_of_n_json_repeated]` in `tensorzero.toml`.
> 
>   - **Configuration Update**:
>     - Add missing `json_mode = "strict"` field to `[functions.mixture_of_n_json_repeated]` in `tensorzero.toml` to ensure consistent JSON handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 690a8f123babcb988edfc83f6b22f63cd1b3f0cf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->