### PR TITLE
Remove duplicate minijinja tests from live-tests job

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -218,17 +218,6 @@ jobs:
         with:
           node-version: "22.9.0"
 
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
-      - name: Build minijinja WASM bindings
-        working-directory: ui/app/utils/minijinja
-        run: wasm-pack build --features console_error_panic_hook
-
-      - name: Run minijinja WASM tests
-        working-directory: ui/app/utils/minijinja
-        run: wasm-pack test --node --features console_error_panic_hook
-
       - name: Build Docker container for production deployment tests
         run: docker build -t tensorzero/gateway -f gateway/Dockerfile .
 


### PR DESCRIPTION
We already run this in the 'validate' job, which is run for both PR CI and the merge queue.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
