### PR TITLE
Handle deprecation #1170 properly with custom types for Python PyO3 client

### DIFF
--- a/clients/python-pyo3/tensorzero/types.py
+++ b/clients/python-pyo3/tensorzero/types.py
@@ -51,12 +51,10 @@ class Text(ContentBlock):
             )
 
     def to_dict(self) -> Dict[str, Any]:
-        print("AAAA", self)
         if self.text is not None:
             # Handle ongoing deprecation: https://github.com/tensorzero/tensorzero/issues/1170
             # The first branch will be removed in a future release.
             if isinstance(self.text, dict):
-                print("BBBB", self.text)
                 return dict(type="text", arguments=self.text)
             else:
                 return dict(type="text", text=self.text)

--- a/clients/python-pyo3/tensorzero/types.py
+++ b/clients/python-pyo3/tensorzero/types.py
@@ -40,15 +40,19 @@ class Text(ContentBlock):
 
     def __post_init__(self):
         if self.text is None and self.arguments is None:
-            raise ValueError("Either `text` or `arguments` must be provided")
+            raise ValueError("Either `text` or `arguments` must be provided.")
+
+        if self.text is not None and self.arguments is not None:
+            raise ValueError("Only one of `text` or `arguments` must be provided.")
 
         # Warn about on going deprecation: https://github.com/tensorzero/tensorzero/issues/1170
-        if not isinstance(self.text, str):
-            warnings.warn(
-                'Please use `ContentBlock(type="text", arguments=...)` when providing arguments for a prompt template/schema. In a future release, `Text(type="text", text=...)` will require a string literal.',
-                DeprecationWarning,
-                stacklevel=2,
-            )
+        if self.text is not None:
+            if not isinstance(self.text, str):
+                warnings.warn(
+                    'Please use `ContentBlock(type="text", arguments=...)` when providing arguments for a prompt template/schema. In a future release, `Text(type="text", text=...)` will require a string literal.',
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
 
     def to_dict(self) -> Dict[str, Any]:
         if self.text is not None:

--- a/clients/python-pyo3/tensorzero/types.py
+++ b/clients/python-pyo3/tensorzero/types.py
@@ -46,13 +46,12 @@ class Text(ContentBlock):
             raise ValueError("Only one of `text` or `arguments` must be provided.")
 
         # Warn about on going deprecation: https://github.com/tensorzero/tensorzero/issues/1170
-        if self.text is not None:
-            if not isinstance(self.text, str):
-                warnings.warn(
-                    'Please use `ContentBlock(type="text", arguments=...)` when providing arguments for a prompt template/schema. In a future release, `Text(type="text", text=...)` will require a string literal.',
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
+        if self.text is not None and not isinstance(self.text, str):
+            warnings.warn(
+                'Please use `ContentBlock(type="text", arguments=...)` when providing arguments for a prompt template/schema. In a future release, `Text(type="text", text=...)` will require a string literal.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     def to_dict(self) -> Dict[str, Any]:
         if self.text is not None:

--- a/clients/python-pyo3/tensorzero/types.py
+++ b/clients/python-pyo3/tensorzero/types.py
@@ -35,10 +35,35 @@ class ContentBlock(ABC):
 
 @dataclass
 class Text(ContentBlock):
-    text: str
+    text: Optional[str] = None
+    arguments: Optional[Any] = None
+
+    def __post_init__(self):
+        if self.text is None and self.arguments is None:
+            raise ValueError("Either `text` or `arguments` must be provided")
+
+        # Warn about on going deprecation: https://github.com/tensorzero/tensorzero/issues/1170
+        if not isinstance(self.text, str):
+            warnings.warn(
+                'Please use `ContentBlock(type="text", arguments=...)` when providing arguments for a prompt template/schema. In a future release, `Text(type="text", text=...)` will require a string literal.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     def to_dict(self) -> Dict[str, Any]:
-        return dict(type="text", value=self.text)
+        print("AAAA", self)
+        if self.text is not None:
+            # Handle ongoing deprecation: https://github.com/tensorzero/tensorzero/issues/1170
+            # The first branch will be removed in a future release.
+            if isinstance(self.text, dict):
+                print("BBBB", self.text)
+                return dict(type="text", arguments=self.text)
+            else:
+                return dict(type="text", text=self.text)
+        elif self.arguments is not None:
+            return dict(type="text", arguments=self.arguments)
+        else:
+            raise ValueError("Either `text` or `arguments` must be provided.")
 
 
 @dataclass

--- a/clients/python-pyo3/tests/test_client.py
+++ b/clients/python-pyo3/tests/test_client.py
@@ -2369,7 +2369,8 @@ def test_text_arguments_deprecation_1170_warning(sync_client):
     """Test that using Text with dictionary for text parameter works but emits DeprecationWarning for #1170."""
 
     with pytest.warns(
-        DeprecationWarning, match="Please use `ContentBlock.*when providing arguments"
+        DeprecationWarning,
+        match=r"Please use `ContentBlock\(type=\"text\", arguments=...\)` when providing arguments for a prompt template/schema. In a future release, `Text\(type=\"text\", text=...\)` will require a string literal.",
     ):
         response = sync_client.inference(
             function_name="json_success",

--- a/clients/python-pyo3/tests/test_client.py
+++ b/clients/python-pyo3/tests/test_client.py
@@ -2392,3 +2392,29 @@ def test_text_arguments_deprecation_1170_warning(sync_client):
     assert response.usage.input_tokens == 10
     assert response.usage.output_tokens == 10
     assert response.finish_reason == FinishReason.STOP
+
+
+def test_content_block_text_init_validation():
+    """Test Text initialization validation for text and arguments parameters."""
+
+    # Test providing neither text nor arguments fails
+    with pytest.raises(
+        ValueError, match=r"Either `text` or `arguments` must be provided."
+    ):
+        Text(type="text")
+
+    with pytest.raises(
+        ValueError, match=r"Only one of `text` or `arguments` must be provided."
+    ):
+        Text(type="text", text="Hello", arguments={"foo": "bar"})
+
+    # Test with valid text parameter
+    text = Text(type="text", text="Hello")
+    assert text.text == "Hello"
+    assert text.arguments is None
+
+    # Test with valid arguments parameter
+    arguments = {"foo": "bar"}
+    text = Text(type="text", arguments=arguments)
+    assert text.text is None
+    assert text.arguments == arguments


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance `Text` class in `types.py` to handle deprecation by allowing either `text` or `arguments`, with updated tests in `test_client.py`.
> 
>   - **Behavior**:
>     - `Text` class in `types.py` now accepts either `text` or `arguments`, not both, raising `ValueError` if both or neither are provided.
>     - Adds `DeprecationWarning` for non-string `text` values, suggesting use of `arguments`.
>   - **Tests**:
>     - Updates `test_client.py` to use `arguments` instead of `text` where applicable.
>     - Adds `test_text_arguments_deprecation_1170_warning` to check for `DeprecationWarning`.
>     - Adds `test_content_block_text_init_validation` to validate `Text` initialization logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 96dd103ce151c981d15a42d9ba846fa6215be60a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->