### PR TITLE
Try 'docker compose rm' in ui e2e tests

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -474,6 +474,7 @@ jobs:
           echo "S3_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> fixtures/.env
           echo "S3_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> fixtures/.env
           echo "TENSORZERO_UI_FF_ENABLE_PYTHON=${{ matrix.feature_flag.enable_python }}" >> fixtures/.env
+          docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml rm
           docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml up --wait --build --force-recreate
 
       - name: Install playwright dependencies


### PR DESCRIPTION
Let's see if this helps with the weird caching issue

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `docker compose rm` in `ui-tests-e2e` job to address caching issues in GitHub Actions workflow.
> 
>   - **GitHub Actions Workflow**:
>     - Adds `docker compose rm` command in `ui-tests-e2e` job in `general.yml` to remove stopped service containers before starting them, aiming to resolve caching issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ca357451196788d3e38b4f124fc97ead2b0df5ec. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->