### PR TITLE
Run flaky tests in separate allow-failure step on CI

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -179,7 +179,7 @@ jobs:
 
       - name: Test (Rust)
         run: |
-          cargo test-unit ${{vars.CARGO_NEXTEST_ARGS}}
+          cargo test-unit ${{ vars.CARGO_NEXTEST_EXTRA_ARGS }}
 
       - name: Install Python for python async client tests
         run: uv python install 3.9

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -106,9 +106,19 @@ jobs:
           echo "GATEWAY_PID=$!" >> $GITHUB_ENV
 
       # We set 'TENSORZERO_E2E_PROXY' here so that embedded gateway tests can use it
+      # The 'CARGO_NEXTEST_FLAKY_TESTS' variable allows us to mark tests as flaky without merging a PR (if a provider happens to break or goes down)
+      # We run the tests without the flaky tests, and require them to pass
       - name: Run all tests (including E2E tests)
         run: |
-          TENSORZERO_E2E_PROXY="http://localhost:3003" cargo test-all --profile ci ${{ vars.CARGO_NEXTEST_ARGS }}
+          TENSORZERO_E2E_PROXY="http://localhost:3003" cargo test-all --profile ci ${{ vars.CARGO_NEXTEST_EXTRA_ARGS }} -E "not(${{ vars.CARGO_NEXTEST_FLAKY_TESTS }})"
+
+      # As a separate step, we run just the flaky tests, and allow them to fail.
+      # This lets us see if any flaky tests have started succeeding (by looking at the job output),
+      # so that we can decide to mark them as non-flaky.
+      - name: Run flaky E2E tests
+        run: |
+          TENSORZERO_E2E_PROXY="http://localhost:3003" cargo test-all --profile ci --no-fail-fast ${{ vars.CARGO_NEXTEST_EXTRA_ARGS }} -E "${{ vars.CARGO_NEXTEST_FLAKY_TESTS }}"
+        continue-on-error: true
 
       - name: Print e2e logs
         if: always()


### PR DESCRIPTION
This will help us to determine when a provider has started succeeding again, so that we can mark the test as non-flaky

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
