### PR TITLE
Use `DisplayOrDebugGateway` for errors throughout the provider code

### DIFF
--- a/tensorzero-internal/src/inference/providers/aws_bedrock.rs
+++ b/tensorzero-internal/src/inference/providers/aws_bedrock.rs
@@ -20,7 +20,7 @@ use super::aws_common::{self, build_interceptor, InterceptorAndRawBody};
 use super::helpers::peek_first_chunk;
 use crate::cache::ModelProviderRequest;
 use crate::endpoints::inference::InferenceCredentials;
-use crate::error::{Error, ErrorDetails};
+use crate::error::{DisplayOrDebugGateway, Error, ErrorDetails};
 use crate::inference::providers::provider_trait::InferenceProvider;
 use crate::inference::types::batch::BatchRequestRow;
 use crate::inference::types::batch::PollBatchInferenceResponse;
@@ -128,7 +128,10 @@ impl InferenceProvider for AWSBedrockProvider {
                             raw_request: None,
                             raw_response: None,
                             status_code: Some(StatusCode::INTERNAL_SERVER_ERROR),
-                            message: format!("Error configuring AWS Bedrock tool config: {e}"),
+                            message: format!(
+                                "Error configuring AWS Bedrock tool config: {}",
+                                DisplayOrDebugGateway::new(e)
+                            ),
                             provider_type: PROVIDER_TYPE.to_string(),
                         })
                     })?;
@@ -249,7 +252,10 @@ impl InferenceProvider for AWSBedrockProvider {
                             raw_request: None,
                             raw_response: None,
                             status_code: Some(StatusCode::INTERNAL_SERVER_ERROR),
-                            message: format!("Error configuring AWS Bedrock tool config: {e}"),
+                            message: format!(
+                                "Error configuring AWS Bedrock tool config: {}",
+                                DisplayOrDebugGateway::new(e)
+                            ),
                             provider_type: PROVIDER_TYPE.to_string(),
                         })
                     })?;
@@ -531,7 +537,10 @@ impl TryFrom<&ContentBlock> for Option<BedrockContentBlock> {
                         raw_request: None,
                         raw_response: Some(tool_call.arguments.clone()),
                         status_code: Some(StatusCode::BAD_REQUEST),
-                        message: format!("Error parsing tool call arguments as JSON Value: {e}"),
+                        message: format!(
+                            "Error parsing tool call arguments as JSON Value: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
                         provider_type: PROVIDER_TYPE.to_string(),
                     })
                 })?;
@@ -615,7 +624,10 @@ impl TryFrom<BedrockContentBlock> for ContentBlockOutput {
                     Error::new(ErrorDetails::InferenceServer {
                         raw_request: None,
                         raw_response: None,
-                        message: format!("Error parsing tool call arguments from AWS Bedrock: {e}"),
+                        message: format!(
+                            "Error parsing tool call arguments from AWS Bedrock: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
                         provider_type: PROVIDER_TYPE.to_string(),
                     })
                 })?;
@@ -782,7 +794,10 @@ fn serialize_aws_bedrock_struct<T: std::fmt::Debug>(output: &T) -> Result<String
         Error::new(ErrorDetails::InferenceServer {
             raw_request: None,
             raw_response: Some(format!("{:?}", output)),
-            message: format!("Error parsing response from AWS Bedrock: {e}"),
+            message: format!(
+                "Error parsing response from AWS Bedrock: {}",
+                DisplayOrDebugGateway::new(e)
+            ),
             provider_type: PROVIDER_TYPE.to_string(),
         })
     })
@@ -798,7 +813,10 @@ impl TryFrom<&ToolConfig> for Tool {
                     raw_request: None,
                     raw_response: Some(format!("{:?}", tool_config.parameters())),
                     status_code: Some(StatusCode::INTERNAL_SERVER_ERROR),
-                    message: format!("Error parsing tool input schema: {e}"),
+                    message: format!(
+                        "Error parsing tool input schema: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?,

--- a/tensorzero-internal/src/inference/providers/aws_common.rs
+++ b/tensorzero-internal/src/inference/providers/aws_common.rs
@@ -10,7 +10,7 @@ use aws_types::SdkConfig;
 use reqwest::StatusCode;
 
 use crate::{
-    error::{Error, ErrorDetails},
+    error::{DisplayOrDebugGateway, Error, ErrorDetails},
     inference::types::{extra_body::FullExtraBodyConfig, ModelInferenceRequest},
     model::{ModelProvider, ModelProviderRequestInfo},
 };
@@ -81,7 +81,10 @@ impl Intercept for TensorZeroInterceptor {
         })?;
         let mut body_json: serde_json::Value = serde_json::from_slice(bytes).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Failed to deserialize AWS request body: {e}"),
+                message: format!(
+                    "Failed to deserialize AWS request body: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         let headers = inject_extra_request_data(
@@ -92,7 +95,10 @@ impl Intercept for TensorZeroInterceptor {
         )?;
         let raw_request = serde_json::to_string(&body_json).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Failed to serialize AWS request body: {e}"),
+                message: format!(
+                    "Failed to serialize AWS request body: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         // AWS inexplicably sets this header before calling this interceptor, so we need to update

--- a/tensorzero-internal/src/inference/providers/azure.rs
+++ b/tensorzero-internal/src/inference/providers/azure.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 use crate::cache::ModelProviderRequest;
 use crate::endpoints::inference::InferenceCredentials;
-use crate::error::{Error, ErrorDetails};
+use crate::error::{DisplayOrDebugGateway, Error, ErrorDetails};
 use crate::inference::types::batch::BatchRequestRow;
 use crate::inference::types::batch::PollBatchInferenceResponse;
 use crate::inference::types::{
@@ -125,7 +125,10 @@ impl InferenceProvider for AzureProvider {
     ) -> Result<ProviderInferenceResponse, Error> {
         let mut request_body = serde_json::to_value(AzureRequest::new(request)?).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing Azure request: {e}"),
+                message: format!(
+                    "Error serializing Azure request: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         let headers = inject_extra_request_data(
@@ -161,7 +164,10 @@ impl InferenceProvider for AzureProvider {
 
             let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing text response: {e}"),
+                    message: format!(
+                        "Error parsing text response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
@@ -189,7 +195,10 @@ impl InferenceProvider for AzureProvider {
             let status = res.status();
             let response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing error response: {e}"),
+                    message: format!(
+                        "Error parsing error response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
@@ -212,7 +221,10 @@ impl InferenceProvider for AzureProvider {
     ) -> Result<(PeekableProviderInferenceResponseStream, String), Error> {
         let mut request_body = serde_json::to_value(AzureRequest::new(request)?).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing Azure request: {e}"),
+                message: format!(
+                    "Error serializing Azure request: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         let headers = inject_extra_request_data(
@@ -223,7 +235,10 @@ impl InferenceProvider for AzureProvider {
         )?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing request body as JSON: {e}"),
+                message: format!(
+                    "Error serializing request body as JSON: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         let request_url = get_azure_chat_url(&self.endpoint, &self.deployment_id)?;
@@ -238,7 +253,10 @@ impl InferenceProvider for AzureProvider {
             .eventsource()
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
-                    message: format!("Error sending request to Azure: {e}"),
+                    message: format!(
+                        "Error sending request to Azure: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     status_code: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(raw_request.clone()),
@@ -475,7 +493,10 @@ impl<'a> TryFrom<AzureResponseWithMetadata<'a>> for ProviderInferenceResponse {
         }
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing request body as JSON: {e}"),
+                message: format!(
+                    "Error serializing request body as JSON: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
 

--- a/tensorzero-internal/src/inference/providers/deepseek.rs
+++ b/tensorzero-internal/src/inference/providers/deepseek.rs
@@ -10,7 +10,7 @@ use url::Url;
 
 use crate::cache::ModelProviderRequest;
 use crate::endpoints::inference::InferenceCredentials;
-use crate::error::{Error, ErrorDetails};
+use crate::error::{DisplayOrDebugGateway, Error, ErrorDetails};
 use crate::inference::providers::provider_trait::InferenceProvider;
 use crate::inference::types::batch::{BatchRequestRow, PollBatchInferenceResponse};
 use crate::inference::types::{
@@ -134,7 +134,10 @@ impl InferenceProvider for DeepSeekProvider {
             serde_json::to_value(DeepSeekRequest::new(&self.model_name, request)?).map_err(
                 |e| {
                     Error::new(ErrorDetails::Serialization {
-                        message: format!("Error serializing DeepSeek request: {e}"),
+                        message: format!(
+                            "Error serializing DeepSeek request: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
                     })
                 },
             )?;
@@ -159,8 +162,11 @@ impl InferenceProvider for DeepSeekProvider {
             .await
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
-                    message: format!("Error sending request to DeepSeek: {e}"),
                     status_code: e.status(),
+                    message: format!(
+                        "Error sending request to DeepSeek: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -170,7 +176,10 @@ impl InferenceProvider for DeepSeekProvider {
         if res.status().is_success() {
             let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing text response: {e}"),
+                    message: format!(
+                        "Error parsing text response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -179,7 +188,10 @@ impl InferenceProvider for DeepSeekProvider {
 
             let response = serde_json::from_str(&raw_response).map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing JSON response: {e}"),
+                    message: format!(
+                        "Error parsing JSON response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: Some(raw_response.clone()),
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -202,7 +214,10 @@ impl InferenceProvider for DeepSeekProvider {
 
             let response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing error response: {e}"),
+                    message: format!(
+                        "Error parsing error response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -227,7 +242,10 @@ impl InferenceProvider for DeepSeekProvider {
             serde_json::to_value(DeepSeekRequest::new(&self.model_name, request)?).map_err(
                 |e| {
                     Error::new(ErrorDetails::Serialization {
-                        message: format!("Error serializing DeepSeek request: {e}"),
+                        message: format!(
+                            "Error serializing DeepSeek request: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
                     })
                 },
             )?;
@@ -239,7 +257,10 @@ impl InferenceProvider for DeepSeekProvider {
         )?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::InferenceServer {
-                message: format!("Error serializing request: {e}"),
+                message: format!(
+                    "Error serializing request: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
                 raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                 raw_response: None,
                 provider_type: PROVIDER_TYPE.to_string(),
@@ -257,7 +278,7 @@ impl InferenceProvider for DeepSeekProvider {
             .eventsource()
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
-                    message: format!("Error sending request: {e}"),
+                    message: format!("Error sending request: {}", DisplayOrDebugGateway::new(e)),
                     status_code: None,
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
@@ -490,7 +511,10 @@ fn deepseek_to_tensorzero_chunk(
 ) -> Result<ProviderInferenceResponseChunk, Error> {
     let raw_message = serde_json::to_string(&chunk).map_err(|e| {
         Error::new(ErrorDetails::InferenceServer {
-            message: format!("Error parsing response from DeepSeek: {e}"),
+            message: format!(
+                "Error parsing response from DeepSeek: {}",
+                DisplayOrDebugGateway::new(e)
+            ),
             raw_request: None,
             raw_response: Some(serde_json::to_string(&chunk).unwrap_or_default()),
             provider_type: PROVIDER_TYPE.to_string(),
@@ -699,7 +723,10 @@ impl<'a> TryFrom<DeepSeekResponseWithMetadata<'a>> for ProviderInferenceResponse
         }
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing request body as JSON: {e}"),
+                message: format!(
+                    "Error serializing request body as JSON: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         let system = generic_request.system.clone();

--- a/tensorzero-internal/src/inference/providers/fireworks.rs
+++ b/tensorzero-internal/src/inference/providers/fireworks.rs
@@ -13,7 +13,7 @@ use url::Url;
 use crate::{
     cache::ModelProviderRequest,
     endpoints::inference::InferenceCredentials,
-    error::{Error, ErrorDetails},
+    error::{DisplayOrDebugGateway, Error, ErrorDetails},
     inference::types::{
         batch::{BatchRequestRow, PollBatchInferenceResponse, StartBatchProviderInferenceResponse},
         ContentBlockChunk, ContentBlockOutput, FinishReason, Latency, ModelInferenceRequest,
@@ -150,7 +150,10 @@ impl InferenceProvider for FireworksProvider {
             serde_json::to_value(FireworksRequest::new(&self.model_name, request)?).map_err(
                 |e| {
                     Error::new(ErrorDetails::Serialization {
-                        message: format!("Error serializing Fireworks request: {e}"),
+                        message: format!(
+                            "Error serializing Fireworks request: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
                     })
                 },
             )?;
@@ -173,8 +176,11 @@ impl InferenceProvider for FireworksProvider {
             .await
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
-                    message: format!("Error sending request to Fireworks: {e}"),
                     status_code: e.status(),
+                    message: format!(
+                        "Error sending request to Fireworks: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
@@ -186,7 +192,10 @@ impl InferenceProvider for FireworksProvider {
         if res.status().is_success() {
             let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing text response: {e}"),
+                    message: format!(
+                        "Error parsing text response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
@@ -216,7 +225,10 @@ impl InferenceProvider for FireworksProvider {
                 res.status(),
                 &res.text().await.map_err(|e| {
                     Error::new(ErrorDetails::InferenceServer {
-                        message: format!("Error parsing error response: {e}"),
+                        message: format!(
+                            "Error parsing error response: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
                         provider_type: PROVIDER_TYPE.to_string(),
                         raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                         raw_response: None,
@@ -242,7 +254,10 @@ impl InferenceProvider for FireworksProvider {
             serde_json::to_value(FireworksRequest::new(&self.model_name, request)?).map_err(
                 |e| {
                     Error::new(ErrorDetails::Serialization {
-                        message: format!("Error serializing Fireworks request: {e}"),
+                        message: format!(
+                            "Error serializing Fireworks request: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
                     })
                 },
             )?;
@@ -254,7 +269,10 @@ impl InferenceProvider for FireworksProvider {
         )?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::InferenceServer {
-                message: format!("Error serializing request body: {e}"),
+                message: format!(
+                    "Error serializing request body: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
                 provider_type: PROVIDER_TYPE.to_string(),
                 raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                 raw_response: None,
@@ -272,7 +290,10 @@ impl InferenceProvider for FireworksProvider {
             .eventsource()
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
-                    message: format!("Error sending request to Fireworks: {e}"),
+                    message: format!(
+                        "Error sending request to Fireworks: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     status_code: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(raw_request.clone()),
@@ -599,7 +620,10 @@ fn fireworks_to_tensorzero_chunk(
 ) -> Result<ProviderInferenceResponseChunk, Error> {
     let raw_message = serde_json::to_string(&chunk).map_err(|e| {
         Error::new(ErrorDetails::InferenceServer {
-            message: format!("Error parsing response from Fireworks: {e}"),
+            message: format!(
+                "Error parsing response from Fireworks: {}",
+                DisplayOrDebugGateway::new(e)
+            ),
             raw_request: None,
             raw_response: Some(serde_json::to_string(&chunk).unwrap_or_default()),
             provider_type: PROVIDER_TYPE.to_string(),
@@ -771,7 +795,10 @@ impl<'a> TryFrom<FireworksResponseWithMetadata<'a>> for ProviderInferenceRespons
         }
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing request body as JSON: {e}"),
+                message: format!(
+                    "Error serializing request body as JSON: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         let system = generic_request.system.clone();

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
@@ -12,7 +12,7 @@ use tokio::time::Instant;
 
 use crate::cache::ModelProviderRequest;
 use crate::endpoints::inference::InferenceCredentials;
-use crate::error::{Error, ErrorDetails};
+use crate::error::{DisplayOrDebugGateway, Error, ErrorDetails};
 use crate::inference::providers::provider_trait::InferenceProvider;
 use crate::inference::types::batch::BatchRequestRow;
 use crate::inference::types::batch::PollBatchInferenceResponse;
@@ -98,7 +98,10 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
         let mut request_body = serde_json::to_value(GCPVertexAnthropicRequestBody::new(request)?)
             .map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing GCP Vertex Anthropic request: {e}"),
+                message: format!(
+                    "Error serializing GCP Vertex Anthropic request: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         let headers = inject_extra_request_data(
@@ -120,8 +123,8 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
             .await
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
-                    message: format!("Error sending request: {e}"),
                     status_code: e.status(),
+                    message: format!("Error sending request: {}", DisplayOrDebugGateway::new(e)),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
@@ -133,7 +136,10 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
         if res.status().is_success() {
             let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing text response: {e}"),
+                    message: format!(
+                        "Error parsing text response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
@@ -188,7 +194,10 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
         let mut request_body = serde_json::to_value(GCPVertexAnthropicRequestBody::new(request)?)
             .map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing GCP Vertex Anthropic request: {e}"),
+                message: format!(
+                    "Error serializing GCP Vertex Anthropic request: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         let headers = inject_extra_request_data(
@@ -199,7 +208,10 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
         )?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing request body as JSON: {e}"),
+                message: format!(
+                    "Error serializing request body as JSON: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         let api_key = self
@@ -215,7 +227,7 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
             .eventsource()
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
-                    message: format!("Error sending request: {e}"),
+                    message: format!("Error sending request: {}", DisplayOrDebugGateway::new(e)),
                     status_code: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
@@ -415,7 +427,10 @@ impl<'a> TryFrom<&'a ContentBlock>
                 let input: Value = serde_json::from_str(&tool_call.arguments).map_err(|e| {
                     Error::new(ErrorDetails::InferenceClient {
                         status_code: Some(StatusCode::BAD_REQUEST),
-                        message: format!("Error parsing tool call arguments as JSON Value: {e}"),
+                        message: format!(
+                            "Error parsing tool call arguments as JSON Value: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
                         provider_type: PROVIDER_TYPE.to_string(),
                         raw_request: None,
                         raw_response: Some(tool_call.arguments.clone()),
@@ -693,7 +708,10 @@ impl TryFrom<GCPVertexAnthropicContentBlock> for ContentBlockOutput {
                     name,
                     arguments: serde_json::to_string(&input).map_err(|e| {
                         Error::new(ErrorDetails::Serialization {
-                            message: format!("Error parsing input for tool call: {e}"),
+                            message: format!(
+                                "Error parsing input for tool call: {}",
+                                DisplayOrDebugGateway::new(e)
+                            ),
                         })
                     })?,
                 }))
@@ -762,7 +780,10 @@ impl<'a> TryFrom<GCPVertexAnthropicResponseWithMetadata<'a>> for ProviderInferen
             .collect::<Result<Vec<_>, _>>()?;
         let raw_request = serde_json::to_string(&request).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing request to GCP Vertex Anthropic: {e}"),
+                message: format!(
+                    "Error serializing request to GCP Vertex Anthropic: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
 
@@ -883,7 +904,10 @@ fn anthropic_to_tensorzero_stream_message(
 ) -> Result<Option<ProviderInferenceResponseChunk>, Error> {
     let raw_message = serde_json::to_string(&message).map_err(|e| {
         Error::new(ErrorDetails::Serialization {
-            message: format!("Error parsing response from Anthropic: {e}"),
+            message: format!(
+                "Error parsing response from Anthropic: {}",
+                DisplayOrDebugGateway::new(e)
+            ),
         })
     })?;
     match message {

--- a/tensorzero-internal/src/inference/providers/helpers.rs
+++ b/tensorzero-internal/src/inference/providers/helpers.rs
@@ -5,7 +5,7 @@ use futures::{stream::Peekable, Stream};
 use serde_json::{map::Entry, Map, Value};
 
 use crate::{
-    error::{Error, ErrorDetails},
+    error::{DisplayOrDebugGateway, Error, ErrorDetails},
     inference::types::{
         extra_body::{ExtraHeader, FullExtraBodyConfig, InferenceExtraBody},
         ProviderInferenceResponseChunk,
@@ -80,12 +80,18 @@ pub fn inject_extra_request_data(
             headers.insert(
                 http::header::HeaderName::from_bytes(name.as_bytes()).map_err(|e| {
                     Error::new(ErrorDetails::Serialization {
-                        message: format!("Invalid header name `{name}`: {e}"),
+                        message: format!(
+                            "Invalid header name `{name}`: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
                     })
                 })?,
                 http::header::HeaderValue::from_bytes(value.as_bytes()).map_err(|e| {
                     Error::new(ErrorDetails::Serialization {
-                        message: format!("Invalid header value `{value}`: {e}"),
+                        message: format!(
+                            "Invalid header value `{value}`: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
                     })
                 })?,
             );

--- a/tensorzero-internal/src/inference/providers/hyperbolic.rs
+++ b/tensorzero-internal/src/inference/providers/hyperbolic.rs
@@ -2,7 +2,7 @@ use std::sync::OnceLock;
 
 use crate::cache::ModelProviderRequest;
 use crate::endpoints::inference::InferenceCredentials;
-use crate::error::{Error, ErrorDetails};
+use crate::error::{DisplayOrDebugGateway, Error, ErrorDetails};
 use crate::inference::types::batch::{BatchRequestRow, PollBatchInferenceResponse};
 use crate::inference::types::{
     batch::StartBatchProviderInferenceResponse, Latency, ModelInferenceRequest,
@@ -126,7 +126,10 @@ impl InferenceProvider for HyperbolicProvider {
             serde_json::to_value(HyperbolicRequest::new(&self.model_name, request)?).map_err(
                 |e| {
                     Error::new(ErrorDetails::Serialization {
-                        message: format!("Error serializing Hyperbolic request: {e}"),
+                        message: format!(
+                            "Error serializing Hyperbolic request: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
                     })
                 },
             )?;
@@ -151,8 +154,11 @@ impl InferenceProvider for HyperbolicProvider {
             .await
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
-                    message: format!("Error sending request to Hyperbolic: {e}"),
                     status_code: e.status(),
+                    message: format!(
+                        "Error sending request to Hyperbolic: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -162,7 +168,10 @@ impl InferenceProvider for HyperbolicProvider {
         if res.status().is_success() {
             let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing text response: {e}"),
+                    message: format!(
+                        "Error parsing text response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -171,7 +180,10 @@ impl InferenceProvider for HyperbolicProvider {
 
             let response = serde_json::from_str(&raw_response).map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing JSON response: {e}"),
+                    message: format!(
+                        "Error parsing JSON response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: Some(raw_response.clone()),
@@ -194,7 +206,10 @@ impl InferenceProvider for HyperbolicProvider {
                 res.status(),
                 &res.text().await.map_err(|e| {
                     Error::new(ErrorDetails::InferenceServer {
-                        message: format!("Error parsing error response: {e}"),
+                        message: format!(
+                            "Error parsing error response: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
                         raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                         raw_response: None,
                         provider_type: PROVIDER_TYPE.to_string(),
@@ -220,7 +235,10 @@ impl InferenceProvider for HyperbolicProvider {
             serde_json::to_value(HyperbolicRequest::new(&self.model_name, request)?).map_err(
                 |e| {
                     Error::new(ErrorDetails::Serialization {
-                        message: format!("Error serializing Hyperbolic request: {e}"),
+                        message: format!(
+                            "Error serializing Hyperbolic request: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
                     })
                 },
             )?;
@@ -232,7 +250,10 @@ impl InferenceProvider for HyperbolicProvider {
         )?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing request: {e}"),
+                message: format!(
+                    "Error serializing request: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         let request_url = get_chat_url(&HYPERBOLIC_DEFAULT_BASE_URL)?;
@@ -247,7 +268,10 @@ impl InferenceProvider for HyperbolicProvider {
             .eventsource()
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
-                    message: format!("Error sending request to Hyperbolic: {e}"),
+                    message: format!(
+                        "Error sending request to Hyperbolic: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     status_code: None,
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
@@ -400,7 +424,10 @@ impl<'a> TryFrom<HyperbolicResponseWithMetadata<'a>> for ProviderInferenceRespon
         }
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing request body as JSON: {e}"),
+                message: format!(
+                    "Error serializing request body as JSON: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         let system = generic_request.system.clone();

--- a/tensorzero-internal/src/inference/providers/mistral.rs
+++ b/tensorzero-internal/src/inference/providers/mistral.rs
@@ -12,7 +12,7 @@ use url::Url;
 use crate::{
     cache::ModelProviderRequest,
     endpoints::inference::InferenceCredentials,
-    error::{Error, ErrorDetails},
+    error::{DisplayOrDebugGateway, Error, ErrorDetails},
     inference::types::{
         batch::{BatchRequestRow, PollBatchInferenceResponse, StartBatchProviderInferenceResponse},
         ContentBlockChunk, ContentBlockOutput, FinishReason, Latency, ModelInferenceRequest,
@@ -133,7 +133,10 @@ impl InferenceProvider for MistralProvider {
         let mut request_body =
             serde_json::to_value(MistralRequest::new(&self.model_name, request)?).map_err(|e| {
                 Error::new(ErrorDetails::Serialization {
-                    message: format!("Error serializing Mistral request: {e}"),
+                    message: format!(
+                        "Error serializing Mistral request: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                 })
             })?;
         let headers = inject_extra_request_data(
@@ -155,8 +158,11 @@ impl InferenceProvider for MistralProvider {
             .await
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
-                    message: format!("Error sending request to Mistral: {e}"),
                     status_code: e.status(),
+                    message: format!(
+                        "Error sending request to Mistral: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
@@ -168,7 +174,10 @@ impl InferenceProvider for MistralProvider {
         if res.status().is_success() {
             let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing text response: {e}"),
+                    message: format!(
+                        "Error parsing text response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
@@ -177,7 +186,10 @@ impl InferenceProvider for MistralProvider {
 
             let response = serde_json::from_str(&raw_response).map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing JSON response: {e}"),
+                    message: format!(
+                        "Error parsing JSON response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: Some(raw_response.clone()),
@@ -197,7 +209,10 @@ impl InferenceProvider for MistralProvider {
                 res.status(),
                 &res.text().await.map_err(|e| {
                     Error::new(ErrorDetails::InferenceServer {
-                        message: format!("Error parsing error response: {e}"),
+                        message: format!(
+                            "Error parsing error response: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
                         provider_type: PROVIDER_TYPE.to_string(),
                         raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                         raw_response: None,
@@ -221,7 +236,10 @@ impl InferenceProvider for MistralProvider {
         let mut request_body =
             serde_json::to_value(MistralRequest::new(&self.model_name, request)?).map_err(|e| {
                 Error::new(ErrorDetails::Serialization {
-                    message: format!("Error serializing Mistral request: {e}"),
+                    message: format!(
+                        "Error serializing Mistral request: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                 })
             })?;
         let headers = inject_extra_request_data(
@@ -232,7 +250,10 @@ impl InferenceProvider for MistralProvider {
         )?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing request: {e}"),
+                message: format!(
+                    "Error serializing request: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         let request_url = get_chat_url(&MISTRAL_API_BASE)?;
@@ -247,7 +268,10 @@ impl InferenceProvider for MistralProvider {
             .eventsource()
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
-                    message: format!("Error sending request to Mistral: {e}"),
+                    message: format!(
+                        "Error sending request to Mistral: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     status_code: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(raw_request.clone()),
@@ -650,7 +674,10 @@ impl<'a> TryFrom<MistralResponseWithMetadata<'a>> for ProviderInferenceResponse 
         }
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing request body as JSON: {e}"),
+                message: format!(
+                    "Error serializing request body as JSON: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         let system = generic_request.system.clone();
@@ -716,7 +743,10 @@ fn mistral_to_tensorzero_chunk(
 ) -> Result<ProviderInferenceResponseChunk, Error> {
     let raw_message = serde_json::to_string(&chunk).map_err(|e| {
         Error::new(ErrorDetails::Serialization {
-            message: format!("Error parsing response from Mistral: {e}"),
+            message: format!(
+                "Error parsing response from Mistral: {}",
+                DisplayOrDebugGateway::new(e)
+            ),
         })
     })?;
     if chunk.choices.len() > 1 {

--- a/tensorzero-internal/src/inference/providers/sglang.rs
+++ b/tensorzero-internal/src/inference/providers/sglang.rs
@@ -10,7 +10,7 @@ use url::Url;
 
 use crate::cache::ModelProviderRequest;
 use crate::endpoints::inference::InferenceCredentials;
-use crate::error::{Error, ErrorDetails};
+use crate::error::{DisplayOrDebugGateway, Error, ErrorDetails};
 use crate::inference::providers::provider_trait::InferenceProvider;
 use crate::inference::types::batch::{BatchRequestRow, PollBatchInferenceResponse};
 use crate::inference::types::ContentBlockOutput;
@@ -124,7 +124,10 @@ impl InferenceProvider for SGLangProvider {
         let mut request_body = serde_json::to_value(SGLangRequest::new(&self.model_name, request)?)
             .map_err(|e| {
                 Error::new(ErrorDetails::Serialization {
-                    message: format!("Error serializing SGLang request: {e}"),
+                    message: format!(
+                        "Error serializing SGLang request: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                 })
             })?;
         let headers = inject_extra_request_data(
@@ -149,8 +152,11 @@ impl InferenceProvider for SGLangProvider {
             .await
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
-                    message: format!("Error sending request to SGLang: {e}"),
                     status_code: e.status(),
+                    message: format!(
+                        "Error sending request to SGLang: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
@@ -159,7 +165,10 @@ impl InferenceProvider for SGLangProvider {
         if res.status().is_success() {
             let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing text response: {e}"),
+                    message: format!(
+                        "Error parsing text response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -168,7 +177,10 @@ impl InferenceProvider for SGLangProvider {
 
             let response = serde_json::from_str(&raw_response).map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing JSON response: {e}"),
+                    message: format!(
+                        "Error parsing JSON response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: Some(raw_response.clone()),
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -191,7 +203,10 @@ impl InferenceProvider for SGLangProvider {
                 res.status(),
                 &res.text().await.map_err(|e| {
                     Error::new(ErrorDetails::InferenceServer {
-                        message: format!("Error parsing error response: {e}"),
+                        message: format!(
+                            "Error parsing error response: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
                         raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                         raw_response: None,
                         provider_type: PROVIDER_TYPE.to_string(),
@@ -216,7 +231,10 @@ impl InferenceProvider for SGLangProvider {
         let mut request_body = serde_json::to_value(SGLangRequest::new(&self.model_name, request)?)
             .map_err(|e| {
                 Error::new(ErrorDetails::Serialization {
-                    message: format!("Error serializing SGLang request: {e}"),
+                    message: format!(
+                        "Error serializing SGLang request: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                 })
             })?;
         let headers = inject_extra_request_data(
@@ -227,7 +245,10 @@ impl InferenceProvider for SGLangProvider {
         )?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing request: {e}"),
+                message: format!(
+                    "Error serializing request: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         let request_url = get_chat_url(&self.api_base)?;
@@ -245,7 +266,10 @@ impl InferenceProvider for SGLangProvider {
             .eventsource()
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
-                    message: format!("Error sending request to SGLang: {e}"),
+                    message: format!(
+                        "Error sending request to SGLang: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     status_code: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
@@ -449,7 +473,10 @@ impl<'a> TryFrom<SGLangResponseWithMetadata<'a>> for ProviderInferenceResponse {
         }
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing request body as JSON: {e}"),
+                message: format!(
+                    "Error serializing request body as JSON: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         let system = generic_request.system.clone();

--- a/tensorzero-internal/src/inference/providers/tgi.rs
+++ b/tensorzero-internal/src/inference/providers/tgi.rs
@@ -28,6 +28,7 @@ use super::openai::{
 };
 use crate::cache::ModelProviderRequest;
 use crate::endpoints::inference::InferenceCredentials;
+use crate::error::DisplayOrDebugGateway;
 use crate::error::{Error, ErrorDetails};
 use crate::inference::providers::provider_trait::InferenceProvider;
 use crate::inference::types::batch::{
@@ -132,7 +133,10 @@ impl InferenceProvider for TGIProvider {
         let mut request_body = serde_json::to_value(TGIRequest::new(PROVIDER_TYPE, request)?)
             .map_err(|e| {
                 Error::new(ErrorDetails::Serialization {
-                    message: format!("Error serializing TGI request: {e}"),
+                    message: format!(
+                        "Error serializing TGI request: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                 })
             })?;
         let headers = inject_extra_request_data(
@@ -160,8 +164,11 @@ impl InferenceProvider for TGIProvider {
             .await
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
-                    message: format!("Error sending request to TGI: {e}"),
                     status_code: e.status(),
+                    message: format!(
+                        "Error sending request to TGI: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: serde_json::to_string(&request_body).ok(),
                     raw_response: None,
@@ -171,7 +178,10 @@ impl InferenceProvider for TGIProvider {
         if res.status().is_success() {
             let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing text response: {e}"),
+                    message: format!(
+                        "Error parsing text response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: serde_json::to_string(&request_body).ok(),
                     raw_response: None,
@@ -180,7 +190,10 @@ impl InferenceProvider for TGIProvider {
 
             let response = serde_json::from_str(&raw_response).map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing JSON response: {e}"),
+                    message: format!(
+                        "Error parsing JSON response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: serde_json::to_string(&request_body).ok(),
                     raw_response: Some(raw_response.clone()),
@@ -203,7 +216,10 @@ impl InferenceProvider for TGIProvider {
                 res.status(),
                 &res.text().await.map_err(|e| {
                     Error::new(ErrorDetails::InferenceServer {
-                        message: format!("Error parsing error response: {e}"),
+                        message: format!(
+                            "Error parsing error response: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
                         provider_type: PROVIDER_TYPE.to_string(),
                         raw_request: serde_json::to_string(&request_body).ok(),
                         raw_response: None,
@@ -227,7 +243,10 @@ impl InferenceProvider for TGIProvider {
         let mut request_body = serde_json::to_value(TGIRequest::new(PROVIDER_NAME, request)?)
             .map_err(|e| {
                 Error::new(ErrorDetails::Serialization {
-                    message: format!("Error serializing TGI request: {e}"),
+                    message: format!(
+                        "Error serializing TGI request: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                 })
             })?;
         let headers = inject_extra_request_data(
@@ -245,7 +264,10 @@ impl InferenceProvider for TGIProvider {
         }
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing request: {e}"),
+                message: format!(
+                    "Error serializing request: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         let request_url = get_chat_url(&self.api_base)?;
@@ -263,7 +285,10 @@ impl InferenceProvider for TGIProvider {
             .eventsource()
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
-                    message: format!("Error sending request to OpenAI: {e}"),
+                    message: format!(
+                        "Error sending request to OpenAI: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     status_code: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                     raw_request: Some(raw_request.clone()),
@@ -483,7 +508,10 @@ impl<'a> TryFrom<TGIResponseWithMetadata<'a>> for ProviderInferenceResponse {
         }
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing request body as JSON: {e}"),
+                message: format!(
+                    "Error serializing request body as JSON: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         let system = generic_request.system.clone();
@@ -663,7 +691,10 @@ fn tgi_to_tensorzero_chunk(
 ) -> Result<ProviderInferenceResponseChunk, Error> {
     let raw_message = serde_json::to_string(&chunk).map_err(|e| {
         Error::new(ErrorDetails::InferenceServer {
-            message: format!("Error parsing response from OpenAI: {e}"),
+            message: format!(
+                "Error parsing response from OpenAI: {}",
+                DisplayOrDebugGateway::new(e)
+            ),
             raw_request: None,
             raw_response: Some(serde_json::to_string(&chunk).unwrap_or_default()),
             provider_type: PROVIDER_TYPE.to_string(),

--- a/tensorzero-internal/src/inference/providers/xai.rs
+++ b/tensorzero-internal/src/inference/providers/xai.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 use crate::cache::ModelProviderRequest;
 use crate::endpoints::inference::InferenceCredentials;
-use crate::error::{Error, ErrorDetails};
+use crate::error::{DisplayOrDebugGateway, Error, ErrorDetails};
 use crate::inference::providers::provider_trait::InferenceProvider;
 use crate::inference::types::batch::{BatchRequestRow, PollBatchInferenceResponse};
 use crate::inference::types::{
@@ -129,7 +129,10 @@ impl InferenceProvider for XAIProvider {
         let mut request_body = serde_json::to_value(XAIRequest::new(&self.model_name, request)?)
             .map_err(|e| {
                 Error::new(ErrorDetails::Serialization {
-                    message: format!("Error serializing xAI request: {e}"),
+                    message: format!(
+                        "Error serializing xAI request: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                 })
             })?;
         let headers = inject_extra_request_data(
@@ -153,8 +156,11 @@ impl InferenceProvider for XAIProvider {
             .await
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
-                    message: format!("Error sending request to xAI: {e}"),
                     status_code: e.status(),
+                    message: format!(
+                        "Error sending request to xAI: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -164,7 +170,10 @@ impl InferenceProvider for XAIProvider {
         if res.status().is_success() {
             let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing text response: {e}"),
+                    message: format!(
+                        "Error parsing text response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -173,7 +182,10 @@ impl InferenceProvider for XAIProvider {
 
             let response = serde_json::from_str(&raw_response).map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing JSON response: {e}"),
+                    message: format!(
+                        "Error parsing JSON response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: Some(raw_response.clone()),
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -196,7 +208,10 @@ impl InferenceProvider for XAIProvider {
 
             let response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
-                    message: format!("Error parsing error response: {e}"),
+                    message: format!(
+                        "Error parsing error response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
@@ -220,7 +235,10 @@ impl InferenceProvider for XAIProvider {
         let mut request_body = serde_json::to_value(XAIRequest::new(&self.model_name, request)?)
             .map_err(|e| {
                 Error::new(ErrorDetails::Serialization {
-                    message: format!("Error serializing xAI request: {e}"),
+                    message: format!(
+                        "Error serializing xAI request: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                 })
             })?;
         let headers = inject_extra_request_data(
@@ -231,7 +249,10 @@ impl InferenceProvider for XAIProvider {
         )?;
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::InferenceServer {
-                message: format!("Error serializing request: {e}"),
+                message: format!(
+                    "Error serializing request: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
                 raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                 raw_response: None,
                 provider_type: PROVIDER_TYPE.to_string(),
@@ -249,7 +270,10 @@ impl InferenceProvider for XAIProvider {
             .eventsource()
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {
-                    message: format!("Error sending request to xAI: {e}"),
+                    message: format!(
+                        "Error sending request to xAI: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
                     status_code: None,
                     raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
                     raw_response: None,
@@ -462,7 +486,10 @@ impl<'a> TryFrom<XAIResponseWithMetadata<'a>> for ProviderInferenceResponse {
         }
         let raw_request = serde_json::to_string(&request_body).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing request body as JSON: {e}"),
+                message: format!(
+                    "Error serializing request body as JSON: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
             })
         })?;
         let system = generic_request.system.clone();


### PR DESCRIPTION
This will allow users to get more detailed provider-specific errors by setting the global 'debug' flag

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance error messages across providers using `DisplayOrDebugGateway` for detailed debugging information.
> 
>   - **Error Handling**:
>     - Replaces error message formatting with `DisplayOrDebugGateway::new(e)` in `aws_bedrock.rs`, `aws_common.rs`, and `azure.rs` to provide detailed error messages when the 'debug' flag is set.
>     - Similar changes applied to `deepseek.rs`, `fireworks.rs`, and `gcp_vertex_anthropic.rs`.
>     - Updates `gcp_vertex_gemini.rs`, `google_ai_studio_gemini.rs`, and `helpers.rs` for consistent error handling.
>     - Modifies `hyperbolic.rs`, `mistral.rs`, and `openai.rs` to use `DisplayOrDebugGateway` for error messages.
>     - Applies changes to `sglang.rs`, `tgi.rs`, and `together.rs` for improved error detail.
>     - Updates `vllm.rs` and `xai.rs` to utilize `DisplayOrDebugGateway` for error message formatting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7b27256065d5c60cffca5b2a5ee921e307a1eb4e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->