### PR TITLE
Only log JsonSchemaValidation data in debug mode

### DIFF
--- a/tensorzero-internal/src/error.rs
+++ b/tensorzero-internal/src/error.rs
@@ -765,11 +765,14 @@ impl std::fmt::Display for ErrorDetails {
                 schema,
             } => {
                 write!(f, "JSON Schema validation failed:\n{}", messages.join("\n"))?;
-                write!(
-                    f,
-                    "\n\nData:\n{}",
-                    serde_json::to_string(data).map_err(|_| std::fmt::Error)?
-                )?;
+                // `debug` defaults to false so we don't log data by default
+                if *DEBUG.get().unwrap_or(&false) {
+                    write!(
+                        f,
+                        "\n\nData:\n{}",
+                        serde_json::to_string(data).map_err(|_| std::fmt::Error)?
+                    )?;
+                }
                 write!(
                     f,
                     "\n\nSchema:\n{}",


### PR DESCRIPTION
This prevents demonstration data from getting logged by default.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
