### PR TITLE
Create (but skip) ClickHouse cloud jobs for prs

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           cargo run-e2e > e2e_logs.txt 2>&1 &
             count=0
-            max_attempts=10
+            max_attempts=30
             while ! curl -s -f http://localhost:3000/health >/dev/null 2>&1; do
               echo "Waiting for gateway to be healthy..."
               sleep 1

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -69,6 +69,22 @@ jobs:
         if: always()
         run: cat e2e_logs.txt
 
+  # This is the job that we actually mark as required in the branch protection rules
+  #
+  # For PR ci, the 'clickhouse-tests-cloud' job will be skipped, and this job will exit successfully
+  # (since the 'needs' status will be 'skipped')
+  #
+  # For merge_group ci, we'll create a matrix of tests for 'clickhouse-tests-cloud', and this job
+  # will check all of their statuses when they finish.
+  #
+  # See https://github.com/orgs/community/discussions/103114#discussioncomment-8359045
+  clickhouse-tests-cloud-status-check:
+    if: always()
+    needs: [clickhouse-tests-cloud]
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1
 
   check-docker-compose:
     runs-on: ubuntu-latest

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -10,6 +10,66 @@ env:
   TENSORZERO_CLICKHOUSE_URL: "http://chuser:chpassword@localhost:8123/tensorzero"
 
 jobs:
+
+  clickhouse-tests-cloud:
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cloud_instance:
+          - release_channel: regular
+            url_secret: CLICKHOUSE_CLOUD_URL
+          - release_channel: fast
+            url_secret: CLICKHOUSE_CLOUD_FAST_CHANNEL_URL
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@37bdc826eaedac215f638a96472df572feab0f9b
+        with:
+          tool: cargo-nextest
+
+      - name: Set up TENSORZERO_CLICKHOUSE_URL
+        run: |
+          echo "TENSORZERO_CLICKHOUSE_URL=${{ secrets[matrix.cloud_instance.url_secret] }}" >> $GITHUB_ENV
+
+      - name: Wake up ClickHouse cloud
+        run: |
+          curl $TENSORZERO_CLICKHOUSE_URL --data-binary 'SHOW DATABASES'
+
+      - name: Delete old ClickHouse cloud dbs
+        run: ./ci/delete-clickhouse-dbs.sh
+
+      # We run this as a separate step so that we can see live build logs
+      # (and fail the job immediately if the build fails)
+      - name: Build the gateway for E2E tests
+        run: cargo build-e2e
+
+      - name: Launch the gateway for E2E tests
+        run: |
+          cargo run-e2e > e2e_logs.txt 2>&1 &
+            count=0
+            max_attempts=10
+            while ! curl -s -f http://localhost:3000/health >/dev/null 2>&1; do
+              echo "Waiting for gateway to be healthy..."
+              sleep 1
+              count=$((count + 1))
+              if [ $count -ge $max_attempts ]; then
+                echo "Gateway failed to become healthy after $max_attempts attempts"
+                exit 1
+              fi
+            done
+          echo "GATEWAY_PID=$!" >> $GITHUB_ENV
+
+      - name: Test (Rust)
+        run: cargo test-e2e-no-creds
+
+      - name: Print e2e logs
+        if: always()
+        run: cat e2e_logs.txt
+
+
   check-docker-compose:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -34,63 +34,6 @@ env:
   XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
 
 jobs:
-  clickhouse-tests-cloud:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        cloud_instance:
-          - release_channel: regular
-            url_secret: CLICKHOUSE_CLOUD_URL
-          - release_channel: fast
-            url_secret: CLICKHOUSE_CLOUD_FAST_CHANNEL_URL
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@37bdc826eaedac215f638a96472df572feab0f9b
-        with:
-          tool: cargo-nextest
-
-      - name: Set up TENSORZERO_CLICKHOUSE_URL
-        run: |
-          echo "TENSORZERO_CLICKHOUSE_URL=${{ secrets[matrix.cloud_instance.url_secret] }}" >> $GITHUB_ENV
-
-      - name: Wake up ClickHouse cloud
-        run: |
-          curl $TENSORZERO_CLICKHOUSE_URL --data-binary 'SHOW DATABASES'
-
-      - name: Delete old ClickHouse cloud dbs
-        run: ./ci/delete-clickhouse-dbs.sh
-
-      # We run this as a separate step so that we can see live build logs
-      # (and fail the job immediately if the build fails)
-      - name: Build the gateway for E2E tests
-        run: cargo build-e2e
-
-      - name: Launch the gateway for E2E tests
-        run: |
-          cargo run-e2e > e2e_logs.txt 2>&1 &
-            count=0
-            max_attempts=10
-            while ! curl -s -f http://localhost:3000/health >/dev/null 2>&1; do
-              echo "Waiting for gateway to be healthy..."
-              sleep 1
-              count=$((count + 1))
-              if [ $count -ge $max_attempts ]; then
-                echo "Gateway failed to become healthy after $max_attempts attempts"
-                exit 1
-              fi
-            done
-          echo "GATEWAY_PID=$!" >> $GITHUB_ENV
-
-      - name: Test (Rust)
-        run: cargo test-e2e-no-creds
-
-      - name: Print e2e logs
-        if: always()
-        run: cat e2e_logs.txt
-
   live-tests:
     runs-on: namespace-profile-tensorzero-8x16
 


### PR DESCRIPTION
This is needed in order for us to be able to mark these checks as required in the branch protection rules.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `clickhouse-tests-cloud` job in `general.yml` for merge group events and remove it from `merge-queue.yml`, ensuring branch protection with a status check.
> 
>   - **Workflows**:
>     - Add `clickhouse-tests-cloud` job in `general.yml` for `merge_group` events, skipped for pull requests.
>     - Remove `clickhouse-tests-cloud` job from `merge-queue.yml`.
>     - Add `clickhouse-tests-cloud-status-check` job in `general.yml` to ensure status check for branch protection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for cb0f7afda4a84a0d0253304e51b8437debe4f208. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->