### PR TITLE
Test that all OpenAI fields are included in OpenAI-compatible response

### DIFF
--- a/tensorzero-internal/src/endpoints/openai_compatible.rs
+++ b/tensorzero-internal/src/endpoints/openai_compatible.rs
@@ -307,6 +307,7 @@ struct OpenAICompatibleResponse {
     created: u32,
     model: String,
     system_fingerprint: String,
+    service_tier: String,
     object: String,
     usage: OpenAICompatibleUsage,
 }
@@ -759,6 +760,7 @@ impl From<(InferenceResponse, String)> for OpenAICompatibleResponse {
                     }],
                     created: current_timestamp() as u32,
                     model: format!("{response_model_prefix}{}", response.variant_name),
+                    service_tier: "".to_string(),
                     system_fingerprint: "".to_string(),
                     object: "chat.completion".to_string(),
                     usage: response.usage.into(),
@@ -779,6 +781,7 @@ impl From<(InferenceResponse, String)> for OpenAICompatibleResponse {
                 created: current_timestamp() as u32,
                 model: format!("{response_model_prefix}{}", response.variant_name),
                 system_fingerprint: "".to_string(),
+                service_tier: "".to_string(),
                 object: "chat.completion".to_string(),
                 usage: OpenAICompatibleUsage {
                     prompt_tokens: response.usage.input_tokens,


### PR DESCRIPTION
We return extra fields (e.g. 'episode_id'), so we don't check for strict equality.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add test to ensure all OpenAI-required fields are present in responses, even with extra fields.
> 
>   - **Tests**:
>     - Add `test_openai_compatible_matches_response_fields` in `openai_compatible.rs` to ensure all OpenAI-required fields are present in the response, even with extra fields like `episode_id`.
>   - **Structs**:
>     - Add `service_tier` field to `OpenAICompatibleResponse` in `openai_compatible.rs`.
>     - Initialize `service_tier` as an empty string in `From<(InferenceResponse, String)>` for `OpenAICompatibleResponse` in `openai_compatible.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 89d4f6df4a4b026732b13396906182107e0aa994. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->