### PR TITLE
Try sccache in UI e2e tests

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -84,7 +84,7 @@ WORKDIR /build/optimizations-server
 # UV_PYTHON_DOWNLOADS=never
 # https://hynek.me/articles/docker-uv/
 ENV UV_COMPILE_BYTECODE=1
-RUN --mount=type=cache,target=/uv-cache CARGO_TARGET_DIR=/uv-cache/cargo-target uv --cache-dir /uv-cache --verbose sync --locked --no-dev
+RUN --mount=type=cache,sharing=locked,target=/uv-cache CARGO_TARGET_DIR=/uv-cache/cargo-target uv --cache-dir /uv-cache --verbose sync --locked --no-dev
 
 # ========== ui ==========
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -40,7 +40,9 @@ RUN wasm-pack build --features console_error_panic_hook
 
 FROM rust:latest AS evaluations-build-env
 
+RUN cargo install sccache --locked
 RUN apt-get update && apt-get install -y clang libc++-dev && rm -rf /var/lib/apt/lists/*
+ENV RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache
 
 COPY . /tensorzero
 
@@ -50,6 +52,7 @@ ARG CARGO_BUILD_FLAGS=""
 
 RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/registry \
     --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/git \
+    --mount=type=cache,id=tensorzero-evaluations-release,sharing=locked,target=/sccache \
     cargo build --release -p evaluations $CARGO_BUILD_FLAGS && \
     cp -r /tensorzero/target/release /release
 


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Integrate `sccache` in `ui/Dockerfile` to optimize Rust build caching for `evaluations`.
> 
>   - **Build Optimization**:
>     - Install `sccache` in `evaluations-build-env` stage of `ui/Dockerfile` to cache Rust builds.
>     - Set `RUSTC_WRAPPER=sccache` and `SCCACHE_DIR=/sccache` environment variables in `ui/Dockerfile`.
>     - Add cache mount for `/sccache` in `cargo build` command in `ui/Dockerfile` to utilize `sccache`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d9eb44e01ad1217a7c6914029046ebbfba186176. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->