### PR TITLE
Added handling for images to address https://github.com/tensorzero/tensorzero/issues/1132

### DIFF
--- a/ui/app/utils/supervised_fine_tuning/openai.ts
+++ b/ui/app/utils/supervised_fine_tuning/openai.ts
@@ -279,9 +279,22 @@ export function content_block_to_openai_message(
         content: content.result,
       };
     case "image":
-      throw new Error(
-        "Image content is not supported for OpenAI fine-tuning. We have an open issue for this feature at https://github.com/tensorzero/tensorzero/issues/1132.",
-      );
+      // For fine-tuning, we need to ensure the image URL is accessible
+      const imageUrl = content.image.url;
+      if (!imageUrl) {
+        throw new Error("Image URL is required for fine-tuning");
+      }
+      return {
+        role: role as OpenAIRole,
+        content: [{
+          type: "image_url",
+          image_url: {
+            url: imageUrl,
+          },
+        }],
+      };
+    default:
+      throw new Error(`Unsupported content type: ${(content as any).type}`);
   }
 }
 

--- a/ui/app/utils/supervised_fine_tuning/types.ts
+++ b/ui/app/utils/supervised_fine_tuning/types.ts
@@ -4,7 +4,12 @@ export type OpenAIRole = (typeof OPENAI_ROLES)[number];
 
 export type OpenAIMessage = {
   role: OpenAIRole;
-  content?: string;
+  content?: string | Array<{
+    type: "image_url";
+    image_url: {
+      url: string;
+    };
+  }>;
   name?: string;
   function_call?: {
     name: string;


### PR DESCRIPTION
* Addresses: https://github.com/tensorzero/tensorzero/issues/1132
* Made changes to  openai.ts to not throw error if the content is of type image. Instead it should return OpenAIMessage in correspondence with the docs (https://openai.com/index/introducing-vision-to-the-fine-tuning-api/)
* Made changes to types.ts, specifically to the OpenAIMessage class to be able to handle image types according to the docs 

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for image content in OpenAI fine-tuning by handling image URLs in `openai.ts` and updating `OpenAIMessage` in `types.ts`.
> 
>   - **Behavior**:
>     - `content_block_to_openai_message()` in `openai.ts` now handles `image` type by returning an `OpenAIMessage` with `image_url`.
>     - Throws error if `image_url` is missing.
>   - **Types**:
>     - `OpenAIMessage` in `types.ts` updated to include `content` as `string` or `image_url` array.
>   - **Misc**:
>     - Removes error for unsupported image content in `openai.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 9167e65e6c03c5b40d01763e55565eb68ef672d9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->