### PR TITLE
Use Namespace docker builder for check-docker-compose job

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -70,6 +70,11 @@ jobs:
         run: cat e2e_logs.txt
 
   check-docker-compose:
+    permissions:
+      # Permission to checkout the repository
+      contents: read
+      # Permission to fetch GitHub OIDC token authentication
+      id-token: write
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -76,6 +76,18 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      # We allow the namespace builder setup to fail on Dependabot PRs and PRs from forks
+      # (where the oidc token is not available)
+
+      - name: Install Namespace CLI
+        uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
+
+      - name: Configure Namespace-powered Buildx
+        uses: namespacelabs/nscloud-setup-buildx-action@84ca8c58fdf372d6a4750476cd09b7b96ee778ca
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
+
+
       - name: Check all docker-compose.yml files
         run: ./ci/check-all-docker-compose.sh
 


### PR DESCRIPTION
This job ends up building the gateway Docker image, so this should speed it up

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> The `check-docker-compose` job now uses Namespace for Docker builds, improving speed and handling OIDC token unavailability for Dependabot and forked PRs.
> 
>   - **Workflow Changes**:
>     - `check-docker-compose` job in `general.yml` now uses Namespace for Docker builds.
>     - Adds `Install Namespace CLI` and `Configure Namespace-powered Buildx` steps.
>     - Handles OIDC token unavailability for Dependabot and forked PRs with `continue-on-error`.
>   - **Permissions**:
>     - Adds `contents: read` and `id-token: write` permissions to `check-docker-compose` job.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 9de77cfe413e460ee838d202cadc92add30ed125. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->