### PR TITLE
Rename `use_async` to `async_setup`Update

### DIFF
--- a/clients/openai-python/tests/test_openai_compatibility.py
+++ b/clients/openai-python/tests/test_openai_compatibility.py
@@ -975,7 +975,7 @@ async def test_async_multi_turn_parallel_tool_use(async_client):
 
 
 @pytest.mark.asyncio
-async def test_patch_openai_client_with_async_client_use_async_true():
+async def test_patch_openai_client_with_async_client_async_setup_true():
     """Tests that tensorzero.patch_openai_client works with AsyncOpenAI client."""
     client = AsyncOpenAI(api_key="donotuse")
 
@@ -1015,7 +1015,7 @@ async def test_patch_openai_client_with_async_client_use_async_true():
 
 
 @pytest.mark.asyncio
-async def test_patch_openai_client_with_async_client_use_async_false():
+async def test_patch_openai_client_with_async_client_async_setup_false():
     """Tests that tensorzero.patch_openai_client works with AsyncOpenAI client using sync setup."""
     client = AsyncOpenAI(api_key="donotuse")
 

--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -677,19 +677,19 @@ impl AsyncTensorZeroGateway {
     }
 
     #[classmethod]
-    #[pyo3(signature = (*, gateway_url, timeout=None, verbose_errors=false, use_async=true))]
+    #[pyo3(signature = (*, gateway_url, timeout=None, verbose_errors=false, async_setup=true))]
     /// Initialize the TensorZero client, using the HTTP gateway.
     /// :param gateway_url: The base URL of the TensorZero gateway. Example: "http://localhost:3000"
     /// :param timeout: The timeout for the HTTP client in seconds. If not provided, no timeout will be set.
     /// :param verbose_errors: If true, the client will increase the detail in errors (increasing the risk of leaking sensitive information).
-    /// :param use_async: If true, this method will return a `Future` that resolves to an `AsyncTensorZeroGateway` instance. Otherwise, it will block and construct the `AsyncTensorZeroGateway`
+    /// :param async_setup: If true, this method will return a `Future` that resolves to an `AsyncTensorZeroGateway` instance. Otherwise, it will block and construct the `AsyncTensorZeroGateway`
     /// :return: An `AsyncTensorZeroGateway` instance configured to use the HTTP gateway.
     fn build_http(
         cls: &Bound<'_, PyType>,
         gateway_url: &str,
         timeout: Option<f64>,
         verbose_errors: bool,
-        use_async: bool,
+        async_setup: bool,
     ) -> PyResult<Py<PyAny>> {
         let gateway_url = gateway_url.to_string();
         let build_gateway = move |py: Python<'_>| {
@@ -697,7 +697,7 @@ impl AsyncTensorZeroGateway {
             let instance = PyClassInitializer::from(client).add_subclass(AsyncTensorZeroGateway {});
             Ok(Py::new(py, instance)?.into_any())
         };
-        if use_async {
+        if async_setup {
             // This doesn't actually do anything async at the moment, but we run
             // 'build_gateway' inside the future so that any exception is thrown by the future
             Ok(
@@ -750,22 +750,22 @@ impl AsyncTensorZeroGateway {
     // as `AsyncTensorZeroGateway` would be completely async *except* for this one method
     // (which potentially takes a very long time due to running DB migrations).
     #[classmethod]
-    #[pyo3(signature = (*, config_file=None, clickhouse_url=None, timeout=None, use_async=true))]
+    #[pyo3(signature = (*, config_file=None, clickhouse_url=None, timeout=None, async_setup=true))]
     /// Initialize the TensorZero client, using an embedded gateway.
     /// This connects to ClickHouse (if provided) and runs DB migrations.
     ///
     /// :param config_file: The path to the TensorZero configuration file. Example: "tensorzero.toml"
     /// :param clickhouse_url: The URL of the ClickHouse instance to use for the gateway. If observability is disabled in the config, this can be `None`
     /// :param timeout: The timeout for embedded gateway request processing, in seconds. If this timeout is hit, any in-progress LLM requests may be aborted. If not provided, no timeout will be set.
-    /// :param use_async: If true, this method will return a `Future` that resolves to an `AsyncTensorZeroGateway` instance. Otherwise, it will block and construct the `AsyncTensorZeroGateway`
-    /// :return: A `Future` that resolves to an `AsyncTensorZeroGateway` instance configured to use an embedded gateway (or an `AsyncTensorZeroGateway` if `use_async=False`).
+    /// :param async_setup: If true, this method will return a `Future` that resolves to an `AsyncTensorZeroGateway` instance. Otherwise, it will block and construct the `AsyncTensorZeroGateway`
+    /// :return: A `Future` that resolves to an `AsyncTensorZeroGateway` instance configured to use an embedded gateway (or an `AsyncTensorZeroGateway` if `async_setup=False`).
     fn build_embedded(
         // This is a classmethod, so it receives the class object as a parameter.
         cls: &Bound<'_, PyType>,
         config_file: Option<&str>,
         clickhouse_url: Option<String>,
         timeout: Option<f64>,
-        use_async: bool,
+        async_setup: bool,
     ) -> PyResult<Py<PyAny>> {
         warn_no_config(cls.py(), config_file)?;
         let timeout = timeout
@@ -802,7 +802,7 @@ impl AsyncTensorZeroGateway {
                 Py::new(py, instance)
             })
         };
-        if use_async {
+        if async_setup {
             // See `AsyncStreamWrapper::__anext__` for more details about `future_into_py`
             Ok(pyo3_async_runtimes::tokio::future_into_py(cls.py(), fut)?.unbind())
         } else {

--- a/clients/python-pyo3/tensorzero/tensorzero.pyi
+++ b/clients/python-pyo3/tensorzero/tensorzero.pyi
@@ -173,14 +173,14 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         gateway_url: str,
         timeout: Optional[float] = None,
         verbose_errors: bool = False,
-        use_async: bool = True,
+        async_setup: bool = True,
     ) -> "AsyncTensorZeroGateway":
         """
         Initialize the TensorZero client, using the HTTP gateway.
         :param gateway_url: The base URL of the TensorZero gateway. Example: "http://localhost:3000"
         :param timeout: The timeout for the HTTP client in seconds. If not provided, no timeout will be set.
         :param verbose_errors: If true, the client will increase the detail in errors (increasing the risk of leaking sensitive information).
-        :param use_async (Optional): If True, this method will return a `Future` that resolves to an `AsyncTensorZeroGateway` instance. Otherwise, it will block and return an `AsyncTensorZeroGateway` directly.
+        :param async_setup (Optional): If True, this method will return a `Future` that resolves to an `AsyncTensorZeroGateway` instance. Otherwise, it will block and return an `AsyncTensorZeroGateway` directly.
         :return: An `AsyncTensorZeroGateway` instance configured to use the HTTP gateway.
         """
 
@@ -191,7 +191,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         config_file: Optional[str] = None,
         clickhouse_url: Optional[str] = None,
         timeout: Optional[float] = None,
-        use_async: bool = True,
+        async_setup: bool = True,
     ) -> "AsyncTensorZeroGateway":
         """
         Build an AsyncTensorZeroGateway instance.
@@ -199,7 +199,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         :param config_file: (Optional) The path to the TensorZero configuration file.
         :param clickhouse_url: (Optional) The URL of the ClickHouse database.
         :param timeout: The timeout for embedded gateway request processing, in seconds. If this timeout is hit, any in-progress LLM requests may be aborted. If not provided, no timeout will be set.
-        :param use_async (Optional): If True, this method will return a `Future` that resolves to an `AsyncTensorZeroGateway` instance. Otherwise, it will block and return an `AsyncTensorZeroGateway` directly.
+        :param async_setup (Optional): If True, this method will return a `Future` that resolves to an `AsyncTensorZeroGateway` instance. Otherwise, it will block and return an `AsyncTensorZeroGateway` directly.
         """
 
     async def inference(  # type: ignore[override]

--- a/clients/python-pyo3/tests/test_client.py
+++ b/clients/python-pyo3/tests/test_client.py
@@ -224,7 +224,7 @@ async def test_async_basic_inference(async_client):
 async def test_async_client_build_http_sync():
     async with AsyncTensorZeroGateway.build_http(
         gateway_url="http://localhost:3000",
-        use_async=False,
+        async_setup=False,
     ) as client:
         input = {
             "system": {"assistant_name": "Alfred Pennyworth"},
@@ -260,7 +260,7 @@ async def test_async_client_build_embedded_sync():
     async with AsyncTensorZeroGateway.build_embedded(
         config_file=TEST_CONFIG_FILE,
         clickhouse_url="http://chuser:chpassword@localhost:8123/tensorzero-python-e2e",
-        use_async=False,
+        async_setup=False,
     ) as client:
         input = {
             "system": {"assistant_name": "Alfred Pennyworth"},


### PR DESCRIPTION
Fix #1466 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rename `use_async` to `async_setup` in `AsyncTensorZeroGateway` methods and related tests.
> 
>   - **Renames**:
>     - Rename `use_async` to `async_setup` in `AsyncTensorZeroGateway` methods `build_http` and `build_embedded` in `lib.rs`.
>     - Update parameter name in `tensorzero.pyi` for `AsyncTensorZeroGateway` methods `build_http` and `build_embedded`.
>     - Update test function names in `test_openai_compatibility.py` and `test_client.py` to reflect the parameter rename.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0f7517b3ec6802c9d45a096e304d3e82bf91f3c3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->