### PR TITLE
Bump UI dependencies

### DIFF
--- a/ui/app/utils/supervised_fine_tuning/openAITokenCounter.test.ts
+++ b/ui/app/utils/supervised_fine_tuning/openAITokenCounter.test.ts
@@ -24,7 +24,7 @@ const shouldRunApiTests =
   process.env.ENABLE_TEST_WITH_OPENAI_API === "true";
 
 const client = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
+  apiKey: process.env.OPENAI_API_KEY || "fake-api-key",
 });
 
 describe("openAITokenCounter", () => {

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,6 +13,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@babel/runtime": "7.26.10",
     "@clickhouse/client": "^1.10.1",
     "@eslint/js": "^9.19.0",
     "@hookform/resolvers": "^3.10.0",
@@ -64,15 +65,16 @@
     "@typescript-eslint/eslint-plugin": "^8.22.0",
     "@typescript-eslint/parser": "^8.22.0",
     "autoprefixer": "^10.4.20",
+    "esbuild": "0.25.1",
     "eslint": "^9.21.0",
-    "postcss": "^8.5.1",
+    "postcss": "^8.5.3",
     "prettier": "^3.4.2",
     "prettier-plugin-tailwindcss": "^0.6.11",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.3",
-    "vite": "^5.4.14",
+    "vite": "^6.2.2",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^2.1.9"
+    "vitest": "^3.0.8"
   },
   "overrides": {
     "react-is": "^19.0.0-rc-69d4b800-20241021"

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     dependencies:
+      "@babel/runtime":
+        specifier: 7.26.10
+        version: 7.26.10
       "@clickhouse/client":
         specifier: ^1.10.1
         version: 1.10.1
@@ -126,14 +129,14 @@ importers:
         version: 11.0.5
       vite-plugin-wasm:
         specifier: ^3.4.1
-        version: 3.4.1(vite@5.4.14(@types/node@20.17.16))
+        version: 3.4.1(vite@6.2.2(@types/node@20.17.16)(jiti@1.21.7)(yaml@2.7.0))
       zod:
         specifier: ^3.24.1
         version: 3.24.1
     devDependencies:
       "@react-router/dev":
         specifier: ^7.1.4
-        version: 7.1.4(@react-router/serve@7.1.4(react-router@7.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.7.3))(@types/node@20.17.16)(react-router@7.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.7.3)(vite@5.4.14(@types/node@20.17.16))
+        version: 7.1.4(@react-router/serve@7.1.4(react-router@7.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.7.3))(@types/node@20.17.16)(react-router@7.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.7.3)(vite@6.2.2(@types/node@20.17.16)(jiti@1.21.7)(yaml@2.7.0))
       "@types/json-schema":
         specifier: ^7.0.15
         version: 7.0.15
@@ -154,13 +157,16 @@ importers:
         version: 8.22.0(eslint@9.21.0(jiti@1.21.7))(typescript@5.7.3)
       autoprefixer:
         specifier: ^10.4.20
-        version: 10.4.20(postcss@8.5.1)
+        version: 10.4.20(postcss@8.5.3)
+      esbuild:
+        specifier: 0.25.1
+        version: 0.25.1
       eslint:
         specifier: ^9.21.0
         version: 9.21.0(jiti@1.21.7)
       postcss:
-        specifier: ^8.5.1
-        version: 8.5.1
+        specifier: ^8.5.3
+        version: 8.5.3
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
@@ -174,14 +180,14 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
       vite:
-        specifier: ^5.4.14
-        version: 5.4.14(@types/node@20.17.16)
+        specifier: ^6.2.2
+        version: 6.2.2(@types/node@20.17.16)(jiti@1.21.7)(yaml@2.7.0)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.7.3)(vite@5.4.14(@types/node@20.17.16))
+        version: 5.1.4(typescript@5.7.3)(vite@6.2.2(@types/node@20.17.16)(jiti@1.21.7)(yaml@2.7.0))
       vitest:
-        specifier: ^2.1.9
-        version: 2.1.9(@types/node@20.17.16)
+        specifier: ^3.0.8
+        version: 3.0.8(@types/node@20.17.16)
 
 packages:
   "@alloc/quick-lru@5.2.0":
@@ -464,12 +470,30 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  "@esbuild/aix-ppc64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
+    os: [aix]
+
   "@esbuild/android-arm64@0.21.5":
     resolution:
       {
         integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==,
       }
     engines: { node: ">=12" }
+    cpu: [arm64]
+    os: [android]
+
+  "@esbuild/android-arm64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [android]
 
@@ -482,12 +506,30 @@ packages:
     cpu: [arm]
     os: [android]
 
+  "@esbuild/android-arm@0.25.1":
+    resolution:
+      {
+        integrity: sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
+    os: [android]
+
   "@esbuild/android-x64@0.21.5":
     resolution:
       {
         integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==,
       }
     engines: { node: ">=12" }
+    cpu: [x64]
+    os: [android]
+
+  "@esbuild/android-x64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [android]
 
@@ -500,12 +542,30 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  "@esbuild/darwin-arm64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [darwin]
+
   "@esbuild/darwin-x64@0.21.5":
     resolution:
       {
         integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==,
       }
     engines: { node: ">=12" }
+    cpu: [x64]
+    os: [darwin]
+
+  "@esbuild/darwin-x64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [darwin]
 
@@ -518,12 +578,30 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  "@esbuild/freebsd-arm64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [freebsd]
+
   "@esbuild/freebsd-x64@0.21.5":
     resolution:
       {
         integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==,
       }
     engines: { node: ">=12" }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@esbuild/freebsd-x64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [freebsd]
 
@@ -536,12 +614,30 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  "@esbuild/linux-arm64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [linux]
+
   "@esbuild/linux-arm@0.21.5":
     resolution:
       {
         integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==,
       }
     engines: { node: ">=12" }
+    cpu: [arm]
+    os: [linux]
+
+  "@esbuild/linux-arm@0.25.1":
+    resolution:
+      {
+        integrity: sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm]
     os: [linux]
 
@@ -554,12 +650,30 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  "@esbuild/linux-ia32@0.25.1":
+    resolution:
+      {
+        integrity: sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [linux]
+
   "@esbuild/linux-loong64@0.21.5":
     resolution:
       {
         integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==,
       }
     engines: { node: ">=12" }
+    cpu: [loong64]
+    os: [linux]
+
+  "@esbuild/linux-loong64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==,
+      }
+    engines: { node: ">=18" }
     cpu: [loong64]
     os: [linux]
 
@@ -572,12 +686,30 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  "@esbuild/linux-mips64el@0.25.1":
+    resolution:
+      {
+        integrity: sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [mips64el]
+    os: [linux]
+
   "@esbuild/linux-ppc64@0.21.5":
     resolution:
       {
         integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==,
       }
     engines: { node: ">=12" }
+    cpu: [ppc64]
+    os: [linux]
+
+  "@esbuild/linux-ppc64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==,
+      }
+    engines: { node: ">=18" }
     cpu: [ppc64]
     os: [linux]
 
@@ -590,12 +722,30 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  "@esbuild/linux-riscv64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [riscv64]
+    os: [linux]
+
   "@esbuild/linux-s390x@0.21.5":
     resolution:
       {
         integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==,
       }
     engines: { node: ">=12" }
+    cpu: [s390x]
+    os: [linux]
+
+  "@esbuild/linux-s390x@0.25.1":
+    resolution:
+      {
+        integrity: sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [s390x]
     os: [linux]
 
@@ -608,6 +758,24 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  "@esbuild/linux-x64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [linux]
+
+  "@esbuild/netbsd-arm64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [netbsd]
+
   "@esbuild/netbsd-x64@0.21.5":
     resolution:
       {
@@ -617,12 +785,39 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  "@esbuild/netbsd-x64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [netbsd]
+
+  "@esbuild/openbsd-arm64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openbsd]
+
   "@esbuild/openbsd-x64@0.21.5":
     resolution:
       {
         integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==,
       }
     engines: { node: ">=12" }
+    cpu: [x64]
+    os: [openbsd]
+
+  "@esbuild/openbsd-x64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [openbsd]
 
@@ -635,12 +830,30 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  "@esbuild/sunos-x64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [sunos]
+
   "@esbuild/win32-arm64@0.21.5":
     resolution:
       {
         integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==,
       }
     engines: { node: ">=12" }
+    cpu: [arm64]
+    os: [win32]
+
+  "@esbuild/win32-arm64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [win32]
 
@@ -653,12 +866,30 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  "@esbuild/win32-ia32@0.25.1":
+    resolution:
+      {
+        integrity: sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [win32]
+
   "@esbuild/win32-x64@0.21.5":
     resolution:
       {
         integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==,
       }
     engines: { node: ">=12" }
+    cpu: [x64]
+    os: [win32]
+
+  "@esbuild/win32-x64@0.25.1":
+    resolution:
+      {
+        integrity: sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [win32]
 
@@ -1991,54 +2222,60 @@ packages:
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  "@vitest/expect@2.1.9":
+  "@vitest/expect@3.0.8":
     resolution:
       {
-        integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==,
+        integrity: sha512-Xu6TTIavTvSSS6LZaA3EebWFr6tsoXPetOWNMOlc7LO88QVVBwq2oQWBoDiLCN6YTvNYsGSjqOO8CAdjom5DCQ==,
       }
 
-  "@vitest/mocker@2.1.9":
+  "@vitest/mocker@3.0.8":
     resolution:
       {
-        integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==,
+        integrity: sha512-n3LjS7fcW1BCoF+zWZxG7/5XvuYH+lsFg+BDwwAz0arIwHQJFUEsKBQ0BLU49fCxuM/2HSeBPHQD8WjgrxMfow==,
       }
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0
+      vite: ^5.0.0 || ^6.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  "@vitest/pretty-format@2.1.9":
+  "@vitest/pretty-format@3.0.8":
     resolution:
       {
-        integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==,
+        integrity: sha512-BNqwbEyitFhzYMYHUVbIvepOyeQOSFA/NeJMIP9enMntkkxLgOcgABH6fjyXG85ipTgvero6noreavGIqfJcIg==,
       }
 
-  "@vitest/runner@2.1.9":
+  "@vitest/pretty-format@3.0.9":
     resolution:
       {
-        integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==,
+        integrity: sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==,
       }
 
-  "@vitest/snapshot@2.1.9":
+  "@vitest/runner@3.0.8":
     resolution:
       {
-        integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==,
+        integrity: sha512-c7UUw6gEcOzI8fih+uaAXS5DwjlBaCJUo7KJ4VvJcjL95+DSR1kova2hFuRt3w41KZEFcOEiq098KkyrjXeM5w==,
       }
 
-  "@vitest/spy@2.1.9":
+  "@vitest/snapshot@3.0.8":
     resolution:
       {
-        integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==,
+        integrity: sha512-x8IlMGSEMugakInj44nUrLSILh/zy1f2/BgH0UeHpNyOocG18M9CWVIFBaXPt8TrqVZWmcPjwfG/ht5tnpba8A==,
       }
 
-  "@vitest/utils@2.1.9":
+  "@vitest/spy@3.0.8":
     resolution:
       {
-        integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==,
+        integrity: sha512-MR+PzJa+22vFKYb934CejhR4BeRpMSoxkvNoDit68GQxRLSf11aT6CTj3XaqUU9rxgWJFnqicN/wxw6yBRkI1Q==,
+      }
+
+  "@vitest/utils@3.0.8":
+    resolution:
+      {
+        integrity: sha512-nkBC3aEhfX2PdtQI/QwAWp8qZWwzASsU4Npbcd5RdMPBSSLCpkZp52P3xku3s3uA0HIEhGvEcF8rNkBsz9dQ4Q==,
       }
 
   abort-controller@3.0.0:
@@ -2369,10 +2606,10 @@ packages:
         integrity: sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==,
       }
 
-  chai@5.1.2:
+  chai@5.2.0:
     resolution:
       {
-        integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==,
+        integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==,
       }
     engines: { node: ">=12" }
 
@@ -2893,6 +3130,14 @@ packages:
         integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==,
       }
     engines: { node: ">=12" }
+    hasBin: true
+
+  esbuild@0.25.1:
+    resolution:
+      {
+        integrity: sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==,
+      }
+    engines: { node: ">=18" }
     hasBin: true
 
   escalade@3.2.0:
@@ -4264,6 +4509,12 @@ packages:
         integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==,
       }
 
+  pathe@2.0.3:
+    resolution:
+      {
+        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+      }
+
   pathval@2.0.0:
     resolution:
       {
@@ -4366,10 +4617,10 @@ packages:
         integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==,
       }
 
-  postcss@8.5.1:
+  postcss@8.5.3:
     resolution:
       {
-        integrity: sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==,
+        integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==,
       }
     engines: { node: ^10 || ^12 || >=14 }
 
@@ -5189,10 +5440,10 @@ packages:
       }
     engines: { node: ^18.0.0 || >=20.0.0 }
 
-  tinyrainbow@1.2.0:
+  tinyrainbow@2.0.0:
     resolution:
       {
-        integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==,
+        integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==,
       }
     engines: { node: ">=14.0.0" }
 
@@ -5469,18 +5720,18 @@ packages:
         integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==,
       }
 
-  vite-node@2.1.9:
-    resolution:
-      {
-        integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==,
-      }
-    engines: { node: ^18.0.0 || >=20.0.0 }
-    hasBin: true
-
   vite-node@3.0.0-beta.2:
     resolution:
       {
         integrity: sha512-ofTf6cfRdL30Wbl9n/BX81EyIR5s4PReLmSurrxQ+koLaWUNOEo8E0lCM53OJkb8vpa2URM2nSrxZsIFyvY1rg==,
+      }
+    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    hasBin: true
+
+  vite-node@3.0.8:
+    resolution:
+      {
+        integrity: sha512-6PhR4H9VGlcwXZ+KWCdMqbtG649xCPZqfI9j2PsK1FcXgEzro5bGHcVKFCTqPLaNKZES8Evqv4LwvZARsq5qlg==,
       }
     engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
     hasBin: true
@@ -5538,22 +5789,68 @@ packages:
       terser:
         optional: true
 
-  vitest@2.1.9:
+  vite@6.2.2:
     resolution:
       {
-        integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==,
+        integrity: sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==,
       }
-    engines: { node: ^18.0.0 || >=20.0.0 }
+    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    hasBin: true
+    peerDependencies:
+      "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: ">=1.21.0"
+      less: "*"
+      lightningcss: ^1.21.0
+      sass: "*"
+      sass-embedded: "*"
+      stylus: "*"
+      sugarss: "*"
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.0.8:
+    resolution:
+      {
+        integrity: sha512-dfqAsNqRGUc8hB9OVR2P0w8PZPEckti2+5rdZip0WIz9WW0MnImJ8XiR61QhqLa92EQzKP2uPkzenKOAHyEIbA==,
+      }
+    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
     hasBin: true
     peerDependencies:
       "@edge-runtime/vm": "*"
-      "@types/node": ^18.0.0 || >=20.0.0
-      "@vitest/browser": 2.1.9
-      "@vitest/ui": 2.1.9
+      "@types/debug": ^4.1.12
+      "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+      "@vitest/browser": 3.0.8
+      "@vitest/ui": 3.0.8
       happy-dom: "*"
       jsdom: "*"
     peerDependenciesMeta:
       "@edge-runtime/vm":
+        optional: true
+      "@types/debug":
         optional: true
       "@types/node":
         optional: true
@@ -5923,70 +6220,145 @@ snapshots:
   "@esbuild/aix-ppc64@0.21.5":
     optional: true
 
+  "@esbuild/aix-ppc64@0.25.1":
+    optional: true
+
   "@esbuild/android-arm64@0.21.5":
+    optional: true
+
+  "@esbuild/android-arm64@0.25.1":
     optional: true
 
   "@esbuild/android-arm@0.21.5":
     optional: true
 
+  "@esbuild/android-arm@0.25.1":
+    optional: true
+
   "@esbuild/android-x64@0.21.5":
+    optional: true
+
+  "@esbuild/android-x64@0.25.1":
     optional: true
 
   "@esbuild/darwin-arm64@0.21.5":
     optional: true
 
+  "@esbuild/darwin-arm64@0.25.1":
+    optional: true
+
   "@esbuild/darwin-x64@0.21.5":
+    optional: true
+
+  "@esbuild/darwin-x64@0.25.1":
     optional: true
 
   "@esbuild/freebsd-arm64@0.21.5":
     optional: true
 
+  "@esbuild/freebsd-arm64@0.25.1":
+    optional: true
+
   "@esbuild/freebsd-x64@0.21.5":
+    optional: true
+
+  "@esbuild/freebsd-x64@0.25.1":
     optional: true
 
   "@esbuild/linux-arm64@0.21.5":
     optional: true
 
+  "@esbuild/linux-arm64@0.25.1":
+    optional: true
+
   "@esbuild/linux-arm@0.21.5":
+    optional: true
+
+  "@esbuild/linux-arm@0.25.1":
     optional: true
 
   "@esbuild/linux-ia32@0.21.5":
     optional: true
 
+  "@esbuild/linux-ia32@0.25.1":
+    optional: true
+
   "@esbuild/linux-loong64@0.21.5":
+    optional: true
+
+  "@esbuild/linux-loong64@0.25.1":
     optional: true
 
   "@esbuild/linux-mips64el@0.21.5":
     optional: true
 
+  "@esbuild/linux-mips64el@0.25.1":
+    optional: true
+
   "@esbuild/linux-ppc64@0.21.5":
+    optional: true
+
+  "@esbuild/linux-ppc64@0.25.1":
     optional: true
 
   "@esbuild/linux-riscv64@0.21.5":
     optional: true
 
+  "@esbuild/linux-riscv64@0.25.1":
+    optional: true
+
   "@esbuild/linux-s390x@0.21.5":
+    optional: true
+
+  "@esbuild/linux-s390x@0.25.1":
     optional: true
 
   "@esbuild/linux-x64@0.21.5":
     optional: true
 
+  "@esbuild/linux-x64@0.25.1":
+    optional: true
+
+  "@esbuild/netbsd-arm64@0.25.1":
+    optional: true
+
   "@esbuild/netbsd-x64@0.21.5":
+    optional: true
+
+  "@esbuild/netbsd-x64@0.25.1":
+    optional: true
+
+  "@esbuild/openbsd-arm64@0.25.1":
     optional: true
 
   "@esbuild/openbsd-x64@0.21.5":
     optional: true
 
+  "@esbuild/openbsd-x64@0.25.1":
+    optional: true
+
   "@esbuild/sunos-x64@0.21.5":
+    optional: true
+
+  "@esbuild/sunos-x64@0.25.1":
     optional: true
 
   "@esbuild/win32-arm64@0.21.5":
     optional: true
 
+  "@esbuild/win32-arm64@0.25.1":
+    optional: true
+
   "@esbuild/win32-ia32@0.21.5":
     optional: true
 
+  "@esbuild/win32-ia32@0.25.1":
+    optional: true
+
   "@esbuild/win32-x64@0.21.5":
+    optional: true
+
+  "@esbuild/win32-x64@0.25.1":
     optional: true
 
   "@eslint-community/eslint-utils@4.4.1(eslint@9.21.0(jiti@1.21.7))":
@@ -6719,7 +7091,7 @@ snapshots:
 
   "@radix-ui/rect@1.1.0": {}
 
-  "@react-router/dev@7.1.4(@react-router/serve@7.1.4(react-router@7.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.7.3))(@types/node@20.17.16)(react-router@7.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.7.3)(vite@5.4.14(@types/node@20.17.16))":
+  "@react-router/dev@7.1.4(@react-router/serve@7.1.4(react-router@7.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.7.3))(@types/node@20.17.16)(react-router@7.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.7.3)(vite@6.2.2(@types/node@20.17.16)(jiti@1.21.7)(yaml@2.7.0))":
     dependencies:
       "@babel/core": 7.26.7
       "@babel/generator": 7.26.5
@@ -6750,7 +7122,7 @@ snapshots:
       semver: 7.7.0
       set-cookie-parser: 2.7.1
       valibot: 0.41.0(typescript@5.7.3)
-      vite: 5.4.14(@types/node@20.17.16)
+      vite: 6.2.2(@types/node@20.17.16)(jiti@1.21.7)(yaml@2.7.0)
       vite-node: 3.0.0-beta.2(@types/node@20.17.16)
     optionalDependencies:
       "@react-router/serve": 7.1.4(react-router@7.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.7.3)
@@ -6985,45 +7357,49 @@ snapshots:
       "@typescript-eslint/types": 8.22.0
       eslint-visitor-keys: 4.2.0
 
-  "@vitest/expect@2.1.9":
+  "@vitest/expect@3.0.8":
     dependencies:
-      "@vitest/spy": 2.1.9
-      "@vitest/utils": 2.1.9
-      chai: 5.1.2
-      tinyrainbow: 1.2.0
+      "@vitest/spy": 3.0.8
+      "@vitest/utils": 3.0.8
+      chai: 5.2.0
+      tinyrainbow: 2.0.0
 
-  "@vitest/mocker@2.1.9(vite@5.4.14(@types/node@20.17.16))":
+  "@vitest/mocker@3.0.8(vite@5.4.14(@types/node@20.17.16))":
     dependencies:
-      "@vitest/spy": 2.1.9
+      "@vitest/spy": 3.0.8
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       vite: 5.4.14(@types/node@20.17.16)
 
-  "@vitest/pretty-format@2.1.9":
+  "@vitest/pretty-format@3.0.8":
     dependencies:
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
 
-  "@vitest/runner@2.1.9":
+  "@vitest/pretty-format@3.0.9":
     dependencies:
-      "@vitest/utils": 2.1.9
-      pathe: 1.1.2
+      tinyrainbow: 2.0.0
 
-  "@vitest/snapshot@2.1.9":
+  "@vitest/runner@3.0.8":
     dependencies:
-      "@vitest/pretty-format": 2.1.9
+      "@vitest/utils": 3.0.8
+      pathe: 2.0.3
+
+  "@vitest/snapshot@3.0.8":
+    dependencies:
+      "@vitest/pretty-format": 3.0.8
       magic-string: 0.30.17
-      pathe: 1.1.2
+      pathe: 2.0.3
 
-  "@vitest/spy@2.1.9":
+  "@vitest/spy@3.0.8":
     dependencies:
       tinyspy: 3.0.2
 
-  "@vitest/utils@2.1.9":
+  "@vitest/utils@3.0.8":
     dependencies:
-      "@vitest/pretty-format": 2.1.9
+      "@vitest/pretty-format": 3.0.8
       loupe: 3.1.3
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
 
   abort-controller@3.0.0:
     dependencies:
@@ -7146,14 +7522,14 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  autoprefixer@10.4.20(postcss@8.5.1):
+  autoprefixer@10.4.20(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
       caniuse-lite: 1.0.30001696
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -7247,7 +7623,7 @@ snapshots:
 
   caniuse-lite@1.0.30001696: {}
 
-  chai@5.1.2:
+  chai@5.2.0:
     dependencies:
       assertion-error: 2.0.1
       check-error: 2.1.1
@@ -7615,6 +7991,34 @@ snapshots:
       "@esbuild/win32-arm64": 0.21.5
       "@esbuild/win32-ia32": 0.21.5
       "@esbuild/win32-x64": 0.21.5
+
+  esbuild@0.25.1:
+    optionalDependencies:
+      "@esbuild/aix-ppc64": 0.25.1
+      "@esbuild/android-arm": 0.25.1
+      "@esbuild/android-arm64": 0.25.1
+      "@esbuild/android-x64": 0.25.1
+      "@esbuild/darwin-arm64": 0.25.1
+      "@esbuild/darwin-x64": 0.25.1
+      "@esbuild/freebsd-arm64": 0.25.1
+      "@esbuild/freebsd-x64": 0.25.1
+      "@esbuild/linux-arm": 0.25.1
+      "@esbuild/linux-arm64": 0.25.1
+      "@esbuild/linux-ia32": 0.25.1
+      "@esbuild/linux-loong64": 0.25.1
+      "@esbuild/linux-mips64el": 0.25.1
+      "@esbuild/linux-ppc64": 0.25.1
+      "@esbuild/linux-riscv64": 0.25.1
+      "@esbuild/linux-s390x": 0.25.1
+      "@esbuild/linux-x64": 0.25.1
+      "@esbuild/netbsd-arm64": 0.25.1
+      "@esbuild/netbsd-x64": 0.25.1
+      "@esbuild/openbsd-arm64": 0.25.1
+      "@esbuild/openbsd-x64": 0.25.1
+      "@esbuild/sunos-x64": 0.25.1
+      "@esbuild/win32-arm64": 0.25.1
+      "@esbuild/win32-ia32": 0.25.1
+      "@esbuild/win32-x64": 0.25.1
 
   escalade@3.2.0: {}
 
@@ -8433,6 +8837,8 @@ snapshots:
 
   pathe@1.1.2: {}
 
+  pathe@2.0.3: {}
+
   pathval@2.0.0: {}
 
   peek-stream@1.1.3:
@@ -8451,28 +8857,28 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss-import@15.1.0(postcss@8.5.1):
+  postcss-import@15.1.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.10
 
-  postcss-js@4.0.1(postcss@8.5.1):
+  postcss-js@4.0.1(postcss@8.5.3):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  postcss-load-config@4.0.2(postcss@8.5.1):
+  postcss-load-config@4.0.2(postcss@8.5.3):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.7.0
     optionalDependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  postcss-nested@6.2.0(postcss@8.5.1):
+  postcss-nested@6.2.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -8482,7 +8888,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.1:
+  postcss@8.5.3:
     dependencies:
       nanoid: 3.3.8
       picocolors: 1.1.1
@@ -8992,11 +9398,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.1
-      postcss-import: 15.1.0(postcss@8.5.1)
-      postcss-js: 4.0.1(postcss@8.5.1)
-      postcss-load-config: 4.0.2(postcss@8.5.1)
-      postcss-nested: 6.2.0(postcss@8.5.1)
+      postcss: 8.5.3
+      postcss-import: 15.1.0(postcss@8.5.3)
+      postcss-js: 4.0.1(postcss@8.5.3)
+      postcss-load-config: 4.0.2(postcss@8.5.3)
+      postcss-nested: 6.2.0(postcss@8.5.3)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
       sucrase: 3.35.0
@@ -9026,7 +9432,7 @@ snapshots:
 
   tinypool@1.0.2: {}
 
-  tinyrainbow@1.2.0: {}
+  tinyrainbow@2.0.0: {}
 
   tinyspy@3.0.2: {}
 
@@ -9188,24 +9594,6 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-node@2.1.9(@types/node@20.17.16):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.0
-      es-module-lexer: 1.6.0
-      pathe: 1.1.2
-      vite: 5.4.14(@types/node@20.17.16)
-    transitivePeerDependencies:
-      - "@types/node"
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   vite-node@3.0.0-beta.2(@types/node@20.17.16):
     dependencies:
       cac: 6.7.14
@@ -9224,17 +9612,35 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-wasm@3.4.1(vite@5.4.14(@types/node@20.17.16)):
+  vite-node@3.0.8(@types/node@20.17.16):
     dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.6.0
+      pathe: 2.0.3
       vite: 5.4.14(@types/node@20.17.16)
+    transitivePeerDependencies:
+      - "@types/node"
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
-  vite-tsconfig-paths@5.1.4(typescript@5.7.3)(vite@5.4.14(@types/node@20.17.16)):
+  vite-plugin-wasm@3.4.1(vite@6.2.2(@types/node@20.17.16)(jiti@1.21.7)(yaml@2.7.0)):
+    dependencies:
+      vite: 6.2.2(@types/node@20.17.16)(jiti@1.21.7)(yaml@2.7.0)
+
+  vite-tsconfig-paths@5.1.4(typescript@5.7.3)(vite@6.2.2(@types/node@20.17.16)(jiti@1.21.7)(yaml@2.7.0)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.4(typescript@5.7.3)
     optionalDependencies:
-      vite: 5.4.14(@types/node@20.17.16)
+      vite: 6.2.2(@types/node@20.17.16)(jiti@1.21.7)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9242,33 +9648,44 @@ snapshots:
   vite@5.4.14(@types/node@20.17.16):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.5.1
+      postcss: 8.5.3
       rollup: 4.32.1
     optionalDependencies:
       "@types/node": 20.17.16
       fsevents: 2.3.3
 
-  vitest@2.1.9(@types/node@20.17.16):
+  vite@6.2.2(@types/node@20.17.16)(jiti@1.21.7)(yaml@2.7.0):
     dependencies:
-      "@vitest/expect": 2.1.9
-      "@vitest/mocker": 2.1.9(vite@5.4.14(@types/node@20.17.16))
-      "@vitest/pretty-format": 2.1.9
-      "@vitest/runner": 2.1.9
-      "@vitest/snapshot": 2.1.9
-      "@vitest/spy": 2.1.9
-      "@vitest/utils": 2.1.9
-      chai: 5.1.2
+      esbuild: 0.25.1
+      postcss: 8.5.3
+      rollup: 4.32.1
+    optionalDependencies:
+      "@types/node": 20.17.16
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      yaml: 2.7.0
+
+  vitest@3.0.8(@types/node@20.17.16):
+    dependencies:
+      "@vitest/expect": 3.0.8
+      "@vitest/mocker": 3.0.8(vite@5.4.14(@types/node@20.17.16))
+      "@vitest/pretty-format": 3.0.9
+      "@vitest/runner": 3.0.8
+      "@vitest/snapshot": 3.0.8
+      "@vitest/spy": 3.0.8
+      "@vitest/utils": 3.0.8
+      chai: 5.2.0
       debug: 4.4.0
       expect-type: 1.1.0
       magic-string: 0.30.17
-      pathe: 1.1.2
+      pathe: 2.0.3
       std-env: 3.8.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
       tinypool: 1.0.2
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
       vite: 5.4.14(@types/node@20.17.16)
-      vite-node: 2.1.9(@types/node@20.17.16)
+      vite-node: 3.0.8(@types/node@20.17.16)
       why-is-node-running: 2.3.0
     optionalDependencies:
       "@types/node": 20.17.16

--- a/ui/vitest.config.js
+++ b/ui/vitest.config.js
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+import wasm from "vite-plugin-wasm";
+
+export default defineConfig({
+  plugins: [tsconfigPaths(), wasm()],
+  test: {
+    environment: "node",
+    include: ["**/*.test.ts", "**/*.test.tsx"],
+    deps: {
+      optimizer: {
+        ssr: {
+          include: ["tslib"],
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
Manually apply #1354
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update UI dependencies, add Vitest configuration, and modify test file for default API key usage.
> 
>   - **Dependencies**:
>     - Add `@babel/runtime` version `7.26.10` and `esbuild` version `0.25.1` to `package.json`.
>     - Update `postcss` to `^8.5.3`, `vite` to `^6.2.2`, and `vitest` to `^3.0.8` in `package.json`.
>   - **Configuration**:
>     - Add `vitest.config.js` to configure Vitest with `vite-tsconfig-paths` and `vite-plugin-wasm` plugins.
>   - **Tests**:
>     - Modify `openAITokenCounter.test.ts` to use `process.env.OPENAI_API_KEY || "fake-api-key"` for `OpenAI` client initialization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 044ddf210dc784ff8d62e71d4803b1e5029b67da. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->