### PR TITLE
Use Github actions concurrency group for clickhouse cloud tests

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -21,6 +21,10 @@ jobs:
             url_secret: CLICKHOUSE_CLOUD_URL
           - release_channel: fast
             url_secret: CLICKHOUSE_CLOUD_FAST_CHANNEL_URL
+    # Only run a single instance of the job (per release channel) within the repository at once
+    # This prevents us from overloading the ClickHouse cloud instance with our concurrent migration tests
+    concurrency:
+      group: clickhouse-cloud-${{ matrix.release_channel }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
When we have lots of prs in the merge queue, all of them try to run our concurrent migrations tests against the same ClickHouse cloud instances, which can lead to timeouts.

Let's use a concurrency group to let at most one instance of this job run per ClickHouse Cloud server (across the entire repository)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add concurrency group to ClickHouse cloud tests in GitHub Actions to prevent overload.
> 
>   - **GitHub Actions**:
>     - Adds `concurrency` group `clickhouse-cloud-${{ matrix.release_channel }}` to `clickhouse-tests-cloud` job in `.github/workflows/general.yml`.
>     - Ensures only one instance of the job runs per ClickHouse Cloud server across the repository.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 90b990c65c5b824abe9a50108bda6d673f008371. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->