### PR TITLE
Only run Python/node tests in the live-tests job

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -128,28 +128,6 @@ jobs:
       - name: Install Python for python async client tests
         run: uv python install 3.9
 
-      - name: "Python: ruff"
-        run: |
-          uvx ruff@0.9.0 check --output-format=github --extend-select I .
-          uvx ruff@0.9.0 format --check .
-
-      - name: "Python: PyO3 Client: Install dependencies"
-        working-directory: clients/python-pyo3
-        run: |
-          uv venv
-          uv sync
-
-      - name: "Python: PyO3 Client: pyright"
-        working-directory: clients/python-pyo3
-        run: |
-          uv pip install pyright==1.1.394
-          uv run pyright
-
-      - name: "Python: PyO3 Client: stubtest"
-        working-directory: clients/python-pyo3
-        run: |
-          uv run stubtest tensorzero.tensorzero
-
       - name: "Python: PyO3 Client: pytest"
         working-directory: clients/python-pyo3
         run: |
@@ -161,12 +139,6 @@ jobs:
           uv venv
           uv pip sync requirements.txt
 
-      - name: "Python: OpenAI Client: pyright"
-        working-directory: clients/openai-python
-        run: |
-          uv pip install pyright==1.1.394
-          uv run pyright
-
       - name: "Python: OpenAI Client: pytest"
         working-directory: clients/openai-python
         run: |
@@ -177,31 +149,10 @@ jobs:
         run: |
           pnpm install
 
-      - name: "Node.js: OpenAI Client: typecheck"
-        working-directory: clients/openai-node
-        run: |
-          pnpm run typecheck
-
-      - name: "Node.js: OpenAI Client: lint"
-        working-directory: clients/openai-node
-        run: |
-          pnpm run lint
-
       - name: "Node.js: OpenAI Client: test"
         working-directory: clients/openai-node
         run: |
           pnpm run test
-
-      - name: "Python: Recipes: Install dependencies"
-        working-directory: recipes
-        run: |
-          uv venv
-          uv sync
-
-      - name: "Python: Recipes: pyright"
-        working-directory: recipes
-        run: |
-          uv run pyright
 
       - name: "Python: Recipes: pytest"
         working-directory: recipes


### PR DESCRIPTION
We already run linters/typechecking in the 'validate' job (which runs in both PR CI and the merge queue), so there's no need to also run them here. We only need to run the tests (which need credentials).

I've also removed some of the explicit 'uv venv' steps, as 'uv run' takes care of this automatically

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Streamline CI workflow by removing redundant linter/typechecking steps and simplifying setup in `merge-queue.yml`.
> 
>   - **CI Workflow**:
>     - Remove redundant linter and typechecking steps from `merge-queue.yml`.
>     - Retain only Python and Node.js test steps that require credentials.
>   - **Setup Simplification**:
>     - Remove explicit `uv venv` steps as `uv run` handles it automatically.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b4f029858d0722bd0ef6dd0e233c0ad525176a7d. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->