### PR TITLE
Remove a usage of string 'ToolCall.arguments' in test input

### DIFF
--- a/tensorzero-internal/tests/e2e/providers/batch.rs
+++ b/tensorzero-internal/tests/e2e/providers/batch.rs
@@ -2399,13 +2399,13 @@ pub async fn test_multi_turn_parallel_tool_use_batch_inference_request_with_prov
             "content": [
               {
                 "type": "tool_call",
-                "arguments": "{\"location\":\"Tokyo\",\"units\":\"fahrenheit\"}",
+                "arguments": {"location":"Tokyo","units":"fahrenheit"},
                 "id": "1234",
                 "name": "get_temperature"
               },
               {
                 "type": "tool_call",
-                "arguments": "{\"location\":\"Tokyo\"}",
+                "arguments": {"location":"Tokyo"},
                 "id": "5678",
                 "name": "get_humidity"
               }

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -6758,7 +6758,7 @@ pub async fn test_tool_multi_turn_inference_request_with_provider(provider: E2ET
                             "type": "tool_call",
                             "id": "123456789",
                             "name": "get_temperature",
-                            "arguments": "{\"location\": \"Tokyo\", \"units\": \"celsius\"}"
+                            "arguments": {"location": "Tokyo", "units": "celsius"}
                         }
                     ]
                 },
@@ -6864,7 +6864,7 @@ pub async fn check_tool_use_multi_turn_inference_response(
             },
             {
                 "role": "assistant",
-                "content": [{"type": "tool_call", "id": "123456789", "name": "get_temperature", "arguments": "{\"location\": \"Tokyo\", \"units\": \"celsius\"}"}]
+                "content": [{"type": "tool_call", "id": "123456789", "name": "get_temperature", "arguments": "{\"location\":\"Tokyo\",\"units\":\"celsius\"}"}]
             },
             {
                 "role": "user",
@@ -6982,7 +6982,7 @@ pub async fn check_tool_use_multi_turn_inference_response(
             content: vec![ContentBlock::ToolCall(ToolCall {
                 id: "123456789".to_string(),
                 name: "get_temperature".to_string(),
-                arguments: "{\"location\": \"Tokyo\", \"units\": \"celsius\"}".to_string(),
+                arguments: "{\"location\":\"Tokyo\",\"units\":\"celsius\"}".to_string(),
             })],
         },
         RequestMessage {


### PR DESCRIPTION
This fixes some deprecation warnings

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `arguments` from string to JSON object in test functions to fix deprecation warnings.
> 
>   - **Behavior**:
>     - Change `arguments` from string to JSON object in `test_multi_turn_parallel_tool_use_batch_inference_request_with_prov` in `batch.rs`.
>     - Change `arguments` from string to JSON object in `test_tool_multi_turn_inference_request_with_provider` and `check_tool_use_multi_turn_inference_response` in `common.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5e99d5d4816fe32ad549b2bf70c69a15d1aec01a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->