### PR TITLE
Get ui e2e tests running in the merge queue

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -397,8 +397,8 @@ jobs:
     runs-on: ubuntu-latest
     # We currently only run this job when we have secrets available, since we need to use an S3 object_store
     # In the future, we might want to fix this so that it can run in PR CI for external (forked) PRs
-    # For now, it just runs in the merge queue
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
+    # For now, it just runs in the merge queue and on prs from the main repo
+    if: ${{ (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') || github.event_name == 'merge_group' }}
     permissions:
       # Permission to checkout the repository
       contents: read


### PR DESCRIPTION
These tests are currently only running on PR CI
(for prs made from the main repo). Let's run them
in the merge queue for all prs, since secrets are always available there.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `ui-tests-e2e` job in `general.yml` to run on merge group events and main repo PRs, ensuring UI E2E tests run with available secrets.
> 
>   - **Workflow Changes**:
>     - Modify `if` condition in `ui-tests-e2e` job in `general.yml` to run on merge group events and PRs from the main repo.
>     - Ensures UI E2E tests run when secrets are available, expanding beyond just PRs from the main repo.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3d4cb82340cdeb4d581721df4c56a97f5096fad9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->