### PR TITLE
added new version of output component to eval results view

### DIFF
--- a/ui/app/components/inference/NewOutput.tsx
+++ b/ui/app/components/inference/NewOutput.tsx
@@ -11,6 +11,11 @@ import {
 } from "~/components/layout/SnippetLayout";
 import { CodeMessage, TextMessage } from "~/components/layout/SnippetContent";
 
+/*
+NOTE: This is the new output component but it is not editable yet so we are rolling
+it out across the UI incrementally.
+*/
+
 interface OutputProps {
   output: JsonInferenceOutput | ContentBlockOutput[];
   outputSchema?: Record<string, unknown>;

--- a/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/route.tsx
+++ b/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/route.tsx
@@ -10,7 +10,7 @@ import {
 import { PageLayout } from "~/components/layout/PageLayout";
 import Input from "~/components/inference/Input";
 import { data, isRouteErrorResponse, redirect } from "react-router";
-import Output from "~/components/inference/Output";
+import Output from "~/components/inference/NewOutput";
 import {
   consolidate_evaluation_results,
   getEvaluatorMetricName,

--- a/ui/app/routes/observability/inferences/$inference_id/route.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/route.tsx
@@ -18,7 +18,7 @@ import {
 import PageButtons from "~/components/utils/PageButtons";
 import BasicInfo from "./InferenceBasicInfo";
 import Input from "~/components/inference/Input";
-import Output from "./InferenceOutput";
+import Output from "~/components/inference/NewOutput";
 import FeedbackTable from "~/components/feedback/FeedbackTable";
 import { tensorZeroClient } from "~/utils/tensorzero.server";
 import { ParameterCard } from "./InferenceParameters";


### PR DESCRIPTION
Closes #1545 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces `NewOutput` component for evaluation and inference routes, replacing the old output component with a new version that supports JSON and content block outputs.
> 
>   - **Component Update**:
>     - Renames `InferenceOutput.tsx` to `NewOutput.tsx` and updates the component to a new version in `NewOutput.tsx`.
>     - Adds a note indicating the component is not editable and is being rolled out incrementally.
>   - **Route Updates**:
>     - Replaces `Output` with `NewOutput` in `route.tsx` for `evaluations/$evaluation_name/$datapoint_id` and `observability/inferences/$inference_id`.
>   - **Behavior**:
>     - `NewOutput` handles `JsonInferenceOutput` and `ContentBlockOutput[]`, with tabs for "Parsed Output", "Raw Output", and "Output Schema" if applicable.
>     - Default tab is "Parsed" if content exists, otherwise "Raw".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 791b46bc160088352390226139c8cb72183d03db. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->