### PR TITLE
Check production Docker image in separate merge-queue job

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -165,11 +165,10 @@ jobs:
           echo "Killing gateway with pid $GATEWAY_PID"
           kill $GATEWAY_PID
 
-      - name: Setup Node.js
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
-        with:
-          node-version: "22.9.0"
-
+  check-production-docker-container:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Build Docker container for production deployment tests
         run: docker build -t tensorzero/gateway -f gateway/Dockerfile .
 
@@ -192,7 +191,7 @@ jobs:
   # See 'ci/README.md' at the repository root for more details.
   check-all-live-tests-passed:
     if: always()
-    needs: [live-tests]
+    needs: [check-production-docker-container, live-tests]
     runs-on: ubuntu-latest
     steps:
       - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -172,6 +172,11 @@ jobs:
       - name: Build Docker container for production deployment tests
         run: docker build -t tensorzero/gateway -f gateway/Dockerfile .
 
+      - name: Launch ClickHouse container for E2E tests
+        run: |
+          # 'docker compose' will exit with status code 1 if any container exits, even if the container exits with status code 0
+          docker compose -f tensorzero-internal/tests/e2e/docker-compose.yml up -d --wait || true
+
       - name: Set up .env file for production deployment tests
         run: |
           echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" > examples/production-deployment/.env


### PR DESCRIPTION
This should speed up CI slightly by letting this run in parallel (it should always be faster than running the e2e tests, so we don't need a Namespace runner)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `check-production-docker-container` job to CI workflow for parallel Docker image testing.
> 
>   - **CI Workflow**:
>     - Adds `check-production-docker-container` job in `.github/workflows/merge-queue.yml` to build and test the production Docker image.
>     - Runs `check-production-docker-container` in parallel with `live-tests` by adding it to the `needs` list of `check-all-live-tests-passed`.
>     - Includes steps to build Docker image, set up environment, and run production deployment tests in `check-production-docker-container`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2a9a175815241fc2d8b6a78dfe01a0e48c5c273a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->