### PR TITLE
fixed pagination with datasets table

### DIFF
--- a/ui/app/routes/datasets/route.tsx
+++ b/ui/app/routes/datasets/route.tsx
@@ -1,4 +1,7 @@
-import { getDatasetCounts } from "~/utils/clickhouse/datasets.server";
+import {
+  getDatasetCounts,
+  getNumberOfDatasets,
+} from "~/utils/clickhouse/datasets.server";
 import type { Route } from "./+types/route";
 import DatasetTable from "./DatasetTable";
 import { data, isRouteErrorResponse } from "react-router";
@@ -18,12 +21,13 @@ export async function loader({ request }: Route.LoaderArgs) {
   if (pageSize > 100) {
     throw data("Page size cannot exceed 100", { status: 400 });
   }
-  const counts = await getDatasetCounts();
-  return { counts, pageSize, offset };
+  const counts = await getDatasetCounts(pageSize, offset);
+  const numberOfDatasets = await getNumberOfDatasets();
+  return { counts, pageSize, offset, numberOfDatasets };
 }
 
 export default function DatasetListPage({ loaderData }: Route.ComponentProps) {
-  const { counts, pageSize, offset } = loaderData;
+  const { counts, pageSize, offset, numberOfDatasets } = loaderData;
   const navigate = useNavigate();
   const handleNextPage = () => {
     const searchParams = new URLSearchParams(window.location.search);
@@ -37,7 +41,7 @@ export default function DatasetListPage({ loaderData }: Route.ComponentProps) {
   };
   return (
     <PageLayout>
-      <PageHeader heading="Datasets" count={counts.length} />
+      <PageHeader heading="Datasets" count={numberOfDatasets} />
       <SectionLayout>
         <DatasetsActions onBuildDataset={() => navigate("/datasets/builder")} />
         <DatasetTable counts={counts} />
@@ -45,7 +49,7 @@ export default function DatasetListPage({ loaderData }: Route.ComponentProps) {
           onPreviousPage={handlePreviousPage}
           onNextPage={handleNextPage}
           disablePrevious={offset === 0}
-          disableNext={offset + pageSize >= counts.length}
+          disableNext={offset + pageSize >= numberOfDatasets}
         />
       </SectionLayout>
     </PageLayout>

--- a/ui/app/utils/clickhouse/datasets.server.ts
+++ b/ui/app/utils/clickhouse/datasets.server.ts
@@ -256,7 +256,10 @@ Get name and count for all datasets.
 This function should sum the counts of chat and json inferences for each dataset.
 The groups should be ordered by last_updated in descending order.
 */
-export async function getDatasetCounts(): Promise<DatasetCountInfo[]> {
+export async function getDatasetCounts(
+  page_size?: number,
+  offset: number = 0,
+): Promise<DatasetCountInfo[]> {
   const resultSet = await clickhouseClient.query({
     query: `
       SELECT
@@ -284,11 +287,38 @@ export async function getDatasetCounts(): Promise<DatasetCountInfo[]> {
       )
       GROUP BY dataset_name
       ORDER BY last_updated DESC
+      ${page_size ? "LIMIT {page_size:UInt32}" : ""}
+      ${offset ? "OFFSET {offset:UInt32}" : ""}
     `,
     format: "JSONEachRow",
+    query_params: {
+      page_size,
+      offset,
+    },
   });
   const rows = await resultSet.json<DatasetCountInfo[]>();
   return z.array(DatasetCountInfoSchema).parse(rows);
+}
+
+export async function getNumberOfDatasets(): Promise<number> {
+  const resultSet = await clickhouseClient.query({
+    query: `
+      SELECT
+        toUInt32(uniqExact(dataset_name)) as count
+      FROM (
+        SELECT dataset_name
+        FROM ChatInferenceDatapoint FINAL
+        WHERE staled_at IS NULL
+        UNION ALL
+        SELECT dataset_name
+        FROM JsonInferenceDatapoint FINAL
+        WHERE staled_at IS NULL
+      )
+    `,
+    format: "JSONEachRow",
+  });
+  const rows = await resultSet.json<{ count: number }>();
+  return rows[0].count;
 }
 /**
  * Executes an INSERT INTO ... SELECT ... query to insert rows into the dataset table.

--- a/ui/app/utils/clickhouse/datasets.test.ts
+++ b/ui/app/utils/clickhouse/datasets.test.ts
@@ -10,6 +10,7 @@ import {
   getDatapoint,
   getDatasetCounts,
   getDatasetRows,
+  getNumberOfDatasets,
   insertDatapoint,
   insertRowsForDataset,
   staleDatapoint,
@@ -273,6 +274,13 @@ describe("getDatasetCounts", () => {
         },
       ]),
     );
+  });
+});
+
+describe("getNumberOfDatasets", () => {
+  test("returns the correct number of datasets", async () => {
+    const count = await getNumberOfDatasets();
+    expect(count).toBe(2);
   });
 });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes pagination in datasets table by adding total dataset count retrieval and updating dataset count function for pagination.
> 
>   - **Behavior**:
>     - Fixes pagination in `DatasetListPage` by using `getNumberOfDatasets()` to determine total dataset count.
>     - Updates `getDatasetCounts()` to accept `page_size` and `offset` for pagination.
>   - **Functions**:
>     - Adds `getNumberOfDatasets()` in `datasets.server.ts` to return total dataset count.
>     - Modifies `getDatasetCounts()` in `datasets.server.ts` to support pagination with `page_size` and `offset`.
>   - **Tests**:
>     - Adds test for `getNumberOfDatasets()` in `datasets.test.ts`.
>     - Updates tests for `getDatasetCounts()` to verify pagination behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 79789750a818a7006aec5d1261184558600fb233. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->