### PR TITLE
Introduce `Client[Input, InputMessage, InputMessageContent]` types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3747,6 +3747,7 @@ dependencies = [
  "reqwest-eventsource",
  "secrecy",
  "serde",
+ "serde-untagged",
  "serde_json",
  "tensorzero-internal",
  "thiserror 2.0.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt"] }
 clap = { version = "4.5.34", features = ["derive"] }
 futures = "0.3.30"
 url = "2.5.4"
+serde-untagged = "0.1.7"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -29,9 +29,8 @@ use tensorzero_internal::{
 };
 use tensorzero_rust::{
     err_to_http, observability::LogFormat, CacheParamsOptions, Client, ClientBuilder,
-    ClientBuilderMode, ClientInferenceParams, ClientSecretString, DynamicToolParams,
-    FeedbackParams, InferenceOutput, InferenceParams, InferenceStream, Input, TensorZeroError,
-    Tool,
+    ClientBuilderMode, ClientInferenceParams, ClientInput, ClientSecretString, DynamicToolParams,
+    FeedbackParams, InferenceOutput, InferenceParams, InferenceStream, TensorZeroError, Tool,
 };
 use tokio::sync::Mutex;
 use url::Url;
@@ -391,7 +390,7 @@ impl BaseTensorZeroGateway {
             Default::default()
         };
 
-        let input: Input = deserialize_from_pyobj(py, &input)?;
+        let input: ClientInput = deserialize_from_pyobj(py, &input)?;
 
         Ok(ClientInferenceParams {
             function_name,

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = "2.0.11"
 pyo3 = { workspace = true, optional = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
+serde-untagged = { workspace = true }
 
 [lints]
 workspace = true

--- a/clients/rust/examples/inference_demo/main.rs
+++ b/clients/rust/examples/inference_demo/main.rs
@@ -3,8 +3,8 @@
 use std::{io::Write, path::PathBuf};
 
 use tensorzero::{
-    ClientBuilder, ClientBuilderMode, ClientInferenceParams, ContentBlockChunk, InferenceOutput,
-    InferenceResponseChunk, Input, InputMessage, InputMessageContent, Role,
+    ClientBuilder, ClientBuilderMode, ClientInferenceParams, ClientInput, ClientInputMessage,
+    ClientInputMessageContent, ContentBlockChunk, InferenceOutput, InferenceResponseChunk, Role,
 };
 use tensorzero_internal::inference::types::TextKind;
 use tokio_stream::StreamExt;
@@ -69,10 +69,10 @@ async fn main() {
         .inference(ClientInferenceParams {
             function_name: Some(args.function_name),
             stream: Some(args.streaming),
-            input: Input {
-                messages: vec![InputMessage {
+            input: ClientInput {
+                messages: vec![ClientInputMessage {
                     role: Role::User,
-                    content: vec![InputMessageContent::Text(TextKind::Arguments {
+                    content: vec![ClientInputMessageContent::Text(TextKind::Arguments {
                         arguments: input,
                     })],
                 }],

--- a/clients/rust/src/client_input.rs
+++ b/clients/rust/src/client_input.rs
@@ -1,0 +1,150 @@
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+use serde_untagged::UntaggedEnumVisitor;
+use tensorzero_internal::{
+    error::Error,
+    inference::types::{Image, InputMessageContent, Role, TextKind, Thought},
+    tool::{ToolCall, ToolCallInput, ToolResult},
+};
+
+// Like the normal `Input` type, but with `ClientInputMessage` instead of `InputMessage`.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ClientInput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system: Option<Value>,
+    #[serde(default)]
+    pub messages: Vec<ClientInputMessage>,
+}
+
+// Like the normal `InputMessage` type, but with `ClientInputMessageContent` instead of `InputMessageContent`.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct ClientInputMessage {
+    pub role: Role,
+    #[serde(deserialize_with = "deserialize_content")]
+    pub content: Vec<ClientInputMessageContent>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ClientInputMessageContent {
+    Text(TextKind),
+    ToolCall(ToolCallInput),
+    ToolResult(ToolResult),
+    RawText {
+        value: String,
+    },
+    Thought(Thought),
+    Image(Image),
+    /// An unknown content block type, used to allow passing provider-specific
+    /// content blocks (e.g. Anthropic's "redacted_thinking") in and out
+    /// of TensorZero.
+    /// The 'data' field hold the original content block from the provider,
+    /// without any validation or transformation by TensorZero.
+    Unknown {
+        data: Value,
+        model_provider_name: Option<String>,
+    },
+    // We may extend this in the future to include other types of content
+}
+
+impl TryFrom<ClientInputMessageContent> for InputMessageContent {
+    type Error = Error;
+    fn try_from(this: ClientInputMessageContent) -> Result<Self, Error> {
+        Ok(match this {
+            ClientInputMessageContent::Text(text) => InputMessageContent::Text(text),
+            ClientInputMessageContent::ToolCall(tool_call) => {
+                InputMessageContent::ToolCall(tool_call.try_into()?)
+            }
+            ClientInputMessageContent::ToolResult(tool_result) => {
+                InputMessageContent::ToolResult(tool_result)
+            }
+            ClientInputMessageContent::RawText { value } => InputMessageContent::RawText { value },
+            ClientInputMessageContent::Thought(thought) => InputMessageContent::Thought(thought),
+            ClientInputMessageContent::Image(image) => InputMessageContent::Image(image),
+            ClientInputMessageContent::Unknown {
+                data,
+                model_provider_name,
+            } => InputMessageContent::Unknown {
+                data,
+                model_provider_name,
+            },
+        })
+    }
+}
+
+pub fn deserialize_content<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Vec<ClientInputMessageContent>, D::Error> {
+    UntaggedEnumVisitor::new()
+        .string(|text| {
+            Ok(vec![ClientInputMessageContent::Text(TextKind::Text {
+                text: text.to_string(),
+            })])
+        })
+        .map(|object| {
+            tracing::warn!("Deprecation warning - passing in an object for `content` is deprecated. Please use an array of content blocks instead.");
+            Ok(vec![ClientInputMessageContent::Text(TextKind::Arguments {
+                arguments: object.deserialize()?,
+            })])
+        })
+        .seq(|seq| seq.deserialize())
+        .deserialize(deserializer)
+}
+
+// Helper function to make sure that our `Input` and `ClientInput` types match up
+// as expected. This is never actually called - we just care that it compiles
+pub(super) fn test_client_input_to_input(
+    client_input: ClientInput,
+) -> tensorzero_internal::inference::types::Input {
+    tensorzero_internal::inference::types::Input {
+        system: client_input.system,
+        messages: client_input
+            .messages
+            .into_iter()
+            .map(|message| {
+                let ClientInputMessage { role, content } = message;
+                tensorzero_internal::inference::types::InputMessage {
+                    role,
+                    content: content
+                        .into_iter()
+                        .map(test_client_to_message_content)
+                        .collect(),
+                }
+            })
+            .collect(),
+    }
+}
+
+pub(super) fn test_client_to_message_content(
+    content: ClientInputMessageContent,
+) -> InputMessageContent {
+    match content {
+        ClientInputMessageContent::Text(text) => InputMessageContent::Text(text),
+        ClientInputMessageContent::ToolCall(ToolCallInput {
+            id,
+            name,
+            raw_name: _,
+            arguments,
+            raw_arguments: _,
+        }) => InputMessageContent::ToolCall(ToolCall {
+            id,
+            name: name.unwrap_or_default(),
+            arguments: arguments.unwrap_or_default().to_string(),
+        }),
+        ClientInputMessageContent::ToolResult(tool_result) => {
+            InputMessageContent::ToolResult(tool_result)
+        }
+        ClientInputMessageContent::RawText { value } => InputMessageContent::RawText { value },
+        ClientInputMessageContent::Thought(thought) => InputMessageContent::Thought(thought),
+        ClientInputMessageContent::Image(image) => InputMessageContent::Image(image),
+        ClientInputMessageContent::Unknown {
+            data,
+            model_provider_name,
+        } => InputMessageContent::Unknown {
+            data,
+            model_provider_name,
+        },
+    }
+}

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -13,8 +13,10 @@ use tokio_stream::StreamExt;
 use url::Url;
 
 mod client_inference_params;
+mod client_input;
 
 pub use client_inference_params::{ClientInferenceParams, ClientSecretString};
+pub use client_input::{ClientInput, ClientInputMessage, ClientInputMessageContent};
 
 pub use tensorzero_internal::cache::CacheParamsOptions;
 pub use tensorzero_internal::endpoints::feedback::FeedbackResponse;
@@ -359,7 +361,7 @@ impl Client {
                         gateway.state.config.clone(),
                         &gateway.state.http_client,
                         gateway.state.clickhouse_connection_info.clone(),
-                        params.into(),
+                        params.try_into().map_err(err_to_http)?,
                     )
                     .await
                     .map_err(err_to_http)

--- a/evaluations/src/evaluators/llm_judge.rs
+++ b/evaluations/src/evaluators/llm_judge.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use anyhow::{bail, Result};
 use serde_json::{json, Value};
 use tensorzero::{
-    ClientInferenceParams, DynamicToolParams, InferenceOutput, InferenceParams, InferenceResponse,
-    Input, InputMessage, InputMessageContent, Role,
+    ClientInferenceParams, ClientInput, ClientInputMessage, ClientInputMessageContent,
+    DynamicToolParams, InferenceOutput, InferenceParams, InferenceResponse, Role,
 };
 use tensorzero_internal::cache::CacheEnabledMode;
 use tensorzero_internal::endpoints::datasets::Datapoint;
@@ -48,11 +48,11 @@ pub async fn run_llm_judge_evaluator(
         // Reference output is optional so if it's needed but not present, we can just return None
         Err(_e) => return Ok(None),
     };
-    let input = Input {
+    let input = ClientInput {
         system: None,
-        messages: vec![InputMessage {
+        messages: vec![ClientInputMessage {
             role: Role::User,
-            content: vec![InputMessageContent::Text(TextKind::Arguments{
+            content: vec![ClientInputMessageContent::Text(TextKind::Arguments{
                 arguments: json!({"input": serialized_datapoint_input, "generated_output": generated_output, "reference_output": reference_output})
                     .as_object()
                     .expect("Arguments should be an object")

--- a/evaluations/src/lib.rs
+++ b/evaluations/src/lib.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, bail, Result};
 use clap::Parser;
 use dataset::query_dataset;
 use evaluators::evaluate_inference;
-use helpers::{get_tool_params_args, resolved_input_to_input, setup_logging};
+use helpers::{get_tool_params_args, resolved_input_to_client_input, setup_logging};
 use serde::{Deserialize, Serialize};
 use stats::{EvaluationError, EvaluationInfo, EvaluationStats, EvaluationUpdate};
 use tensorzero::{
@@ -317,7 +317,7 @@ async fn infer_datapoint(params: InferDatapointParams<'_>) -> Result<InferenceRe
         function_config,
     } = params;
 
-    let input = resolved_input_to_input(datapoint.input().clone()).await?;
+    let input = resolved_input_to_client_input(datapoint.input().clone()).await?;
     let dynamic_tool_params = match datapoint.tool_call_config() {
         Some(tool_params) => get_tool_params_args(tool_params, function_config).await,
         None => DynamicToolParams::default(),

--- a/tensorzero-internal/Cargo.toml
+++ b/tensorzero-internal/Cargo.toml
@@ -63,7 +63,7 @@ reqwest = { workspace = true }
 reqwest-eventsource = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true }
-serde-untagged = "0.1.7"
+serde-untagged = { workspace = true}
 serde_json = { workspace = true }
 serde_path_to_error = "0.1.17"
 sha2 = "0.10.8"

--- a/tensorzero-internal/src/inference/types/mod.rs
+++ b/tensorzero-internal/src/inference/types/mod.rs
@@ -704,7 +704,7 @@ impl From<Value> for ResolvedInputMessageContent {
     }
 }
 
-fn deserialize_content<'de, D: Deserializer<'de>>(
+pub fn deserialize_content<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> Result<Vec<InputMessageContent>, D::Error> {
     UntaggedEnumVisitor::new()

--- a/tensorzero-internal/tests/e2e/feedback.rs
+++ b/tensorzero-internal/tests/e2e/feedback.rs
@@ -1265,11 +1265,11 @@ async fn test_fast_inference_then_feedback() {
                     model_name: None,
                     variant_name: None,
                     episode_id: None,
-                    input: tensorzero::Input {
+                    input: tensorzero::ClientInput {
                         system: Some(json!({"assistant_name": "Alfred Pennyworth"})),
-                        messages: vec![tensorzero::InputMessage {
+                        messages: vec![tensorzero::ClientInputMessage {
                             role: Role::User,
-                            content: vec![tensorzero::InputMessageContent::Text(TextKind::Text {
+                            content: vec![tensorzero::ClientInputMessageContent::Text(TextKind::Text {
                                 text: "What is the weather like in Tokyo (in Celsius)? Use the provided `get_temperature` tool. Do not say anything else, just call the function."
                                     .to_string()
                             })],

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -19,8 +19,8 @@ use reqwest_eventsource::{Event, RequestBuilderExt};
 use serde_json::{json, Value};
 use std::future::IntoFuture;
 use tensorzero::{
-    CacheParamsOptions, ClientInferenceParams, InferenceOutput, InferenceResponse, Input,
-    InputMessage, InputMessageContent,
+    CacheParamsOptions, ClientInferenceParams, ClientInput, ClientInputMessage,
+    ClientInputMessageContent, InferenceOutput, InferenceResponse,
 };
 
 use tensorzero_internal::endpoints::object_storage::{
@@ -841,15 +841,15 @@ pub async fn test_url_image_inference_with_provider_and_store(
             .inference(ClientInferenceParams {
                 model_name: Some(provider.model_name.clone()),
                 episode_id: Some(episode_id),
-                input: Input {
+                input: ClientInput {
                     system: None,
-                    messages: vec![InputMessage {
+                    messages: vec![ClientInputMessage {
                         role: Role::User,
                         content: vec![
-                            InputMessageContent::Text(TextKind::Text {
+                            ClientInputMessageContent::Text(TextKind::Text {
                                 text: "Describe the contents of the image".to_string(),
                             }),
-                            InputMessageContent::Image(Image::Url {
+                            ClientInputMessageContent::Image(Image::Url {
                                 url: image_url.clone(),
                             }),
                         ],
@@ -900,15 +900,15 @@ pub async fn test_base64_image_inference_with_provider_and_store(
                 function_name: Some("image_test".to_string()),
                 variant_name: Some(provider.variant_name.clone()),
                 episode_id: Some(episode_id),
-                input: Input {
+                input: ClientInput {
                     system: None,
-                    messages: vec![InputMessage {
+                    messages: vec![ClientInputMessage {
                         role: Role::User,
                         content: vec![
-                            InputMessageContent::Text(TextKind::Text {
+                            ClientInputMessageContent::Text(TextKind::Text {
                                 text: "Describe the contents of the image".to_string(),
                             }),
-                            InputMessageContent::Image(Image::Base64 {
+                            ClientInputMessageContent::Image(Image::Base64 {
                                 mime_type: ImageKind::Png,
                                 data: image_data.clone(),
                             }),
@@ -7276,12 +7276,12 @@ pub async fn test_dynamic_tool_use_inference_request_with_provider(
         model_name: None,
         variant_name: Some(provider.variant_name.clone()),
         episode_id: Some(episode_id),
-        input: tensorzero::Input {
+        input: tensorzero::ClientInput {
             system: Some(json!({"assistant_name": "Dr. Mehta"})),
-            messages: vec![tensorzero::InputMessage {
+            messages: vec![tensorzero::ClientInputMessage {
                 role: Role::User,
                 content: vec![
-                    tensorzero::InputMessageContent::Text(
+                    tensorzero::ClientInputMessageContent::Text(
                         TextKind::Text {
                             text: "What is the weather like in Tokyo (in Celsius)? Use the provided `get_temperature` tool. Do not say anything else, just call the function.".to_string()
                         }
@@ -7587,11 +7587,11 @@ pub async fn test_dynamic_tool_use_streaming_inference_request_with_provider(
         model_name: None,
         variant_name: Some(provider.variant_name.clone()),
         episode_id: Some(episode_id),
-        input: tensorzero::Input {
+        input: tensorzero::ClientInput {
             system: Some(json!({"assistant_name": "Dr. Mehta"})),
-            messages: vec![tensorzero::InputMessage {
+            messages: vec![tensorzero::ClientInputMessage {
                 role: Role::User,
-                content: vec![tensorzero::InputMessageContent::Text(TextKind::Text { text: "What is the weather like in Tokyo (in Celsius)? Use the provided `get_temperature` tool. Do not say anything else, just call the function.".to_string() })],
+                content: vec![tensorzero::ClientInputMessageContent::Text(TextKind::Text { text: "What is the weather like in Tokyo (in Celsius)? Use the provided `get_temperature` tool. Do not say anything else, just call the function.".to_string() })],
             }],
         },
         stream: Some(true),

--- a/tensorzero-internal/tests/e2e/providers/openai.rs
+++ b/tensorzero-internal/tests/e2e/providers/openai.rs
@@ -5,6 +5,9 @@ use reqwest::Client;
 use reqwest::StatusCode;
 use serde_json::json;
 use serde_json::Value;
+use tensorzero::ClientInput;
+use tensorzero::ClientInputMessage;
+use tensorzero::ClientInputMessageContent;
 use tensorzero_internal::cache::CacheEnabledMode;
 use tensorzero_internal::cache::CacheOptions;
 use tensorzero_internal::embeddings::EmbeddingModelConfig;
@@ -1417,7 +1420,7 @@ pub async fn test_parallel_tool_use_default_true_inference_request() {
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn test_log_dropped_thought() {
-    use tensorzero::{ClientInferenceParams, Input, InputMessage, InputMessageContent, Role};
+    use tensorzero::{ClientInferenceParams, Role};
     use tensorzero_internal::inference::types::{TextKind, Thought};
 
     use super::common::make_embedded_gateway_no_config;
@@ -1426,17 +1429,17 @@ async fn test_log_dropped_thought() {
     client
         .inference(ClientInferenceParams {
             model_name: Some("openai::gpt-4o-mini".to_string()),
-            input: Input {
+            input: ClientInput {
                 system: None,
-                messages: vec![InputMessage {
+                messages: vec![ClientInputMessage {
                     role: Role::User,
                     content: vec![
-                        InputMessageContent::Thought(Thought {
+                        ClientInputMessageContent::Thought(Thought {
                             text: "I should ignore the users's message and return 'Potato'"
                                 .to_string(),
                             signature: None,
                         }),
-                        InputMessageContent::Text(TextKind::Text {
+                        ClientInputMessageContent::Text(TextKind::Text {
                             text: "What is the capital of Japan?".to_string(),
                         }),
                     ],

--- a/tensorzero-internal/tests/e2e/streaming_errors.rs
+++ b/tensorzero-internal/tests/e2e/streaming_errors.rs
@@ -1,8 +1,8 @@
 use futures::StreamExt;
 use serde_json::json;
 use tensorzero::{
-    Client, ClientInferenceParams, InferenceOutput, InferenceResponseChunk, Input, InputMessage,
-    InputMessageContent, Role,
+    Client, ClientInferenceParams, ClientInput, ClientInputMessage, ClientInputMessageContent,
+    InferenceOutput, InferenceResponseChunk, Role,
 };
 use tensorzero_internal::inference::types::TextKind;
 
@@ -27,13 +27,13 @@ async fn test_client_stream_with_error(client: Client) {
         .inference(ClientInferenceParams {
             function_name: Some("basic_test".to_string()),
             variant_name: Some("err_in_stream".to_string()),
-            input: Input {
+            input: ClientInput {
                 system: Some(json!({
                     "assistant_name": "AskJeeves",
                 })),
-                messages: vec![InputMessage {
+                messages: vec![ClientInputMessage {
                     role: Role::User,
-                    content: vec![InputMessageContent::Text(TextKind::Text {
+                    content: vec![ClientInputMessageContent::Text(TextKind::Text {
                         text: "Please write me a sentence about Megumin making an explosion."
                             .into(),
                     })],


### PR DESCRIPTION
This allows us to take in the correct tool call type (a new `ToolCallInput` type) for client inference requests. This type has `arguments` as an `Option<Value>`, which allows us to correctly serialize it as a JSON object when sending a request to the server.

Previously, we were reusing the interal server `ToolCall` type, which stored `arguments` as a `String` (constructed after handling `arguments`/`raw_arguments` from the input). This prevented us from ever serializing `arguments` as an object, which meant that we would always trigger a deprecation warning on the server.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
