### PR TITLE
changed --variant to --variant-name in evals binary

### DIFF
--- a/evaluations/src/lib.rs
+++ b/evaluations/src/lib.rs
@@ -58,7 +58,7 @@ pub struct Args {
 
     /// Name of the variant to run.
     #[arg(short, long)]
-    pub variant: String,
+    pub variant_name: String,
 
     /// Number of concurrent requests to make.
     #[arg(short, long, default_value = "1")]
@@ -111,7 +111,7 @@ pub async fn run_evaluation(
         function_config,
     )
     .await?;
-    let variant = Arc::new(args.variant);
+    let variant = Arc::new(args.variant_name);
     let evaluation_name = Arc::new(args.name);
     let dataset_len = dataset.len();
     let mut task_id_to_datapoint_id = HashMap::new();

--- a/evaluations/tests/tests.rs
+++ b/evaluations/tests/tests.rs
@@ -54,7 +54,7 @@ async fn run_evaluations_json() {
         config_file: config_path,
         gateway_url: None,
         name: "entity_extraction".to_string(),
-        variant: "gpt_4o_mini".to_string(),
+        variant_name: "gpt_4o_mini".to_string(),
         concurrency: 10,
         format: OutputFormat::Jsonl,
     };
@@ -193,7 +193,7 @@ async fn run_exact_match_evaluation_chat() {
         config_file: config_path,
         gateway_url: None,
         name: "haiku_with_outputs".to_string(),
-        variant: "gpt_4o_mini".to_string(),
+        variant_name: "gpt_4o_mini".to_string(),
         concurrency: 10,
         format: OutputFormat::Jsonl,
     };
@@ -298,7 +298,7 @@ async fn run_llm_judge_evaluation_chat() {
         config_file: config_path,
         gateway_url: None,
         name: "haiku_without_outputs".to_string(),
-        variant: "gpt_4o_mini".to_string(),
+        variant_name: "gpt_4o_mini".to_string(),
         concurrency: 10,
         format: OutputFormat::Jsonl,
     };
@@ -418,7 +418,7 @@ async fn run_llm_judge_evaluation_chat_human_readable() {
         config_file: config_path,
         gateway_url: None,
         name: "haiku_without_outputs".to_string(),
-        variant: "gpt_4o_mini".to_string(),
+        variant_name: "gpt_4o_mini".to_string(),
         concurrency: 10,
         format: OutputFormat::HumanReadable,
     };
@@ -453,7 +453,7 @@ async fn run_llm_judge_evaluation_json_human_readable() {
         config_file: config_path,
         gateway_url: None,
         name: "entity_extraction".to_string(),
-        variant: "gpt_4o_mini".to_string(),
+        variant_name: "gpt_4o_mini".to_string(),
         concurrency: 10,
         format: OutputFormat::HumanReadable,
     };
@@ -484,13 +484,19 @@ async fn test_parse_args() {
         .to_string()
         .contains("the following required arguments were not provided:"));
     assert!(args.to_string().contains("--name <NAME>"));
-    assert!(args.to_string().contains("--variant <VARIANT>"));
+    assert!(args.to_string().contains("--variant-name <VARIANT_NAME>"));
 
     // Test required arguments
-    let args = Args::try_parse_from(["test", "--name", "my-evaluation", "--variant", "my-variant"])
-        .unwrap();
+    let args = Args::try_parse_from([
+        "test",
+        "--name",
+        "my-evaluation",
+        "--variant-name",
+        "my-variant",
+    ])
+    .unwrap();
     assert_eq!(args.name, "my-evaluation");
-    assert_eq!(args.variant, "my-variant");
+    assert_eq!(args.variant_name, "my-variant");
     assert_eq!(args.config_file, PathBuf::from("./config/tensorzero.toml"));
     assert_eq!(args.concurrency, 1);
     assert_eq!(args.gateway_url, None);
@@ -501,7 +507,7 @@ async fn test_parse_args() {
         "test",
         "--name",
         "my-evaluation",
-        "--variant",
+        "--variant-name",
         "my-variant",
         "--config-file",
         "/path/to/config.toml",
@@ -514,7 +520,7 @@ async fn test_parse_args() {
     ])
     .unwrap();
     assert_eq!(args.name, "my-evaluation");
-    assert_eq!(args.variant, "my-variant");
+    assert_eq!(args.variant_name, "my-variant");
     assert_eq!(args.config_file, PathBuf::from("/path/to/config.toml"));
     assert_eq!(
         args.gateway_url,
@@ -528,7 +534,7 @@ async fn test_parse_args() {
         "test",
         "--name",
         "my-evaluation",
-        "--variant",
+        "--variant-name",
         "my-variant",
         "--gateway-url",
         "not-a-url",
@@ -543,7 +549,7 @@ async fn test_parse_args() {
         "test",
         "--name",
         "my-evaluation",
-        "--variant",
+        "--variant-name",
         "my-variant",
         "--format",
         "invalid",
@@ -583,7 +589,7 @@ async fn run_evaluations_errors() {
         config_file: config_path,
         gateway_url: None,
         name: "entity_extraction".to_string(),
-        variant: "dummy_error".to_string(),
+        variant_name: "dummy_error".to_string(),
         concurrency: 10,
         format: OutputFormat::Jsonl,
     };

--- a/ui/app/utils/evaluations.server.ts
+++ b/ui/app/utils/evaluations.server.ts
@@ -50,7 +50,9 @@ export function runEvaluation(
   const evaluationsPath = getEvaluationsPath();
   const gatewayURL = getGatewayURL();
   // Construct the command to run the evaluations binary
-  // Example: evaluations --gateway-url http://localhost:3000 --name entity_extraction --variant llama_8b_initial_prompt --concurrency 10 --format jsonl
+  // Example: evaluations --gateway-url http://localhost:3000 --name entity_extraction --variant-name llama_8b_initial_prompt --concurrency 10 --format jsonl
+  // We do not need special escaping for the evaluation name or variant name because
+  // Node's spawn() does not use the shell to run the command.
   const command = [
     evaluationsPath,
     "--gateway-url",
@@ -59,7 +61,7 @@ export function runEvaluation(
     getConfigPath(),
     "--name",
     evaluationName,
-    "--variant",
+    "--variant-name",
     variantName,
     "--concurrency",
     concurrency.toString(),


### PR DESCRIPTION
Closes #1560 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Renamed `--variant` to `--variant-name` in the `evals` binary and updated related code and tests.
> 
>   - **Behavior**:
>     - Renamed command-line argument `--variant` to `--variant-name` in `Args` struct in `lib.rs`.
>     - Updated `run_evaluation()` function in `lib.rs` to use `args.variant_name`.
>   - **Tests**:
>     - Updated test cases in `tests.rs` to use `--variant-name` instead of `--variant`.
>     - Modified `test_parse_args()` to check for `--variant-name`.
>   - **Misc**:
>     - Updated `runEvaluation()` function in `evaluations.server.ts` to use `--variant-name` in command construction.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2eeba8bd49f1aff5cae78199e1a642870d3cfc35. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->