### PR TITLE
Allow CI to fail for ClickHouse 'latest-alpine'

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -303,6 +303,9 @@ jobs:
             allow_failure: false
           - tag: "latest-alpine"
             prefix: ""
+            # ClickHouse can make new releases at any time, which might break our tests.
+            # We allow this job to fail to avoid blocking CI whenever this happens.
+            # However, we'll still want to fix the failing tests soon after we notice the failure
             allow_failure: true
 
     steps:
@@ -375,6 +378,9 @@ jobs:
           - tag: "25.2-alpine"
             allow_failure: false
           - tag: "latest-alpine"
+            # ClickHouse can make new releases at any time, which might break our tests.
+            # We allow this job to fail to avoid blocking CI whenever this happens.
+            # However, we'll still want to fix the failing tests soon after we notice the failure
             allow_failure: true
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -291,15 +291,19 @@ jobs:
     # to avoid unnecessarily using Namespace credits (it should still always finish before
     # the main 'validate' job)
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.clickhouse_version.allow_failure }}
     strategy:
       matrix:
         clickhouse_version:
           - tag: "24.12-alpine"
             prefix: "24.12"
+            allow_failure: false
           - tag: "25.2-alpine"
             prefix: "25.2"
+            allow_failure: false
           - tag: "latest-alpine"
             prefix: ""
+            allow_failure: true
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -362,9 +366,16 @@ jobs:
       contents: read
       # Permission to fetch GitHub OIDC token authentication
       id-token: write
+    continue-on-error: ${{ matrix.clickhouse_version.allow_failure }}
     strategy:
       matrix:
-        clickhouse_version: ["24.12-alpine", "25.2-alpine", "latest-alpine"]
+        clickhouse_version:
+          - tag: "24.12-alpine"
+            allow_failure: false
+          - tag: "25.2-alpine"
+            allow_failure: false
+          - tag: "latest-alpine"
+            allow_failure: true
     steps:
       - uses: actions/checkout@v4
 
@@ -407,7 +418,7 @@ jobs:
           echo "FIREWORKS_API_KEY=not_used" >> fixtures/.env
           echo "FIREWORKS_ACCOUNT_ID=not_used" >> fixtures/.env
           echo "TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@localhost:8123/tensorzero_ui_fixtures" >> fixtures/.env
-          TENSORZERO_CLICKHOUSE_VERSION=${{ matrix.clickhouse_version }} docker compose -f fixtures/docker-compose.yml up -d --build --force-recreate --wait
+          TENSORZERO_CLICKHOUSE_VERSION=${{ matrix.clickhouse_version.tag }} docker compose -f fixtures/docker-compose.yml up -d --build --force-recreate --wait
 
       - name: Run ui tests
         working-directory: ui


### PR DESCRIPTION
This will alert us to issues with a new ClickHouse release, without blocking CI whenever ClickHouse makes a breaking release

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Allow CI failures for 'latest-alpine' ClickHouse version in `general.yml` to handle potential breaking changes without blocking CI.
> 
>   - **CI Workflow**:
>     - In `.github/workflows/general.yml`, allow failures for `clickhouse_version: latest-alpine` in `clickhouse-tests`, `ui-tests`, and `ui-tests-e2e` jobs.
>     - Adds `allow_failure: true` for `latest-alpine` to handle potential breaking changes in new ClickHouse releases without blocking CI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 94a69f4721158e1de9b22d6d7ed991fad62b0fe3. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->