### PR TITLE
Remove Docker cache mount for 'target' directory

### DIFF
--- a/evaluations/Dockerfile
+++ b/evaluations/Dockerfile
@@ -12,7 +12,6 @@ ARG CARGO_BUILD_FLAGS=""
 
 RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/registry \
     --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/git \
-    --mount=type=cache,id=tensorzero-evaluations-release,sharing=locked,target=/src/target \
     cargo build --release -p evaluations $CARGO_BUILD_FLAGS && \
     cp -r /src/target/release /release
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -12,7 +12,6 @@ ARG CARGO_BUILD_FLAGS=""
 
 RUN --mount=type=cache,id=tensorzero-gateway-release,sharing=shared,target=/usr/local/cargo/registry \
     --mount=type=cache,id=tensorzero-gateway-release,sharing=shared,target=/usr/local/cargo/git \
-    --mount=type=cache,id=tensorzero-gateway-release,sharing=locked,target=/src/target \
     cargo build --release -p gateway $CARGO_BUILD_FLAGS && \
     cp -r /src/target/release /release
 

--- a/tensorzero-internal/tests/mock-inference-provider/Dockerfile
+++ b/tensorzero-internal/tests/mock-inference-provider/Dockerfile
@@ -9,7 +9,6 @@ ARG CARGO_BUILD_FLAGS=""
 
 RUN --mount=type=cache,id=tensorzero-mock-inference-provider-release,sharing=shared,target=/usr/local/cargo/registry \
     --mount=type=cache,id=tensorzero-mock-inference-provider-release,sharing=shared,target=/usr/local/cargo/git \
-    --mount=type=cache,id=tensorzero-mock-inference-provider-release,sharing=locked,target=/src/target \
     cargo build --release -p mock-inference-provider $CARGO_BUILD_FLAGS && \
     cp -r /src/target/release /release
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -50,7 +50,6 @@ ARG CARGO_BUILD_FLAGS=""
 
 RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/registry \
     --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/git \
-    --mount=type=cache,id=tensorzero-evaluations-release,sharing=locked,target=/tensorzero/target \
     cargo build --release -p evaluations $CARGO_BUILD_FLAGS && \
     cp -r /tensorzero/target/release /release
 


### PR DESCRIPTION
In https://github.com/tensorzero/tensorzero/actions/runs/14524961439/job/40754404251?pr=1856 we observed a gateway binary **from another PR** being run.

Specifically, we got an error message:
"tensorzero::evaluator_inference_id is required when tensorzero::datapoint_id and tensorzero::human_feedback are provided"

which was only added in a not-yet-merged PR:
https://github.com/tensorzero/tensorzero/pull/1855

This issue seems to be caused by the fact that Cargo detects a stale crate by comparing file mtimes to
the dep-info mtime (which is located in the `target` directory):
https://github.com/rust-lang/cargo/blob/185c6952617bcdb73d9082ad145d4f0b46a0dbfc/src/cargo/core/compiler/fingerprint/mod.rs#L29-L34

When we re-use a Docker cache volume for a 'target' directory, Cargo will see that the dep-info has a newer mtime than our file mtimes (since the dep-info mtime can come from a just-finished build in another job), and skip rebuilding the crate. However, this does not depend on the actual file contents, so we can end up with an incorrect artifact (from a random open PR)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove Docker cache mounts for 'target' directory in multiple Dockerfiles to prevent incorrect artifact usage due to stale crate detection by Cargo.
> 
>   - **Docker Cache Mount Removal**:
>     - Removed cache mount for 'target' directory in `evaluations/Dockerfile`, `gateway/Dockerfile`, and `tensorzero-internal/tests/mock-inference-provider/Dockerfile`.
>     - Removed cache mount for 'target' directory in `ui/Dockerfile`.
>   - **Issue Addressed**:
>     - Prevents incorrect artifact usage due to stale crate detection by Cargo, which was causing errors with binaries from other PRs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 14a32e4100605fdd2a3baae6cced11e94c94aa16. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->