### PR TITLE
Paginate evaluation results page properly

### DIFF
--- a/ui/app/routes/evaluations/$eval_name/AutoRefreshIndicator.tsx
+++ b/ui/app/routes/evaluations/$eval_name/AutoRefreshIndicator.tsx
@@ -30,7 +30,7 @@ export default function AutoRefreshIndicator({
           d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
         ></path>
       </svg>
-      Auto-refreshing
+      Auto-refreshing...
     </div>
   );
 }

--- a/ui/app/utils/clickhouse/evaluations.server.ts
+++ b/ui/app/utils/clickhouse/evaluations.server.ts
@@ -160,16 +160,16 @@ export async function getEvalStatistics(
   FROM (
     ${getEvalResultDatapointIdsQuery}
   ) dp
-  LEFT JOIN TagInference datapoint_tag FINAL
+  INNER JOIN TagInference datapoint_tag FINAL
     ON dp_id = toUUIDOrNull(datapoint_tag.value)
     AND datapoint_tag.key = 'tensorzero::datapoint_id'
     AND datapoint_tag.function_name = {function_name:String}
-  LEFT JOIN {inference_table_name:Identifier} ci
+  INNER JOIN {inference_table_name:Identifier} ci
     ON datapoint_tag.inference_id = ci.id
     AND ci.function_name = {function_name:String}
     AND ci.variant_name = datapoint_tag.variant_name
     AND ci.episode_id = datapoint_tag.episode_id
-  LEFT JOIN (
+  INNER JOIN (
     SELECT target_id, metric_name, value
     FROM BooleanMetricFeedback
     WHERE metric_name IN ({metric_names:Array(String)})

--- a/ui/app/utils/clickhouse/evaluations.test.ts
+++ b/ui/app/utils/clickhouse/evaluations.test.ts
@@ -181,7 +181,8 @@ describe("getEvalResults", () => {
 
   test("should return correct results for entity_extraction eval that skips a staled datapoint", async () => {
     // There is a datapoint that was inserted and deleted before the last eval run after the first two.
-    // We test here that it is not included and the data is not ragged.
+    // We test here that it is not included and the data is ragged due to the datapoint at the top of the
+    // table only having one eval run.
     const results = await getEvalResults(
       "foo",
       "extract_entities",
@@ -195,10 +196,10 @@ describe("getEvalResults", () => {
         "0195aef7-ec99-7312-924f-32b71c3496ee",
         "0195aef8-36bf-7c02-b8a2-40d78049a4a0",
       ],
-      6,
+      2,
       0,
     );
-    expect(results.length).toBe(36); // 6 datapoints * 3 eval runs * 2 metrics
+    expect(results.length).toBe(8); // 1 datapoints * 3 eval runs * 2 metrics + 1 ragged datapoint * 1 eval run * 2 metrics
     // Verify that we have both metrics in the results
     const metricNames = new Set(results.map((r) => r.metric_name));
     expect(
@@ -211,9 +212,9 @@ describe("getEvalResults", () => {
         "tensorzero::eval_name::entity_extraction::evaluator_name::count_sports",
       ),
     ).toBe(true);
-    // Verify that the number of distinct datapoint ids is 6
+    // Verify that the number of distinct datapoint ids is 2
     const datapointIds = new Set(results.map((r) => r.datapoint_id));
-    expect(datapointIds.size).toBe(6);
+    expect(datapointIds.size).toBe(2);
   });
 
   test("should return correct results for ragged haiku eval", async () => {


### PR DESCRIPTION
Just a vibe PR for discussion. Need to implement properly, test, etc.


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add pagination to evaluation results and update related SQL queries and tests.
> 
>   - **Pagination**:
>     - Added pagination to `getEvalResults`, `getEvalStatistics`, and `countDatapointsForEval` in `evaluations.server.ts` using `LIMIT` and `OFFSET`.
>     - Introduced `getEvalResultDatapointIdsQuery` to fetch distinct datapoint IDs for pagination.
>   - **Query Modifications**:
>     - Removed `getStaledWindowQuery` and related logic from `evaluations.server.ts`.
>     - Updated SQL queries to use `INNER JOIN` instead of `LEFT JOIN` for `TagInference` and `inference_table_name`.
>   - **Tests**:
>     - Updated tests in `evaluations.test.ts` to reflect pagination changes, including expected result counts.
>     - Adjusted test cases for `getEvalResults` to verify correct handling of ragged data and pagination.
>   - **Misc**:
>     - Minor text change in `AutoRefreshIndicator.tsx` from "Auto-refreshing" to "Auto-refreshing...".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c0deea16452d38ad1547ed5c4eb32bf39e1df743. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->