### PR TITLE
Re-enable stream_options for xAI

### DIFF
--- a/tensorzero-internal/src/inference/providers/xai.rs
+++ b/tensorzero-internal/src/inference/providers/xai.rs
@@ -341,15 +341,12 @@ impl<'a> XAIRequest<'a> {
             ..
         } = *request;
 
-        // xAI suddenly started rejecting 'stream_options' as a parameter.
-        // If they change the behavior back, we can start using this again.
-        let _stream_options = match request.stream {
+        let stream_options = match request.stream {
             true => Some(StreamOptions {
                 include_usage: true,
             }),
             false => None,
         };
-        let stream_options = None;
 
         let response_format = Some(XAIResponseFormat::new(
             &request.json_mode,


### PR DESCRIPTION
xAI has started accepting `stream_options` again (and only sends usage information when it's set), so let's re-enable it.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Re-enables `stream_options` in `XAIRequest` to allow usage information when streaming is enabled.
> 
>   - **Behavior**:
>     - Re-enables `stream_options` in `XAIRequest` in `xai.rs`, allowing usage information to be sent when streaming is enabled.
>   - **Code Changes**:
>     - Removes the line setting `stream_options` to `None` in `XAIRequest::new()`.
>     - Updates `stream_options` to conditionally include `StreamOptions` based on `request.stream` value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ef005e6d343884838913ce048fc7b0d428f4f4c2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->