### PR TITLE
Use Github Actions cache for check-pyo3-build

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -114,6 +114,7 @@ jobs:
             target: aarch64
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
       - name: "TensorZero PyO3 Client: Build"
         uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
         with:


### PR DESCRIPTION
This just does a build (without running any tests), so using Namespace runners is probably overkill here

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add caching to `check-pyo3-build` job in GitHub Actions to optimize build times.
> 
>   - **GitHub Actions**:
>     - Add `Swatinem/rust-cache` to `check-pyo3-build` job in `general.yml` to cache Rust dependencies and optimize build times.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6ed78ad4c83f01bdf7e6f1284293e34bbc92d61a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->