### PR TITLE
moved autorefresh indicator next to results heading

### DIFF
--- a/ui/app/routes/evaluations/$evaluation_name/route.tsx
+++ b/ui/app/routes/evaluations/$evaluation_name/route.tsx
@@ -221,8 +221,8 @@ export default function EvaluationsPage({ loaderData }: Route.ComponentProps) {
               <EvaluationErrorInfo errors={errors} />
             </>
           )}
-          <div className="flex items-center justify-between">
-            <SectionHeader heading="Results" />
+          <div className="flex items-center">
+            <SectionHeader heading="Results" className="mr-4" />
             <AutoRefreshIndicator isActive={any_evaluation_is_running} />
           </div>
           <EvaluationTable


### PR DESCRIPTION
Closes #1555 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Moved `AutoRefreshIndicator` next to `Results` heading in `EvaluationsPage` component for improved layout.
> 
>   - **UI Adjustment**:
>     - Moved `AutoRefreshIndicator` next to `Results` heading in `EvaluationsPage` component in `route.tsx` for better layout alignment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b4adf4fc80e7316e0aad20fed2de0900b8e6d2f5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->