### PR TITLE
Warn when 'tensorzero.patch_openai_client' is called with no config

### DIFF
--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -87,6 +87,7 @@ fn _start_http_gateway(
     clickhouse_url: Option<String>,
     async_setup: bool,
 ) -> PyResult<Bound<'_, PyAny>> {
+    warn_no_config(py, config_file.as_deref())?;
     let gateway_fut = async move {
         let (addr, handle) = tensorzero_internal::gateway_util::start_openai_compatible_gateway(
             config_file,

--- a/clients/python-pyo3/tests/test_client.py
+++ b/clients/python-pyo3/tests/test_client.py
@@ -2052,7 +2052,8 @@ async def test_patch_sync_openai_client_async_setup():
 
 def test_patch_openai_client_no_config():
     client = OpenAI()
-    tensorzero.patch_openai_client(client, async_setup=False)
+    with pytest.warns(UserWarning, match="No config file provided"):
+        tensorzero.patch_openai_client(client, async_setup=False)
     response = client.chat.completions.create(
         model="tensorzero::model_name::dummy::json",
         messages=[


### PR DESCRIPTION
Fixes https://github.com/tensorzero/tensorzero/issues/1497

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a warning when `tensorzero.patch_openai_client` is called without a config file, verified by a new test.
> 
>   - **Behavior**:
>     - Adds a warning in `warn_no_config` in `lib.rs` when `tensorzero.patch_openai_client` is called without a config file.
>     - The warning message indicates that only default functions will be available and suggests specifying a config file.
>   - **Tests**:
>     - Adds `test_patch_openai_client_no_config` in `test_client.py` to verify that a `UserWarning` is raised when no config file is provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a54f22f4be8bee8af2c52907e17654a40f646cf6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->