### PR TITLE
Use ToolChoice::Auto for default functions

### DIFF
--- a/tensorzero-internal/src/endpoints/inference.rs
+++ b/tensorzero-internal/src/endpoints/inference.rs
@@ -507,7 +507,7 @@ fn find_function(params: &Params, config: &Config) -> Result<(Arc<FunctionConfig
                     user_schema: None,
                     assistant_schema: None,
                     tools: vec![],
-                    tool_choice: ToolChoice::None,
+                    tool_choice: ToolChoice::Auto,
                     parallel_tool_calls: None,
                     description: None,
                 })),

--- a/tensorzero-internal/tests/e2e/providers/openai.rs
+++ b/tensorzero-internal/tests/e2e/providers/openai.rs
@@ -307,7 +307,7 @@ async fn test_default_function_default_tool_choice() {
     );
 
     // Sleep for 100ms second to allow time for data to be inserted into ClickHouse (trailing writes from API)
-    tokio::time::sleep(std::time::Duration::from_millis(10 - 0)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
     // Just check 'tool_choice' in the raw request, since we already have lots of tests
     // that check the full ChatInference/ModelInference rows


### PR DESCRIPTION
This allows using `additional_tools` with a default function without needing to explicitly specify `tool_choice` in the inference request.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sets default `tool_choice` to `ToolChoice::Auto` in `inference.rs`, enabling `additional_tools` without explicit `tool_choice`, and adds a test in `openai.rs`.
> 
>   - **Behavior**:
>     - Default `tool_choice` set to `ToolChoice::Auto` in `find_function()` in `inference.rs`.
>     - Allows `additional_tools` usage without specifying `tool_choice`.
>   - **Testing**:
>     - Adds `test_default_function_default_tool_choice` in `openai.rs` to verify default `tool_choice` behavior.
>     - Confirms `tool_choice` is set to `auto` in raw request in ClickHouse.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1a0e22dbd9f892bb354e9066f15784056a73c6e5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->