### PR TITLE
Run uvicorn directly with 'log-level warning' in UI container

### DIFF
--- a/ui/entrypoint.sh
+++ b/ui/entrypoint.sh
@@ -39,7 +39,7 @@ source /build/optimizations-server/.venv/bin/activate
 # TODO: use 'uv run' once this issue is fixed: https://github.com/astral-sh/uv/issues/9191
 #RUST_LOG=trace uv run --verbose --frozen --no-dev fastapi run --port 7000 src/ &
 
-fastapi run --port 7000 /build/optimizations-server/src/ &
+uv run uvicorn --app-dir /build/optimizations-server --port 7000 src:app --log-level warning &
 
 # Wait for any process to exit
 wait -n


### PR DESCRIPTION
This avoids printing lots of FastAPI messages

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch FastAPI server startup to `uv run uvicorn` with `--log-level warning` in `ui/entrypoint.sh` to reduce log verbosity.
> 
>   - **Behavior**:
>     - Change FastAPI server startup in `ui/entrypoint.sh` from `fastapi run` to `uv run uvicorn`.
>     - Set `--log-level warning` to reduce log verbosity.
>   - **Misc**:
>     - Removes excessive FastAPI log messages by adjusting log level.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5d5d17f99ac64453e77869dadd1a2b5ac90ad071. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->