### PR TITLE
Only run ClickHouse Cloud tests in merge queue

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -277,62 +277,7 @@ jobs:
         if: always()
         run: cat e2e_logs.txt
 
-  clickhouse-tests-cloud:
-    runs-on: ubuntu-latest
-    # Skip this job for PRs from forks, since we don't have secrets available.
-    # Dependabot PRs also don't have secrets available
-    if: |
-      (github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == 'tensorzero/tensorzero'
-      ) && github.actor != 'dependabot[bot]'
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@37bdc826eaedac215f638a96472df572feab0f9b
-        with:
-          tool: cargo-nextest
-
-      - name: Wake up ClickHouse cloud
-        run: |
-          curl ${{ secrets.CLICKHOUSE_CLOUD_URL }} --data-binary 'SHOW DATABASES'
-
-      - name: Set up TENSORZERO_CLICKHOUSE_URL
-        run: |
-          echo "TENSORZERO_CLICKHOUSE_URL=${{ secrets.CLICKHOUSE_CLOUD_URL }}" >> $GITHUB_ENV
-
-      - name: Delete old ClickHouse cloud dbs
-        run: ./ci/delete-clickhouse-dbs.sh
-
-      # We run this as a separate step so that we can see live build logs
-      # (and fail the job immediately if the build fails)
-      - name: Build the gateway for E2E tests
-        run: cargo build-e2e
-
-      - name: Launch the gateway for E2E tests
-        run: |
-          cargo run-e2e > e2e_logs.txt 2>&1 &
-            count=0
-            max_attempts=10
-            while ! curl -s -f http://localhost:3000/health >/dev/null 2>&1; do
-              echo "Waiting for gateway to be healthy..."
-              sleep 1
-              count=$((count + 1))
-              if [ $count -ge $max_attempts ]; then
-                echo "Gateway failed to become healthy after $max_attempts attempts"
-                exit 1
-              fi
-            done
-          echo "GATEWAY_PID=$!" >> $GITHUB_ENV
-
-      - name: Test (Rust)
-        run: cargo test-e2e-no-creds
-
-      - name: Print e2e logs
-        if: always()
-        run: cat e2e_logs.txt
-
+=
   ui-tests:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -277,7 +277,7 @@ jobs:
         if: always()
         run: cat e2e_logs.txt
 
-=
+
   ui-tests:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -34,6 +34,57 @@ env:
   XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
 
 jobs:
+
+  clickhouse-tests-cloud:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@37bdc826eaedac215f638a96472df572feab0f9b
+        with:
+          tool: cargo-nextest
+
+      - name: Wake up ClickHouse cloud
+        run: |
+          curl ${{ secrets.CLICKHOUSE_CLOUD_URL }} --data-binary 'SHOW DATABASES'
+
+      - name: Set up TENSORZERO_CLICKHOUSE_URL
+        run: |
+          echo "TENSORZERO_CLICKHOUSE_URL=${{ secrets.CLICKHOUSE_CLOUD_URL }}" >> $GITHUB_ENV
+
+      - name: Delete old ClickHouse cloud dbs
+        run: ./ci/delete-clickhouse-dbs.sh
+
+      # We run this as a separate step so that we can see live build logs
+      # (and fail the job immediately if the build fails)
+      - name: Build the gateway for E2E tests
+        run: cargo build-e2e
+
+      - name: Launch the gateway for E2E tests
+        run: |
+          cargo run-e2e > e2e_logs.txt 2>&1 &
+            count=0
+            max_attempts=10
+            while ! curl -s -f http://localhost:3000/health >/dev/null 2>&1; do
+              echo "Waiting for gateway to be healthy..."
+              sleep 1
+              count=$((count + 1))
+              if [ $count -ge $max_attempts ]; then
+                echo "Gateway failed to become healthy after $max_attempts attempts"
+                exit 1
+              fi
+            done
+          echo "GATEWAY_PID=$!" >> $GITHUB_ENV
+
+      - name: Test (Rust)
+        run: cargo test-e2e-no-creds
+
+      - name: Print e2e logs
+        if: always()
+        run: cat e2e_logs.txt
+
   live-tests:
     runs-on: namespace-profile-tensorzero-8x16
 


### PR DESCRIPTION
This should help avoid the issue of having lots of temporary databases.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Move ClickHouse Cloud tests to only run in the merge queue to reduce temporary databases.
> 
>   - **Workflows**:
>     - Remove `clickhouse-tests-cloud` job from `general.yml`.
>     - Add `clickhouse-tests-cloud` job to `merge-queue.yml`.
>   - **Behavior**:
>     - ClickHouse Cloud tests now only run in the merge queue, not on every pull request.
>     - Aims to reduce the number of temporary databases created during testing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ca675a09b4b07f72fc60ed7feb2bfd577788dd29. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->