### PR TITLE
Fix breadcrumb for dataset builder

### DIFF
--- a/ui/app/components/layout/SubNavBreadcrumbs.tsx
+++ b/ui/app/components/layout/SubNavBreadcrumbs.tsx
@@ -123,10 +123,17 @@ export function SubNavBreadcrumbs() {
         }
 
         if (prevSegment === "datasets") {
-          breadcrumbs.push({
-            label: segment,
-            href: `/datasets/${segment}`,
-          });
+          if (segment === "builder") {
+            breadcrumbs.push({
+              label: "Builder",
+              href: `/datasets/builder`,
+            });
+          } else {
+            breadcrumbs.push({
+              label: segment,
+              href: `/datasets/${segment}`,
+            });
+          }
           continue;
         }
 


### PR DESCRIPTION
Fix #1778
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes breadcrumb for 'builder' segment under 'datasets' in `SubNavBreadcrumbs.tsx`.
> 
>   - **Behavior**:
>     - Fixes breadcrumb for 'builder' segment under 'datasets' in `SubNavBreadcrumbs()`.
>     - When 'builder' is encountered, breadcrumb now shows 'Builder' with href `/datasets/builder`.
>   - **Files**:
>     - Changes in `SubNavBreadcrumbs.tsx` to handle 'builder' segment specifically.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a3cd6dd15c1226c2e7a89ca0c66e16bee7701b05. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->