### PR TITLE
Refresh SFT progress bar every 1 second

### DIFF
--- a/ui/app/routes/optimization/supervised-fine-tuning/ProgressIndicator.tsx
+++ b/ui/app/routes/optimization/supervised-fine-tuning/ProgressIndicator.tsx
@@ -1,13 +1,14 @@
 import { Progress } from "~/components/ui/progress";
 import { CountdownTimer } from "~/components/ui/CountdownTimer";
+import { useState, useEffect } from "react";
 
 function getProgressPercentage(
   createdAt: Date,
   estimatedCompletion: Date,
+  currentTime: Date,
 ): number {
-  const now = new Date();
   const total = estimatedCompletion.getTime() - createdAt.getTime();
-  const elapsed = now.getTime() - createdAt.getTime();
+  const elapsed = currentTime.getTime() - createdAt.getTime();
 
   return Math.min(Math.max((elapsed / total) * 100, 0), 100);
 }
@@ -21,6 +22,28 @@ export function ProgressIndicator({
   createdAt,
   estimatedCompletion,
 }: ProgressIndicatorProps) {
+  const [progress, setProgress] = useState(
+    getProgressPercentage(createdAt, estimatedCompletion, new Date())
+  );
+
+  useEffect(() => {
+    // Update progress every second
+    const intervalId = setInterval(() => {
+      const now = new Date();
+      setProgress(getProgressPercentage(
+        createdAt,
+        estimatedCompletion,
+        now
+      ));
+      if (now >= estimatedCompletion) {
+        clearInterval(intervalId);
+      }
+    }, 1000);
+
+    // Clean up interval on component unmount
+    return () => clearInterval(intervalId);
+  }, [createdAt, estimatedCompletion]);
+
   return (
     <div className="max-w-lg space-y-2">
       <div className="flex items-center justify-between">
@@ -28,7 +51,7 @@ export function ProgressIndicator({
         <CountdownTimer targetDate={estimatedCompletion} />
       </div>
       <Progress
-        value={getProgressPercentage(createdAt, estimatedCompletion)}
+        value={progress}
         className="w-full"
       />
     </div>


### PR DESCRIPTION
We were previously never explicitly re-rendering it, so the progress bar would be stuck until React happened to re-render it.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refreshes the progress bar every second in `ProgressIndicator` to ensure real-time updates until `estimatedCompletion`.
> 
>   - **Behavior**:
>     - Refreshes progress bar every second in `ProgressIndicator` using `setInterval` in `useEffect`.
>     - Stops updating when `estimatedCompletion` is reached.
>   - **Functions**:
>     - `getProgressPercentage` now takes `currentTime` as a parameter instead of using `new Date()` internally.
>   - **State Management**:
>     - Introduces `useState` to manage `progress` state in `ProgressIndicator`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 588519a96d6f7c00d3df97a59a590b24d839eb72. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->