### PR TITLE
Add script to delete ClickHouse cloud dbs, and run in pr ci

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -303,6 +303,9 @@ jobs:
         run: |
           echo "TENSORZERO_CLICKHOUSE_URL=${{ secrets.CLICKHOUSE_CLOUD_URL }}" >> $GITHUB_ENV
 
+      - name: Delete old ClickHouse cloud dbs
+        run: ./ci/delete-clickhouse-dbs.sh
+
       # We run this as a separate step so that we can see live build logs
       # (and fail the job immediately if the build fails)
       - name: Build the gateway for E2E tests

--- a/ci/delete-clickhouse-dbs.sh
+++ b/ci/delete-clickhouse-dbs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "Fetching databases"
+# Get all 'tensorzero_e2e_tests_migration_manager' databases older than 1 day (to avoid deleting dbs used by currently running tests)
+# We use the 'metadata_modification_time' of a known table ('ChatInference') to get a lower bound on the database age.
+databases=$(curl -X POST $TENSORZERO_CLICKHOUSE_URL \
+    --data-binary "select database from system.tables where name = 'ChatInference' and startsWith(database, 'tensorzero_e2e_tests_migration_manager') and metadata_modification_time < subtractDays(now(), 1);")
+
+echo "The following databases will be deleted:"
+echo "$databases"
+
+# Delete each database
+echo "$databases" | while read db; do
+    if [ -n "$db" ]; then
+        echo "Dropping database: $db"
+        curl -X POST "${TENSORZERO_CLICKHOUSE_URL%/}/?param_target=$db" \
+            --data-binary "DROP DATABASE IF EXISTS {target:Identifier}"
+        echo "Database $db dropped."
+    fi
+done
+
+echo "All matching databases have been deleted."


### PR DESCRIPTION
Fixes https://github.com/tensorzero/tensorzero/issues/1516

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a script to delete old ClickHouse databases and integrates it into the CI workflow to maintain a clean test environment.
> 
>   - **Script Addition**:
>     - Adds `delete-clickhouse-dbs.sh` to delete ClickHouse databases older than 1 day.
>     - Targets databases starting with `tensorzero_e2e_tests_migration_manager`.
>   - **CI Integration**:
>     - Updates `general.yml` to run `delete-clickhouse-dbs.sh` in `clickhouse-tests-cloud` job.
>     - Ensures old databases are deleted before running E2E tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for aba919a66a5767579e28a8e78dd47603e888fa4d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->