### PR TITLE
Stringify tool call args in client based on gateway version

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -19,3 +19,7 @@ serde = { workspace = true }
 
 [lints]
 workspace = true
+
+[features]
+e2e_tests = ["tensorzero-internal/e2e_tests"]
+default = []

--- a/tensorzero-internal/tests/e2e/inference.rs
+++ b/tensorzero-internal/tests/e2e/inference.rs
@@ -2997,7 +2997,7 @@ async fn test_client_adjust_tool_call() {
 
     assert_eq!(last_body, stringified_tool_call_args);
 
-    // Set an older gateway version, and verify that we still stringify the tool call arugments
+    // Set an older gateway version, and verify that we still stringify the tool call arguments
     bad_gateway
         .e2e_update_gateway_version("2025.03.2".to_string())
         .await;


### PR DESCRIPTION
We use the 'x-tensorzero-gateway-version' header to detect the gateway version. If it's older than '2025.03.3"' (or if we don't detect a version), then we convert an object tool call arguments (`{"arguments": {"my": "object"}}`) to a string (`{"arguments": "{\"my\":\"object\"}"}`)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adjust tool call arguments based on gateway version using headers, ensuring compatibility with older versions.
> 
>   - **Behavior**:
>     - Adjusts tool call arguments in `inference()` in `lib.rs` based on `x-tensorzero-gateway-version` header.
>     - Stringifies arguments if gateway version is older than `2025.03.3` or not detected.
>   - **Functions**:
>     - Adds `compare_versions()` and `supports_tool_call_arguments_object()` in `lib.rs` to handle version comparison.
>     - Implements `try_adjust_tool_call_arguments()` in `lib.rs` to modify tool call arguments.
>   - **Tests**:
>     - Adds tests in `inference.rs` to verify behavior with different gateway versions and argument formats.
>   - **Misc**:
>     - Updates `add_version_header()` in `main.rs` to handle version headers for e2e tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 9cda1d5a0c94d5e44af33e5264299da727a58bed. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->