### PR TITLE
Emit a warning when gateway/Dockerfile is used with default CMD

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -38,4 +38,4 @@ EXPOSE 3000
 
 ENTRYPOINT ["gateway"]
 
-CMD ["--config-file", "config/tensorzero.toml"]
+CMD ["--warn-default-cmd", "--config-file", "config/tensorzero.toml"]

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -32,6 +32,11 @@ struct Args {
     #[arg(long)]
     default_config: bool,
 
+    // Hidden flag used by our `Dockerfile` to warn users who have not overridden the default CMD
+    #[arg(long)]
+    #[clap(hide = true)]
+    warn_default_cmd: bool,
+
     /// Deprecated: use `--config-file` instead
     tensorzero_toml: Option<PathBuf>,
 }
@@ -42,6 +47,10 @@ async fn main() {
     observability::setup_logs(true);
     let metrics_handle = observability::setup_metrics().expect_pretty("Failed to set up metrics");
     let args = Args::parse();
+
+    if args.warn_default_cmd {
+        tracing::warn!("Deprecation warning: Running gateway from Docker container without overriding default CMD. Please override the command to either '--config-file path/to/tensorzero.toml' or '--default-config'.");
+    }
 
     if args.tensorzero_toml.is_some() && args.config_file.is_some() {
         tracing::error!("Cannot specify both `--config-file` and a positional path argument");


### PR DESCRIPTION
We'd like to eventually change this to require '--default-config' or '--config-file <path>'. Let's start emitting a warning when users rely on our current default behavior.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add warning for default CMD usage in `gateway/Dockerfile` and log deprecation notice in `main.rs`.
> 
>   - **Behavior**:
>     - Adds `--warn-default-cmd` to `CMD` in `gateway/Dockerfile` to emit a warning when default CMD is used.
>     - In `main.rs`, checks for `warn_default_cmd` flag and logs a deprecation warning if set.
>   - **Flags**:
>     - Introduces `warn_default_cmd` flag in `Args` struct in `main.rs`, hidden from users.
>   - **Warnings**:
>     - Logs a warning in `main.rs` if `warn_default_cmd` is true, advising users to override the default CMD with `--config-file` or `--default-config`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 434caddb26f8fded2cca5f92d8468f8d44915e86. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->