### PR TITLE
Fix tests on ClickHouse 25.4

### DIFF
--- a/tensorzero-internal/tests/e2e/clickhouse-configs/latest-alpine/users.xml
+++ b/tensorzero-internal/tests/e2e/clickhouse-configs/latest-alpine/users.xml
@@ -1,0 +1,9 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <!-- Disable this check by setting min and max to the same value, as we intentionally generate lots of load in `test_concurrent_clickhouse_migrations` -->
+            <min_os_cpu_wait_time_ratio_to_throw>2</min_os_cpu_wait_time_ratio_to_throw>
+            <max_os_cpu_wait_time_ratio_to_throw>2</max_os_cpu_wait_time_ratio_to_throw>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tensorzero-internal/tests/e2e/clickhouse-users.xml
+++ b/tensorzero-internal/tests/e2e/clickhouse-users.xml
@@ -1,9 +1,0 @@
-<clickhouse>
-<profiles>
-    <default>
-        <!-- Disable this check by setting min and max to the same value, as we intentionally generate lots of load in `test_concurrent_clickhouse_migrations` -->
-        <min_os_cpu_wait_time_ratio_to_throw>2</min_os_cpu_wait_time_ratio_to_throw>
-        <max_os_cpu_wait_time_ratio_to_throw>2</max_os_cpu_wait_time_ratio_to_throw>
-    </default>
-</profiles>
-</clickhouse>

--- a/tensorzero-internal/tests/e2e/clickhouse-users.xml
+++ b/tensorzero-internal/tests/e2e/clickhouse-users.xml
@@ -1,0 +1,9 @@
+<clickhouse>
+<profiles>
+    <default>
+        <!-- Disable this check by setting min and max to the same value, as we intentionally generate lots of load in `test_concurrent_clickhouse_migrations` -->
+        <min_os_cpu_wait_time_ratio_to_throw>2</min_os_cpu_wait_time_ratio_to_throw>
+        <max_os_cpu_wait_time_ratio_to_throw>2</max_os_cpu_wait_time_ratio_to_throw>
+    </default>
+</profiles>
+</clickhouse>

--- a/tensorzero-internal/tests/e2e/clickhouse.rs
+++ b/tensorzero-internal/tests/e2e/clickhouse.rs
@@ -246,9 +246,11 @@ async fn test_bad_clickhouse_write() {
         .write(&[payload], "BooleanMetricFeedback")
         .await
         .unwrap_err();
-    assert!(err
-        .to_string()
-        .contains("Unknown field found while parsing JSONEachRow format: name"));
+    assert!(
+        err.to_string()
+            .contains("Unknown field found while parsing JSONEachRow format: name"),
+        "Unexpected error: {err}"
+    );
 }
 
 #[tokio::test]
@@ -343,9 +345,11 @@ async fn test_migration_0013_old_table() {
     })
     .await
     .unwrap_err();
-    assert!(err
-        .to_string()
-        .contains("InferenceById table is in an invalid state. Please contact TensorZero team."));
+    assert!(
+        err.to_string().contains("InferenceById table is in an invalid state. Please contact TensorZero team.") ||
+        err.to_string().contains("SELECT query outputs column with name 'id_uint', which is not found in the target table."),
+        "Unexpected error: {err}",
+    );
 }
 
 /// For this test, we will run all the migrations up to 0011, add some data to

--- a/tensorzero-internal/tests/e2e/docker-compose.yml
+++ b/tensorzero-internal/tests/e2e/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       - CLICKHOUSE_USER=chuser
       - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
       - CLICKHOUSE_PASSWORD=chpassword
+    volumes:
+      - ./clickhouse-users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "8123:8123" # HTTP port
       - "9000:9000" # Native port

--- a/tensorzero-internal/tests/e2e/docker-compose.yml
+++ b/tensorzero-internal/tests/e2e/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     # If the directory doesn't exist locally (i.e. we haven't defined a version-specific config),
     # an empty dir will get mounted in the container
       - ./clickhouse-configs/${TENSORZERO_CLICKHOUSE_VERSION:-24.12-alpine}/users.xml:/etc/clickhouse-server/users.d/users.xml
-      - ./logs:/var/log/clickhouse-server/
     ports:
       - "8123:8123" # HTTP port
       - "9000:9000" # Native port

--- a/tensorzero-internal/tests/e2e/docker-compose.yml
+++ b/tensorzero-internal/tests/e2e/docker-compose.yml
@@ -6,7 +6,10 @@ services:
       - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
       - CLICKHOUSE_PASSWORD=chpassword
     volumes:
-      - ./clickhouse-users.xml:/etc/clickhouse-server/users.d/users.xml
+    # If the directory doesn't exist locally (i.e. we haven't defined a version-specific config),
+    # an empty dir will get mounted in the container
+      - ./clickhouse-configs/${TENSORZERO_CLICKHOUSE_VERSION:-24.12-alpine}/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./logs:/var/log/clickhouse-server/
     ports:
       - "8123:8123" # HTTP port
       - "9000:9000" # Native port


### PR DESCRIPTION
ClickHouse 25.4 has a new setting which rejects queries when the CPU is overloaded. We turn this off when running our e2e tests, as we intentionally generate high load in
'test_concurrent_clickhouse_migrations'

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Disable CPU overload rejection in ClickHouse 25.4 for e2e tests by configuring `users.xml` and updating test assertions.
> 
>   - **Configuration**:
>     - Add `users.xml` in `clickhouse-configs/latest-alpine` to set `min_os_cpu_wait_time_ratio_to_throw` and `max_os_cpu_wait_time_ratio_to_throw` to 2, disabling CPU overload rejection.
>     - Update `docker-compose.yml` to mount version-specific `users.xml` for ClickHouse configuration.
>   - **Tests**:
>     - Modify assertions in `test_bad_clickhouse_write()` and `test_migration_0013_old_table()` in `clickhouse.rs` to include error message checks for unexpected errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4befa47ec827007e3dcca26ec1fc2f15ce294309. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->