### PR TITLE
Remove 'tensorzero-' prefix from published images

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -53,7 +53,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: tensorzero-${{ matrix.container.name }}
+          images: ${{ matrix.container.name }}
 
       - name: Build and push Docker image
         id: push
@@ -65,7 +65,7 @@ jobs:
           push: true
           provenance: mode=max
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-          tags: ${{ env.DOCKERHUB_USER }}/tensorzero-${{ matrix.container.name }}
+          tags: ${{ env.DOCKERHUB_USER }}/${{ matrix.container.name }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Export digest
@@ -114,7 +114,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.DOCKERHUB_USER }}/tensorzero-${{ matrix.container.name }}
+          images: ${{ env.DOCKERHUB_USER }}/${{ matrix.container.name }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -125,8 +125,8 @@ jobs:
         working-directory: ${{ runner.temp }}/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.DOCKERHUB_USER }}/tensorzero-${{ matrix.container.name }}@sha256:%s ' *)
+            $(printf '${{ env.DOCKERHUB_USER }}/${{ matrix.container.name }}@sha256:%s ' *)
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.DOCKERHUB_USER }}/tensorzero-${{ matrix.container.name }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.DOCKERHUB_USER }}/${{ matrix.container.name }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove 'tensorzero-' prefix from Docker image names in GitHub Actions workflow.
> 
>   - **Docker Image Naming**:
>     - Remove 'tensorzero-' prefix from image names in `.github/workflows/docker-hub-publish.yml`.
>     - Affects `images` and `tags` fields in `docker/metadata-action` and `docker/build-push-action` steps.
>     - Ensures consistent naming in `create manifest list` and `inspect image` steps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1ba0d0cc416406978be2aebcfec197992ed449c4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->