### PR TITLE
Skip ClickHouse cloud tests for PR ci for dependabot

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -281,9 +281,11 @@ jobs:
   clickhouse-tests-cloud:
     runs-on: ubuntu-latest
     # Skip this job for PRs from forks, since we don't have secrets available.
+    # Dependabot PRs also don't have secrets available
     if: |
-      github.event_name != 'pull_request' ||
+      (github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == 'tensorzero/tensorzero'
+      ) && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
These tests should still be run in the merge queue, but not as part of normal PR CI (since dependabot PRs don't have secrets available)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Skip ClickHouse cloud tests for dependabot PRs in GitHub Actions workflow due to unavailable secrets.
> 
>   - **Workflow Changes**:
>     - In `.github/workflows/general.yml`, update `clickhouse-tests-cloud` job to skip for `dependabot` PRs by adding `github.actor != 'dependabot[bot]'` condition.
>     - Ensures tests still run in the merge queue but not in normal PR CI for dependabot due to unavailable secrets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 70c4daa3fb2fc17787e8d7ea3b7dd0cf64dc8b48. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->