### PR TITLE
Use BuildJet cache in all Swatinem/rust-cache usages

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
         with:
+          cache-provider: "buildjet"
           save-if: ${{ github.event_name == 'merge_group' }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@37bdc826eaedac215f638a96472df572feab0f9b
@@ -305,6 +306,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
         with:
+          cache-provider: "buildjet"
           save-if: ${{ github.event_name == 'merge_group' }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@37bdc826eaedac215f638a96472df572feab0f9b


### PR DESCRIPTION
This is working correctly for the PyO3 builds, so let's use it instead of the Github Actions cache (which is broken when using a merge queue)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switches to BuildJet cache for Rust builds in GitHub Actions workflow.
> 
>   - **Workflow Changes**:
>     - In `.github/workflows/general.yml`, set `cache-provider: "buildjet"` for `Swatinem/rust-cache` in `clickhouse-tests-cloud`, `check-pyo3-build`, and `clickhouse-tests` jobs.
>     - Applies to jobs triggered by `merge_group` events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a03a1d82d5b670131e712d4b98b74bc0efa81fc6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->