### PR TITLE
Make deprecation warning clearer

### DIFF
--- a/clients/rust/src/client_input.rs
+++ b/clients/rust/src/client_input.rs
@@ -84,7 +84,7 @@ pub fn deserialize_content<'de, D: Deserializer<'de>>(
             })])
         })
         .map(|object| {
-            tracing::warn!("Deprecation warning - passing in an object for `content` is deprecated. Please use an array of content blocks instead.");
+            tracing::warn!("Deprecation Warning - passing in an object for `content` is deprecated. Please use an array of content blocks instead.");
             Ok(vec![ClientInputMessageContent::Text(TextKind::Arguments {
                 arguments: object.deserialize()?,
             })])

--- a/clients/rust/src/client_input.rs
+++ b/clients/rust/src/client_input.rs
@@ -84,7 +84,7 @@ pub fn deserialize_content<'de, D: Deserializer<'de>>(
             })])
         })
         .map(|object| {
-            tracing::warn!("Deprecation Warning - passing in an object for `content` is deprecated. Please use an array of content blocks instead.");
+            tracing::warn!("Deprecation Warning: passing in an object for `content` is deprecated. Please use an array of content blocks instead.");
             Ok(vec![ClientInputMessageContent::Text(TextKind::Arguments {
                 arguments: object.deserialize()?,
             })])

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -83,7 +83,7 @@ async fn main() {
     let metrics_handle = observability::setup_metrics().expect_pretty("Failed to set up metrics");
 
     if args.warn_default_cmd {
-        tracing::warn!("Deprecation warning: Running gateway from Docker container without overriding default CMD. Please override the command to either '--config-file path/to/tensorzero.toml' or '--default-config'.");
+        tracing::warn!("Deprecation Warning: Running gateway from Docker container without overriding default CMD. Please override the command to either `--config-file` to specify a custom configuration file (e.g. `--config-file /path/to/tensorzero.toml`) or `--default-config` to use default settings (i.e. no custom functions, metrics, etc.).");
     }
 
     if args.tensorzero_toml.is_some() && args.config_file.is_some() {

--- a/tensorzero-internal/src/endpoints/openai_compatible.rs
+++ b/tensorzero-internal/src/endpoints/openai_compatible.rs
@@ -353,7 +353,7 @@ impl Params {
         let header_episode_id = headers
             .get("episode_id")
             .map(|h| {
-                tracing::warn!("Deprecation warning: Please use the `tensorzero::episode_id` field instead of the `episode_id` header. The header will be removed in a future release.");
+                tracing::warn!("Deprecation Warning: Please use the `tensorzero::episode_id` field instead of the `episode_id` header. The header will be removed in a future release.");
                 h.to_str()
                     .map_err(|_| {
                         Error::new(ErrorDetails::InvalidOpenAICompatibleRequest {
@@ -407,7 +407,7 @@ impl Params {
         let header_variant_name = headers
             .get("variant_name")
             .map(|h| {
-                tracing::warn!("Deprecation warning: Please use the `tensorzero::variant_name` field instead of the `variant_name` header. The header will be removed in a future release.");
+                tracing::warn!("Deprecation Warning: Please use the `tensorzero::variant_name` field instead of the `variant_name` header. The header will be removed in a future release.");
                 h.to_str()
                     .map_err(|_| {
                         Error::new(ErrorDetails::InvalidOpenAICompatibleRequest {
@@ -420,7 +420,7 @@ impl Params {
         let header_dryrun = headers
             .get("dryrun")
             .map(|h| {
-                tracing::warn!("Deprecation warning: Please use the `tensorzero::dryrun` field instead of the `dryrun` header. The header will be removed in a future release.");
+                tracing::warn!("Deprecation Warning: Please use the `tensorzero::dryrun` field instead of the `dryrun` header. The header will be removed in a future release.");
                 h.to_str()
                     .map_err(|_| {
                         Error::new(ErrorDetails::InvalidOpenAICompatibleRequest {

--- a/tensorzero-internal/src/inference/types/mod.rs
+++ b/tensorzero-internal/src/inference/types/mod.rs
@@ -714,7 +714,7 @@ fn deserialize_content<'de, D: Deserializer<'de>>(
             })])
         })
         .map(|object| {
-            tracing::warn!("Deprecation Warning - passing in an object for `content` is deprecated. Please use an array of content blocks instead.");
+            tracing::warn!("Deprecation Warning: passing in an object for `content` is deprecated. Please use an array of content blocks instead.");
             Ok(vec![InputMessageContent::Text(TextKind::Arguments {
                 arguments: object.deserialize()?,
             })])

--- a/tensorzero-internal/src/inference/types/mod.rs
+++ b/tensorzero-internal/src/inference/types/mod.rs
@@ -126,7 +126,7 @@ impl InputMessageContent {
             InputMessageContent::Thought(thought) => ResolvedInputMessageContent::Thought(thought),
             InputMessageContent::Text(TextKind::LegacyValue { value }) => {
                 tracing::warn!(
-                    r#"Deprecation warning: `{{"type": "text", "value", ...}}` is deprecated. Please use `{{"type": "text", "text": "String input"}}` or `{{"type": "text", "arguments": {{..}}}} ` instead."#
+                    r#"Deprecation Warning: `{{"type": "text", "value", ...}}` is deprecated. Please use `{{"type": "text", "text": "String input"}}` or `{{"type": "text", "arguments": {{..}}}} ` instead."#
                 );
                 ResolvedInputMessageContent::Text { value }
             }
@@ -714,7 +714,7 @@ fn deserialize_content<'de, D: Deserializer<'de>>(
             })])
         })
         .map(|object| {
-            tracing::warn!("Deprecation warning - passing in an object for `content` is deprecated. Please use an array of content blocks instead.");
+            tracing::warn!("Deprecation Warning - passing in an object for `content` is deprecated. Please use an array of content blocks instead.");
             Ok(vec![InputMessageContent::Text(TextKind::Arguments {
                 arguments: object.deserialize()?,
             })])


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Clarified deprecation warnings across multiple files to improve user guidance.
> 
>   - **Deprecation Warnings**:
>     - Updated deprecation warning messages in `client_input.rs`, `main.rs`, and `openai_compatible.rs` to use a more explicit format: "Deprecation Warning: ...".
>     - Clarified instructions in `main.rs` for overriding default CMD when running the gateway from a Docker container.
>     - Updated warnings in `openai_compatible.rs` to suggest using `tensorzero::` fields instead of headers for `episode_id`, `variant_name`, and `dryrun`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a06ad20595416ca33792d84dde0e83870d6c6af2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->