### PR TITLE
Fixed bug in ModelInference Input field

### DIFF
--- a/ui/app/utils/clickhouse/common.ts
+++ b/ui/app/utils/clickhouse/common.ts
@@ -10,6 +10,14 @@ export const textInputSchema = z.object({
 });
 export type TextInput = z.infer<typeof textInputSchema>;
 
+export const modelInferenceTextInputSchema = z.object({
+  type: z.literal("text"),
+  text: z.string(),
+});
+export type ModelInferenceTextInput = z.infer<
+  typeof modelInferenceTextInputSchema
+>;
+
 export const rawTextInputSchema = z.object({
   type: z.literal("raw_text"),
   value: z.string(),
@@ -124,6 +132,20 @@ export const inputMessageContentSchema = z.discriminatedUnion("type", [
 ]);
 export type InputMessageContent = z.infer<typeof inputMessageContentSchema>;
 
+export const modelInferenceInputMessageContentSchema = z.discriminatedUnion(
+  "type",
+  [
+    modelInferenceTextInputSchema,
+    toolCallContentSchema,
+    toolResultContentSchema,
+    imageContentSchema,
+    rawTextInputSchema,
+  ],
+);
+export type ModelInferenceInputMessageContent = z.infer<
+  typeof modelInferenceInputMessageContentSchema
+>;
+
 export const resolvedInputMessageContentSchema = z.discriminatedUnion("type", [
   textInputSchema,
   toolCallContentSchema,
@@ -145,6 +167,16 @@ export const inputMessageSchema = z
   .strict();
 export type InputMessage = z.infer<typeof inputMessageSchema>;
 
+export const modelInferenceInputMessageSchema = z
+  .object({
+    role: roleSchema,
+    content: z.array(modelInferenceInputMessageContentSchema),
+  })
+  .strict();
+export type ModelInferenceInputMessage = z.infer<
+  typeof modelInferenceInputMessageSchema
+>;
+
 export const resolvedInputMessageSchema = z
   .object({
     role: roleSchema,
@@ -160,6 +192,14 @@ export const inputSchema = z
   })
   .strict();
 export type Input = z.infer<typeof inputSchema>;
+
+export const modelInferenceInputSchema = z
+  .object({
+    system: z.any().optional(), // Value type from Rust maps to any in TS
+    messages: z.array(modelInferenceInputMessageSchema).default([]),
+  })
+  .strict();
+export type ModelInferenceInput = z.infer<typeof modelInferenceInputSchema>;
 
 export const resolvedInputSchema = z
   .object({

--- a/ui/app/utils/clickhouse/inference.ts
+++ b/ui/app/utils/clickhouse/inference.ts
@@ -2,6 +2,7 @@ import z from "zod";
 import {
   type ContentBlockOutput,
   type JsonInferenceOutput,
+  modelInferenceInputMessageSchema,
   resolvedInputMessageSchema,
   resolvedInputSchema,
   type TableBounds,
@@ -13,12 +14,11 @@ import {
   getInferenceTableName,
   inputSchema,
   jsonInferenceOutputSchema,
-  requestMessageSchema,
 } from "./common";
 import { data } from "react-router";
 import type { FunctionConfig } from "../config/function";
 import { clickhouseClient } from "./client.server";
-import { resolveInput, resolveMessages } from "../resolve.server";
+import { resolveInput, resolveModelInferenceMessages } from "../resolve.server";
 
 export const inferenceByIdRowSchema = z
   .object({
@@ -735,9 +735,9 @@ async function parseModelInferenceRow(
   row: ModelInferenceRow,
 ): Promise<ParsedModelInferenceRow> {
   const parsedMessages = z
-    .array(requestMessageSchema)
+    .array(modelInferenceInputMessageSchema)
     .parse(JSON.parse(row.input_messages));
-  const resolvedMessages = await resolveMessages(parsedMessages);
+  const resolvedMessages = await resolveModelInferenceMessages(parsedMessages);
   return {
     ...row,
     input_messages: resolvedMessages,

--- a/ui/app/utils/resolve.server.ts
+++ b/ui/app/utils/resolve.server.ts
@@ -1,5 +1,8 @@
 import type {
   ImageContent,
+  ModelInferenceInput,
+  ModelInferenceInputMessage,
+  ModelInferenceInputMessageContent,
   ResolvedBase64Image,
   ResolvedInputMessageContent,
 } from "./clickhouse/common";
@@ -18,6 +21,16 @@ export async function resolveInput(input: Input): Promise<ResolvedInput> {
   };
 }
 
+export async function resolveModelInferenceInput(
+  input: ModelInferenceInput,
+): Promise<ResolvedInput> {
+  const resolvedMessages = await resolveMessages(input.messages);
+  return {
+    ...input,
+    messages: resolvedMessages,
+  };
+}
+
 export async function resolveMessages(
   messages: InputMessage[],
 ): Promise<ResolvedInputMessage[]> {
@@ -28,12 +41,35 @@ export async function resolveMessages(
   );
 }
 
+export async function resolveModelInferenceMessages(
+  messages: ModelInferenceInputMessage[],
+): Promise<ResolvedInputMessage[]> {
+  return Promise.all(
+    messages.map(async (message) => {
+      return resolveModelInferenceMessage(message);
+    }),
+  );
+}
 async function resolveMessage(
   message: InputMessage,
 ): Promise<ResolvedInputMessage> {
   const resolvedContent = await Promise.all(
     message.content.map(async (content) => {
       return resolveContent(content);
+    }),
+  );
+  return {
+    ...message,
+    content: resolvedContent,
+  };
+}
+
+async function resolveModelInferenceMessage(
+  message: ModelInferenceInputMessage,
+): Promise<ResolvedInputMessage> {
+  const resolvedContent = await Promise.all(
+    message.content.map(async (content) => {
+      return resolveModelInferenceContent(content);
     }),
   );
   return {
@@ -66,6 +102,33 @@ async function resolveContent(
   }
 }
 
+async function resolveModelInferenceContent(
+  content: ModelInferenceInputMessageContent,
+): Promise<ResolvedInputMessageContent> {
+  switch (content.type) {
+    case "text":
+      return {
+        type: "text",
+        value: content.text,
+      };
+    case "tool_call":
+    case "tool_result":
+    case "raw_text":
+      return content;
+    case "image":
+      try {
+        return {
+          ...content,
+          image: await resolveImage(content as ImageContent),
+        };
+      } catch (error) {
+        return {
+          type: "image_error",
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+  }
+}
 async function resolveImage(
   content: ImageContent,
 ): Promise<ResolvedBase64Image> {


### PR DESCRIPTION
There was a bug in the way we were deserializing ModelInference input messages. This is now fixed by introducing separate types and a separate resolution method.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes ModelInference input deserialization bug by adding new types and resolution methods in `common.ts`, `inference.ts`, and `resolve.server.ts`.
> 
>   - **Behavior**:
>     - Fixes deserialization bug for ModelInference input messages by introducing `modelInferenceInputMessageContentSchema` and `modelInferenceInputMessageSchema` in `common.ts`.
>     - Adds `resolveModelInferenceInput` and `resolveModelInferenceMessages` functions in `resolve.server.ts` to handle ModelInference inputs.
>   - **Schemas**:
>     - Adds `ModelInferenceTextInput`, `ModelInferenceInputMessageContent`, and `ModelInferenceInputMessage` types in `common.ts`.
>     - Updates `parseModelInferenceRow` in `inference.ts` to use new schemas and resolution methods.
>   - **Functions**:
>     - Modifies `parseModelInferenceRow` in `inference.ts` to use `resolveModelInferenceMessages` for resolving input messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 324b39278e5bf557014451e8458a5a13ab3bb3c7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->