### PR TITLE
Move 'supports_batch_inference' to `E2ETestProvider`

### DIFF
--- a/tensorzero-internal/tests/e2e/providers/anthropic.rs
+++ b/tensorzero-internal/tests/e2e/providers/anthropic.rs
@@ -25,6 +25,7 @@ async fn get_providers() -> E2ETestProviders {
     };
 
     let standard_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "anthropic".to_string(),
         model_name: "claude-3-haiku-20240307-anthropic".into(),
         model_provider_name: "anthropic".into(),
@@ -32,6 +33,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let image_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "anthropic".to_string(),
         model_name: "anthropic::claude-3-haiku-20240307".into(),
         model_provider_name: "anthropic".into(),
@@ -39,6 +41,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let extra_body_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "anthropic-extra-body".to_string(),
         model_name: "claude-3-haiku-20240307-anthropic".into(),
         model_provider_name: "anthropic".into(),
@@ -46,6 +49,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let bad_auth_extra_headers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "anthropic-extra-headers".to_string(),
         model_name: "claude-3-haiku-20240307-anthropic".into(),
         model_provider_name: "anthropic".into(),
@@ -53,6 +57,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let inference_params_dynamic_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "anthropic-dynamic".to_string(),
         model_name: "claude-3-haiku-20240307-anthropic-dynamic".into(),
         model_provider_name: "anthropic".into(),
@@ -61,18 +66,21 @@ async fn get_providers() -> E2ETestProviders {
 
     let json_providers = vec![
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "anthropic".to_string(),
             model_name: "claude-3-haiku-20240307-anthropic".into(),
             model_provider_name: "anthropic".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "anthropic-implicit".to_string(),
             model_name: "claude-3-haiku-20240307-anthropic".into(),
             model_provider_name: "anthropic".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "anthropic-default".to_string(),
             model_name: "claude-3-haiku-20240307-anthropic".into(),
             model_provider_name: "anthropic".into(),
@@ -81,6 +89,7 @@ async fn get_providers() -> E2ETestProviders {
     ];
 
     let shorthand_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "anthropic-shorthand".to_string(),
         model_name: "anthropic::claude-3-haiku-20240307".into(),
         model_provider_name: "anthropic".into(),
@@ -102,7 +111,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: image_providers,
 
         shorthand_inference: shorthand_providers.clone(),
-        supports_batch_inference: false,
     }
 }
 

--- a/tensorzero-internal/tests/e2e/providers/aws_bedrock.rs
+++ b/tensorzero-internal/tests/e2e/providers/aws_bedrock.rs
@@ -19,6 +19,7 @@ crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
     let standard_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "aws-bedrock".to_string(),
         model_name: "claude-3-haiku-20240307-aws-bedrock".into(),
         model_provider_name: "aws_bedrock".into(),
@@ -26,6 +27,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let extra_body_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "aws-bedrock-extra-body".to_string(),
         model_name: "claude-3-haiku-20240307-aws-bedrock".into(),
         model_provider_name: "aws_bedrock".into(),
@@ -33,6 +35,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let bad_auth_extra_headers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "aws-bedrock-extra-headers".to_string(),
         model_name: "claude-3-haiku-20240307-aws-bedrock".into(),
         model_provider_name: "aws_bedrock".into(),
@@ -41,18 +44,21 @@ async fn get_providers() -> E2ETestProviders {
 
     let json_providers = vec![
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "aws-bedrock".to_string(),
             model_name: "claude-3-haiku-20240307-aws-bedrock".into(),
             model_provider_name: "aws_bedrock".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "aws-bedrock-implicit".to_string(),
             model_name: "claude-3-haiku-20240307-aws-bedrock".into(),
             model_provider_name: "aws_bedrock".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "aws-bedrock-default".to_string(),
             model_name: "claude-3-haiku-20240307-aws-bedrock".into(),
             model_provider_name: "aws_bedrock".into(),
@@ -75,7 +81,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
 
         shorthand_inference: vec![],
-        supports_batch_inference: false,
     }
 }
 

--- a/tensorzero-internal/tests/e2e/providers/aws_sagemaker.rs
+++ b/tensorzero-internal/tests/e2e/providers/aws_sagemaker.rs
@@ -14,6 +14,7 @@ crate::generate_batch_inference_tests!(get_providers);
 // As a result, we leave most of the fields in `E2ETestProviders` empty.
 async fn get_providers() -> E2ETestProviders {
     let standard_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "aws-sagemaker".to_string(),
         model_name: "gemma-3-1b-aws-sagemaker".into(),
         model_provider_name: "aws_sagemaker".into(),
@@ -21,6 +22,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let extra_body_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "aws-sagemaker-extra-body".to_string(),
         model_name: "gemma-3-1b-aws-sagemaker".into(),
         model_provider_name: "aws_sagemaker".into(),
@@ -28,6 +30,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let bad_auth_extra_headers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "aws-sagemaker-extra-headers".to_string(),
         model_name: "gemma-3-1b-aws-sagemaker".into(),
         model_provider_name: "aws_sagemaker".into(),
@@ -49,6 +52,5 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
 
         shorthand_inference: vec![],
-        supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/azure.rs
+++ b/tensorzero-internal/tests/e2e/providers/azure.rs
@@ -12,6 +12,7 @@ async fn get_providers() -> E2ETestProviders {
     };
 
     let standard_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "azure".to_string(),
         model_name: "gpt-4o-mini-azure".into(),
         model_provider_name: "azure".into(),
@@ -19,6 +20,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let extra_body_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "azure-extra-body".to_string(),
         model_name: "gpt-4o-mini-azure".into(),
         model_provider_name: "azure".into(),
@@ -26,6 +28,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let bad_auth_extra_headers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "azure-extra-headers".to_string(),
         model_name: "gpt-4o-mini-azure".into(),
         model_provider_name: "azure".into(),
@@ -33,6 +36,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let inference_params_dynamic_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "azure-dynamic".to_string(),
         model_name: "gpt-4o-mini-azure-dynamic".into(),
         model_provider_name: "azure".into(),
@@ -41,24 +45,28 @@ async fn get_providers() -> E2ETestProviders {
 
     let json_providers = vec![
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "azure".to_string(),
             model_name: "gpt-4o-mini-azure".into(),
             model_provider_name: "azure".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "azure-implicit".to_string(),
             model_name: "gpt-4o-mini-azure".into(),
             model_provider_name: "azure".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "azure-strict".to_string(),
             model_name: "gpt-4o-mini-azure".into(),
             model_provider_name: "azure".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "azure-default".to_string(),
             model_name: "gpt-4o-mini-azure".into(),
             model_provider_name: "azure".into(),
@@ -81,6 +89,5 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
 
         shorthand_inference: vec![],
-        supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/batch.rs
+++ b/tensorzero-internal/tests/e2e/providers/batch.rs
@@ -88,8 +88,8 @@ macro_rules! generate_batch_inference_tests {
         async fn test_start_simple_image_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.simple_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_start_simple_image_batch_inference_request_with_provider(provider).await;
                 }
             }
@@ -99,8 +99,8 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_existing_simple_image_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.simple_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_existing_simple_image_batch_inference_request_with_provider(provider).await;
                 }
             }
@@ -110,8 +110,8 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_completed_simple_image_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.simple_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_completed_simple_image_batch_inference_request_with_provider(provider).await;
                 }
             }
@@ -121,8 +121,8 @@ macro_rules! generate_batch_inference_tests {
         async fn test_start_inference_params_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.inference_params_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_start_inference_params_batch_inference_request_with_provider(provider).await;
                 }
             }
@@ -132,8 +132,8 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_existing_inference_params_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.inference_params_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_existing_inference_params_batch_inference_request_with_provider(provider).await;
                 }
             }
@@ -143,8 +143,8 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_completed_inference_params_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.inference_params_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_completed_inference_params_batch_inference_request_with_provider(provider).await;
                 }
             }
@@ -154,8 +154,8 @@ macro_rules! generate_batch_inference_tests {
         async fn test_start_tool_use_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.tool_use_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_tool_use_batch_inference_request_with_provider(provider).await;
                 }
             }
@@ -165,9 +165,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_existing_tool_choice_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.tool_use_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_existing_tool_choice_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -176,9 +177,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_completed_tool_use_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.tool_use_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_completed_tool_use_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -187,9 +189,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_start_tool_multi_turn_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.tool_multi_turn_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_tool_multi_turn_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -198,9 +201,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_existing_multi_turn_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.tool_multi_turn_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_existing_multi_turn_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -209,9 +213,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_completed_multi_turn_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.tool_multi_turn_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_completed_multi_turn_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -220,9 +225,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_start_multi_turn_parallel_tool_use_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.parallel_tool_use_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_multi_turn_parallel_tool_use_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -231,9 +237,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_existing_multi_turn_parallel_tool_use_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.parallel_tool_use_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_existing_multi_turn_parallel_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -242,9 +249,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_completed_multi_turn_parallel_tool_use_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.parallel_tool_use_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_completed_multi_turn_parallel_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -253,9 +261,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_start_dynamic_tool_use_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.dynamic_tool_use_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_dynamic_tool_use_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -264,9 +273,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_existing_dynamic_tool_use_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.dynamic_tool_use_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_existing_dynamic_tool_use_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -275,9 +285,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_completed_dynamic_tool_use_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.dynamic_tool_use_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_completed_dynamic_tool_use_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -286,9 +297,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_start_parallel_tool_use_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.parallel_tool_use_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_parallel_tool_use_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -297,9 +309,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_existing_parallel_tool_use_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.parallel_tool_use_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_existing_parallel_tool_use_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -308,9 +321,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_completed_parallel_tool_use_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.parallel_tool_use_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_completed_parallel_tool_use_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -319,9 +333,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_start_json_mode_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.json_mode_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_json_mode_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -330,9 +345,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_existing_json_mode_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.json_mode_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_existing_json_mode_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -341,9 +357,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_completed_json_mode_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.json_mode_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_completed_json_mode_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -352,9 +369,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_start_dynamic_json_mode_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.json_mode_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_dynamic_json_mode_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -363,9 +381,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_existing_dynamic_json_mode_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.json_mode_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_existing_dynamic_json_mode_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -374,9 +393,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_completed_dynamic_json_mode_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.json_mode_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_completed_dynamic_json_mode_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -385,9 +405,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_start_allowed_tools_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.tool_use_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_allowed_tools_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -396,9 +417,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_existing_allowed_tools_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.tool_use_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_existing_allowed_tools_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }
@@ -407,9 +429,10 @@ macro_rules! generate_batch_inference_tests {
         async fn test_poll_completed_allowed_tools_batch_inference_request() {
             let all_providers = $func().await;
             let providers = all_providers.tool_use_inference;
-            if all_providers.supports_batch_inference {
-                for provider in providers {
+            for provider in providers {
+                if provider.supports_batch_inference {
                     test_poll_completed_allowed_tools_batch_inference_request_with_provider(provider).await;
+
                 }
             }
         }

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -55,6 +55,8 @@ pub struct E2ETestProvider {
     pub model_provider_name: String,
 
     pub credentials: HashMap<String, String>,
+
+    pub supports_batch_inference: bool,
 }
 
 /// Enforce that every provider implements a common set of tests.
@@ -84,7 +86,6 @@ pub struct E2ETestProviders {
     pub image_inference: Vec<E2ETestProvider>,
 
     pub shorthand_inference: Vec<E2ETestProvider>,
-    pub supports_batch_inference: bool,
 }
 
 pub async fn make_http_gateway() -> tensorzero::Client {

--- a/tensorzero-internal/tests/e2e/providers/deepseek.rs
+++ b/tensorzero-internal/tests/e2e/providers/deepseek.rs
@@ -11,6 +11,7 @@ async fn get_providers() -> E2ETestProviders {
         Err(_) => HashMap::new(),
     };
     let standard_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "deepseek-chat".to_string(),
         model_name: "deepseek-chat".to_string(),
         model_provider_name: "deepseek".to_string(),
@@ -18,6 +19,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let extra_body_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "deepseek-chat-extra-body".to_string(),
         model_name: "deepseek-chat".to_string(),
         model_provider_name: "deepseek".to_string(),
@@ -25,6 +27,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let bad_auth_extra_headers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "deepseek-chat-extra-headers".to_string(),
         model_name: "deepseek-chat".to_string(),
         model_provider_name: "deepseek".to_string(),
@@ -32,6 +35,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let reasoning_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "deepseek-reasoner".to_string(),
         model_name: "deepseek-reasoner".to_string(),
         model_provider_name: "deepseek".to_string(),
@@ -39,6 +43,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let inference_params_dynamic_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "deepseek-dynamic".to_string(),
         model_name: "deepseek-chat-dynamic".to_string(),
         model_provider_name: "deepseek".to_string(),
@@ -47,12 +52,14 @@ async fn get_providers() -> E2ETestProviders {
 
     let json_providers = vec![
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "deepseek-chat".to_string(),
             model_name: "deepseek-chat".to_string(),
             model_provider_name: "deepseek".to_string(),
             credentials: credentials.clone(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "deepseek-chat-default".to_string(),
             model_name: "deepseek-chat".to_string(),
             model_provider_name: "deepseek".to_string(),
@@ -61,6 +68,7 @@ async fn get_providers() -> E2ETestProviders {
     ];
 
     let shorthand_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "deepseek-shorthand".to_string(),
         model_name: "deepseek::deepseek-chat".to_string(),
         model_provider_name: "deepseek".to_string(),
@@ -82,6 +90,5 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
 
         shorthand_inference: shorthand_providers.clone(),
-        supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/fireworks.rs
+++ b/tensorzero-internal/tests/e2e/providers/fireworks.rs
@@ -12,6 +12,7 @@ async fn get_providers() -> E2ETestProviders {
     };
 
     let providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "fireworks".to_string(),
         model_name: "qwen2p5-72b-instruct".into(),
         model_provider_name: "fireworks".into(),
@@ -19,6 +20,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let extra_body_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "fireworks-extra-body".to_string(),
         model_name: "qwen2p5-72b-instruct".into(),
         model_provider_name: "fireworks".into(),
@@ -26,6 +28,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let bad_auth_extra_headers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "fireworks-extra-headers".to_string(),
         model_name: "qwen2p5-72b-instruct".into(),
         model_provider_name: "fireworks".into(),
@@ -33,6 +36,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let inference_params_dynamic_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "fireworks-dynamic".to_string(),
         model_name: "llama3.3-70b-instruct-fireworks-dynamic".into(),
         model_provider_name: "fireworks".into(),
@@ -40,6 +44,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let tool_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "fireworks".to_string(),
         model_name: "qwen2p5-72b-instruct".into(),
         model_provider_name: "fireworks".into(),
@@ -48,18 +53,21 @@ async fn get_providers() -> E2ETestProviders {
 
     let json_providers = vec![
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "fireworks".to_string(),
             model_name: "llama3.3-70b-instruct-fireworks".into(),
             model_provider_name: "fireworks".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "fireworks-implicit".to_string(),
             model_name: "qwen2p5-72b-instruct".into(),
             model_provider_name: "fireworks".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "fireworks-default".to_string(),
             model_name: "llama3.3-70b-instruct-fireworks".into(),
             model_provider_name: "fireworks".into(),
@@ -68,6 +76,7 @@ async fn get_providers() -> E2ETestProviders {
     ];
 
     let shorthand_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "fireworks-shorthand".to_string(),
         model_name: "fireworks::accounts/fireworks/models/llama-v3p1-8b-instruct".into(),
         model_provider_name: "fireworks".into(),
@@ -75,6 +84,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let thinking_block_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "fireworks-deepseek".to_string(),
         model_name: "deepseek-r1".into(),
         model_provider_name: "fireworks".into(),
@@ -96,6 +106,5 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
 
         shorthand_inference: shorthand_providers,
-        supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/tests/e2e/providers/gcp_vertex_anthropic.rs
@@ -7,6 +7,7 @@ crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
     let standard_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "gcp-vertex-haiku".to_string(),
         model_name: "claude-3-haiku-20240307-gcp-vertex".into(),
         model_provider_name: "gcp_vertex_anthropic".into(),
@@ -14,6 +15,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let image_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "gcp-vertex-haiku".to_string(),
         model_name: "claude-3-haiku-20240307-gcp-vertex".into(),
         model_provider_name: "gcp_vertex_anthropic".into(),
@@ -21,6 +23,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let extra_body_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "gcp-vertex-haiku-extra-body".to_string(),
         model_name: "claude-3-haiku-20240307-gcp-vertex".into(),
         model_provider_name: "gcp_vertex_anthropic".into(),
@@ -28,6 +31,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let bad_auth_extra_headers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "gcp-vertex-haiku-extra-headers".to_string(),
         model_name: "claude-3-haiku-20240307-gcp-vertex".into(),
         model_provider_name: "gcp_vertex_anthropic".into(),
@@ -36,18 +40,21 @@ async fn get_providers() -> E2ETestProviders {
 
     let json_providers = vec![
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "gcp-vertex-haiku".to_string(),
             model_name: "claude-3-haiku-20240307-gcp-vertex".into(),
             model_provider_name: "gcp_vertex_anthropic".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "gcp-vertex-haiku-implicit".to_string(),
             model_name: "claude-3-haiku-20240307-gcp-vertex".into(),
             model_provider_name: "gcp_vertex_anthropic".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "gcp-vertex-haiku-default".to_string(),
             model_name: "claude-3-haiku-20240307-gcp-vertex".into(),
             model_provider_name: "gcp_vertex_anthropic".into(),
@@ -70,6 +77,5 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: image_providers,
 
         shorthand_inference: vec![],
-        supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/tests/e2e/providers/gcp_vertex_gemini.rs
@@ -8,12 +8,14 @@ crate::generate_batch_inference_tests!(get_providers);
 async fn get_providers() -> E2ETestProviders {
     let standard_providers = vec![
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "gcp-vertex-gemini-flash".to_string(),
             model_name: "gemini-2.0-flash-001".into(),
             model_provider_name: "gcp_vertex_gemini".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "gcp-vertex-gemini-pro".to_string(),
             model_name: "gemini-1.5-pro-001".into(),
             model_provider_name: "gcp_vertex_gemini".into(),
@@ -22,6 +24,7 @@ async fn get_providers() -> E2ETestProviders {
     ];
 
     let image_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "gcp_vertex".to_string(),
         model_name: "gemini-1.5-pro-001".into(),
         model_provider_name: "gcp_vertex_gemini".into(),
@@ -29,6 +32,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let extra_body_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "gcp-vertex-gemini-flash-extra-body".to_string(),
         model_name: "gemini-2.0-flash-001".into(),
         model_provider_name: "gcp_vertex_gemini".into(),
@@ -36,6 +40,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let bad_auth_extra_headers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "gcp-vertex-gemini-flash-extra-headers".to_string(),
         model_name: "gemini-2.0-flash-001".into(),
         model_provider_name: "gcp_vertex_gemini".into(),
@@ -44,24 +49,28 @@ async fn get_providers() -> E2ETestProviders {
 
     let json_providers = vec![
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "gcp-vertex-gemini-flash".to_string(),
             model_name: "gemini-2.0-flash-001".into(),
             model_provider_name: "gcp_vertex_gemini".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "gcp-vertex-gemini-pro".to_string(),
             model_name: "gemini-1.5-pro-001".into(),
             model_provider_name: "gcp_vertex_gemini".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "gcp-vertex-gemini-pro-implicit".to_string(),
             model_name: "gemini-1.5-pro-001".into(),
             model_provider_name: "gcp_vertex_gemini".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "gcp-vertex-gemini-flash-default".to_string(),
             model_name: "gemini-2.0-flash-001".into(),
             model_provider_name: "gcp_vertex_gemini".into(),
@@ -84,6 +93,5 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: image_providers,
 
         shorthand_inference: vec![],
-        supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-internal/tests/e2e/providers/google_ai_studio_gemini.rs
@@ -13,12 +13,14 @@ async fn get_providers() -> E2ETestProviders {
 
     let standard_providers = vec![
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "google-ai-studio-gemini-flash-8b".to_string(),
             model_name: "gemini-2.0-flash-lite".into(),
             model_provider_name: "google_ai_studio_gemini".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "google-ai-studio-gemini-pro-002".to_string(),
             model_name: "gemini-1.5-pro-002".into(),
             model_provider_name: "google_ai_studio_gemini".into(),
@@ -27,12 +29,14 @@ async fn get_providers() -> E2ETestProviders {
     ];
 
     let image_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "google_ai_studio".to_string(),
         model_name: "google_ai_studio_gemini::gemini-2.0-flash-lite".into(),
         model_provider_name: "google_ai_studio_gemini".into(),
         credentials: HashMap::new(),
     }];
     let extra_body_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "google-ai-studio-gemini-flash-8b-extra-body".to_string(),
         model_name: "gemini-2.0-flash-lite".into(),
         model_provider_name: "google_ai_studio_gemini".into(),
@@ -40,6 +44,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let bad_auth_extra_headers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "google-ai-studio-gemini-flash-8b-extra-headers".to_string(),
         model_name: "gemini-2.0-flash-lite".into(),
         model_provider_name: "google_ai_studio_gemini".into(),
@@ -48,12 +53,14 @@ async fn get_providers() -> E2ETestProviders {
 
     let inference_params_dynamic_providers = vec![
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "google-ai-studio-gemini-flash-8b-dynamic".to_string(),
             model_name: "gemini-2.0-flash-lite-dynamic".into(),
             model_provider_name: "google_ai_studio_gemini".into(),
             credentials: credentials.clone(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "google-ai-studio-gemini-pro-002-dynamic".to_string(),
             model_name: "gemini-1.5-pro-002-dynamic".into(),
             model_provider_name: "google_ai_studio_gemini".into(),
@@ -62,6 +69,7 @@ async fn get_providers() -> E2ETestProviders {
     ];
 
     let tool_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "google-ai-studio-gemini-flash-8b".to_string(),
         model_name: "gemini-2.0-flash-lite".into(),
         model_provider_name: "google_ai_studio_gemini".into(),
@@ -70,30 +78,35 @@ async fn get_providers() -> E2ETestProviders {
 
     let json_providers = vec![
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "google-ai-studio-gemini-flash-8b".to_string(),
             model_name: "gemini-2.0-flash-lite".into(),
             model_provider_name: "google_ai_studio_gemini".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "google-ai-studio-gemini-flash-8b-implicit".to_string(),
             model_name: "gemini-2.0-flash-lite".into(),
             model_provider_name: "google_ai_studio_gemini".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "google-ai-studio-gemini-pro-002".to_string(),
             model_name: "gemini-1.5-pro-002".into(),
             model_provider_name: "google_ai_studio_gemini".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "google-ai-studio-gemini-pro-002-implicit".to_string(),
             model_name: "gemini-1.5-pro-002".into(),
             model_provider_name: "google_ai_studio_gemini".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "google-ai-studio-gemini-flash-8b-default".to_string(),
             model_name: "gemini-2.0-flash-lite".into(),
             model_provider_name: "google_ai_studio_gemini".into(),
@@ -102,6 +115,7 @@ async fn get_providers() -> E2ETestProviders {
     ];
 
     let shorthand_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "google-ai-studio-gemini-flash-8b-shorthand".to_string(),
         model_name: "google_ai_studio_gemini::gemini-2.0-flash-lite".into(),
         model_provider_name: "google_ai_studio_gemini".into(),
@@ -123,6 +137,5 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: image_providers,
 
         shorthand_inference: shorthand_providers.clone(),
-        supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/hyperbolic.rs
+++ b/tensorzero-internal/tests/e2e/providers/hyperbolic.rs
@@ -12,6 +12,7 @@ async fn get_providers() -> E2ETestProviders {
     };
 
     let standard_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "hyperbolic".to_string(),
         model_name: "meta-llama/Meta-Llama-3-70B-Instruct".into(),
         model_provider_name: "hyperbolic".into(),
@@ -19,6 +20,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let extra_body_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "hyperbolic-extra-body".to_string(),
         model_name: "meta-llama/Meta-Llama-3-70B-Instruct".into(),
         model_provider_name: "hyperbolic".into(),
@@ -26,6 +28,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let bad_auth_extra_headers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "hyperbolic-extra-headers".to_string(),
         model_name: "meta-llama/Meta-Llama-3-70B-Instruct".into(),
         model_provider_name: "hyperbolic".into(),
@@ -33,6 +36,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let inference_params_dynamic_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "hyperbolic-dynamic".to_string(),
         model_name: "meta-llama/Meta-Llama-3-70B-Instruct-dynamic".into(),
         model_provider_name: "hyperbolic".into(),
@@ -40,6 +44,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let shorthand_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "hyperbolic-shorthand".to_string(),
         model_name: "hyperbolic::meta-llama/Meta-Llama-3-70B-Instruct".into(),
         model_provider_name: "hyperbolic".into(),
@@ -61,6 +66,5 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
 
         shorthand_inference: shorthand_providers.clone(),
-        supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/mistral.rs
+++ b/tensorzero-internal/tests/e2e/providers/mistral.rs
@@ -12,6 +12,7 @@ async fn get_providers() -> E2ETestProviders {
     };
 
     let providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "mistral".to_string(),
         model_name: "open-mistral-nemo-2407".into(),
         model_provider_name: "mistral".into(),
@@ -19,6 +20,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let extra_body_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "mistral-extra-body".to_string(),
         model_name: "open-mistral-nemo-2407".into(),
         model_provider_name: "mistral".into(),
@@ -26,6 +28,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let bad_auth_extra_headers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "mistral-extra-headers".to_string(),
         model_name: "open-mistral-nemo-2407".into(),
         model_provider_name: "mistral".into(),
@@ -34,12 +37,14 @@ async fn get_providers() -> E2ETestProviders {
 
     let json_providers = vec![
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "mistral".to_string(),
             model_name: "open-mistral-nemo-2407".into(),
             model_provider_name: "mistral".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "mistral-default".to_string(),
             model_name: "open-mistral-nemo-2407".into(),
             model_provider_name: "mistral".into(),
@@ -48,6 +53,7 @@ async fn get_providers() -> E2ETestProviders {
     ];
 
     let inference_params_dynamic_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "mistral-dynamic".to_string(),
         model_name: "open-mistral-nemo-2407-dynamic".into(),
         model_provider_name: "mistral".into(),
@@ -55,6 +61,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let shorthand_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "mistral-shorthand".to_string(),
         model_name: "mistral::open-mistral-nemo-2407".into(),
         model_provider_name: "mistral".into(),
@@ -76,6 +83,5 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
 
         shorthand_inference: shorthand_providers.clone(),
-        supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/openai.rs
+++ b/tensorzero-internal/tests/e2e/providers/openai.rs
@@ -37,6 +37,7 @@ async fn get_providers() -> E2ETestProviders {
     };
 
     let standard_without_o1 = vec![E2ETestProvider {
+        supports_batch_inference: true,
         variant_name: "openai".to_string(),
         model_name: "gpt-4o-mini-2024-07-18".into(),
         model_provider_name: "openai".into(),
@@ -44,6 +45,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let extra_body_providers = vec![E2ETestProvider {
+        supports_batch_inference: true,
         variant_name: "openai-extra-body".to_string(),
         model_name: "gpt-4o-mini-2024-07-18".into(),
         model_provider_name: "openai".into(),
@@ -51,6 +53,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let bad_auth_extra_headers = vec![E2ETestProvider {
+        supports_batch_inference: true,
         variant_name: "openai-extra-headers".to_string(),
         model_name: "gpt-4o-mini-2024-07-18".into(),
         model_provider_name: "openai".into(),
@@ -59,12 +62,14 @@ async fn get_providers() -> E2ETestProviders {
 
     let standard_providers = vec![
         E2ETestProvider {
+            supports_batch_inference: true,
             variant_name: "openai".to_string(),
             model_name: "gpt-4o-mini-2024-07-18".into(),
             model_provider_name: "openai".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: true,
             variant_name: "openai-o1".to_string(),
             model_name: "o1-2024-12-17".into(),
             model_provider_name: "openai".into(),
@@ -73,6 +78,7 @@ async fn get_providers() -> E2ETestProviders {
     ];
 
     let inference_params_providers = vec![E2ETestProvider {
+        supports_batch_inference: true,
         variant_name: "openai".to_string(),
         model_name: "gpt-4o-mini-2024-07-18".into(),
         model_provider_name: "openai".into(),
@@ -80,6 +86,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let inference_params_dynamic_providers = vec![E2ETestProvider {
+        supports_batch_inference: true,
         variant_name: "openai-dynamic".to_string(),
         model_name: "gpt-4o-mini-2024-07-18-dynamic".into(),
         model_provider_name: "openai".into(),
@@ -87,6 +94,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let image_providers = vec![E2ETestProvider {
+        supports_batch_inference: true,
         variant_name: "openai".to_string(),
         model_name: "openai::gpt-4o-mini-2024-07-18".into(),
         model_provider_name: "openai".into(),
@@ -95,36 +103,42 @@ async fn get_providers() -> E2ETestProviders {
 
     let json_providers = vec![
         E2ETestProvider {
+            supports_batch_inference: true,
             variant_name: "openai".to_string(),
             model_name: "gpt-4o-mini-2024-07-18".into(),
             model_provider_name: "openai".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: true,
             variant_name: "openai-implicit".to_string(),
             model_name: "gpt-4o-mini-2024-07-18".into(),
             model_provider_name: "openai".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: true,
             variant_name: "openai-strict".to_string(),
             model_name: "gpt-4o-mini-2024-07-18".into(),
             model_provider_name: "openai".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: true,
             variant_name: "openai-o1".to_string(),
             model_name: "o1-2024-12-17".into(),
             model_provider_name: "openai".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: true,
             variant_name: "openai-default".to_string(),
             model_name: "gpt-4o-mini-2024-07-18".into(),
             model_provider_name: "openai".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: true,
             variant_name: "openai-cot".to_string(),
             model_name: "openai::gpt-4.1-nano-2025-04-14".into(),
             model_provider_name: "openai".into(),
@@ -133,6 +147,7 @@ async fn get_providers() -> E2ETestProviders {
     ];
 
     let shorthand_providers = vec![E2ETestProvider {
+        supports_batch_inference: true,
         variant_name: "openai-shorthand".to_string(),
         model_name: "openai::gpt-4o-mini-2024-07-18".into(),
         model_provider_name: "openai".into(),
@@ -154,7 +169,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: image_providers.clone(),
 
         shorthand_inference: shorthand_providers.clone(),
-        supports_batch_inference: true,
     }
 }
 
@@ -1252,6 +1266,7 @@ pub async fn test_image_inference_with_provider_cloudflare_r2() {
     std::env::set_var("S3_SECRET_ACCESS_KEY", r2_secret_access_key);
 
     let provider = E2ETestProvider {
+        supports_batch_inference: true,
         variant_name: "openai".to_string(),
         model_name: "openai::gpt-4o-mini-2024-07-18".into(),
         model_provider_name: "openai".into(),
@@ -1445,6 +1460,7 @@ pub async fn test_image_inference_with_provider_gcp_storage() {
     std::env::set_var("S3_SECRET_ACCESS_KEY", gcloud_secret_access_key);
 
     let provider = E2ETestProvider {
+        supports_batch_inference: true,
         variant_name: "openai".to_string(),
         model_name: "openai::gpt-4o-mini-2024-07-18".into(),
         model_provider_name: "openai".into(),
@@ -1517,6 +1533,7 @@ pub async fn test_image_inference_with_provider_docker_minio() {
     std::env::set_var("S3_SECRET_ACCESS_KEY", minio_secret_access_key);
 
     let provider = E2ETestProvider {
+        supports_batch_inference: true,
         variant_name: "openai".to_string(),
         model_name: "openai::gpt-4o-mini-2024-07-18".into(),
         model_provider_name: "openai".into(),
@@ -1578,6 +1595,7 @@ pub async fn test_parallel_tool_use_default_true_inference_request() {
     let episode_id = Uuid::now_v7();
 
     let provider = E2ETestProvider {
+        supports_batch_inference: true,
         variant_name: "openai".to_string(),
         model_name: "gpt-4o-mini-2024-07-18".into(),
         model_provider_name: "openai".into(),

--- a/tensorzero-internal/tests/e2e/providers/sglang.rs
+++ b/tensorzero-internal/tests/e2e/providers/sglang.rs
@@ -7,6 +7,7 @@ crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
     let standard_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "sglang".to_string(),
         model_name: "HuggingFaceTB/SmolLM-1.7B-Instruct".to_string(),
         model_provider_name: "sglang".to_string(),
@@ -14,6 +15,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let extra_body_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "sglang-extra-body".to_string(),
         model_name: "HuggingFaceTB/SmolLM-1.7B-Instruct".to_string(),
         model_provider_name: "sglang".to_string(),
@@ -21,6 +23,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let bad_auth_extra_headers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "sglang-extra-headers".to_string(),
         model_name: "HuggingFaceTB/SmolLM-1.7B-Instruct".to_string(),
         model_provider_name: "sglang".to_string(),
@@ -29,12 +32,14 @@ async fn get_providers() -> E2ETestProviders {
 
     let json_providers = vec![
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "sglang".to_string(),
             model_name: "HuggingFaceTB/SmolLM-1.7B-Instruct".to_string(),
             model_provider_name: "sglang".to_string(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "sglang-default".to_string(),
             model_name: "HuggingFaceTB/SmolLM-1.7B-Instruct".to_string(),
             model_provider_name: "sglang".to_string(),
@@ -58,6 +63,5 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
 
         shorthand_inference: vec![],
-        supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/tgi.rs
+++ b/tensorzero-internal/tests/e2e/providers/tgi.rs
@@ -7,6 +7,7 @@ crate::generate_batch_inference_tests!(get_providers);
 async fn get_providers() -> E2ETestProviders {
     let model_name = "phi-3.5-mini-instruct-tgi".to_string();
     let standard_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "tgi".to_string(),
         model_name: model_name.clone(),
         model_provider_name: "tgi".into(),
@@ -14,6 +15,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let extra_body_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "tgi-extra-body".to_string(),
         model_name: model_name.clone(),
         model_provider_name: "tgi".into(),
@@ -21,6 +23,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let bad_auth_extra_headers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "tgi-extra-headers".to_string(),
         model_name: model_name.clone(),
         model_provider_name: "tgi".into(),
@@ -28,6 +31,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let json_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "tgi-default".to_string(),
         model_name: model_name.clone(),
         model_provider_name: "tgi".into(),
@@ -49,6 +53,5 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
 
         shorthand_inference: vec![],
-        supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/together.rs
+++ b/tensorzero-internal/tests/e2e/providers/together.rs
@@ -12,6 +12,7 @@ async fn get_providers() -> E2ETestProviders {
     };
 
     let standard_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "together".to_string(),
         model_name: "llama3.1-8b-instruct-together".into(),
         model_provider_name: "together".into(),
@@ -19,6 +20,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let extra_body_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "together-extra-body".to_string(),
         model_name: "llama3.1-8b-instruct-together".into(),
         model_provider_name: "together".into(),
@@ -26,6 +28,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let bad_auth_extra_headers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "together-extra-headers".to_string(),
         model_name: "llama3.1-8b-instruct-together".into(),
         model_provider_name: "together".into(),
@@ -33,6 +36,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let inference_params_dynamic_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "together-dynamic".to_string(),
         model_name: "llama3.1-8b-instruct-together-dynamic".into(),
         model_provider_name: "together".into(),
@@ -41,12 +45,14 @@ async fn get_providers() -> E2ETestProviders {
 
     let json_providers = vec![
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "together".to_string(),
             model_name: "llama3.1-8b-instruct-together".into(),
             model_provider_name: "together".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "together-default".to_string(),
             model_name: "llama3.1-8b-instruct-together".into(),
             model_provider_name: "together".into(),
@@ -55,6 +61,7 @@ async fn get_providers() -> E2ETestProviders {
     ];
 
     let tool_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "together-tool".to_string(),
         model_name: "llama3.1-405b-instruct-turbo-together".into(),
         model_provider_name: "together".into(),
@@ -62,6 +69,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let reasoning_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "together-deepseek-r1".to_string(),
         model_name: "together-deepseek-r1".to_string(),
         model_provider_name: "together".to_string(),
@@ -69,6 +77,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let shorthand_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "together-shorthand".to_string(),
         model_name: "together::meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo".into(),
         model_provider_name: "together".into(),
@@ -90,6 +99,5 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
 
         shorthand_inference: shorthand_providers.clone(),
-        supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/vllm.rs
+++ b/tensorzero-internal/tests/e2e/providers/vllm.rs
@@ -12,6 +12,7 @@ async fn get_providers() -> E2ETestProviders {
     };
 
     let providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "vllm".to_string(),
         model_name: "microsoft/Phi-3.5-mini-instruct".into(),
         model_provider_name: "vllm".into(),
@@ -19,6 +20,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let extra_body_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "vllm-extra-body".to_string(),
         model_name: "microsoft/Phi-3.5-mini-instruct".into(),
         model_provider_name: "vllm".into(),
@@ -26,6 +28,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let bad_auth_extra_headers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "vllm-extra-headers".to_string(),
         model_name: "microsoft/Phi-3.5-mini-instruct".into(),
         model_provider_name: "vllm".into(),
@@ -34,12 +37,14 @@ async fn get_providers() -> E2ETestProviders {
 
     let json_providers = vec![
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "vllm-default".to_string(),
             model_name: "microsoft/Phi-3.5-mini-instruct".into(),
             model_provider_name: "vllm".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "vllm-default".to_string(),
             model_name: "microsoft/Phi-3.5-mini-instruct".into(),
             model_provider_name: "vllm".into(),
@@ -48,6 +53,7 @@ async fn get_providers() -> E2ETestProviders {
     ];
 
     let inference_params_dynamic_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "vllm-dynamic".to_string(),
         model_name: "microsoft/Phi-3.5-mini-instruct-dynamic".into(),
         model_provider_name: "vllm".into(),
@@ -70,6 +76,5 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
 
         shorthand_inference: vec![],
-        supports_batch_inference: false,
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/xai.rs
+++ b/tensorzero-internal/tests/e2e/providers/xai.rs
@@ -12,6 +12,7 @@ async fn get_providers() -> E2ETestProviders {
     };
 
     let standard_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "xai".to_string(),
         model_name: "grok_2_1212".into(),
         model_provider_name: "xai".into(),
@@ -19,6 +20,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let extra_body_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "xai-extra-body".to_string(),
         model_name: "grok_2_1212".into(),
         model_provider_name: "xai".into(),
@@ -26,6 +28,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let bad_auth_extra_headers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "xai-extra-headers".to_string(),
         model_name: "grok_2_1212".into(),
         model_provider_name: "xai".into(),
@@ -34,18 +37,21 @@ async fn get_providers() -> E2ETestProviders {
 
     let json_providers = vec![
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "xai".to_string(),
             model_name: "grok_2_1212".into(),
             model_provider_name: "xai".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "xai-default".to_string(),
             model_name: "grok_2_1212".into(),
             model_provider_name: "xai".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
+            supports_batch_inference: false,
             variant_name: "xai-strict".to_string(),
             model_name: "grok_2_1212".into(),
             model_provider_name: "xai".into(),
@@ -53,6 +59,7 @@ async fn get_providers() -> E2ETestProviders {
         },
     ];
     let inference_params_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "xai".to_string(),
         model_name: "grok_2_1212".into(),
         model_provider_name: "xai".into(),
@@ -60,6 +67,7 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let shorthand_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
         variant_name: "xai-shorthand".to_string(),
         model_name: "xai::grok-2-1212".into(),
         model_provider_name: "xai".into(),
@@ -81,6 +89,5 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
 
         shorthand_inference: shorthand_providers.clone(),
-        supports_batch_inference: false,
     }
 }


### PR DESCRIPTION
We now configure `supports_batch_inference` for each individual provider, rather for than an entire provider type. This will let us run batch tests against Gemini 2.0 models (and skip running them against Gemini 1.5, which doesn't support batch)

This commit is a pure refactor, with no behavior changes

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `supports_batch_inference` to be configured per `E2ETestProvider` instead of globally, allowing specific batch inference support for individual models.
> 
>   - **Configuration Refactor**:
>     - Moves `supports_batch_inference` from a global setting in `E2ETestProviders` to individual `E2ETestProvider` instances.
>     - Allows specific configuration for each provider, enabling batch inference for some models (e.g., Gemini 2.0) while disabling it for others (e.g., Gemini 1.5).
>   - **Code Changes**:
>     - Updates `supports_batch_inference` in `E2ETestProvider` instances across multiple files, including `anthropic.rs`, `aws_bedrock.rs`, and `openai.rs`.
>     - Removes `supports_batch_inference` from `E2ETestProviders` struct in `common.rs`.
>     - Modifies batch inference test logic in `batch.rs` to check `supports_batch_inference` per provider instead of globally.
>   - **No Behavior Change**:
>     - This is a pure refactor with no changes to existing behavior or functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0d875fe2187bb5b2cb4bfa1ef3b9a659fe3dfc67. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->