### PR TITLE
Terminate batch tests after 45 seconds

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -54,7 +54,7 @@ slow-timeout = { period = "65s" }
 [[profile.default.overrides]]
 # Settings for running batch tests
 filter = 'test(batch)'
-slow-timeout = { period = "15s", terminate-after = 1 }
+slow-timeout = { period = "15s", terminate-after = 3 }
 
 [[profile.default.overrides]]
 # Settings for running unit tests


### PR DESCRIPTION
We saw OpenAI batch test timeouts twice, so let's bump the timeout to see if this is just OpenAI being slow

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
