### PR TITLE
Add centralized empty state for the table

### DIFF
--- a/ui/app/components/feedback/FeedbackTable.tsx
+++ b/ui/app/components/feedback/FeedbackTable.tsx
@@ -5,6 +5,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableEmptyState,
 } from "~/components/ui/table";
 import FeedbackValue from "~/components/feedback/FeedbackValue";
 import { getMetricName } from "~/utils/clickhouse/helpers";
@@ -33,14 +34,7 @@ export default function FeedbackTable({
         </TableHeader>
         <TableBody>
           {feedback.length === 0 ? (
-            <TableRow className="hover:bg-bg-primary">
-              <TableCell
-                colSpan={4}
-                className="text-fg-muted px-3 py-8 text-center"
-              >
-                No feedback found.
-              </TableCell>
-            </TableRow>
+            <TableEmptyState message="No feedback found" />
           ) : (
             feedback.map((item) => (
               <TableRow key={item.id}>

--- a/ui/app/components/ui/table.tsx
+++ b/ui/app/components/ui/table.tsx
@@ -108,6 +108,28 @@ const TableCaption = React.forwardRef<
 ));
 TableCaption.displayName = "TableCaption";
 
+interface TableEmptyStateProps
+  extends React.TdHTMLAttributes<HTMLTableCellElement> {
+  message?: string;
+}
+
+const TableEmptyState = React.forwardRef<
+  HTMLTableCellElement,
+  TableEmptyStateProps
+>(({ message = "No data found", ...props }, ref) => (
+  <TableRow>
+    <TableCell
+      ref={ref}
+      colSpan={1000}
+      className="text-fg-muted py-10 text-center"
+      {...props}
+    >
+      {message}
+    </TableCell>
+  </TableRow>
+));
+TableEmptyState.displayName = "TableEmptyState";
+
 export {
   Table,
   TableHeader,
@@ -117,4 +139,5 @@ export {
   TableRow,
   TableCell,
   TableCaption,
+  TableEmptyState,
 };

--- a/ui/app/components/utils/TagsTable.tsx
+++ b/ui/app/components/utils/TagsTable.tsx
@@ -5,6 +5,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableEmptyState,
 } from "~/components/ui/table";
 import { Code } from "~/components/ui/code";
 import { useNavigate } from "react-router";
@@ -79,14 +80,7 @@ export function TagsTable({ tags }: TagsTableProps) {
       </TableHeader>
       <TableBody>
         {Object.keys(tags).length === 0 ? (
-          <TableRow className="hover:bg-bg-primary">
-            <TableCell
-              colSpan={2}
-              className="text-fg-muted px-3 py-8 text-center"
-            >
-              No tags found.
-            </TableCell>
-          </TableRow>
+          <TableEmptyState message="No tags found" />
         ) : (
           Object.entries(tags).map(([key, value]) => (
             <TableRow

--- a/ui/app/routes/datasets/$dataset_name/DatasetRowTable.tsx
+++ b/ui/app/routes/datasets/$dataset_name/DatasetRowTable.tsx
@@ -5,6 +5,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableEmptyState,
 } from "~/components/ui/table";
 import { formatDate } from "~/utils/date";
 import type { DatasetDetailRow } from "~/utils/clickhouse/datasets";
@@ -33,14 +34,7 @@ export default function DatasetRowTable({
         </TableHeader>
         <TableBody>
           {rows.length === 0 ? (
-            <TableRow className="hover:bg-bg-primary">
-              <TableCell
-                colSpan={5}
-                className="text-fg-muted px-3 py-8 text-center"
-              >
-                No datapoints found.
-              </TableCell>
-            </TableRow>
+            <TableEmptyState message="No datapoints found" />
           ) : (
             rows.map((row) => (
               <TableRow key={row.id} id={row.id}>

--- a/ui/app/routes/datasets/DatasetTable.tsx
+++ b/ui/app/routes/datasets/DatasetTable.tsx
@@ -5,6 +5,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableEmptyState,
 } from "~/components/ui/table";
 import { formatDate } from "~/utils/date";
 import type { DatasetCountInfo } from "~/utils/clickhouse/datasets";
@@ -27,14 +28,7 @@ export default function DatasetTable({
         </TableHeader>
         <TableBody>
           {counts.length === 0 ? (
-            <TableRow className="hover:bg-bg-primary">
-              <TableCell
-                colSpan={3}
-                className="text-fg-muted px-3 py-8 text-center"
-              >
-                No datasets found.
-              </TableCell>
-            </TableRow>
+            <TableEmptyState message="No datasets found" />
           ) : (
             counts.map((count) => (
               <TableRow key={count.dataset_name} id={count.dataset_name}>

--- a/ui/app/routes/evaluations/EvaluationRunsTable.tsx
+++ b/ui/app/routes/evaluations/EvaluationRunsTable.tsx
@@ -6,6 +6,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableEmptyState,
 } from "~/components/ui/table";
 import { formatDate } from "~/utils/date";
 import { FunctionLink } from "~/components/function/FunctionLink";
@@ -32,14 +33,7 @@ export default function EvaluationRunsTable({
         </TableHeader>
         <TableBody>
           {evaluationRuns.length === 0 ? (
-            <TableRow className="hover:bg-bg-primary">
-              <TableCell
-                colSpan={6}
-                className="text-fg-muted px-3 py-8 text-center"
-              >
-                No evaluation runs found.
-              </TableCell>
-            </TableRow>
+            <TableEmptyState message="No evaluation runs found" />
           ) : (
             evaluationRuns.map((evaluationRun) => (
               <TableRow

--- a/ui/app/routes/observability/episodes/$episode_id/EpisodeInferenceTable.tsx
+++ b/ui/app/routes/observability/episodes/$episode_id/EpisodeInferenceTable.tsx
@@ -5,6 +5,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableEmptyState,
 } from "~/components/ui/table";
 import type { InferenceByIdRow } from "~/utils/clickhouse/inference";
 import { formatDate } from "~/utils/date";
@@ -29,14 +30,7 @@ export default function EpisodeInferenceTable({
       </TableHeader>
       <TableBody>
         {inferences.length === 0 ? (
-          <TableRow className="hover:bg-bg-primary">
-            <TableCell
-              colSpan={4}
-              className="text-fg-muted px-3 py-8 text-center"
-            >
-              No inferences found.
-            </TableCell>
-          </TableRow>
+          <TableEmptyState message="No inferences found" />
         ) : (
           inferences.map((inference) => (
             <TableRow key={inference.id} id={inference.id}>

--- a/ui/app/routes/observability/episodes/EpisodesTable.tsx
+++ b/ui/app/routes/observability/episodes/EpisodesTable.tsx
@@ -6,6 +6,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableEmptyState,
 } from "~/components/ui/table";
 import type { EpisodeByIdRow } from "~/utils/clickhouse/inference";
 
@@ -43,14 +44,7 @@ export default function EpisodesTable({
         </TableHeader>
         <TableBody>
           {episodes.length === 0 ? (
-            <TableRow className="hover:bg-bg-primary">
-              <TableCell
-                colSpan={3}
-                className="text-fg-muted px-3 py-8 text-center"
-              >
-                No episodes found.
-              </TableCell>
-            </TableRow>
+            <TableEmptyState message="No episodes found" />
           ) : (
             episodes.map((episode) => (
               <TableRow key={episode.episode_id} id={episode.episode_id}>

--- a/ui/app/routes/observability/functions/$function_name/FunctionInferenceTable.tsx
+++ b/ui/app/routes/observability/functions/$function_name/FunctionInferenceTable.tsx
@@ -5,6 +5,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableEmptyState,
 } from "~/components/ui/table";
 import type { InferenceByIdRow } from "~/utils/clickhouse/inference";
 import { formatDate } from "~/utils/date";
@@ -28,14 +29,7 @@ export default function FunctionInferenceTable({
       </TableHeader>
       <TableBody>
         {inferences.length === 0 ? (
-          <TableRow className="hover:bg-bg-primary">
-            <TableCell
-              colSpan={4}
-              className="text-fg-muted px-3 py-8 text-center"
-            >
-              No inferences found.
-            </TableCell>
-          </TableRow>
+          <TableEmptyState message="No inferences found" />
         ) : (
           inferences.map((inference) => (
             <TableRow key={inference.id} id={inference.id}>

--- a/ui/app/routes/observability/functions/$function_name/FunctionVariantTable.tsx
+++ b/ui/app/routes/observability/functions/$function_name/FunctionVariantTable.tsx
@@ -6,6 +6,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableEmptyState,
 } from "~/components/ui/table";
 import type { VariantCounts } from "~/utils/clickhouse/function";
 import { formatDate } from "~/utils/date";
@@ -36,14 +37,7 @@ export default function FunctionVariantTable({
       </TableHeader>
       <TableBody>
         {variant_counts.length === 0 ? (
-          <TableRow className="hover:bg-bg-primary">
-            <TableCell
-              colSpan={5}
-              className="text-fg-muted px-3 py-8 text-center"
-            >
-              No variants found.
-            </TableCell>
-          </TableRow>
+          <TableEmptyState message="No variants found" />
         ) : (
           variant_counts.map((variant_count) => (
             <TableRow

--- a/ui/app/routes/observability/functions/$function_name/variants/VariantInferenceTable.tsx
+++ b/ui/app/routes/observability/functions/$function_name/variants/VariantInferenceTable.tsx
@@ -5,6 +5,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableEmptyState,
 } from "~/components/ui/table";
 import type { InferenceByIdRow } from "~/utils/clickhouse/inference";
 import { formatDate } from "~/utils/date";
@@ -26,14 +27,7 @@ export default function VariantInferenceTable({
       </TableHeader>
       <TableBody>
         {inferences.length === 0 ? (
-          <TableRow className="hover:bg-bg-primary">
-            <TableCell
-              colSpan={3}
-              className="text-fg-muted px-3 py-8 text-center"
-            >
-              No inferences found.
-            </TableCell>
-          </TableRow>
+          <TableEmptyState message="No inferences found" />
         ) : (
           inferences.map((inference) => (
             <TableRow key={inference.id} id={inference.id}>

--- a/ui/app/routes/observability/functions/FunctionsTable.tsx
+++ b/ui/app/routes/observability/functions/FunctionsTable.tsx
@@ -5,6 +5,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableEmptyState,
 } from "~/components/ui/table";
 import type { FunctionConfig } from "~/utils/config/function";
 import type { FunctionCountInfo } from "~/utils/clickhouse/inference";
@@ -60,14 +61,7 @@ export default function FunctionsTable({
         </TableHeader>
         <TableBody>
           {mergedFunctions.length === 0 ? (
-            <TableRow className="hover:bg-bg-primary">
-              <TableCell
-                colSpan={4}
-                className="text-fg-muted px-3 py-8 text-center"
-              >
-                No functions found.
-              </TableCell>
-            </TableRow>
+            <TableEmptyState message="No functions found" />
           ) : (
             mergedFunctions.map(
               ({ function_name, count, max_timestamp, type }) => (

--- a/ui/app/routes/observability/inferences/$inference_id/ModelInferencesTable.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/ModelInferencesTable.tsx
@@ -6,6 +6,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableEmptyState,
 } from "~/components/ui/table";
 import { Sheet, SheetContent } from "~/components/ui/sheet";
 import type { ParsedModelInferenceRow } from "~/utils/clickhouse/inference";
@@ -38,11 +39,7 @@ export function ModelInferencesTable({
         </TableHeader>
         <TableBody>
           {modelInferences.length === 0 ? (
-            <TableRow>
-              <TableCell colSpan={2} className="text-fg-muted py-4 text-center">
-                No model inferences available.
-              </TableCell>
-            </TableRow>
+            <TableEmptyState message="No model inferences available" />
           ) : (
             modelInferences.map((inference) => (
               <TableRow

--- a/ui/app/routes/observability/inferences/InferencesTable.tsx
+++ b/ui/app/routes/observability/inferences/InferencesTable.tsx
@@ -7,6 +7,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableEmptyState,
 } from "~/components/ui/table";
 import { formatDate } from "~/utils/date";
 import { FunctionLink } from "~/components/function/FunctionLink";
@@ -31,14 +32,7 @@ export default function InferencesTable({
         </TableHeader>
         <TableBody>
           {inferences.length === 0 ? (
-            <TableRow className="hover:bg-bg-primary">
-              <TableCell
-                colSpan={5}
-                className="text-fg-muted px-3 py-8 text-center"
-              >
-                No inferences found.
-              </TableCell>
-            </TableRow>
+            <TableEmptyState message="No inferences found" />
           ) : (
             inferences.map((inference) => (
               <TableRow key={inference.id} id={inference.id}>

--- a/ui/app/routes/optimization/supervised-fine-tuning/ProgressIndicator.tsx
+++ b/ui/app/routes/optimization/supervised-fine-tuning/ProgressIndicator.tsx
@@ -23,18 +23,14 @@ export function ProgressIndicator({
   estimatedCompletion,
 }: ProgressIndicatorProps) {
   const [progress, setProgress] = useState(
-    getProgressPercentage(createdAt, estimatedCompletion, new Date())
+    getProgressPercentage(createdAt, estimatedCompletion, new Date()),
   );
 
   useEffect(() => {
     // Update progress every second
     const intervalId = setInterval(() => {
       const now = new Date();
-      setProgress(getProgressPercentage(
-        createdAt,
-        estimatedCompletion,
-        now
-      ));
+      setProgress(getProgressPercentage(createdAt, estimatedCompletion, now));
       if (now >= estimatedCompletion) {
         clearInterval(intervalId);
       }
@@ -50,10 +46,7 @@ export function ProgressIndicator({
         <span className="font-medium">Estimated Completion</span>
         <CountdownTimer targetDate={estimatedCompletion} />
       </div>
-      <Progress
-        value={progress}
-        className="w-full"
-      />
+      <Progress value={progress} className="w-full" />
     </div>
   );
 }

--- a/ui/e2e_tests/optimization.supervised-fine-tuning.spec.ts
+++ b/ui/e2e_tests/optimization.supervised-fine-tuning.spec.ts
@@ -9,26 +9,49 @@ test("should show the supervised fine-tuning page", async ({ page }) => {
 });
 
 test("should fine-tune with a mocked OpenAI server", async ({ page }) => {
-  await page.goto('/optimization/supervised-fine-tuning');
-  await page.getByRole('combobox').filter({ hasText: 'Select a function' }).click();
-  await page.getByRole('option', { name: 'extract_entities JSON' }).click();
-  await page.getByRole('combobox').filter({ hasText: 'Select a metric' }).click();
-  await page.getByText('exact_match', { exact: true }).click();
-  await page.getByRole('combobox').filter({ hasText: 'Select a variant name' }).click();
-  await page.getByLabel('gpt4o_mini_initial_prompt').getByText('gpt4o_mini_initial_prompt').click();
-  await page.getByRole('combobox').filter({ hasText: 'Select a model...' }).click();
-  await page.getByRole('option', { name: 'gpt-4o-2024-08-06 OpenAI' }).click();
-  await page.getByRole('button', { name: 'Start Fine-tuning Job' }).click();
-  await page.getByText('running', { exact: true }).waitFor({ timeout: 3000 });
-  await expect(page.locator('body')).toContainText('Base Model: gpt-4o-2024-08-06');
-  await expect(page.locator('body')).toContainText('Function: extract_entities');
-  await expect(page.locator('body')).toContainText('Metric: exact_match');
-  await expect(page.locator('body')).toContainText('Prompt: gpt4o_mini_initial_prompt');
+  await page.goto("/optimization/supervised-fine-tuning");
+  await page
+    .getByRole("combobox")
+    .filter({ hasText: "Select a function" })
+    .click();
+  await page.getByRole("option", { name: "extract_entities JSON" }).click();
+  await page
+    .getByRole("combobox")
+    .filter({ hasText: "Select a metric" })
+    .click();
+  await page.getByText("exact_match", { exact: true }).click();
+  await page
+    .getByRole("combobox")
+    .filter({ hasText: "Select a variant name" })
+    .click();
+  await page
+    .getByLabel("gpt4o_mini_initial_prompt")
+    .getByText("gpt4o_mini_initial_prompt")
+    .click();
+  await page
+    .getByRole("combobox")
+    .filter({ hasText: "Select a model..." })
+    .click();
+  await page.getByRole("option", { name: "gpt-4o-2024-08-06 OpenAI" }).click();
+  await page.getByRole("button", { name: "Start Fine-tuning Job" }).click();
+  await page.getByText("running", { exact: true }).waitFor({ timeout: 3000 });
+  await expect(page.locator("body")).toContainText(
+    "Base Model: gpt-4o-2024-08-06",
+  );
+  await expect(page.locator("body")).toContainText(
+    "Function: extract_entities",
+  );
+  await expect(page.locator("body")).toContainText("Metric: exact_match");
+  await expect(page.locator("body")).toContainText(
+    "Prompt: gpt4o_mini_initial_prompt",
+  );
 
   // We poll every 10 seconds, so wait for up to 20 seconds to see the completion status
-  await page.getByText('completed', { exact: true }).waitFor({ timeout: 20000 });
-  await expect(page.locator('body')).toContainText('Configuration');
-  await expect(page.locator('body')).toContainText(`
+  await page
+    .getByText("completed", { exact: true })
+    .waitFor({ timeout: 20000 });
+  await expect(page.locator("body")).toContainText("Configuration");
+  await expect(page.locator("body")).toContainText(`
 [models.mock-inference-finetune-1234]
 routing = [ "mock-inference-finetune-1234" ]
 
@@ -36,5 +59,4 @@ routing = [ "mock-inference-finetune-1234" ]
 type = "openai"
 model_name = "mock-inference-finetune-1234"
 `);
-
 });


### PR DESCRIPTION
Empty states are currently set up per page, which makes it hard to manage / update the design consistently, so I'm moving it to the table component.

- Added the empty state export to the table;
- It takes a custom message as an optional prop;
- Updated tables to use it instead of file-by-file setup;

It currently sets a very large colSpan to take the whole table width, which is a hack but looks ok to me for this iteration. I don't know a smarter way to do it in the shadcn setup without over-complicating it.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Centralizes table empty state handling with a new `TableEmptyState` component, ensuring consistent design across various tables.
> 
>   - **Behavior**:
>     - Introduces `TableEmptyState` component in `table.tsx` for centralized empty state handling in tables.
>     - `TableEmptyState` accepts an optional `message` prop for custom messages.
>     - Sets a large `colSpan` to span the entire table width.
>   - **Refactoring**:
>     - Replaces individual empty state implementations with `TableEmptyState` in `FeedbackTable.tsx`, `TagsTable.tsx`, and `DatasetRowTable.tsx`.
>     - Applies `TableEmptyState` to `DatasetTable.tsx`, `EvaluationRunsTable.tsx`, and `EpisodeInferenceTable.tsx`.
>     - Updates `EpisodesTable.tsx`, `FunctionInferenceTable.tsx`, and `FunctionVariantTable.tsx` to use `TableEmptyState`.
>     - Refactors `VariantInferenceTable.tsx`, `FunctionsTable.tsx`, and `ModelInferencesTable.tsx` to utilize `TableEmptyState`.
>     - Implements `TableEmptyState` in `InferencesTable.tsx` and `ProgressIndicator.tsx`.
>   - **Testing**:
>     - Adjusts e2e tests in `optimization.supervised-fine-tuning.spec.ts` to align with the new table empty state behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ef46e1cf6796a0209a618fb9e0b46c1c7318e8a0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->