### PR TITLE
bumped version to 2025.03.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.3.3"
+version = "2025.3.4"
 dependencies = [
  "futures",
  "pyo3",

--- a/clients/python-pyo3/Cargo.toml
+++ b/clients/python-pyo3/Cargo.toml
@@ -3,7 +3,7 @@
 # It's named 'tensorzero-python' to avoid confusion with the Rust client
 # (which has a crate name of 'tensorzero')
 name = "tensorzero-python"
-version = "2025.3.3"
+version = "2025.3.4"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/tensorzero-internal/src/clickhouse/migration_manager/mod.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/mod.rs
@@ -77,17 +77,11 @@ pub async fn run(clickhouse: &ClickHouseConnectionInfo) -> Result<(), Error> {
         clean_start,
     })
     .await?;
-    if std::env::var("TENSORZERO_FF_DANGEROUS_MIGRATION_STALING")
-        .ok()
-        .as_deref()
-        == Some("1")
-    {
-        run_migration(&Migration0021 {
-            clickhouse,
-            clean_start,
-        })
-        .await?;
-    }
+    run_migration(&Migration0021 {
+        clickhouse,
+        clean_start,
+    })
+    .await?;
     // NOTE:
     // When we add more migrations, we need to add a test that applies them in a cumulative (N^2) way.
     //

--- a/tensorzero-internal/src/endpoints/status.rs
+++ b/tensorzero-internal/src/endpoints/status.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::response::Json;
 use serde_json::{json, Value};
 
-pub const TENSORZERO_VERSION: &str = "2025.03.3";
+pub const TENSORZERO_VERSION: &str = "2025.03.4";
 
 /// A handler for a simple liveness check
 #[debug_handler]

--- a/tensorzero-internal/tests/e2e/datasets.rs
+++ b/tensorzero-internal/tests/e2e/datasets.rs
@@ -83,7 +83,8 @@ async fn test_datapoint_insert_synthetic_chat() {
       "tool_params": "",
       "tags": {},
       "auxiliary": "",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -274,7 +275,8 @@ async fn test_datapoint_insert_synthetic_chat_with_tools() {
       "tool_params": "{\"tools_available\":[{\"description\":\"Get the current temperature in a given location\",\"parameters\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"The location to get the temperature for (e.g. \\\"New York\\\")\"},\"units\":{\"type\":\"string\",\"description\":\"The units to get the temperature in (must be \\\"fahrenheit\\\" or \\\"celsius\\\")\",\"enum\":[\"fahrenheit\",\"celsius\"]}},\"required\":[\"location\"],\"additionalProperties\":false},\"name\":\"get_temperature\",\"strict\":false}],\"tool_choice\":\"auto\",\"parallel_tool_calls\":false}",
       "tags": {},
       "auxiliary": "",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -349,7 +351,8 @@ async fn test_datapoint_insert_synthetic_json() {
       "output_schema": "{}",
       "tags": {},
       "auxiliary": "",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 
@@ -458,7 +461,8 @@ async fn test_datapoint_insert_synthetic_json() {
       "output_schema": "{}",
       "tags": {},
       "auxiliary": "",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -708,7 +712,8 @@ async fn test_datapoint_insert_output_inherit_chat() {
       "tool_params": "",
       "tags": {},
       "auxiliary": "{}",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 
@@ -763,7 +768,8 @@ async fn test_datapoint_insert_output_inherit_chat() {
       "tool_params": "",
       "tags": {},
       "auxiliary": "{}",
-      "is_deleted": true
+      "is_deleted": true,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
     assert_ne!(
@@ -882,7 +888,8 @@ async fn test_datapoint_insert_output_none_chat() {
       "tool_params": "",
       "tags": {},
       "auxiliary": "{}",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -990,7 +997,8 @@ async fn test_datapoint_insert_output_demonstration_chat() {
       "tool_params": "",
       "tags": {},
       "auxiliary": "{}",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -1077,6 +1085,7 @@ async fn test_datapoint_insert_output_inherit_json() {
       "tags": {},
       "auxiliary": "{}",
       "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 
@@ -1131,7 +1140,8 @@ async fn test_datapoint_insert_output_inherit_json() {
       "output_schema": "{\"type\":\"object\",\"properties\":{\"answer\":{\"type\":\"string\"}},\"required\":[\"answer\"],\"additionalProperties\":false}",
       "tags": {},
       "auxiliary": "{}",
-      "is_deleted": true
+      "is_deleted": true,
+      "staled_at": null
     });
     assert_eq!(
         datapoint,
@@ -1227,6 +1237,7 @@ async fn test_datapoint_insert_output_none_json() {
       "tags": {},
       "auxiliary": "{}",
       "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -1335,6 +1346,7 @@ async fn test_datapoint_insert_output_demonstration_json() {
       "tags": {},
       "auxiliary": "{}",
       "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -1466,7 +1478,8 @@ async fn test_datapoint_insert_missing_output_chat() {
       "tool_params": "",
       "tags": {},
       "auxiliary": "",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -1528,7 +1541,8 @@ async fn test_datapoint_insert_null_output_chat() {
       "tool_params": "",
       "tags": {},
       "auxiliary": "",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -1591,7 +1605,8 @@ async fn test_datapoint_insert_missing_output_json() {
       "output_schema": "{}",
       "tags": {},
       "auxiliary": "",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }
@@ -1654,7 +1669,8 @@ async fn test_datapoint_insert_null_output_json() {
       "output_schema": "{}",
       "tags": {},
       "auxiliary": "",
-      "is_deleted": false
+      "is_deleted": false,
+      "staled_at": null
     });
     assert_eq!(datapoint, expected);
 }

--- a/ui/fixtures/docker-compose.yml
+++ b/ui/fixtures/docker-compose.yml
@@ -30,7 +30,6 @@ services:
       - ./config:/app/config:ro
     environment:
       - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero_ui_fixtures
-      - TENSORZERO_FF_DANGEROUS_MIGRATION_STALING=1
     env_file:
       - ${ENV_FILE:-../.env}
     ports:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `tensorzero-python` version to `2025.3.4`, ensure `Migration0021` always runs, and update tests for `staled_at` field.
> 
>   - **Version Updates**:
>     - Bump `tensorzero-python` version from `2025.3.3` to `2025.3.4` in `Cargo.lock` and `Cargo.toml`.
>     - Update `TENSORZERO_VERSION` in `status.rs` to `2025.03.4`.
>   - **Migration Manager**:
>     - Remove feature flag check for `Migration0021` in `mod.rs`, ensuring it always runs.
>   - **Tests**:
>     - Add `staled_at: null` to expected JSON in `datasets.rs` for various test cases.
>   - **Misc**:
>     - Remove `TENSORZERO_FF_DANGEROUS_MIGRATION_STALING` from `docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e38ae1f5af26d459123cbb5162792d210554c900. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->