### PR TITLE
serialize tool results to GCP as strings not JSONs

### DIFF
--- a/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
@@ -556,8 +556,6 @@ impl<'a> TryFrom<&'a ContentBlock> for Option<FlattenUnknown<'a, GCPVertexGemini
                 GCPVertexGeminiContentPart::Text { text },
             ))),
             ContentBlock::ToolResult(tool_result) => {
-                // let response = convert_tool_result_to_json_object(tool_result);
-
                 // GCP expects the format below according to [the documentation](https://ai.google.dev/gemini-api/docs/function-calling#multi-turn-example-1)
                 let response = serde_json::json!({
                     "name": tool_result.name,

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
@@ -9,7 +9,7 @@ use reqwest::StatusCode;
 use reqwest_eventsource::{Event, EventSource, RequestBuilderExt};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Map, Value};
+use serde_json::{json, Value};
 use tokio::time::Instant;
 use uuid::Uuid;
 
@@ -549,13 +549,11 @@ enum GCPVertexGeminiContentPart<'a> {
 
 /// Since GCP expects a JSON object, we need to convert the tool result from String to JSON Object
 /// If it doesn't parse as an object, we wrap the result in a JSON object ourselves
-pub(crate) fn convert_tool_result_to_json_object(tool_result: &ToolResult) -> Map<String, Value> {
+pub(crate) fn convert_tool_result_to_json_object(tool_result: &ToolResult) -> Value {
     match serde_json::from_str(&tool_result.result) {
         Ok(response) => response,
         Err(_) => {
-            let mut map = Map::new();
-            map.insert("response".to_string(), json!(tool_result.result));
-            map
+            json!(tool_result.result)
         }
     }
 }


### PR DESCRIPTION
We were previously attempting to parse tool results as JSON and sending that but it turns out GCP will accept any string so we should just send it as a  string and not parse. 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Change tool result serialization to send as strings instead of JSON objects in `gcp_vertex_gemini.rs` and `google_ai_studio_gemini.rs`.
> 
>   - **Behavior**:
>     - Change tool result serialization in `gcp_vertex_gemini.rs` and `google_ai_studio_gemini.rs` to send as strings instead of JSON objects.
>     - Removes JSON parsing of tool results, directly using the string content.
>   - **Tests**:
>     - Update tests in `gcp_vertex_gemini.rs` and `google_ai_studio_gemini.rs` to reflect string serialization of tool results.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 61404a7f3fbb302643f6dd827b216b4e025a2d65. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->