### PR TITLE
Bump ClickHouse test duration check to 40s

### DIFF
--- a/tensorzero-internal/tests/e2e/clickhouse.rs
+++ b/tensorzero-internal/tests/e2e/clickhouse.rs
@@ -243,8 +243,8 @@ async fn test_clean_clickhouse_start() {
     migration_manager::run(&clickhouse).await.unwrap();
     let duration = start.elapsed();
     assert!(
-        duration < std::time::Duration::from_secs(20),
-        "Migrations took longer than 20 seconds: {duration:?}"
+        duration < std::time::Duration::from_secs(40),
+        "Migrations took longer than 40 seconds: {duration:?}"
     );
 }
 


### PR DESCRIPTION
This just failed on a PR with 20.06 seconds

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
