### PR TITLE
Delete ClickHouse cloud dbs older than 1 hour

### DIFF
--- a/ci/delete-clickhouse-dbs.sh
+++ b/ci/delete-clickhouse-dbs.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 echo "Fetching databases"
-# Get all 'tensorzero_e2e_tests_migration_manager' databases older than 1 day (to avoid deleting dbs used by currently running tests)
+# Get all 'tensorzero_e2e_tests_migration_manager' databases older than 1 hour (to avoid deleting dbs used by currently running tests)
 # We use the 'metadata_modification_time' of a known table ('ChatInference') to get a lower bound on the database age.
 databases=$(curl -X POST $TENSORZERO_CLICKHOUSE_URL \
-    --data-binary "select database from system.tables where name = 'ChatInference' and startsWith(database, 'tensorzero_e2e_tests_migration_manager') and metadata_modification_time < subtractDays(now(), 1);")
+    --data-binary "select database from system.tables where name = 'ChatInference' and startsWith(database, 'tensorzero_e2e_tests_migration_manager') and metadata_modification_time < subtractHours(now(), 1);")
 
 echo "The following databases will be deleted:"
 echo "$databases"


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `delete-clickhouse-dbs.sh` to delete databases older than 1 hour instead of 1 day.
> 
>   - **Behavior**:
>     - Modify `delete-clickhouse-dbs.sh` to delete `tensorzero_e2e_tests_migration_manager` databases older than 1 hour instead of 1 day.
>     - Uses `metadata_modification_time` of `ChatInference` table to determine database age.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 9e9bf16365b7c820a7900ab7d32cb5b71b86c6e4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->