### PR TITLE
Only save rust cache from merge queue for clickhouse-tests-cloud

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
+        with:
+          save-if: ${{ github.event_name == 'merge_group' }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@37bdc826eaedac215f638a96472df572feab0f9b
         with:


### PR DESCRIPTION
This will stop us from using up our Github cache quota from lots of temporary pr commits (since the main benefit of this cache is preventing us from rebuilding rarely-changed dependencies).

We'll still restore cache entries when PR CI runs, but the only available cache keys will come from merge queue jobs

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize GitHub Actions workflow by saving Rust cache only for merge queue events in `clickhouse-tests-cloud` job to manage cache quota effectively.
> 
>   - **Workflow Changes**:
>     - In `.github/workflows/general.yml`, modify `clickhouse-tests-cloud` job to save Rust cache only if `github.event_name` is `merge_group`.
>     - This change prevents using GitHub cache quota on temporary PR commits, focusing cache usage on merge queue jobs.
>   - **Cache Behavior**:
>     - Cache entries are still restored during PR CI runs, but only merge queue jobs can create new cache keys.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 495151bcce34351777b548bda8331b9536f0ec90. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->