### PR TITLE
Publish Docker images to ui-dev and gateway-dev on push to main

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -11,6 +11,8 @@ on:
 
 env:
   DOCKERHUB_USER: tensorzero
+  UI_CONTAINER: ${{ github.event_name == 'push' && 'ui-dev' || 'ui' }}
+  GATEWAY_CONTAINER: ${{ github.event_name == 'push' && 'gateway-dev' || 'gateway' }}
 
 jobs:
   build:
@@ -24,8 +26,8 @@ jobs:
           - runner: ubuntu-24.04-arm
             target: linux/arm64
         container:
-          - name: ui
-          - name: gateway
+          - name: ${{ env.UI_CONTAINER }}
+          - name: ${{ env.GATEWAY_CONTAINER }}
     permissions:
       packages: write
       contents: read
@@ -86,8 +88,8 @@ jobs:
     strategy:
       matrix:
         container:
-          - name: ui
-          - name: gateway
+          - name: ${{ env.UI_CONTAINER }}
+          - name: ${{ env.GATEWAY_CONTAINER }}
     runs-on: ubuntu-latest
     needs:
       - build


### PR DESCRIPTION
This will prevent the ui and gateway repos from getting clutted with images

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
