### PR TITLE
Print sccache stats in Dockerfile

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -54,6 +54,7 @@ RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/
     --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/git \
     --mount=type=cache,id=tensorzero-evaluations-release,sharing=locked,target=/sccache \
     cargo build --release -p evaluations $CARGO_BUILD_FLAGS && \
+    sccache --show-stats && \
     cp -r /tensorzero/target/release /release
 
 


### PR DESCRIPTION
This will let us know if the cache mount is actually working

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `sccache --show-stats` to Dockerfile to print cache statistics after build.
> 
>   - **Dockerfile**:
>     - Add `sccache --show-stats` command after `cargo build` in `evaluations-build-env` stage to print cache statistics.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c864801144694a6a954775f653855c2ee44093ba. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->