### PR TITLE
Disable Namespace docker builder for ui-tests-e2e

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -434,13 +434,16 @@ jobs:
       # We allow the namespace builder setup to fail on Dependabot PRs and PRs from forks
       # (where the oidc token is not available)
 
-      - name: Install and configure Namespace CLI
-        uses: namespacelabs/nscloud-setup@v0
-        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
+      # TODO - turn namespace builders back on once we've solved the weird ClickHouse caching issue
+      # See https://github.com/tensorzero/tensorzero/issues/1845
 
-      - name: Configure Namespace powered Buildx
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
-        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
+      # - name: Install and configure Namespace CLI
+      #   uses: namespacelabs/nscloud-setup@v0
+      #   continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
+
+      # - name: Configure Namespace powered Buildx
+      #   uses: namespacelabs/nscloud-setup-buildx-action@v0
+      #   continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
This will hopefully fix our strange ClickHouse issues on ci

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disable Namespace docker builder for `ui-tests-e2e` in `general.yml` to address ClickHouse caching issues.
> 
>   - **Behavior**:
>     - Disables Namespace docker builder for `ui-tests-e2e` in `general.yml` by commenting out Namespace CLI and Buildx configuration steps.
>     - Aims to resolve ClickHouse caching issues in CI.
>   - **Misc**:
>     - Adds a TODO comment to re-enable Namespace builders after resolving the issue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 547706c4c628c176e092097e8848380177265311. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->