### PR TITLE
Changing util.py to return a uuid of type UUID

### DIFF
--- a/clients/python-pyo3/tensorzero/util.py
+++ b/clients/python-pyo3/tensorzero/util.py
@@ -1,3 +1,11 @@
-from uuid_utils import uuid7
+from uuid import UUID
+from uuid_utils import uuid7 as _uuid7
+
+def uuid7() -> UUID:
+    """
+    Generate a UUID v7 using uuid_utils and convert it to a standard uuid.UUID.
+    This ensures type compatibility with the rest of the TensorZero client.
+    """
+    return UUID(str(_uuid7()))
 
 __all__ = ["uuid7"]

--- a/clients/python-pyo3/tensorzero/util.py
+++ b/clients/python-pyo3/tensorzero/util.py
@@ -1,10 +1,14 @@
-from uuid_utils import compat as uuid
+import uuid
+
+from uuid_utils import compat
+
 
 def uuid7() -> uuid.UUID:
     """
     Generate a UUID v7 using uuid_utils compatibility layer.
     This ensures type compatibility with the rest of the TensorZero client.
     """
-    return uuid.uuid7()
+    return compat.uuid7()
+
 
 __all__ = ["uuid7"]

--- a/clients/python-pyo3/tensorzero/util.py
+++ b/clients/python-pyo3/tensorzero/util.py
@@ -1,11 +1,10 @@
-from uuid import UUID
-from uuid_utils import uuid7 as _uuid7
+from uuid_utils import compat as uuid
 
-def uuid7() -> UUID:
+def uuid7() -> uuid.UUID:
     """
-    Generate a UUID v7 using uuid_utils and convert it to a standard uuid.UUID.
+    Generate a UUID v7 using uuid_utils compatibility layer.
     This ensures type compatibility with the rest of the TensorZero client.
     """
-    return UUID(str(_uuid7()))
+    return uuid.uuid7()
 
 __all__ = ["uuid7"]


### PR DESCRIPTION
Addresses https://github.com/tensorzero/tensorzero/issues/1184. 
> Figure out why pyright is not catching this (probably an optional lint)

I think this is because there is no pyrightconfig.json file for tensorzero client (unlike the open AI client). I tried to create one and added it 
```{
  "typeCheckingMode": "strict"
}
```
but it shows multiple type check errors so I'm not including them in this PR. Let me know if I should do that.
Would appreciate any insights / reviews / concerns on the PR. 

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `uuid7()` in `util.py` to return a `UUID` object for type compatibility and add a docstring.
> 
>   - **Functionality**:
>     - Modify `uuid7()` in `util.py` to return a `UUID` object instead of a string for type compatibility.
>     - Add docstring to `uuid7()` to explain its purpose.
>   - **Imports**:
>     - Import `UUID` from `uuid`.
>     - Alias `uuid7` from `uuid_utils` as `_uuid7`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 61995942b8039e9e3ff9698dda39625110a13dd9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->