### PR TITLE
Use a single Tiktoken instance during OpenAI SFT analysis

### DIFF
--- a/ui/app/utils/supervised_fine_tuning/openAITokenCounter.test.ts
+++ b/ui/app/utils/supervised_fine_tuning/openAITokenCounter.test.ts
@@ -15,6 +15,7 @@ import {
   countAssistantTokens,
   getSimpleTokenCount,
   getModelTokenLimit,
+  getEncodingForModel,
 } from "./openAITokenCounter";
 import { CURRENT_MODEL_VERSIONS } from "./constants";
 import type { OpenAIMessage, ToolFunction } from "./types";
@@ -35,7 +36,7 @@ describe("openAITokenCounter", () => {
         { role: "user", content: "Hello!" },
         { role: "assistant", content: "Hi there! How can I help you today?" },
       ];
-      const count = getTokensFromMessages(messages, "gpt-3.5-turbo");
+      const count = getTokensFromMessages(messages, "gpt-3.5-turbo", getEncodingForModel("gpt-3.5-turbo"));
       expect(count).toBeGreaterThan(0);
     });
 
@@ -43,13 +44,13 @@ describe("openAITokenCounter", () => {
       const messages: OpenAIMessage[] = [
         { role: "assistant", content: "Hello", name: "AI" },
       ];
-      const count = getTokensFromMessages(messages, "gpt-4");
+      const count = getTokensFromMessages(messages, "gpt-4", getEncodingForModel("gpt-4"));
       expect(count).toBeGreaterThan(4); // base(3) + content + name + name_tax(1)
     });
 
     it("should handle empty messages", () => {
       const messages: OpenAIMessage[] = [];
-      const count = getTokensFromMessages(messages, "gpt-3.5-turbo");
+      const count = getTokensFromMessages(messages, "gpt-3.5-turbo", getEncodingForModel("gpt-3.5-turbo"));
       expect(count).toBe(3); // priming tokens
     });
   });
@@ -81,13 +82,13 @@ describe("openAITokenCounter", () => {
       const messages: OpenAIMessage[] = [
         { role: "user", content: "What's the weather?" },
       ];
-      const count = getTokensForTools([sampleFunction], messages, "gpt-4");
+      const count = getTokensForTools([sampleFunction], messages, "gpt-4", getEncodingForModel("gpt-4"));
       expect(count).toBeGreaterThan(0);
     });
 
     it("should handle empty functions array", () => {
       const messages: OpenAIMessage[] = [{ role: "user", content: "Hello" }];
-      const count = getTokensForTools([], messages, "gpt-4");
+      const count = getTokensForTools([], messages, "gpt-4", getEncodingForModel("gpt-4"));
       expect(count).toBeGreaterThan(0);
     });
   });
@@ -100,7 +101,7 @@ describe("openAITokenCounter", () => {
         { role: "user", content: "How are you?" },
         { role: "assistant", content: "I'm doing well, thanks!" },
       ];
-      const count = countAssistantTokens(messages, "gpt-3.5-turbo");
+      const count = countAssistantTokens(messages, getEncodingForModel("gpt-3.5-turbo"));
       expect(count).toBeGreaterThan(0);
     });
 
@@ -114,7 +115,7 @@ describe("openAITokenCounter", () => {
           },
         },
       ];
-      const count = countAssistantTokens(messages, "gpt-4");
+      const count = countAssistantTokens(messages, getEncodingForModel("gpt-4"));
       expect(count).toBeGreaterThan(3); // base tokens + function call tokens
     });
 
@@ -134,7 +135,7 @@ describe("openAITokenCounter", () => {
           ],
         },
       ];
-      const count = countAssistantTokens(messages, "gpt-4");
+      const count = countAssistantTokens(messages, getEncodingForModel("gpt-4"));
       expect(count).toBeGreaterThan(3); // base tokens + tool call tokens
     });
   });
@@ -222,7 +223,7 @@ describe("openAITokenCounter", () => {
       "should match OpenAI API token count for %s",
       async (model) => {
         // Calculate tokens using our function
-        const calculatedTokens = getTokensFromMessages(example_messages, model);
+        const calculatedTokens = getTokensFromMessages(example_messages, model, getEncodingForModel(model));
 
         // Convert messages to OpenAI API format
         const apiMessages: ChatCompletionMessageParam[] = example_messages.map(
@@ -328,6 +329,7 @@ describe("openAITokenCounter", () => {
           example_tools,
           example_messages,
           model,
+          getEncodingForModel(model),
         );
 
         // Convert messages to OpenAI API format

--- a/ui/app/utils/supervised_fine_tuning/openai.ts
+++ b/ui/app/utils/supervised_fine_tuning/openai.ts
@@ -20,8 +20,9 @@ import { splitValidationData, type SFTJobStatus } from "./common";
 import { render_message } from "./rendering";
 import { SFTJob } from "./common";
 import { validateMessage, analyzeDataset } from "./validation";
-import { getModelTokenLimit } from "./openAITokenCounter";
+import { getEncodingForModel, getModelTokenLimit } from "./openAITokenCounter";
 import type { OpenAIMessage, OpenAIRole } from "./types";
+import type { Tiktoken } from "tiktoken";
 
 export const client = process.env.OPENAI_API_KEY
   ? new OpenAI({
@@ -307,6 +308,7 @@ export function content_block_to_openai_message(
 function validateAndConvertMessages(
   inferences: ParsedInferenceExample[],
   modelName: string,
+  enc: Tiktoken,
   templateEnv: JsExposedEnv,
   type: "training" | "validation",
 ): OpenAIMessage[][] {
@@ -315,7 +317,7 @@ function validateAndConvertMessages(
       inference,
       templateEnv,
     );
-    const validation = validateMessage(messages, modelName);
+    const validation = validateMessage(messages, modelName, enc);
 
     if (!validation.isValid) {
       const errors = [];
@@ -377,6 +379,7 @@ export async function start_sft_openai(
   templateEnv: JsExposedEnv,
   formData: SFTFormValues,
 ) {
+  const enc = getEncodingForModel(modelName);
   const { trainInferences, valInferences } = splitValidationData(
     inferences,
     validationSplitPercent,
@@ -396,7 +399,7 @@ export async function start_sft_openai(
   });
 
   // Analyze dataset for model improvement insights
-  const analysis = analyzeDataset(trainMessagesForAnalysis, modelName);
+  const analysis = analyzeDataset(trainMessagesForAnalysis, modelName, enc);
   const tokenLimit = getModelTokenLimit(modelName);
 
   const analysisData: AnalysisData = {
@@ -418,12 +421,14 @@ export async function start_sft_openai(
   const trainMessages = validateAndConvertMessages(
     trainInferences,
     modelName,
+    enc,
     templateEnv,
     "training",
   );
   const valMessages = validateAndConvertMessages(
     valInferences,
     modelName,
+    enc,
     templateEnv,
     "validation",
   );
@@ -441,6 +446,7 @@ export async function start_sft_openai(
   );
 
   const jobId = job.id;
+  enc.free();
   return new OpenAISFTJob({
     jobId: jobId,
     status: "created",

--- a/ui/app/utils/supervised_fine_tuning/validation.test.ts
+++ b/ui/app/utils/supervised_fine_tuning/validation.test.ts
@@ -9,7 +9,7 @@ import {
   analyzeDataset,
 } from "./validation";
 import { MODEL_TOKEN_LIMITS } from "./constants";
-import { getModelTokenLimit, countAssistantTokens } from "./openAITokenCounter";
+import { getModelTokenLimit, countAssistantTokens, getEncodingForModel } from "./openAITokenCounter";
 import type { OpenAIMessage, OpenAIRole } from "./types";
 import { CURRENT_MODEL_VERSIONS } from "./constants";
 
@@ -39,19 +39,19 @@ describe("convertToTiktokenModel", () => {
       { role: "assistant" as OpenAIRole, content: "Test" },
     ];
     expect(() =>
-      validateMessageLength(messages, "gpt-4o-2024-08-06"),
+      validateMessageLength(messages, "gpt-4o-2024-08-06", getEncodingForModel("gpt-4o-2024-08-06")),
     ).not.toThrow();
     expect(() =>
-      validateMessageLength(messages, "gpt-4o-mini-2024-07-18"),
+      validateMessageLength(messages, "gpt-4o-mini-2024-07-18", getEncodingForModel("gpt-4o-mini-2024-07-18")),
     ).not.toThrow();
-    expect(() => validateMessageLength(messages, "gpt-4-0613")).not.toThrow();
+    expect(() => validateMessageLength(messages, "gpt-4-0613", getEncodingForModel("gpt-4-0613"))).not.toThrow();
   });
 
   it("should handle gpt-3.5-turbo models", () => {
     const messages: OpenAIMessage[] = [
       { role: "assistant" as OpenAIRole, content: "Test" },
     ];
-    expect(() => validateMessageLength(messages, "gpt-4-0613")).not.toThrow();
+    expect(() => validateMessageLength(messages, "gpt-4-0613", getEncodingForModel("got-4-0613"))).not.toThrow();
   });
 
   it("should throw error for unsupported models", () => {
@@ -59,7 +59,7 @@ describe("convertToTiktokenModel", () => {
     const messages: OpenAIMessage[] = [
       { role: "assistant" as OpenAIRole, content: "Test" },
     ];
-    expect(() => validateMessageLength(messages, model)).toThrow(
+    expect(() => validateMessageLength(messages, model, getEncodingForModel(model))).toThrow(
       `Unsupported model: ${model}. Supported models are: ${CURRENT_MODEL_VERSIONS.join(", ")}`,
     );
   });
@@ -77,14 +77,14 @@ describe("validateMessageLength", () => {
     ];
 
     // Test with gpt-4o-2024-08-06 (65536 token limit)
-    const result1 = validateMessageLength(messages, "gpt-4o-2024-08-06");
+    const result1 = validateMessageLength(messages, "gpt-4o-2024-08-06", getEncodingForModel("gpt-4o-2024-08-06"));
     expect(result1.isValid).toBe(true);
     expect(result1.tokenCount).toBeLessThan(
       MODEL_TOKEN_LIMITS["gpt-4o-2024-08-06"],
     );
 
     // Test with gpt-3.5-turbo-0125 (16385 token limit)
-    const result2 = validateMessageLength(messages, "gpt-3.5-turbo-0125");
+    const result2 = validateMessageLength(messages, "gpt-3.5-turbo-0125", getEncodingForModel("gpt-3.5-turbo-0125"));
     expect(result2.isValid).toBe(true);
     expect(result2.tokenCount).toBeLessThan(
       MODEL_TOKEN_LIMITS["gpt-3.5-turbo-0125"],
@@ -106,7 +106,7 @@ describe("validateMessageLength", () => {
       },
     ];
 
-    const result = validateMessageLength(messages, "gpt-4-0613");
+    const result = validateMessageLength(messages, "gpt-4-0613", getEncodingForModel("gpt-4-0613"));
     expect(result.isValid).toBe(true);
   });
 
@@ -116,7 +116,7 @@ describe("validateMessageLength", () => {
       { role: "user" as OpenAIRole, content: "Hello!" },
     ];
 
-    const result = validateMessageLength(messages, "gpt-4-0613", 10);
+    const result = validateMessageLength(messages, "gpt-4-0613", getEncodingForModel("gpt-4-0613"), 10);
     expect(result.isValid).toBe(false);
   });
 });
@@ -228,13 +228,14 @@ describe("countAssistantTokens", () => {
       },
     ];
 
-    const assistantTokens = countAssistantTokens(messages, "gpt-4-0613");
+    const assistantTokens = countAssistantTokens(messages, getEncodingForModel("gpt-4-0613"));
     expect(assistantTokens).toBeGreaterThan(0);
 
     // Only assistant message should be counted
     const totalTokens = validateMessageLength(
       messages,
       "gpt-4-0613",
+      getEncodingForModel("gpt-4-0613"),
     ).tokenCount;
     expect(assistantTokens).toBeLessThan(totalTokens);
   });
@@ -248,7 +249,7 @@ describe("countAssistantTokens", () => {
       { role: "user" as OpenAIRole, content: "Hello!" },
     ];
 
-    const assistantTokens = countAssistantTokens(messages, "gpt-4-0613");
+    const assistantTokens = countAssistantTokens(messages, getEncodingForModel("gpt-4-0613"));
     expect(assistantTokens).toBe(0);
   });
 });
@@ -315,7 +316,7 @@ describe("analyzeDataset", () => {
       },
     ];
 
-    const analysis = analyzeDataset(dataset, "gpt-4-0613");
+    const analysis = analyzeDataset(dataset, "gpt-4-0613", getEncodingForModel("gpt-4-0613"));
 
     expect(analysis.missingSystemCount).toBe(2);
     expect(analysis.missingUserCount).toBe(0);
@@ -337,8 +338,8 @@ describe("analyzeDataset", () => {
     ];
 
     // Test with different models
-    const analysis1 = analyzeDataset(dataset, "gpt-4-0613");
-    const analysis2 = analyzeDataset(dataset, "gpt-4o-2024-08-06");
+    const analysis1 = analyzeDataset(dataset, "gpt-4-0613", getEncodingForModel("gpt-4-0613"));
+    const analysis2 = analyzeDataset(dataset, "gpt-4o-2024-08-06", getEncodingForModel("gpt-4o-2024-08-06"));
 
     // Both should pass with the small test messages
     expect(analysis1.tooLongCount).toBe(0);
@@ -360,7 +361,7 @@ describe("analyzeDataset", () => {
     ];
 
     // Set a very low token limit to force examples to exceed it
-    const analysis = analyzeDataset(dataset, "gpt-4-0613", 5);
+    const analysis = analyzeDataset(dataset, "gpt-4-0613", getEncodingForModel("gpt-4-0613"), 5);
 
     expect(analysis.tooLongCount).toBe(1);
   });
@@ -473,7 +474,7 @@ describe("validateMessage", () => {
       },
     ];
 
-    const result = validateMessage(messages, "gpt-4-0613");
+    const result = validateMessage(messages, "gpt-4-0613", getEncodingForModel("gpt-4-0613"));
     expect(result.isValid).toBe(true);
     expect(result.lengthValidation.isValid).toBe(true);
     expect(result.rolesValidation.isValid).toBe(true);
@@ -490,7 +491,7 @@ describe("validateMessage", () => {
       },
     ];
 
-    const result = validateMessage(messages, "gpt-4-0613", 10);
+    const result = validateMessage(messages, "gpt-4-0613", getEncodingForModel("gpt-4-0613"), 10);
     expect(result.isValid).toBe(false);
     expect(result.lengthValidation.isValid).toBe(false);
     expect(result.rolesValidation.isValid).toBe(true);
@@ -505,7 +506,7 @@ describe("validateMessage", () => {
       },
     ];
 
-    const result = validateMessage(messages, "gpt-4-0613");
+    const result = validateMessage(messages, "gpt-4-0613", getEncodingForModel("gpt-4-0613"));
     expect(result.isValid).toBe(true); // Should be valid since assistant is present
     expect(result.lengthValidation.isValid).toBe(true);
     expect(result.rolesValidation.isValid).toBe(true); // Should be true since only assistant is required
@@ -527,7 +528,7 @@ describe("validateDataset", () => {
       },
     ];
 
-    const result = validateDataset(dataset, "gpt-4-0613");
+    const result = validateDataset(dataset, "gpt-4-0613", getEncodingForModel("gpt-4-0613"));
     expect(result.isValid).toBe(false);
     expect(result.invalidEntries).toBe(0);
     expect(result.errorCounts.insufficient_examples).toBe(1);
@@ -567,7 +568,7 @@ describe("validateDataset", () => {
       },
     ];
 
-    const result = validateDataset(dataset, "gpt-4-0613");
+    const result = validateDataset(dataset, "gpt-4-0613", getEncodingForModel("gpt-4-0613"));
     expect(result.isValid).toBe(true);
     expect(result.invalidEntries).toBe(0);
     expect(result.errorCounts.insufficient_examples).toBe(0);
@@ -624,7 +625,7 @@ describe("validateDataset", () => {
       },
     ];
 
-    const result = validateDataset(dataset, "gpt-4-0613");
+    const result = validateDataset(dataset, "gpt-4-0613", getEncodingForModel("gpt-4-0613"));
     expect(result.isValid).toBe(false);
     expect(result.invalidEntries).toBe(2);
     expect(result.errorCounts.data_type).toBe(1);

--- a/ui/app/utils/supervised_fine_tuning/validation.test.ts
+++ b/ui/app/utils/supervised_fine_tuning/validation.test.ts
@@ -51,7 +51,7 @@ describe("convertToTiktokenModel", () => {
     const messages: OpenAIMessage[] = [
       { role: "assistant" as OpenAIRole, content: "Test" },
     ];
-    expect(() => validateMessageLength(messages, "gpt-4-0613", getEncodingForModel("got-4-0613"))).not.toThrow();
+    expect(() => validateMessageLength(messages, "gpt-4-0613", getEncodingForModel("gpt-4-0613"))).not.toThrow();
   });
 
   it("should throw error for unsupported models", () => {


### PR DESCRIPTION
We were repeatedly re-creating Tiktoken instances for the same model. Each call takes hundreds of milliseconds, resulting in the SFT route spending over 10 seconds in the 'analysis' code.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize token counting by reusing Tiktoken instances across functions, reducing overhead in OpenAI SFT analysis.
> 
>   - **Optimization**:
>     - Reuse `Tiktoken` instances across multiple functions to reduce overhead in `openAITokenCounter.ts`.
>     - Pass `Tiktoken` instance as a parameter to `getTokensFromMessages`, `getTokensForTools`, and `countAssistantTokens`.
>   - **Function Changes**:
>     - Modify `getTokensFromMessages`, `getTokensForTools`, and `countAssistantTokens` to accept `Tiktoken` as a parameter.
>     - Update `getEncodingForModel` to be exported and used externally.
>   - **Test Updates**:
>     - Update tests in `openAITokenCounter.test.ts` and `validation.test.ts` to pass `Tiktoken` instance to functions.
>   - **Miscellaneous**:
>     - Free `Tiktoken` instance after use in `start_sft_openai` in `openai.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b7dec6675d13962bd7da07dd126179a09d3e2533. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->