### PR TITLE
Show more detailed error when config file is invalid TOML

### DIFF
--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -84,6 +84,7 @@ async fn main() {
         Arc::new(
             Config::load_and_verify_from_path(Path::new(&path))
                 .await
+                .ok() // Don't print the erorr here, since it was already printed when it was constructed
                 .expect_pretty("Failed to load config"),
         )
     } else {

--- a/tensorzero-internal/src/config_parser.rs
+++ b/tensorzero-internal/src/config_parser.rs
@@ -593,11 +593,12 @@ impl UninitializedConfig {
                     })
                 })?
                 .parse::<toml::Table>()
-                .map_err(|_| {
+                .map_err(|e| {
                     Error::new(ErrorDetails::Config {
                         message: format!(
-                            "Failed to parse config file as valid TOML: {}",
-                            path.to_string_lossy()
+                            "Failed to parse config file `{}` as valid TOML: {}",
+                            path.to_string_lossy(),
+                            e
                         ),
                     })
                 })?,


### PR DESCRIPTION
The error error output looks like this:
```
2025-03-31T21:00:31.506381Z ERROR tensorzero_internal::error: Failed to parse config file `tensorzero-internal/tests/e2e/tensorzero.toml` as valid TOML: TOML parse error at line 180, column 1
    |
180 | [models."gemini-1.5-pro-002"]
    | ^
invalid table header
duplicate key `"gemini-1.5-pro-002"` in table `models`

2025-03-31T21:00:31.506603Z ERROR gateway: Failed to load config
```

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
