### PR TITLE
Skip running ui e2e tests on PRs from forks/dependabot

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -395,6 +395,10 @@ jobs:
 
   ui-tests-e2e:
     runs-on: ubuntu-latest
+    # We currently only run this job when we have secrets available, since we need to use an S3 object_store
+    # In the future, we might want to fix this so that it can run in PR CI for external (forked) PRs
+    # For now, it just runs in the merge queue
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
     permissions:
       # Permission to checkout the repository
       contents: read


### PR DESCRIPTION
This will unblock external PRs, until we decide what we want to do about the S3 object_store

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `ui-tests-e2e` job in `general.yml` to skip execution for PRs from forks and Dependabot.
> 
>   - **Workflow Changes**:
>     - In `general.yml`, modify `ui-tests-e2e` job to skip execution for PRs from forks and Dependabot by adding a condition to check if the PR is from the main repository and not from Dependabot.
>     - The condition is: `${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 082e950a57c5310acbbf6b38b68a13644837ba08. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->