### PR TITLE
bumped version to 2025.4.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2025.4.5"
+version = "2025.4.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2025.4.5"
+version = "2025.4.6"
 dependencies = [
  "axum",
  "clap",
@@ -2431,7 +2431,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-bindings"
-version = "2025.4.5"
+version = "2025.4.6"
 dependencies = [
  "console_error_panic_hook",
  "minijinja",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-internal"
-version = "2025.4.5"
+version = "2025.4.6"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.4.5"
+version = "2025.4.6"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2025.4.5"
+version = "2025.4.6"
 
 [workspace.dependencies]
 reqwest = { version = "0.12.15", features = [

--- a/ui/app/utils/version.ts
+++ b/ui/app/utils/version.ts
@@ -5,4 +5,4 @@
  * It serves as a single source of truth for version information.
  */
 
-export const VERSION = "2025.4.5";
+export const VERSION = "2025.4.6";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump version to `2025.4.6` across multiple packages and files.
> 
>   - **Version Bump**:
>     - Update version to `2025.4.6` in `Cargo.lock`, `Cargo.toml`, and `version.ts`.
>     - Affects packages: `evaluations`, `gateway`, `minijinja-bindings`, `tensorzero-internal`, `tensorzero-python`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e0c14071f0f4488280ab2b81eed9737c7801b990. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->