### PR TITLE
Enable workspace lints and fix Clippy lints in some crates

### DIFF
--- a/clients/python-pyo3/Cargo.toml
+++ b/clients/python-pyo3/Cargo.toml
@@ -7,6 +7,9 @@ version = "2025.4.2"
 edition = "2021"
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 # This is used by 'maturin' as the name of the Python package

--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -53,15 +53,12 @@ fn tensorzero(m: &Bound<'_, PyModule>) -> PyResult<()> {
     let py_json = PyModule::import(m.py(), "json")?;
     let json_loads = py_json.getattr("loads")?;
     let json_dumps = py_json.getattr("dumps")?;
-    JSON_LOADS
-        .set(m.py(), json_loads.unbind())
-        .expect("Failed to set JSON_LOADS");
-    JSON_DUMPS
-        .set(m.py(), json_dumps.unbind())
-        .expect("Failed to set JSON_DUMPS");
 
-    m.add_wrapped(wrap_pyfunction!(_start_http_gateway))
-        .expect("Failed to add start_http_gateway");
+    // We don't care if the GILOnceCell was already set
+    let _ = JSON_LOADS.set(m.py(), json_loads.unbind());
+    let _ = JSON_DUMPS.set(m.py(), json_dumps.unbind());
+
+    m.add_wrapped(wrap_pyfunction!(_start_http_gateway))?;
 
     Ok(())
 }
@@ -1045,7 +1042,8 @@ fn convert_error(py: Python<'_>, e: TensorZeroError) -> PyErr {
         // Required due to the `#[non_exhaustive]` attribute on `TensorZeroError` - we want to force
         // downstream consumers to handle all possible error types, but the compiler also requires us
         // to do this (since our python bindings are in a different crate from the Rust client.)
-        _ => unreachable!(),
+        _ => tensorzero_internal_error(py, &format!("Unexpected TensorZero error: {e:?}"))
+            .unwrap_or_else(|e| e),
     }
 }
 

--- a/clients/python-pyo3/src/python_helpers.rs
+++ b/clients/python-pyo3/src/python_helpers.rs
@@ -3,7 +3,13 @@
 
 use std::{borrow::Cow, collections::HashMap};
 
-use pyo3::{exceptions::PyValueError, intern, prelude::*, sync::GILOnceCell, types::PyDict};
+use pyo3::{
+    exceptions::{PyRuntimeError, PyValueError},
+    intern,
+    prelude::*,
+    sync::GILOnceCell,
+    types::PyDict,
+};
 use tensorzero_rust::{FeedbackResponse, InferenceResponse, InferenceResponseChunk, Tool};
 use uuid::Uuid;
 
@@ -63,7 +69,11 @@ pub fn serialize_to_dict<T: serde::ser::Serialize>(py: Python<'_>, val: T) -> Py
         .map_err(|e| PyValueError::new_err(format!("Failed to serialize to JSON: {e:?}")))?;
     JSON_LOADS
         .get(py)
-        .expect("JSON_LOADS was not initialized")
+        .ok_or_else(|| {
+            PyRuntimeError::new_err(
+                "TensorZero: JSON_LOADS was not initialized. This should never happen",
+            )
+        })?
         .call1(py, (json_str.into_pyobject(py)?,))
 }
 
@@ -80,7 +90,11 @@ pub fn deserialize_from_pyobj<'a, T: serde::de::DeserializeOwned>(
 
     let json_str_obj = JSON_DUMPS
         .get(py)
-        .expect("JSON_DUMPS was not initialized")
+        .ok_or_else(|| {
+            PyRuntimeError::new_err(
+                "TensorZero: JSON_DUMPS was not initialized. This should never happen",
+            )
+        })?
         .call(py, (obj,), Some(&kwargs))?;
     let json_str: Cow<'_, str> = json_str_obj.extract(py)?;
     let val = serde_json::from_str::<T>(json_str.as_ref());

--- a/tensorzero-internal/tests/mock-inference-provider/Cargo.toml
+++ b/tensorzero-internal/tests/mock-inference-provider/Cargo.toml
@@ -3,6 +3,9 @@ name = "mock-inference-provider"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 async-stream = { workspace = true }
 axum = { workspace = true, features = ["multipart"] }

--- a/tensorzero-internal/tests/mock-inference-provider/src/main.rs
+++ b/tensorzero-internal/tests/mock-inference-provider/src/main.rs
@@ -1,3 +1,6 @@
+// This project is used only for testing, so it's fine if it panics
+#![allow(clippy::unwrap_used, clippy::panic, clippy::expect_used)]
+
 use async_stream::try_stream;
 use axum::{
     body::Body,

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -59,7 +59,7 @@ FROM base AS build-env
 
 COPY ./ui /app/
 
-COPY --from=minijinja-build-env /minijinja/pkg /app/app/utils/minijinja/pkg
+COPY --from=minijinja-build-env /build/ui/app/utils/minijinja/pkg /app/app/utils/minijinja/pkg
 
 COPY --from=development-dependencies-env /app/node_modules /app/node_modules
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -28,9 +28,9 @@ RUN pnpm install --frozen-lockfile --prod
 
 FROM rust:latest AS minijinja-build-env
 
-COPY ./ui/app/utils/minijinja /minijinja/
+COPY . /build
 
-WORKDIR /minijinja
+WORKDIR /build/ui/app/utils/minijinja
 RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 RUN wasm-pack build --features console_error_panic_hook
 

--- a/ui/app/utils/minijinja/Cargo.toml
+++ b/ui/app/utils/minijinja/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[lints]
+workspace = true
+
 [features]
 default = []
 # Uncomment this to enable the console_error_panic_hook feature


### PR DESCRIPTION
We didn't have our workspace lints enabled for
python-pyo3, mock-inference-provider, and minijinja

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enable workspace lints and fix Clippy lints in `python-pyo3`, `mock-inference-provider`, and `minijinja` crates.
> 
>   - **Lints**:
>     - Enable workspace lints in `Cargo.toml` for `python-pyo3`, `mock-inference-provider`, and `minijinja`.
>   - **Clippy Fixes**:
>     - In `lib.rs` of `python-pyo3`, replace `expect` with `let _ =` for `JSON_LOADS` and `JSON_DUMPS` initialization.
>     - Modify `convert_error()` in `lib.rs` to handle unexpected errors without `unreachable!()`.
>     - In `python_helpers.rs`, replace `expect` with `ok_or_else` for `JSON_LOADS` and `JSON_DUMPS`.
>   - **Dockerfile**:
>     - Update `Dockerfile` to copy the entire build context for `minijinja` instead of just the specific directory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 12e1aaa486bc3ffe6e0de1d1efbcf0f91519b1f6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->