### PR TITLE
fixed ReplacingMergeTree check to work with ClickHouse cloud

### DIFF
--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0020.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0020.rs
@@ -58,7 +58,7 @@ impl Migration for Migration0020<'_> {
             return Ok(true);
         }
         let inference_by_id_engine = get_table_engine(self.clickhouse, "InferenceById").await?;
-        if inference_by_id_engine != "ReplacingMergeTree" {
+        if !inference_by_id_engine.contains("ReplacingMergeTree") {
             // Table was created by an older migration. We should drop and recreate
             return Ok(true);
         }
@@ -69,7 +69,7 @@ impl Migration for Migration0020<'_> {
         }
         let inference_by_episode_id_engine =
             get_table_engine(self.clickhouse, "InferenceByEpisodeId").await?;
-        if inference_by_episode_id_engine != "ReplacingMergeTree" {
+        if !inference_by_episode_id_engine.contains("ReplacingMergeTree") {
             // Table was created by an older migration. We should drop and recreate
             return Ok(true);
         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `migration_0020.rs` to check for "ReplacingMergeTree" in table engine strings for ClickHouse cloud compatibility.
> 
>   - **Behavior**:
>     - In `migration_0020.rs`, update `should_apply()` to check if `inference_by_id_engine` and `inference_by_episode_id_engine` contain "ReplacingMergeTree" instead of exact match.
>     - Ensures compatibility with ClickHouse cloud where engine strings may include additional parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 571b0e1fded5a2ef603d7b433c054aabfc1cf16c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->