### PR TITLE
Add image support to GCP Vertex Anthropic

### DIFF
--- a/tensorzero-internal/src/inference/providers/anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/anthropic.rs
@@ -497,15 +497,15 @@ enum AnthropicMessageContent<'a> {
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
-struct AnthropicImageSource {
-    r#type: AnthropicImageType,
-    media_type: ImageKind,
-    data: String,
+pub struct AnthropicImageSource {
+    pub r#type: AnthropicImageType,
+    pub media_type: ImageKind,
+    pub data: String,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
-enum AnthropicImageType {
+pub enum AnthropicImageType {
     Base64,
 }
 

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
@@ -16,6 +16,7 @@ use crate::error::{DisplayOrDebugGateway, Error, ErrorDetails};
 use crate::inference::providers::provider_trait::InferenceProvider;
 use crate::inference::types::batch::BatchRequestRow;
 use crate::inference::types::batch::PollBatchInferenceResponse;
+use crate::inference::types::resolved_input::ImageWithPath;
 use crate::inference::types::{
     batch::StartBatchProviderInferenceResponse, ContentBlock, ContentBlockChunk, FunctionType,
     Latency, ModelInferenceRequestJsonMode, Role, Text, TextChunk,
@@ -31,7 +32,8 @@ use crate::model::{build_creds_caching_default_with_fn, CredentialLocation};
 use crate::tool::{ToolCall, ToolCallChunk, ToolChoice, ToolConfig};
 
 use super::anthropic::{
-    prefill_json_chunk_response, prefill_json_response, AnthropicMessageDelta, AnthropicStopReason,
+    prefill_json_chunk_response, prefill_json_response, AnthropicImageSource, AnthropicImageType,
+    AnthropicMessageDelta, AnthropicStopReason,
 };
 use super::gcp_vertex_gemini::{default_api_key_location, GCPVertexCredentials};
 use super::helpers::{inject_extra_request_data, peek_first_chunk};
@@ -396,10 +398,12 @@ impl<'a> From<&'a ToolConfig> for GCPVertexAnthropicTool<'a> {
 #[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(tag = "type")]
 #[serde(rename_all = "snake_case")]
-// NB: Anthropic also supports Image blocks here but we won't for now
 enum GCPVertexAnthropicMessageContent<'a> {
     Text {
         text: &'a str,
+    },
+    Image {
+        source: AnthropicImageSource,
     },
     ToolResult {
         tool_use_id: &'a str,
@@ -464,10 +468,18 @@ impl<'a> TryFrom<&'a ContentBlock>
                     }],
                 },
             ))),
-            ContentBlock::Image(_) => Err(Error::new(ErrorDetails::UnsupportedContentBlockType {
-                content_block_type: "image".to_string(),
-                provider_type: PROVIDER_TYPE.to_string(),
-            })),
+            ContentBlock::Image(ImageWithPath {
+                image,
+                storage_path: _,
+            }) => Ok(Some(FlattenUnknown::Normal(
+                GCPVertexAnthropicMessageContent::Image {
+                    source: AnthropicImageSource {
+                        r#type: AnthropicImageType::Base64,
+                        media_type: image.mime_type,
+                        data: image.data()?.clone(),
+                    },
+                },
+            ))),
             // We don't support thought blocks being passed in from a request.
             // These are only possible to be passed in in the scenario where the
             // output of a chat completion is used as an input to another model inference,

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -586,6 +586,19 @@ type = "gcp_vertex_gemini"
 model_id = "gemini-1.5-pro-001"
 location = "us-central1"
 project_id = "tensorzero-public"
+
+[functions.image_test.variants.gcp-vertex-haiku]
+type = "chat_completion"
+model = "claude-3-haiku-20240307-gcp-vertex"
+
+[models.claude-3-haiku-20240307-gcp-vertex]
+routing = ["gcp_vertex_anthropic"]
+
+[models.claude-3-haiku-20240307-gcp-vertex.providers.gcp_vertex_anthropic]
+type = "gcp_vertex_anthropic"
+model_id = "claude-3-haiku@20240307"
+location = "us-central1"
+project_id = "tensorzero-public"
 "#;
 
 pub async fn test_image_url_inference_with_provider_filesystem(provider: E2ETestProvider) {

--- a/tensorzero-internal/tests/e2e/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/tests/e2e/providers/gcp_vertex_anthropic.rs
@@ -13,6 +13,13 @@ async fn get_providers() -> E2ETestProviders {
         credentials: HashMap::new(),
     }];
 
+    let image_providers = vec![E2ETestProvider {
+        variant_name: "gcp-vertex-haiku".to_string(),
+        model_name: "claude-3-haiku-20240307-gcp-vertex".into(),
+        model_provider_name: "gcp_vertex_anthropic".into(),
+        credentials: HashMap::new(),
+    }];
+
     let extra_body_providers = vec![E2ETestProvider {
         variant_name: "gcp-vertex-haiku-extra-body".to_string(),
         model_name: "claude-3-haiku-20240307-gcp-vertex".into(),
@@ -60,7 +67,7 @@ async fn get_providers() -> E2ETestProviders {
         dynamic_tool_use_inference: standard_providers.clone(),
         parallel_tool_use_inference: vec![],
         json_mode_inference: json_providers.clone(),
-        image_inference: vec![],
+        image_inference: image_providers,
 
         shorthand_inference: vec![],
         supports_batch_inference: false,


### PR DESCRIPTION
I re-used some of the types from the normal Anthropic providers, since the APIs are intentionally very similar.

Partially addresses https://github.com/tensorzero/tensorzero/issues/1871

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add image support to GCP Vertex Anthropic provider and update tests accordingly.
> 
>   - **Behavior**:
>     - Adds image support to `GCPVertexAnthropicMessageContent` in `gcp_vertex_anthropic.rs`.
>     - Handles `ContentBlock::Image` in `TryFrom<&ContentBlock>` implementation.
>   - **Types**:
>     - Makes `AnthropicImageSource` and `AnthropicImageType` public in `anthropic.rs`.
>   - **Tests**:
>     - Adds `image_providers` to `get_providers()` in `gcp_vertex_anthropic.rs`.
>     - Updates E2E tests in `common.rs` to include image inference.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b974ac4b0449aa654f6bd96eb51de08c34d856e5. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->