### PR TITLE
Store a `Box<ErrorDetails>` inside of `Error`

### DIFF
--- a/tensorzero-internal/src/error.rs
+++ b/tensorzero-internal/src/error.rs
@@ -30,16 +30,17 @@ pub fn set_debug(debug: bool) -> Result<(), Error> {
 
 #[derive(Debug, PartialEq)]
 // As long as the struct member is private, we force people to use the `new` method and log the error.
-pub struct Error(ErrorDetails);
+// We box `ErrorDetails` per the `clippy::result_large_err` lint
+pub struct Error(Box<ErrorDetails>);
 
 impl Error {
     pub fn new(details: ErrorDetails) -> Self {
         details.log();
-        Error(details)
+        Error(Box::new(details))
     }
 
     pub fn new_without_logging(details: ErrorDetails) -> Self {
-        Error(details)
+        Error(Box::new(details))
     }
 
     pub fn status_code(&self) -> StatusCode {
@@ -51,7 +52,7 @@ impl Error {
     }
 
     pub fn get_owned_details(self) -> ErrorDetails {
-        self.0
+        *self.0
     }
 }
 


### PR DESCRIPTION
The `clippy::result_large_err` lint was firing for this enum, so let's box it to reduce the size of the `Result` types.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Box `ErrorDetails` in `Error` struct to address `clippy::result_large_err` lint in `tensorzero-internal/src/error.rs`.
> 
>   - **Behavior**:
>     - Box `ErrorDetails` in `Error` struct in `tensorzero-internal/src/error.rs` to address `clippy::result_large_err` lint.
>     - Affects `new`, `new_without_logging`, and `get_owned_details` methods in `Error` implementation.
>   - **Misc**:
>     - Update comments to reflect boxing of `ErrorDetails`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 31ac0331d762a11b7d5d0d498c7c053eb002bd2e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->