### PR TITLE
Set Playwright maxFailures to 1 on CI

### DIFF
--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.TENSORZERO_CI ? 1 : undefined,
   /* Fail immediately while we're debugging the CI issue */
-  maxFailures: process.env.CI ? 1 : undefined,
+  maxFailures: process.env.TENSORZERO_CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -21,6 +21,8 @@ export default defineConfig({
   retries: process.env.TENSORZERO_CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.TENSORZERO_CI ? 1 : undefined,
+  /* Fail immediately while we're debugging the CI issue */
+  maxFailures: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
This will make our tests fail faster while we're debugging the ui e2e test ClickHouse issue

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `maxFailures` to 1 in `ui/playwright.config.ts` for CI to fail tests immediately, aiding in debugging UI e2e test issues.
> 
>   - **Behavior**:
>     - Set `maxFailures` to 1 in `ui/playwright.config.ts` for CI environments to fail tests immediately, aiding in debugging UI e2e test issues with ClickHouse.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 039e8b893956fd34df16ce699eea313414ea5e2c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->