### PR TITLE
added dataset builder button to Datasets page

### DIFF
--- a/ui/app/routes/datasets/BuildDatasetButton.tsx
+++ b/ui/app/routes/datasets/BuildDatasetButton.tsx
@@ -1,0 +1,27 @@
+import { Plus } from "lucide-react";
+import { Button } from "~/components/ui/button";
+
+interface BuildDatasetButtonProps {
+  onClick: () => void;
+  className?: string;
+  disabled?: boolean;
+}
+
+export function BuildDatasetButton({
+  onClick,
+  className,
+  disabled = false,
+}: BuildDatasetButtonProps) {
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={onClick}
+      className={className}
+      disabled={disabled}
+    >
+      <Plus className="mr-2 h-4 w-4 text-fg-tertiary" />
+      Build Dataset
+    </Button>
+  );
+}

--- a/ui/app/routes/datasets/DatasetsActions.tsx
+++ b/ui/app/routes/datasets/DatasetsActions.tsx
@@ -1,0 +1,18 @@
+import { ActionBar } from "~/components/layout/ActionBar";
+import { BuildDatasetButton } from "./BuildDatasetButton";
+
+interface DatasetsActionsProps {
+  onBuildDataset: () => void;
+  className?: string;
+}
+
+export function DatasetsActions({
+  onBuildDataset,
+  className,
+}: DatasetsActionsProps) {
+  return (
+    <ActionBar className={className}>
+      <BuildDatasetButton onClick={onBuildDataset} />
+    </ActionBar>
+  );
+}

--- a/ui/app/routes/datasets/route.tsx
+++ b/ui/app/routes/datasets/route.tsx
@@ -9,6 +9,7 @@ import {
   PageLayout,
   SectionLayout,
 } from "~/components/layout/PageLayout";
+import { DatasetsActions } from "./DatasetsActions";
 
 export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url);
@@ -38,6 +39,7 @@ export default function DatasetListPage({ loaderData }: Route.ComponentProps) {
     <PageLayout>
       <PageHeader heading="Datasets" count={counts.length} />
       <SectionLayout>
+        <DatasetsActions onBuildDataset={() => navigate("/datasets/builder")} />
         <DatasetTable counts={counts} />
         <PageButtons
           onPreviousPage={handlePreviousPage}


### PR DESCRIPTION
Closes #1524 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `BuildDatasetButton` to Datasets page for navigating to dataset builder.
> 
>   - **UI Components**:
>     - Add `BuildDatasetButton` component in `BuildDatasetButton.tsx` with `onClick`, `className`, and `disabled` props.
>     - Add `DatasetsActions` component in `DatasetsActions.tsx` to include `BuildDatasetButton`.
>   - **Integration**:
>     - Integrate `DatasetsActions` into `DatasetListPage` in `route.tsx`, with `onBuildDataset` navigating to `/datasets/builder`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4c2ea7580187d509a44c6aaf802a38fd4f950a34. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->