### PR TITLE
Explicitly set cached stream chunk usage to 0

### DIFF
--- a/tensorzero-internal/src/endpoints/inference.rs
+++ b/tensorzero-internal/src/endpoints/inference.rs
@@ -931,6 +931,11 @@ pub struct JsonInferenceResponseChunk {
     pub finish_reason: Option<FinishReason>,
 }
 
+const ZERO_USAGE: Usage = Usage {
+    input_tokens: 0,
+    output_tokens: 0,
+};
+
 impl InferenceResponseChunk {
     fn new(
         inference_result: InferenceResultChunk,
@@ -946,7 +951,13 @@ impl InferenceResponseChunk {
                     episode_id,
                     variant_name,
                     content: result.content,
-                    usage: if cached { None } else { result.usage },
+                    // Token usage is intended to represent 'billed tokens',
+                    // so set it to zero if the result is cached
+                    usage: if cached {
+                        Some(ZERO_USAGE)
+                    } else {
+                        result.usage
+                    },
                     finish_reason: result.finish_reason,
                 })
             }
@@ -959,7 +970,13 @@ impl InferenceResponseChunk {
                     episode_id,
                     variant_name,
                     raw: result.raw.unwrap_or_default(),
-                    usage: if cached { None } else { result.usage },
+                    // Token usage is intended to represent 'billed tokens',
+                    // so set it to zero if the result is cached
+                    usage: if cached {
+                        Some(ZERO_USAGE)
+                    } else {
+                        result.usage
+                    },
                     finish_reason: result.finish_reason,
                 })
             }

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -2398,6 +2398,13 @@ pub async fn test_simple_streaming_inference_request_with_provider_cache(
             full_content.push_str(content);
         }
 
+        // When we get a cache hit, the usage should be explicitly set to 0
+        if check_cache {
+            let usage = chunk_json.get("usage").unwrap();
+            assert_eq!(usage.get("input_tokens").unwrap().as_u64().unwrap(), 0);
+            assert_eq!(usage.get("output_tokens").unwrap().as_u64().unwrap(), 0);
+        }
+
         if let Some(usage) = chunk_json.get("usage") {
             input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
             output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();


### PR DESCRIPTION
This is intended to represent 'billed tokens', so a cached result means that 0 tokens were actually billed
(since we never hit the model provider).

Fixes #1791

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sets token usage to zero for cached results in `InferenceResponseChunk` to represent non-billed tokens.
> 
>   - **Behavior**:
>     - Sets `usage` to zero for cached results in `InferenceResponseChunk::new()` in `inference.rs`.
>     - Introduces `ZERO_USAGE` constant to represent zero token usage.
>   - **Tests**:
>     - Updates `test_simple_streaming_inference_request_with_provider_cache` in `common.rs` to assert `usage` is zero when cache is hit.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 9f24a81bf60f4f513232f81d68038392205cb1ff. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->