### PR TITLE
Refactor feedback query to grab all feedback in database

### DIFF
--- a/ui/app/routes/api/function/$function_name/feedback_counts.route.ts
+++ b/ui/app/routes/api/function/$function_name/feedback_counts.route.ts
@@ -23,7 +23,6 @@ export async function loader({
     const result = await queryMetricsWithFeedback({
       function_name: functionName,
       inference_table: inferenceTable,
-      metrics: config.metrics,
     });
     return Response.json(result);
   } catch (error) {

--- a/ui/app/routes/observability/functions/$function_name/route.tsx
+++ b/ui/app/routes/observability/functions/$function_name/route.tsx
@@ -69,7 +69,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const metricsWithFeedbackPromise = queryMetricsWithFeedback({
     function_name,
     inference_table: getInferenceTableName(function_config),
-    metrics: config.metrics,
   });
   const variantCountsPromise = getVariantCounts({
     function_name,

--- a/ui/app/routes/observability/functions/$function_name/variants/route.tsx
+++ b/ui/app/routes/observability/functions/$function_name/variants/route.tsx
@@ -77,7 +77,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const metricsWithFeedbackPromise = queryMetricsWithFeedback({
     function_name,
     inference_table: getInferenceTableName(function_config),
-    metrics: config.metrics,
     variant_name,
   });
 

--- a/ui/app/utils/clickhouse/feedback.test.ts
+++ b/ui/app/utils/clickhouse/feedback.test.ts
@@ -225,18 +225,6 @@ describe("queryMetricsWithFeedback", () => {
     const jsonResults = await queryMetricsWithFeedback({
       function_name: "extract_entities",
       inference_table: "JsonInference",
-      metrics: {
-        exact_match: {
-          type: "boolean",
-          optimize: "max",
-          level: "inference",
-        },
-        jaccard_similarity: {
-          type: "float",
-          optimize: "max",
-          level: "inference",
-        },
-      },
     });
 
     // Check boolean counts for JSON function
@@ -259,13 +247,6 @@ describe("queryMetricsWithFeedback", () => {
     const chatResults = await queryMetricsWithFeedback({
       function_name: "write_haiku",
       inference_table: "ChatInference",
-      metrics: {
-        haiku_rating: {
-          type: "float",
-          optimize: "max",
-          level: "inference",
-        },
-      },
     });
 
     expect(chatResults.metrics).toContainEqual({
@@ -289,13 +270,6 @@ describe("queryMetricsWithFeedback", () => {
     const results = await queryMetricsWithFeedback({
       function_name: "nonexistent_function",
       inference_table: "ChatInference",
-      metrics: {
-        haiku_rating: {
-          type: "float",
-          optimize: "max",
-          level: "inference",
-        },
-      },
     });
 
     expect(results.metrics).toEqual([]);
@@ -306,18 +280,6 @@ describe("queryMetricsWithFeedback", () => {
     const results = await queryMetricsWithFeedback({
       function_name: "write_haiku",
       inference_table: "ChatInference",
-      metrics: {
-        haiku_rating: {
-          type: "float",
-          optimize: "max",
-          level: "inference",
-        },
-        haiku_rating_episode: {
-          type: "float",
-          optimize: "max",
-          level: "episode",
-        },
-      },
     });
 
     // Check inference level metric
@@ -342,13 +304,6 @@ describe("queryMetricsWithFeedback", () => {
       function_name: "write_haiku",
       variant_name: "initial_prompt_gpt4o_mini",
       inference_table: "ChatInference",
-      metrics: {
-        haiku_rating: {
-          type: "float",
-          optimize: "max",
-          level: "inference",
-        },
-      },
     });
 
     expect(results.metrics).toContainEqual({

--- a/ui/app/utils/clickhouse/feedback.ts
+++ b/ui/app/utils/clickhouse/feedback.ts
@@ -1,9 +1,6 @@
 import { type TableBounds, TableBoundsSchema } from "./common";
 import { data } from "react-router";
-import { InferenceJoinKey } from "./common";
 import { clickhouseClient } from "./client.server";
-import type { MetricConfig } from "~/utils/config/metric";
-import { getInferenceJoinKey } from "~/utils/clickhouse/curation";
 import { z } from "zod";
 
 export const booleanMetricFeedbackRowSchema = z.object({

--- a/ui/app/utils/clickhouse/feedback.ts
+++ b/ui/app/utils/clickhouse/feedback.ts
@@ -771,44 +771,9 @@ export type MetricsWithFeedbackData = z.infer<
 export async function queryMetricsWithFeedback(params: {
   function_name: string;
   inference_table: string;
-  metrics: Record<string, MetricConfig>;
   variant_name?: string;
 }): Promise<MetricsWithFeedbackData> {
-  const { function_name, inference_table, metrics, variant_name } = params;
-
-  const inferenceMetrics = Object.entries(metrics)
-    .filter(([, metric]) => {
-      try {
-        return (
-          "level" in metric &&
-          getInferenceJoinKey(metric.level) === InferenceJoinKey.ID
-        );
-      } catch {
-        return false;
-      }
-    })
-    .map(([name]) => name);
-
-  const episodeMetrics = Object.entries(metrics)
-    .filter(([, metric]) => {
-      try {
-        return (
-          "level" in metric &&
-          getInferenceJoinKey(metric.level) === InferenceJoinKey.EPISODE_ID
-        );
-      } catch {
-        return false;
-      }
-    })
-    .map(([name]) => name);
-
-  const idInClause =
-    inferenceMetrics.length > 0
-      ? `IN ('${inferenceMetrics.join("','")}')`
-      : `= ''`;
-
-  const episodeIdInClause =
-    episodeMetrics.length > 0 ? `IN ('${episodeMetrics.join("','")}')` : `= ''`;
+  const { function_name, inference_table, variant_name } = params;
 
   const variantClause = variant_name
     ? `AND i.variant_name = {variant_name:String}`
@@ -826,7 +791,6 @@ export async function queryMetricsWithFeedback(params: {
       JOIN BooleanMetricFeedback bmf ON bmf.target_id = i.id
       WHERE i.function_name = {function_name:String}
         ${variantClause}
-        AND bmf.metric_name ${idInClause}
       GROUP BY i.function_name, bmf.metric_name
       HAVING feedback_count > 0
     ),
@@ -841,7 +805,6 @@ export async function queryMetricsWithFeedback(params: {
       JOIN BooleanMetricFeedback bmf ON bmf.target_id = i.episode_id
       WHERE i.function_name = {function_name:String}
         ${variantClause}
-        AND bmf.metric_name ${episodeIdInClause}
       GROUP BY i.function_name, bmf.metric_name
       HAVING feedback_count > 0
     ),
@@ -856,7 +819,6 @@ export async function queryMetricsWithFeedback(params: {
       JOIN FloatMetricFeedback fmf ON fmf.target_id = i.id
       WHERE i.function_name = {function_name:String}
         ${variantClause}
-        AND fmf.metric_name ${idInClause}
       GROUP BY i.function_name, fmf.metric_name
       HAVING feedback_count > 0
     ),
@@ -871,7 +833,6 @@ export async function queryMetricsWithFeedback(params: {
       JOIN FloatMetricFeedback fmf ON fmf.target_id = i.episode_id
       WHERE i.function_name = {function_name:String}
         ${variantClause}
-        AND fmf.metric_name ${episodeIdInClause}
       GROUP BY i.function_name, fmf.metric_name
       HAVING feedback_count > 0
     ),


### PR DESCRIPTION
Previously the `queryMetricsWithFeedback` function took a metric config and only looked for metric that were explicitly present in the config. 

I refactored this query to no longer take the config as argument and rather grab all the metrics for which there are inferences for a given function from the database.

No changes to tests were required for this change as currently our fixtures don't include out-of-config data. In our upcoming rebuild of the UI fixtures we should include data like that.

This will be useful for our upcoming feedback UI elements.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `queryMetricsWithFeedback` to fetch all feedback metrics from the database, removing the need for metric configuration.
> 
>   - **Behavior**:
>     - `queryMetricsWithFeedback` in `feedback.ts` now fetches all metrics with feedback for a function, removing the `metrics` parameter.
>     - Updated SQL queries in `queryMetricsWithFeedback` to remove metric filtering clauses.
>   - **Routes**:
>     - Removed `metrics` parameter from `queryMetricsWithFeedback` calls in `feedback_counts.route.ts`, `route.tsx`, and `variants/route.tsx`.
>   - **Tests**:
>     - Removed `metrics` parameter from `queryMetricsWithFeedback` calls in `feedback.test.ts`.
>     - No changes to test logic, ensuring compatibility with existing fixtures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 54619b663b5dbaba27eb0cd150a9f3778379b453. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->