### PR TITLE
dataset builder button is disabled until a dataset is selected

### DIFF
--- a/ui/app/routes/datasets/builder/DatasetBuilderForm.tsx
+++ b/ui/app/routes/datasets/builder/DatasetBuilderForm.tsx
@@ -49,10 +49,10 @@ export function DatasetBuilderForm({
 
   const watchedFields = useWatch({
     control: form.control,
-    name: ["function", "metric_name", "threshold"] as const,
+    name: ["function", "metric_name", "threshold", "dataset"] as const,
   });
 
-  const [functionName, metricName, threshold] = watchedFields;
+  const [functionName, metricName, threshold, selectedDataset] = watchedFields;
   const counts = useCountFetcher({
     functionName: functionName ?? undefined,
     metricName: metricName ?? undefined,
@@ -153,7 +153,8 @@ export function DatasetBuilderForm({
           disabled={
             submissionPhase !== "idle" ||
             countToInsert === null ||
-            countToInsert === 0
+            countToInsert === 0 ||
+            !selectedDataset
           }
           onClick={() => {
             if (submissionPhase === "complete") {


### PR DESCRIPTION
Closes #1553 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disable dataset builder button in `DatasetBuilderForm.tsx` until a dataset is selected.
> 
>   - **Behavior**:
>     - In `DatasetBuilderForm.tsx`, the submit button is now disabled if no dataset is selected (`!selectedDataset`).
>     - Uses `useWatch` to track `dataset` field in addition to `function`, `metric_name`, and `threshold`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for bab0b49b11b5afc031b565bf6a594423db02952c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->