### PR TITLE
removed migration flag on Migration 0021

### DIFF
--- a/tensorzero-internal/src/clickhouse/migration_manager/mod.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/mod.rs
@@ -77,17 +77,11 @@ pub async fn run(clickhouse: &ClickHouseConnectionInfo) -> Result<(), Error> {
         clean_start,
     })
     .await?;
-    if std::env::var("TENSORZERO_FF_DANGEROUS_MIGRATION_STALING")
-        .ok()
-        .as_deref()
-        == Some("1")
-    {
-        run_migration(&Migration0021 {
-            clickhouse,
-            clean_start,
-        })
-        .await?;
-    }
+    run_migration(&Migration0021 {
+        clickhouse,
+        clean_start,
+    })
+    .await?;
     // NOTE:
     // When we add more migrations, we need to add a test that applies them in a cumulative (N^2) way.
     //

--- a/tensorzero-internal/tests/e2e/datasets.rs
+++ b/tensorzero-internal/tests/e2e/datasets.rs
@@ -83,7 +83,8 @@ async fn test_datapoint_insert_synthetic_chat() {
       "tool_params": "",
       "tags": {},
       "auxiliary": "",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -274,7 +275,8 @@ async fn test_datapoint_insert_synthetic_chat_with_tools() {
       "tool_params": "{\"tools_available\":[{\"description\":\"Get the current temperature in a given location\",\"parameters\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"The location to get the temperature for (e.g. \\\"New York\\\")\"},\"units\":{\"type\":\"string\",\"description\":\"The units to get the temperature in (must be \\\"fahrenheit\\\" or \\\"celsius\\\")\",\"enum\":[\"fahrenheit\",\"celsius\"]}},\"required\":[\"location\"],\"additionalProperties\":false},\"name\":\"get_temperature\",\"strict\":false}],\"tool_choice\":\"auto\",\"parallel_tool_calls\":false}",
       "tags": {},
       "auxiliary": "",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -349,7 +351,8 @@ async fn test_datapoint_insert_synthetic_json() {
       "output_schema": "{}",
       "tags": {},
       "auxiliary": "",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 
@@ -458,7 +461,8 @@ async fn test_datapoint_insert_synthetic_json() {
       "output_schema": "{}",
       "tags": {},
       "auxiliary": "",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -708,7 +712,8 @@ async fn test_datapoint_insert_output_inherit_chat() {
       "tool_params": "",
       "tags": {},
       "auxiliary": "{}",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 
@@ -763,7 +768,8 @@ async fn test_datapoint_insert_output_inherit_chat() {
       "tool_params": "",
       "tags": {},
       "auxiliary": "{}",
-      "is_deleted": true
+      "is_deleted": true,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
     assert_ne!(
@@ -882,7 +888,8 @@ async fn test_datapoint_insert_output_none_chat() {
       "tool_params": "",
       "tags": {},
       "auxiliary": "{}",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -990,7 +997,8 @@ async fn test_datapoint_insert_output_demonstration_chat() {
       "tool_params": "",
       "tags": {},
       "auxiliary": "{}",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -1077,6 +1085,7 @@ async fn test_datapoint_insert_output_inherit_json() {
       "tags": {},
       "auxiliary": "{}",
       "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 
@@ -1131,7 +1140,8 @@ async fn test_datapoint_insert_output_inherit_json() {
       "output_schema": "{\"type\":\"object\",\"properties\":{\"answer\":{\"type\":\"string\"}},\"required\":[\"answer\"],\"additionalProperties\":false}",
       "tags": {},
       "auxiliary": "{}",
-      "is_deleted": true
+      "is_deleted": true,
+      "staled_at": null
     });
     assert_eq!(
         datapoint,
@@ -1227,6 +1237,7 @@ async fn test_datapoint_insert_output_none_json() {
       "tags": {},
       "auxiliary": "{}",
       "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -1335,6 +1346,7 @@ async fn test_datapoint_insert_output_demonstration_json() {
       "tags": {},
       "auxiliary": "{}",
       "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -1466,7 +1478,8 @@ async fn test_datapoint_insert_missing_output_chat() {
       "tool_params": "",
       "tags": {},
       "auxiliary": "",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -1528,7 +1541,8 @@ async fn test_datapoint_insert_null_output_chat() {
       "tool_params": "",
       "tags": {},
       "auxiliary": "",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -1591,7 +1605,8 @@ async fn test_datapoint_insert_missing_output_json() {
       "output_schema": "{}",
       "tags": {},
       "auxiliary": "",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -1654,7 +1669,8 @@ async fn test_datapoint_insert_null_output_json() {
       "output_schema": "{}",
       "tags": {},
       "auxiliary": "",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }

--- a/ui/fixtures/docker-compose.yml
+++ b/ui/fixtures/docker-compose.yml
@@ -30,7 +30,6 @@ services:
       - ./config:/app/config:ro
     environment:
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero_ui_fixtures
-      - TENSORZERO_FF_DANGEROUS_MIGRATION_STALING=1
     env_file:
       - ${ENV_FILE:-../.env}
     ports:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove feature flag for Migration 0021, update tests for `staled_at` field, and adjust Docker Compose configuration.
> 
>   - **Migration**:
>     - Removed feature flag `TENSORZERO_FF_DANGEROUS_MIGRATION_STALING` check for `Migration0021` in `mod.rs`, making it always run.
>   - **Tests**:
>     - Updated expected JSON outputs in `datasets.rs` to include `"staled_at": null` in 14 test cases.
>   - **Configuration**:
>     - Removed `TENSORZERO_FF_DANGEROUS_MIGRATION_STALING=1` from `docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e3229706dd44471d343bb72df4df126d8c069644. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->