### PR TITLE
Minor button enhancements to standardize icons

### DIFF
--- a/ui/app/components/feedback/HumanFeedbackButton.tsx
+++ b/ui/app/components/feedback/HumanFeedbackButton.tsx
@@ -1,14 +1,19 @@
-import { Button } from "~/components/ui/button";
+import { Button, type ButtonProps, ButtonIcon } from "~/components/ui/button";
 import { Feedback } from "../icons/Icons";
 
 export interface HumanFeedbackButtonProps {
   onClick: () => void;
 }
 
-export function HumanFeedbackButton({ onClick }: HumanFeedbackButtonProps) {
+export function HumanFeedbackButton(
+  props: Omit<
+    ButtonProps,
+    "children" | "variant" | "size" | "slotLeft" | "slotRight" | "asChild"
+  >,
+) {
   return (
-    <Button variant="outline" size="sm" onClick={onClick}>
-      <Feedback className="text-fg-tertiary h-4 w-4" />
+    <Button variant="outline" size="sm" {...props}>
+      <ButtonIcon as={Feedback} variant="tertiary" />
       Add feedback
     </Button>
   );

--- a/ui/app/components/feedback/HumanFeedbackButton.tsx
+++ b/ui/app/components/feedback/HumanFeedbackButton.tsx
@@ -1,16 +1,12 @@
 import { Button, type ButtonProps, ButtonIcon } from "~/components/ui/button";
 import { Feedback } from "../icons/Icons";
 
-export interface HumanFeedbackButtonProps {
-  onClick: () => void;
-}
+export type HumanFeedbackButtonProps = Omit<
+  ButtonProps,
+  "children" | "variant" | "size" | "slotLeft" | "slotRight" | "asChild"
+>;
 
-export function HumanFeedbackButton(
-  props: Omit<
-    ButtonProps,
-    "children" | "variant" | "size" | "slotLeft" | "slotRight" | "asChild"
-  >,
-) {
+export function HumanFeedbackButton(props: HumanFeedbackButtonProps) {
   return (
     <Button variant="outline" size="sm" {...props}>
       <ButtonIcon as={Feedback} variant="tertiary" />

--- a/ui/app/components/inference/TryWithVariantButton.tsx
+++ b/ui/app/components/inference/TryWithVariantButton.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Button } from "~/components/ui/button";
+import { Button, ButtonIcon } from "~/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -26,9 +26,9 @@ export function TryWithVariantButton({
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenuTrigger asChild>
         <Button variant="outline" size="sm" disabled={isLoading}>
-          <Compare className="text-fg-tertiary h-4 w-4" />
+          <ButtonIcon as={Compare} variant="tertiary" />
           Try with variant
-          <ChevronDown className="text-fg-tertiary h-4 w-4" />
+          <ButtonIcon as={ChevronDown} variant="tertiary" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent>

--- a/ui/app/components/ui/button.tsx
+++ b/ui/app/components/ui/button.tsx
@@ -50,6 +50,10 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  /**
+   * When using `asChild` only a single child is allowed. Using `slotLeft` or
+   * `slotRight` allows rendering elements adjacent to the child.
+   */
   slotLeft?: React.ReactNode;
   slotRight?: React.ReactNode;
 }

--- a/ui/app/components/ui/button.tsx
+++ b/ui/app/components/ui/button.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
-import { Slot } from "@radix-ui/react-slot";
+import * as Slot from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "~/utils/common";
+import type { IconProps } from "../icons/Icons";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 select-none",
   {
     variants: {
       variant: {
@@ -14,9 +15,9 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-bg hover:bg-bg-hover hover:text-accent-foreground",
+          "border border-input text-fg bg-bg hover:bg-bg-hover hover:text-accent-foreground",
         secondary: "bg-bg-hover text-secondary-foreground hover:bg-bg-hover/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-accent text-fg hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
@@ -34,24 +35,104 @@ const buttonVariants = cva(
   },
 );
 
+type Variant = VariantProps<typeof buttonVariants>["variant"];
+type Size = VariantProps<typeof buttonVariants>["size"];
+
+interface ButtonContextValue {
+  variant: Variant;
+  size: Size;
+}
+
+const ButtonContext = React.createContext<ButtonContextValue | null>(null);
+ButtonContext.displayName = "ButtonContext";
+
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  slotLeft?: React.ReactNode;
+  slotRight?: React.ReactNode;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button";
+  (
+    {
+      className,
+      variant = "default",
+      size = "default",
+      asChild = false,
+      children,
+      slotLeft,
+      slotRight,
+      ...props
+    },
+    ref,
+  ) => {
+    const Comp = asChild ? Slot.Root : "button";
+    const child = asChild ? (
+      <Slot.Slottable>{children}</Slot.Slottable>
+    ) : (
+      children
+    );
+
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
-      />
+      >
+        <ButtonContext value={{ variant, size }}>
+          {slotLeft}
+          {child}
+          {slotRight}
+        </ButtonContext>
+      </Comp>
     );
   },
 );
 Button.displayName = "Button";
+
+const buttonIconVariants = cva(null, {
+  variants: {
+    variant: {
+      default: "text-current",
+      muted: "text-fg-muted",
+      tertiary: "text-fg-tertiary",
+    },
+    size: {
+      default: "h-4 w-4",
+      sm: "h-3 w-3",
+      lg: "h-5 w-5",
+      icon: "h-4 h-4",
+      iconSm: "h-3 w-3",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+    size: "default",
+  },
+});
+
+interface ButtonIconProps
+  extends Omit<IconProps, "size">,
+    Omit<VariantProps<typeof buttonIconVariants>, "size"> {
+  as: React.ElementType<IconProps>;
+}
+
+export function ButtonIcon({
+  as: Comp,
+  className,
+  variant,
+  ...props
+}: ButtonIconProps) {
+  const { size = "default" } = React.use(ButtonContext) || {};
+  return (
+    <Comp
+      {...props}
+      aria-hidden
+      className={cn(buttonIconVariants({ variant, size, className }))}
+    />
+  );
+}
 
 export { Button, buttonVariants };

--- a/ui/app/routes/observability/inferences/$inference_id/AddToDatasetButton.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/AddToDatasetButton.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Button } from "~/components/ui/button";
+import { Button, ButtonIcon } from "~/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -97,11 +97,11 @@ export function AddToDatasetButton({
               </div>
             ) : (
               <>
-                <AddToDataset className="text-fg-tertiary h-4 w-4" />
+                <ButtonIcon as={AddToDataset} variant="tertiary" />
                 Add to dataset
               </>
             )}
-            <ChevronDown className="text-fg-tertiary h-4 w-4" />
+            <ButtonIcon as={ChevronDown} variant="tertiary" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent className="w-80 p-0">


### PR DESCRIPTION
This PR makes minor changes to the `Button` component to standardize how icons are displayed (just something small I noticed could be improved when working in the human feedback modal).

With this change you can use `ButtonIcon` inside of any button and it will adapt to the button's size. By default the icon would render as the same color as the text, or it could use its own `muted` or `tertiary` which uses colors commonly found across the app depending on surrounding context.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances `Button` component with `ButtonIcon` for standardized icon usage, updating several components for consistent styling.
> 
>   - **Button Enhancements**:
>     - Introduces `ButtonIcon` component in `button.tsx` for standardized icon usage in buttons.
>     - `ButtonIcon` adapts to button size and supports `default`, `muted`, and `tertiary` color variants.
>     - Updates `Button` to include `slotLeft` and `slotRight` for adjacent element rendering.
>   - **Component Updates**:
>     - Replaces direct icon usage with `ButtonIcon` in `HumanFeedbackButton.tsx`, `TryWithVariantButton.tsx`, and `AddToDatasetButton.tsx`.
>     - Ensures icons use `tertiary` variant for consistent styling.
>   - **Misc**:
>     - Adjusts `buttonVariants` in `button.tsx` to include `text-fg` for `outline` and `ghost` variants.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 550eb3056863b961585f0dae86980c027bfc22ab. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->