### PR TITLE
added handling for badges for comments and demonstrations

### DIFF
--- a/ui/app/components/feedback/FeedbackTable.stories.tsx
+++ b/ui/app/components/feedback/FeedbackTable.stories.tsx
@@ -27,6 +27,13 @@ const config: Config = {
       optimize: "min" as const,
       level: "inference" as const,
     },
+    demonstration: {
+      type: "demonstration" as const,
+      level: "inference" as const,
+    },
+    comment: {
+      type: "comment" as const,
+    },
   },
   tools: {},
   evaluations: {},

--- a/ui/app/components/feedback/FeedbackTable.tsx
+++ b/ui/app/components/feedback/FeedbackTable.tsx
@@ -52,7 +52,10 @@ export default function FeedbackTable({
                 <TableCell>
                   <div className="flex items-center gap-2">
                     <span className="font-mono">{getMetricName(item)}</span>
-                    <MetricBadges metric={metrics[getMetricName(item)]} />
+                    <MetricBadges
+                      metric={metrics[getMetricName(item)]}
+                      row={item}
+                    />
                   </div>
                 </TableCell>
                 <TableCell>

--- a/ui/app/components/metric/MetricBadges.tsx
+++ b/ui/app/components/metric/MetricBadges.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "~/components/ui/badge";
+import type { FeedbackRow } from "~/utils/clickhouse/feedback";
 import type { MetricConfig } from "~/utils/config/metric";
 
 // Move the getBadgeStyle function from MetricSelector
@@ -37,16 +38,19 @@ const getBadgeStyle = (
 
 type MetricBadgesProps = {
   metric: MetricConfig;
+  row?: FeedbackRow;
 };
 
-export function MetricBadges({ metric }: MetricBadgesProps) {
+export function MetricBadges({ metric, row }: MetricBadgesProps) {
   if (!metric) return null;
   return (
     <div className="flex gap-1.5">
       {/* Type badge */}
-      <Badge className={getBadgeStyle("type", metric.type)}>
-        {metric.type}
-      </Badge>
+      {metric.type !== "comment" && metric.type !== "demonstration" && (
+        <Badge className={getBadgeStyle("type", metric.type)}>
+          {metric.type}
+        </Badge>
+      )}
 
       {/* Only show optimize badge if it's defined */}
       {"optimize" in metric && metric.optimize && (
@@ -56,6 +60,14 @@ export function MetricBadges({ metric }: MetricBadgesProps) {
       )}
 
       {/* Level badge */}
+      {/* If the metric is a comment take the level from the row if available */}
+      {metric.type === "comment" &&
+        row?.type === "comment" &&
+        row?.target_type && (
+          <Badge className={getBadgeStyle("level", row.target_type)}>
+            {row.target_type}
+          </Badge>
+        )}
       {metric.type !== "comment" && (
         <Badge className={getBadgeStyle("level", metric.level)}>
           {metric.level}

--- a/ui/app/utils/config/index.server.ts
+++ b/ui/app/utils/config/index.server.ts
@@ -97,6 +97,14 @@ export async function loadConfig(config_path?: string): Promise<Config> {
     },
   };
 
+  // Add comment metric to the config
+  loadedConfig.metrics = {
+    ...loadedConfig.metrics,
+    comment: {
+      type: "comment" as const,
+    },
+  };
+
   // Add default function to the config
   loadedConfig.functions = {
     ...loadedConfig.functions,


### PR DESCRIPTION
needed to add instantiation of metric named "comment" at init. Also, added the same fixtures to storybook so you can look there. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add handling for 'comment' and 'demonstration' metrics in feedback system, updating UI components and configuration.
> 
>   - **Behavior**:
>     - Add handling for 'comment' and 'demonstration' metrics in `FeedbackTable.tsx` and `MetricBadges.tsx`.
>     - `MetricBadges` now conditionally displays badges based on metric type, omitting 'comment' and 'demonstration' types from type badges.
>     - For 'comment' metrics, level badge is derived from `row.target_type` if available.
>   - **Configuration**:
>     - Add 'comment' and 'demonstration' metrics to the configuration in `index.server.ts`.
>   - **Storybook**:
>     - Add fixtures for 'comment' and 'demonstration' metrics in `FeedbackTable.stories.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2b5fa066babf0d0ded2bc2ed8ddff8303558b511. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->