### PR TITLE
Use media query list for matching mobile breakpoints

### DIFF
--- a/ui/app/hooks/use-mobile.tsx
+++ b/ui/app/hooks/use-mobile.tsx
@@ -9,11 +9,11 @@ export function useIsMobile() {
 
   React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    const onChange = (event: MediaQueryListEvent) => {
+      setIsMobile(event.matches);
     };
     mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    setIsMobile(mql.matches);
     return () => mql.removeEventListener("change", onChange);
   }, []);
 

--- a/ui/app/hooks/use-mobile.tsx
+++ b/ui/app/hooks/use-mobile.tsx
@@ -3,9 +3,7 @@ import * as React from "react";
 const MOBILE_BREAKPOINT = 768;
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
-    undefined,
-  );
+  const [isMobile, setIsMobile] = React.useState(false);
 
   React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
@@ -17,5 +15,5 @@ export function useIsMobile() {
     return () => mql.removeEventListener("change", onChange);
   }, []);
 
-  return !!isMobile;
+  return isMobile;
 }


### PR DESCRIPTION
Very minor change, but since `useIsMobile` is using the matchMedia API we can return the `matches` property instead of checking the inner width of the window.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Simplifies `useIsMobile` by using `matchMedia` API's `matches` property for mobile detection.
> 
>   - **Behavior**:
>     - `useIsMobile` in `use-mobile.tsx` now uses `matchMedia` API's `matches` property directly to determine if the viewport is mobile.
>     - Removes the need to check `window.innerWidth` for mobile breakpoint detection.
>   - **State Management**:
>     - Initializes `isMobile` state to `false` instead of `undefined`.
>     - Updates `isMobile` state based on `MediaQueryListEvent.matches`.
>   - **Misc**:
>     - Removes redundant `!!` operator when returning `isMobile`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 497a3051d17d76e0a629faa3384998be99a3a9c9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->