### PR TITLE
fixed image placeholders in ModelInference section

### DIFF
--- a/ui/app/components/inference/ImageBlock.tsx
+++ b/ui/app/components/inference/ImageBlock.tsx
@@ -1,0 +1,17 @@
+import type { ResolvedImageContent } from "~/utils/clickhouse/common";
+
+export default function ImageBlock({ image }: { image: ResolvedImageContent }) {
+  return (
+    <div className="w-60 rounded bg-slate-100 p-2 text-xs text-slate-300">
+      <div className="mb-2">Image</div>
+      <a
+        href={image.image.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        download={"tensorzero_" + image.storage_path.path}
+      >
+        <img src={image.image.url} alt="Image" />
+      </a>
+    </div>
+  );
+}

--- a/ui/app/components/inference/Input.tsx
+++ b/ui/app/components/inference/Input.tsx
@@ -2,7 +2,6 @@ import { Card, CardContent } from "~/components/ui/card";
 import type {
   Input,
   InputMessageContent,
-  ResolvedImageContent,
   ResolvedInput,
   ResolvedInputMessage,
   ResolvedInputMessageContent,
@@ -10,6 +9,7 @@ import type {
 import { SystemContent } from "./SystemContent";
 import { useEffect, useState } from "react";
 import { SkeletonImage } from "./SkeletonImage";
+import ImageBlock from "./ImageBlock";
 
 // Base interface with just the common required properties
 interface BaseInputProps {
@@ -387,22 +387,6 @@ function ToolResultBlock({
     <div className="rounded bg-slate-100 p-2 dark:bg-slate-800">
       <div className="font-medium">Result from: {block.name}</div>
       <pre className="mt-1 text-sm">{block.result}</pre>
-    </div>
-  );
-}
-
-function ImageBlock({ image }: { image: ResolvedImageContent }) {
-  return (
-    <div className="w-60 rounded bg-slate-100 p-2 text-xs text-slate-300">
-      <div className="mb-2">Image</div>
-      <a
-        href={image.image.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        download={"tensorzero_" + image.storage_path.path}
-      >
-        <img src={image.image.url} alt="Image" />
-      </a>
     </div>
   );
 }

--- a/ui/app/components/model/ModelInput.tsx
+++ b/ui/app/components/model/ModelInput.tsx
@@ -1,17 +1,22 @@
 import { SkeletonImage } from "~/components/inference/SkeletonImage";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import type {
-  ContentBlock,
   Input,
-  RequestMessage,
+  ResolvedInputMessage,
+  ResolvedInputMessageContent,
 } from "~/utils/clickhouse/common";
+import ImageBlock from "../inference/ImageBlock";
 
 interface InputProps {
-  input_messages: RequestMessage[];
+  input_messages: ResolvedInputMessage[];
   system: string | null;
 }
 
-function MessageContent({ content }: { content: ContentBlock[] }) {
+function MessageContent({
+  content,
+}: {
+  content: ResolvedInputMessageContent[];
+}) {
   return (
     <div className="space-y-2">
       {content.map((block, blockIndex) => {
@@ -20,9 +25,9 @@ function MessageContent({ content }: { content: ContentBlock[] }) {
             return (
               <div key={blockIndex} className="whitespace-pre-wrap">
                 <code className="text-sm">
-                  {typeof block.text === "object"
-                    ? JSON.stringify(block.text, null, 2)
-                    : block.text}
+                  {typeof block.value === "object"
+                    ? JSON.stringify(block.value, null, 2)
+                    : block.value}
                 </code>
               </div>
             );
@@ -47,14 +52,20 @@ function MessageContent({ content }: { content: ContentBlock[] }) {
               </div>
             );
           case "image":
-            return <SkeletonImage />;
+            return <ImageBlock key={blockIndex} image={block} />;
+          case "image_error":
+            return (
+              <div key={blockIndex}>
+                <SkeletonImage error={true} />
+              </div>
+            );
         }
       })}
     </div>
   );
 }
 
-function Message({ message }: { message: RequestMessage }) {
+function Message({ message }: { message: ResolvedInputMessage }) {
   return (
     <div className="space-y-1">
       <div className="font-medium capitalize text-slate-600 dark:text-slate-400">

--- a/ui/app/routes/observability/inferences/$inference_id/ModelInferenceItem.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/ModelInferenceItem.tsx
@@ -8,7 +8,6 @@ interface ModelInferenceItemProps {
 }
 
 export function ModelInferenceItem({ inference }: ModelInferenceItemProps) {
-  console.log("inference", inference);
   return (
     <div className="space-y-6">
       <div className="grid grid-cols-2 gap-4">

--- a/ui/app/routes/observability/inferences/$inference_id/ModelInferenceItem.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/ModelInferenceItem.tsx
@@ -8,6 +8,7 @@ interface ModelInferenceItemProps {
 }
 
 export function ModelInferenceItem({ inference }: ModelInferenceItemProps) {
+  console.log("inference", inference);
   return (
     <div className="space-y-6">
       <div className="grid grid-cols-2 gap-4">

--- a/ui/app/utils/clickhouse/inference.ts
+++ b/ui/app/utils/clickhouse/inference.ts
@@ -740,7 +740,6 @@ const resolvedInput = await resolveInput(input);
 async function parseModelInferenceRow(
   row: ModelInferenceRow,
 ): Promise<ParsedModelInferenceRow> {
-  console.log("row.");
   const parsedMessages = z
     .array(requestMessageSchema)
     .parse(JSON.parse(row.input_messages));

--- a/ui/app/utils/clickhouse/inference.ts
+++ b/ui/app/utils/clickhouse/inference.ts
@@ -730,9 +730,7 @@ export const parsedModelInferenceRowSchema = modelInferenceRowSchema
 export type ParsedModelInferenceRow = z.infer<
   typeof parsedModelInferenceRowSchema
 >;
-/*
-const resolvedInput = await resolveInput(input);
-*/
+
 async function parseModelInferenceRow(
   row: ModelInferenceRow,
 ): Promise<ParsedModelInferenceRow> {

--- a/ui/app/utils/clickhouse/inference.ts
+++ b/ui/app/utils/clickhouse/inference.ts
@@ -18,7 +18,7 @@ import {
 import { data } from "react-router";
 import type { FunctionConfig } from "../config/function";
 import { clickhouseClient } from "./client.server";
-import { resolveMessages } from "../resolve.server";
+import { resolveInput, resolveMessages } from "../resolve.server";
 
 export const inferenceByIdRowSchema = z
   .object({
@@ -595,11 +595,7 @@ async function parseInferenceRow(
   row: InferenceRow,
 ): Promise<ParsedInferenceRow> {
   const input = inputSchema.parse(JSON.parse(row.input));
-  const resolvedMessages = await resolveMessages(input.messages);
-  const resolvedInput = {
-    ...input,
-    messages: resolvedMessages,
-  };
+  const resolvedInput = await resolveInput(input);
   if (row.function_type === "chat") {
     return {
       ...row,

--- a/ui/app/utils/resolve.server.ts
+++ b/ui/app/utils/resolve.server.ts
@@ -11,15 +11,21 @@ import type { Input } from "./clickhouse/common";
 import { tensorZeroClient } from "./tensorzero.server";
 
 export async function resolveInput(input: Input): Promise<ResolvedInput> {
-  const resolvedMessages = await Promise.all(
-    input.messages.map(async (message) => {
-      return resolveMessage(message);
-    }),
-  );
+  const resolvedMessages = await resolveMessages(input.messages);
   return {
     ...input,
     messages: resolvedMessages,
   };
+}
+
+export async function resolveMessages(
+  messages: InputMessage[],
+): Promise<ResolvedInputMessage[]> {
+  return Promise.all(
+    messages.map(async (message) => {
+      return resolveMessage(message);
+    }),
+  );
 }
 
 async function resolveMessage(

--- a/ui/e2e_tests/observability.inferences.$inference_id.spec.ts
+++ b/ui/e2e_tests/observability.inferences.$inference_id.spec.ts
@@ -30,6 +30,21 @@ test("should display inferences with image content", async ({ page }) => {
   // Verify images have loaded correctly
   await expect(firstImage).toHaveJSProperty("complete", true);
   await expect(secondImage).toHaveJSProperty("complete", true);
+
+  // Verify that images display in the modelInference section too
+  // Click on the modelInference section
+  await page.getByText("0195e31b-703c-74a3-bbdd-e252ca10a86d").click();
+  // Assert that the images are visible
+  const newImages = page.locator("img");
+  await expect(newImages).toHaveCount(4);
+  const firstNewImage = newImages.nth(0);
+  const secondNewImage = newImages.nth(1);
+  const thirdNewImage = newImages.nth(2);
+  const fourthNewImage = newImages.nth(3);
+  await expect(firstNewImage).toBeVisible();
+  await expect(secondNewImage).toBeVisible();
+  await expect(thirdNewImage).toBeVisible();
+  await expect(fourthNewImage).toBeVisible();
 });
 
 test("tag navigation works by evaluation_name", async ({ page }) => {


### PR DESCRIPTION
Added image resolution logic there
added a playwright test to make sure this works
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor image handling in ModelInference section with `ImageBlock` component and add Playwright test for verification.
> 
>   - **Behavior**:
>     - Added `ImageBlock` component in `ImageBlock.tsx` to handle image resolution and display.
>     - Updated `Input.tsx` and `ModelInput.tsx` to use `ImageBlock` for rendering images.
>     - Modified `resolveMessages` in `resolve.server.ts` to handle image resolution errors.
>   - **Testing**:
>     - Added Playwright test in `observability.inferences.$inference_id.spec.ts` to verify image display in ModelInference section.
>   - **Misc**:
>     - Removed duplicate `ImageBlock` definition from `Input.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6222578241d2338939102e0b36f2f54ccf70263f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->