### PR TITLE
Run ClickHouse Cloud ci against regular and fast channels

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -36,6 +36,13 @@ env:
 jobs:
   clickhouse-tests-cloud:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cloud_instance:
+          - release_channel: regular
+            url_secret: CLICKHOUSE_CLOUD_URL
+          - release_channel: fast
+            url_secret: CLICKHOUSE_CLOUD_FAST_CHANNEL_URL
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: dtolnay/rust-toolchain@stable
@@ -45,13 +52,13 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Wake up ClickHouse cloud
-        run: |
-          curl ${{ secrets.CLICKHOUSE_CLOUD_URL }} --data-binary 'SHOW DATABASES'
-
       - name: Set up TENSORZERO_CLICKHOUSE_URL
         run: |
-          echo "TENSORZERO_CLICKHOUSE_URL=${{ secrets.CLICKHOUSE_CLOUD_URL }}" >> $GITHUB_ENV
+          echo "TENSORZERO_CLICKHOUSE_URL=${{ secrets[matrix.cloud_instance.url_secret] }}" >> $GITHUB_ENV
+
+      - name: Wake up ClickHouse cloud
+        run: |
+          curl $TENSORZERO_CLICKHOUSE_URL --data-binary 'SHOW DATABASES'
 
       - name: Delete old ClickHouse cloud dbs
         run: ./ci/delete-clickhouse-dbs.sh


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add matrix strategy to ClickHouse Cloud CI tests for regular and fast channels in `merge-queue.yml`.
> 
>   - **CI Workflow**:
>     - Adds matrix strategy to `clickhouse-tests-cloud` job in `merge-queue.yml` to test against `regular` and `fast` release channels.
>     - Adjusts step order: `Set up TENSORZERO_CLICKHOUSE_URL` now precedes `Wake up ClickHouse cloud`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 06dba6ac75194f1787d4295a39009f2af484996e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->