### PR TITLE
Use route function props instead of `useLoaderData`

### DIFF
--- a/ui/app/root.tsx
+++ b/ui/app/root.tsx
@@ -5,7 +5,6 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
-  useLoaderData,
 } from "react-router";
 
 import { ConfigProvider } from "./context/config";
@@ -60,9 +59,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
   );
 }
 
-export default function App() {
-  const config = useLoaderData<typeof loader>();
-
+export default function App({ loaderData: config }: Route.ComponentProps) {
   return (
     <ConfigProvider value={config}>
       <SidebarProvider>

--- a/ui/app/routes/datasets/builder/route.tsx
+++ b/ui/app/routes/datasets/builder/route.tsx
@@ -1,7 +1,5 @@
 import { data, redirect } from "react-router";
-import { useLoaderData } from "react-router";
 import { DatasetBuilderForm } from "./DatasetBuilderForm";
-import type { DatasetCountInfo } from "~/utils/clickhouse/datasets";
 import {
   countRowsForDataset,
   getDatasetCounts,
@@ -14,6 +12,7 @@ import {
   PageLayout,
   SectionLayout,
 } from "~/components/layout/PageLayout";
+import type { Route } from "./+types/route";
 
 export const meta = () => {
   return [
@@ -56,10 +55,8 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 }
 
-export default function DatasetBuilder() {
-  const { dataset_counts } = useLoaderData() as {
-    dataset_counts: DatasetCountInfo[];
-  };
+export default function DatasetBuilder({ loaderData }: Route.ComponentProps) {
+  const { dataset_counts } = loaderData;
 
   return (
     <PageLayout>

--- a/ui/app/routes/index.tsx
+++ b/ui/app/routes/index.tsx
@@ -19,10 +19,10 @@ import {
   countEpisodes,
 } from "~/utils/clickhouse/inference";
 import { getConfig } from "~/utils/config/index.server";
-import { useLoaderData } from "react-router";
 import { getDatasetCounts } from "~/utils/clickhouse/datasets.server";
 import { countTotalEvaluationRuns } from "~/utils/clickhouse/evaluations.server";
 import { useConfig } from "~/context/config";
+import type { Route } from "./+types/index";
 
 const FF_ENABLE_DATASETS =
   import.meta.env.VITE_TENSORZERO_UI_FF_ENABLE_DATASETS === "1";
@@ -94,14 +94,14 @@ export async function loader() {
   };
 }
 
-export default function Home() {
+export default function Home({ loaderData }: Route.ComponentProps) {
   const {
     totalInferences,
     numFunctions,
     numEpisodes,
     numDatasets,
     numEvaluationRuns,
-  } = useLoaderData<typeof loader>();
+  } = loaderData;
   const config = useConfig();
   const numEvaluations = Object.keys(config.evaluations).length;
 

--- a/ui/app/routes/observability/functions/$function_name/variants/route.tsx
+++ b/ui/app/routes/observability/functions/$function_name/variants/route.tsx
@@ -2,7 +2,6 @@ import {
   data,
   isRouteErrorResponse,
   redirect,
-  useLoaderData,
   useNavigate,
   useSearchParams,
 } from "react-router";
@@ -118,7 +117,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   };
 }
 
-export default function VariantDetails() {
+export default function VariantDetails({ loaderData }: Route.ComponentProps) {
   const {
     function_name,
     variant_name,
@@ -127,7 +126,7 @@ export default function VariantDetails() {
     inference_bounds,
     variant_performances,
     metricsWithFeedback,
-  } = useLoaderData<typeof loader>();
+  } = loaderData;
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const config = useConfig();


### PR DESCRIPTION
React Router 7 now provides loader data to route modules directly via props (and types via the generated type modules), so no need for `useLoaderData`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `useLoaderData` with route function props in components to utilize React Router 7's new data handling feature.
> 
>   - **Behavior**:
>     - Replace `useLoaderData` with route function props in `App`, `DatasetBuilder`, `Home`, and `VariantDetails` components.
>     - Loader data is now accessed via `loaderData` prop in `Route.ComponentProps`.
>   - **Files Affected**:
>     - `root.tsx`: `App` component updated to use `loaderData` prop.
>     - `datasets/builder/route.tsx`: `DatasetBuilder` component updated to use `loaderData` prop.
>     - `index.tsx`: `Home` component updated to use `loaderData` prop.
>     - `observability/functions/$function_name/variants/route.tsx`: `VariantDetails` component updated to use `loaderData` prop.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b65324afff21131517b21e7c7d82b1ef8903bbf4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->