### PR TITLE
Rust HTTP client should keep track of the server version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3742,6 +3742,7 @@ version = "0.1.0"
 dependencies = [
  "async-stream",
  "clap",
+ "lazy_static",
  "pyo3",
  "reqwest",
  "reqwest-eventsource",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ anyhow = "1.0.97"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt"] }
 clap = { version = "4.5.34", features = ["derive"] }
 futures = "0.3.30"
+lazy_static = { version = "1.5.0" }
 url = "2.5.4"
 
 [workspace.lints.rust]

--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -736,24 +736,6 @@ impl AsyncTensorZeroGateway {
         verbose_errors: bool,
         async_setup: bool,
     ) -> PyResult<Py<PyAny>> {
-        // let gateway_url = gateway_url.to_string();
-        // let build_gateway = move |py: Python<'_>| {
-        //     let client = BaseTensorZeroGateway::new(py, &gateway_url, timeout, verbose_errors)?;
-        //     let instance = PyClassInitializer::from(client).add_subclass(AsyncTensorZeroGateway {});
-        //     Ok(Py::new(py, instance)?.into_any())
-        // };
-        // if async_setup {
-        //     // This doesn't actually do anything async at the moment, but we run
-        //     // 'build_gateway' inside the future so that any exception is thrown by the future
-        //     Ok(
-        //         pyo3_async_runtimes::tokio::future_into_py(cls.py(), async move {
-        //             Python::with_gil(build_gateway)
-        //         })?
-        //         .unbind(),
-        //     )
-        // } else {
-        //     build_gateway(cls.py())
-        // }
         let mut client_builder = ClientBuilder::new(ClientBuilderMode::HTTPGateway {
             url: Url::parse(gateway_url)
                 .map_err(|e| PyValueError::new_err(format!("Invalid gateway URL: {e}")))?,

--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -448,8 +448,36 @@ impl TensorZeroGateway {
         timeout: Option<f64>,
         verbose_errors: bool,
     ) -> PyResult<Py<TensorZeroGateway>> {
-        let client = BaseTensorZeroGateway::new(cls.py(), gateway_url, timeout, verbose_errors)?;
-        let instance = PyClassInitializer::from(client).add_subclass(TensorZeroGateway {});
+        let mut client_builder = ClientBuilder::new(ClientBuilderMode::HTTPGateway {
+            url: Url::parse(gateway_url)
+                .map_err(|e| PyValueError::new_err(format!("Invalid gateway URL: {e}")))?,
+        })
+        .with_verbose_errors(verbose_errors);
+        if let Some(timeout) = timeout {
+            let http_client = reqwest::Client::builder()
+                .timeout(
+                    Duration::try_from_secs_f64(timeout)
+                        .map_err(|e| PyValueError::new_err(format!("Invalid timeout: {e}")))?,
+                )
+                .build()
+                .map_err(|e| PyValueError::new_err(format!("Failed to build HTTP client: {e}")))?;
+            client_builder = client_builder.with_http_client(http_client);
+        }
+        let client_fut = client_builder.build();
+        let client_res = tokio_block_on_without_gil(cls.py(), client_fut);
+        let client = match client_res {
+            Ok(client) => client,
+            Err(e) => {
+                return Err(tensorzero_internal_error(
+                    cls.py(),
+                    &format!("Failed to construct TensorZero client: {e:?}"),
+                )?);
+            }
+        };
+        let instance = PyClassInitializer::from(BaseTensorZeroGateway {
+            client: Arc::new(client),
+        })
+        .add_subclass(TensorZeroGateway {});
         Py::new(cls.py(), instance)
     }
 
@@ -708,23 +736,64 @@ impl AsyncTensorZeroGateway {
         verbose_errors: bool,
         async_setup: bool,
     ) -> PyResult<Py<PyAny>> {
-        let gateway_url = gateway_url.to_string();
-        let build_gateway = move |py: Python<'_>| {
-            let client = BaseTensorZeroGateway::new(py, &gateway_url, timeout, verbose_errors)?;
-            let instance = PyClassInitializer::from(client).add_subclass(AsyncTensorZeroGateway {});
-            Ok(Py::new(py, instance)?.into_any())
+        // let gateway_url = gateway_url.to_string();
+        // let build_gateway = move |py: Python<'_>| {
+        //     let client = BaseTensorZeroGateway::new(py, &gateway_url, timeout, verbose_errors)?;
+        //     let instance = PyClassInitializer::from(client).add_subclass(AsyncTensorZeroGateway {});
+        //     Ok(Py::new(py, instance)?.into_any())
+        // };
+        // if async_setup {
+        //     // This doesn't actually do anything async at the moment, but we run
+        //     // 'build_gateway' inside the future so that any exception is thrown by the future
+        //     Ok(
+        //         pyo3_async_runtimes::tokio::future_into_py(cls.py(), async move {
+        //             Python::with_gil(build_gateway)
+        //         })?
+        //         .unbind(),
+        //     )
+        // } else {
+        //     build_gateway(cls.py())
+        // }
+        let mut client_builder = ClientBuilder::new(ClientBuilderMode::HTTPGateway {
+            url: Url::parse(gateway_url)
+                .map_err(|e| PyValueError::new_err(format!("Invalid gateway URL: {e}")))?,
+        })
+        .with_verbose_errors(verbose_errors);
+        if let Some(timeout) = timeout {
+            let http_client = reqwest::Client::builder()
+                .timeout(Duration::from_secs_f64(timeout))
+                .build()
+                .map_err(|e| PyValueError::new_err(format!("Failed to build HTTP client: {e}")))?;
+            client_builder = client_builder.with_http_client(http_client);
+        }
+        let client_fut = client_builder.build();
+        let build_gateway = async move {
+            let client = client_fut.await;
+            // We need to interact with Python objects here (to build up a Python `AsyncTensorZeroGateway`),
+            // so we need the GIL
+            Python::with_gil(|py| {
+                let client = match client {
+                    Ok(client) => client,
+                    Err(e) => {
+                        return Err(tensorzero_internal_error(
+                            py,
+                            &format!("Failed to construct TensorZero client: {e:?}"),
+                        )?);
+                    }
+                };
+
+                // Construct an instance of `AsyncTensorZeroGateway` (while providing the fields from the `BaseTensorZeroGateway` superclass).
+                let instance = PyClassInitializer::from(BaseTensorZeroGateway {
+                    client: Arc::new(client),
+                })
+                .add_subclass(AsyncTensorZeroGateway {});
+                Py::new(py, instance)
+            })
         };
         if async_setup {
-            // This doesn't actually do anything async at the moment, but we run
-            // 'build_gateway' inside the future so that any exception is thrown by the future
-            Ok(
-                pyo3_async_runtimes::tokio::future_into_py(cls.py(), async move {
-                    Python::with_gil(build_gateway)
-                })?
-                .unbind(),
-            )
+            Ok(pyo3_async_runtimes::tokio::future_into_py(cls.py(), build_gateway)?.unbind())
         } else {
-            build_gateway(cls.py())
+            Ok(tokio_block_on_without_gil(cls.py(), build_gateway)?.into_any())
         }
     }
 

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [[test]]
 name = "client_tests"
-path = "tests/tests.rs"
+path = "tests/versioning.rs"
 required-features = ["e2e_tests"]
 
 [dependencies]

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -3,6 +3,11 @@ name = "tensorzero"
 version = "0.1.0"
 edition = "2021"
 
+[[test]]
+name = "client_tests"
+path = "tests/tests.rs"
+required-features = ["e2e_tests"]
+
 [dependencies]
 reqwest = { workspace = true }
 serde = { workspace = true }
@@ -24,6 +29,7 @@ workspace = true
 
 [dev-dependencies]
 clap = { workspace = true }
+lazy_static = { workspace = true }
 tokio = { workspace = true }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -71,8 +71,8 @@ impl HTTPGateway {
             };
 
             // If we fail to parse the /status response, we throw an error because this is very wrong.
-            let status_response: StatusResponse = status_response.json().await.map_err(|_| {
-                ClientBuilderError::GatewayVersion("Failed to parse /status response".to_string())
+            let status_response: StatusResponse = status_response.json().await.map_err(|e| {
+                ClientBuilderError::GatewayVersion(format!("Failed to parse /status response: {e}"))
             })?;
             Some(status_response.version)
         } else {

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -1,14 +1,15 @@
-use std::{fmt::Display, future::Future, path::PathBuf, sync::Arc, time::Duration};
+use std::{env, fmt::Display, future::Future, path::PathBuf, sync::Arc, time::Duration};
 
 use reqwest_eventsource::{Event, EventSource, RequestBuilderExt};
 use std::fmt::Debug;
 use tensorzero_internal::{
     config_parser::Config,
+    endpoints::status::StatusResponse,
     error::ErrorDetails,
     gateway_util::{setup_clickhouse, setup_http_client, AppStateData},
 };
 use thiserror::Error;
-use tokio::time::error::Elapsed;
+use tokio::{sync::Mutex, time::error::Elapsed};
 use tokio_stream::StreamExt;
 use url::Url;
 
@@ -52,6 +53,39 @@ impl Debug for ClientMode {
 struct HTTPGateway {
     base_url: Url,
     http_client: reqwest::Client,
+    gateway_version: Mutex<Option<String>>, // Needs interior mutability so it can be set on every request
+}
+
+impl HTTPGateway {
+    /// Sets the gateway version on the HTTPGateway struct.
+    /// This should be called if the HTTPGateway is constructed within an async context.
+    pub async fn discover_initialize_gateway_version(&self) -> Result<(), ClientBuilderError> {
+        let status_url = self.base_url.join("status").map_err(|_| {
+            ClientBuilderError::GatewayVersion("Failed to construct /status URL".to_string())
+        })?;
+        if !cfg!(feature = "e2e_tests") {
+            let status_response = self
+                .http_client
+                .get(status_url)
+                .send()
+                .await
+                .map_err(|e| ClientBuilderError::GatewayVersion(e.to_string()))?;
+            let status_response: StatusResponse = status_response.json().await.map_err(|_| {
+                ClientBuilderError::GatewayVersion("Failed to parse /status response".to_string())
+            })?;
+            let mut gateway_version = self.gateway_version.lock().await;
+            *gateway_version = Some(status_response.version);
+        } else {
+            let version = env::var("TENSORZERO_E2E_GATEWAY_VERSION_OVERRIDE").map_err(|_| {
+                ClientBuilderError::GatewayVersion(
+                    "TENSORZERO_E2E_GATEWAY_VERSION_OVERRIDE is not set".to_string(),
+                )
+            })?;
+            let mut gateway_version = self.gateway_version.lock().await;
+            *gateway_version = Some(version);
+        }
+        Ok(())
+    }
 }
 
 struct EmbeddedGateway {
@@ -110,6 +144,8 @@ pub enum ClientBuilderError {
     ConfigParsing(TensorZeroError),
     #[error("Failed to build HTTP client: {0}")]
     HTTPClientBuild(TensorZeroError),
+    #[error("Failed to get gateway version: {0}")]
+    GatewayVersion(String),
 }
 
 // Helper type to choose between using Debug or Display for a type
@@ -175,7 +211,13 @@ impl ClientBuilder {
     /// Constructs a `Client`, returning an error if the configuration is invalid.
     pub async fn build(self) -> Result<Client, ClientBuilderError> {
         match &self.mode {
-            ClientBuilderMode::HTTPGateway { .. } => self.build_http(),
+            ClientBuilderMode::HTTPGateway { .. } => {
+                let client = self.build_http()?;
+                if let ClientMode::HTTPGateway(mode) = &client.mode {
+                    mode.discover_initialize_gateway_version().await?;
+                }
+                Ok(client)
+            }
             ClientBuilderMode::EmbeddedGateway {
                 config_file,
                 clickhouse_url,
@@ -239,6 +281,7 @@ impl ClientBuilder {
             mode: ClientMode::HTTPGateway(HTTPGateway {
                 base_url: url,
                 http_client: self.http_client.unwrap_or_default(),
+                gateway_version: Mutex::new(None),
             }),
             verbose_errors: self.verbose_errors,
         })
@@ -392,6 +435,17 @@ impl Client {
             }
         })?;
 
+        let headers = resp.headers();
+        let version = headers.get("x-tensorzero-gateway-version");
+        if let Some(version) = version {
+            match version.to_str() {
+                Ok(version) => self.update_gateway_version(version.to_string()).await,
+                Err(e) => {
+                    tracing::warn!("Gateway version header is not valid UTF-8: {e}");
+                }
+            }
+        }
+
         if let Err(e) = resp.error_for_status_ref() {
             let status_code = resp.status().as_u16();
             let text = resp.text().await.ok();
@@ -524,6 +578,26 @@ impl Client {
         match &self.mode {
             ClientMode::EmbeddedGateway { gateway, .. } => Some(&gateway.state),
             _ => None,
+        }
+    }
+
+    async fn update_gateway_version(&self, version: String) {
+        match &self.mode {
+            ClientMode::HTTPGateway(client) => {
+                // Acquire the lock on the gateway version
+                let mut gateway_version = client.gateway_version.lock().await;
+                *gateway_version = Some(version)
+            }
+            // Should never be called
+            ClientMode::EmbeddedGateway { .. } => {}
+        }
+    }
+
+    #[cfg(feature = "e2e_tests")]
+    pub async fn get_gateway_version(&self) -> Option<String> {
+        match &self.mode {
+            ClientMode::HTTPGateway(client) => client.gateway_version.lock().await.clone(),
+            ClientMode::EmbeddedGateway { .. } => None,
         }
     }
 }

--- a/clients/rust/tests/tests.rs
+++ b/clients/rust/tests/tests.rs
@@ -1,3 +1,3 @@
 #![cfg(feature = "e2e_tests")]
-mod common;
+#![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
 mod versioning;

--- a/clients/rust/tests/tests.rs
+++ b/clients/rust/tests/tests.rs
@@ -1,3 +1,2 @@
 #![cfg(feature = "e2e_tests")]
-#![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
 mod versioning;

--- a/clients/rust/tests/tests.rs
+++ b/clients/rust/tests/tests.rs
@@ -1,0 +1,3 @@
+#![cfg(feature = "e2e_tests")]
+mod common;
+mod versioning;

--- a/clients/rust/tests/tests.rs
+++ b/clients/rust/tests/tests.rs
@@ -1,2 +1,0 @@
-#![cfg(feature = "e2e_tests")]
-mod versioning;

--- a/clients/rust/tests/versioning.rs
+++ b/clients/rust/tests/versioning.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "e2e_tests")]
 #![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
 use serde_json::json;
-use tensorzero::{ClientBuilder, ClientBuilderMode, ClientInferenceParams, Input};
+use tensorzero::{ClientBuilder, ClientBuilderMode, ClientInferenceParams, ClientInput};
 
 use reqwest::Url;
 
@@ -42,7 +42,7 @@ async fn test_versioning() {
         .inference(ClientInferenceParams {
             function_name: Some("basic_test".to_string()),
             episode_id: None,
-            input: Input {
+            input: ClientInput {
                 system: Some(json!({"assistant_name": "John"})),
                 messages: vec![],
             },

--- a/clients/rust/tests/versioning.rs
+++ b/clients/rust/tests/versioning.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "e2e_tests")]
 #![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
 use serde_json::json;
 use tensorzero::{ClientBuilder, ClientBuilderMode, ClientInferenceParams, Input};

--- a/clients/rust/tests/versioning.rs
+++ b/clients/rust/tests/versioning.rs
@@ -1,0 +1,54 @@
+#![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
+use serde_json::json;
+use tensorzero::{ClientBuilder, ClientBuilderMode, ClientInferenceParams, Input};
+
+use reqwest::Url;
+
+lazy_static::lazy_static! {
+    static ref GATEWAY_URL: String = std::env::var("GATEWAY_URL").unwrap_or("http://localhost:3000".to_string());
+}
+
+pub fn get_gateway_endpoint(endpoint: Option<&str>) -> Url {
+    let base_url: Url = GATEWAY_URL.parse().unwrap();
+    match endpoint {
+        Some(endpoint) => base_url.join(endpoint).unwrap(),
+        None => base_url,
+    }
+}
+
+#[tokio::test]
+async fn test_versioning() {
+    std::env::set_var("TENSORZERO_E2E_GATEWAY_VERSION_OVERRIDE", "0.1.0");
+    let client = ClientBuilder::new(ClientBuilderMode::HTTPGateway {
+        url: get_gateway_endpoint(None),
+    })
+    .build_http()
+    .unwrap();
+    let version = client.get_gateway_version().await;
+    assert!(version.is_none());
+
+    let client = ClientBuilder::new(ClientBuilderMode::HTTPGateway {
+        url: get_gateway_endpoint(None),
+    })
+    .build()
+    .await
+    .unwrap();
+    let version = client.get_gateway_version().await;
+    assert_eq!(version.unwrap(), "0.1.0");
+
+    std::env::set_var("TENSORZERO_E2E_GATEWAY_VERSION_OVERRIDE", "0.2.0");
+    client
+        .inference(ClientInferenceParams {
+            function_name: Some("basic_test".to_string()),
+            episode_id: None,
+            input: Input {
+                system: Some(json!({"assistant_name": "John"})),
+                messages: vec![],
+            },
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let version = client.get_gateway_version().await;
+    assert_eq!(version.unwrap(), "0.2.0");
+}

--- a/tensorzero-internal/Cargo.toml
+++ b/tensorzero-internal/Cargo.toml
@@ -45,7 +45,7 @@ image = { version = "0.25.6", default-features = false }
 itertools = "0.14.0"
 jsonschema = "0.29.1"
 jsonwebtoken = "9.3.1"
-lazy_static = { version = "1.5.0" }
+lazy_static = { workspace = true }
 metrics = "0.24.1"
 metrics-exporter-prometheus = { version = "0.16.2", features = [
     "http-listener",
@@ -80,7 +80,7 @@ tracing-subscriber = { version = "0.3.18", features = [
 ] }
 url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true }
-tensorzero-derive = { path = "../tensorzero-derive"}
+tensorzero-derive = { path = "../tensorzero-derive" }
 clap = { workspace = true }
 scoped-tls = "1.0.1"
 

--- a/tensorzero-internal/src/endpoints/status.rs
+++ b/tensorzero-internal/src/endpoints/status.rs
@@ -3,14 +3,24 @@ use axum::debug_handler;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::Json;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 pub const TENSORZERO_VERSION: &str = "2025.03.4";
 
 /// A handler for a simple liveness check
 #[debug_handler]
-pub async fn status_handler() -> Json<Value> {
-    Json(json!({ "status": "ok", "version": TENSORZERO_VERSION }))
+pub async fn status_handler() -> Json<StatusResponse> {
+    Json(StatusResponse {
+        status: "ok".to_string(),
+        version: TENSORZERO_VERSION.to_string(),
+    })
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct StatusResponse {
+    pub status: String,
+    pub version: String,
 }
 
 /// A handler for a health check that includes availability of related services (for now, ClickHouse)
@@ -64,6 +74,6 @@ mod tests {
     #[tokio::test]
     async fn test_status_handler() {
         let response = status_handler().await;
-        assert_eq!(response.get("version").unwrap(), TENSORZERO_VERSION);
+        assert_eq!(response.version, TENSORZERO_VERSION);
     }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add server version tracking to Rust HTTP client with new tests for verification.
> 
>   - **Behavior**:
>     - `HTTPGateway` in `lib.rs` now tracks server version using `gateway_version` field.
>     - `discover_initialize_gateway_version()` added to `HTTPGateway` to fetch and store version from `/status` endpoint.
>     - `parse_http_response()` in `Client` updated to capture version from response headers.
>   - **Testing**:
>     - New test `test_versioning` in `tests/versioning.rs` to verify version tracking.
>   - **Misc**:
>     - Add `lazy_static` dependency in `Cargo.toml` and `Cargo.lock` for test setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 560d0e80129bee67d2e2c982720529d29cb99f1f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->