### PR TITLE
Fix "Publish Docker images" issues (#1633)

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -23,9 +23,7 @@ jobs:
             target: linux/arm64
         container:
           - name: ui
-            context: ./ui
           - name: gateway
-            context: .
     permissions:
       packages: write
       contents: read
@@ -60,7 +58,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: ${{ matrix.platform.target }}
-          context: ${{ matrix.container.context }}
           file: ./${{ matrix.container.name }}/Dockerfile
           push: true
           provenance: mode=max
@@ -88,9 +85,7 @@ jobs:
       matrix:
         container:
           - name: ui
-            context: ./ui
           - name: gateway
-            context: .
     runs-on: ubuntu-latest
     needs:
       - build

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -58,7 +58,9 @@ RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/
 FROM base AS build-env
 
 COPY ./ui /app/
+
 COPY --from=minijinja-build-env /minijinja/pkg /app/app/utils/minijinja/pkg
+
 COPY --from=development-dependencies-env /app/node_modules /app/node_modules
 
 WORKDIR /app


### PR DESCRIPTION
Fix #1633.

We previously move the context for building the UI container to the root folder, not `ui/`.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix Docker image publishing by removing unnecessary context specifications in workflow and updating `ui/Dockerfile`.
> 
>   - **Workflow Changes**:
>     - Removed `context` specification for `ui` and `gateway` containers in `.github/workflows/docker-hub-publish.yml`.
>     - Simplified Docker build process by using default context.
>   - **Dockerfile Changes**:
>     - Added missing newline after `COPY ./ui /app/` in `ui/Dockerfile` for clarity.
>     - Ensured all necessary files are copied for the build process in `ui/Dockerfile`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 07be92416258177ee50a875c9c054266dfc97518. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->