### PR TITLE
Use explicit 'docker buildx build' for ui e2e tests

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -433,7 +433,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build ui container
-        run: docker build -f ui/Dockerfile . -t tensorzero/ui
+        run: docker buildx build -f ui/Dockerfile . -t tensorzero/ui
 
       - name: Start services for ui e2e tests
         working-directory: ui


### PR DESCRIPTION
This seems to be needed to actually use the Namespace docker builder

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch `docker build` to `docker buildx build` in `ui-tests-e2e` job to use Namespace docker builder.
> 
>   - **Build Process**:
>     - Change `docker build` to `docker buildx build` in `ui-tests-e2e` job in `general.yml` to utilize Namespace docker builder.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2d2f0abe7362f42d410fa18a5149ee9b4d7eb2f5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->