### PR TITLE
Added flagged icons to homepage and sidebar for evals & datasets

### DIFF
--- a/ui/app/components/icons/Icons.tsx
+++ b/ui/app/components/icons/Icons.tsx
@@ -310,6 +310,27 @@ export const Compare: React.FC<IconProps> = (props) => (
   </IconWrapper>
 );
 
+export const Evaluation: React.FC<IconProps> = (props) => (
+  <IconWrapper {...props}>
+    <path
+      d="M12 3v17a1 1 0 0 1-1 1H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v6a1 1 0 0 1-1 1H3"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="m16 19 2 2 4-4"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </IconWrapper>
+);
+
 export const iconComponents: Record<string, React.FC<IconProps>> = {
   TensorZeroLogo,
   Placeholder,

--- a/ui/app/components/icons/Icons.tsx
+++ b/ui/app/components/icons/Icons.tsx
@@ -313,18 +313,18 @@ export const Compare: React.FC<IconProps> = (props) => (
 export const Evaluation: React.FC<IconProps> = (props) => (
   <IconWrapper {...props}>
     <path
-      d="M12 3v17a1 1 0 0 1-1 1H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v6a1 1 0 0 1-1 1H3"
+      d="M8 2v11.33a.67.67 0 0 1-.67.67H3.33A1.33 1.33 0 0 1 2 12.67V3.33A1.33 1.33 0 0 1 3.33 2h9.34A1.33 1.33 0 0 1 14 3.33v4A.67.67 0 0 1 13.33 8H2"
       fill="none"
       stroke="currentColor"
-      strokeWidth="1.5"
+      strokeWidth="1.33"
       strokeLinecap="round"
       strokeLinejoin="round"
     />
     <path
-      d="m16 19 2 2 4-4"
+      d="m10.67 12.67 1.33 1.33 2.67-2.67"
       fill="none"
       stroke="currentColor"
-      strokeWidth="1.5"
+      strokeWidth="1.33"
       strokeLinecap="round"
       strokeLinejoin="round"
     />

--- a/ui/app/components/layout/app.sidebar.tsx
+++ b/ui/app/components/layout/app.sidebar.tsx
@@ -7,6 +7,7 @@ import {
   SupervisedFineTuning,
   Documentation,
   Dataset,
+  Evaluation,
 } from "~/components/icons/Icons";
 import { useSidebar } from "~/components/ui/sidebar";
 import { cn } from "~/utils/common";
@@ -88,7 +89,7 @@ const navigation: NavigationSection[] = [
             {
               title: "Evaluations",
               url: "/evaluations",
-              icon: SupervisedFineTuning,
+              icon: Evaluation,
             },
           ],
         },

--- a/ui/app/components/layout/app.sidebar.tsx
+++ b/ui/app/components/layout/app.sidebar.tsx
@@ -6,6 +6,7 @@ import {
   Functions,
   SupervisedFineTuning,
   Documentation,
+  Dataset,
 } from "~/components/icons/Icons";
 import { useSidebar } from "~/components/ui/sidebar";
 import { cn } from "~/utils/common";
@@ -28,6 +29,9 @@ import {
   SidebarGroupLabel,
   SidebarGroupContent,
 } from "~/components/ui/sidebar";
+
+const FF_ENABLE_DATASETS =
+  import.meta.env.VITE_TENSORZERO_UI_FF_ENABLE_DATASETS === "1";
 
 interface NavigationItem {
   title: string;
@@ -71,6 +75,25 @@ const navigation: NavigationSection[] = [
       },
     ],
   },
+  ...(FF_ENABLE_DATASETS
+    ? [
+        {
+          title: "Workflows",
+          items: [
+            {
+              title: "Datasets",
+              url: "/datasets",
+              icon: Dataset,
+            },
+            {
+              title: "Evaluations",
+              url: "/evaluations",
+              icon: SupervisedFineTuning,
+            },
+          ],
+        },
+      ]
+    : []),
 ];
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {

--- a/ui/app/routes/index.tsx
+++ b/ui/app/routes/index.tsx
@@ -114,7 +114,7 @@ export default function Home() {
               source="/observability/inferences"
               icon={Inferences}
               title="Inferences"
-              description={`${totalInferences.toLocaleString()} total inferences`}
+              description={`${totalInferences.toLocaleString()} inferences`}
             />
             <FeatureCard
               source="/observability/episodes"

--- a/ui/app/routes/index.tsx
+++ b/ui/app/routes/index.tsx
@@ -12,6 +12,7 @@ import {
   Globe,
   Documentation,
   Dataset,
+  Evaluation,
 } from "~/components/icons/Icons";
 import {
   countInferencesByFunction,
@@ -160,7 +161,7 @@ export default function Home() {
               />
               <FeatureCard
                 source="/evaluations"
-                icon={SupervisedFineTuning}
+                icon={Evaluation}
                 title="Evaluations"
                 description={`${numEvals} evaluations, ${numEvalRuns} runs`}
               />

--- a/ui/app/routes/index.tsx
+++ b/ui/app/routes/index.tsx
@@ -111,7 +111,7 @@ export default function Home() {
           </div>
         </div>
 
-        <div id="optimization" className="mb-12">
+        <div id="optimization" className="mb-16">
           <h2 className="mb-1 text-2xl font-medium">Optimization</h2>
           <p className="mb-6 max-w-[640px] text-sm text-fg-tertiary">
             Optimize your prompts, models, and inference strategies.
@@ -121,7 +121,28 @@ export default function Home() {
               source="/optimization/supervised-fine-tuning"
               icon={SupervisedFineTuning}
               title="Supervised Fine-tuning"
-              description={`${numFunctions} functions available`}
+              description={`${numFunctions} functions`}
+            />
+          </div>
+        </div>
+
+        <div id="optimization" className="mb-12">
+          <h2 className="mb-1 text-2xl font-medium">Workflows</h2>
+          <p className="mb-6 max-w-[640px] text-sm text-fg-tertiary">
+            Manage your LLM engineering workflows.
+          </p>
+          <div className="grid gap-6 md:grid-cols-3">
+            <FeatureCard
+              source="/datasets"
+              icon={SupervisedFineTuning}
+              title="Datasets"
+              description={`3 datasets`}
+            />
+            <FeatureCard
+              source="/evaluations"
+              icon={SupervisedFineTuning}
+              title="Evaluations"
+              description={`7 evaluations, 183 runs`}
             />
           </div>
         </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `Datasets` and `Evaluations` icons to homepage and sidebar with feature flag support.
> 
>   - **Icons**:
>     - Add `Evaluation` icon to `Icons.tsx`.
>     - Add `Dataset` icon to `Icons.tsx`.
>   - **Sidebar**:
>     - Add `Datasets` and `Evaluations` sections to `navigation` in `app.sidebar.tsx` under `Workflows` if `FF_ENABLE_DATASETS` is enabled.
>   - **Homepage**:
>     - Add `Datasets` and `Evaluations` feature cards to `index.tsx` under `Workflows` if `FF_ENABLE_DATASETS` is enabled.
>     - Update loader in `index.tsx` to fetch `numDatasets` and `numEvalRuns`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b098560e9065e1fa3cab344b550b6d17600fa886. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->