### PR TITLE
Use 'us' prefix for AWS model names in e2e tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -25,7 +25,7 @@ retries = { backoff = "exponential", count = 8, delay = "5s", jitter = true, max
 
 # Run E2E provider tests sequentially to avoid rate limits
 [test-groups]
-e2e_aws_bedrock = { max-threads = 1 }
+e2e_aws_bedrock = { max-threads = 2 }
 e2e_fireworks = { max-threads = 1 }
 # Our Sagemaker instance seems to be able to handle 2 concurrent requests
 e2e_aws_sagemaker = { max-threads = 2 }

--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -105,7 +105,7 @@ model_name = "claude-3-haiku-20240307"
 
 [models.claude-3-haiku-20240307.providers.aws_bedrock]
 type = "aws_bedrock"
-model_id = "anthropic.claude-3-haiku-20240307-v1:0"
+model_id = "us.anthropic.claude-3-haiku-20240307-v1:0"
 region = "us-east-1"
 
 [models.claude-3-haiku-20240307-us-east-1]
@@ -113,7 +113,7 @@ routing = ["aws-bedrock-us-east-1"]
 
 [models.claude-3-haiku-20240307-us-east-1.providers.aws-bedrock-us-east-1]
 type = "aws_bedrock"
-model_id = "anthropic.claude-3-haiku-20240307-v1:0"
+model_id = "us.anthropic.claude-3-haiku-20240307-v1:0"
 region = "us-east-1"
 
 [models.claude-3-haiku-20240307-uk-hogwarts-1]
@@ -146,7 +146,7 @@ routing = ["aws_bedrock"]
 
 [models.claude-3-haiku-20240307-aws-bedrock.providers.aws_bedrock]
 type = "aws_bedrock"
-model_id = "anthropic.claude-3-haiku-20240307-v1:0"
+model_id = "us.anthropic.claude-3-haiku-20240307-v1:0"
 region = "us-east-1"
 
 [models.gemma-3-1b-aws-sagemaker]


### PR DESCRIPTION
This distributes our queries across multiple regions, giving us a higher total quota.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds 'us' prefix to AWS model names in e2e tests and increases concurrency for AWS Bedrock tests.
> 
>   - **Behavior**:
>     - Adds 'us' prefix to AWS model names in `tensorzero.toml` to distribute queries across regions.
>     - Increases `max-threads` for `e2e_aws_bedrock` in `.config/nextest.toml` from 1 to 2.
>   - **Models**:
>     - Updates `model_id` for `claude-3-haiku-20240307` in `tensorzero.toml` to `us.anthropic.claude-3-haiku-20240307-v1:0`.
>     - Similar update for `claude-3-haiku-20240307-us-east-1` and `claude-3-haiku-20240307-aws-bedrock`.
>   - **Misc**:
>     - No changes to support for other regions or providers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c93002ba26226942408b9e90d90aaddd09db5f07. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->