### PR TITLE
Implement reasoning support for Fireworks AI

### DIFF
--- a/tensorzero-internal/src/inference/providers/fireworks.rs
+++ b/tensorzero-internal/src/inference/providers/fireworks.rs
@@ -1,11 +1,12 @@
 use std::{borrow::Cow, sync::OnceLock};
 
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use lazy_static::lazy_static;
-use reqwest_eventsource::RequestBuilderExt;
+use reqwest_eventsource::{Event, EventSource, RequestBuilderExt};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::time::Duration;
 use tokio::time::Instant;
 use url::Url;
 
@@ -15,22 +16,24 @@ use crate::{
     error::{Error, ErrorDetails},
     inference::types::{
         batch::{BatchRequestRow, PollBatchInferenceResponse, StartBatchProviderInferenceResponse},
-        ContentBlockOutput, Latency, ModelInferenceRequest, ModelInferenceRequestJsonMode,
-        PeekableProviderInferenceResponseStream, ProviderInferenceResponse,
-        ProviderInferenceResponseArgs,
+        ContentBlockChunk, ContentBlockOutput, FinishReason, Latency, ModelInferenceRequest,
+        ModelInferenceRequestJsonMode, PeekableProviderInferenceResponseStream,
+        ProviderInferenceResponse, ProviderInferenceResponseArgs, ProviderInferenceResponseChunk,
+        ProviderInferenceResponseStreamInner, Text, TextChunk, Thought, ThoughtChunk,
     },
     model::{build_creds_caching_default, Credential, CredentialLocation, ModelProvider},
+    tool::{ToolCall, ToolCallChunk},
 };
 
 use super::{
     helpers::inject_extra_request_data,
+    helpers_thinking_block::{process_think_blocks, ThinkingState},
     openai::{
-        get_chat_url, handle_openai_error, prepare_openai_tools, stream_openai,
-        tensorzero_to_openai_messages, OpenAIFunction, OpenAIRequestMessage, OpenAIResponse,
-        OpenAIResponseChoice, OpenAISystemRequestMessage, OpenAITool, OpenAIToolChoice,
-        OpenAIToolType,
+        get_chat_url, handle_openai_error, prepare_openai_tools, tensorzero_to_openai_messages,
+        OpenAIFunction, OpenAIRequestMessage, OpenAISystemRequestMessage, OpenAITool,
+        OpenAIToolChoice, OpenAIToolType, OpenAIUsage,
     },
-    provider_trait::{InferenceProvider, TensorZeroEventError},
+    provider_trait::InferenceProvider,
 };
 
 lazy_static! {
@@ -48,6 +51,7 @@ const PROVIDER_TYPE: &str = "fireworks";
 pub struct FireworksProvider {
     model_name: String,
     credentials: FireworksCredentials,
+    parse_think_blocks: bool,
 }
 
 static DEFAULT_CREDENTIALS: OnceLock<FireworksCredentials> = OnceLock::new();
@@ -56,6 +60,7 @@ impl FireworksProvider {
     pub fn new(
         model_name: String,
         api_key_location: Option<CredentialLocation>,
+        parse_think_blocks: bool,
     ) -> Result<Self, Error> {
         let credentials = build_creds_caching_default(
             api_key_location,
@@ -66,8 +71,13 @@ impl FireworksProvider {
         Ok(FireworksProvider {
             model_name,
             credentials,
+            parse_think_blocks,
         })
     }
+}
+
+pub fn default_parse_think_blocks() -> bool {
+    true
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -174,7 +184,7 @@ impl InferenceProvider for FireworksProvider {
             response_time: start_time.elapsed(),
         };
         if res.status().is_success() {
-            let response_text = res.text().await.map_err(|e| {
+            let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
                     message: format!("Error parsing text response: {e}"),
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -183,12 +193,12 @@ impl InferenceProvider for FireworksProvider {
                 })
             })?;
 
-            let response = serde_json::from_str(&response_text).map_err(|e| {
+            let response: FireworksResponse = serde_json::from_str(&raw_response).map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing JSON response: {e}: {response_text}"),
+                    message: format!("Error parsing JSON response: {e}: {raw_response}"),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
-                    raw_response: Some(response_text.clone()),
+                    raw_response: Some(raw_response.clone()),
                 })
             })?;
 
@@ -197,7 +207,8 @@ impl InferenceProvider for FireworksProvider {
                 latency,
                 request: request_body,
                 generic_request: request,
-                raw_response: response_text,
+                raw_response,
+                parse_think_blocks: self.parse_think_blocks,
             }
             .try_into()?)
         } else {
@@ -268,11 +279,8 @@ impl InferenceProvider for FireworksProvider {
                     raw_response: None,
                 })
             })?;
-        let stream = stream_openai(
-            event_source.map_err(TensorZeroEventError::EventSource),
-            start_time,
-        )
-        .peekable();
+        // Use our own stream implementation to handle thinking blocks
+        let stream = stream_fireworks(event_source, start_time, self.parse_think_blocks).peekable();
         Ok((stream, raw_request))
     }
 
@@ -416,12 +424,292 @@ impl<'a> From<OpenAITool<'a>> for FireworksTool<'a> {
     }
 }
 
+#[derive(Serialize, Debug, Clone, PartialEq, Deserialize)]
+struct FireworksResponseFunctionCall {
+    name: String,
+    arguments: String,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Deserialize)]
+struct FireworksResponseToolCall {
+    id: String,
+    r#type: OpenAIToolType,
+    function: FireworksResponseFunctionCall,
+}
+
+impl From<FireworksResponseToolCall> for ToolCall {
+    fn from(fireworks_tool_call: FireworksResponseToolCall) -> Self {
+        ToolCall {
+            id: fireworks_tool_call.id,
+            name: fireworks_tool_call.function.name,
+            arguments: fireworks_tool_call.function.arguments,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+struct FireworksResponseMessage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_calls: Option<Vec<FireworksResponseToolCall>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+enum FireworksFinishReason {
+    Stop,
+    Length,
+    ToolCalls,
+    ContentFilter,
+    #[serde(other)]
+    Unknown,
+}
+
+impl From<FireworksFinishReason> for FinishReason {
+    fn from(reason: FireworksFinishReason) -> Self {
+        match reason {
+            FireworksFinishReason::Stop => FinishReason::Stop,
+            FireworksFinishReason::Length => FinishReason::Length,
+            FireworksFinishReason::ToolCalls => FinishReason::ToolCall,
+            FireworksFinishReason::ContentFilter => FinishReason::ContentFilter,
+            FireworksFinishReason::Unknown => FinishReason::Unknown,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FireworksResponseChoice {
+    index: u8,
+    message: FireworksResponseMessage,
+    finish_reason: Option<FireworksFinishReason>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FireworksResponse {
+    choices: Vec<FireworksResponseChoice>,
+    usage: OpenAIUsage,
+}
+
+// Streaming-specific structs
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+struct FireworksFunctionCallChunk {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    arguments: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+struct FireworksToolCallChunk {
+    index: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<String>,
+    function: FireworksFunctionCallChunk,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+struct FireworksDelta {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_calls: Option<Vec<FireworksToolCallChunk>>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+struct FireworksChatChunkChoice {
+    delta: FireworksDelta,
+    #[serde(default)]
+    finish_reason: Option<FireworksFinishReason>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+struct FireworksChatChunk {
+    choices: Vec<FireworksChatChunkChoice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    usage: Option<OpenAIUsage>,
+}
+
+/// Streams the Fireworks response events and converts them into ProviderInferenceResponseChunks
+/// This function handles parsing and processing of thinking blocks with proper state tracking
+fn stream_fireworks(
+    mut event_source: EventSource,
+    start_time: Instant,
+    parse_think_blocks: bool,
+) -> ProviderInferenceResponseStreamInner {
+    let mut tool_call_ids = Vec::new();
+    let mut tool_call_names = Vec::new();
+    let mut thinking_state = ThinkingState::Normal;
+    Box::pin(async_stream::stream! {
+        while let Some(ev) = event_source.next().await {
+            match ev {
+                Err(e) => {
+                    let message = e.to_string();
+                    let mut raw_response = None;
+                    if let reqwest_eventsource::Error::InvalidStatusCode(_, resp) = e {
+                        raw_response = resp.text().await.ok();
+                    }
+                    yield Err(ErrorDetails::InferenceServer {
+                        message,
+                        raw_request: None,
+                        raw_response,
+                        provider_type: PROVIDER_TYPE.to_string(),
+                    }.into());
+                }
+                Ok(event) => match event {
+                    Event::Open => continue,
+                    Event::Message(message) => {
+                        if message.data == "[DONE]" {
+                            break;
+                        }
+                        let data: Result<FireworksChatChunk, Error> =
+                            serde_json::from_str(&message.data).map_err(|e| Error::new(ErrorDetails::InferenceServer {
+                                message: format!("Error parsing chunk. Error: {}", e),
+                                raw_request: None,
+                                raw_response: Some(message.data.clone()),
+                                provider_type: PROVIDER_TYPE.to_string(),
+                            }));
+
+                        let latency = start_time.elapsed();
+                        let stream_message = data.and_then(|d| {
+                            fireworks_to_tensorzero_chunk(d, latency, &mut tool_call_ids, &mut tool_call_names, &mut thinking_state, parse_think_blocks)
+                        });
+                        yield stream_message;
+                    }
+                },
+            }
+        }
+
+        event_source.close();
+    })
+}
+
+/// Maps a Fireworks chunk to a TensorZero chunk for streaming inferences
+///
+/// This function handles the conversion of Fireworks chat chunks into TensorZero chunks.
+/// It processes the content and tool calls from the Fireworks response, updating the tool call IDs and names.
+/// If parsing think blocks is enabled, it also processes the thinking state and extracts reasoning.
+fn fireworks_to_tensorzero_chunk(
+    mut chunk: FireworksChatChunk,
+    latency: Duration,
+    tool_call_ids: &mut Vec<String>,
+    tool_call_names: &mut Vec<String>,
+    thinking_state: &mut ThinkingState,
+    parse_think_blocks: bool,
+) -> Result<ProviderInferenceResponseChunk, Error> {
+    let raw_message = serde_json::to_string(&chunk).map_err(|e| {
+        Error::new(ErrorDetails::InferenceServer {
+            message: format!("Error parsing response from Fireworks: {e}"),
+            raw_request: None,
+            raw_response: Some(serde_json::to_string(&chunk).unwrap_or_default()),
+            provider_type: PROVIDER_TYPE.to_string(),
+        })
+    })?;
+    if chunk.choices.len() > 1 {
+        return Err(ErrorDetails::InferenceServer {
+            message: "Response has invalid number of choices: {}. Expected 1.".to_string(),
+            raw_request: None,
+            raw_response: Some(serde_json::to_string(&chunk).unwrap_or_default()),
+            provider_type: PROVIDER_TYPE.to_string(),
+        }
+        .into());
+    }
+    let usage = chunk.usage.map(|u| u.into());
+    let mut finish_reason = None;
+    let mut content = vec![];
+    if let Some(choice) = chunk.choices.pop() {
+        if let Some(reason) = choice.finish_reason {
+            finish_reason = Some(reason.into());
+        }
+        if let Some(text) = choice.delta.content {
+            if parse_think_blocks {
+                if !thinking_state.update(&text, PROVIDER_TYPE)? {
+                    match thinking_state {
+                        ThinkingState::Normal | ThinkingState::Finished => {
+                            content.push(ContentBlockChunk::Text(TextChunk {
+                                text: text.to_string(),
+                                id: thinking_state.get_id(),
+                            }));
+                        }
+                        ThinkingState::Thinking => {
+                            content.push(ContentBlockChunk::Thought(ThoughtChunk {
+                                text: Some(text.to_string()),
+                                signature: None,
+                                id: thinking_state.get_id(),
+                            }));
+                        }
+                    }
+                }
+            } else {
+                // Just add the text verbatim if we're not parsing think blocks.
+                content.push(ContentBlockChunk::Text(TextChunk {
+                    text: text.to_string(),
+                    id: "0".to_string(),
+                }));
+            }
+        }
+        if let Some(tool_calls) = choice.delta.tool_calls {
+            for tool_call in tool_calls {
+                let index = tool_call.index;
+                let id = match tool_call.id {
+                    Some(id) => {
+                        tool_call_ids.push(id.clone());
+                        id
+                    }
+                    None => {
+                        tool_call_ids
+                            .get(index as usize)
+                            .ok_or_else(|| Error::new(ErrorDetails::InferenceServer {
+                                message: "Tool call index out of bounds (meaning we haven't seen this many ids in the stream)".to_string(),
+                                raw_request: None,
+                                raw_response: None,
+                                provider_type: PROVIDER_TYPE.to_string(),
+                            }))?
+                            .clone()
+                    }
+                };
+                let name = match tool_call.function.name {
+                    Some(name) => {
+                        tool_call_names.push(name.clone());
+                        name
+                    }
+                    None => {
+                        tool_call_names
+                            .get(index as usize)
+                            .ok_or_else(|| Error::new(ErrorDetails::InferenceServer {
+                                message: "Tool call index out of bounds (meaning we haven't seen this many names in the stream)".to_string(),
+                                raw_request: None,
+                                raw_response: None,
+                                provider_type: PROVIDER_TYPE.to_string(),
+                            }))?
+                            .clone()
+                    }
+                };
+                content.push(ContentBlockChunk::ToolCall(ToolCallChunk {
+                    id,
+                    raw_name: name,
+                    raw_arguments: tool_call.function.arguments.unwrap_or_default(),
+                }));
+            }
+        }
+    }
+
+    Ok(ProviderInferenceResponseChunk::new(
+        content,
+        usage,
+        raw_message,
+        latency,
+        finish_reason,
+    ))
+}
+
 struct FireworksResponseWithMetadata<'a> {
-    response: OpenAIResponse,
+    response: FireworksResponse,
     raw_response: String,
     latency: Latency,
     request: serde_json::Value,
     generic_request: &'a ModelInferenceRequest<'a>,
+    parse_think_blocks: bool,
 }
 
 impl<'a> TryFrom<FireworksResponseWithMetadata<'a>> for ProviderInferenceResponse {
@@ -433,6 +721,7 @@ impl<'a> TryFrom<FireworksResponseWithMetadata<'a>> for ProviderInferenceRespons
             request: request_body,
             generic_request,
             raw_response,
+            parse_think_blocks,
         } = value;
         if response.choices.len() != 1 {
             return Err(ErrorDetails::InferenceServer {
@@ -447,7 +736,7 @@ impl<'a> TryFrom<FireworksResponseWithMetadata<'a>> for ProviderInferenceRespons
             .into());
         }
         let usage = response.usage.into();
-        let OpenAIResponseChoice {
+        let FireworksResponseChoice {
             message,
             finish_reason,
             ..
@@ -462,8 +751,18 @@ impl<'a> TryFrom<FireworksResponseWithMetadata<'a>> for ProviderInferenceRespons
             }
             ))?;
         let mut content: Vec<ContentBlockOutput> = Vec::new();
-        if let Some(text) = message.content {
-            content.push(text.into());
+        if let Some(raw_text) = message.content {
+            let (clean_text, extracted_reasoning) =
+                process_think_blocks(&raw_text, parse_think_blocks, PROVIDER_TYPE)?;
+            if let Some(reasoning) = extracted_reasoning {
+                content.push(ContentBlockOutput::Thought(Thought {
+                    text: reasoning,
+                    signature: None,
+                }));
+            }
+            if !clean_text.is_empty() {
+                content.push(ContentBlockOutput::Text(Text { text: clean_text }));
+            }
         }
         if let Some(tool_calls) = message.tool_calls {
             for tool_call in tool_calls {
@@ -486,7 +785,7 @@ impl<'a> TryFrom<FireworksResponseWithMetadata<'a>> for ProviderInferenceRespons
                 raw_response,
                 usage,
                 latency,
-                finish_reason: Some(finish_reason.into()),
+                finish_reason: finish_reason.map(|r| r.into()),
             },
         ))
     }
@@ -501,13 +800,120 @@ mod tests {
 
     use super::*;
 
-    use crate::inference::providers::openai::{
-        OpenAIFinishReason, OpenAIResponseChoice, OpenAIResponseMessage, OpenAIToolType,
-        OpenAIUsage,
-    };
+    use crate::inference::providers::openai::{OpenAIToolType, OpenAIUsage};
     use crate::inference::providers::openai::{SpecificToolChoice, SpecificToolFunction};
     use crate::inference::providers::test_helpers::{WEATHER_TOOL, WEATHER_TOOL_CONFIG};
-    use crate::inference::types::{FunctionType, RequestMessage, Role};
+    use crate::inference::types::{FunctionType, RequestMessage, Role, Usage};
+
+    #[test]
+    fn test_fireworks_response_with_thinking_blocks() {
+        let test_response_with_thinking = "Hello <think>This is reasoning</think> world";
+        let generic_request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
+            messages: vec![RequestMessage {
+                role: Role::User,
+                content: vec!["test_user".to_string().into()],
+            }],
+            system: None,
+            temperature: Some(0.5),
+            top_p: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            max_tokens: Some(100),
+            stream: false,
+            seed: Some(69),
+            json_mode: ModelInferenceRequestJsonMode::Off,
+            tool_config: None,
+            function_type: FunctionType::Chat,
+            output_schema: None,
+            extra_body: Default::default(),
+            ..Default::default()
+        };
+
+        // Create a valid response with thinking blocks in the content
+        let valid_response = FireworksResponse {
+            choices: vec![FireworksResponseChoice {
+                index: 0,
+                finish_reason: Some(FireworksFinishReason::Stop),
+                message: FireworksResponseMessage {
+                    content: Some(test_response_with_thinking.to_string()),
+                    tool_calls: None,
+                },
+            }],
+            usage: OpenAIUsage {
+                prompt_tokens: 10,
+                completion_tokens: 20,
+                total_tokens: 30,
+            },
+        };
+
+        // Test with parsing enabled
+        let fireworks_response_with_metadata = FireworksResponseWithMetadata {
+            response: valid_response.clone(),
+            raw_response: "test_response".to_string(),
+            latency: Latency::NonStreaming {
+                response_time: Duration::from_secs(0),
+            },
+            request: serde_json::to_value(
+                FireworksRequest::new("test-model", &generic_request).unwrap(),
+            )
+            .unwrap(),
+            generic_request: &generic_request,
+            parse_think_blocks: true,
+        };
+
+        let inference_response: ProviderInferenceResponse =
+            fireworks_response_with_metadata.try_into().unwrap();
+
+        // Should have two content blocks: thought and text
+        assert_eq!(inference_response.output.len(), 2);
+
+        // First block should be a thought
+        match &inference_response.output[0] {
+            ContentBlockOutput::Thought(thought) => {
+                assert_eq!(thought.text, "This is reasoning");
+                assert_eq!(thought.signature, None);
+            }
+            _ => panic!("Expected a thought block"),
+        }
+
+        // Second block should be text
+        match &inference_response.output[1] {
+            ContentBlockOutput::Text(text) => {
+                assert_eq!(text.text, "Hello  world");
+            }
+            _ => panic!("Expected a text block"),
+        }
+
+        // Test with parsing disabled
+        let fireworks_response_with_metadata = FireworksResponseWithMetadata {
+            response: valid_response,
+            raw_response: "test_response".to_string(),
+            latency: Latency::NonStreaming {
+                response_time: Duration::from_secs(0),
+            },
+            request: serde_json::to_value(
+                FireworksRequest::new("test-model", &generic_request).unwrap(),
+            )
+            .unwrap(),
+            generic_request: &generic_request,
+            parse_think_blocks: false,
+        };
+
+        let inference_response: ProviderInferenceResponse =
+            fireworks_response_with_metadata.try_into().unwrap();
+
+        // Should have only one content block with the original text
+        assert_eq!(inference_response.output.len(), 1);
+
+        // Block should be text with thinking tags preserved
+        match &inference_response.output[0] {
+            ContentBlockOutput::Text(text) => {
+                assert_eq!(text.text, test_response_with_thinking);
+            }
+            _ => panic!("Expected a text block"),
+        }
+    }
 
     #[test]
     fn test_fireworks_request_new() {
@@ -607,11 +1013,11 @@ mod tests {
 
     #[test]
     fn test_fireworks_response_with_metadata_try_into() {
-        let valid_response = OpenAIResponse {
-            choices: vec![OpenAIResponseChoice {
+        let valid_response = FireworksResponse {
+            choices: vec![FireworksResponseChoice {
                 index: 0,
-                finish_reason: OpenAIFinishReason::Stop,
-                message: OpenAIResponseMessage {
+                finish_reason: Some(FireworksFinishReason::Stop),
+                message: FireworksResponseMessage {
                     content: Some("Hello, world!".to_string()),
                     tool_calls: None,
                 },
@@ -654,6 +1060,7 @@ mod tests {
             )
             .unwrap(),
             generic_request: &generic_request,
+            parse_think_blocks: false,
         };
         let inference_response: ProviderInferenceResponse =
             fireworks_response_with_metadata.try_into().unwrap();
@@ -672,5 +1079,355 @@ mod tests {
                 response_time: Duration::from_secs(0)
             }
         );
+    }
+
+    #[test]
+    fn test_fireworks_to_tensorzero_chunk() {
+        let chunk = FireworksChatChunk {
+            choices: vec![FireworksChatChunkChoice {
+                delta: FireworksDelta {
+                    content: Some("Hello".to_string()),
+                    tool_calls: None,
+                },
+                finish_reason: Some(FireworksFinishReason::Stop),
+            }],
+            usage: None,
+        };
+        let mut tool_call_ids = vec!["id1".to_string()];
+        let mut tool_call_names = vec!["name1".to_string()];
+        let mut thinking_state = ThinkingState::Normal;
+        let message = fireworks_to_tensorzero_chunk(
+            chunk.clone(),
+            Duration::from_millis(50),
+            &mut tool_call_ids,
+            &mut tool_call_names,
+            &mut thinking_state,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(
+            message.content,
+            vec![ContentBlockChunk::Text(TextChunk {
+                text: "Hello".to_string(),
+                id: "0".to_string(),
+            })]
+        );
+        assert_eq!(message.finish_reason, Some(FinishReason::Stop));
+
+        // Test what an intermediate tool chunk should look like
+        let chunk = FireworksChatChunk {
+            choices: vec![FireworksChatChunkChoice {
+                delta: FireworksDelta {
+                    content: None,
+                    tool_calls: Some(vec![FireworksToolCallChunk {
+                        index: 0,
+                        id: None,
+                        function: FireworksFunctionCallChunk {
+                            name: None,
+                            arguments: Some("{\"hello\":\"world\"}".to_string()),
+                        },
+                    }]),
+                },
+                finish_reason: Some(FireworksFinishReason::ToolCalls),
+            }],
+            usage: None,
+        };
+        let message = fireworks_to_tensorzero_chunk(
+            chunk.clone(),
+            Duration::from_millis(50),
+            &mut tool_call_ids,
+            &mut tool_call_names,
+            &mut thinking_state,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(
+            message.content,
+            vec![ContentBlockChunk::ToolCall(ToolCallChunk {
+                id: "id1".to_string(),
+                raw_name: "name1".to_string(),
+                raw_arguments: "{\"hello\":\"world\"}".to_string(),
+            })]
+        );
+        assert_eq!(message.finish_reason, Some(FinishReason::ToolCall));
+
+        // Test a chunk with no choices and only usage
+        let chunk = FireworksChatChunk {
+            choices: vec![],
+            usage: Some(OpenAIUsage {
+                prompt_tokens: 10,
+                completion_tokens: 20,
+                total_tokens: 30,
+            }),
+        };
+        let message = fireworks_to_tensorzero_chunk(
+            chunk.clone(),
+            Duration::from_millis(50),
+            &mut tool_call_ids,
+            &mut tool_call_names,
+            &mut thinking_state,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(message.content, vec![]);
+        assert_eq!(
+            message.usage,
+            Some(Usage {
+                input_tokens: 10,
+                output_tokens: 20,
+            })
+        );
+    }
+
+    #[test]
+    fn test_fireworks_to_tensorzero_chunk_thinking() {
+        // Test that the streaming function correctly handles thinking blocks
+        let chunk = FireworksChatChunk {
+            choices: vec![FireworksChatChunkChoice {
+                delta: FireworksDelta {
+                    content: Some("<think>".to_string()),
+                    tool_calls: None,
+                },
+                finish_reason: None,
+            }],
+            usage: None,
+        };
+
+        let mut tool_call_ids = Vec::new();
+        let mut tool_call_names = Vec::new();
+        let mut thinking_state = ThinkingState::Normal;
+
+        // With parsing enabled
+        let result = fireworks_to_tensorzero_chunk(
+            chunk.clone(),
+            Duration::from_millis(100),
+            &mut tool_call_ids,
+            &mut tool_call_names,
+            &mut thinking_state,
+            true,
+        )
+        .unwrap();
+
+        // Should transition to Thinking state
+        assert!(matches!(thinking_state, ThinkingState::Thinking));
+        // No content should be added for the opening tag
+        assert!(result.content.is_empty());
+
+        // Now process some thinking content
+        let chunk = FireworksChatChunk {
+            choices: vec![FireworksChatChunkChoice {
+                delta: FireworksDelta {
+                    content: Some("reasoning".to_string()),
+                    tool_calls: None,
+                },
+                finish_reason: None,
+            }],
+            usage: None,
+        };
+
+        let result = fireworks_to_tensorzero_chunk(
+            chunk,
+            Duration::from_millis(100),
+            &mut tool_call_ids,
+            &mut tool_call_names,
+            &mut thinking_state,
+            true,
+        )
+        .unwrap();
+
+        // Should still be in Thinking state
+        assert!(matches!(thinking_state, ThinkingState::Thinking));
+        // Content should be added as thought
+        assert_eq!(result.content.len(), 1);
+        assert!(matches!(result.content[0], ContentBlockChunk::Thought(_)));
+        if let ContentBlockChunk::Thought(thought) = &result.content[0] {
+            assert_eq!(thought.text, Some("reasoning".to_string()));
+            assert_eq!(thought.id, "1");
+        }
+
+        // Close the thinking block
+        let chunk = FireworksChatChunk {
+            choices: vec![FireworksChatChunkChoice {
+                delta: FireworksDelta {
+                    content: Some("</think>".to_string()),
+                    tool_calls: None,
+                },
+                finish_reason: None,
+            }],
+            usage: None,
+        };
+
+        let result = fireworks_to_tensorzero_chunk(
+            chunk,
+            Duration::from_millis(100),
+            &mut tool_call_ids,
+            &mut tool_call_names,
+            &mut thinking_state,
+            true,
+        )
+        .unwrap();
+
+        // Should transition to Finished state
+        assert!(matches!(thinking_state, ThinkingState::Finished));
+        // No content should be added for the closing tag
+        assert!(result.content.is_empty());
+
+        // After closing, regular text should be treated as text content
+        let chunk = FireworksChatChunk {
+            choices: vec![FireworksChatChunkChoice {
+                delta: FireworksDelta {
+                    content: Some("Final answer".to_string()),
+                    tool_calls: None,
+                },
+                finish_reason: None,
+            }],
+            usage: None,
+        };
+
+        let result = fireworks_to_tensorzero_chunk(
+            chunk,
+            Duration::from_millis(100),
+            &mut tool_call_ids,
+            &mut tool_call_names,
+            &mut thinking_state,
+            true,
+        )
+        .unwrap();
+
+        // Should remain in Finished state
+        assert!(matches!(thinking_state, ThinkingState::Finished));
+        // Content should be added as text
+        assert_eq!(result.content.len(), 1);
+        assert!(matches!(result.content[0], ContentBlockChunk::Text(_)));
+        if let ContentBlockChunk::Text(text) = &result.content[0] {
+            assert_eq!(text.text, "Final answer");
+            assert_eq!(text.id, "2");
+        }
+    }
+
+    #[test]
+    fn test_fireworks_to_tensorzero_chunk_without_think_parsing() {
+        let chunk = FireworksChatChunk {
+            choices: vec![FireworksChatChunkChoice {
+                delta: FireworksDelta {
+                    content: Some("Hello <think>should not parse</think>".to_string()),
+                    tool_calls: None,
+                },
+                finish_reason: Some(FireworksFinishReason::Stop),
+            }],
+            usage: None,
+        };
+        let mut tool_call_ids = vec![];
+        let mut tool_call_names = vec![];
+        let mut thinking_state = ThinkingState::Normal;
+        let message = fireworks_to_tensorzero_chunk(
+            chunk,
+            Duration::from_millis(50),
+            &mut tool_call_ids,
+            &mut tool_call_names,
+            &mut thinking_state,
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            message.content,
+            vec![ContentBlockChunk::Text(TextChunk {
+                text: "Hello <think>should not parse</think>".to_string(),
+                id: "0".to_string(),
+            })]
+        );
+    }
+
+    #[test]
+    fn test_fireworks_stream_tool_call_handling() {
+        // Test new tool call with ID and name
+        let chunk = FireworksChatChunk {
+            choices: vec![FireworksChatChunkChoice {
+                delta: FireworksDelta {
+                    content: None,
+                    tool_calls: Some(vec![FireworksToolCallChunk {
+                        index: 0,
+                        id: Some("new_id".to_string()),
+                        function: FireworksFunctionCallChunk {
+                            name: Some("new_name".to_string()),
+                            arguments: Some("{\"param\":\"value\"}".to_string()),
+                        },
+                    }]),
+                },
+                finish_reason: None,
+            }],
+            usage: None,
+        };
+
+        let mut tool_call_ids = Vec::new();
+        let mut tool_call_names = Vec::new();
+        let mut thinking_state = ThinkingState::Normal;
+
+        let result = fireworks_to_tensorzero_chunk(
+            chunk,
+            Duration::from_millis(100),
+            &mut tool_call_ids,
+            &mut tool_call_names,
+            &mut thinking_state,
+            true,
+        )
+        .unwrap();
+
+        // Should add the tool call to the state and the result
+        assert_eq!(tool_call_ids, vec!["new_id"]);
+        assert_eq!(tool_call_names, vec!["new_name"]);
+        assert_eq!(result.content.len(), 1);
+
+        if let ContentBlockChunk::ToolCall(tool_call) = &result.content[0] {
+            assert_eq!(tool_call.id, "new_id");
+            assert_eq!(tool_call.raw_name, "new_name");
+            assert_eq!(tool_call.raw_arguments, "{\"param\":\"value\"}");
+        } else {
+            panic!("Expected a tool call chunk");
+        }
+
+        // Test continuation of a tool call (id and name already known)
+        let chunk = FireworksChatChunk {
+            choices: vec![FireworksChatChunkChoice {
+                delta: FireworksDelta {
+                    content: None,
+                    tool_calls: Some(vec![FireworksToolCallChunk {
+                        index: 0,
+                        id: None,
+                        function: FireworksFunctionCallChunk {
+                            name: None,
+                            arguments: Some(",\"more\":\"data\"}".to_string()),
+                        },
+                    }]),
+                },
+                finish_reason: Some(FireworksFinishReason::ToolCalls),
+            }],
+            usage: None,
+        };
+
+        let result = fireworks_to_tensorzero_chunk(
+            chunk,
+            Duration::from_millis(100),
+            &mut tool_call_ids,
+            &mut tool_call_names,
+            &mut thinking_state,
+            true,
+        )
+        .unwrap();
+
+        // Should reference the existing ID and name
+        assert_eq!(result.content.len(), 1);
+        assert_eq!(result.finish_reason, Some(FinishReason::ToolCall));
+
+        if let ContentBlockChunk::ToolCall(tool_call) = &result.content[0] {
+            assert_eq!(tool_call.id, "new_id");
+            assert_eq!(tool_call.raw_name, "new_name");
+            assert_eq!(tool_call.raw_arguments, ",\"more\":\"data\"}");
+        } else {
+            panic!("Expected a tool call chunk");
+        }
     }
 }

--- a/tensorzero-internal/src/inference/providers/helpers_thinking_block.rs
+++ b/tensorzero-internal/src/inference/providers/helpers_thinking_block.rs
@@ -1,0 +1,365 @@
+use crate::error::{Error, ErrorDetails};
+
+pub const THINK_TAG: &str = "<think>";
+pub const THINK_TAG_LEN: usize = THINK_TAG.len();
+pub const END_THINK_TAG: &str = "</think>";
+pub const END_THINK_TAG_LEN: usize = END_THINK_TAG.len();
+
+/// Processes the thinking blocks from a span of text.
+/// If parsing is disabled, the text is returned as is.
+/// If parsing is enabled, the text is checked for a single thinking block.
+/// If there is one, the text is cleaned of the thinking block and the reasoning is returned.
+/// If there is no thinking block, the text is returned as is and the reasoning is None.
+/// If there is more than one thinking block, an error is returned.
+///
+/// The function also validates that tags are properly matched - an error is returned
+/// if there are mismatched opening/closing tags.
+///
+/// Returns a tuple of (cleaned_text, optional_reasoning).
+/// The reasoning, if present, will have leading/trailing whitespace trimmed.
+pub fn process_think_blocks(
+    text: &str,
+    parse: bool,
+    provider_type: &str,
+) -> Result<(String, Option<String>), Error> {
+    if !parse {
+        return Ok((text.to_string(), None));
+    }
+    let think_count = text.matches(THINK_TAG).count();
+    if think_count > 1 {
+        return Err(Error::new(ErrorDetails::InferenceServer {
+            message: "Multiple thinking blocks found".to_string(),
+            raw_request: None,
+            raw_response: None,
+            provider_type: provider_type.to_string(),
+        }));
+    }
+
+    if think_count != text.matches(END_THINK_TAG).count() {
+        Err(Error::new(ErrorDetails::InferenceServer {
+            message: "Mismatched thinking tags".to_string(),
+            raw_request: None,
+            raw_response: None,
+            provider_type: provider_type.to_string(),
+        }))
+    } else if let (Some(start), Some(end)) = (text.find(THINK_TAG), text.find(END_THINK_TAG)) {
+        let reasoning = text[start + THINK_TAG_LEN..end].to_string();
+        let cleaned = format!("{}{}", &text[..start], &text[end + END_THINK_TAG_LEN..]);
+        Ok((cleaned, Some(reasoning)))
+    } else {
+        Ok((text.to_string(), None))
+    }
+}
+
+/// State machine for tracking thinking tag transitions during streaming
+pub enum ThinkingState {
+    Normal,
+    Thinking,
+    Finished,
+}
+
+impl ThinkingState {
+    pub fn get_id(&self) -> String {
+        match self {
+            ThinkingState::Normal => "0".to_string(),
+            ThinkingState::Thinking => "1".to_string(),
+            ThinkingState::Finished => "2".to_string(),
+        }
+    }
+
+    fn make_error(msg: &str, provider_type: &str) -> Error {
+        Error::new(ErrorDetails::InferenceServer {
+            message: msg.to_string(),
+            raw_request: None,
+            raw_response: None,
+            provider_type: provider_type.to_string(),
+        })
+    }
+
+    /// Returns true if an update was made to the thinking state
+    /// Returns false if the text is not a thinking block
+    /// Returns an error if the thinking state is invalid
+    pub fn update(&mut self, text: &str, provider_type: &str) -> Result<bool, Error> {
+        // Early return for empty strings, whitespace-only strings, or just newlines
+        if text.trim().is_empty() {
+            return Ok(false);
+        }
+
+        let has_open = text.contains("<think>");
+        let has_close = text.contains("</think>");
+
+        match self {
+            ThinkingState::Normal => match (has_open, has_close) {
+                (true, false) => {
+                    *self = ThinkingState::Thinking;
+                    Ok(true)
+                }
+                (false, true) => Err(Self::make_error(
+                    "Found </think> while not thinking",
+                    provider_type,
+                )),
+                _ => Ok(false),
+            },
+            ThinkingState::Thinking => match (has_open, has_close) {
+                (false, true) => {
+                    *self = ThinkingState::Finished;
+                    Ok(true)
+                }
+                (true, false) => Err(Self::make_error(
+                    "Found <think> while already thinking",
+                    provider_type,
+                )),
+                _ => Ok(false),
+            },
+            ThinkingState::Finished => {
+                if has_open || has_close {
+                    Err(Self::make_error(
+                        "Found thinking tags after thinking finished",
+                        provider_type,
+                    ))
+                } else {
+                    Ok(false)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_process_think_blocks_single() {
+        let text = "Hello <think>this is thinking</think> world";
+        let provider_type = "test_provider";
+
+        // With parsing enabled
+        let (cleaned_text, reasoning) = process_think_blocks(text, true, provider_type).unwrap();
+        assert_eq!(cleaned_text, "Hello  world");
+        assert_eq!(reasoning, Some("this is thinking".to_string()));
+
+        // With parsing disabled
+        let (cleaned_text, reasoning) = process_think_blocks(text, false, provider_type).unwrap();
+        assert_eq!(cleaned_text, text);
+        assert_eq!(reasoning, None);
+    }
+
+    #[test]
+    fn test_process_think_blocks_multiple() {
+        let text = "Hello <think>thinking 1</think> middle <think>thinking 2</think>";
+        let provider_type = "test_provider";
+
+        // With parsing enabled - should error on multiple blocks
+        let result = process_think_blocks(text, true, provider_type);
+        assert!(result.is_err());
+        if let Err(err) = result {
+            if let ErrorDetails::InferenceServer { message, .. } = err.get_owned_details() {
+                assert_eq!(message, "Multiple thinking blocks found");
+            }
+        }
+
+        // With parsing disabled
+        let (cleaned_text, reasoning) = process_think_blocks(text, false, provider_type).unwrap();
+        assert_eq!(cleaned_text, text);
+        assert_eq!(reasoning, None);
+    }
+
+    #[test]
+    fn test_process_think_blocks_mismatched_tags() {
+        let provider_type = "test_provider";
+
+        // Extra closing tag
+        let text = "Hello <think>Extra closing tag</think></think> world";
+        let result = process_think_blocks(text, true, provider_type);
+        assert!(result.is_err());
+        if let Err(err) = result {
+            if let ErrorDetails::InferenceServer { message, .. } = err.get_owned_details() {
+                assert_eq!(message, "Mismatched thinking tags");
+            }
+        }
+
+        // Missing closing tag
+        let text = "Hello <think>thinking without end tag";
+        let result = process_think_blocks(text, true, provider_type);
+        assert!(result.is_err());
+        if let Err(err) = result {
+            if let ErrorDetails::InferenceServer { message, .. } = err.get_owned_details() {
+                assert_eq!(message, "Mismatched thinking tags");
+            }
+        }
+    }
+
+    #[test]
+    fn test_thinking_state_transitions() {
+        let provider_type = "test_provider";
+
+        // Normal state tests
+        let mut state = ThinkingState::Normal;
+        assert_eq!(state.get_id(), "0");
+
+        // Valid transition: Normal -> Thinking
+        assert!(state.update("<think>", provider_type).unwrap());
+        assert!(matches!(state, ThinkingState::Thinking));
+        assert_eq!(state.get_id(), "1");
+
+        // Valid transition: Thinking -> Finished
+        assert!(state.update("</think>", provider_type).unwrap());
+        assert!(matches!(state, ThinkingState::Finished));
+        assert_eq!(state.get_id(), "2");
+
+        // Invalid transitions
+        let mut state = ThinkingState::Normal;
+        assert!(state.update("</think>", provider_type).is_err());
+
+        let mut state = ThinkingState::Thinking;
+        assert!(state.update("<think>", provider_type).is_err());
+
+        let mut state = ThinkingState::Finished;
+        assert!(state.update("<think>", provider_type).is_err());
+        assert!(state.update("</think>", provider_type).is_err());
+
+        // Non-tag text shouldn't change state
+        let mut state = ThinkingState::Normal;
+        assert!(!state.update("random text", provider_type).unwrap());
+        assert!(matches!(state, ThinkingState::Normal));
+
+        let mut state = ThinkingState::Thinking;
+        assert!(!state.update("random text", provider_type).unwrap());
+        assert!(matches!(state, ThinkingState::Thinking));
+    }
+
+    #[test]
+    fn test_thinking_state_with_newline_and_whitespace() {
+        let provider_type = "test_provider";
+
+        // Test with newline character - issue reported for Together/Fireworks
+        let mut state = ThinkingState::Normal;
+
+        // This should not change state since it's just a newline
+        assert!(!state.update("\n", provider_type).unwrap());
+        assert!(matches!(state, ThinkingState::Normal));
+
+        // Empty string should also not change state
+        assert!(!state.update("", provider_type).unwrap());
+        assert!(matches!(state, ThinkingState::Normal));
+
+        // Space characters should not change state
+        assert!(!state.update("   ", provider_type).unwrap());
+        assert!(matches!(state, ThinkingState::Normal));
+    }
+
+    #[test]
+    fn test_thinking_state_update_with_newline() {
+        // This test verifies that the ThinkingState.update function correctly handles
+        // newlines, which was causing issues in the Fireworks/Together implementation
+        let provider_type = "fireworks";
+
+        // Test that a newline doesn't change the state
+        let mut state = ThinkingState::Normal;
+        let result = state.update("\n", provider_type);
+
+        // Should succeed without error
+        assert!(result.is_ok());
+
+        // Should return false indicating no change to state
+        assert!(!result.unwrap());
+
+        // State should remain Normal
+        assert!(matches!(state, ThinkingState::Normal));
+    }
+
+    #[test]
+    fn test_empty_string_handling() {
+        // This simulates the issue reported with the Together/Fireworks providers
+        // where a newline chunk was causing errors
+        let provider_type = "together";
+
+        // Start with Normal state
+        let mut state = ThinkingState::Normal;
+
+        // Test empty string
+        let result = state.update("", provider_type);
+        assert!(result.is_ok());
+        assert!(!result.unwrap()); // Should not change state
+        assert!(matches!(state, ThinkingState::Normal));
+
+        // Test whitespace string
+        let result = state.update("   ", provider_type);
+        assert!(result.is_ok());
+        assert!(!result.unwrap()); // Should not change state
+        assert!(matches!(state, ThinkingState::Normal));
+
+        // Test newline
+        let result = state.update("\n", provider_type);
+        assert!(result.is_ok());
+        assert!(!result.unwrap()); // Should not change state
+        assert!(matches!(state, ThinkingState::Normal));
+
+        // Test multiple newlines
+        let result = state.update("\n\n\n", provider_type);
+        assert!(result.is_ok());
+        assert!(!result.unwrap()); // Should not change state
+        assert!(matches!(state, ThinkingState::Normal));
+    }
+
+    #[test]
+    fn test_thinking_tag_with_surrounding_whitespace() {
+        // Test that tags with surrounding whitespace are still recognized
+        let provider_type = "together";
+
+        // Start with Normal state
+        let mut state = ThinkingState::Normal;
+
+        // Open tag with leading/trailing whitespace
+        let result = state.update("  <think>  ", provider_type);
+        assert!(result.is_ok());
+        assert!(result.unwrap()); // Should change state
+        assert!(matches!(state, ThinkingState::Thinking));
+
+        // Close tag with leading/trailing whitespace
+        let result = state.update(" </think> ", provider_type);
+        assert!(result.is_ok());
+        assert!(result.unwrap()); // Should change state
+        assert!(matches!(state, ThinkingState::Finished));
+    }
+
+    #[test]
+    fn test_thinking_tag_in_multiline_text() {
+        // Test that tags embedded in multiline text are recognized
+        let provider_type = "together";
+
+        // Start with Normal state
+        let mut state = ThinkingState::Normal;
+
+        // Tag in multiline text
+        let result = state.update("Some text\n<think>\nMore text", provider_type);
+        assert!(result.is_ok());
+        assert!(result.unwrap()); // Should change state
+        assert!(matches!(state, ThinkingState::Thinking));
+
+        // Close tag in multiline text
+        let result = state.update("Some text\n</think>\nMore text", provider_type);
+        assert!(result.is_ok());
+        assert!(result.unwrap()); // Should change state
+        assert!(matches!(state, ThinkingState::Finished));
+    }
+
+    #[test]
+    fn test_fireworks_deepseek_reported_issue() {
+        // Test the specific issue reported with fireworks-deepseek
+        let provider_type = "together";
+
+        // Create the thinking state tracking
+        let mut thinking_state = ThinkingState::Normal;
+
+        // After a newline response that reportedly triggered the issue
+        let text = "\n";
+        let result = thinking_state.update(text, provider_type);
+
+        // Should succeed without error
+        assert!(result.is_ok());
+        assert!(!result.unwrap()); // Should not change state
+        assert!(matches!(thinking_state, ThinkingState::Normal));
+    }
+}

--- a/tensorzero-internal/src/inference/providers/mod.rs
+++ b/tensorzero-internal/src/inference/providers/mod.rs
@@ -11,6 +11,7 @@ pub mod gcp_vertex_anthropic;
 pub mod gcp_vertex_gemini;
 pub mod google_ai_studio_gemini;
 pub mod helpers;
+pub mod helpers_thinking_block;
 pub mod hyperbolic;
 pub mod mistral;
 pub mod openai;

--- a/tensorzero-internal/src/inference/providers/together.rs
+++ b/tensorzero-internal/src/inference/providers/together.rs
@@ -30,6 +30,7 @@ use crate::{
 };
 
 use super::helpers::inject_extra_request_data;
+use super::helpers_thinking_block::{process_think_blocks, ThinkingState};
 use super::{
     openai::{
         get_chat_url, handle_openai_error, prepare_openai_tools, tensorzero_to_openai_messages,
@@ -437,52 +438,7 @@ struct TogetherResponseMessage {
     tool_calls: Option<Vec<TogetherResponseToolCall>>,
 }
 
-const THINK_TAG: &str = "<think>";
-const THINK_TAG_LEN: usize = THINK_TAG.len();
-const END_THINK_TAG: &str = "</think>";
-const END_THINK_TAG_LEN: usize = END_THINK_TAG.len();
-
-/// Processes the thinking blocks from a span of text.
-/// If parsing is disabled, the text is returned as is.
-/// If parsing is enabled, the text is checked for a single thinking block.
-/// If there is one, the text is cleaned of the thinking block and the reasoning is returned.
-/// If there is no thinking block, the text is returned as is and the reasoning is None.
-/// If there is more than one thinking block, an error is returned.
-///
-/// The function also validates that tags are properly matched - an error is returned
-/// if there are mismatched opening/closing tags.
-///
-/// Returns a tuple of (cleaned_text, optional_reasoning).
-/// The reasoning, if present, will have leading/trailing whitespace trimmed.
-fn process_think_blocks(text: &str, parse: bool) -> Result<(String, Option<String>), Error> {
-    if !parse {
-        return Ok((text.to_string(), None));
-    }
-    let think_count = text.matches(THINK_TAG).count();
-    if think_count > 1 {
-        return Err(Error::new(ErrorDetails::InferenceServer {
-            message: "Multiple thinking blocks found".to_string(),
-            raw_request: None,
-            raw_response: None,
-            provider_type: PROVIDER_TYPE.to_string(),
-        }));
-    }
-
-    if think_count != text.matches(END_THINK_TAG).count() {
-        Err(Error::new(ErrorDetails::InferenceServer {
-            message: "Mismatched thinking tags".to_string(),
-            raw_request: None,
-            raw_response: None,
-            provider_type: PROVIDER_TYPE.to_string(),
-        }))
-    } else if let (Some(start), Some(end)) = (text.find(THINK_TAG), text.find(END_THINK_TAG)) {
-        let reasoning = text[start + THINK_TAG_LEN..end].to_string();
-        let cleaned = format!("{}{}", &text[..start], &text[end + END_THINK_TAG_LEN..]);
-        Ok((cleaned, Some(reasoning)))
-    } else {
-        Ok((text.to_string(), None))
-    }
-}
+// The thinking block processing has been moved to helpers_thinking_block.rs
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -573,7 +529,7 @@ impl<'a> TryFrom<TogetherResponseWithMetadata<'a>> for ProviderInferenceResponse
         let mut content: Vec<ContentBlockOutput> = Vec::new();
         if let Some(raw_text) = message.content {
             let (clean_text, extracted_reasoning) =
-                process_think_blocks(&raw_text, parse_think_blocks)?;
+                process_think_blocks(&raw_text, parse_think_blocks, PROVIDER_TYPE)?;
             if let Some(reasoning) = extracted_reasoning {
                 content.push(ContentBlockOutput::Thought(Thought {
                     text: reasoning,
@@ -611,60 +567,7 @@ impl<'a> TryFrom<TogetherResponseWithMetadata<'a>> for ProviderInferenceResponse
     }
 }
 
-enum ThinkingState {
-    Normal,
-    Thinking,
-    Finished,
-}
-
-impl ThinkingState {
-    fn get_id(&self) -> String {
-        match self {
-            ThinkingState::Normal => "0".to_string(),
-            ThinkingState::Thinking => "1".to_string(),
-            ThinkingState::Finished => "2".to_string(),
-        }
-    }
-
-    // Returns true if an update was made to the thinking state
-    // Returns false if the text is not a thinking block
-    // Returns an error if the thinking state is invalid
-    fn update(&mut self, text: &str) -> Result<bool, Error> {
-        match (&mut *self, text) {
-            (ThinkingState::Normal, "<think>") => {
-                *self = ThinkingState::Thinking;
-                Ok(true)
-            }
-            (ThinkingState::Normal, "</think>") => Err(Error::new(ErrorDetails::InferenceServer {
-                message: "Found </think> while not thinking".to_string(),
-                raw_request: None,
-                raw_response: None,
-                provider_type: PROVIDER_TYPE.to_string(),
-            })),
-            (ThinkingState::Thinking, "</think>") => {
-                *self = ThinkingState::Finished;
-                Ok(true)
-            }
-            (ThinkingState::Thinking, "<think>") => {
-                Err(Error::new(ErrorDetails::InferenceServer {
-                    message: "Found <think> while already thinking".to_string(),
-                    raw_request: None,
-                    raw_response: None,
-                    provider_type: PROVIDER_TYPE.to_string(),
-                }))
-            }
-            (ThinkingState::Finished, "<think>") | (ThinkingState::Finished, "</think>") => {
-                Err(Error::new(ErrorDetails::InferenceServer {
-                    message: "Found thinking tags after thinking finished".to_string(),
-                    raw_request: None,
-                    raw_response: None,
-                    provider_type: PROVIDER_TYPE.to_string(),
-                }))
-            }
-            _ => Ok(false),
-        }
-    }
-}
+// ThinkingState has been moved to helpers_thinking_block.rs
 
 fn stream_together(
     mut event_source: EventSource,
@@ -757,7 +660,7 @@ fn together_to_tensorzero_chunk(
         }
         if let Some(text) = choice.delta.content {
             if parse_think_blocks {
-                if !thinking_state.update(&text)? {
+                if !thinking_state.update(&text, PROVIDER_TYPE)? {
                     match thinking_state {
                         ThinkingState::Normal | ThinkingState::Finished => {
                             content.push(ContentBlockChunk::Text(TextChunk {
@@ -1137,131 +1040,240 @@ mod tests {
     }
 
     #[test]
-    fn test_single_thinking() {
-        let text = "Hello <think>this is thinking</think> world";
-        let (cleaned_text, reasoning) = process_think_blocks(text, true).unwrap();
-        assert_eq!(cleaned_text, "Hello  world");
-        assert_eq!(reasoning, Some("this is thinking".to_string()));
+    fn test_together_think_block_parsing_in_response() {
+        // Test how TogetherAI integration works with think blocks in response parsing
+        let response_with_thinking = TogetherResponse {
+            choices: vec![TogetherResponseChoice {
+                index: 0,
+                message: TogetherResponseMessage {
+                    content: Some(
+                        "<think>This is the reasoning process</think>This is the answer"
+                            .to_string(),
+                    ),
+                    tool_calls: None,
+                },
+                finish_reason: None,
+            }],
+            usage: OpenAIUsage {
+                prompt_tokens: 10,
+                completion_tokens: 20,
+                total_tokens: 30,
+            },
+        };
 
-        let (cleaned_text, reasoning) = process_think_blocks(text, false).unwrap();
-        assert_eq!(cleaned_text, text);
-        assert_eq!(reasoning, None);
+        let generic_request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
+            messages: vec![RequestMessage {
+                role: Role::User,
+                content: vec!["test_user".to_string().into()],
+            }],
+            system: None,
+            temperature: Some(0.5),
+            max_tokens: Some(100),
+            stream: false,
+            seed: Some(69),
+            json_mode: ModelInferenceRequestJsonMode::Off,
+            tool_config: None,
+            function_type: FunctionType::Chat,
+            output_schema: None,
+            extra_body: Default::default(),
+            ..Default::default()
+        };
+
+        // With parsing enabled
+        let metadata = TogetherResponseWithMetadata {
+            response: response_with_thinking.clone(),
+            raw_response: "test_response".to_string(),
+            latency: Latency::NonStreaming {
+                response_time: Duration::from_secs(0),
+            },
+            request: serde_json::to_value(
+                TogetherRequest::new("test-model", &generic_request).unwrap(),
+            )
+            .unwrap(),
+            generic_request: &generic_request,
+            parse_think_blocks: true,
+        };
+
+        let inference_response: ProviderInferenceResponse = metadata.try_into().unwrap();
+
+        // We should have two content blocks - one thought and one text
+        assert_eq!(inference_response.output.len(), 2);
+
+        // First block should be the thought
+        assert!(matches!(
+            inference_response.output[0],
+            ContentBlockOutput::Thought(_)
+        ));
+        if let ContentBlockOutput::Thought(thought) = &inference_response.output[0] {
+            assert_eq!(thought.text, "This is the reasoning process");
+            assert_eq!(thought.signature, None);
+        }
+
+        // Second block should be the text
+        assert!(matches!(
+            inference_response.output[1],
+            ContentBlockOutput::Text(_)
+        ));
+        if let ContentBlockOutput::Text(text) = &inference_response.output[1] {
+            assert_eq!(text.text, "This is the answer");
+        }
+
+        // With parsing disabled
+        let metadata = TogetherResponseWithMetadata {
+            response: response_with_thinking,
+            raw_response: "test_response".to_string(),
+            latency: Latency::NonStreaming {
+                response_time: Duration::from_secs(0),
+            },
+            request: serde_json::to_value(
+                TogetherRequest::new("test-model", &generic_request).unwrap(),
+            )
+            .unwrap(),
+            generic_request: &generic_request,
+            parse_think_blocks: false,
+        };
+
+        let inference_response: ProviderInferenceResponse = metadata.try_into().unwrap();
+
+        // We should have one content block with the raw text
+        assert_eq!(inference_response.output.len(), 1);
+        assert!(matches!(
+            inference_response.output[0],
+            ContentBlockOutput::Text(_)
+        ));
+        if let ContentBlockOutput::Text(text) = &inference_response.output[0] {
+            assert_eq!(
+                text.text,
+                "<think>This is the reasoning process</think>This is the answer"
+            );
+        }
     }
 
     #[test]
-    fn test_multiple_thinking_blocks() {
-        let text = "Hello <think>thinking 1</think> middle <think>thinking 2</think>";
-        let result = process_think_blocks(text, true);
-        assert!(result.is_err());
-        if let Err(err) = result {
-            if let ErrorDetails::InferenceServer { message, .. } = err.get_owned_details() {
-                assert_eq!(message, "Multiple thinking blocks found");
-            }
+    fn test_together_to_tensorzero_chunk_thinking() {
+        // Test that the streaming function correctly handles thinking blocks
+        let chunk = TogetherChatChunk {
+            choices: vec![TogetherChatChunkChoice {
+                delta: TogetherDelta {
+                    content: Some("<think>".to_string()),
+                    tool_calls: None,
+                },
+                finish_reason: None,
+            }],
+            usage: None,
+        };
+
+        let mut tool_call_ids = Vec::new();
+        let mut tool_call_names = Vec::new();
+        let mut thinking_state = ThinkingState::Normal;
+
+        // With parsing enabled
+        let result = together_to_tensorzero_chunk(
+            chunk.clone(),
+            Duration::from_millis(100),
+            &mut tool_call_ids,
+            &mut tool_call_names,
+            &mut thinking_state,
+            true,
+        )
+        .unwrap();
+
+        // Should transition to Thinking state
+        assert!(matches!(thinking_state, ThinkingState::Thinking));
+        // No content should be added for the opening tag
+        assert!(result.content.is_empty());
+
+        // Now process some thinking content
+        let chunk = TogetherChatChunk {
+            choices: vec![TogetherChatChunkChoice {
+                delta: TogetherDelta {
+                    content: Some("reasoning".to_string()),
+                    tool_calls: None,
+                },
+                finish_reason: None,
+            }],
+            usage: None,
+        };
+
+        let result = together_to_tensorzero_chunk(
+            chunk,
+            Duration::from_millis(100),
+            &mut tool_call_ids,
+            &mut tool_call_names,
+            &mut thinking_state,
+            true,
+        )
+        .unwrap();
+
+        // Should still be in Thinking state
+        assert!(matches!(thinking_state, ThinkingState::Thinking));
+        // Content should be added as thought
+        assert_eq!(result.content.len(), 1);
+        assert!(matches!(result.content[0], ContentBlockChunk::Thought(_)));
+        if let ContentBlockChunk::Thought(thought) = &result.content[0] {
+            assert_eq!(thought.text, Some("reasoning".to_string()));
+            assert_eq!(thought.id, "1");
         }
 
-        let (cleaned_text, reasoning) = process_think_blocks(text, false).unwrap();
-        assert_eq!(cleaned_text, text);
-        assert_eq!(reasoning, None);
-    }
+        // Close the thinking block
+        let chunk = TogetherChatChunk {
+            choices: vec![TogetherChatChunkChoice {
+                delta: TogetherDelta {
+                    content: Some("</think>".to_string()),
+                    tool_calls: None,
+                },
+                finish_reason: None,
+            }],
+            usage: None,
+        };
 
-    #[test]
-    fn test_extra_closing_tag() {
-        let text = "Hello <think>Extra closing tag</think></think> world";
-        let result = process_think_blocks(text, true);
-        assert!(result.is_err());
-        if let Err(err) = result {
-            if let ErrorDetails::InferenceServer { message, .. } = err.get_owned_details() {
-                assert_eq!(message, "Mismatched thinking tags");
-            }
+        let result = together_to_tensorzero_chunk(
+            chunk,
+            Duration::from_millis(100),
+            &mut tool_call_ids,
+            &mut tool_call_names,
+            &mut thinking_state,
+            true,
+        )
+        .unwrap();
+
+        // Should transition to Finished state
+        assert!(matches!(thinking_state, ThinkingState::Finished));
+        // No content should be added for the closing tag
+        assert!(result.content.is_empty());
+
+        // After closing, regular text should be treated as text content
+        let chunk = TogetherChatChunk {
+            choices: vec![TogetherChatChunkChoice {
+                delta: TogetherDelta {
+                    content: Some("Final answer".to_string()),
+                    tool_calls: None,
+                },
+                finish_reason: None,
+            }],
+            usage: None,
+        };
+
+        let result = together_to_tensorzero_chunk(
+            chunk,
+            Duration::from_millis(100),
+            &mut tool_call_ids,
+            &mut tool_call_names,
+            &mut thinking_state,
+            true,
+        )
+        .unwrap();
+
+        // Should remain in Finished state
+        assert!(matches!(thinking_state, ThinkingState::Finished));
+        // Content should be added as text
+        assert_eq!(result.content.len(), 1);
+        assert!(matches!(result.content[0], ContentBlockChunk::Text(_)));
+        if let ContentBlockChunk::Text(text) = &result.content[0] {
+            assert_eq!(text.text, "Final answer");
+            assert_eq!(text.id, "2");
         }
-
-        let (cleaned_text, reasoning) = process_think_blocks(text, false).unwrap();
-        assert_eq!(cleaned_text, text);
-        assert_eq!(reasoning, None);
-    }
-
-    #[test]
-    fn test_mismatched_tags() {
-        let text = "Hello <think>thinking without end tag";
-        let result = process_think_blocks(text, true);
-        assert!(result.is_err());
-        if let Err(err) = result {
-            if let ErrorDetails::InferenceServer { message, .. } = err.get_owned_details() {
-                assert_eq!(message, "Mismatched thinking tags");
-            }
-        }
-
-        let (cleaned_text, reasoning) = process_think_blocks(text, false).unwrap();
-        assert_eq!(cleaned_text, text);
-        assert_eq!(reasoning, None);
-    }
-
-    #[test]
-    fn test_thinking_state() {
-        // Test initial state and ID
-        let mut state = ThinkingState::Normal;
-        assert_eq!(state.get_id(), "0");
-
-        // Test normal state transitions and IDs
-        assert!(state.update("<think>").is_ok());
-        assert!(matches!(state, ThinkingState::Thinking));
-        assert_eq!(state.get_id(), "1");
-
-        assert!(state.update("</think>").is_ok());
-        assert!(matches!(state, ThinkingState::Finished));
-        assert_eq!(state.get_id(), "2");
-
-        // Test invalid transitions from Normal state
-        let mut state = ThinkingState::Normal;
-        let err = state.update("</think>").unwrap_err();
-        assert!(matches!(
-            err.get_details(),
-            ErrorDetails::InferenceServer { .. }
-        ));
-        if let ErrorDetails::InferenceServer { message, .. } = err.get_owned_details() {
-            assert_eq!(message, "Found </think> while not thinking");
-        }
-
-        // Test invalid transitions from Thinking state
-        let mut state = ThinkingState::Thinking;
-        let err = state.update("<think>").unwrap_err();
-        assert!(matches!(
-            err.get_details(),
-            ErrorDetails::InferenceServer { .. }
-        ));
-        if let ErrorDetails::InferenceServer { message, .. } = err.get_owned_details() {
-            assert_eq!(message, "Found <think> while already thinking");
-        }
-
-        // Test invalid transitions from Finished state
-        let mut state = ThinkingState::Finished;
-        let err = state.update("<think>").unwrap_err();
-        assert!(matches!(
-            err.get_details(),
-            ErrorDetails::InferenceServer { .. }
-        ));
-        if let ErrorDetails::InferenceServer { message, .. } = err.get_owned_details() {
-            assert_eq!(message, "Found thinking tags after thinking finished");
-        }
-
-        let err = state.update("</think>").unwrap_err();
-        assert!(matches!(
-            err.get_details(),
-            ErrorDetails::InferenceServer { .. }
-        ));
-        if let ErrorDetails::InferenceServer { message, .. } = err.get_owned_details() {
-            assert_eq!(message, "Found thinking tags after thinking finished");
-        }
-
-        // Test that random text is allowed in any state
-        let mut state = ThinkingState::Normal;
-        assert!(state.update("random text").is_ok());
-
-        state = ThinkingState::Thinking;
-        assert!(state.update("random text").is_ok());
-
-        state = ThinkingState::Finished;
-        assert!(state.update("random text").is_ok());
     }
 
     #[test]

--- a/tensorzero-internal/src/model.rs
+++ b/tensorzero-internal/src/model.rs
@@ -596,6 +596,8 @@ pub(super) enum ProviderConfigHelper {
     Fireworks {
         model_name: String,
         api_key_location: Option<CredentialLocation>,
+        #[serde(default = "crate::inference::providers::fireworks::default_parse_think_blocks")]
+        parse_think_blocks: bool,
     },
     Mistral {
         model_name: String,
@@ -730,8 +732,9 @@ impl<'de> Deserialize<'de> for ProviderConfig {
             ProviderConfigHelper::Fireworks {
                 model_name,
                 api_key_location,
+                parse_think_blocks,
             } => ProviderConfig::Fireworks(
-                FireworksProvider::new(model_name, api_key_location)
+                FireworksProvider::new(model_name, api_key_location, parse_think_blocks)
                     .map_err(|e| D::Error::custom(e.to_string()))?,
             ),
             ProviderConfigHelper::GCPVertexAnthropic {
@@ -1398,7 +1401,11 @@ impl ShorthandModelConfig for ModelConfig {
         let provider_config = match provider_type {
             "anthropic" => ProviderConfig::Anthropic(AnthropicProvider::new(model_name, None)?),
             "deepseek" => ProviderConfig::DeepSeek(DeepSeekProvider::new(model_name, None)?),
-            "fireworks" => ProviderConfig::Fireworks(FireworksProvider::new(model_name, None)?),
+            "fireworks" => ProviderConfig::Fireworks(FireworksProvider::new(
+                model_name,
+                None,
+                crate::inference::providers::fireworks::default_parse_think_blocks(),
+            )?),
             "google_ai_studio_gemini" => ProviderConfig::GoogleAIStudioGemini(
                 GoogleAIStudioGeminiProvider::new(model_name, None)?,
             ),

--- a/tensorzero-internal/tests/e2e/providers/fireworks.rs
+++ b/tensorzero-internal/tests/e2e/providers/fireworks.rs
@@ -74,11 +74,18 @@ async fn get_providers() -> E2ETestProviders {
         credentials: HashMap::new(),
     }];
 
+    let thinking_block_providers = vec![E2ETestProvider {
+        variant_name: "fireworks-deepseek".to_string(),
+        model_name: "deepseek-r1".into(),
+        model_provider_name: "fireworks".into(),
+        credentials: HashMap::new(),
+    }];
+
     E2ETestProviders {
         simple_inference: providers.clone(),
         extra_body_inference: extra_body_providers,
         bad_auth_extra_headers,
-        reasoning_inference: vec![],
+        reasoning_inference: thinking_block_providers.clone(),
         inference_params_inference: providers.clone(),
         inference_params_dynamic_credentials: inference_params_dynamic_providers,
         tool_use_inference: tool_providers.clone(),

--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -238,6 +238,13 @@ api_key_location = "dynamic::fireworks_api_key"
 [models.qwen2p5-72b-instruct]
 routing = ["fireworks"]
 
+[models."deepseek-r1"]
+routing = ["fireworks"]
+
+[models."deepseek-r1".providers.fireworks]
+type = "fireworks"
+model_name = "accounts/fireworks/models/deepseek-r1"
+
 [models.qwen2p5-72b-instruct.providers.fireworks]
 type = "fireworks"
 model_name = "accounts/fireworks/models/qwen2p5-72b-instruct"
@@ -1100,6 +1107,13 @@ type = "chat_completion"
 model = "deepseek::deepseek-chat"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
+
+[functions.basic_test.variants.fireworks-deepseek]
+type = "chat_completion"
+model = "deepseek-r1"
+system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
+max_tokens = 800
+
 [functions.basic_test.variants.flaky]
 type = "chat_completion"
 model = "flaky_basic_test"
@@ -1573,6 +1587,14 @@ system_template = "../../fixtures/config/functions/json_success/prompt/system_te
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 max_tokens = 100
 json_mode = "strict"
+
+[functions.json_success.variants.fireworks-deepseek]
+type = "chat_completion"
+model = "deepseek-r1"
+system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
+user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
+json_mode = "off"
+max_tokens = 800
 
 [functions.json_success.variants.xai]
 type = "chat_completion"


### PR DESCRIPTION
This PR implements thinking block support for the Fireworks provider, allowing it to extract reasoning from <think>...</think> tags in model responses.

This fixes the issues #1412 and #1411 (The 1411 is not failing anymore, but the thinking was not being extract)

## Approach

This approach refactored the together.rs to reuse the same logic used to parse the <think> fields.

## What's Changed

Created a reusable helper module for thinking block parsing logic
Added thinking blocks support (streaming and non-streaming) to the Fireworks provider
Added e2e test configuration for Fireworks with deepseek-r1 model

## Implementation Details

First, I refactored the existing thinking block functionality by extracting the parsing logic into a shared helper module (helpers_thinking_block.rs). This allows multiple providers to handle <think> tags consistently.
Then, I implemented thinking blocks support in the Fireworks provider, following the same pattern already used by the Together provider. This includes proper handling for both streaming and non-streaming responses.
Finally, I added end-to-end test configurations to verify the integration works correctly with the deepseek-r1 model.

## Testing

Added unit tests for the helper module functions
Improved test coverage for thinking block functionality
Added e2e tests to verify Fireworks integration with deepseek-r1




<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add reasoning extraction from `<think>` tags to Fireworks provider using shared parsing logic.
> 
>   - **Behavior**:
>     - Adds reasoning extraction from `<think>` tags to Fireworks provider in `fireworks.rs`.
>     - Refactors `together.rs` to use shared logic for `<think>` tag parsing.
>   - **Helper Module**:
>     - Introduces `helpers_thinking_block.rs` for shared `<think>` tag parsing logic.
>   - **Testing**:
>     - Adds unit tests for `helpers_thinking_block.rs`.
>     - Adds e2e tests for Fireworks with `deepseek-r1` model in `fireworks.rs` and `tensorzero.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2d65100cbdc05919d33400ef97001a7feb7bff70. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->