### PR TITLE
Fix inference-only extra_body and expose it to Python

### DIFF
--- a/clients/python-pyo3/tensorzero/tensorzero.pyi
+++ b/clients/python-pyo3/tensorzero/tensorzero.pyi
@@ -20,6 +20,7 @@ from tensorzero import (
     InferenceInput,
     InferenceResponse,
 )
+from tensorzero.types import ExtraBody
 
 class BaseTensorZeroGateway:
     pass
@@ -87,6 +88,7 @@ class TensorZeroGateway(BaseTensorZeroGateway):
         tags: Optional[Dict[str, str]] = None,
         credentials: Optional[Dict[str, str]] = None,
         cache_options: Optional[Dict[str, Any]] = None,
+        extra_body: Optional[List[ExtraBody | Dict[str, Any]]] = None,
     ) -> Union[InferenceResponse, Iterator[InferenceChunk]]:
         """
         Make a POST request to the /inference endpoint.
@@ -115,6 +117,7 @@ class TensorZeroGateway(BaseTensorZeroGateway):
                             It should be one of: "auto", "required", "off", or {"specific": str}. The last option pins the request to a specific tool name.
         :param parallel_tool_calls: If true, the request will allow for multiple tool calls in a single inference request.
         :param tags: If set, adds tags to the inference request.
+        :param extra_body: If set, injects extra fields into the provider request body.
         :return: If stream is false, returns an InferenceResponse.
                  If stream is true, returns an async iterator that yields InferenceChunks as they come in.
         """
@@ -226,6 +229,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         tags: Optional[Dict[str, str]] = None,
         credentials: Optional[Dict[str, str]] = None,
         cache_options: Optional[Dict[str, Any]] = None,
+        extra_body: Optional[List[ExtraBody | Dict[str, Any]]] = None,
     ) -> Union[InferenceResponse, AsyncIterator[InferenceChunk]]:
         """
         Make a POST request to the /inference endpoint.
@@ -254,6 +258,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
                             It should be one of: "auto", "required", "off", or {"specific": str}. The last option pins the request to a specific tool name.
         :param parallel_tool_calls: If true, the request will allow for multiple tool calls in a single inference request.
         :param tags: If set, adds tags to the inference request.
+        :param extra_body: If set, injects extra fields into the provider request body.
         :return: If stream is false, returns an InferenceResponse.
                  If stream is true, returns an async iterator that yields InferenceChunks as they come in.
         """

--- a/clients/python-pyo3/tensorzero/types.py
+++ b/clients/python-pyo3/tensorzero/types.py
@@ -281,6 +281,21 @@ class JsonChunk:
 InferenceChunk = Union[ChatChunk, JsonChunk]
 
 
+class VariantExtraBody(TypedDict):
+    variant_name: str
+    pointer: str
+    value: t.Any
+
+
+class ProviderExtraBody(TypedDict):
+    model_provider_name: str
+    pointer: str
+    value: t.Any
+
+
+ExtraBody = Union[VariantExtraBody, ProviderExtraBody]
+
+
 def parse_inference_chunk(chunk: Dict[str, Any]) -> InferenceChunk:
     finish_reason = chunk.get("finish_reason")
     finish_reason_enum = FinishReason(finish_reason) if finish_reason else None

--- a/tensorzero-internal/src/cache.rs
+++ b/tensorzero-internal/src/cache.rs
@@ -471,7 +471,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             extra_cache_key: None,
         };
         let model_provider_request = ModelProviderRequest {
@@ -495,7 +495,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             extra_cache_key: None,
         };
         let model_provider_request = ModelProviderRequest {
@@ -521,7 +521,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             extra_cache_key: None,
         };
         let model_provider_request = ModelProviderRequest {

--- a/tensorzero-internal/src/evals/mod.rs
+++ b/tensorzero-internal/src/evals/mod.rs
@@ -531,7 +531,7 @@ mod tests {
                         seed: None,
                         json_mode: JsonMode::ImplicitTool,
                         retries: RetryConfig::default(),
-                        extra_body: None,
+                        extra_body: Default::default(),
                     },
                 ),
             );
@@ -648,7 +648,7 @@ mod tests {
                         seed: None,
                         json_mode: JsonMode::ImplicitTool,
                         retries: RetryConfig::default(),
-                        extra_body: None,
+                        extra_body: Default::default(),
                     },
                 ),
             );
@@ -797,7 +797,7 @@ mod tests {
                         seed: None,
                         json_mode: JsonMode::ImplicitTool,
                         retries: RetryConfig::default(),
-                        extra_body: None,
+                        extra_body: Default::default(),
                     },
                 ),
             );
@@ -820,7 +820,7 @@ mod tests {
                         seed: None,
                         json_mode: JsonMode::ImplicitTool,
                         retries: RetryConfig::default(),
-                        extra_body: None,
+                        extra_body: Default::default(),
                     },
                 ),
             );
@@ -931,7 +931,7 @@ mod tests {
                         seed: None,
                         json_mode: JsonMode::ImplicitTool,
                         retries: RetryConfig::default(),
-                        extra_body: None,
+                        extra_body: Default::default(),
                     },
                 ),
             );

--- a/tensorzero-internal/src/inference/providers/anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/anthropic.rs
@@ -1468,7 +1468,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let anthropic_request_body = AnthropicRequestBody::new(&model, &inference_request);
@@ -1500,7 +1500,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let anthropic_request_body = AnthropicRequestBody::new(&model, &inference_request);
@@ -1550,7 +1550,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let anthropic_request_body = AnthropicRequestBody::new(&model, &inference_request);
@@ -1604,7 +1604,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let anthropic_request_body = AnthropicRequestBody::new(&model, &inference_request);
@@ -1658,7 +1658,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::On,
             function_type: FunctionType::Json,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let anthropic_request_body = AnthropicRequestBody::new(&model, &inference_request);

--- a/tensorzero-internal/src/inference/providers/aws_bedrock.rs
+++ b/tensorzero-internal/src/inference/providers/aws_bedrock.rs
@@ -106,7 +106,7 @@ fn attach_interceptor<T, E: std::error::Error + Send + Sync, S>(
         /// Captures the raw request from `modify_before_signing`.
         /// After the request is executed, we use this to retrieve the raw request.
         raw_request: Arc<Mutex<Option<String>>>,
-        extra_body: Option<FullExtraBodyConfig>,
+        extra_body: FullExtraBodyConfig,
         model_provider_info: ModelProviderRequestInfo,
         model_name: String,
     }

--- a/tensorzero-internal/src/inference/providers/azure.rs
+++ b/tensorzero-internal/src/inference/providers/azure.rs
@@ -528,7 +528,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&WEATHER_TOOL_CONFIG)),
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -574,7 +574,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&WEATHER_TOOL_CONFIG)),
             function_type: FunctionType::Json,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -719,7 +719,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let azure_response_with_metadata = AzureResponseWithMetadata {

--- a/tensorzero-internal/src/inference/providers/deepseek.rs
+++ b/tensorzero-internal/src/inference/providers/deepseek.rs
@@ -813,7 +813,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&WEATHER_TOOL_CONFIG)),
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -859,7 +859,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&WEATHER_TOOL_CONFIG)),
             function_type: FunctionType::Json,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -978,7 +978,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let deepseek_response_with_metadata = DeepSeekResponseWithMetadata {
@@ -1042,7 +1042,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -1090,7 +1090,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -1127,7 +1127,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 

--- a/tensorzero-internal/src/inference/providers/fireworks.rs
+++ b/tensorzero-internal/src/inference/providers/fireworks.rs
@@ -526,7 +526,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&WEATHER_TOOL_CONFIG)),
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -640,7 +640,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let fireworks_response_with_metadata = FireworksResponseWithMetadata {

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
@@ -1231,7 +1231,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let anthropic_request_body = GCPVertexAnthropicRequestBody::new(&inference_request);
@@ -1269,7 +1269,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let anthropic_request_body = GCPVertexAnthropicRequestBody::new(&inference_request);
@@ -1324,7 +1324,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::On,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let anthropic_request_body = GCPVertexAnthropicRequestBody::new(&inference_request);
@@ -1393,7 +1393,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::On,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -1806,7 +1806,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let request_body = GCPVertexAnthropicRequestBody {
@@ -1887,7 +1887,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let request_body = GCPVertexAnthropicRequestBody {
@@ -1977,7 +1977,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let request_body = GCPVertexAnthropicRequestBody {

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
@@ -1390,7 +1390,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let result = GCPVertexGeminiRequest::new(&inference_request, "gemini-pro");
@@ -1428,7 +1428,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let result = GCPVertexGeminiRequest::new(&inference_request, "gemini-pro");
@@ -1479,7 +1479,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::On,
             function_type: FunctionType::Chat,
             output_schema: Some(&output_schema),
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         // JSON schema should be supported for Gemini Pro models
@@ -1547,7 +1547,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::On,
             function_type: FunctionType::Chat,
             output_schema: Some(&output_schema),
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         // JSON mode should be supported for Gemini Flash models but without a schema
@@ -1647,7 +1647,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let request_body = GCPVertexGeminiRequest {
@@ -1733,7 +1733,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let request_body = GCPVertexGeminiRequest {
@@ -1908,7 +1908,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&MULTI_TOOL_CONFIG)),
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let (tools, tool_choice) = prepare_tools(&request_with_tools, "gemini-1.5-pro-001");
@@ -1952,7 +1952,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&MULTI_TOOL_CONFIG)),
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let (tools, tool_choice) = prepare_tools(&request_with_tools, "gemini-2.0-flash-lite");

--- a/tensorzero-internal/src/inference/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/google_ai_studio_gemini.rs
@@ -1194,7 +1194,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let result = GeminiRequest::new(&inference_request);
@@ -1232,7 +1232,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let result = GeminiRequest::new(&inference_request);
@@ -1283,7 +1283,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::On,
             function_type: FunctionType::Chat,
             output_schema: Some(&output_schema),
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         // JSON schema should be supported for Gemini Pro models
@@ -1386,7 +1386,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let request_body = GeminiRequest {
@@ -1475,7 +1475,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let request_body = GeminiRequest {
@@ -1653,7 +1653,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&MULTI_TOOL_CONFIG)),
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let (tools, tool_choice) = prepare_tools(&request_with_tools);
@@ -1696,7 +1696,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&MULTI_TOOL_CONFIG)),
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let (tools, tool_choice) = prepare_tools(&request_with_tools);

--- a/tensorzero-internal/src/inference/providers/hyperbolic.rs
+++ b/tensorzero-internal/src/inference/providers/hyperbolic.rs
@@ -453,7 +453,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&WEATHER_TOOL_CONFIG)),
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -540,7 +540,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let hyperbolic_response_with_metadata = HyperbolicResponseWithMetadata {

--- a/tensorzero-internal/src/inference/providers/mistral.rs
+++ b/tensorzero-internal/src/inference/providers/mistral.rs
@@ -796,7 +796,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&WEATHER_TOOL_CONFIG)),
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -857,7 +857,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&WEATHER_TOOL_CONFIG)),
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -952,7 +952,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&WEATHER_TOOL_CONFIG)),
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let request_body = MistralRequest {

--- a/tensorzero-internal/src/inference/providers/openai.rs
+++ b/tensorzero-internal/src/inference/providers/openai.rs
@@ -2262,7 +2262,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -2304,7 +2304,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&WEATHER_TOOL_CONFIG)),
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -2356,7 +2356,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -2397,7 +2397,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: Some(&output_schema),
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -2441,7 +2441,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -2481,7 +2481,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -2550,7 +2550,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -2647,7 +2647,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -2826,7 +2826,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&MULTI_TOOL_CONFIG)),
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let (tools, tool_choice, parallel_tool_calls) = prepare_openai_tools(&request_with_tools);
@@ -2868,7 +2868,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&tool_config)),
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let (tools, tool_choice, parallel_tool_calls) =

--- a/tensorzero-internal/src/inference/providers/sglang.rs
+++ b/tensorzero-internal/src/inference/providers/sglang.rs
@@ -508,7 +508,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let sglang_request = SGLangRequest::new(&model_name, &basic_request).unwrap();
@@ -545,7 +545,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&WEATHER_TOOL_CONFIG)),
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         SGLangRequest::new(&model_name, &request_with_tools).expect_err("requires a schema");
@@ -569,7 +569,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         SGLangRequest::new(&model_name, &request_with_tools).expect_err("requires a schema");
@@ -594,7 +594,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: Some(&output_schema),
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -646,7 +646,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let sglang_response_with_metadata = SGLangResponseWithMetadata {

--- a/tensorzero-internal/src/inference/providers/tgi.rs
+++ b/tensorzero-internal/src/inference/providers/tgi.rs
@@ -755,7 +755,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let tgi_request = TGIRequest::new(&model_name, &basic_request).unwrap();
@@ -792,7 +792,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&WEATHER_TOOL_CONFIG)),
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -840,7 +840,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -876,7 +876,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: Some(&output_schema),
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -950,7 +950,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let tgi_response_with_metadata = TGIResponseWithMetadata {

--- a/tensorzero-internal/src/inference/providers/together.rs
+++ b/tensorzero-internal/src/inference/providers/together.rs
@@ -914,7 +914,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&WEATHER_TOOL_CONFIG)),
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -1015,7 +1015,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let together_response_with_metadata = TogetherResponseWithMetadata {

--- a/tensorzero-internal/src/inference/providers/vllm.rs
+++ b/tensorzero-internal/src/inference/providers/vllm.rs
@@ -492,7 +492,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: Some(&output_schema),
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -530,7 +530,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&WEATHER_TOOL_CONFIG)),
             function_type: FunctionType::Chat,
             output_schema: Some(&output_schema),
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -605,7 +605,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let vllm_response_with_metadata = VLLMResponseWithMetadata {

--- a/tensorzero-internal/src/inference/providers/xai.rs
+++ b/tensorzero-internal/src/inference/providers/xai.rs
@@ -510,7 +510,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&WEATHER_TOOL_CONFIG)),
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -556,7 +556,7 @@ mod tests {
             tool_config: Some(Cow::Borrowed(&WEATHER_TOOL_CONFIG)),
             function_type: FunctionType::Json,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -658,7 +658,7 @@ mod tests {
             tool_config: None,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let xai_response_with_metadata = XAIResponseWithMetadata {

--- a/tensorzero-internal/src/inference/types/extra_body.rs
+++ b/tensorzero-internal/src/inference/types/extra_body.rs
@@ -50,7 +50,7 @@ pub struct FilteredInferenceExtraBody {
 /// Holds the config-level and inference-level extra body options
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct FullExtraBodyConfig {
-    pub extra_body: ExtraBodyConfig,
+    pub extra_body: Option<ExtraBodyConfig>,
     pub inference_extra_body: FilteredInferenceExtraBody,
 }
 

--- a/tensorzero-internal/src/inference/types/mod.rs
+++ b/tensorzero-internal/src/inference/types/mod.rs
@@ -382,7 +382,7 @@ pub struct ModelInferenceRequest<'a> {
     pub json_mode: ModelInferenceRequestJsonMode,
     pub function_type: FunctionType,
     pub output_schema: Option<&'a Value>,
-    pub extra_body: Option<FullExtraBodyConfig>,
+    pub extra_body: FullExtraBodyConfig,
     /// Optional arbitrary data, only used when constructing the cache key.
     /// This is used by best_of_n/mixture_of_n to force different sub-variants
     /// to have different cache keys.

--- a/tensorzero-internal/src/model.rs
+++ b/tensorzero-internal/src/model.rs
@@ -1348,7 +1348,7 @@ impl ShorthandModelConfig for ModelConfig {
                 ModelProvider {
                     name: provider_type.into(),
                     config: provider_config,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         })
@@ -1446,7 +1446,7 @@ mod tests {
                 ModelProvider {
                     name: "good_provider".into(),
                     config: good_provider_config,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         };
@@ -1484,7 +1484,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let model_name = "test model";
@@ -1511,7 +1511,7 @@ mod tests {
                 ModelProvider {
                     name: "error".into(),
                     config: bad_provider_config,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         };
@@ -1580,7 +1580,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -1595,7 +1595,7 @@ mod tests {
                     ModelProvider {
                         name: "error_provider".into(),
                         config: bad_provider_config,
-                        extra_body: None,
+                        extra_body: Default::default(),
                     },
                 ),
                 (
@@ -1603,7 +1603,7 @@ mod tests {
                     ModelProvider {
                         name: "good_provider".into(),
                         config: good_provider_config,
-                        extra_body: None,
+                        extra_body: Default::default(),
                     },
                 ),
             ]),
@@ -1656,7 +1656,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -1668,7 +1668,7 @@ mod tests {
                 ModelProvider {
                     name: "good_provider".into(),
                     config: good_provider_config,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         };
@@ -1736,7 +1736,7 @@ mod tests {
                 ModelProvider {
                     name: "error".to_string().into(),
                     config: bad_provider_config,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         };
@@ -1809,7 +1809,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -1822,7 +1822,7 @@ mod tests {
                     ModelProvider {
                         name: "error_provider".to_string().into(),
                         config: bad_provider_config,
-                        extra_body: None,
+                        extra_body: Default::default(),
                     },
                 ),
                 (
@@ -1830,7 +1830,7 @@ mod tests {
                     ModelProvider {
                         name: "good_provider".to_string().into(),
                         config: good_provider_config,
-                        extra_body: None,
+                        extra_body: Default::default(),
                     },
                 ),
             ]),
@@ -1907,7 +1907,7 @@ mod tests {
                 ModelProvider {
                     name: "model".into(),
                     config: provider_config,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         };
@@ -1944,7 +1944,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let model_name = "test model";
@@ -2012,7 +2012,7 @@ mod tests {
                 ModelProvider {
                     name: "model".to_string().into(),
                     config: provider_config,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         };
@@ -2049,7 +2049,7 @@ mod tests {
             json_mode: ModelInferenceRequestJsonMode::Off,
             function_type: FunctionType::Chat,
             output_schema: None,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let error = model_config
@@ -2131,7 +2131,7 @@ mod tests {
                 ModelProvider {
                     name: "anthropic".into(),
                     config: anthropic_provider_config,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         };

--- a/tensorzero-internal/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-internal/src/variant/best_of_n_sampling.rs
@@ -668,6 +668,10 @@ impl EvaluatorConfig {
             }
             .into());
         }
+        let extra_body = FullExtraBodyConfig {
+            extra_body: self.inner.extra_body.clone(),
+            inference_extra_body: Default::default(),
+        };
         Ok((
             ModelInferenceRequest {
                 inference_id: inference_config.ids.inference_id,
@@ -684,10 +688,7 @@ impl EvaluatorConfig {
                 json_mode: json_mode.into(),
                 function_type: FunctionType::Json,
                 output_schema: Some(EVALUATOR_OUTPUT_SCHEMA.value),
-                extra_body: self.inner.extra_body.clone().map(|c| FullExtraBodyConfig {
-                    extra_body: c,
-                    inference_extra_body: Default::default(),
-                }),
+                extra_body,
                 extra_cache_key: inference_config.extra_cache_key.clone(),
             },
             skipped_indices,
@@ -1202,7 +1203,7 @@ mod tests {
                             model_name: "best_of_n_1".into(),
                             ..Default::default()
                         }),
-                        extra_body: None,
+                        extra_body: Default::default(),
                     },
                 )]),
             },
@@ -1297,7 +1298,7 @@ mod tests {
                                 model_name: "error".into(),
                                 ..Default::default()
                             }),
-                            extra_body: None,
+                            extra_body: Default::default(),
                         },
                     )]),
                 },
@@ -1360,7 +1361,7 @@ mod tests {
                                 model_name: "regular".into(),
                                 ..Default::default()
                             }),
-                            extra_body: None,
+                            extra_body: Default::default(),
                         },
                     )]),
                 },
@@ -1440,7 +1441,7 @@ mod tests {
                             model_name: "best_of_n_big".into(),
                             ..Default::default()
                         }),
-                        extra_body: None,
+                        extra_body: Default::default(),
                     },
                 )]),
             },

--- a/tensorzero-internal/src/variant/chat_completion.rs
+++ b/tensorzero-internal/src/variant/chat_completion.rs
@@ -207,6 +207,14 @@ impl ChatCompletionConfig {
                 self.presence_penalty,
                 self.frequency_penalty,
             );
+
+        let extra_body = FullExtraBodyConfig {
+            extra_body: self.extra_body.clone(),
+            inference_extra_body: inference_config
+                .extra_body
+                .clone()
+                .filter(inference_config.variant_name),
+        };
         prepare_model_inference_request(
             messages,
             system,
@@ -215,16 +223,7 @@ impl ChatCompletionConfig {
             stream,
             inference_params,
             self.json_mode,
-            self.extra_body.clone().map(|extra_body| {
-                let inference_extra_body = inference_config
-                    .extra_body
-                    .clone()
-                    .filter(inference_config.variant_name);
-                FullExtraBodyConfig {
-                    extra_body,
-                    inference_extra_body,
-                }
-            }),
+            extra_body,
         )
     }
 }
@@ -507,7 +506,7 @@ mod tests {
             max_tokens: None,
             seed: None,
             retries: RetryConfig::default(),
-            extra_body: None,
+            extra_body: Default::default(),
         };
 
         // Test case 1: Regular user message
@@ -867,7 +866,7 @@ mod tests {
                 ModelProvider {
                     name: "good".into(),
                     config: good_provider_config,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         };
@@ -878,7 +877,7 @@ mod tests {
                 ModelProvider {
                     name: "json_provider".into(),
                     config: json_provider_config,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         };
@@ -893,7 +892,7 @@ mod tests {
                 ModelProvider {
                     name: "tool_provider".into(),
                     config: tool_provider_config,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         };
@@ -904,7 +903,7 @@ mod tests {
                 ModelProvider {
                     name: "error".into(),
                     config: error_provider_config,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         };
@@ -1091,7 +1090,7 @@ mod tests {
                 ModelProvider {
                     name: "good_provider".into(),
                     config: good_provider_config,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         };
@@ -1351,7 +1350,7 @@ mod tests {
                 path: user_template_name.into(),
                 contents: "".to_string(),
             }),
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
         let result = chat_completion_config
@@ -1649,7 +1648,7 @@ mod tests {
                 ModelProvider {
                     name: "good_provider".into(),
                     config: good_provider_config,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         };
@@ -1660,7 +1659,7 @@ mod tests {
                 ModelProvider {
                     name: "error_provider".into(),
                     config: error_provider_config,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         };

--- a/tensorzero-internal/src/variant/dicl.rs
+++ b/tensorzero-internal/src/variant/dicl.rs
@@ -513,6 +513,10 @@ impl DiclConfig {
             }
             .into());
         }
+        let extra_body = FullExtraBodyConfig {
+            extra_body: self.extra_body.clone(),
+            inference_extra_body: Default::default(),
+        };
         prepare_model_inference_request(
             messages,
             system,
@@ -521,12 +525,7 @@ impl DiclConfig {
             stream,
             inference_params,
             self.json_mode,
-            self.extra_body
-                .clone()
-                .map(|extra_body| FullExtraBodyConfig {
-                    extra_body,
-                    inference_extra_body: Default::default(),
-                }),
+            extra_body,
         )
     }
 }

--- a/tensorzero-internal/src/variant/mixture_of_n.rs
+++ b/tensorzero-internal/src/variant/mixture_of_n.rs
@@ -539,6 +539,10 @@ impl FuserConfig {
             }
             .into());
         }
+        let extra_body = FullExtraBodyConfig {
+            extra_body: self.inner.extra_body.clone(),
+            inference_extra_body: Default::default(),
+        };
         let model_inference_request = prepare_model_inference_request(
             messages,
             system,
@@ -547,13 +551,7 @@ impl FuserConfig {
             false,
             inference_params,
             self.inner.json_mode,
-            self.inner
-                .extra_body
-                .clone()
-                .map(|extra_body| FullExtraBodyConfig {
-                    extra_body,
-                    inference_extra_body: Default::default(),
-                }),
+            extra_body,
         )?;
         Ok((model_inference_request, included_indices))
     }
@@ -1033,7 +1031,7 @@ mod tests {
                             model_name: "json".into(),
                             ..Default::default()
                         }),
-                        extra_body: None,
+                        extra_body: Default::default(),
                     },
                 )]),
             },
@@ -1127,7 +1125,7 @@ mod tests {
                                 model_name: "error".into(),
                                 ..Default::default()
                             }),
-                            extra_body: None,
+                            extra_body: Default::default(),
                         },
                     )]),
                 },
@@ -1191,7 +1189,7 @@ mod tests {
                                 model_name: "regular".into(),
                                 ..Default::default()
                             }),
-                            extra_body: None,
+                            extra_body: Default::default(),
                         },
                     )]),
                 },

--- a/tensorzero-internal/src/variant/mod.rs
+++ b/tensorzero-internal/src/variant/mod.rs
@@ -409,7 +409,7 @@ fn prepare_model_inference_request<'a, 'request>(
     stream: bool,
     inference_params: &InferenceParams,
     base_json_mode: Option<JsonMode>,
-    extra_body: Option<FullExtraBodyConfig>,
+    extra_body: FullExtraBodyConfig,
 ) -> Result<ModelInferenceRequest<'request>, Error>
 where
     'a: 'request,
@@ -707,7 +707,7 @@ mod tests {
             stream,
             &inference_params,
             Some(json_mode),
-            None,
+            Default::default(),
         )
         .unwrap();
 
@@ -755,7 +755,7 @@ mod tests {
             stream,
             &inference_params,
             Some(json_mode),
-            None,
+            Default::default(),
         )
         .unwrap();
 
@@ -802,7 +802,7 @@ mod tests {
             stream,
             &inference_params,
             Some(json_mode),
-            None,
+            Default::default(),
         )
         .unwrap();
 
@@ -825,7 +825,7 @@ mod tests {
             stream,
             &inference_params,
             Some(json_mode),
-            None,
+            Default::default(),
         )
         .unwrap();
 
@@ -844,7 +844,7 @@ mod tests {
             stream,
             &inference_params,
             Some(json_mode),
-            None,
+            Default::default(),
         )
         .unwrap();
 
@@ -916,7 +916,7 @@ mod tests {
             output_schema: None,
             tool_config: None,
             function_type: FunctionType::Chat,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -934,7 +934,7 @@ mod tests {
                 ModelProvider {
                     name: model_name.into(),
                     config: dummy_provider_config,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         };
@@ -1021,7 +1021,7 @@ mod tests {
             output_schema: Some(&output_schema),
             tool_config: None,
             function_type: FunctionType::Json,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -1038,7 +1038,7 @@ mod tests {
                 ModelProvider {
                     name: model_name_json.into(),
                     config: dummy_provider_config_json,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         };
@@ -1092,7 +1092,7 @@ mod tests {
                 ModelProvider {
                     name: error_model_name.into(),
                     config: error_provider_config,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         };
@@ -1184,7 +1184,7 @@ mod tests {
             output_schema: None,
             tool_config: None,
             function_type: FunctionType::Chat,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -1209,7 +1209,7 @@ mod tests {
                     ModelProvider {
                         name: error_model_name.into(),
                         config: error_provider_config,
-                        extra_body: None,
+                        extra_body: Default::default(),
                     },
                 ),
                 (
@@ -1217,7 +1217,7 @@ mod tests {
                     ModelProvider {
                         name: model_name.into(),
                         config: dummy_provider_config,
-                        extra_body: None,
+                        extra_body: Default::default(),
                     },
                 ),
             ]),
@@ -1312,7 +1312,7 @@ mod tests {
                 ModelProvider {
                     name: "good_provider".into(),
                     config: dummy_provider_config,
-                    extra_body: None,
+                    extra_body: Default::default(),
                 },
             )]),
         }));
@@ -1333,7 +1333,7 @@ mod tests {
             seed: None,
             tool_config: None,
             function_type: FunctionType::Chat,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -1454,7 +1454,7 @@ mod tests {
             output_schema: None,
             tool_config: None,
             function_type: FunctionType::Chat,
-            extra_body: None,
+            extra_body: Default::default(),
             ..Default::default()
         };
 
@@ -1479,7 +1479,7 @@ mod tests {
                     ModelProvider {
                         name: error_model_name.into(),
                         config: error_provider_config,
-                        extra_body: None,
+                        extra_body: Default::default(),
                     },
                 ),
                 (
@@ -1487,7 +1487,7 @@ mod tests {
                     ModelProvider {
                         name: model_name.into(),
                         config: dummy_provider_config,
-                        extra_body: None,
+                        extra_body: Default::default(),
                     },
                 ),
             ]),

--- a/tensorzero-internal/tests/e2e/cache.rs
+++ b/tensorzero-internal/tests/e2e/cache.rs
@@ -65,7 +65,7 @@ async fn test_cache_write_and_read() {
         json_mode: ModelInferenceRequestJsonMode::Off,
         function_type: FunctionType::Chat,
         output_schema: None,
-        extra_body: None,
+        extra_body: Default::default(),
         ..Default::default()
     };
     let model_provider_request = ModelProviderRequest {
@@ -189,7 +189,7 @@ async fn test_cache_stream_write_and_read() {
         json_mode: ModelInferenceRequestJsonMode::Off,
         function_type: FunctionType::Chat,
         output_schema: None,
-        extra_body: None,
+        extra_body: Default::default(),
         ..Default::default()
     };
     let model_provider_request = ModelProviderRequest {


### PR DESCRIPTION
We were incorrectly ignoring the inference level 'extra_body' parameter when extra_body was unset at the provider/variant level.

The Python client can now pass an 'extra_body' parameter to 'inference' (a list of dictionaries or
'VariantExtraBody/ProviderExtraBody')

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `extra_body` handling at inference level and exposes it to Python client for inference requests.
> 
>   - **Behavior**:
>     - Fixes bug where `extra_body` was ignored at inference level when unset at provider/variant level.
>     - Allows Python client to pass `extra_body` to `inference` as a list of dictionaries or `VariantExtraBody/ProviderExtraBody`.
>   - **Code Changes**:
>     - Updates `deserialize_from_pydict` to `deserialize_from_pyobj` in `python_helpers.rs`.
>     - Modifies `prepare_inference_request` in `lib.rs` to include `extra_body` parameter.
>     - Changes `FullExtraBodyConfig` to use `Default::default()` instead of `None` in multiple files.
>   - **Tests**:
>     - Adds tests for `extra_body` handling in `test_client.py`.
>     - Updates existing tests to reflect changes in `extra_body` handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 66580eab490989ad5c670e5d41bb69b5c6898e28. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->