### PR TITLE
Remove some usages of `{"content" {"some": "object"}}` in tests

### DIFF
--- a/clients/python-pyo3/tests/test_client.py
+++ b/clients/python-pyo3/tests/test_client.py
@@ -792,7 +792,12 @@ async def test_async_json_streaming_reasoning(async_client: AsyncTensorZeroGatew
         variant_name="json_reasoner",
         input={
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}],
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "arguments": {"country": "Japan"}}],
+                }
+            ],
         },
         stream=True,
     )
@@ -832,7 +837,12 @@ async def test_async_json_success(async_client: AsyncTensorZeroGateway):
         function_name="json_success",
         input={
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}],
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "arguments": {"country": "Japan"}}],
+                }
+            ],
         },
         output_schema={"type": "object", "properties": {"answer": {"type": "string"}}},
         stream=False,
@@ -852,7 +862,12 @@ async def test_async_json_reasoning(async_client: AsyncTensorZeroGateway):
         variant_name="json_reasoner",
         input={
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}],
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "arguments": {"country": "Japan"}}],
+                }
+            ],
         },
         stream=False,
     )
@@ -1513,7 +1528,12 @@ def test_sync_json_streaming(sync_client: TensorZeroGateway):
         function_name="json_success",
         input={
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}],
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "arguments": {"country": "Japan"}}],
+                }
+            ],
         },
         stream=True,
     )
@@ -1563,7 +1583,12 @@ def test_sync_json_streaming_reasoning(sync_client: TensorZeroGateway):
         variant_name="json_reasoner",
         input={
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}],
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "arguments": {"country": "Japan"}}],
+                }
+            ],
         },
         stream=True,
     )
@@ -1602,7 +1627,12 @@ def test_sync_json_success(sync_client: TensorZeroGateway):
         function_name="json_success",
         input={
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}],
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "arguments": {"country": "Japan"}}],
+                }
+            ],
         },
         output_schema={"type": "object", "properties": {"answer": {"type": "string"}}},
         stream=False,
@@ -1621,7 +1651,12 @@ def test_sync_json_reasoning(sync_client: TensorZeroGateway):
         variant_name="json_reasoner",
         input={
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}],
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "arguments": {"country": "Japan"}}],
+                }
+            ],
         },
         stream=False,
     )

--- a/tensorzero-internal/tests/e2e/datasets.rs
+++ b/tensorzero-internal/tests/e2e/datasets.rs
@@ -1257,7 +1257,9 @@ async fn test_datapoint_insert_output_inherit_json() {
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+            "messages": [{"role": "user", "content": [
+                {"type": "text", "arguments": {"country": "Japan"}}
+            ]}],
         },
         "stream": false,
     });
@@ -1408,7 +1410,7 @@ async fn test_datapoint_insert_output_none_json() {
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+            "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "Japan"}}]}]
         },
         "stream": false,
     });
@@ -1496,7 +1498,7 @@ async fn test_datapoint_insert_output_demonstration_json() {
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+            "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "Japan"}}]}]
         },
         "stream": false,
     });
@@ -1629,7 +1631,7 @@ async fn test_datapoint_missing_demonstration() {
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+            "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "Japan"}}]}]
         },
         "stream": false,
     });

--- a/tensorzero-internal/tests/e2e/feedback.rs
+++ b/tensorzero-internal/tests/e2e/feedback.rs
@@ -49,7 +49,7 @@ async fn e2e_test_comment_feedback() {
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+            "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "Japan"}}]}]
         },
         "stream": false,
     });
@@ -123,7 +123,7 @@ async fn e2e_test_comment_feedback() {
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+            "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "Japan"}}]}]
         },
         "stream": false,
     });
@@ -320,7 +320,7 @@ async fn e2e_test_demonstration_feedback_json() {
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+            "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "Japan"}}]}]
         },
         "stream": false,
     });
@@ -445,7 +445,7 @@ async fn e2e_test_demonstration_feedback_dynamic_json() {
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+            "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "Japan"}}]}]
         },
         "stream": false,
         "output_schema": new_output_schema,
@@ -886,7 +886,7 @@ async fn e2e_test_float_feedback() {
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+            "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "Japan"}}]}]
         },
         "stream": false,
     });
@@ -992,7 +992,7 @@ async fn e2e_test_float_feedback() {
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+            "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "Japan"}}]}]
         },
         "stream": false,
     });
@@ -1066,7 +1066,7 @@ async fn e2e_test_boolean_feedback() {
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+            "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "Japan"}}]}]
         },
         "stream": false,
     });
@@ -1179,7 +1179,7 @@ async fn e2e_test_boolean_feedback() {
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+            "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "Japan"}}]}]
         },
         "stream": false,
     });

--- a/tensorzero-internal/tests/e2e/prometheus.rs
+++ b/tensorzero-internal/tests/e2e/prometheus.rs
@@ -177,7 +177,7 @@ async fn test_prometheus_metrics_feedback_boolean() {
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+            "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "Japan"}}]}]
         },
         "stream": false,
     });
@@ -236,7 +236,7 @@ async fn test_prometheus_metrics_feedback_boolean_dryrun() {
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+            "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "Japan"}}]}]
         },
         "stream": false,
     });
@@ -295,7 +295,7 @@ async fn test_prometheus_metrics_feedback_float() {
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+            "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "Japan"}}]}]
         },
         "stream": false,
     });
@@ -353,7 +353,7 @@ async fn test_prometheus_metrics_feedback_float_dryrun() {
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+            "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "Japan"}}]}]
         },
         "stream": false,
     });
@@ -416,7 +416,7 @@ async fn test_prometheus_metrics_feedback_comment() {
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
-            "messages": [{"role": "user", "content": {"country": "Japan"}}]
+            "messages": [{"role": "user", "content": [{"type": "text", "arguments": {"country": "Japan"}}]}]
         },
         "stream": false,
     });

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -8691,7 +8691,7 @@ pub async fn test_json_mode_inference_request_with_provider(provider: E2ETestPro
                "messages": [
                 {
                     "role": "user",
-                    "content": {"country": "Japan"}
+                    "content": [{"type": "text", "arguments": {"country": "Japan"}}]
                 }
             ]},
         "stream": false,
@@ -8933,7 +8933,7 @@ pub async fn test_dynamic_json_mode_inference_request_with_provider(provider: E2
                "messages": [
                 {
                     "role": "user",
-                    "content": {"country": "Japan"}
+                    "content": [{"type": "text", "arguments": {"country": "Japan"}}]
                 }
             ]},
         "stream": false,

--- a/tensorzero-internal/tests/e2e/providers/reasoning.rs
+++ b/tensorzero-internal/tests/e2e/providers/reasoning.rs
@@ -536,7 +536,7 @@ pub async fn test_reasoning_inference_request_with_provider_json_mode(provider: 
                "messages": [
                 {
                     "role": "user",
-                    "content": {"country": "Japan"}
+                    "content": [{"type": "text", "arguments": {"country": "Japan"}}]
                 }
             ]},
         "stream": false,


### PR DESCRIPTION
This reduces the number of deprecation warnings that our tests produce. We still need to adjust batch tests, but I'm going to do those separately to ensure that we don't cause any problems in CI.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update test JSON structure to reduce deprecation warnings by changing 'content' field format.
> 
>   - **Behavior**:
>     - Update JSON structure in test cases to replace `{"content": {"some": "object"}}` with `{"content": [{"type": "text", "arguments": {"some": "object"}}]}`.
>     - Affects `test_client.py`, `datasets.rs`, `feedback.rs`, `prometheus.rs`, `common.rs`, and `reasoning.rs`.
>   - **Tests**:
>     - Adjusts test cases in `test_client.py` for async and sync JSON streaming and reasoning.
>     - Modifies e2e tests in `datasets.rs`, `feedback.rs`, `prometheus.rs`, `common.rs`, and `reasoning.rs` to use the new JSON structure.
>   - **Misc**:
>     - Reduces deprecation warnings in test outputs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 50a6a50826f591dc4a42210168f148ec5897218e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->