### PR TITLE
Remove nextest test-group for xAI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -27,7 +27,6 @@ retries = { backoff = "exponential", count = 8, delay = "5s", jitter = true, max
 [test-groups]
 e2e_aws_bedrock = { max-threads = 1 }
 e2e_fireworks = { max-threads = 1 }
-e2e_xai = { max-threads = 1 }
 # Our Sagemaker instance seems to be able to handle 2 concurrent requests
 e2e_aws_sagemaker = { max-threads = 2 }
 
@@ -42,10 +41,6 @@ test-group = 'e2e_aws_sagemaker'
 [[profile.default.overrides]]
 filter = 'binary(e2e) and test(providers::fireworks::)'
 test-group = 'e2e_fireworks'
-
-[[profile.default.overrides]]
-filter = 'binary(e2e) and test(providers::xai::)'
-test-group = 'e2e_xai'
 
 [[profile.default.overrides]]
 filter = 'test(test_concurrent_clickhouse_migrations)'


### PR DESCRIPTION
The combination of our provider-proxy cache and the higher rate limits for grok-2 is enough to have these tests pass consistently without explicit throttling.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `e2e_xai` test group from `.config/nextest.toml` as existing infrastructure suffices without explicit throttling.
> 
>   - **Configuration Changes**:
>     - Remove `e2e_xai` test group from `.config/nextest.toml`.
>     - Delete `profile.default.overrides` for `e2e_xai` in `.config/nextest.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f27ad7dca00d75192dd13a7a0cd48b0dcc9562d8. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->