### PR TITLE
Add 'save-if' to remaining  Swatinem/rust-cache action usages

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -115,6 +115,8 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
+        with:
+          save-if: ${{ github.event_name == 'merge_group' }}
       - name: "TensorZero PyO3 Client: Build"
         uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
         with:
@@ -300,6 +302,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
+        with:
+          save-if: ${{ github.event_name == 'merge_group' }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@37bdc826eaedac215f638a96472df572feab0f9b
         with:


### PR DESCRIPTION
We now only write to the cache from the merge queue (but still read from it in all builds). This should stop us from hitting our cache quota limit.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add conditional cache saving to `Swatinem/rust-cache` in GitHub Actions to manage cache quota.
> 
>   - **Workflow Changes**:
>     - Add `save-if: ${{ github.event_name == 'merge_group' }}` to `Swatinem/rust-cache` usage in `general.yml`.
>     - Affects `clickhouse-tests-cloud`, `check-pyo3-build`, and `clickhouse-tests` jobs.
>   - **Behavior**:
>     - Cache is only saved during merge group events, reducing cache quota usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ec2b4f330d4bf6d670f6a9927c9ce61d594e7bc0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->