### PR TITLE
Minor improvements to the [M]IPRO recipe

### DIFF
--- a/recipes/mipro/config/functions/judge_answer/baseline/system_template.minijinja
+++ b/recipes/mipro/config/functions/judge_answer/baseline/system_template.minijinja
@@ -8,10 +8,10 @@ Desired Metric Properties:
 {{ metric_properties }}
 
 You will receive two inputs:
-1. prediction: The model's predicted answer.
-2. truth: The ground-truth or reference answer.
+1. Prediction: The model's predicted answer.
+2. Ground Truth: The correct or reference answer.
 
-Think step by step about how well `prediction` matches `truth`, according to the task and metric properties above.
+Think step by step about how well "Prediction" matches "Ground Truth", according to the task and metric properties above.
 Respond only with a JSON object in the following format:
 
 {

--- a/recipes/mipro/config/functions/judge_answer/baseline/user_template.minijinja
+++ b/recipes/mipro/config/functions/judge_answer/baseline/user_template.minijinja
@@ -1,2 +1,7 @@
-prediction: {{ prediction }}
-truth: {{ truth }}
+# Prediction
+
+{{ prediction }}
+
+# Ground Truth
+
+{{ ground_truth }}

--- a/recipes/mipro/config/functions/judge_answer/user_schema.json
+++ b/recipes/mipro/config/functions/judge_answer/user_schema.json
@@ -5,10 +5,10 @@
       "prediction": {
         "type": "string"
       },
-      "truth": {
+      "ground_truth": {
         "type": "string"
       }
     },
-    "required": ["prediction", "truth"],
+    "required": ["prediction", "ground_truth"],
     "additionalProperties": false
   }

--- a/recipes/mipro/mipro.ipynb
+++ b/recipes/mipro/mipro.ipynb
@@ -130,7 +130,7 @@
     "\n",
     "    - `MAX_ITERATIONS`: Number of optimization steps.\n",
     "\n",
-    "    - `MAX_DEMONSTRATIONS`: Maximum few-shot examples per demonstration."
+    "    - `MAX_EXAMPLES_PER_DEMONSTRATION`: Maximum few-shot examples per demonstration."
    ]
   },
   {
@@ -145,8 +145,8 @@
     "# Number of candidate demonstrations to sample and search over\n",
     "NUM_CANDIDATE_DEMONSTRATIONS = 10\n",
     "\n",
-    "# Maximum number of demonstrations in each example\n",
-    "MAX_DEMONSTRATIONS = 10\n",
+    "# Maximum number of examples (historical inferences) per demonstration\n",
+    "MAX_EXAMPLES_PER_DEMONSTRATION = 10\n",
     "\n",
     "# Maximum number of search steps taken by the optimization algorithm for evaluating instruction-demonstration pairs\n",
     "MAX_ITERATIONS = 5\n",
@@ -573,9 +573,11 @@
     "    df: pd.DataFrame, input_col: str, output_col: str, system_col: str, seed: int = 42\n",
     ") -> str:\n",
     "    # Perform a bootstrap sample (with replacement) of the entire DataFrame.\n",
-    "    sample = df.sample(n=MAX_DEMONSTRATIONS, replace=False, random_state=seed)\n",
+    "    sample = df.sample(\n",
+    "        n=MAX_EXAMPLES_PER_DEMONSTRATION, replace=False, random_state=seed\n",
+    "    )\n",
     "    # Remove duplicate rows that may have been sampled multiple times.\n",
-    "    # unique_sample = bootstrap_sample.drop_duplicates(subset=['episode_id'])[:MAX_DEMONSTRATIONS]\n",
+    "    # unique_sample = bootstrap_sample.drop_duplicates(subset=['episode_id'])[:MAX_EXAMPLES_PER_DEMONSTRATION]\n",
     "    demonstrations = \"\"\n",
     "    for _, row in sample.iterrows():\n",
     "        if row[system_col] is not None:\n",
@@ -705,7 +707,7 @@
     "                task_description=TASK_DESCRIPTION,\n",
     "                metric_properties=METRIC_PROPERTIES,\n",
     "                prediction=format_response(response) if response is not None else \"\",\n",
-    "                truth=str(ground_truth),\n",
+    "                ground_truth=str(ground_truth),\n",
     "                semaphore=semaphore,\n",
     "            )\n",
     "            for response, ground_truth in zip(responses, eval_df[\"value_str\"])\n",

--- a/recipes/mipro/mipro.ipynb
+++ b/recipes/mipro/mipro.ipynb
@@ -146,7 +146,7 @@
     "NUM_CANDIDATE_DEMONSTRATIONS = 10\n",
     "\n",
     "# Maximum number of examples (historical inferences) per demonstration\n",
-    "MAX_EXAMPLES_PER_DEMONSTRATION = 3\n",
+    "MAX_EXAMPLES_PER_DEMONSTRATION = 10\n",
     "\n",
     "# Maximum number of search steps taken by the optimization algorithm for evaluating instruction-demonstration pairs\n",
     "MAX_ITERATIONS = 5\n",

--- a/recipes/mipro/mipro.ipynb
+++ b/recipes/mipro/mipro.ipynb
@@ -146,7 +146,7 @@
     "NUM_CANDIDATE_DEMONSTRATIONS = 10\n",
     "\n",
     "# Maximum number of examples (historical inferences) per demonstration\n",
-    "MAX_EXAMPLES_PER_DEMONSTRATION = 10\n",
+    "MAX_EXAMPLES_PER_DEMONSTRATION = 3\n",
     "\n",
     "# Maximum number of search steps taken by the optimization algorithm for evaluating instruction-demonstration pairs\n",
     "MAX_ITERATIONS = 5\n",

--- a/recipes/mipro/utils/client_calls.py
+++ b/recipes/mipro/utils/client_calls.py
@@ -68,7 +68,7 @@ async def judge_answer(
     task_description: str,
     metric_properties: str,
     prediction: str,
-    truth: str,
+    ground_truth: str,
     semaphore: asyncio.Semaphore,
     variant_name: str = "baseline",
     dryrun: bool = True,
@@ -87,7 +87,10 @@ async def judge_answer(
                         "content": [
                             {
                                 "type": "text",
-                                "arguments": {"prediction": prediction, "truth": truth},
+                                "arguments": {
+                                    "prediction": prediction,
+                                    "ground_truth": ground_truth,
+                                },
                             }
                         ],
                     },


### PR DESCRIPTION
- `judge_answer/baseline/user_template.minijinja` previously would have bad formatting for long multi-line predictions.
- Clarify `MAX_DEMONSTRATIONS` → `MAX_EXAMPLES_PER_DEMONSTRATION`
- Normalize mixed usage of "truth" and "ground truth"
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve formatting and normalize terminology in MIPRO recipe templates and schemas.
> 
>   - **Formatting**:
>     - Improve formatting for multi-line predictions in `user_template.minijinja` by adding headers for `Prediction` and `Ground Truth`.
>   - **Terminology**:
>     - Rename `MAX_DEMONSTRATIONS` to `MAX_EXAMPLES_PER_DEMONSTRATION`.
>     - Normalize usage of "truth" to "ground truth" in `system_template.minijinja`, `user_schema.json`, and `client_calls.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 29699838ee5d2ff386c842635994b07c8e0f1d2c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->