### PR TITLE
Remove duration check from ClickHouse migration tests

### DIFF
--- a/tensorzero-internal/tests/e2e/clickhouse.rs
+++ b/tensorzero-internal/tests/e2e/clickhouse.rs
@@ -254,21 +254,13 @@ async fn test_bad_clickhouse_write() {
 #[tokio::test]
 async fn test_clean_clickhouse_start() {
     let clickhouse = get_clean_clickhouse();
-    let start = std::time::Instant::now();
     migration_manager::run(&clickhouse).await.unwrap();
-    let duration = start.elapsed();
-    assert!(
-        duration < std::time::Duration::from_secs(40),
-        "Migrations took longer than 40 seconds: {duration:?}"
-    );
 }
 
 #[tokio::test]
 async fn test_concurrent_clickhouse_migrations() {
     let clickhouse = Arc::new(get_clean_clickhouse());
     let num_concurrent_starts = 50;
-    let start = std::time::Instant::now();
-
     let mut handles = Vec::with_capacity(num_concurrent_starts);
     for _ in 0..num_concurrent_starts {
         let clickhouse_clone = clickhouse.clone();
@@ -279,12 +271,6 @@ async fn test_concurrent_clickhouse_migrations() {
     for handle in handles {
         handle.await.unwrap();
     }
-
-    let duration = start.elapsed();
-    assert!(
-        duration < std::time::Duration::from_secs(400),
-        "Migrations took longer than 400 seconds: {duration:?}"
-    );
 }
 
 /// Migration 0013 has some checks that enforce that concurrent migrations can't break


### PR DESCRIPTION
These are unreliable on CI (since we can have multiplies instances running in the merge queue simultaneously), and the actual duration will just keep increasing as we add migrations.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unreliable duration checks from ClickHouse migration tests in `clickhouse.rs`.
> 
>   - **Tests**:
>     - Remove duration check from `test_clean_clickhouse_start()` in `clickhouse.rs`.
>     - Remove duration check from `test_concurrent_clickhouse_migrations()` in `clickhouse.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 316401161ce345ff7f4694a45b79f715c7d2572b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->