### PR TITLE
Add explicit `json_mode = "strict"` in ui fixtures config

### DIFF
--- a/ui/fixtures/config/tensorzero.toml
+++ b/ui/fixtures/config/tensorzero.toml
@@ -42,16 +42,19 @@ output_schema = "functions/extract_entities/output_schema.json"
 type = "chat_completion"
 model = "gpt-4o-mini-2024-07-18"
 system_template = "functions/extract_entities/initial_prompt/system_template.minijinja"
+json_mode = "strict"
 
 [functions.extract_entities.variants.gpt4o_initial_prompt]
 type = "chat_completion"
 model = "openai::gpt-4o"
 system_template = "functions/extract_entities/initial_prompt/system_template.minijinja"
+json_mode = "strict"
 
 [functions.extract_entities.variants.llama_8b_initial_prompt]
 type = "chat_completion"
 model = "llama-3.1-8b-instruct"
 system_template = "functions/extract_entities/initial_prompt/system_template.minijinja"
+json_mode = "strict"
 
 [functions.extract_entities.variants.baseline]
 type = "chat_completion"
@@ -72,6 +75,7 @@ weight = 1
 type = "chat_completion"
 model = "ft:gpt-4o-mini-2024-07-18:tensorzero::ALHEaw1j"
 system_template = "functions/extract_entities/baseline/system_template.minijinja"
+json_mode = "strict"
 
 [functions.write_haiku]
 type = "chat"
@@ -118,6 +122,7 @@ type = "chat_completion"
 weight = 1
 model = "openai::gpt-4o-mini-2024-07-18"
 system_template = "functions/ask_question/baseline/system_template.minijinja"
+json_mode = "strict"
 
 [functions.answer_question]
 type = "chat"


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `json_mode = "strict"` to various function and evaluation configurations in `tensorzero.toml` for strict JSON handling.
> 
>   - **Configuration Changes**:
>     - Add `json_mode = "strict"` to `functions.extract_entities.variants.gpt4o_mini_initial_prompt`, `functions.extract_entities.variants.gpt4o_initial_prompt`, and `functions.extract_entities.variants.llama_8b_initial_prompt`.
>     - Add `json_mode = "strict"` to `functions.extract_entities.variants.baseline`, `functions.extract_entities.variants.dicl`, and `functions.extract_entities.variants.turbo`.
>     - Add `json_mode = "strict"` to `functions.generate_secret.variants.baseline`, `functions.ask_question.variants.baseline`, and `evaluations.entity_extraction.evaluators.count_sports.variants.mini`.
>     - Add `json_mode = "strict"` to `evaluations.haiku.evaluators.topic_starts_with_f.variants.mini`, `evaluations.images.evaluators.honest_answer.variants.mini`, and `evaluations.images.evaluators.matches_reference.variants.mini`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e3babc5dc77cede422ef34581f262c8617df26c5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->