### PR TITLE
Publish SBOM to docker hub

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -67,6 +67,7 @@ jobs:
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           tags: ${{ env.DOCKERHUB_USER }}/${{ matrix.container.name }}
           labels: ${{ steps.meta.outputs.labels }}
+          sbom: true
 
       - name: Export digest
         run: |


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add SBOM support to Docker image publishing workflow in `.github/workflows/docker-hub-publish.yml`.
> 
>   - **Workflow Update**:
>     - Adds `sbom: true` to the `docker/build-push-action` step in `.github/workflows/docker-hub-publish.yml` to include SBOM in Docker image publishing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2266a9567f2ef0499bd2a1533b88f54a76e8ca35. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->