### PR TITLE
Try to fix fixtures race condition in CI tests

### DIFF
--- a/ui/fixtures/docker-compose.e2e.yml
+++ b/ui/fixtures/docker-compose.e2e.yml
@@ -86,7 +86,7 @@ services:
       ["bash", "-c", "cd /fixtures && ./load_fixtures.sh && sleep infinity"]
     # Added healthcheck to wait for the marker file created by the script
     healthcheck:
-      test: ["CMD", "test", "-f", "/fixtures/load_complete.marker"]
+      test: ["CMD", "test", "-f", "/tmp/load_complete.marker"]
       interval: 5s
       timeout: 1s
       retries: 12 # Retry for up to a minute

--- a/ui/fixtures/load_fixtures.sh
+++ b/ui/fixtures/load_fixtures.sh
@@ -11,6 +11,11 @@ clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO JsonInferenceDatapoint FORMAT JSONEachRow" < json_inference_datapoint_examples.jsonl
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO JsonInferenceDatapoint FORMAT JSONEachRow" < json_inference_many_datasets_examples.jsonl
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO ModelInferenceCache FORMAT JSONEachRow" < model_inference_cache_examples.jsonl
+
+# Give ClickHouse some time to make the writes visible
+sleep 1
 # Create the marker file to signal completion for the healthcheck
-touch /fixtures/load_complete.marker
+# Write it to an ephemeral location to make sure that we don't see a marker file
+# from a previous container run.
+touch /tmp/load_complete.marker
 echo "Fixtures loaded; this script will now exit with status 0"


### PR DESCRIPTION
There were two problems:
* The marker file may have been cached in the volume, so let's write it to /tmp instead
* ClickHouse writes don't become immediately visible, so let's add in a sleep to make this lees

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix CI test race condition by changing marker file location and adding a sleep for ClickHouse write visibility.
> 
>   - **CI Test Fixes**:
>     - Change marker file location from `/fixtures/load_complete.marker` to `/tmp/load_complete.marker` in `docker-compose.e2e.yml` and `load_fixtures.sh` to avoid caching issues.
>     - Add `sleep 1` in `load_fixtures.sh` to ensure ClickHouse writes are visible before proceeding.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f41ac9cd2e724dbd475f36ac026cd64aad1f575d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->