### PR TITLE
Allow Namespace buildx setup to fail for fork prs / dependabot

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -111,11 +111,16 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      # We allow the namespace builder setup to fail on Dependabot PRs and PRs from forks
+      # (where the oidc token is not available)
+
       - name: Install Namespace CLI
         uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx
         uses: namespacelabs/nscloud-setup-buildx-action@84ca8c58fdf372d6a4750476cd09b7b96ee778ca
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Print Rust version
         run: rustc --version
@@ -337,11 +342,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # We allow the namespace builder setup to fail on Dependabot PRs and PRs from forks
+      # (where the oidc token is not available)
+
+
       - name: Install and configure Namespace CLI
         uses: namespacelabs/nscloud-setup@v0
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace powered Buildx
         uses: namespacelabs/nscloud-setup-buildx-action@v0
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -392,11 +403,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # We allow the namespace builder setup to fail on Dependabot PRs and PRs from forks
+      # (where the oidc token is not available)
+
       - name: Install and configure Namespace CLI
         uses: namespacelabs/nscloud-setup@v0
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace powered Buildx
         uses: namespacelabs/nscloud-setup-buildx-action@v0
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
The OIDC token is not available in these contexts, so we allow the namespace builder setup to fail. This will allow the job to run with the default Docker builder.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allows namespace builder setup to fail for forked PRs and Dependabot in `general.yml` by using `continue-on-error` for specific steps.
> 
>   - **Behavior**:
>     - Allows namespace builder setup to fail for forked PRs and Dependabot in `general.yml`.
>     - Uses `continue-on-error` for `Install Namespace CLI` and `Configure Namespace-powered Buildx` steps in `validate`, `ui-tests`, and `ui-tests-e2e` jobs.
>   - **Context**:
>     - Handles cases where OIDC token is unavailable, allowing jobs to proceed with default Docker builder.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f30969d4f7160cadebccf2aa76b900c36c34f1ac. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->