### PR TITLE
Fix casing of CLI flags in evaluations binary

### DIFF
--- a/evaluations/src/lib.rs
+++ b/evaluations/src/lib.rs
@@ -32,6 +32,7 @@ pub mod helpers;
 pub mod stats;
 
 #[derive(clap::ValueEnum, Clone, Debug, Default, PartialEq)]
+#[clap(rename_all = "snake_case")]
 pub enum OutputFormat {
     Jsonl,
     #[default]
@@ -65,7 +66,7 @@ pub struct Args {
     #[arg(short, long, default_value = "1")]
     pub concurrency: usize,
 
-    #[arg(short, long, default_value = "human-readable")]
+    #[arg(short, long, default_value = "human_readable")]
     pub format: OutputFormat,
 
     #[arg(long, default_value = "on")]

--- a/evaluations/tests/tests.rs
+++ b/evaluations/tests/tests.rs
@@ -906,7 +906,7 @@ async fn test_parse_args() {
         "--format",
         "jsonl",
         "--inference-cache",
-        "write-only",
+        "write_only",
     ])
     .unwrap();
     assert_eq!(args.evaluation_name, "my-evaluation");

--- a/tensorzero-internal/src/cache.rs
+++ b/tensorzero-internal/src/cache.rs
@@ -17,6 +17,7 @@ use std::fmt::Debug;
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize, ValueEnum)]
 #[serde(rename_all = "snake_case")]
+#[clap(rename_all = "snake_case")]
 pub enum CacheEnabledMode {
     On,
     Off,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix casing of CLI flags in evaluations binary to use snake_case consistently.
> 
>   - **Behavior**:
>     - Add `#[clap(rename_all = "snake_case")]` to `OutputFormat` in `lib.rs` and `CacheEnabledMode` in `cache.rs` to enforce snake_case for CLI flags.
>     - Change default value of `format` in `Args` from `human-readable` to `human_readable` in `lib.rs`.
>   - **Tests**:
>     - Update `test_parse_args()` in `tests.rs` to use `write_only` instead of `write-only` for `--inference-cache` flag.
>     - Ensure tests reflect snake_case changes for CLI flags.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a92844952d5c6715104b16f7b114044272000a15. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->