### PR TITLE
Add type="static" to configs for evals

### DIFF
--- a/evaluations/src/evaluators/mod.rs
+++ b/evaluations/src/evaluators/mod.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use tensorzero::{FeedbackParams, InferenceResponse};
 use tensorzero_internal::endpoints::datasets::Datapoint;
 use tensorzero_internal::evaluations::{
-    get_evaluator_metric_name, EvaluationConfig, EvaluatorConfig,
+    get_evaluator_metric_name, EvaluatorConfig, StaticEvaluationConfig,
 };
 
 mod exact_match;
@@ -29,7 +29,7 @@ pub type EvaluationResult = HashMap<String, Result<Option<Value>>>;
 pub(crate) async fn evaluate_inference(
     inference_response: Arc<InferenceResponse>,
     datapoint: Arc<Datapoint>,
-    evaluation_config: Arc<EvaluationConfig>,
+    evaluation_config: Arc<StaticEvaluationConfig>,
     evaluation_name: Arc<String>,
     tensorzero_client: Arc<ThrottledTensorZeroClient>,
     evaluation_run_id: Uuid,
@@ -107,7 +107,7 @@ pub(crate) async fn evaluate_inference(
 ///
 /// NOTE: Each evaluator we implement in the match statement below should follow this contract.
 async fn run_evaluator(
-    evaluation_config: &EvaluationConfig,
+    evaluation_config: &StaticEvaluationConfig,
     evaluator_name: String,
     inference_response: &InferenceResponse,
     tensorzero_client: &ThrottledTensorZeroClient,

--- a/tensorzero-internal/fixtures/config/tensorzero.test.toml
+++ b/tensorzero-internal/fixtures/config/tensorzero.test.toml
@@ -174,6 +174,7 @@ parameters = "fixtures/config/tools/get_temperature.json"
 # │                                EVALUATIONS                                 │
 # └────────────────────────────────────────────────────────────────────────────┘
 [evaluations.evaluation1]
+type = "static"
 dataset_name = "dataset1"
 function_name = "generate_draft"
 

--- a/tensorzero-internal/fixtures/config/tensorzero.toml
+++ b/tensorzero-internal/fixtures/config/tensorzero.toml
@@ -174,6 +174,7 @@ parameters = "fixtures/config/tools/get_temperature.json"
 # │                                EVALUATIONS                                 │
 # └────────────────────────────────────────────────────────────────────────────┘
 [evaluations.evaluation1]
+type = "static"
 dataset_name = "dataset1"
 function_name = "generate_draft"
 

--- a/tensorzero-internal/src/config_parser.rs
+++ b/tensorzero-internal/src/config_parser.rs
@@ -10,7 +10,7 @@ use tracing::instrument;
 
 use crate::embeddings::EmbeddingModelTable;
 use crate::error::{Error, ErrorDetails};
-use crate::evaluations::{EvaluationConfig, UninitializedEvaluationConfig};
+use crate::evaluations::{StaticEvaluationConfig, UninitializedEvaluationConfig};
 use crate::function::{FunctionConfig, FunctionConfigChat, FunctionConfigJson};
 use crate::inference::types::storage::StorageKind;
 use crate::jsonschema_util::JSONSchemaFromPath;
@@ -33,7 +33,7 @@ pub struct Config<'c> {
     pub functions: HashMap<String, Arc<FunctionConfig>>, // function name => function config
     pub metrics: HashMap<String, MetricConfig>, // metric name => metric config
     pub tools: HashMap<String, Arc<StaticToolConfig>>, // tool name => tool config
-    pub evaluations: HashMap<String, Arc<EvaluationConfig>>, // evaluation name => evaluation config
+    pub evaluations: HashMap<String, Arc<StaticEvaluationConfig>>, // evaluation name => evaluation config
     pub templates: TemplateConfig<'c>,
     pub object_store_info: Option<ObjectStoreInfo>,
 }

--- a/tensorzero-internal/src/config_parser.rs
+++ b/tensorzero-internal/src/config_parser.rs
@@ -10,7 +10,7 @@ use tracing::instrument;
 
 use crate::embeddings::EmbeddingModelTable;
 use crate::error::{Error, ErrorDetails};
-use crate::evaluations::{StaticEvaluationConfig, UninitializedEvaluationConfig};
+use crate::evaluations::{EvaluationConfig, UninitializedEvaluationConfig};
 use crate::function::{FunctionConfig, FunctionConfigChat, FunctionConfigJson};
 use crate::inference::types::storage::StorageKind;
 use crate::jsonschema_util::JSONSchemaFromPath;
@@ -33,7 +33,7 @@ pub struct Config<'c> {
     pub functions: HashMap<String, Arc<FunctionConfig>>, // function name => function config
     pub metrics: HashMap<String, MetricConfig>, // metric name => metric config
     pub tools: HashMap<String, Arc<StaticToolConfig>>, // tool name => tool config
-    pub evaluations: HashMap<String, Arc<StaticEvaluationConfig>>, // evaluation name => evaluation config
+    pub evaluations: HashMap<String, Arc<EvaluationConfig>>, // evaluation name => evaluation config
     pub templates: TemplateConfig<'c>,
     pub object_store_info: Option<ObjectStoreInfo>,
 }
@@ -359,7 +359,7 @@ impl<'c> Config<'c> {
         for (name, evaluation_config) in uninitialized_config.evaluations {
             let (evaluation_config, evaluation_function_configs, evaluation_metric_configs) =
                 evaluation_config.load(&config.functions, &base_path, &name)?;
-            evaluations.insert(name, Arc::new(evaluation_config));
+            evaluations.insert(name, Arc::new(EvaluationConfig::Static(evaluation_config)));
             for (evaluation_function_name, evaluation_function_config) in
                 evaluation_function_configs
             {

--- a/tensorzero-internal/src/evaluations/mod.rs
+++ b/tensorzero-internal/src/evaluations/mod.rs
@@ -28,7 +28,7 @@ pub const LLM_JUDGE_BOOLEAN_OUTPUT_SCHEMA_TEXT: &str =
     include_str!("llm_judge_boolean_output_schema.json");
 
 #[derive(Debug)]
-pub struct EvaluationConfig {
+pub struct StaticEvaluationConfig {
     pub evaluators: HashMap<String, EvaluatorConfig>,
     pub dataset_name: String,
     pub function_name: String,
@@ -131,7 +131,7 @@ pub struct UninitializedEvaluationConfig {
 
 type EvaluationLoadResult = Result<
     (
-        EvaluationConfig,                     // The evaluation itself
+        StaticEvaluationConfig,               // The evaluation itself
         HashMap<String, Arc<FunctionConfig>>, // All functions which the evaluation needs {function_name -> function_config}
         HashMap<String, MetricConfig>, // All metrics which the evaluation needs {metric_name -> metric_config}
     ),
@@ -199,7 +199,7 @@ impl UninitializedEvaluationConfig {
             );
         }
         Ok((
-            EvaluationConfig {
+            StaticEvaluationConfig {
                 evaluators,
                 dataset_name: self.dataset_name,
                 function_name: self.function_name,

--- a/tensorzero-internal/src/evaluations/mod.rs
+++ b/tensorzero-internal/src/evaluations/mod.rs
@@ -35,6 +35,11 @@ pub struct StaticEvaluationConfig {
 }
 
 #[derive(Debug)]
+pub enum EvaluationConfig {
+    Static(StaticEvaluationConfig),
+}
+
+#[derive(Debug)]
 pub enum EvaluatorConfig {
     ExactMatch(ExactMatchConfig),
     LLMJudge(LLMJudgeConfig),

--- a/tensorzero-internal/src/evaluations/mod.rs
+++ b/tensorzero-internal/src/evaluations/mod.rs
@@ -122,8 +122,31 @@ pub fn get_evaluator_metric_name(evaluation_name: &str, evaluator_name: &str) ->
     )
 }
 
+#[derive(Debug, TensorZeroDeserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+pub enum UninitializedEvaluationConfig {
+    Static(UninitializedStaticEvaluationConfig),
+}
+
+impl UninitializedEvaluationConfig {
+    pub fn load<P: AsRef<Path>>(
+        self,
+        functions: &HashMap<String, Arc<FunctionConfig>>,
+        base_path: P,
+        evaluation_name: &str,
+    ) -> EvaluationLoadResult {
+        match self {
+            UninitializedEvaluationConfig::Static(config) => {
+                config.load(functions, base_path, evaluation_name)
+            }
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
-pub struct UninitializedEvaluationConfig {
+pub struct UninitializedStaticEvaluationConfig {
     evaluators: HashMap<String, UninitializedEvaluatorConfig>,
     dataset_name: String,
     function_name: String,
@@ -138,7 +161,7 @@ type EvaluationLoadResult = Result<
     Error,
 >;
 
-impl UninitializedEvaluationConfig {
+impl UninitializedStaticEvaluationConfig {
     pub fn load<P: AsRef<Path>>(
         self,
         functions: &HashMap<String, Arc<FunctionConfig>>,
@@ -510,7 +533,7 @@ mod tests {
                 UninitializedEvaluatorConfig::ExactMatch(ExactMatchConfig { cutoff: Some(0.4) }),
             );
 
-            let uninitialized_config = UninitializedEvaluationConfig {
+            let uninitialized_config = UninitializedStaticEvaluationConfig {
                 evaluators,
                 dataset_name: "test_dataset".to_string(),
                 function_name: function_name.to_string(),
@@ -589,7 +612,7 @@ mod tests {
                 UninitializedEvaluatorConfig::LLMJudge(llm_judge_config),
             );
 
-            let uninitialized_config = UninitializedEvaluationConfig {
+            let uninitialized_config = UninitializedStaticEvaluationConfig {
                 evaluators,
                 dataset_name: "test_dataset".to_string(),
                 function_name: function_name.to_string(),
@@ -709,7 +732,7 @@ mod tests {
                 UninitializedEvaluatorConfig::LLMJudge(llm_judge_config),
             );
 
-            let uninitialized_config = UninitializedEvaluationConfig {
+            let uninitialized_config = UninitializedStaticEvaluationConfig {
                 evaluators,
                 dataset_name: "test_dataset".to_string(),
                 function_name: function_name.to_string(),
@@ -781,7 +804,7 @@ mod tests {
                 UninitializedEvaluatorConfig::ExactMatch(ExactMatchConfig { cutoff: None }),
             );
 
-            let uninitialized_config = UninitializedEvaluationConfig {
+            let uninitialized_config = UninitializedStaticEvaluationConfig {
                 evaluators,
                 dataset_name: "test_dataset".to_string(),
                 function_name: "nonexistent_function".to_string(),
@@ -803,7 +826,7 @@ mod tests {
                 UninitializedEvaluatorConfig::ExactMatch(ExactMatchConfig { cutoff: None }),
             );
 
-            let uninitialized_config = UninitializedEvaluationConfig {
+            let uninitialized_config = UninitializedStaticEvaluationConfig {
                 evaluators,
                 dataset_name: "test_dataset".to_string(),
                 function_name: function_name.to_string(),
@@ -891,7 +914,7 @@ mod tests {
                 UninitializedEvaluatorConfig::LLMJudge(llm_judge_config),
             );
 
-            let uninitialized_config = UninitializedEvaluationConfig {
+            let uninitialized_config = UninitializedStaticEvaluationConfig {
                 evaluators,
                 dataset_name: "test_dataset".to_string(),
                 function_name: function_name.to_string(),
@@ -934,7 +957,7 @@ mod tests {
                 UninitializedEvaluatorConfig::ExactMatch(ExactMatchConfig { cutoff: None }),
             );
 
-            let uninitialized_config = UninitializedEvaluationConfig {
+            let uninitialized_config = UninitializedStaticEvaluationConfig {
                 evaluators,
                 dataset_name: "test_dataset".to_string(),
                 function_name: function_name.to_string(),
@@ -993,7 +1016,7 @@ mod tests {
                 UninitializedEvaluatorConfig::LLMJudge(llm_judge_config),
             );
 
-            let uninitialized_config = UninitializedEvaluationConfig {
+            let uninitialized_config = UninitializedStaticEvaluationConfig {
                 evaluators,
                 dataset_name: "test_dataset".to_string(),
                 function_name: function_name.to_string(),
@@ -1057,7 +1080,7 @@ mod tests {
                 UninitializedEvaluatorConfig::LLMJudge(llm_judge_config),
             );
 
-            let uninitialized_config = UninitializedEvaluationConfig {
+            let uninitialized_config = UninitializedStaticEvaluationConfig {
                 evaluators,
                 dataset_name: "test_dataset".to_string(),
                 function_name: function_name.to_string(),
@@ -1127,7 +1150,7 @@ mod tests {
                 UninitializedEvaluatorConfig::LLMJudge(llm_judge_config),
             );
 
-            let uninitialized_config = UninitializedEvaluationConfig {
+            let uninitialized_config = UninitializedStaticEvaluationConfig {
                 evaluators,
                 dataset_name: "test_dataset".to_string(),
                 function_name: function_name.to_string(),

--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -2381,6 +2381,7 @@ parameters = "../../fixtures/config/tools/get_humidity.json"
 # └────────────────────────────────────────────────────────────────────────────┘
 
 [evaluations.test_evaluation]
+type = "static"
 dataset_name = "test_dataset"
 function_name = "basic_test"
 
@@ -2433,6 +2434,7 @@ system_instructions = "../../fixtures/config/evaluations/test_evaluation/llm_jud
 json_mode = "on"
 
 [evaluations.json_evaluation]
+type = "static"
 dataset_name = "test_dataset"
 function_name = "json_success"
 
@@ -2486,6 +2488,7 @@ json_mode = "on"
 
 
 [evaluations.entity_extraction]
+type = "static"
 function_name = "extract_entities"
 dataset_name = "extract_entities_0.8"
 
@@ -2522,6 +2525,7 @@ system_instructions = "../../fixtures/config/evaluations/test_evaluation/llm_jud
 json_mode = "on"
 
 [evaluations.haiku_with_outputs]
+type = "static"
 function_name = "write_haiku"
 dataset_name = "good-haiku-data"
 
@@ -2529,6 +2533,7 @@ dataset_name = "good-haiku-data"
 type = "exact_match"
 
 [evaluations.haiku_without_outputs]
+type = "static"
 function_name = "write_haiku"
 dataset_name = "good-haikus-no-output"
 

--- a/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/EvaluationDatapointBasicInfo.tsx
+++ b/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/EvaluationDatapointBasicInfo.tsx
@@ -7,11 +7,11 @@ import {
 } from "~/components/layout/BasicInfoLayout";
 import Chip from "~/components/ui/Chip";
 import { getFunctionTypeIcon } from "~/utils/icon";
-import type { EvaluationConfig } from "~/utils/config/evaluations";
+import type { StaticEvaluationConfig } from "~/utils/config/evaluations";
 
 interface BasicInfoProps {
   evaluation_name: string;
-  evaluation_config: EvaluationConfig;
+  evaluation_config: StaticEvaluationConfig;
 }
 
 export default function BasicInfo({

--- a/ui/app/routes/evaluations/$evaluation_name/EvaluationBasicInfo.tsx
+++ b/ui/app/routes/evaluations/$evaluation_name/EvaluationBasicInfo.tsx
@@ -7,10 +7,10 @@ import {
 } from "~/components/layout/BasicInfoLayout";
 import Chip from "~/components/ui/Chip";
 import { getFunctionTypeIcon } from "~/utils/icon";
-import type { EvaluationConfig } from "~/utils/config/evaluations";
+import type { StaticEvaluationConfig } from "~/utils/config/evaluations";
 
 interface BasicInfoProps {
-  evaluation_config: EvaluationConfig;
+  evaluation_config: StaticEvaluationConfig;
 }
 
 export default function BasicInfo({ evaluation_config }: BasicInfoProps) {

--- a/ui/app/utils/config/evaluations.server.ts
+++ b/ui/app/utils/config/evaluations.server.ts
@@ -7,8 +7,8 @@ import { type VariantConfig } from "./variant";
 import {
   LLMJudgeIncludeConfigSchema,
   ExactMatchConfigSchema,
-  type EvaluationConfig,
   type EvaluatorConfig,
+  type EvaluationConfig,
 } from "./evaluations";
 import type { MetricConfig } from "./metric";
 import type { RawFunctionConfig } from "./function.server";
@@ -137,11 +137,21 @@ export const UninitializedEvaluatorConfigSchema = z.discriminatedUnion("type", [
   }),
 ]);
 
-export const UninitializedEvaluationConfigSchema = z.object({
+export const UninitializedStaticEvaluationConfigSchema = z.object({
   evaluators: z.record(z.string(), UninitializedEvaluatorConfigSchema),
   dataset_name: z.string(),
   function_name: z.string(),
 });
+
+export const UninitializedEvaluationConfigSchema = z.discriminatedUnion(
+  "type",
+  [
+    z.object({
+      type: z.literal("static"),
+      ...UninitializedStaticEvaluationConfigSchema.shape,
+    }),
+  ],
+);
 
 // Helper function to read system instructions from a file
 async function readSystemInstructions(
@@ -367,59 +377,66 @@ export const RawEvaluationConfigSchema =
         functionConfigs: Record<string, FunctionConfig>;
         metricConfigs: Record<string, MetricConfig>;
       }> {
-        // Check for valid evaluation name
-        if (evaluationName.includes("::")) {
-          throw new Error(
-            `evaluation names cannot contain "::" (referenced in [evaluations.${evaluationName}])`,
-          );
-        }
+        switch (raw.type) {
+          case "static": {
+            // Check for valid evaluation name
+            if (evaluationName.includes("::")) {
+              throw new Error(
+                `evaluation names cannot contain "::" (referenced in [evaluations.${evaluationName}])`,
+              );
+            }
 
-        // Check if referenced function exists
-        if (!functions[raw.function_name]) {
-          throw new Error(
-            `Function \`${raw.function_name}\` not found (referenced in \`[evaluations.${evaluationName}]\`)`,
-          );
-        }
+            // Check if referenced function exists
+            if (!functions[raw.function_name]) {
+              throw new Error(
+                `Function \`${raw.function_name}\` not found (referenced in \`[evaluations.${evaluationName}]\`)`,
+              );
+            }
 
-        // Load all evaluators
-        const evaluators: Record<string, EvaluatorConfig> = {};
-        const functionConfigs: Record<string, FunctionConfig> = {};
-        const metricConfigs: Record<
-          string,
-          {
-            type: "float" | "boolean";
-            optimize: "min" | "max";
-            level: "inference";
+            // Load all evaluators
+            const evaluators: Record<string, EvaluatorConfig> = {};
+            const functionConfigs: Record<string, FunctionConfig> = {};
+            const metricConfigs: Record<
+              string,
+              {
+                type: "float" | "boolean";
+                optimize: "min" | "max";
+                level: "inference";
+              }
+            > = {};
+
+            for (const [name, config] of Object.entries(raw.evaluators)) {
+              const { evaluatorConfig, functionConfig, metricConfig } =
+                await loadEvaluator(config, configPath, evaluationName, name);
+
+              // Add evaluator config
+              evaluators[name] = evaluatorConfig;
+
+              // Add function config if it exists
+              if (functionConfig) {
+                functionConfigs[getLLMJudgeFunctionName(evaluationName, name)] =
+                  functionConfig;
+              }
+
+              // Add metric config
+              metricConfigs[getEvaluatorMetricName(evaluationName, name)] =
+                metricConfig;
+            }
+
+            return {
+              EvaluationConfig: {
+                type: "static",
+                evaluators,
+                dataset_name: raw.dataset_name,
+                function_name: raw.function_name,
+              },
+              functionConfigs,
+              metricConfigs,
+            };
           }
-        > = {};
-
-        for (const [name, config] of Object.entries(raw.evaluators)) {
-          const { evaluatorConfig, functionConfig, metricConfig } =
-            await loadEvaluator(config, configPath, evaluationName, name);
-
-          // Add evaluator config
-          evaluators[name] = evaluatorConfig;
-
-          // Add function config if it exists
-          if (functionConfig) {
-            functionConfigs[getLLMJudgeFunctionName(evaluationName, name)] =
-              functionConfig;
-          }
-
-          // Add metric config
-          metricConfigs[getEvaluatorMetricName(evaluationName, name)] =
-            metricConfig;
+          default:
+            throw new Error(`Unsupported evaluation type: ${raw.type}`);
         }
-
-        return {
-          EvaluationConfig: {
-            evaluators,
-            dataset_name: raw.dataset_name,
-            function_name: raw.function_name,
-          },
-          functionConfigs,
-          metricConfigs,
-        };
       },
     };
   });

--- a/ui/app/utils/config/evaluations.ts
+++ b/ui/app/utils/config/evaluations.ts
@@ -32,11 +32,21 @@ export const EvaluatorConfigSchema = z.discriminatedUnion("type", [
 ]);
 export type EvaluatorConfig = z.infer<typeof EvaluatorConfigSchema>;
 
-export const EvaluationConfigSchema = z.object({
+export const StaticEvaluationConfigSchema = z.object({
   evaluators: z.record(z.string(), EvaluatorConfigSchema),
   dataset_name: z.string(),
   function_name: z.string(),
 });
+export type StaticEvaluationConfig = z.infer<
+  typeof StaticEvaluationConfigSchema
+>;
+
+export const EvaluationConfigSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("static"),
+    ...StaticEvaluationConfigSchema.shape,
+  }),
+]);
 export type EvaluationConfig = z.infer<typeof EvaluationConfigSchema>;
 
 export const getOptimize = (evaluatorConfig: EvaluatorConfig) => {

--- a/ui/fixtures/config/tensorzero.e2e.toml
+++ b/ui/fixtures/config/tensorzero.e2e.toml
@@ -197,6 +197,7 @@ optimize = "min"
 # └────────────────────────────────────────────────────────────────────────────┘
 
 [evaluations.entity_extraction]
+type = "static"
 function_name = "extract_entities"
 dataset_name = "foo"
 
@@ -220,6 +221,7 @@ json_mode = "strict"
 temperature = 0.1
 
 [evaluations.haiku]
+type = "static"
 function_name = "write_haiku"
 dataset_name = "foo"
 

--- a/ui/fixtures/config/tensorzero.toml
+++ b/ui/fixtures/config/tensorzero.toml
@@ -197,6 +197,7 @@ optimize = "min"
 # └────────────────────────────────────────────────────────────────────────────┘
 
 [evaluations.entity_extraction]
+type = "static"
 function_name = "extract_entities"
 dataset_name = "foo"
 
@@ -220,6 +221,7 @@ json_mode = "strict"
 temperature = 0.1
 
 [evaluations.haiku]
+type = "static"
 function_name = "write_haiku"
 dataset_name = "foo"
 


### PR DESCRIPTION
Handled in both .ts* and .rs codebase.


Closes #1568 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `type="static"` to evaluation configurations and update related logic in Rust and TypeScript codebases.
> 
>   - **Behavior**:
>     - Add `type="static"` to evaluation configurations in `tensorzero.test.toml`, `tensorzero.toml`, and `tensorzero.e2e.toml`.
>     - Update `evaluate_inference()` and `run_evaluation()` in `mod.rs` to handle `StaticEvaluationConfig`.
>   - **Models**:
>     - Introduce `StaticEvaluationConfig` and `EvaluationConfig` enum in `mod.rs`.
>     - Update `UninitializedEvaluationConfig` and `UninitializedStaticEvaluationConfig` in `mod.rs`.
>   - **UI**:
>     - Update `EvaluationDatapointBasicInfo.tsx` and `EvaluationBasicInfo.tsx` to use `StaticEvaluationConfig`.
>     - Modify `evaluations.server.ts` and `evaluations.ts` to include `StaticEvaluationConfig` handling.
>   - **Misc**:
>     - Update `config_parser.rs` to insert `StaticEvaluationConfig` into evaluations.
>     - Adjust `UninitializedEvaluationConfigSchema` in `evaluations.server.ts` to support `static` type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7141be529f0442fd3d26b843b25457e442a5c8cd. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->