### PR TITLE
Publish a docker image on every push to 'main'

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -117,7 +117,7 @@ jobs:
             latest=false
           tags: |
             type=ref,event=tag,
-            type=sha,
+            type=sha,format=long
             type=raw,value=latest,enable=${{ github.event_name == 'release' && github.event.prerelease == false }}
 
       - name: Create manifest list and push

--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -6,6 +6,8 @@ on:
   workflow_dispatch:
   release:
     types: [published]
+  push:
+    branches: ["main"]
 
 env:
   DOCKERHUB_USER: tensorzero
@@ -111,8 +113,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKERHUB_USER }}/${{ matrix.container.name }}
+          flavor: |
+            latest=false
           tags: |
-            type=ref,event=tag
+            type=ref,event=tag,
+            type=sha,
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && github.event.prerelease == false }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests


### PR DESCRIPTION
This will ensure that we notice if our docker build process is brokem before we try to make a release.

When a release happens, we will run the 'docker-hub-publish' action again, and produce addition tags: 'latest', and the git tag (e.g. '2025.04.0')

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Trigger Docker image builds on every push to 'main' and update tagging logic in GitHub Actions workflow.
> 
>   - **Workflow Trigger**:
>     - Adds `push` event for `main` branch in `.github/workflows/docker-hub-publish.yml` to trigger Docker image builds on every push.
>   - **Tagging Logic**:
>     - Updates `docker/metadata-action` to include SHA-based tags for non-release builds.
>     - Adds 'latest' tag for release builds when not a pre-release.
>   - **Misc**:
>     - No changes to Docker build steps or environment variables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 58825ca2b961a403fc1faac28ead1e70001e92bc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->