### PR TITLE
version bumped to 2025.03.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.3.2"
+version = "2025.3.3"
 dependencies = [
  "futures",
  "pyo3",

--- a/clients/python-pyo3/Cargo.toml
+++ b/clients/python-pyo3/Cargo.toml
@@ -3,7 +3,7 @@
 # It's named 'tensorzero-python' to avoid confusion with the Rust client
 # (which has a crate name of 'tensorzero')
 name = "tensorzero-python"
-version = "2025.3.2"
+version = "2025.3.3"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/tensorzero-internal/src/endpoints/status.rs
+++ b/tensorzero-internal/src/endpoints/status.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::response::Json;
 use serde_json::{json, Value};
 
-pub const TENSORZERO_VERSION: &str = "2025.03.2";
+pub const TENSORZERO_VERSION: &str = "2025.03.3";
 
 /// A handler for a simple liveness check
 #[debug_handler]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `tensorzero-python` version to `2025.3.3` in `Cargo.lock`, `Cargo.toml`, and `status.rs`.
> 
>   - **Version Bump**:
>     - Update `tensorzero-python` version from `2025.3.2` to `2025.3.3` in `Cargo.lock`.
>     - Update `tensorzero-python` version from `2025.3.2` to `2025.3.3` in `clients/python-pyo3/Cargo.toml`.
>     - Update `TENSORZERO_VERSION` constant from `2025.03.2` to `2025.03.3` in `status.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b24bbc9ef7cbd18b6f2ca1aeef80c57d42641391. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->