### PR TITLE
Enable pyright for test_client.py and fix type annotations

### DIFF
--- a/clients/python-pyo3/pyrightconfig.json
+++ b/clients/python-pyo3/pyrightconfig.json
@@ -1,0 +1,3 @@
+{
+  "typeCheckingMode": "strict"
+}

--- a/clients/python-pyo3/tensorzero/__init__.py
+++ b/clients/python-pyo3/tensorzero/__init__.py
@@ -83,7 +83,7 @@ async def _async_attach_fields(client: T, awaitable: t.Awaitable[t.Any]) -> T:
 class ATTENTION_TENSORZERO_PLEASE_AWAIT_RESULT_OF_PATCH_OPENAI_CLIENT(httpx.URL):
     # This is called by httpx when making a request (to join the base url with the path)
     # We throw an error to try to produce a nicer message for the user
-    def copy_with(self, *args, **kwargs):
+    def copy_with(self, *args: t.Any, **kwargs: t.Any):
         raise RuntimeError(
             "TensorZero: Please await the result of `tensorzero.patch_openai_client` before using the client."
         )
@@ -109,7 +109,7 @@ def patch_openai_client(
     *,
     config_file: t.Optional[str] = None,
     clickhouse_url: t.Optional[str] = None,
-    async_setup=True,
+    async_setup: bool = True,
 ) -> t.Union[T, t.Awaitable[T]]:
     """
     Starts a new TensorZero gateway, and patching the provided OpenAI client to use it

--- a/clients/python-pyo3/tensorzero/tensorzero.pyi
+++ b/clients/python-pyo3/tensorzero/tensorzero.pyi
@@ -24,7 +24,7 @@ class BaseTensorZeroGateway:
 
 @final
 class TensorZeroGateway(BaseTensorZeroGateway):
-    def __init__(self, base_url: str, *, timeout: Optional[float] = None):
+    def __init__(self, base_url: str, *, timeout: Optional[float] = None) -> None:
         """
         Initialize the TensorZero client.
 
@@ -159,7 +159,7 @@ class TensorZeroGateway(BaseTensorZeroGateway):
 
 @final
 class AsyncTensorZeroGateway(BaseTensorZeroGateway):
-    def __init__(self, base_url: str, *, timeout: Optional[float] = None):
+    def __init__(self, base_url: str, *, timeout: Optional[float] = None) -> None:
         """
         Initialize the TensorZero client.
 

--- a/clients/python-pyo3/tensorzero/tensorzero.pyi
+++ b/clients/python-pyo3/tensorzero/tensorzero.pyi
@@ -1,9 +1,9 @@
 from typing import (
     Any,
-    AsyncGenerator,
+    AsyncIterator,
     Awaitable,
     Dict,
-    Generator,
+    Iterator,
     List,
     Literal,
     Optional,
@@ -11,6 +11,8 @@ from typing import (
     final,
 )
 from uuid import UUID
+
+import uuid_utils
 
 from tensorzero import (
     FeedbackResponse,
@@ -66,10 +68,10 @@ class TensorZeroGateway(BaseTensorZeroGateway):
     def inference(
         self,
         *,
-        input: InferenceInput,
+        input: InferenceInput | Dict[str, Any],
         function_name: Optional[str] = None,
         model_name: Optional[str] = None,
-        episode_id: Optional[UUID] = None,
+        episode_id: Optional[str | UUID | uuid_utils.UUID] = None,
         stream: Optional[bool] = None,
         params: Optional[Dict[str, Any]] = None,
         variant_name: Optional[str] = None,
@@ -85,7 +87,7 @@ class TensorZeroGateway(BaseTensorZeroGateway):
         tags: Optional[Dict[str, str]] = None,
         credentials: Optional[Dict[str, str]] = None,
         cache_options: Optional[Dict[str, Any]] = None,
-    ) -> Union[InferenceResponse, Generator[InferenceChunk, None, None]]:
+    ) -> Union[InferenceResponse, Iterator[InferenceChunk]]:
         """
         Make a POST request to the /inference endpoint.
 
@@ -114,7 +116,7 @@ class TensorZeroGateway(BaseTensorZeroGateway):
         :param parallel_tool_calls: If true, the request will allow for multiple tool calls in a single inference request.
         :param tags: If set, adds tags to the inference request.
         :return: If stream is false, returns an InferenceResponse.
-                 If stream is true, returns an async generator that yields InferenceChunks as they come in.
+                 If stream is true, returns an async iterator that yields InferenceChunks as they come in.
         """
 
     def feedback(
@@ -122,8 +124,8 @@ class TensorZeroGateway(BaseTensorZeroGateway):
         *,
         metric_name: str,
         value: Any,
-        inference_id: Optional[UUID] = None,
-        episode_id: Optional[UUID] = None,
+        inference_id: Optional[str | UUID | uuid_utils.UUID] = None,
+        episode_id: Optional[str | UUID | uuid_utils.UUID] = None,
         dryrun: Optional[bool] = None,
         internal: Optional[bool] = None,
         tags: Optional[Dict[str, str]] = None,
@@ -167,14 +169,14 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         """
 
     @classmethod
-    async def build_http(
+    def build_http(
         cls,
         *,
         gateway_url: str,
         timeout: Optional[float] = None,
         verbose_errors: bool = False,
         async_setup: bool = True,
-    ) -> "AsyncTensorZeroGateway":
+    ) -> Union[Awaitable["AsyncTensorZeroGateway"], "AsyncTensorZeroGateway"]:
         """
         Initialize the TensorZero client, using the HTTP gateway.
         :param gateway_url: The base URL of the TensorZero gateway. Example: "http://localhost:3000"
@@ -185,14 +187,14 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         """
 
     @classmethod
-    async def build_embedded(
+    def build_embedded(
         cls,
         *,
         config_file: Optional[str] = None,
         clickhouse_url: Optional[str] = None,
         timeout: Optional[float] = None,
         async_setup: bool = True,
-    ) -> "AsyncTensorZeroGateway":
+    ) -> Union[Awaitable["AsyncTensorZeroGateway"], "AsyncTensorZeroGateway"]:
         """
         Build an AsyncTensorZeroGateway instance.
 
@@ -205,10 +207,10 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
     async def inference(  # type: ignore[override]
         self,
         *,
-        input: InferenceInput,
+        input: InferenceInput | Dict[str, Any],
         function_name: Optional[str] = None,
         model_name: Optional[str] = None,
-        episode_id: Optional[UUID] = None,
+        episode_id: Optional[str | UUID | uuid_utils.UUID] = None,
         stream: Optional[bool] = None,
         params: Optional[Dict[str, Any]] = None,
         variant_name: Optional[str] = None,
@@ -224,7 +226,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         tags: Optional[Dict[str, str]] = None,
         credentials: Optional[Dict[str, str]] = None,
         cache_options: Optional[Dict[str, Any]] = None,
-    ) -> Union[InferenceResponse, AsyncGenerator[InferenceChunk, None]]:
+    ) -> Union[InferenceResponse, AsyncIterator[InferenceChunk]]:
         """
         Make a POST request to the /inference endpoint.
 
@@ -253,7 +255,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         :param parallel_tool_calls: If true, the request will allow for multiple tool calls in a single inference request.
         :param tags: If set, adds tags to the inference request.
         :return: If stream is false, returns an InferenceResponse.
-                 If stream is true, returns an async generator that yields InferenceChunks as they come in.
+                 If stream is true, returns an async iterator that yields InferenceChunks as they come in.
         """
 
     async def feedback(  # type: ignore[override]
@@ -261,8 +263,8 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         *,
         metric_name: str,
         value: Any,
-        inference_id: Optional[UUID] = None,
-        episode_id: Optional[UUID] = None,
+        inference_id: Optional[str | UUID | uuid_utils.UUID] = None,
+        episode_id: Optional[str | UUID | uuid_utils.UUID] = None,
         dryrun: Optional[bool] = None,
         internal: Optional[bool] = None,
         tags: Optional[Dict[str, str]] = None,

--- a/clients/python-pyo3/tensorzero/types.py
+++ b/clients/python-pyo3/tensorzero/types.py
@@ -46,7 +46,7 @@ class Text(ContentBlock):
             raise ValueError("Only one of `text` or `arguments` must be provided.")
 
         # Warn about on going deprecation: https://github.com/tensorzero/tensorzero/issues/1170
-        if self.text is not None and not isinstance(self.text, str):
+        if self.text is not None and not isinstance(self.text, str):  # pyright: ignore [reportUnnecessaryIsInstance]
             warnings.warn(
                 'Please use `ContentBlock(type="text", arguments=...)` when providing arguments for a prompt template/schema. In a future release, `Text(type="text", text=...)` will require a string literal.',
                 DeprecationWarning,

--- a/clients/python-pyo3/tensorzero/types.py
+++ b/clients/python-pyo3/tensorzero/types.py
@@ -171,7 +171,7 @@ class Message(TypedDict):
 
 
 class InferenceInput(TypedDict):
-    messages: List[Message]
+    messages: List[Message] | Dict[str, Any]
     system: Optional[Union[str, Dict[str, Any]]]
 
 

--- a/clients/python-pyo3/tensorzero/types.py
+++ b/clients/python-pyo3/tensorzero/types.py
@@ -171,7 +171,7 @@ class Message(TypedDict):
 
 
 class InferenceInput(TypedDict):
-    messages: List[Message] | Dict[str, Any]
+    messages: Union[List[Message], Dict[str, Any]]
     system: Optional[Union[str, Dict[str, Any]]]
 
 

--- a/clients/python-pyo3/tests/test_client.py
+++ b/clients/python-pyo3/tests/test_client.py
@@ -1,4 +1,3 @@
-# type: ignore
 """
 Tests for the TensorZero client
 
@@ -19,10 +18,12 @@ uv run pytest
 """
 
 import base64
+import inspect
 import json
 import os
 import threading
 import time
+import typing as t
 from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
@@ -31,8 +32,11 @@ from uuid import UUID
 
 import pytest
 import pytest_asyncio
-import tensorzero
 from openai import AsyncOpenAI, OpenAI
+from pytest import FixtureRequest
+from uuid_utils import uuid7
+
+import tensorzero
 from tensorzero import (
     AsyncTensorZeroGateway,
     ChatInferenceResponse,
@@ -40,16 +44,19 @@ from tensorzero import (
     FinishReason,
     ImageBase64,
     ImageUrl,
+    InferenceChunk,
     JsonInferenceResponse,
     RawText,
     TensorZeroError,
     TensorZeroGateway,
     TensorZeroInternalError,
     Text,
+    TextChunk,
+    ThoughtChunk,
     ToolCall,
     ToolResult,
 )
-from uuid_utils import uuid7
+from tensorzero.types import ChatChunk, JsonChunk, Thought, ToolCallChunk
 
 TEST_CONFIG_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
@@ -62,18 +69,23 @@ class ClientType(Enum):
     EmbeddedGateway = 1
 
 
-@pytest_asyncio.fixture(params=[ClientType.HttpGateway, ClientType.EmbeddedGateway])
-async def async_client(request):
+# TODO - get type checking working with this decorator
+@pytest_asyncio.fixture(params=[ClientType.HttpGateway, ClientType.EmbeddedGateway])  # type: ignore
+async def async_client(request: FixtureRequest):
     if request.param == ClientType.HttpGateway:
-        async with await AsyncTensorZeroGateway.build_http(
+        client_fut = AsyncTensorZeroGateway.build_http(
             gateway_url="http://localhost:3000"
-        ) as client:
+        )
+        assert inspect.isawaitable(client_fut)
+        async with await client_fut as client:
             yield client
     else:
-        async with await AsyncTensorZeroGateway.build_embedded(
+        client_fut = AsyncTensorZeroGateway.build_embedded(
             config_file=TEST_CONFIG_FILE,
             clickhouse_url="http://chuser:chpassword@localhost:8123/tensorzero-python-e2e",
-        ) as client:
+        )
+        assert inspect.isawaitable(client_fut)
+        async with await client_fut as client:
             yield client
 
 
@@ -90,7 +102,9 @@ def test_sync_embedded_gateway_no_config():
 @pytest.mark.asyncio
 async def test_async_embedded_gateway_no_config():
     with pytest.warns(UserWarning, match="No config file provided"):
-        client = await AsyncTensorZeroGateway.build_embedded()
+        client_fut = AsyncTensorZeroGateway.build_embedded()
+        assert inspect.isawaitable(client_fut)
+        client = await client_fut
     with pytest.raises(TensorZeroError) as exc_info:
         await client.inference(function_name="my_missing_func", input={})
 
@@ -104,7 +118,7 @@ class CountData:
 
 
 @pytest.mark.asyncio
-async def test_async_gil_unlock(async_client):
+async def test_async_gil_unlock(async_client: AsyncTensorZeroGateway):
     input = {
         "system": {"assistant_name": "Alfred Pennyworth"},
         "messages": [{"role": "user", "content": [Text(type="text", text="Hello")]}],
@@ -137,7 +151,7 @@ async def test_async_gil_unlock(async_client):
     assert val >= 20
 
 
-def test_sync_gil_unlock(sync_client):
+def test_sync_gil_unlock(sync_client: TensorZeroGateway):
     input = {
         "system": {"assistant_name": "Alfred Pennyworth"},
         "messages": [{"role": "user", "content": [Text(type="text", text="Hello")]}],
@@ -171,7 +185,7 @@ def test_sync_gil_unlock(sync_client):
 
 
 @pytest.mark.asyncio
-async def test_async_basic_inference(async_client):
+async def test_async_basic_inference(async_client: AsyncTensorZeroGateway):
     input = {
         "system": {"assistant_name": "Alfred Pennyworth"},
         "messages": [{"role": "user", "content": [Text(type="text", text="Hello")]}],
@@ -183,12 +197,14 @@ async def test_async_basic_inference(async_client):
         episode_id=uuid7(),  # This would not typically be done but this partially verifies that uuid7 is using a correct implementation
         # because the gateway validates some of the properties needed
     )
+    assert isinstance(result, ChatInferenceResponse)
     assert input == input_copy, "Input should not be modified by the client"
     assert result.variant_name == "test"
     assert isinstance(result, ChatInferenceResponse)
     content = result.content
     assert len(content) == 1
     assert content[0].type == "text"
+    assert isinstance(content[0], Text)
     assert (
         content[0].text
         == "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."
@@ -205,11 +221,12 @@ async def test_async_basic_inference(async_client):
         input=input,
         cache_options={"max_age_s": 10, "enabled": "on"},
     )
-    assert result.variant_name == "test"
     assert isinstance(result, ChatInferenceResponse)
+    assert result.variant_name == "test"
     content = result.content
     assert len(content) == 1
     assert content[0].type == "text"
+    assert isinstance(content[0], Text)
     assert (
         content[0].text
         == "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."
@@ -222,10 +239,12 @@ async def test_async_basic_inference(async_client):
 
 @pytest.mark.asyncio
 async def test_async_client_build_http_sync():
-    async with AsyncTensorZeroGateway.build_http(
+    client_ = AsyncTensorZeroGateway.build_http(
         gateway_url="http://localhost:3000",
         async_setup=False,
-    ) as client:
+    )
+    assert isinstance(client_, AsyncTensorZeroGateway)
+    async with client_ as client:
         input = {
             "system": {"assistant_name": "Alfred Pennyworth"},
             "messages": [
@@ -239,12 +258,14 @@ async def test_async_client_build_http_sync():
             episode_id=uuid7(),  # This would not typically be done but this partially verifies that uuid7 is using a correct implementation
             # because the gateway validates some of the properties needed
         )
+        assert isinstance(result, ChatInferenceResponse)
         assert input == input_copy, "Input should not be modified by the client"
         assert result.variant_name == "test"
         assert isinstance(result, ChatInferenceResponse)
         content = result.content
         assert len(content) == 1
         assert content[0].type == "text"
+        assert isinstance(content[0], Text)
         assert (
             content[0].text
             == "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."
@@ -257,11 +278,13 @@ async def test_async_client_build_http_sync():
 
 @pytest.mark.asyncio
 async def test_async_client_build_embedded_sync():
-    async with AsyncTensorZeroGateway.build_embedded(
+    client_ = AsyncTensorZeroGateway.build_embedded(
         config_file=TEST_CONFIG_FILE,
         clickhouse_url="http://chuser:chpassword@localhost:8123/tensorzero-python-e2e",
         async_setup=False,
-    ) as client:
+    )
+    assert isinstance(client_, AsyncTensorZeroGateway)
+    async with client_ as client:
         input = {
             "system": {"assistant_name": "Alfred Pennyworth"},
             "messages": [
@@ -275,12 +298,14 @@ async def test_async_client_build_embedded_sync():
             episode_id=uuid7(),  # This would not typically be done but this partially verifies that uuid7 is using a correct implementation
             # because the gateway validates some of the properties needed
         )
+        assert isinstance(result, ChatInferenceResponse)
         assert input == input_copy, "Input should not be modified by the client"
         assert result.variant_name == "test"
         assert isinstance(result, ChatInferenceResponse)
         content = result.content
         assert len(content) == 1
         assert content[0].type == "text"
+        assert isinstance(content[0], Text)
         assert (
             content[0].text
             == "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."
@@ -292,7 +317,7 @@ async def test_async_client_build_embedded_sync():
 
 
 @pytest.mark.asyncio
-async def test_async_reasoning_inference(async_client):
+async def test_async_reasoning_inference(async_client: AsyncTensorZeroGateway):
     result = await async_client.inference(
         function_name="basic_test",
         variant_name="reasoner",
@@ -302,12 +327,15 @@ async def test_async_reasoning_inference(async_client):
         },
         tags={"key": "value"},
     )
+    assert isinstance(result, ChatInferenceResponse)
     assert result.variant_name == "reasoner"
     assert isinstance(result, ChatInferenceResponse)
     content = result.content
     assert len(content) == 2
+    assert isinstance(content[0], Thought)
     assert content[0].type == "thought"
     assert content[0].text == "hmmm"
+    assert isinstance(content[1], Text)
     assert content[1].type == "text"
     assert (
         content[1].text
@@ -319,7 +347,7 @@ async def test_async_reasoning_inference(async_client):
 
 
 @pytest.mark.asyncio
-async def test_async_default_function_inference(async_client):
+async def test_async_default_function_inference(async_client: AsyncTensorZeroGateway):
     input = {
         "system": "You are a helpful assistant named Alfred Pennyworth.",
         "messages": [{"role": "user", "content": [RawText(value="Hello")]}],
@@ -332,12 +360,14 @@ async def test_async_default_function_inference(async_client):
         # because the gateway validates some of the properties needed
         tags={"key": "value"},
     )
+    assert isinstance(result, ChatInferenceResponse)
     assert input == input_copy, "Input should not be modified by the client"
     assert result.variant_name == "dummy::test"
     assert isinstance(result, ChatInferenceResponse)
     content = result.content
     assert len(content) == 1
     assert content[0].type == "text"
+    assert isinstance(content[0], Text)
     assert (
         content[0].text
         == "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."
@@ -348,7 +378,9 @@ async def test_async_default_function_inference(async_client):
 
 
 @pytest.mark.asyncio
-async def test_async_default_function_inference_plain_dict(async_client):
+async def test_async_default_function_inference_plain_dict(
+    async_client: AsyncTensorZeroGateway,
+):
     input = {
         "system": "You are a helpful assistant named Alfred Pennyworth.",
         "messages": [
@@ -363,12 +395,13 @@ async def test_async_default_function_inference_plain_dict(async_client):
         # because the gateway validates some of the properties needed
         tags={"key": "value"},
     )
+    assert isinstance(result, ChatInferenceResponse)
     assert input == input_copy, "Input should not be modified by the client"
     assert result.variant_name == "dummy::test"
-    assert isinstance(result, ChatInferenceResponse)
     content = result.content
     assert len(content) == 1
     assert content[0].type == "text"
+    assert isinstance(content[0], Text)
     assert (
         content[0].text
         == "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."
@@ -379,7 +412,7 @@ async def test_async_default_function_inference_plain_dict(async_client):
 
 
 @pytest.mark.asyncio
-async def test_async_inference_streaming(async_client):
+async def test_async_inference_streaming(async_client: AsyncTensorZeroGateway):
     stream = await async_client.inference(
         function_name="basic_test",
         input={
@@ -389,10 +422,11 @@ async def test_async_inference_streaming(async_client):
         tags={"key": "value"},
         stream=True,
     )
+    assert isinstance(stream, t.AsyncIterator)
 
-    chunks = []
+    chunks: t.List[InferenceChunk] = []
     previous_chunk_timestamp = None
-    last_chunk_duration = None
+    last_chunk_duration = -1
     async for chunk in stream:
         if previous_chunk_timestamp is not None:
             last_chunk_duration = time.time() - previous_chunk_timestamp
@@ -430,19 +464,24 @@ async def test_async_inference_streaming(async_client):
         previous_episode_id = chunk.episode_id
         variant_name = chunk.variant_name
         assert variant_name == "test"
+        assert isinstance(chunk, ChatChunk)
         if i + 1 < len(chunks):
             assert len(chunk.content) == 1
+            assert isinstance(chunk.content[0], TextChunk)
             assert chunk.content[0].type == "text"
             assert chunk.content[0].text == expected_text[i]
         else:
             assert len(chunk.content) == 0
+            assert chunk.usage is not None
             assert chunk.usage.input_tokens == 10
             assert chunk.usage.output_tokens == 16
             assert chunk.finish_reason == FinishReason.STOP
 
 
 @pytest.mark.asyncio
-async def test_async_reasoning_inference_streaming(async_client):
+async def test_async_reasoning_inference_streaming(
+    async_client: AsyncTensorZeroGateway,
+):
     stream = await async_client.inference(
         function_name="basic_test",
         variant_name="reasoner",
@@ -453,10 +492,11 @@ async def test_async_reasoning_inference_streaming(async_client):
         tags={"key": "value"},
         stream=True,
     )
+    assert isinstance(stream, t.AsyncIterator)
 
-    chunks = []
+    chunks: t.List[InferenceChunk] = []
     previous_chunk_timestamp = None
-    last_chunk_duration = None
+    last_chunk_duration = -1
     async for chunk in stream:
         if previous_chunk_timestamp is not None:
             last_chunk_duration = time.time() - previous_chunk_timestamp
@@ -497,23 +537,29 @@ async def test_async_reasoning_inference_streaming(async_client):
         previous_episode_id = chunk.episode_id
         variant_name = chunk.variant_name
         assert variant_name == "reasoner"
+        assert isinstance(chunk, ChatChunk)
         if i < len(expected_thinking):
             assert len(chunk.content) == 1
             assert chunk.content[0].type == "thought"
+            assert isinstance(chunk.content[0], ThoughtChunk)
             assert chunk.content[0].text == expected_thinking[i]
         elif i < len(expected_thinking) + len(expected_text):
             assert len(chunk.content) == 1
             assert chunk.content[0].type == "text"
+            assert isinstance(chunk.content[0], TextChunk)
             assert chunk.content[0].text == expected_text[i - len(expected_thinking)]
         else:
             assert len(chunk.content) == 0
+            assert chunk.usage is not None
             assert chunk.usage.input_tokens == 10
             assert chunk.usage.output_tokens == 10
             assert chunk.finish_reason == FinishReason.STOP
 
 
 @pytest.mark.asyncio
-async def test_async_inference_streaming_nonexistent_function(async_client):
+async def test_async_inference_streaming_nonexistent_function(
+    async_client: AsyncTensorZeroGateway,
+):
     with pytest.raises(TensorZeroError) as exc_info:
         stream = await async_client.inference(
             function_name="does_not_exist",
@@ -523,9 +569,10 @@ async def test_async_inference_streaming_nonexistent_function(async_client):
             },
             stream=True,
         )
+        assert isinstance(stream, t.AsyncIterator)
 
         # The httpx client won't make a request until you start consuming the stream
-        async for chunk in stream:
+        async for _chunk in stream:
             pass
 
     assert exc_info.value.status_code == 404
@@ -536,7 +583,9 @@ async def test_async_inference_streaming_nonexistent_function(async_client):
 
 
 @pytest.mark.asyncio
-async def test_async_inference_streaming_malformed_input(async_client):
+async def test_async_inference_streaming_malformed_input(
+    async_client: AsyncTensorZeroGateway,
+):
     with pytest.raises(TensorZeroError) as exc_info:
         stream = await async_client.inference(
             function_name="basic_test",
@@ -546,9 +595,10 @@ async def test_async_inference_streaming_malformed_input(async_client):
             },
             stream=True,
         )
+        assert isinstance(stream, t.AsyncIterator)
 
         # The httpx client won't make a request until you start consuming the stream
-        async for chunk in stream:
+        async for _chunk in stream:
             pass
 
     assert exc_info.value.status_code == 400
@@ -559,7 +609,7 @@ async def test_async_inference_streaming_malformed_input(async_client):
 
 
 @pytest.mark.asyncio
-async def test_async_tool_call_inference(async_client):
+async def test_async_tool_call_inference(async_client: AsyncTensorZeroGateway):
     result = await async_client.inference(
         function_name="weather_helper",
         input={
@@ -572,11 +622,13 @@ async def test_async_tool_call_inference(async_client):
             ],
         },
     )
+    assert isinstance(result, ChatInferenceResponse)
     assert result.variant_name == "variant"
     assert isinstance(result, ChatInferenceResponse)
     content = result.content
     assert len(content) == 1
     assert content[0].type == "tool_call"
+    assert isinstance(content[0], ToolCall)
     assert content[0].raw_name == "get_temperature"
     assert content[0].id == "0"
     assert content[0].raw_arguments == '{"location":"Brooklyn","units":"celsius"}'
@@ -589,7 +641,9 @@ async def test_async_tool_call_inference(async_client):
 
 
 @pytest.mark.asyncio
-async def test_async_malformed_tool_call_inference(async_client):
+async def test_async_malformed_tool_call_inference(
+    async_client: AsyncTensorZeroGateway,
+):
     result = await async_client.inference(
         function_name="weather_helper",
         input={
@@ -603,10 +657,12 @@ async def test_async_malformed_tool_call_inference(async_client):
         },
         variant_name="bad_tool",
     )
+    assert isinstance(result, ChatInferenceResponse)
     assert result.variant_name == "bad_tool"
     assert isinstance(result, ChatInferenceResponse)
     content = result.content
     assert len(content) == 1
+    assert isinstance(content[0], ToolCall)
     assert content[0].type == "tool_call"
     assert content[0].raw_name == "get_temperature"
     assert content[0].id == "0"
@@ -619,7 +675,7 @@ async def test_async_malformed_tool_call_inference(async_client):
 
 
 @pytest.mark.asyncio
-async def test_async_tool_call_streaming(async_client):
+async def test_async_tool_call_streaming(async_client: AsyncTensorZeroGateway):
     stream = await async_client.inference(
         function_name="weather_helper",
         input={
@@ -633,6 +689,7 @@ async def test_async_tool_call_streaming(async_client):
         },
         stream=True,
     )
+    assert isinstance(stream, t.AsyncIterator)
     chunks = [chunk async for chunk in stream]
     expected_text = [
         '{"location"',
@@ -652,21 +709,24 @@ async def test_async_tool_call_streaming(async_client):
         previous_episode_id = chunk.episode_id
         variant_name = chunk.variant_name
         assert variant_name == "variant"
+        assert isinstance(chunk, ChatChunk)
         if i + 1 < len(chunks):
             assert len(chunk.content) == 1
+            assert isinstance(chunk.content[0], ToolCallChunk)
             assert chunk.content[0].type == "tool_call"
             assert chunk.content[0].raw_name == "get_temperature"
             assert chunk.content[0].id == "0"
             assert chunk.content[0].raw_arguments == expected_text[i]
         else:
             assert len(chunk.content) == 0
+            assert chunk.usage is not None
             assert chunk.usage.input_tokens == 10
             assert chunk.usage.output_tokens == 5
             assert chunk.finish_reason == FinishReason.TOOL_CALL
 
 
 @pytest.mark.asyncio
-async def test_async_json_streaming(async_client):
+async def test_async_json_streaming(async_client: AsyncTensorZeroGateway):
     # We don't actually have a streaming JSON function implemented in `dummy.rs` but it doesn't matter for this test since
     # TensorZero doesn't parse the JSON output of the function for streaming calls.
     stream = await async_client.inference(
@@ -682,6 +742,7 @@ async def test_async_json_streaming(async_client):
         },
         stream=True,
     )
+    assert isinstance(stream, t.AsyncIterator)
     chunks = [chunk async for chunk in stream]
     expected_text = [
         "Wally,",
@@ -712,15 +773,17 @@ async def test_async_json_streaming(async_client):
         previous_episode_id = chunk.episode_id
         variant_name = chunk.variant_name
         assert variant_name == "test"
+        assert isinstance(chunk, JsonChunk)
         if i + 1 < len(chunks):
             assert chunk.raw == expected_text[i]
         else:
+            assert chunk.usage is not None
             assert chunk.usage.input_tokens == 10
             assert chunk.usage.output_tokens == 16
 
 
 @pytest.mark.asyncio
-async def test_async_json_streaming_reasoning(async_client):
+async def test_async_json_streaming_reasoning(async_client: AsyncTensorZeroGateway):
     stream = await async_client.inference(
         function_name="json_success",
         variant_name="json_reasoner",
@@ -730,6 +793,7 @@ async def test_async_json_streaming_reasoning(async_client):
         },
         stream=True,
     )
+    assert isinstance(stream, t.AsyncIterator)
     chunks = [chunk async for chunk in stream]
     expected_text = [
         '{"name"',
@@ -749,16 +813,18 @@ async def test_async_json_streaming_reasoning(async_client):
         previous_episode_id = chunk.episode_id
         variant_name = chunk.variant_name
         assert variant_name == "json_reasoner"
+        assert isinstance(chunk, JsonChunk)
         if i < len(expected_text):
             assert chunk.raw == expected_text[i]
         else:
             assert chunk.raw == ""
+            assert chunk.usage is not None
             assert chunk.usage.input_tokens == 10
             assert chunk.usage.output_tokens == 10
 
 
 @pytest.mark.asyncio
-async def test_async_json_success(async_client):
+async def test_async_json_success(async_client: AsyncTensorZeroGateway):
     result = await async_client.inference(
         function_name="json_success",
         input={
@@ -768,8 +834,8 @@ async def test_async_json_success(async_client):
         output_schema={"type": "object", "properties": {"answer": {"type": "string"}}},
         stream=False,
     )
-    assert result.variant_name == "test"
     assert isinstance(result, JsonInferenceResponse)
+    assert result.variant_name == "test"
     assert result.output.raw == '{"answer":"Hello"}'
     assert result.output.parsed == {"answer": "Hello"}
     assert result.usage.input_tokens == 10
@@ -777,7 +843,7 @@ async def test_async_json_success(async_client):
 
 
 @pytest.mark.asyncio
-async def test_async_json_reasoning(async_client):
+async def test_async_json_reasoning(async_client: AsyncTensorZeroGateway):
     result = await async_client.inference(
         function_name="json_success",
         variant_name="json_reasoner",
@@ -787,8 +853,8 @@ async def test_async_json_reasoning(async_client):
         },
         stream=False,
     )
-    assert result.variant_name == "json_reasoner"
     assert isinstance(result, JsonInferenceResponse)
+    assert result.variant_name == "json_reasoner"
     assert result.output.raw == '{"answer":"Hello"}'
     assert result.output.parsed == {"answer": "Hello"}
     assert result.usage.input_tokens == 10
@@ -796,7 +862,7 @@ async def test_async_json_reasoning(async_client):
 
 
 @pytest.mark.asyncio
-async def test_async_json_failure(async_client):
+async def test_async_json_failure(async_client: AsyncTensorZeroGateway):
     result = await async_client.inference(
         function_name="json_fail",
         input={
@@ -805,8 +871,8 @@ async def test_async_json_failure(async_client):
         },
         stream=False,
     )
-    assert result.variant_name == "test"
     assert isinstance(result, JsonInferenceResponse)
+    assert result.variant_name == "test"
     assert (
         result.output.raw
         == "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."
@@ -817,7 +883,7 @@ async def test_async_json_failure(async_client):
 
 
 @pytest.mark.asyncio
-async def test_async_feedback(async_client):
+async def test_async_feedback(async_client: AsyncTensorZeroGateway):
     # Run inference to get a valid inference id and episode id.
     result = await async_client.inference(
         function_name="basic_test",
@@ -826,6 +892,7 @@ async def test_async_feedback(async_client):
             "messages": [{"role": "user", "content": "Hello"}],
         },
     )
+    assert isinstance(result, ChatInferenceResponse)
     inference_id = result.inference_id
     episode_id = result.episode_id
 
@@ -849,7 +916,7 @@ async def test_async_feedback(async_client):
 
 
 @pytest.mark.asyncio
-async def test_async_feedback_invalid_input(async_client):
+async def test_async_feedback_invalid_input(async_client: AsyncTensorZeroGateway):
     with pytest.raises(TensorZeroError):
         await async_client.feedback(metric_name="test_metric", value=5)
 
@@ -863,7 +930,7 @@ async def test_async_feedback_invalid_input(async_client):
 
 
 @pytest.mark.asyncio
-async def test_async_tensorzero_error(async_client):
+async def test_async_tensorzero_error(async_client: AsyncTensorZeroGateway):
     with pytest.raises(TensorZeroError) as excinfo:
         await async_client.inference(
             function_name="not_a_function", input={"messages": []}
@@ -876,7 +943,7 @@ async def test_async_tensorzero_error(async_client):
 
 
 @pytest.mark.asyncio
-async def test_async_dynamic_credentials(async_client):
+async def test_async_dynamic_credentials(async_client: AsyncTensorZeroGateway):
     result = await async_client.inference(
         function_name="basic_test",
         variant_name="test_dynamic_api_key",
@@ -886,11 +953,13 @@ async def test_async_dynamic_credentials(async_client):
         },
         credentials={"DUMMY_API_KEY": "good_key"},
     )
+    assert isinstance(result, ChatInferenceResponse)
     assert result.variant_name == "test_dynamic_api_key"
     assert isinstance(result, ChatInferenceResponse)
     content = result.content
     assert len(content) == 1
     assert content[0].type == "text"
+    assert isinstance(content[0], Text)
     assert (
         content[0].text
         == "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."
@@ -910,15 +979,17 @@ def test_sync_error():
 @pytest.mark.asyncio
 async def test_async_error():
     with pytest.raises(Exception) as exc_info:
-        async with await AsyncTensorZeroGateway.build_http(
+        client_fut = AsyncTensorZeroGateway.build_http(
             gateway_url="http://localhost:3000"
-        ):
+        )
+        assert isinstance(client_fut, t.Awaitable)
+        async with await client_fut:
             raise Exception("My error")
     assert str(exc_info.value) == "My error"
 
 
 @pytest.fixture(params=[ClientType.HttpGateway, ClientType.EmbeddedGateway])
-def sync_client(request):
+def sync_client(request: FixtureRequest):
     if request.param == ClientType.HttpGateway:
         with TensorZeroGateway.build_http(
             gateway_url="http://localhost:3000"
@@ -932,7 +1003,7 @@ def sync_client(request):
             yield client
 
 
-def test_sync_basic_inference(sync_client):
+def test_sync_basic_inference(sync_client: TensorZeroGateway):
     result = sync_client.inference(
         function_name="basic_test",
         input={
@@ -941,11 +1012,12 @@ def test_sync_basic_inference(sync_client):
         },
         tags={"key": "value"},
     )
-    assert result.variant_name == "test"
     assert isinstance(result, ChatInferenceResponse)
+    assert result.variant_name == "test"
     content = result.content
     assert len(content) == 1
     assert content[0].type == "text"
+    assert isinstance(content[0], Text)
     assert (
         content[0].text
         == "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."
@@ -964,11 +1036,12 @@ def test_sync_basic_inference(sync_client):
         cache_options={"max_age_s": 10, "enabled": "on"},
         tags={"key": "value"},
     )
-    assert result.variant_name == "test"
     assert isinstance(result, ChatInferenceResponse)
+    assert result.variant_name == "test"
     content = result.content
     assert len(content) == 1
     assert content[0].type == "text"
+    assert isinstance(content[0], Text)
     assert (
         content[0].text
         == "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."
@@ -978,7 +1051,7 @@ def test_sync_basic_inference(sync_client):
     assert usage.output_tokens == 0  # should be cached
 
 
-def test_default_function_inference(sync_client):
+def test_default_function_inference(sync_client: TensorZeroGateway):
     input = {
         "system": "You are a helpful assistant named Alfred Pennyworth.",
         "messages": [{"role": "user", "content": [Text(type="text", text="Hello")]}],
@@ -991,12 +1064,14 @@ def test_default_function_inference(sync_client):
         # because the gateway validates some of the properties needed
         tags={"key": "value"},
     )
+    assert isinstance(result, ChatInferenceResponse)
     assert input == input_copy, "Input should not be modified by the client"
     assert result.variant_name == "dummy::test"
     assert isinstance(result, ChatInferenceResponse)
     content = result.content
     assert len(content) == 1
     assert content[0].type == "text"
+    assert isinstance(content[0], Text)
     assert (
         content[0].text
         == "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."
@@ -1006,7 +1081,7 @@ def test_default_function_inference(sync_client):
     assert usage.output_tokens == 10
 
 
-def test_image_inference_base64(sync_client):
+def test_image_inference_base64(sync_client: TensorZeroGateway):
     basepath = path.dirname(__file__)
     with open(
         f"{basepath}/../../../tensorzero-internal/tests/e2e/providers/ferris.png", "rb"
@@ -1034,12 +1109,14 @@ def test_image_inference_base64(sync_client):
         episode_id=uuid7(),  # This would not typically be done but this partially verifies that uuid7 is using a correct implementation
         # because the gateway validates some of the properties needed
     )
+    assert isinstance(result, ChatInferenceResponse)
     assert input == input_copy, "Input should not be modified by the client"
     assert result.variant_name == "dummy::extract_images"
-    assert isinstance(result, ChatInferenceResponse)
     content = result.content
     assert len(content) == 1
     assert content[0].type == "text"
+    assert isinstance(content[0], Text)
+    assert content[0].text is not None
     json_content = json.loads(content[0].text)
     assert json_content == [
         {
@@ -1052,7 +1129,7 @@ def test_image_inference_base64(sync_client):
     ]
 
 
-def test_image_inference_url(sync_client):
+def test_image_inference_url(sync_client: TensorZeroGateway):
     input = {
         "system": "You are a helpful assistant named Alfred Pennyworth.",
         "messages": [
@@ -1073,12 +1150,15 @@ def test_image_inference_url(sync_client):
         episode_id=uuid7(),  # This would not typically be done but this partially verifies that uuid7 is using a correct implementation
         # because the gateway validates some of the properties needed
     )
+    assert isinstance(result, ChatInferenceResponse)
     assert input == input_copy, "Input should not be modified by the client"
     assert result.variant_name == "dummy::extract_images"
     assert isinstance(result, ChatInferenceResponse)
     content = result.content
     assert len(content) == 1
     assert content[0].type == "text"
+    assert isinstance(content[0], Text)
+    assert content[0].text is not None
     json_content = json.loads(content[0].text)
     assert json_content == [
         {
@@ -1094,7 +1174,7 @@ def test_image_inference_url(sync_client):
     ]
 
 
-def test_sync_malformed_inference(sync_client):
+def test_sync_malformed_inference(sync_client: TensorZeroGateway):
     with pytest.raises(TensorZeroError) as exc_info:
         sync_client.inference(
             function_name="basic_test",
@@ -1106,7 +1186,7 @@ def test_sync_malformed_inference(sync_client):
     assert exc_info.value.status_code == 400
 
 
-def test_sync_inference_streaming(sync_client):
+def test_sync_inference_streaming(sync_client: TensorZeroGateway):
     stream = sync_client.inference(
         function_name="basic_test",
         input={
@@ -1116,10 +1196,11 @@ def test_sync_inference_streaming(sync_client):
         stream=True,
         tags={"key": "value"},
     )
+    assert isinstance(stream, t.Iterator)
 
-    chunks = []
+    chunks: t.List[InferenceChunk] = []
     previous_chunk_timestamp = None
-    last_chunk_duration = None
+    last_chunk_duration = -1
     for chunk in stream:
         if previous_chunk_timestamp is not None:
             last_chunk_duration = time.time() - previous_chunk_timestamp
@@ -1157,17 +1238,20 @@ def test_sync_inference_streaming(sync_client):
         previous_episode_id = chunk.episode_id
         variant_name = chunk.variant_name
         assert variant_name == "test"
+        assert isinstance(chunk, ChatChunk)
         if i + 1 < len(chunks):
             assert len(chunk.content) == 1
             assert chunk.content[0].type == "text"
+            assert isinstance(chunk.content[0], TextChunk)
             assert chunk.content[0].text == expected_text[i]
         else:
             assert len(chunk.content) == 0
+            assert chunk.usage is not None
             assert chunk.usage.input_tokens == 10
             assert chunk.usage.output_tokens == 16
 
 
-def test_sync_inference_streaming_nonexistent_function(sync_client):
+def test_sync_inference_streaming_nonexistent_function(sync_client: TensorZeroGateway):
     with pytest.raises(TensorZeroError) as exc_info:
         stream = sync_client.inference(
             function_name="does_not_exist",
@@ -1177,15 +1261,16 @@ def test_sync_inference_streaming_nonexistent_function(sync_client):
             },
             stream=True,
         )
+        assert isinstance(stream, t.Iterator)
 
         # The httpx client won't make a request until you start consuming the stream
-        for chunk in stream:
+        for _chunk in stream:
             pass
 
     assert exc_info.value.status_code == 404
 
 
-def test_sync_inference_streaming_malformed_input(sync_client):
+def test_sync_inference_streaming_malformed_input(sync_client: TensorZeroGateway):
     with pytest.raises(TensorZeroError) as exc_info:
         stream = sync_client.inference(
             function_name="basic_test",
@@ -1195,9 +1280,10 @@ def test_sync_inference_streaming_malformed_input(sync_client):
             },
             stream=True,
         )
+        assert isinstance(stream, t.Iterator)
 
         # The httpx client won't make a request until you start consuming the stream
-        for chunk in stream:
+        for _chunk in stream:
             pass
 
     assert exc_info.value.status_code == 400
@@ -1207,7 +1293,7 @@ def test_sync_inference_streaming_malformed_input(sync_client):
     )
 
 
-def test_sync_tool_call_inference(sync_client):
+def test_sync_tool_call_inference(sync_client: TensorZeroGateway):
     result = sync_client.inference(
         function_name="weather_helper",
         input={
@@ -1220,10 +1306,12 @@ def test_sync_tool_call_inference(sync_client):
             ],
         },
     )
-    assert result.variant_name == "variant"
+
     assert isinstance(result, ChatInferenceResponse)
+    assert result.variant_name == "variant"
     content = result.content
     assert len(content) == 1
+    assert isinstance(content[0], ToolCall)
     assert content[0].type == "tool_call"
     assert content[0].raw_name == "get_temperature"
     assert content[0].id == "0"
@@ -1235,7 +1323,7 @@ def test_sync_tool_call_inference(sync_client):
     assert usage.output_tokens == 10
 
 
-def test_sync_reasoning_inference(sync_client):
+def test_sync_reasoning_inference(sync_client: TensorZeroGateway):
     result = sync_client.inference(
         function_name="basic_test",
         variant_name="reasoner",
@@ -1245,13 +1333,16 @@ def test_sync_reasoning_inference(sync_client):
         },
         tags={"key": "value"},
     )
+    assert isinstance(result, ChatInferenceResponse)
     assert result.variant_name == "reasoner"
     assert isinstance(result, ChatInferenceResponse)
     content = result.content
     assert len(content) == 2
+    assert isinstance(content[0], Thought)
     assert content[0].type == "thought"
     assert content[0].text == "hmmm"
     assert content[1].type == "text"
+    assert isinstance(content[1], Text)
     assert (
         content[1].text
         == "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."
@@ -1261,7 +1352,7 @@ def test_sync_reasoning_inference(sync_client):
     assert usage.output_tokens == 10
 
 
-def test_sync_malformed_tool_call_inference(sync_client):
+def test_sync_malformed_tool_call_inference(sync_client: TensorZeroGateway):
     result = sync_client.inference(
         function_name="weather_helper",
         input={
@@ -1275,11 +1366,13 @@ def test_sync_malformed_tool_call_inference(sync_client):
         },
         variant_name="bad_tool",
     )
+    assert isinstance(result, ChatInferenceResponse)
     assert result.variant_name == "bad_tool"
     assert isinstance(result, ChatInferenceResponse)
     content = result.content
     assert len(content) == 1
     assert content[0].type == "tool_call"
+    assert isinstance(content[0], ToolCall)
     assert content[0].raw_name == "get_temperature"
     assert content[0].id == "0"
     assert content[0].raw_arguments == '{"location":"Brooklyn","units":"Celsius"}'
@@ -1290,7 +1383,7 @@ def test_sync_malformed_tool_call_inference(sync_client):
     assert usage.output_tokens == 10
 
 
-def test_sync_tool_call_streaming(sync_client):
+def test_sync_tool_call_streaming(sync_client: TensorZeroGateway):
     stream = sync_client.inference(
         function_name="weather_helper",
         input={
@@ -1304,6 +1397,7 @@ def test_sync_tool_call_streaming(sync_client):
         },
         stream=True,
     )
+    assert isinstance(stream, t.Iterator)
     chunks = list(stream)
     expected_text = [
         '{"location"',
@@ -1323,19 +1417,22 @@ def test_sync_tool_call_streaming(sync_client):
         previous_episode_id = chunk.episode_id
         variant_name = chunk.variant_name
         assert variant_name == "variant"
+        assert isinstance(chunk, ChatChunk)
         if i + 1 < len(chunks):
             assert len(chunk.content) == 1
+            assert isinstance(chunk.content[0], ToolCallChunk)
             assert chunk.content[0].type == "tool_call"
             assert chunk.content[0].raw_name == "get_temperature"
             assert chunk.content[0].id == "0"
             assert chunk.content[0].raw_arguments == expected_text[i]
         else:
             assert len(chunk.content) == 0
+            assert chunk.usage is not None
             assert chunk.usage.input_tokens == 10
             assert chunk.usage.output_tokens == 5
 
 
-def test_sync_reasoning_inference_streaming(sync_client):
+def test_sync_reasoning_inference_streaming(sync_client: TensorZeroGateway):
     stream = sync_client.inference(
         function_name="basic_test",
         variant_name="reasoner",
@@ -1346,10 +1443,11 @@ def test_sync_reasoning_inference_streaming(sync_client):
         tags={"key": "value"},
         stream=True,
     )
+    assert isinstance(stream, t.Iterator)
 
-    chunks = []
+    chunks: t.List[InferenceChunk] = []
     previous_chunk_timestamp = None
-    last_chunk_duration = None
+    last_chunk_duration = -1
     for chunk in stream:
         if previous_chunk_timestamp is not None:
             last_chunk_duration = time.time() - previous_chunk_timestamp
@@ -1390,21 +1488,25 @@ def test_sync_reasoning_inference_streaming(sync_client):
         previous_episode_id = chunk.episode_id
         variant_name = chunk.variant_name
         assert variant_name == "reasoner"
+        assert isinstance(chunk, ChatChunk)
         if i < len(expected_thinking):
             assert len(chunk.content) == 1
             assert chunk.content[0].type == "thought"
+            assert isinstance(chunk.content[0], ThoughtChunk)
             assert chunk.content[0].text == expected_thinking[i]
         elif i < len(expected_thinking) + len(expected_text):
             assert len(chunk.content) == 1
+            assert isinstance(chunk.content[0], TextChunk)
             assert chunk.content[0].type == "text"
             assert chunk.content[0].text == expected_text[i - len(expected_thinking)]
         else:
             assert len(chunk.content) == 0
+            assert chunk.usage is not None
             assert chunk.usage.input_tokens == 10
             assert chunk.usage.output_tokens == 10
 
 
-def test_sync_json_streaming(sync_client):
+def test_sync_json_streaming(sync_client: TensorZeroGateway):
     # We don't actually have a streaming JSON function implemented in `dummy.rs` but it doesn't matter for this test since
     # TensorZero doesn't parse the JSON output of the function for streaming calls.
     stream = sync_client.inference(
@@ -1415,6 +1517,7 @@ def test_sync_json_streaming(sync_client):
         },
         stream=True,
     )
+    assert isinstance(stream, t.Iterator)
     chunks = list(stream)
     expected_text = [
         "Wally,",
@@ -1445,14 +1548,16 @@ def test_sync_json_streaming(sync_client):
         previous_episode_id = chunk.episode_id
         variant_name = chunk.variant_name
         assert variant_name == "test"
+        assert isinstance(chunk, JsonChunk)
         if i + 1 < len(chunks):
             assert chunk.raw == expected_text[i]
         else:
+            assert chunk.usage is not None
             assert chunk.usage.input_tokens == 10
             assert chunk.usage.output_tokens == 16
 
 
-def test_sync_json_streaming_reasoning(sync_client):
+def test_sync_json_streaming_reasoning(sync_client: TensorZeroGateway):
     stream = sync_client.inference(
         function_name="json_success",
         variant_name="json_reasoner",
@@ -1462,6 +1567,7 @@ def test_sync_json_streaming_reasoning(sync_client):
         },
         stream=True,
     )
+    assert isinstance(stream, t.Iterator)
     chunks = list(stream)
     expected_text = [
         '{"name"',
@@ -1481,15 +1587,17 @@ def test_sync_json_streaming_reasoning(sync_client):
         previous_episode_id = chunk.episode_id
         variant_name = chunk.variant_name
         assert variant_name == "json_reasoner"
+        assert isinstance(chunk, JsonChunk)
         if i < len(expected_text):
             assert chunk.raw == expected_text[i]
         else:
             assert chunk.raw == ""
+            assert chunk.usage is not None
             assert chunk.usage.input_tokens == 10
             assert chunk.usage.output_tokens == 10
 
 
-def test_sync_json_success(sync_client):
+def test_sync_json_success(sync_client: TensorZeroGateway):
     result = sync_client.inference(
         function_name="json_success",
         input={
@@ -1499,15 +1607,15 @@ def test_sync_json_success(sync_client):
         output_schema={"type": "object", "properties": {"answer": {"type": "string"}}},
         stream=False,
     )
-    assert result.variant_name == "test"
     assert isinstance(result, JsonInferenceResponse)
+    assert result.variant_name == "test"
     assert result.output.raw == '{"answer":"Hello"}'
     assert result.output.parsed == {"answer": "Hello"}
     assert result.usage.input_tokens == 10
     assert result.usage.output_tokens == 10
 
 
-def test_sync_json_reasoning(sync_client):
+def test_sync_json_reasoning(sync_client: TensorZeroGateway):
     result = sync_client.inference(
         function_name="json_success",
         variant_name="json_reasoner",
@@ -1517,15 +1625,15 @@ def test_sync_json_reasoning(sync_client):
         },
         stream=False,
     )
-    assert result.variant_name == "json_reasoner"
     assert isinstance(result, JsonInferenceResponse)
+    assert result.variant_name == "json_reasoner"
     assert result.output.raw == '{"answer":"Hello"}'
     assert result.output.parsed == {"answer": "Hello"}
     assert result.usage.input_tokens == 10
     assert result.usage.output_tokens == 10
 
 
-def test_sync_json_failure(sync_client):
+def test_sync_json_failure(sync_client: TensorZeroGateway):
     result = sync_client.inference(
         function_name="json_fail",
         input={
@@ -1534,8 +1642,8 @@ def test_sync_json_failure(sync_client):
         },
         stream=False,
     )
-    assert result.variant_name == "test"
     assert isinstance(result, JsonInferenceResponse)
+    assert result.variant_name == "test"
     assert (
         result.output.raw
         == "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."
@@ -1545,7 +1653,7 @@ def test_sync_json_failure(sync_client):
     assert result.usage.output_tokens == 10
 
 
-def test_sync_feedback(sync_client):
+def test_sync_feedback(sync_client: TensorZeroGateway):
     result = sync_client.inference(
         function_name="basic_test",
         input={
@@ -1553,6 +1661,7 @@ def test_sync_feedback(sync_client):
             "messages": [{"role": "user", "content": "Hello"}],
         },
     )
+    assert isinstance(result, ChatInferenceResponse)
     inference_id = result.inference_id
     episode_id = result.episode_id
 
@@ -1575,7 +1684,7 @@ def test_sync_feedback(sync_client):
     assert isinstance(result, FeedbackResponse)
 
 
-def test_sync_feedback_invalid_input(sync_client):
+def test_sync_feedback_invalid_input(sync_client: TensorZeroGateway):
     with pytest.raises(TensorZeroError):
         sync_client.feedback(metric_name="test_metric", value=5)
 
@@ -1588,7 +1697,7 @@ def test_sync_feedback_invalid_input(sync_client):
         )
 
 
-def test_sync_tensorzero_error(sync_client):
+def test_sync_tensorzero_error(sync_client: TensorZeroGateway):
     with pytest.raises(TensorZeroError) as excinfo:
         sync_client.inference(function_name="not_a_function", input={"messages": []})
 
@@ -1598,7 +1707,7 @@ def test_sync_tensorzero_error(sync_client):
     )
 
 
-def test_sync_basic_inference_with_content_block(sync_client):
+def test_sync_basic_inference_with_content_block(sync_client: TensorZeroGateway):
     result = sync_client.inference(
         function_name="basic_test",
         input={
@@ -1626,11 +1735,12 @@ def test_sync_basic_inference_with_content_block(sync_client):
             ],
         },
     )
-    assert result.variant_name == "test"
     assert isinstance(result, ChatInferenceResponse)
+    assert result.variant_name == "test"
     content = result.content
     assert len(content) == 1
     assert content[0].type == "text"
+    assert isinstance(content[0], Text)
     assert (
         content[0].text
         == "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."
@@ -1640,7 +1750,9 @@ def test_sync_basic_inference_with_content_block(sync_client):
     assert usage.output_tokens == 10
 
 
-def test_sync_basic_inference_with_content_block_plain_dict(sync_client):
+def test_sync_basic_inference_with_content_block_plain_dict(
+    sync_client: TensorZeroGateway,
+):
     result = sync_client.inference(
         function_name="basic_test",
         input={
@@ -1667,11 +1779,12 @@ def test_sync_basic_inference_with_content_block_plain_dict(sync_client):
             ],
         },
     )
-    assert result.variant_name == "test"
     assert isinstance(result, ChatInferenceResponse)
+    assert result.variant_name == "test"
     content = result.content
     assert len(content) == 1
     assert content[0].type == "text"
+    assert isinstance(content[0], Text)
     assert (
         content[0].text
         == "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."
@@ -1681,9 +1794,10 @@ def test_sync_basic_inference_with_content_block_plain_dict(sync_client):
     assert usage.output_tokens == 10
 
 
-def test_prepare_inference_request(sync_client):
+def test_prepare_inference_request(sync_client: TensorZeroGateway):
     # Test a simple request with string input and a structured system message
-    request = sync_client._prepare_inference_request(
+    # This is a private method, so we ignore type checking
+    request = sync_client._prepare_inference_request(  # type: ignore
         function_name="basic_test",
         input={
             "system": {"assistant_name": "Alfred Pennyworth"},
@@ -1698,7 +1812,7 @@ def test_prepare_inference_request(sync_client):
 
     # Test a complex request that covers every argument of the client
     episode_id = uuid7()
-    request = sync_client._prepare_inference_request(
+    request = sync_client._prepare_inference_request(  # type: ignore
         function_name="basic_test",
         input={
             "system": "you are the bad guy",
@@ -1786,13 +1900,13 @@ def test_prepare_inference_request(sync_client):
         "description": "drills",
         "strict": False,
     }
-    assert len(request["additional_tools"]) == 1
+    assert len(request["additional_tools"]) == 1  # type: ignore
     assert request["variant_name"] == "baz"
     assert request["function_name"] == "basic_test"
     assert request["parallel_tool_calls"]
 
 
-def test_sync_dynamic_credentials(sync_client):
+def test_sync_dynamic_credentials(sync_client: TensorZeroGateway):
     result = sync_client.inference(
         function_name="basic_test",
         variant_name="test_dynamic_api_key",
@@ -1802,11 +1916,12 @@ def test_sync_dynamic_credentials(sync_client):
         },
         credentials={"DUMMY_API_KEY": "good_key"},
     )
-    assert result.variant_name == "test_dynamic_api_key"
     assert isinstance(result, ChatInferenceResponse)
+    assert result.variant_name == "test_dynamic_api_key"
     content = result.content
     assert len(content) == 1
     assert content[0].type == "text"
+    assert isinstance(content[0], Text)
     assert (
         content[0].text
         == "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."
@@ -1816,7 +1931,7 @@ def test_sync_dynamic_credentials(sync_client):
     assert usage.output_tokens == 10
 
 
-def test_sync_err_in_stream(sync_client):
+def test_sync_err_in_stream(sync_client: TensorZeroGateway):
     result = sync_client.inference(
         function_name="basic_test",
         variant_name="err_in_stream",
@@ -1826,6 +1941,7 @@ def test_sync_err_in_stream(sync_client):
         },
         stream=True,
     )
+    assert isinstance(result, t.Iterator)
 
     next(result)
     next(result)
@@ -1838,7 +1954,7 @@ def test_sync_err_in_stream(sync_client):
 
 
 @pytest.mark.asyncio
-async def test_async_err_in_stream(async_client):
+async def test_async_err_in_stream(async_client: AsyncTensorZeroGateway):
     result = await async_client.inference(
         function_name="basic_test",
         variant_name="err_in_stream",
@@ -1848,6 +1964,7 @@ async def test_async_err_in_stream(async_client):
         },
         stream=True,
     )
+    assert isinstance(result, t.AsyncIterator)
 
     # anext() was added in Python 3.10, use __anext__() for older versions
     await result.__anext__()
@@ -1857,7 +1974,7 @@ async def test_async_err_in_stream(async_client):
         await result.__anext__()
     assert "Dummy error in stream" in str(exc_info.value)
     # Make this an async collect into a list
-    remaining_chunks = []
+    remaining_chunks: t.List[InferenceChunk] = []
     async for chunk in result:
         remaining_chunks.append(chunk)
     assert len(remaining_chunks) == 13
@@ -1865,10 +1982,12 @@ async def test_async_err_in_stream(async_client):
 
 @pytest.mark.asyncio
 async def test_async_timeout_int_http():
-    async with await AsyncTensorZeroGateway.build_http(
+    client_fut = AsyncTensorZeroGateway.build_http(
         gateway_url="http://localhost:3000",
         timeout=1,
-    ) as async_client:
+    )
+    assert isinstance(client_fut, t.Awaitable)
+    async with await client_fut as async_client:
         with pytest.raises(TensorZeroInternalError) as exc_info:
             await async_client.inference(
                 function_name="basic_test",
@@ -1883,11 +2002,13 @@ async def test_async_timeout_int_http():
 
 @pytest.mark.asyncio
 async def test_async_timeout_int_embedded():
-    async with await AsyncTensorZeroGateway.build_embedded(
+    client_fut = AsyncTensorZeroGateway.build_embedded(
         config_file=TEST_CONFIG_FILE,
         clickhouse_url="http://chuser:chpassword@localhost:8123/tensorzero-python-e2e",
         timeout=1,
-    ) as async_client:
+    )
+    assert inspect.isawaitable(client_fut)
+    async with await client_fut as async_client:
         with pytest.raises(TensorZeroInternalError) as exc_info:
             await async_client.inference(
                 function_name="basic_test",
@@ -1902,10 +2023,12 @@ async def test_async_timeout_int_embedded():
 
 @pytest.mark.asyncio
 async def test_async_timeout_float_http():
-    async with await AsyncTensorZeroGateway.build_http(
+    client_fut = AsyncTensorZeroGateway.build_http(
         gateway_url="http://localhost:3000",
         timeout=0.1,
-    ) as async_client:
+    )
+    assert inspect.isawaitable(client_fut)
+    async with await client_fut as async_client:
         with pytest.raises(TensorZeroInternalError) as exc_info:
             await async_client.inference(
                 function_name="basic_test",
@@ -1920,11 +2043,13 @@ async def test_async_timeout_float_http():
 
 @pytest.mark.asyncio
 async def test_async_timeout_float_embedded():
-    async with await AsyncTensorZeroGateway.build_embedded(
+    client_fut = AsyncTensorZeroGateway.build_embedded(
         config_file=TEST_CONFIG_FILE,
         clickhouse_url="http://chuser:chpassword@localhost:8123/tensorzero-python-e2e",
         timeout=0.1,
-    ) as async_client:
+    )
+    assert inspect.isawaitable(client_fut)
+    async with await client_fut as async_client:
         with pytest.raises(TensorZeroInternalError) as exc_info:
             await async_client.inference(
                 function_name="basic_test",
@@ -1948,9 +2073,11 @@ def test_sync_timeout_invalid():
 
 @pytest.mark.asyncio
 async def test_async_non_verbose_errors():
-    async with await AsyncTensorZeroGateway.build_http(
+    client_fut = AsyncTensorZeroGateway.build_http(
         gateway_url="http://tensorzero.invalid:3000", verbose_errors=False
-    ) as async_client:
+    )
+    assert inspect.isawaitable(client_fut)
+    async with await client_fut as async_client:
         with pytest.raises(TensorZeroInternalError) as exc_info:
             await async_client.inference(
                 function_name="basic_test",
@@ -1963,9 +2090,11 @@ async def test_async_non_verbose_errors():
 
 @pytest.mark.asyncio
 async def test_async_verbose_errors():
-    async with await AsyncTensorZeroGateway.build_http(
+    client_fut = AsyncTensorZeroGateway.build_http(
         gateway_url="http://tensorzero.invalid:3000", verbose_errors=True
-    ) as async_client:
+    )
+    assert inspect.isawaitable(client_fut)
+    async with await client_fut as async_client:
         with pytest.raises(TensorZeroInternalError) as exc_info:
             await async_client.inference(
                 function_name="basic_test",
@@ -2033,11 +2162,13 @@ def test_patch_sync_openai_client_sync_setup():
 @pytest.mark.asyncio
 async def test_patch_sync_openai_client_async_setup():
     client = OpenAI()
-    client = await tensorzero.patch_openai_client(
+    patch_fut = tensorzero.patch_openai_client(
         client,
         config_file="../../examples/quickstart/config/tensorzero.toml",
         async_setup=True,
     )
+    assert isinstance(patch_fut, t.Awaitable)
+    client = await patch_fut
     response = client.chat.completions.create(
         model="tensorzero::model_name::dummy::json",
         messages=[
@@ -2074,7 +2205,7 @@ def test_patch_openai_client_with_config():
     )
     response = client.chat.completions.create(
         model="tensorzero::function_name::json_success",
-        messages=[
+        messages=[  # type: ignore
             {
                 "role": "system",
                 "content": [
@@ -2121,11 +2252,13 @@ async def test_patch_async_openai_client_sync_setup():
 @pytest.mark.asyncio
 async def test_patch_async_openai_client_async_setup():
     client = AsyncOpenAI()
-    client = await tensorzero.patch_openai_client(
+    patch_fut = tensorzero.patch_openai_client(
         client,
         config_file="../../examples/quickstart/config/tensorzero.toml",
         async_setup=True,
     )
+    assert isinstance(patch_fut, t.Awaitable)
+    client = await patch_fut
     response = await client.chat.completions.create(
         model="tensorzero::model_name::dummy::json",
         messages=[
@@ -2162,6 +2295,7 @@ async def test_patch_openai_missing_await():
         str(exc_info.value)
         == "TensorZero: Please await the result of `tensorzero.patch_openai_client` before using the client."
     )
+    assert isinstance(patch_fut, t.Awaitable)
     # Await this before we exit the test, to avoid spurious 'Event loop is closed' errors
     await patch_fut
 
@@ -2190,6 +2324,7 @@ async def test_patch_async_openai_missing_await():
         == "TensorZero: Please await the result of `tensorzero.patch_openai_client` before using the client."
     )
     # Await this before we exit the test, to avoid spurious 'Event loop is closed' errors
+    assert isinstance(patch_fut, t.Awaitable)
     await patch_fut
 
 
@@ -2232,30 +2367,39 @@ def test_repeated_patch_openai_client_sync_setup():
 @pytest.mark.asyncio
 async def test_repeated_patch_openai_client_async_setup():
     sync_client = OpenAI()
-    await tensorzero.patch_openai_client(
+    patch_fut = tensorzero.patch_openai_client(
         sync_client,
         config_file="../../examples/quickstart/config/tensorzero.toml",
         async_setup=True,
     )
+    assert isinstance(patch_fut, t.Awaitable)
+    await patch_fut
+
     with pytest.raises(RuntimeError) as exc_info:
-        await tensorzero.patch_openai_client(
+        new_patch_fut = tensorzero.patch_openai_client(
             sync_client, config_file="../../examples/quickstart/config/tensorzero.toml"
         )
+        assert isinstance(new_patch_fut, t.Awaitable)
+        await new_patch_fut
     assert (
         str(exc_info.value)
         == "TensorZero: Already called 'tensorzero.patch_openai_client' on this OpenAI client."
     )
 
     async_client = AsyncOpenAI()
-    await tensorzero.patch_openai_client(
+    async_patch_fut = tensorzero.patch_openai_client(
         async_client,
         config_file="../../examples/quickstart/config/tensorzero.toml",
         async_setup=True,
     )
+    assert isinstance(async_patch_fut, t.Awaitable)
+    await async_patch_fut
     with pytest.raises(RuntimeError) as exc_info:
-        await tensorzero.patch_openai_client(
+        new_async_patch_fut = tensorzero.patch_openai_client(
             async_client, config_file="../../examples/quickstart/config/tensorzero.toml"
         )
+        assert isinstance(new_async_patch_fut, t.Awaitable)
+        await new_async_patch_fut
     assert (
         str(exc_info.value)
         == "TensorZero: Already called 'tensorzero.patch_openai_client' on this OpenAI client."
@@ -2265,21 +2409,23 @@ async def test_repeated_patch_openai_client_async_setup():
 @pytest.mark.asyncio
 async def test_close_patch_openai_client():
     sync_client = OpenAI()
-    await tensorzero.patch_openai_client(
+    patch_fut = tensorzero.patch_openai_client(
         sync_client,
         config_file="../../examples/quickstart/config/tensorzero.toml",
         async_setup=True,
     )
+    assert isinstance(patch_fut, t.Awaitable)
+    await patch_fut
     tensorzero.close_patched_openai_client_gateway(sync_client)
 
 
 @pytest.mark.asyncio
-async def test_async_multi_turn_parallel_tool_use(async_client):
+async def test_async_multi_turn_parallel_tool_use(async_client: AsyncTensorZeroGateway):
     episode_id = str(uuid7())
 
     system = {"assistant_name": "Dr. Mehta"}
 
-    messages = [
+    messages: t.List[t.Dict[str, t.Any]] = [
         {
             "role": "user",
             "content": [
@@ -2301,6 +2447,7 @@ async def test_async_multi_turn_parallel_tool_use(async_client):
         },
         parallel_tool_calls=True,
     )
+    assert isinstance(response, ChatInferenceResponse)
 
     messages.append(
         {
@@ -2311,12 +2458,13 @@ async def test_async_multi_turn_parallel_tool_use(async_client):
 
     assert len(response.content) == 2
 
-    new_content_blocks = []
+    new_content_blocks: t.List[t.Dict[str, t.Any]] = []
 
     for content_block in response.content:
         if content_block.type == "text":
             print("Got a text block...")
         elif content_block.type == "tool_call":
+            assert isinstance(content_block, ToolCall)
             if content_block.name == "get_temperature":
                 print("Calling get_temperature tool...")
                 new_content_blocks.append(
@@ -2358,14 +2506,16 @@ async def test_async_multi_turn_parallel_tool_use(async_client):
             "system": system,
         },
     )
-
+    assert isinstance(response, ChatInferenceResponse)
+    assert isinstance(response.content[0], Text)
     assistant_message = response.content[0].text
+    assert assistant_message is not None
 
     assert "70" in assistant_message
     assert "30" in assistant_message
 
 
-def test_text_arguments_deprecation_1170_warning(sync_client):
+def test_text_arguments_deprecation_1170_warning(sync_client: TensorZeroGateway):
     """Test that using Text with dictionary for text parameter works but emits DeprecationWarning for #1170."""
 
     with pytest.warns(
@@ -2379,7 +2529,8 @@ def test_text_arguments_deprecation_1170_warning(sync_client):
                 "messages": [
                     {
                         "role": "user",
-                        "content": [Text(type="text", text={"country": "Japan"})],
+                        # Intentionally ignore the type error to check the deprecation warning
+                        "content": [Text(type="text", text={"country": "Japan"})],  # type: ignore
                     }
                 ],
             },

--- a/clients/python-pyo3/tests/test_client.py
+++ b/clients/python-pyo3/tests/test_client.py
@@ -32,11 +32,9 @@ from uuid import UUID
 
 import pytest
 import pytest_asyncio
+import tensorzero
 from openai import AsyncOpenAI, OpenAI
 from pytest import FixtureRequest
-from uuid_utils import uuid7
-
-import tensorzero
 from tensorzero import (
     AsyncTensorZeroGateway,
     ChatInferenceResponse,
@@ -57,6 +55,7 @@ from tensorzero import (
     ToolResult,
 )
 from tensorzero.types import ChatChunk, JsonChunk, Thought, ToolCallChunk
+from uuid_utils import uuid7
 
 TEST_CONFIG_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),


### PR DESCRIPTION
Running pyright on test_client.py revealed several issues with our typing stubs. We now use 'Iterator' instead of 'Generator', and accept/return a 'Union' in more places.

Based on https://github.com/tensorzero/tensorzero/pull/1500

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enable Pyright for `test_client.py` and update type annotations to use `Iterator` and `Union` for better type safety.
> 
>   - **Type Annotations**:
>     - Changed `Generator` to `Iterator` and `AsyncGenerator` to `AsyncIterator` in `tensorzero.pyi`.
>     - Updated function signatures to use `Union` for input types in `tensorzero.pyi`.
>     - Added type assertions and checks in `test_client.py` to ensure correct types are used.
>   - **Behavior**:
>     - Enabled Pyright type checking for `test_client.py` by removing `# type: ignore` comments.
>     - Added type checks for `awaitable` and `iterator` in `test_client.py`.
>   - **Misc**:
>     - Added `uuid_utils` import in `tensorzero.pyi` for UUID handling.
>     - Added `inspect` import in `test_client.py` for runtime type checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7bc572a05f373dc279474c2561e96fc9332a38bc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->