### PR TITLE
added / tested rejection of dataset names in Rust / TS

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -66,4 +66,4 @@ slow-timeout = { period = "500s", terminate-after = 1 }
 # Settings for running unit tests
 filter = 'not binary(e2e)'
 retries = 0
-slow-timeout = { period = "5s", terminate-after = 1 }
+slow-timeout = { period = "10s", terminate-after = 1 }

--- a/tensorzero-internal/src/error.rs
+++ b/tensorzero-internal/src/error.rs
@@ -172,6 +172,9 @@ pub enum ErrorDetails {
         variant_name: String,
         message: String,
     },
+    InvalidDatasetName {
+        dataset_name: String,
+    },
     InvalidDiclConfig {
         message: String,
     },
@@ -348,6 +351,7 @@ impl ErrorDetails {
             ErrorDetails::InvalidBatchParams { .. } => tracing::Level::ERROR,
             ErrorDetails::InvalidCandidate { .. } => tracing::Level::ERROR,
             ErrorDetails::InvalidDiclConfig { .. } => tracing::Level::ERROR,
+            ErrorDetails::InvalidDatasetName { .. } => tracing::Level::WARN,
             ErrorDetails::InvalidTensorzeroUuid { .. } => tracing::Level::WARN,
             ErrorDetails::InvalidFunctionVariants { .. } => tracing::Level::ERROR,
             ErrorDetails::InvalidMessage { .. } => tracing::Level::WARN,
@@ -431,6 +435,7 @@ impl ErrorDetails {
             ErrorDetails::InvalidBatchParams { .. } => StatusCode::BAD_REQUEST,
             ErrorDetails::InvalidCandidate { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::InvalidDiclConfig { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorDetails::InvalidDatasetName { .. } => StatusCode::BAD_REQUEST,
             ErrorDetails::InvalidFunctionVariants { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::InvalidMessage { .. } => StatusCode::BAD_REQUEST,
             ErrorDetails::InvalidModel { .. } => StatusCode::INTERNAL_SERVER_ERROR,
@@ -669,6 +674,9 @@ impl std::fmt::Display for ErrorDetails {
             }
             ErrorDetails::InvalidDiclConfig { message } => {
                 write!(f, "Invalid dynamic in-context learning config: {}. This should never happen. Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new", message)
+            }
+            ErrorDetails::InvalidDatasetName { dataset_name } => {
+                write!(f, "Invalid dataset name: {}. Datasets cannot be named \"builder\" or begin with \"tensorzero::\"", dataset_name)
             }
             ErrorDetails::InvalidFunctionVariants { message } => write!(f, "{}", message),
             ErrorDetails::InvalidTensorzeroUuid { message, kind } => {

--- a/ui/app/utils/clickhouse/datasets.server.ts
+++ b/ui/app/utils/clickhouse/datasets.server.ts
@@ -313,6 +313,7 @@ export async function insertRowsForDataset(
   if (!validatedParams.data.dataset_name) {
     throw new Error("dataset_name is required for dataset insertion");
   }
+  validateDatasetName(validatedParams.data.dataset_name);
 
   const destinationTable =
     validatedParams.data.inferenceType === "chat"
@@ -543,6 +544,7 @@ export async function staleDatapoint(
 export async function insertDatapoint(
   datapoint: ParsedDatasetRow,
 ): Promise<void> {
+  validateDatasetName(datapoint.dataset_name);
   const table =
     "tool_params" in datapoint
       ? "ChatInferenceDatapoint"
@@ -573,4 +575,10 @@ export async function insertDatapoint(
     values,
     format: "JSONEachRow",
   });
+}
+
+function validateDatasetName(dataset_name: string) {
+  if (dataset_name === "builder" || dataset_name.startsWith("tensorzero::")) {
+    throw new Error("Invalid dataset name");
+  }
 }

--- a/ui/app/utils/clickhouse/datasets.test.ts
+++ b/ui/app/utils/clickhouse/datasets.test.ts
@@ -10,6 +10,7 @@ import {
   getDatasetCounts,
   getDatasetRows,
   insertDatapoint,
+  insertRowsForDataset,
   staleDatapoint,
 } from "./datasets.server";
 import { expect, test, describe } from "vitest";
@@ -713,5 +714,40 @@ describe("datapoint operations", () => {
   test("handles staling of non-existent datapoint", async () => {
     // Should not throw
     await expect(staleDatapoint("fake", uuid(), "chat")).resolves.not.toThrow();
+  });
+});
+
+describe("insertRowsForDataset", () => {
+  test("handles invalid dataset names", async () => {
+    await expect(
+      insertRowsForDataset({
+        dataset_name: "builder",
+        inferenceType: "chat",
+        extra_where: [],
+        extra_params: {},
+        output_source: "none",
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("insertDatapoint", () => {
+  test("handles invalid dataset names", async () => {
+    await expect(
+      insertDatapoint({
+        dataset_name: "builder",
+        function_name: "write_haiku",
+        id: uuid(),
+        episode_id: null,
+        input: { messages: [] },
+        output: [],
+        tool_params: {},
+        tags: {},
+        auxiliary: "",
+        updated_at: new Date().toISOString(),
+        is_deleted: false,
+        staled_at: null,
+      }),
+    ).rejects.toThrow();
   });
 });


### PR DESCRIPTION
Closes #1525 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add validation to reject reserved dataset names in dataset creation and update operations in both Rust and TypeScript.
> 
>   - **Validation**:
>     - Added `validate_dataset_name()` in `datasets.rs` to reject dataset names "builder" and those starting with "tensorzero::".
>     - Added `validateDatasetName()` in `datasets.server.ts` for the same purpose.
>   - **Handlers**:
>     - Updated `create_datapoint_handler()` and `update_datapoint_handler()` in `datasets.rs` to use `validate_dataset_name()`.
>     - Updated `insertRowsForDataset()` and `insertDatapoint()` in `datasets.server.ts` to use `validateDatasetName()`.
>   - **Error Handling**:
>     - Added `InvalidDatasetName` to `ErrorDetails` in `error.rs` with `BAD_REQUEST` status.
>   - **Testing**:
>     - Added tests in `datasets.rs` and `datasets.test.ts` to verify rejection of invalid dataset names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4fd720c53956ded65e73868cc573aeccdcd16f58. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->