### PR TITLE
Make docker publish use non-semver tag

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -116,10 +116,7 @@ jobs:
         with:
           images: ${{ env.DOCKERHUB_USER }}/${{ matrix.container.name }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=tag
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests


### PR DESCRIPTION
This will just use the git tag name as the docker tag

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change Docker tag strategy to use git tag name instead of semantic versioning in `docker-hub-publish.yml`.
> 
>   - **Docker Tagging**:
>     - In `.github/workflows/docker-hub-publish.yml`, change Docker tag strategy to use `type=ref,event=tag` instead of semantic versioning patterns.
>     - Removes `type=ref,event=branch`, `type=ref,event=pr`, `type=semver,pattern={{version}}`, and `type=semver,pattern={{major}}.{{minor}}` from Docker tag configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6bb9b875b03817e1f6277958ca3ef770041cfa6d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->