### PR TITLE
Disable `stream_options` for xAI for now

### DIFF
--- a/tensorzero-internal/src/inference/providers/xai.rs
+++ b/tensorzero-internal/src/inference/providers/xai.rs
@@ -340,12 +340,15 @@ impl<'a> XAIRequest<'a> {
             ..
         } = *request;
 
-        let stream_options = match request.stream {
+        // xAI suddenly started rejecting 'stream_options' as a parameter.
+        // If they change the behavior back, we can start using this again.
+        let _stream_options = match request.stream {
             true => Some(StreamOptions {
                 include_usage: true,
             }),
             false => None,
         };
+        let stream_options = None;
 
         let response_format = Some(XAIResponseFormat::new(
             &request.json_mode,


### PR DESCRIPTION
They suddenly stopped accepting this parameter, so let's stop passing it to unbreak the xAI provider

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disable `stream_options` in `XAIRequest` due to xAI provider rejection, setting it to `None` temporarily.
> 
>   - **Behavior**:
>     - Disable `stream_options` in `XAIRequest` in `xai.rs` as xAI provider rejects it.
>     - Temporarily set `stream_options` to `None` to prevent errors.
>   - **Comments**:
>     - Add comments in `XAIRequest::new()` explaining the temporary removal of `stream_options`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for aa91831433f2b53942443337b297db50bb064fc7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->