### PR TITLE
Fix caching in ui Dockerfile for evals build

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -38,17 +38,17 @@ RUN wasm-pack build --features console_error_panic_hook
 
 FROM rust:latest AS evaluations-build-env
 
+RUN apt-get update && apt-get install -y clang libc++-dev && rm -rf /var/lib/apt/lists/*
+
 COPY . /tensorzero
 
 WORKDIR /tensorzero
-
-RUN apt-get update && apt-get install -y clang libc++-dev && rm -rf /var/lib/apt/lists/*
 
 ARG CARGO_BUILD_FLAGS=""
 
 RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/registry \
     --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/git \
-    --mount=type=cache,id=tensorzero-evaluations-release,sharing=locked,target=/src/target \
+    --mount=type=cache,id=tensorzero-evaluations-release,sharing=locked,target=/tensorzero/target \
     cargo build --release -p evaluations $CARGO_BUILD_FLAGS && \
     cp -r /tensorzero/target/release /release
 


### PR DESCRIPTION
We were specifying the wrong path for the /target mount, so we weren't caching any of the Cargo output. Also, the 'RUN apt-get' was after the 'COPY' command, so it was re-run every time files were changed.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes caching issues in `ui/Dockerfile` by correcting mount path and reordering commands for `evaluations-build-env`.
> 
>   - **Caching Fixes**:
>     - Corrects cache mount path from `/src/target` to `/tensorzero/target` in `ui/Dockerfile` for `evaluations-build-env` stage.
>     - Moves `RUN apt-get` command before `COPY` to prevent unnecessary re-execution on file changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6155cb4786bd454b45594b2d95001951c1f86506. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->