### PR TITLE
bumped pyo3 for security update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2792,9 +2792,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1c6c3591120564d64db2261bec5f910ae454f01def849b9c22835a84695e86"
+checksum = "17da310086b068fbdcefbba30aeb3721d5bb9af8db4987d6735b2183ca567229"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -2823,9 +2823,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b6c2b34cf71427ea37c7001aefbaeb85886a074795e35f161f5aecc7620a7a"
+checksum = "e27165889bd793000a098bb966adc4300c312497ea25cf7a690a9f0ac5aa5fc1"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -2833,9 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5507651906a46432cdda02cd02dd0319f6064f1374c9147c45b978621d2c3a9c"
+checksum = "05280526e1dbf6b420062f3ef228b78c0c54ba94e157f5cb724a609d0f2faabc"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2843,9 +2843,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d394b5b4fd8d97d48336bb0dd2aebabad39f1d294edd6bcd2cccf2eefe6f42"
+checksum = "5c3ce5686aa4d3f63359a5100c62a127c9f15e8398e5fdeb5deef1fed5cd5f44"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2855,9 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd72da09cfa943b1080f621f024d2ef7e2773df7badd51aa30a2be1f8caa7c8e"
+checksum = "f4cf6faa0cbfb0ed08e89beb8103ae9724eb4750e3a78084ba4017cbe94f3855"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ async-stream = "0.3.5"
 tokio-stream = "0.1.15"
 tokio = { version = "1.38.1", features = ["full"] }
 tracing = { version = "0.1.40", features = ["log"] }
-pyo3 = { version = "0.24", features = ["experimental-async", "abi3-py39"] }
+pyo3 = { version = "0.24.1", features = ["experimental-async", "abi3-py39"] }
 axum = { version = "0.8", features = ["macros"] }
 anyhow = "1.0.97"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt"] }

--- a/clients/python-pyo3/Cargo.toml
+++ b/clients/python-pyo3/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 tensorzero-internal = { path = "../../tensorzero-internal" }
 futures = { workspace = true }
 pyo3 = { workspace = true }
-pyo3-async-runtimes = { version = "0.24.0", features = ["tokio-runtime"] }
+pyo3-async-runtimes = { version = "0.24.1", features = ["tokio-runtime"] }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/clients/python-pyo3/Cargo.toml
+++ b/clients/python-pyo3/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 tensorzero-internal = { path = "../../tensorzero-internal" }
 futures = { workspace = true }
 pyo3 = { workspace = true }
-pyo3-async-runtimes = { version = "0.24.1", features = ["tokio-runtime"] }
+pyo3-async-runtimes = { version = "0.24.0", features = ["tokio-runtime"] }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Bump `pyo3` and related packages to version `0.24.1` for security updates.
> 
>   - **Dependencies**:
>     - Bump `pyo3` version from `0.24.0` to `0.24.1` in `Cargo.toml` and `Cargo.lock` for security update.
>     - Update related `pyo3` packages: `pyo3-build-config`, `pyo3-ffi`, `pyo3-macros`, and `pyo3-macros-backend` to `0.24.1` in `Cargo.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 187c455f1584d1b393fd924e76dfa2935f084ae5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->