### PR TITLE
Add optional `description` field to functions

### DIFF
--- a/evaluations/src/helpers.rs
+++ b/evaluations/src/helpers.rs
@@ -96,6 +96,7 @@ mod tests {
             tools: vec![],
             tool_choice: ToolChoice::Specific("tool_1".to_string()),
             parallel_tool_calls: None,
+            description: None,
         });
         let tool_params_args = get_tool_params_args(&tool_database_insert, &function_config).await;
         assert_eq!(
@@ -132,6 +133,7 @@ mod tests {
             tools: vec!["tool_1".to_string()],
             tool_choice: ToolChoice::Auto,
             parallel_tool_calls: None,
+            description: None,
         });
         let tool_params_args = get_tool_params_args(&tool_database_insert, &function_config).await;
         assert_eq!(

--- a/tensorzero-internal/src/config_parser.rs
+++ b/tensorzero-internal/src/config_parser.rs
@@ -667,6 +667,8 @@ struct UninitializedFunctionConfigChat {
     tool_choice: ToolChoice,
     #[serde(default)]
     parallel_tool_calls: Option<bool>,
+    #[serde(default)]
+    description: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -724,6 +726,7 @@ impl UninitializedFunctionConfig {
                     tools: params.tools,
                     tool_choice: params.tool_choice,
                     parallel_tool_calls: params.parallel_tool_calls,
+                    description: params.description,
                 }))
             }
             UninitializedFunctionConfig::Json(params) => {
@@ -786,6 +789,7 @@ impl UninitializedFunctionConfig {
                     assistant_schema,
                     output_schema,
                     implicit_tool_call_config,
+                    description: None,
                 }))
             }
         }

--- a/tensorzero-internal/src/endpoints/datasets.rs
+++ b/tensorzero-internal/src/endpoints/datasets.rs
@@ -712,6 +712,7 @@ fn get_possibly_default_function(
             tools: vec![],
             tool_choice: ToolChoice::None,
             parallel_tool_calls: None,
+            description: None,
         })))
     } else {
         config.get_function(function_name).cloned()

--- a/tensorzero-internal/src/endpoints/feedback.rs
+++ b/tensorzero-internal/src/endpoints/feedback.rs
@@ -1097,6 +1097,7 @@ mod tests {
                 tools: vec!["get_temperature".to_string()],
                 tool_choice: ToolChoice::Auto,
                 parallel_tool_calls: None,
+                description: None,
             })));
 
         // Case 1: a string passed to a chat function
@@ -1224,6 +1225,7 @@ mod tests {
             assistant_schema: None,
             output_schema: JSONSchemaFromPath::from_value(&output_schema).unwrap(),
             implicit_tool_call_config,
+            description: None,
         })));
 
         // Case 5: a JSON function with correct output

--- a/tensorzero-internal/src/endpoints/inference.rs
+++ b/tensorzero-internal/src/endpoints/inference.rs
@@ -509,6 +509,7 @@ fn find_function(params: &Params, config: &Config) -> Result<(Arc<FunctionConfig
                     tools: vec![],
                     tool_choice: ToolChoice::None,
                     parallel_tool_calls: None,
+                    description: None,
                 })),
                 DEFAULT_FUNCTION_NAME.to_string(),
             ))

--- a/tensorzero-internal/src/evaluations/mod.rs
+++ b/tensorzero-internal/src/evaluations/mod.rs
@@ -388,6 +388,7 @@ impl UninitializedEvaluatorConfig {
                     assistant_schema: None,
                     output_schema,
                     implicit_tool_call_config,
+                    description: None,
                 });
                 Ok((
                     EvaluatorConfig::LLMJudge(LLMJudgeConfig {
@@ -873,6 +874,7 @@ mod tests {
             assistant_schema: None,
             output_schema: create_test_schema(),
             implicit_tool_call_config: create_implicit_tool_call_config(create_test_schema()),
+            description: None,
         });
         functions.insert(function_name.to_string(), Arc::new(function_config));
 
@@ -1299,6 +1301,7 @@ mod tests {
                     implicit_tool_call_config: create_implicit_tool_call_config(
                         create_test_schema(),
                     ),
+                    description: None,
                 })),
             );
 

--- a/tensorzero-internal/src/inference/types/mod.rs
+++ b/tensorzero-internal/src/inference/types/mod.rs
@@ -2441,6 +2441,7 @@ mod tests {
             assistant_schema: None,
             implicit_tool_call_config,
             output_schema,
+            description: None,
         }));
         let usage1 = Usage {
             input_tokens: 10,
@@ -2701,6 +2702,7 @@ mod tests {
             assistant_schema: None,
             implicit_tool_call_config,
             output_schema,
+            description: None,
         }));
         let usage1 = Usage {
             input_tokens: 10,
@@ -2798,6 +2800,7 @@ mod tests {
             assistant_schema: None,
             implicit_tool_call_config,
             output_schema,
+            description: None,
         }));
         let usage1 = Usage {
             input_tokens: 10,

--- a/tensorzero-internal/src/variant/chat_completion.rs
+++ b/tensorzero-internal/src/variant/chat_completion.rs
@@ -854,6 +854,7 @@ mod tests {
             tools: vec![],
             tool_choice: ToolChoice::Auto,
             parallel_tool_calls: None,
+            description: None,
         });
         let good_provider_config = ProviderConfig::Dummy(DummyProvider {
             model_name: "good".into(),
@@ -1277,6 +1278,7 @@ mod tests {
             user_schema: None,
             output_schema,
             implicit_tool_call_config,
+            description: None,
         });
         let inference_config = InferenceConfig {
             templates: &templates,
@@ -1426,6 +1428,7 @@ mod tests {
             user_schema: None,
             output_schema: hardcoded_output_schema,
             implicit_tool_call_config,
+            description: None,
         });
         let inference_params = InferenceParams {
             chat_completion: ChatCompletionInferenceParams {
@@ -1534,6 +1537,7 @@ mod tests {
             user_schema: None,
             output_schema: hardcoded_output_schema,
             implicit_tool_call_config,
+            description: None,
         });
         let inference_params = InferenceParams::default();
         // Will dynamically set "response" instead of "answer"
@@ -1652,7 +1656,9 @@ mod tests {
             tools: vec![],
             tool_choice: ToolChoice::Auto,
             parallel_tool_calls: None,
+            description: None,
         })));
+
         let system_template_name = "system";
         let user_template_name = "greeting_with_age";
         let good_provider_config = ProviderConfig::Dummy(DummyProvider {
@@ -1883,6 +1889,7 @@ mod tests {
             tools: vec![],
             tool_choice: ToolChoice::Auto,
             parallel_tool_calls: None,
+            description: None,
         });
         let mut inference_params = InferenceParams::default();
         let inference_config = InferenceConfig {
@@ -1989,6 +1996,7 @@ mod tests {
                 tool_choice: ToolChoice::Auto,
                 parallel_tool_calls: None,
             },
+            description: None,
         });
         let inference_config = InferenceConfig {
             ids: InferenceIds {

--- a/tensorzero-internal/src/variant/mixture_of_n.rs
+++ b/tensorzero-internal/src/variant/mixture_of_n.rs
@@ -946,6 +946,7 @@ mod tests {
             assistant_schema: None,
             output_schema: JSONSchemaFromPath::from_value(&json!({})).unwrap(),
             implicit_tool_call_config: ToolCallConfig::default(),
+            description: None,
         });
         // Prepare some candidate InferenceResults
         let model_inference_response0 = ModelInferenceResponseWithMetadata {
@@ -1214,6 +1215,7 @@ mod tests {
             tools: vec![],
             tool_choice: ToolChoice::None,
             parallel_tool_calls: None,
+            description: None,
         });
 
         let result = mixture_of_n_variant

--- a/tensorzero-internal/src/variant/mod.rs
+++ b/tensorzero-internal/src/variant/mod.rs
@@ -696,6 +696,7 @@ mod tests {
             tools: vec![],
             tool_choice: ToolChoice::Auto,
             parallel_tool_calls: None,
+            description: None,
         });
         let json_mode = JsonMode::Off;
 
@@ -743,6 +744,7 @@ mod tests {
             user_schema: None,
             output_schema: output_schema.clone(),
             implicit_tool_call_config: implicit_tool_call_config.clone(),
+            description: None,
         });
 
         let json_mode = JsonMode::On;
@@ -894,6 +896,7 @@ mod tests {
             tools: vec![],
             tool_choice: ToolChoice::Auto,
             parallel_tool_calls: None,
+            description: None,
         });
 
         let request_messages = vec![RequestMessage {
@@ -998,6 +1001,7 @@ mod tests {
                 tool_choice: ToolChoice::Auto,
                 parallel_tool_calls: None,
             },
+            description: None,
         });
         let output_schema = json!({
             "type": "object",
@@ -1167,6 +1171,7 @@ mod tests {
             tools: vec![],
             tool_choice: ToolChoice::Auto,
             parallel_tool_calls: None,
+            description: None,
         });
 
         let request_messages = vec![RequestMessage {
@@ -1297,6 +1302,7 @@ mod tests {
             tools: vec![],
             tool_choice: crate::tool::ToolChoice::Auto,
             parallel_tool_calls: None,
+            description: None,
         });
 
         // Create an input message
@@ -1440,6 +1446,7 @@ mod tests {
             tools: vec![],
             tool_choice: ToolChoice::Auto,
             parallel_tool_calls: None,
+            description: None,
         })));
 
         let request_messages = vec![RequestMessage {


### PR DESCRIPTION
With getter method and tests.

Populates helper and test factories accordingly.

Closes #241

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add optional `description` field to `FunctionConfig` with getter and tests, updating test factories accordingly.
> 
>   - **Behavior**:
>     - Add optional `description` field to `FunctionConfigChat` and `FunctionConfigJson` in `function.rs`.
>     - Add `description()` getter method to `FunctionConfig`.
>     - Update test factories in `helpers.rs`, `datasets.rs`, `feedback.rs`, `inference.rs`, `mod.rs`, `chat_completion.rs`, and `mixture_of_n.rs` to include `description: None`.
>   - **Tests**:
>     - Add `test_description_getter()` in `function.rs` to verify `description()` method.
>     - Update existing tests in `chat_completion.rs` and `mixture_of_n.rs` to handle `description` field.
>   - **Misc**:
>     - Minor updates to `config_parser.rs` to support `description` field in `UninitializedFunctionConfigChat`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 39a3191a6c064d6f97d28a9817694b95d92a91b3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->