### PR TITLE
Add 'x-tensorzero-gateway-version' header to all gateway responses

### DIFF
--- a/tensorzero-internal/tests/e2e/health.rs
+++ b/tensorzero-internal/tests/e2e/health.rs
@@ -1,5 +1,6 @@
 use reqwest::{Client, StatusCode};
 use serde_json::Value;
+use tensorzero_internal::endpoints::status::TENSORZERO_VERSION;
 
 use crate::common::get_gateway_endpoint;
 
@@ -10,6 +11,13 @@ async fn test_health_handler() {
     assert!(response.is_ok());
     let response = response.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
+
+    let version = response
+        .headers()
+        .get("x-tensorzero-gateway-version")
+        .unwrap();
+    assert_eq!(version.to_str().unwrap(), TENSORZERO_VERSION);
+
     let response_value = response.json::<Value>().await;
     assert!(response_value.is_ok());
     let response_value = response_value.unwrap();


### PR DESCRIPTION
We're going to use this to perform feature detection in the client code.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
