### PR TITLE
fixed episode id link in datapoint page: only render when defined

### DIFF
--- a/ui/app/routes/datasets/$dataset_name/datapoint/$id/DatapointBasicInfo.tsx
+++ b/ui/app/routes/datasets/$dataset_name/datapoint/$id/DatapointBasicInfo.tsx
@@ -76,7 +76,11 @@ export default function BasicInfo({ datapoint }: BasicInfoProps) {
         <BasicInfoItemContent>
           <Chip
             label={datapoint.episode_id ?? "N/A"}
-            link={`/observability/episodes/${datapoint.episode_id}`}
+            link={
+              datapoint.episode_id
+                ? `/observability/episodes/${datapoint.episode_id}`
+                : undefined
+            }
             font="mono"
           />
         </BasicInfoItemContent>


### PR DESCRIPTION
Closes #1533 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Conditionally render `episode_id` link in `DatapointBasicInfo.tsx` only when defined to prevent broken links.
> 
>   - **Behavior**:
>     - In `DatapointBasicInfo.tsx`, the `Chip` component for `episode_id` now conditionally renders the link only if `datapoint.episode_id` is defined.
>     - If `episode_id` is undefined, the link is set to `undefined`, preventing broken links.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 96815d68d9397b2154b8b992f30acbc3e155c018. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->