### PR TITLE
Add process lifecycle management for evals

### DIFF
--- a/ui/app/root.tsx
+++ b/ui/app/root.tsx
@@ -7,7 +7,7 @@ import {
   ScrollRestoration,
   useLoaderData,
 } from "react-router";
-import { useEffect } from "react";
+
 import { ConfigProvider } from "./context/config";
 import type { Route } from "./+types/root";
 import "./tailwind.css";
@@ -36,6 +36,8 @@ export const links: Route.LinksFunction = () => [
 ];
 
 export async function loader() {
+  // Initialize eval cleanup when the app loads
+  startPeriodicCleanup();
   return await getConfig();
 }
 
@@ -60,17 +62,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
 
 export default function App() {
   const config = useLoaderData<typeof loader>();
-
-  // Initialize eval cleanup when the app loads
-  useEffect(() => {
-    // Start the periodic cleanup and get the cleanup function
-    const stopCleanup = startPeriodicCleanup();
-
-    // Return cleanup function to stop the interval when the component unmounts
-    return () => {
-      stopCleanup();
-    };
-  }, []);
 
   return (
     <ConfigProvider value={config}>

--- a/ui/app/root.tsx
+++ b/ui/app/root.tsx
@@ -7,7 +7,7 @@ import {
   ScrollRestoration,
   useLoaderData,
 } from "react-router";
-
+import { useEffect } from "react";
 import { ConfigProvider } from "./context/config";
 import type { Route } from "./+types/root";
 import "./tailwind.css";
@@ -15,6 +15,7 @@ import { getConfig } from "./utils/config/index.server";
 import { AppSidebar } from "./components/layout/app.sidebar";
 import { SidebarProvider } from "./components/ui/sidebar";
 import { ContentLayout } from "./components/layout/ContentLayout";
+import { startPeriodicCleanup } from "./utils/evals.server";
 
 export const links: Route.LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -59,6 +60,17 @@ export function Layout({ children }: { children: React.ReactNode }) {
 
 export default function App() {
   const config = useLoaderData<typeof loader>();
+
+  // Initialize eval cleanup when the app loads
+  useEffect(() => {
+    // Start the periodic cleanup and get the cleanup function
+    const stopCleanup = startPeriodicCleanup();
+
+    // Return cleanup function to stop the interval when the component unmounts
+    return () => {
+      stopCleanup();
+    };
+  }, []);
 
   return (
     <ConfigProvider value={config}>

--- a/ui/app/routes/evaluations/$eval_name/AutoRefreshIndicator.tsx
+++ b/ui/app/routes/evaluations/$eval_name/AutoRefreshIndicator.tsx
@@ -35,21 +35,12 @@ export default function AutoRefreshIndicator({
   );
 }
 
-export const useAutoRefresh = (mostRecentDate: Date, interval = 1000) => {
+export const useAutoRefresh = (active: boolean, interval = 1000) => {
   const [isAutoRefreshing, setIsAutoRefreshing] = useState(false);
   const revalidator = useRevalidator();
 
   useEffect(() => {
-    // Only auto-refresh if it's been less than 1 minute since the most recent date
-    const now = new Date();
-    const differenceInMs = now.getTime() - mostRecentDate.getTime();
-    const differenceInMinutes = differenceInMs / (1000 * 60);
-
-    if (differenceInMinutes >= 1) {
-      setIsAutoRefreshing(false);
-      return; // Don't set up auto-refresh if data is older than 1 minute
-    }
-
+    if (!active) return;
     setIsAutoRefreshing(true);
 
     // Set up interval for revalidation
@@ -64,7 +55,7 @@ export const useAutoRefresh = (mostRecentDate: Date, interval = 1000) => {
       clearInterval(intervalId);
       setIsAutoRefreshing(false);
     };
-  }, [mostRecentDate, revalidator, interval]);
+  }, [active, revalidator, interval]);
 
   return isAutoRefreshing;
 };

--- a/ui/app/routes/evaluations/$eval_name/EvalErrorInfo.tsx
+++ b/ui/app/routes/evaluations/$eval_name/EvalErrorInfo.tsx
@@ -1,0 +1,54 @@
+import type { DisplayEvalError, EvalError } from "~/utils/evals";
+import EvalRunBadge from "~/components/evaluations/EvalRunBadge";
+
+export interface EvalErrorDisplayInfo {
+  variantName: string;
+  errors: DisplayEvalError[];
+}
+
+export interface EvalErrorInfoProps {
+  errors: Record<string, EvalErrorDisplayInfo>;
+}
+
+export function EvalErrorInfo({ errors }: EvalErrorInfoProps) {
+  const sortedErrorEntries = Object.entries(errors).sort((a, b) =>
+    b[0].localeCompare(a[0]),
+  ); // Sort in reverse order by key
+  const getColor = () => {
+    return "bg-red-600 hover:bg-red-700";
+  };
+
+  return (
+    <div>
+      {sortedErrorEntries.map(([key, { variantName, errors }]) => {
+        if (!errors || errors.length === 0) return null;
+        const runInfo = {
+          eval_run_id: key,
+          variant_name: variantName,
+        };
+
+        return (
+          <div key={key} className="mt-2">
+            <h3 className="flex items-center gap-2 text-sm font-medium">
+              <EvalRunBadge runInfo={runInfo} getColor={getColor} />
+            </h3>
+            <div className="mb-2 mt-1 max-h-64 overflow-y-auto rounded border p-2">
+              {errors.map((error, index) => (
+                <EvalError key={index} error={error} />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function EvalError({ error }: { error: DisplayEvalError }) {
+  return (
+    <div className="font-mono text-xs">
+      {error.datapoint_id && <h3>{error.datapoint_id}</h3>}
+      <p>{error.message}</p>
+    </div>
+  );
+}

--- a/ui/app/utils/evals.server.ts
+++ b/ui/app/utils/evals.server.ts
@@ -18,7 +18,6 @@ function getGatewayURL(): string {
   }
   return gatewayURL;
 }
-
 interface RunningEvalInfo {
   errors: { datapoint_id?: string; message: string }[];
   completed?: Date;
@@ -27,6 +26,15 @@ interface RunningEvalInfo {
 
 // This is a map of eval run id to running eval info
 const runningEvals: Record<string, RunningEvalInfo> = {};
+
+/**
+ * Returns the running information for a specific evaluation run.
+ * @param evalRunId The ID of the evaluation run to retrieve.
+ * @returns The running information for the specified evaluation run, or undefined if not found.
+ */
+export function getRunningEval(evalRunId: string): RunningEvalInfo | undefined {
+  return runningEvals[evalRunId];
+}
 
 export function runEval(
   evalName: string,
@@ -56,6 +64,7 @@ export function runEval(
   return new Promise<EvalStartInfo>((resolve, reject) => {
     // Spawn a child process to run the evals command
     const child = spawn(command[0], command.slice(1));
+    console.log("Running eval", command.join(" "));
 
     // Variables to track state
     let evalRunId: string | null = null;

--- a/ui/app/utils/evals.server.ts
+++ b/ui/app/utils/evals.server.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { z } from "zod";
 import { getConfigPath } from "./config/index.server";
+import { EvalErrorSchema, type EvalError } from "./evals";
 /**
  * Get the path to the evals binary from environment variables.
  * Defaults to 'evals' if not specified.
@@ -17,6 +18,15 @@ function getGatewayURL(): string {
   }
   return gatewayURL;
 }
+
+interface RunningEvalInfo {
+  errors: { datapoint_id?: string; message: string }[];
+  completed?: Date;
+  started: Date;
+}
+
+// This is a map of eval run id to running eval info
+const runningEvals: Record<string, RunningEvalInfo> = {};
 
 export function runEval(
   evalName: string,
@@ -44,31 +54,117 @@ export function runEval(
   ];
 
   return new Promise<EvalStartInfo>((resolve, reject) => {
+    // Spawn a child process to run the evals command
     const child = spawn(command[0], command.slice(1));
 
-    let firstLine = "";
-    let dataReceived = false;
+    // Variables to track state
+    let evalRunId: string | null = null;
+    let initialDataReceived = false;
 
+    // Buffer for incomplete lines
+    let stdoutBuffer = "";
+
+    // Record the start time of the evaluation
+    const startTime = new Date();
+
+    // Process a complete line from stdout
+    const processCompleteLine = (line: string) => {
+      if (!line.trim()) return; // Skip empty lines
+
+      try {
+        // Try to parse the line as JSON
+        const parsedLine = JSON.parse(line);
+
+        // Check if this is the initial data containing eval_run_id
+        if (
+          !initialDataReceived &&
+          parsedLine.eval_run_id &&
+          parsedLine.num_datapoints
+        ) {
+          try {
+            const evalStartInfo = evalStartInfoSchema.parse(parsedLine);
+            evalRunId = evalStartInfo.eval_run_id;
+
+            // Initialize the tracking entry in our runningEvals map
+            runningEvals[evalRunId] = {
+              errors: [],
+              started: startTime,
+            };
+
+            // Mark that we've received the initial data
+            initialDataReceived = true;
+
+            // Resolve the promise with the eval start info
+            resolve(evalStartInfo);
+          } catch (error) {
+            reject(error);
+          }
+        }
+        // Check if this is an EvalError using the Zod schema
+        else if (evalRunId && parsedLine.datapoint_id && parsedLine.message) {
+          try {
+            // Parse using the Zod schema to validate
+            const evalError = EvalErrorSchema.parse(parsedLine);
+
+            // Add to the beginning of the errors list
+            runningEvals[evalRunId].errors.unshift(evalError);
+          } catch (error) {
+            // If it doesn't match our schema, just ignore it
+          }
+        }
+        // We're ignoring other types of output that don't match these patterns
+      } catch (error) {
+        console.warn(`Bad JSON line: ${line}`);
+      }
+    };
+
+    // Handle stdout data from the process
     child.stdout.on("data", (data) => {
-      if (!dataReceived) {
-        const output = data.toString();
-        const lines = output.split("\n");
-        firstLine = lines[0];
-        dataReceived = true;
-        resolve(evalStartInfoSchema.parse(JSON.parse(firstLine)));
+      // Add new data to our buffer
+      stdoutBuffer += data.toString();
+
+      // Process complete lines
+      let newlineIndex;
+      while ((newlineIndex = stdoutBuffer.indexOf("\n")) !== -1) {
+        // Extract a complete line
+        const line = stdoutBuffer.substring(0, newlineIndex);
+        // Remove the processed line from the buffer
+        stdoutBuffer = stdoutBuffer.substring(newlineIndex + 1);
+        // Process the complete line
+        processCompleteLine(line);
+      }
+      // stdoutBuffer now contains any incomplete line (or nothing)
+    });
+
+    // Ignore stderr completely
+
+    // Handle process errors (e.g., if the process couldn't be spawned)
+    child.on("error", (error) => {
+      if (!initialDataReceived) {
+        reject(error);
       }
     });
 
-    child.stderr.on("data", (data) => {
-      console.error(`stderr: ${data}`);
-    });
-
-    child.on("error", (error) => {
-      reject(error);
-    });
-
+    // Handle process completion
     child.on("close", (code) => {
-      if (!dataReceived) {
+      // Process any remaining data in the buffer
+      if (stdoutBuffer.trim()) {
+        processCompleteLine(stdoutBuffer.trim());
+      }
+
+      if (evalRunId) {
+        // Mark the eval as completed
+        runningEvals[evalRunId].completed = new Date();
+
+        // Add exit code info if not successful
+        if (code !== 0) {
+          runningEvals[evalRunId].errors.push({
+            message: `Process exited with code ${code}`,
+          });
+        }
+      }
+
+      if (!initialDataReceived) {
         reject(
           new Error(
             `Process exited with code ${code} without producing output`,

--- a/ui/app/utils/evals.server.ts
+++ b/ui/app/utils/evals.server.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { z } from "zod";
 import { getConfigPath } from "./config/index.server";
-import { EvalErrorSchema } from "./evals";
+import { EvalErrorSchema, type DisplayEvalError } from "./evals";
 /**
  * Get the path to the evals binary from environment variables.
  * Defaults to 'evals' if not specified.
@@ -19,7 +19,8 @@ function getGatewayURL(): string {
   return gatewayURL;
 }
 interface RunningEvalInfo {
-  errors: { datapoint_id?: string; message: string }[];
+  errors: DisplayEvalError[];
+  variantName: string;
   completed?: Date;
   started: Date;
 }
@@ -64,7 +65,6 @@ export function runEval(
   return new Promise<EvalStartInfo>((resolve, reject) => {
     // Spawn a child process to run the evals command
     const child = spawn(command[0], command.slice(1));
-    console.log("Running eval", command.join(" "));
 
     // Variables to track state
     let evalRunId: string | null = null;
@@ -96,6 +96,7 @@ export function runEval(
 
             // Initialize the tracking entry in our runningEvals map
             runningEvals[evalRunId] = {
+              variantName,
               errors: [],
               started: startTime,
             };

--- a/ui/app/utils/evals.ts
+++ b/ui/app/utils/evals.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const EvalErrorSchema = z.object({
+  datapoint_id: z.string(),
+  message: z.string(),
+});
+export type EvalError = z.infer<typeof EvalErrorSchema>;
+
+export interface DisplayEvalError {
+  datapoint_id?: string;
+  message: string;
+}


### PR DESCRIPTION
We now keep a coroutine that handles stdout and the lifecycle of the process. 
There is a data structure in evals.server.ts that holds the start, end, and errors for a particular evaluation.
We display the errors in a component on the evaluation result page and we also stop the spinner and autorefreshing when the eval process has ended + 2 seconds.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds process lifecycle management for evaluations, including error handling and auto-refreshing, with UI updates to display errors and manage eval states.
> 
>   - **Process Management**:
>     - Adds `RunningEvalInfo` structure in `evals.server.ts` to track eval start, end, and errors.
>     - Implements `runEval()` to manage eval process lifecycle, capturing stdout and errors.
>     - Introduces `cleanupOldEvals()` and `startPeriodicCleanup()` for periodic cleanup of old evals.
>   - **UI Updates**:
>     - Displays errors using `EvalErrorInfo` component in `EvalErrorInfo.tsx`.
>     - Updates `AutoRefreshIndicator` in `AutoRefreshIndicator.tsx` to use `active` state for auto-refreshing.
>     - Modifies `route.tsx` to handle eval errors and manage auto-refresh based on eval state.
>   - **Miscellaneous**:
>     - Adds `EvalErrorSchema` in `evals.ts` for error validation.
>     - Initializes periodic cleanup in `root.tsx` loader.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 475f6953c968e2bab0191d88c16fd1e13578e714. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->