### PR TITLE
chore: inline format args for clarity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,18 +50,17 @@ chrono = { version = "0.4.40", features = ["serde"] }
 [workspace.lints.rust]
 unsafe_code = "forbid"
 
-
 [workspace.lints.clippy]
+dbg_macro = "deny"
 expect_used = "deny"
 panic = "deny"
 print_stderr = "deny"
 print_stdout = "deny"
 todo = "deny"
 unimplemented = "deny"
+uninlined_format_args = "deny"
 unreachable = "deny"
 unwrap_used = "deny"
-dbg_macro = "deny"
-
 
 [profile.performance]
 inherits = "release"

--- a/clients/python-pyo3/src/internal.rs
+++ b/clients/python-pyo3/src/internal.rs
@@ -39,8 +39,7 @@ pub fn get_template_config(
         })?;
     let VariantConfig::ChatCompletion(config) = variant_config else {
         return Err(PyValueError::new_err(format!(
-            "Variant {} is not a ChatCompletion variant",
-            variant_name
+            "Variant {variant_name} is not a ChatCompletion variant"
         )));
     };
     let template_env = PyDict::new(py);
@@ -70,7 +69,7 @@ pub async fn get_curated_inferences(
         .map_err(|e| TensorZeroError::Other { source: e.into() })?;
 
     let limit_clause = max_samples
-        .map(|s| format!("LIMIT {}", s))
+        .map(|s| format!("LIMIT {s}"))
         .unwrap_or_default();
 
     let inference_table_name = match &**function_config {
@@ -220,12 +219,12 @@ async fn query_curated_metric_data(
                     MetricConfigOptimize::Max => 1,
                     MetricConfigOptimize::Min => 0,
                 };
-                value_condition = format!("AND value = {}", value);
+                value_condition = format!("AND value = {value}");
             }
             MetricConfigType::Float => {
                 if threshold.is_some() {
                     let operator = get_comparison_operator(optimize);
-                    value_condition = format!("AND value {} {{threshold:Float}}", operator);
+                    value_condition = format!("AND value {operator} {{threshold:Float}}");
                 }
             }
         }
@@ -360,7 +359,7 @@ async fn query_demonstration_data(
 
 fn get_limit_clause(max_samples: Option<u64>) -> String {
     max_samples
-        .map(|s| format!("LIMIT {}", s))
+        .map(|s| format!("LIMIT {s}"))
         .unwrap_or_default()
 }
 

--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -98,7 +98,7 @@ fn _start_http_gateway(
         )
         .await?;
         Ok(LocalHttpGateway {
-            base_url: format!("http://{}/openai/v1", addr),
+            base_url: format!("http://{addr}/openai/v1"),
             shutdown_handle: Some(handle),
         })
     };

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -53,7 +53,7 @@ impl Debug for ClientMode {
                 gateway: _,
                 timeout,
             } => {
-                write!(f, "EmbeddedGateway {{ timeout: {:?} }}", timeout)
+                write!(f, "EmbeddedGateway {{ timeout: {timeout:?} }}")
             }
         }
     }
@@ -343,8 +343,7 @@ impl Client {
                         source: tensorzero_internal::error::Error::new(
                             ErrorDetails::InvalidBaseUrl {
                                 message: format!(
-                                    "Failed to join base URL with /feedback endpoint: {}",
-                                    e
+                                    "Failed to join base URL with /feedback endpoint: {e}"
                                 ),
                             },
                         )
@@ -388,8 +387,7 @@ impl Client {
                             source: tensorzero_internal::error::Error::new(
                                 ErrorDetails::InvalidBaseUrl {
                                     message: format!(
-                                        "Failed to join base URL with /inference endpoint: {}",
-                                        e
+                                        "Failed to join base URL with /inference endpoint: {e}"
                                     ),
                                 },
                             )
@@ -464,8 +462,7 @@ impl Client {
                         source: tensorzero_internal::error::Error::new(
                             ErrorDetails::InvalidBaseUrl {
                                 message: format!(
-                                    "Failed to join base URL with /internal/object_storage endpoint: {}",
-                                    e
+                                    "Failed to join base URL with /internal/object_storage endpoint: {e}"
                                 ),
                             },
                         )
@@ -475,7 +472,7 @@ impl Client {
                     serde_json::to_string(&storage_path).map_err(|e| TensorZeroError::Other {
                         source: tensorzero_internal::error::Error::new(
                             ErrorDetails::Serialization {
-                                message: format!("Failed to serialize storage path: {}", e),
+                                message: format!("Failed to serialize storage path: {e}"),
                             },
                         )
                         .into(),

--- a/evaluations/src/lib.rs
+++ b/evaluations/src/lib.rs
@@ -237,7 +237,7 @@ pub async fn run_evaluation(
 
         // Print all stats
         for (evaluator_name, evaluator_stats) in &stats {
-            writeln!(writer, "{}: {}", evaluator_name, evaluator_stats)?;
+            writeln!(writer, "{evaluator_name}: {evaluator_stats}")?;
         }
 
         // Check cutoffs and handle failures
@@ -247,8 +247,7 @@ pub async fn run_evaluation(
         for (name, cutoff, actual) in &failures {
             writeln!(
                 writer,
-                "Failed cutoff for evaluator {} ({:.2}, got {:.2})",
-                name, cutoff, actual
+                "Failed cutoff for evaluator {name} ({cutoff:.2}, got {actual:.2})"
             )?;
         }
 
@@ -299,9 +298,7 @@ pub fn check_evaluator_cutoffs(
 pub fn format_cutoff_failures(failures: &[(String, f32, f32)]) -> String {
     failures
         .iter()
-        .map(|(name, cutoff, actual)| {
-            format!("{} (cutoff: {:.2}, got: {:.2})", name, cutoff, actual)
-        })
+        .map(|(name, cutoff, actual)| format!("{name} (cutoff: {cutoff:.2}, got: {actual:.2})"))
         .collect::<Vec<_>>()
         .join("\n")
 }

--- a/tensorzero-derive/src/lib.rs
+++ b/tensorzero-derive/src/lib.rs
@@ -137,7 +137,7 @@ pub fn tensorzero_derive(input: TokenStream) -> TokenStream {
             }
             Fields::Unnamed(fields) => {
                 let field_idents = fields.unnamed.iter().enumerate().map(|(i, field)| {
-                    syn::Ident::new(&format!("field_{}", i), field.ident.as_ref().map(|i| i.span()).unwrap_or_else(Span::call_site))
+                    syn::Ident::new(&format!("field_{i}"), field.ident.as_ref().map(|i| i.span()).unwrap_or_else(Span::call_site))
                 });
                 let field_idents_clone = field_idents.clone();
                 quote! {
@@ -152,7 +152,7 @@ pub fn tensorzero_derive(input: TokenStream) -> TokenStream {
         }
     });
 
-    let tag_err = format!("TensorZeroDerive: missing tag field `{}`", tag);
+    let tag_err = format!("TensorZeroDerive: missing tag field `{tag}`");
 
     let res = quote! {
         #[derive(::serde::Deserialize)]

--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0003.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0003.rs
@@ -35,7 +35,7 @@ impl Migration for Migration0003<'_> {
             if !check_table_exists(self.clickhouse, table, "0003").await? {
                 return Err(ErrorDetails::ClickHouseMigration {
                     id: "0003".to_string(),
-                    message: format!("Table {} does not exist", table),
+                    message: format!("Table {table} does not exist"),
                 }
                 .into());
             }
@@ -67,11 +67,10 @@ impl Migration for Migration0003<'_> {
                 r#"SELECT EXISTS(
                     SELECT 1
                     FROM system.columns
-                    WHERE database = '{}'
-                      AND table = '{}'
+                    WHERE database = '{database}'
+                      AND table = '{table}'
                       AND name = 'tags'
-                )"#,
-                database, table
+                )"#
             );
             match self.clickhouse.run_query_synchronous(query, None).await {
                 Err(e) => {

--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0004.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0004.rs
@@ -38,8 +38,7 @@ impl Migration for Migration0004<'_> {
     async fn should_apply(&self) -> Result<bool, Error> {
         let database = self.clickhouse.database();
         let query = format!(
-            "SELECT name FROM system.columns WHERE database = '{}' AND table = 'ModelInference'",
-            database
+            "SELECT name FROM system.columns WHERE database = '{database}' AND table = 'ModelInference'"
         );
         let response = self
             .clickhouse
@@ -48,7 +47,7 @@ impl Migration for Migration0004<'_> {
             .map_err(|e| {
                 Error::new(ErrorDetails::ClickHouseMigration {
                     id: "0004".to_string(),
-                    message: format!("Failed to fetch columns for ModelInference: {}", e),
+                    message: format!("Failed to fetch columns for ModelInference: {e}"),
                 })
             })?;
         let present_columns: Vec<&str> = response.lines().map(|line| line.trim()).collect();

--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0005.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0005.rs
@@ -30,7 +30,7 @@ impl Migration for Migration0005<'_> {
                     if !exists {
                         return Err(ErrorDetails::ClickHouseMigration {
                             id: "0005".to_string(),
-                            message: format!("Table {} does not exist", table),
+                            message: format!("Table {table} does not exist"),
                         }
                         .into());
                     }
@@ -58,11 +58,10 @@ impl Migration for Migration0005<'_> {
                 r#"SELECT EXISTS(
                     SELECT 1
                     FROM system.columns
-                    WHERE database = '{}'
-                      AND table = '{}'
+                    WHERE database = '{database}'
+                      AND table = '{table}'
                       AND name = 'tags'
-                )"#,
-                database, table
+                )"#
             );
             match self.clickhouse.run_query_synchronous(query, None).await {
                 Err(e) => {

--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0008.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0008.rs
@@ -31,7 +31,7 @@ impl Migration for Migration0008<'_> {
             if !check_table_exists(self.clickhouse, table, "0006").await? {
                 return Err(ErrorDetails::ClickHouseMigration {
                     id: "0008".to_string(),
-                    message: format!("{} table does not exist", table),
+                    message: format!("{table} table does not exist"),
                 }
                 .into());
             }

--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0009.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0009.rs
@@ -29,7 +29,7 @@ impl Migration for Migration0009<'_> {
             if !check_table_exists(self.clickhouse, table, "0009").await? {
                 return Err(ErrorDetails::ClickHouseMigration {
                     id: "0009".to_string(),
-                    message: format!("Table {} does not exist", table),
+                    message: format!("Table {table} does not exist"),
                 }
                 .into());
             }
@@ -107,8 +107,7 @@ impl Migration for Migration0009<'_> {
                     tags
                 FROM BooleanMetricFeedback
                 {view_where_clause};
-            "#,
-            view_where_clause = view_where_clause
+            "#
         );
         let _ = self.clickhouse.run_query_synchronous(query, None).await?;
 
@@ -144,8 +143,7 @@ impl Migration for Migration0009<'_> {
                     tags
                 FROM CommentFeedback
                 {view_where_clause};
-            "#,
-            view_where_clause = view_where_clause
+            "#
         );
         let _ = self.clickhouse.run_query_synchronous(query, None).await?;
 
@@ -179,8 +177,7 @@ impl Migration for Migration0009<'_> {
                     tags
                 FROM DemonstrationFeedback
                 {view_where_clause};
-            "#,
-            view_where_clause = view_where_clause
+            "#
         );
         let _ = self.clickhouse.run_query_synchronous(query, None).await?;
 
@@ -221,8 +218,7 @@ impl Migration for Migration0009<'_> {
                    tags
                FROM FloatMetricFeedback
                {view_where_clause};
-           "#,
-            view_where_clause = view_where_clause
+           "#
         );
         let _ = self.clickhouse.run_query_synchronous(query, None).await?;
 
@@ -242,8 +238,7 @@ impl Migration for Migration0009<'_> {
                         tags
                     FROM BooleanMetricFeedback
                     WHERE UUIDv7ToDateTime(id) < toDateTime(toUnixTimestamp({view_timestamp}));
-                "#,
-                    view_timestamp = view_timestamp
+                "#
                 );
                 self.clickhouse.run_query_synchronous(query, None).await
             };
@@ -260,8 +255,7 @@ impl Migration for Migration0009<'_> {
                         tags
                     FROM CommentFeedback
                     WHERE UUIDv7ToDateTime(id) < toDateTime(toUnixTimestamp({view_timestamp}));
-                "#,
-                    view_timestamp = view_timestamp
+                "#
                 );
                 self.clickhouse.run_query_synchronous(query, None).await
             };
@@ -277,8 +271,7 @@ impl Migration for Migration0009<'_> {
                         tags
                     FROM DemonstrationFeedback
                     WHERE UUIDv7ToDateTime(id) < toDateTime(toUnixTimestamp({view_timestamp}));
-                "#,
-                    view_timestamp = view_timestamp
+                "#
                 );
                 self.clickhouse.run_query_synchronous(query, None).await
             };
@@ -295,8 +288,7 @@ impl Migration for Migration0009<'_> {
                         tags
                     FROM FloatMetricFeedback
                     WHERE UUIDv7ToDateTime(id) < toDateTime(toUnixTimestamp({view_timestamp}));
-                "#,
-                    view_timestamp = view_timestamp
+                "#
                 );
                 self.clickhouse.run_query_synchronous(query, None).await
             };

--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0013.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0013.rs
@@ -35,7 +35,7 @@ impl Migration for Migration0013<'_> {
             if !check_table_exists(self.clickhouse, table, "0013").await? {
                 return Err(ErrorDetails::ClickHouseMigration {
                     id: "0013".to_string(),
-                    message: format!("Table {} does not exist", table),
+                    message: format!("Table {table} does not exist"),
                 }
                 .into());
             }
@@ -246,8 +246,7 @@ impl Migration for Migration0013<'_> {
                     'chat' AS function_type
                 FROM ChatInference
                 {view_where_clause};
-            "#,
-            view_where_clause = view_where_clause
+            "#
         );
         let _ = self.clickhouse.run_query_synchronous(query, None).await?;
 
@@ -265,8 +264,7 @@ impl Migration for Migration0013<'_> {
                     'json' AS function_type
                 FROM JsonInference
                 {view_where_clause};
-            "#,
-            view_where_clause = view_where_clause
+            "#
         );
         let _ = self.clickhouse.run_query_synchronous(query, None).await?;
 
@@ -285,8 +283,7 @@ impl Migration for Migration0013<'_> {
                     'chat' as function_type
                 FROM ChatInference
                 {view_where_clause};
-            "#,
-            view_where_clause = view_where_clause
+            "#
         );
         let _ = self.clickhouse.run_query_synchronous(query, None).await?;
 
@@ -305,8 +302,7 @@ impl Migration for Migration0013<'_> {
                     'json' as function_type
                 FROM JsonInference
                 {view_where_clause};
-            "#,
-            view_where_clause = view_where_clause
+            "#
         );
         let _ = self.clickhouse.run_query_synchronous(query, None).await?;
 

--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0020.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0020.rs
@@ -39,7 +39,7 @@ impl Migration for Migration0020<'_> {
             if !check_table_exists(self.clickhouse, table, MIGRATION_ID).await? {
                 return Err(ErrorDetails::ClickHouseMigration {
                     id: MIGRATION_ID.to_string(),
-                    message: format!("Table {} does not exist", table),
+                    message: format!("Table {table} does not exist"),
                 }
                 .into());
             }
@@ -134,7 +134,7 @@ impl Migration for Migration0020<'_> {
             let random_suffix: String = (0..16)
                 .map(|_| rng.sample(rand::distr::Alphanumeric) as char)
                 .collect();
-            format!("InferenceById_temp0020_{}", random_suffix)
+            format!("InferenceById_temp0020_{random_suffix}")
         } else {
             "InferenceById".to_string()
         };
@@ -149,8 +149,7 @@ impl Migration for Migration0020<'_> {
                 function_type Enum8('chat' = 1, 'json' = 2)
             ) ENGINE = ReplacingMergeTree(id_uint)
             ORDER BY id_uint;
-        "#,
-            create_table_name = create_table_name
+        "#
         );
         let _ = self
             .clickhouse
@@ -158,12 +157,12 @@ impl Migration for Migration0020<'_> {
             .await?;
         // If the InferenceById table exists then we need to swap this table in and drop old one.
         if inference_by_id_exists {
-            let query = format!("EXCHANGE TABLES InferenceById AND {}", create_table_name);
+            let query = format!("EXCHANGE TABLES InferenceById AND {create_table_name}");
             let _ = self
                 .clickhouse
                 .run_query_synchronous(query.to_string(), None)
                 .await?;
-            let query = format!("DROP TABLE IF EXISTS {}", create_table_name);
+            let query = format!("DROP TABLE IF EXISTS {create_table_name}");
             let _ = self
                 .clickhouse
                 .run_query_synchronous(query.to_string(), None)
@@ -178,7 +177,7 @@ impl Migration for Migration0020<'_> {
             let random_suffix: String = (0..16)
                 .map(|_| rng.sample(rand::distr::Alphanumeric) as char)
                 .collect();
-            format!("InferenceByEpisodeId_temp0020_{}", random_suffix)
+            format!("InferenceByEpisodeId_temp0020_{random_suffix}")
         } else {
             "InferenceByEpisodeId".to_string()
         };
@@ -194,8 +193,7 @@ impl Migration for Migration0020<'_> {
             )
             ENGINE = ReplacingMergeTree(id_uint)
             ORDER BY (episode_id_uint, id_uint);
-        "#,
-            create_table_name = create_table_name
+        "#
         );
         let _ = self
             .clickhouse
@@ -203,15 +201,12 @@ impl Migration for Migration0020<'_> {
             .await?;
         // If the InferenceByEpisodeId table exists then we need to swap this table in and drop old one.
         if inference_by_episode_id_exists {
-            let query = format!(
-                "EXCHANGE TABLES InferenceByEpisodeId AND {}",
-                create_table_name
-            );
+            let query = format!("EXCHANGE TABLES InferenceByEpisodeId AND {create_table_name}");
             let _ = self
                 .clickhouse
                 .run_query_synchronous(query.to_string(), None)
                 .await?;
-            let query = format!("DROP TABLE IF EXISTS {}", create_table_name);
+            let query = format!("DROP TABLE IF EXISTS {create_table_name}");
             let _ = self
                 .clickhouse
                 .run_query_synchronous(query.to_string(), None)
@@ -260,8 +255,7 @@ impl Migration for Migration0020<'_> {
                     'chat' AS function_type
                 FROM ChatInference
                 {view_where_clause};
-            "#,
-            view_where_clause = view_where_clause
+            "#
         );
         let _ = self.clickhouse.run_query_synchronous(query, None).await?;
 
@@ -279,8 +273,7 @@ impl Migration for Migration0020<'_> {
                     'json' AS function_type
                 FROM JsonInference
                 {view_where_clause};
-            "#,
-            view_where_clause = view_where_clause
+            "#
         );
         let _ = self.clickhouse.run_query_synchronous(query, None).await?;
 
@@ -299,8 +292,7 @@ impl Migration for Migration0020<'_> {
                     'chat' as function_type
                 FROM ChatInference
                 {view_where_clause};
-            "#,
-            view_where_clause = view_where_clause
+            "#
         );
         let _ = self.clickhouse.run_query_synchronous(query, None).await?;
 
@@ -319,8 +311,7 @@ impl Migration for Migration0020<'_> {
                     'json' as function_type
                 FROM JsonInference
                 {view_where_clause};
-            "#,
-            view_where_clause = view_where_clause
+            "#
         );
         let _ = self.clickhouse.run_query_synchronous(query, None).await?;
 
@@ -341,8 +332,7 @@ impl Migration for Migration0020<'_> {
                     'chat' AS function_type
                 FROM ChatInference
                 WHERE UUIDv7ToDateTime(id) < toDateTime(toUnixTimestamp({view_timestamp}));
-            "#,
-                view_timestamp = view_timestamp
+            "#
             );
             self.clickhouse.run_query_synchronous(query, None).await?;
 
@@ -358,8 +348,7 @@ impl Migration for Migration0020<'_> {
                     'json' AS function_type
                 FROM JsonInference
                 WHERE UUIDv7ToDateTime(id) < toDateTime(toUnixTimestamp({view_timestamp}));
-            "#,
-                view_timestamp = view_timestamp
+            "#
             );
             self.clickhouse.run_query_synchronous(query, None).await?;
 
@@ -375,8 +364,7 @@ impl Migration for Migration0020<'_> {
                     'chat' as function_type
                 FROM ChatInference
                 WHERE UUIDv7ToDateTime(id) < toDateTime(toUnixTimestamp({view_timestamp}));
-            "#,
-                view_timestamp = view_timestamp
+            "#
             );
             self.clickhouse.run_query_synchronous(query, None).await?;
 
@@ -392,8 +380,7 @@ impl Migration for Migration0020<'_> {
                     'json' as function_type
                 FROM JsonInference
                 WHERE UUIDv7ToDateTime(id) < toDateTime(toUnixTimestamp({view_timestamp}));
-            "#,
-                view_timestamp = view_timestamp
+            "#
             );
             self.clickhouse.run_query_synchronous(query, None).await?;
         }

--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0021.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0021.rs
@@ -192,8 +192,7 @@ impl Migration for Migration0021<'_> {
                 FROM ChatInference
                 ARRAY JOIN mapKeys(tags) as key
                 {view_where_clause};
-        "#,
-            view_where_clause = view_where_clause
+        "#
         );
         let _ = self
             .clickhouse
@@ -216,8 +215,7 @@ impl Migration for Migration0021<'_> {
                 FROM JsonInference
                 ARRAY JOIN mapKeys(tags) as key
                 {view_where_clause};
-        "#,
-            view_where_clause = view_where_clause
+        "#
         );
         let _ = self
             .clickhouse
@@ -243,8 +241,7 @@ impl Migration for Migration0021<'_> {
                     FROM ChatInference
                     ARRAY JOIN mapKeys(tags) as key
                     WHERE UUIDv7ToDateTime(id) < toDateTime(toUnixTimestamp({view_timestamp}));
-                "#,
-                    view_timestamp = view_timestamp
+                "#
                 );
                 self.clickhouse.run_query_synchronous(query, None).await
             };
@@ -264,8 +261,7 @@ impl Migration for Migration0021<'_> {
                     FROM JsonInference
                     ARRAY JOIN mapKeys(tags) as key
                     WHERE UUIDv7ToDateTime(id) < toDateTime(toUnixTimestamp({view_timestamp}));
-                "#,
-                    view_timestamp = view_timestamp
+                "#
                 );
                 self.clickhouse.run_query_synchronous(query, None).await
             };

--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/mod.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/mod.rs
@@ -139,7 +139,7 @@ async fn table_is_nonempty(
     table: &str,
     migration_id: &str,
 ) -> Result<bool, Error> {
-    let query = format!("SELECT COUNT() FROM {} FORMAT CSV", table);
+    let query = format!("SELECT COUNT() FROM {table} FORMAT CSV");
     let result = clickhouse.run_query_synchronous(query, None).await?;
     Ok(result.trim().parse::<i64>().map_err(|e| {
         Error::new(ErrorDetails::ClickHouseMigration {

--- a/tensorzero-internal/src/clickhouse/mod.rs
+++ b/tensorzero-internal/src/clickhouse/mod.rs
@@ -214,7 +214,7 @@ impl ClickHouseConnectionInfo {
                 // Add query parameters if provided
                 if let Some(params) = parameters {
                     for (key, value) in params {
-                        let param_key = format!("param_{}", key);
+                        let param_key = format!("param_{key}");
                         database_url
                             .query_pairs_mut()
                             .append_pair(&param_key, value);
@@ -307,17 +307,14 @@ impl ClickHouseConnectionInfo {
                 let metadata = if let Some(summary) = res.headers().get("x-clickhouse-summary") {
                     let summary_str = summary.to_str().map_err(|e| {
                         Error::new(ErrorDetails::ClickHouseQuery {
-                            message: format!("Failed to parse x-clickhouse-summary header: {}", e),
+                            message: format!("Failed to parse x-clickhouse-summary header: {e}"),
                         })
                     })?;
 
                     serde_json::from_str::<ClickHouseResponseMetadata>(summary_str).map_err(
                         |e| {
                             Error::new(ErrorDetails::ClickHouseQuery {
-                                message: format!(
-                                    "Failed to deserialize x-clickhouse-summary: {}",
-                                    e
-                                ),
+                                message: format!("Failed to deserialize x-clickhouse-summary: {e}"),
                             })
                         },
                     )?
@@ -363,7 +360,7 @@ impl ClickHouseConnectionInfo {
                         message: "Invalid ClickHouse database URL".to_string(),
                     })
                 })?;
-                let query = format!("CREATE DATABASE IF NOT EXISTS {}", database);
+                let query = format!("CREATE DATABASE IF NOT EXISTS {database}");
                 // In order to create the database, we need to remove the database query parameter from the URL
                 // Otherwise, ClickHouse will throw an error
                 let mut base_url = database_url.clone();

--- a/tensorzero-internal/src/clickhouse/test_helpers.rs
+++ b/tensorzero-internal/src/clickhouse/test_helpers.rs
@@ -42,8 +42,7 @@ pub async fn select_chat_datapoint_clickhouse(
     clickhouse_flush_async_insert(clickhouse_connection_info).await;
 
     let query = format!(
-        "SELECT * FROM ChatInferenceDatapoint WHERE id = '{}' LIMIT 1 FORMAT JSONEachRow",
-        inference_id
+        "SELECT * FROM ChatInferenceDatapoint WHERE id = '{inference_id}' LIMIT 1 FORMAT JSONEachRow"
     );
 
     let text = clickhouse_connection_info
@@ -63,8 +62,7 @@ pub async fn select_json_datapoint_clickhouse(
     clickhouse_flush_async_insert(clickhouse_connection_info).await;
 
     let query = format!(
-        "SELECT * FROM JsonInferenceDatapoint WHERE id = '{}' LIMIT 1 FORMAT JSONEachRow",
-        inference_id
+        "SELECT * FROM JsonInferenceDatapoint WHERE id = '{inference_id}' LIMIT 1 FORMAT JSONEachRow"
     );
 
     let text = clickhouse_connection_info
@@ -83,8 +81,7 @@ pub async fn select_chat_inference_clickhouse(
     clickhouse_flush_async_insert(clickhouse_connection_info).await;
 
     let query = format!(
-        "SELECT * FROM ChatInference WHERE id = '{}' LIMIT 1 FORMAT JSONEachRow",
-        inference_id
+        "SELECT * FROM ChatInference WHERE id = '{inference_id}' LIMIT 1 FORMAT JSONEachRow"
     );
 
     let text = clickhouse_connection_info
@@ -104,8 +101,7 @@ pub async fn select_json_inference_clickhouse(
 
     // We limit to 1 in case there are duplicate entries (can be caused by a race condition in polling batch inferences)
     let query = format!(
-        "SELECT * FROM JsonInference WHERE id = '{}' LIMIT 1 FORMAT JSONEachRow",
-        inference_id
+        "SELECT * FROM JsonInference WHERE id = '{inference_id}' LIMIT 1 FORMAT JSONEachRow"
     );
 
     let text = clickhouse_connection_info
@@ -125,8 +121,7 @@ pub async fn select_model_inference_clickhouse(
 
     // We limit to 1 in case there are duplicate entries (can be caused by a race condition in polling batch inferences)
     let query = format!(
-        "SELECT * FROM ModelInference WHERE inference_id = '{}' LIMIT 1 FORMAT JSONEachRow",
-        inference_id
+        "SELECT * FROM ModelInference WHERE inference_id = '{inference_id}' LIMIT 1 FORMAT JSONEachRow"
     );
 
     let text = clickhouse_connection_info
@@ -146,8 +141,7 @@ pub async fn select_model_inferences_clickhouse(
 
     // We limit to 1 in case there are duplicate entries (can be caused by a race condition in polling batch inferences)
     let query = format!(
-        "SELECT * FROM ModelInference WHERE inference_id = '{}' FORMAT JSONEachRow",
-        inference_id
+        "SELECT * FROM ModelInference WHERE inference_id = '{inference_id}' FORMAT JSONEachRow"
     );
 
     let text = clickhouse_connection_info
@@ -177,8 +171,7 @@ pub async fn select_inference_tags_clickhouse(
     clickhouse_flush_async_insert(clickhouse_connection_info).await;
 
     let query = format!(
-        "SELECT * FROM InferenceTag WHERE function_name = '{}' AND key = '{}' AND value = '{}' AND inference_id = '{}' FORMAT JSONEachRow",
-        function_name, tag_key, tag_value, inference_id
+        "SELECT * FROM InferenceTag WHERE function_name = '{function_name}' AND key = '{tag_key}' AND value = '{tag_value}' AND inference_id = '{inference_id}' FORMAT JSONEachRow"
     );
 
     let text = clickhouse_connection_info
@@ -198,9 +191,8 @@ pub async fn select_batch_model_inference_clickhouse(
         SELECT bmi.*
         FROM BatchModelInference bmi
         INNER JOIN BatchIdByInferenceId bid ON bmi.inference_id = bid.inference_id
-        WHERE bid.inference_id = '{}'
-        FORMAT JSONEachRow"#,
-        inference_id
+        WHERE bid.inference_id = '{inference_id}'
+        FORMAT JSONEachRow"#
     );
 
     let text = clickhouse_connection_info
@@ -218,9 +210,8 @@ pub async fn select_batch_model_inferences_clickhouse(
         r#"
         SELECT bmi.*
         FROM BatchModelInference bmi
-        WHERE bmi.batch_id = '{}'
-        FORMAT JSONEachRow"#,
-        batch_id
+        WHERE bmi.batch_id = '{batch_id}'
+        FORMAT JSONEachRow"#
     );
 
     let text = clickhouse_connection_info
@@ -240,8 +231,7 @@ pub async fn select_latest_batch_request_clickhouse(
     batch_id: Uuid,
 ) -> Option<Value> {
     let query = format!(
-        "SELECT * FROM BatchRequest WHERE batch_id = '{}' ORDER BY timestamp DESC LIMIT 1 FORMAT JSONEachRow",
-        batch_id
+        "SELECT * FROM BatchRequest WHERE batch_id = '{batch_id}' ORDER BY timestamp DESC LIMIT 1 FORMAT JSONEachRow"
     );
 
     let text = clickhouse_connection_info

--- a/tensorzero-internal/src/clickhouse/test_helpers.rs
+++ b/tensorzero-internal/src/clickhouse/test_helpers.rs
@@ -250,10 +250,7 @@ pub async fn select_feedback_clickhouse(
 ) -> Option<Value> {
     clickhouse_flush_async_insert(clickhouse_connection_info).await;
 
-    let query = format!(
-        "SELECT * FROM {} WHERE id = '{}' FORMAT JSONEachRow",
-        table_name, feedback_id
-    );
+    let query = format!("SELECT * FROM {table_name} WHERE id = '{feedback_id}' FORMAT JSONEachRow");
 
     let text = clickhouse_connection_info
         .run_query_synchronous(query, None)
@@ -273,14 +270,12 @@ pub async fn select_feedback_by_target_id_clickhouse(
     let query = match metric_name {
         Some(metric_name) => {
             format!(
-                "SELECT * FROM {} WHERE target_id = '{}' AND metric_name = '{}' FORMAT JSONEachRow",
-                table_name, target_id, metric_name
+                "SELECT * FROM {table_name} WHERE target_id = '{target_id}' AND metric_name = '{metric_name}' FORMAT JSONEachRow"
             )
         }
-        None => format!(
-            "SELECT * FROM {} WHERE target_id = '{}' FORMAT JSONEachRow",
-            table_name, target_id
-        ),
+        None => {
+            format!("SELECT * FROM {table_name} WHERE target_id = '{target_id}' FORMAT JSONEachRow")
+        }
     };
 
     let text = clickhouse_connection_info
@@ -328,8 +323,7 @@ pub async fn stale_datapoint_clickhouse(
             now64() as staled_at,
             now64() as updated_at
         FROM ChatInferenceDatapoint FINAL
-        WHERE id = '{}'",
-        datapoint_id
+        WHERE id = '{datapoint_id}'"
     );
 
     // Execute the query and ignore errors (in case the datapoint doesn't exist in this table)
@@ -369,8 +363,7 @@ pub async fn stale_datapoint_clickhouse(
             now64() as staled_at,
             now64() as updated_at
         FROM JsonInferenceDatapoint FINAL
-        WHERE id = '{}'",
-        datapoint_id
+        WHERE id = '{datapoint_id}'"
     );
 
     clickhouse_flush_async_insert(clickhouse_connection_info).await;
@@ -390,8 +383,7 @@ pub async fn select_feedback_tags_clickhouse(
     clickhouse_flush_async_insert(clickhouse_connection_info).await;
 
     let query = format!(
-            "SELECT * FROM FeedbackTag WHERE metric_name = '{}' AND key = '{}' AND value = '{}' FORMAT JSONEachRow",
-            metric_name, tag_key, tag_value
+            "SELECT * FROM FeedbackTag WHERE metric_name = '{metric_name}' AND key = '{tag_key}' AND value = '{tag_value}' FORMAT JSONEachRow"
         );
 
     let text = clickhouse_connection_info

--- a/tensorzero-internal/src/config_parser.rs
+++ b/tensorzero-internal/src/config_parser.rs
@@ -383,8 +383,7 @@ impl<'c> Config<'c> {
                 if config.functions.contains_key(&evaluation_function_name) {
                     return Err(ErrorDetails::Config {
                         message: format!(
-                            "Duplicate evaluator function name: `{}` already exists. This should never happen. Please file a bug report at https://github.com/tensorzero/tensorzero/discussions/new?category=bug-reports.",
-                            evaluation_function_name
+                            "Duplicate evaluator function name: `{evaluation_function_name}` already exists. This should never happen. Please file a bug report at https://github.com/tensorzero/tensorzero/discussions/new?category=bug-reports."
                         ),
                     }
                     .into());
@@ -411,7 +410,7 @@ impl<'c> Config<'c> {
             for (evaluation_metric_name, evaluation_metric_config) in evaluation_metric_configs {
                 if config.metrics.contains_key(&evaluation_metric_name) {
                     return Err(ErrorDetails::Config {
-                        message: format!("Duplicate evaluator metric name: `{}` already exists. This should never happen. Please file a bug report at https://github.com/tensorzero/tensorzero/discussions/new?category=bug-reports.", evaluation_metric_name),
+                        message: format!("Duplicate evaluator metric name: `{evaluation_metric_name}` already exists. This should never happen. Please file a bug report at https://github.com/tensorzero/tensorzero/discussions/new?category=bug-reports."),
                     }
                     .into());
                 }
@@ -451,10 +450,7 @@ impl<'c> Config<'c> {
         for metric_name in self.metrics.keys() {
             if metric_name == "comment" || metric_name == "demonstration" {
                 return Err(ErrorDetails::Config {
-                    message: format!(
-                        "Metric name '{}' is reserved and cannot be used",
-                        metric_name
-                    ),
+                    message: format!("Metric name '{metric_name}' is reserved and cannot be used"),
                 }
                 .into());
             }

--- a/tensorzero-internal/src/embeddings.rs
+++ b/tensorzero-internal/src/embeddings.rs
@@ -44,7 +44,7 @@ impl ShorthandModelConfig for EmbeddingModelConfig {
             "dummy" => EmbeddingProviderConfig::Dummy(DummyProvider::new(model_name, None)?),
             _ => {
                 return Err(Error::new(ErrorDetails::Config {
-                    message: format!("Invalid provider type: {}", provider_type),
+                    message: format!("Invalid provider type: {provider_type}"),
                 }));
             }
         };
@@ -296,8 +296,7 @@ impl<'de> Deserialize<'de> for EmbeddingProviderConfig {
             ProviderConfig::OpenAI(provider) => EmbeddingProviderConfig::OpenAI(provider),
             _ => {
                 return Err(serde::de::Error::custom(format!(
-                    "Unsupported provider config: {:?}",
-                    provider_config
+                    "Unsupported provider config: {provider_config:?}"
                 )));
             }
         })

--- a/tensorzero-internal/src/endpoints/batch_inference.rs
+++ b/tensorzero-internal/src/endpoints/batch_inference.rs
@@ -454,12 +454,11 @@ pub async fn get_batch_request(
                         raw_response,
                         errors
                     FROM BatchRequest
-                    WHERE batch_id = '{}'
+                    WHERE batch_id = '{batch_id}'
                     ORDER BY timestamp DESC
                     LIMIT 1
                     FORMAT JSONEachRow
-                "#,
-                batch_id
+                "#
             );
             let response = clickhouse.run_query_synchronous(query, None).await?;
             if response.is_empty() {
@@ -938,7 +937,7 @@ pub async fn get_batch_inferences(
     let query = format!(
         "SELECT * FROM BatchModelInference WHERE batch_id = '{}' AND inference_id IN ({}) FORMAT JSONEachRow",
         batch_id,
-        inference_ids.iter().map(|id| format!("'{}'", id)).join(",")
+        inference_ids.iter().map(|id| format!("'{id}'")).join(",")
     );
     let response = clickhouse_connection_info
         .run_query_synchronous(query, None)
@@ -950,7 +949,7 @@ pub async fn get_batch_inferences(
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Failed to deserialize batch model inference row: {}", e),
+                message: format!("Failed to deserialize batch model inference row: {e}"),
             })
         })?;
     Ok(rows)

--- a/tensorzero-internal/src/endpoints/datasets.rs
+++ b/tensorzero-internal/src/endpoints/datasets.rs
@@ -295,7 +295,7 @@ pub async fn update_datapoint_handler(
     };
     let function_data: WithFunctionName = serde_json::from_value(params.clone()).map_err(|e| {
         Error::new(ErrorDetails::InvalidRequest {
-            message: format!("Failed to deserialize `function_name``: {e}"),
+            message: format!("Failed to deserialize `function_name`: {e}"),
         })
     })?;
     let function_config =

--- a/tensorzero-internal/src/endpoints/datasets.rs
+++ b/tensorzero-internal/src/endpoints/datasets.rs
@@ -74,15 +74,12 @@ async fn query_demonstration(
         .await?;
     if result.is_empty() {
         return Err(Error::new(ErrorDetails::InvalidRequest {
-            message: format!("No demonstration found for inference `{}`", inference_id),
+            message: format!("No demonstration found for inference `{inference_id}`"),
         }));
     }
     let demonstration: Demonstration = serde_json::from_str(&result).map_err(|e| {
         Error::new(ErrorDetails::Serialization {
-            message: format!(
-                "Failed to deserialize demonstration ClickHouse response: {}",
-                e
-            ),
+            message: format!("Failed to deserialize demonstration ClickHouse response: {e}"),
         })
     })?;
     Ok(demonstration)
@@ -149,14 +146,14 @@ FORMAT JSONEachRow;"#
 
     if result.is_empty() {
         return Err(Error::new(ErrorDetails::InvalidRequest {
-            message: format!("Inference `{}` not found", inference_id),
+            message: format!("Inference `{inference_id}` not found"),
         }));
     }
 
     let inference_data: TaggedInferenceDatabaseInsert =
         serde_json::from_str(&result).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Failed to deserialize inference data: {}", e),
+                message: format!("Failed to deserialize inference data: {e}"),
             })
         })?;
     Ok(inference_data)
@@ -180,8 +177,7 @@ async fn insert_from_existing(
                     Some(serde_json::from_str(&demonstration.value).map_err(|e| {
                         Error::new(ErrorDetails::Serialization {
                             message: format!(
-                                "Failed to deserialize JSON demonstration output: {}",
-                                e
+                                "Failed to deserialize JSON demonstration output: {e}"
                             ),
                         })
                     })?)
@@ -218,8 +214,7 @@ async fn insert_from_existing(
                     Some(serde_json::from_str(&demonstration.value).map_err(|e| {
                         Error::new(ErrorDetails::InvalidRequest {
                             message: format!(
-                                "Failed to deserialize chat demonstration output: {}",
-                                e
+                                "Failed to deserialize chat demonstration output: {e}"
                             ),
                         })
                     })?)
@@ -300,7 +295,7 @@ pub async fn update_datapoint_handler(
     };
     let function_data: WithFunctionName = serde_json::from_value(params.clone()).map_err(|e| {
         Error::new(ErrorDetails::InvalidRequest {
-            message: format!("Failed to deserialize `function_name``: {}", e),
+            message: format!("Failed to deserialize `function_name``: {e}"),
         })
     })?;
     let function_config =
@@ -311,7 +306,7 @@ pub async fn update_datapoint_handler(
             let chat: SyntheticChatInferenceDatapoint =
                 serde_json::from_value(params).map_err(|e| {
                     Error::new(ErrorDetails::InvalidRequest {
-                        message: format!("Failed to deserialize chat datapoint: {}", e),
+                        message: format!("Failed to deserialize chat datapoint: {e}"),
                     })
                 })?;
 
@@ -374,7 +369,7 @@ pub async fn update_datapoint_handler(
             let json: SyntheticJsonInferenceDatapoint =
                 serde_json::from_value(params).map_err(|e| {
                     Error::new(ErrorDetails::InvalidRequest {
-                        message: format!("Failed to deserialize JSON datapoint: {}", e),
+                        message: format!("Failed to deserialize JSON datapoint: {e}"),
                     })
                 })?;
             let resolved_input = json.input.clone().resolve(&fetch_context).await?;
@@ -401,7 +396,7 @@ pub async fn update_datapoint_handler(
                 let json_out: JsonInferenceOutput =
                     serde_json::from_value(json_out).map_err(|e| {
                         Error::new(ErrorDetails::Serialization {
-                            message: format!("Failed to deserialize validated JSON output: {}", e),
+                            message: format!("Failed to deserialize validated JSON output: {e}"),
                         })
                     })?;
 
@@ -751,7 +746,7 @@ async fn put_deduped_chat_datapoint(
 ) -> Result<u64, Error> {
     let serialized_datapoint = serde_json::to_string(datapoint).map_err(|e| {
         Error::new(ErrorDetails::Serialization {
-            message: format!("Failed to serialize datapoint: {}", e),
+            message: format!("Failed to serialize datapoint: {e}"),
         })
     })?;
 
@@ -810,7 +805,7 @@ async fn put_deduped_json_datapoint(
 ) -> Result<u64, Error> {
     let serialized_datapoint = serde_json::to_string(datapoint).map_err(|e| {
         Error::new(ErrorDetails::Serialization {
-            message: format!("Failed to serialize datapoint: {}", e),
+            message: format!("Failed to serialize datapoint: {e}"),
         })
     })?;
 

--- a/tensorzero-internal/src/endpoints/feedback.rs
+++ b/tensorzero-internal/src/endpoints/feedback.rs
@@ -232,10 +232,7 @@ fn get_feedback_metadata<'a>(
         MetricConfigLevel::Episode => episode_id,
     }
     .ok_or_else(|| ErrorDetails::InvalidRequest {
-        message: format!(
-            r#"Correct ID was not provided for feedback level "{}"."#,
-            feedback_level
-        ),
+        message: format!(r#"Correct ID was not provided for feedback level "{feedback_level}"."#),
     })?;
     Ok(FeedbackMetadata {
         r#type: feedback_type,
@@ -300,7 +297,7 @@ async fn write_demonstration(
         validate_parse_demonstration(function_config, value, dynamic_demonstration_info).await?;
     let string_value = serde_json::to_string(&parsed_value).map_err(|e| {
         Error::new(ErrorDetails::InvalidRequest {
-            message: format!("Failed to serialize parsed value to json: {}", e),
+            message: format!("Failed to serialize parsed value to json: {e}"),
         })
     })?;
     let payload = json!({"inference_id": inference_id, "value": string_value, "id": feedback_id, "tags": tags});
@@ -457,8 +454,7 @@ async fn get_function_name(
         MetricConfigLevel::Episode => "episode_id_uint",
     };
     let query = format!(
-        "SELECT function_name FROM {} FINAL WHERE {} = toUInt128(toUUID('{}'))",
-        table_name, identifier_key, target_id
+        "SELECT function_name FROM {table_name} FINAL WHERE {identifier_key} = toUInt128(toUUID('{target_id}'))"
     );
     let function_name = connection_info
         .run_query_synchronous(query, None)
@@ -487,10 +483,7 @@ impl TryFrom<DemonstrationToolCall> for ToolCall {
             name: value.name,
             arguments: serde_json::to_string(&value.arguments).map_err(|e| {
                 Error::new(ErrorDetails::InvalidRequest {
-                    message: format!(
-                        "Failed to serialize demonstration tool call arguments: {}",
-                        e
-                    ),
+                    message: format!("Failed to serialize demonstration tool call arguments: {e}"),
                 })
             })?,
             id: "".to_string(),
@@ -548,7 +541,7 @@ pub async fn validate_parse_demonstration(
                         serde_json::from_value::<DemonstrationContentBlock>(block.clone()).map_err(
                             |e| {
                                 Error::new(ErrorDetails::InvalidRequest {
-                                    message: format!("Invalid demonstration content block: {}", e),
+                                    message: format!("Invalid demonstration content block: {e}"),
                                 })
                             },
                         )
@@ -593,14 +586,13 @@ pub async fn validate_parse_demonstration(
                 .map_err(|e| {
                     Error::new(ErrorDetails::InvalidRequest {
                         message: format!(
-                            "Demonstration does not fit function output schema: {}",
-                            e
+                            "Demonstration does not fit function output schema: {e}"
                         ),
                     })
                 })?;
             let raw = serde_json::to_string(value).map_err(|e| {
                 Error::new(ErrorDetails::InvalidRequest {
-                    message: format!("Failed to serialize demonstration to json: {}", e),
+                    message: format!("Failed to serialize demonstration to json: {e}"),
                 })
             })?;
             let json_inference_response = json!({"raw": raw, "parsed": value});
@@ -652,7 +644,7 @@ async fn get_dynamic_demonstration_info(
             let tool_params_result =
                 serde_json::from_str::<ToolParamsResult>(&result).map_err(|e| {
                     Error::new(ErrorDetails::ClickHouseQuery {
-                        message: format!("Failed to parse demonstration result: {}", e),
+                        message: format!("Failed to parse demonstration result: {e}"),
                     })
                 })?;
 
@@ -678,7 +670,7 @@ async fn get_dynamic_demonstration_info(
                 .await?;
             let result_value = serde_json::from_str::<Value>(&result).map_err(|e| {
                 Error::new(ErrorDetails::ClickHouseQuery {
-                    message: format!("Failed to parse demonstration result: {}", e),
+                    message: format!("Failed to parse demonstration result: {e}"),
                 })
             })?;
             let output_schema_str = result_value
@@ -694,7 +686,7 @@ async fn get_dynamic_demonstration_info(
             let mut output_schema =
                 serde_json::from_str::<Value>(output_schema_str).map_err(|e| {
                     Error::new(ErrorDetails::ClickHouseQuery {
-                        message: format!("Failed to parse output schema: {}", e),
+                        message: format!("Failed to parse output schema: {e}"),
                     })
                 })?;
             if function_name.starts_with("tensorzero::llm_judge") {

--- a/tensorzero-internal/src/endpoints/inference.rs
+++ b/tensorzero-internal/src/endpoints/inference.rs
@@ -165,7 +165,7 @@ pub enum InferenceOutput {
 impl std::fmt::Debug for InferenceOutput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            InferenceOutput::NonStreaming(response) => write!(f, "NonStreaming({:?})", response),
+            InferenceOutput::NonStreaming(response) => write!(f, "NonStreaming({response:?})"),
             InferenceOutput::Streaming(_) => write!(f, "Streaming"),
         }
     }
@@ -223,7 +223,7 @@ pub async fn inference(
     // If the function has no variants, return an error
     if candidate_variant_names.is_empty() {
         return Err(ErrorDetails::InvalidFunctionVariants {
-            message: format!("Function `{}` has no variants", function_name),
+            message: format!("Function `{function_name}` has no variants"),
         }
         .into());
     }
@@ -661,7 +661,7 @@ fn prepare_serialized_events(
                 Ok(chunk) => {
                     serde_json::to_value(chunk).map_err(|e| {
                         Error::new(ErrorDetails::Inference {
-                            message: format!("Failed to convert chunk to JSON: {}", e),
+                            message: format!("Failed to convert chunk to JSON: {e}"),
                         })
                     })?
                 },
@@ -672,7 +672,7 @@ fn prepare_serialized_events(
             };
             yield Event::default().json_data(chunk_json).map_err(|e| {
                 Error::new(ErrorDetails::Inference {
-                    message: format!("Failed to convert Value to Event: {}", e),
+                    message: format!("Failed to convert Value to Event: {e}"),
                 })
             })
         }

--- a/tensorzero-internal/src/endpoints/object_storage.rs
+++ b/tensorzero-internal/src/endpoints/object_storage.rs
@@ -43,7 +43,7 @@ pub async fn get_object_handler(
     // Use the existing object store if it matches the requested kind, so
     let storage_path: StoragePath = serde_json::from_str(&params.storage_path).map_err(|e| {
         Error::new(ErrorDetails::InvalidRequest {
-            message: format!("Error parsing storage path: {}", e),
+            message: format!("Error parsing storage path: {e}"),
         })
     })?;
     Ok(Json(get_object(&config, storage_path).await?))
@@ -82,12 +82,12 @@ pub async fn get_object(
         .await
         .map_err(|e| {
             Error::new(ErrorDetails::InternalError {
-                message: format!("Error getting object: {}", e),
+                message: format!("Error getting object: {e}"),
             })
         })?;
     let bytes = object.bytes().await.map_err(|e| {
         Error::new(ErrorDetails::InternalError {
-            message: format!("Error getting object bytes: {}", e),
+            message: format!("Error getting object bytes: {e}"),
         })
     })?;
     Ok(ObjectResponse {

--- a/tensorzero-internal/src/endpoints/openai_compatible.rs
+++ b/tensorzero-internal/src/endpoints/openai_compatible.rs
@@ -72,8 +72,7 @@ pub async fn inference_handler(
     // (We run this disambiguation deep in the `inference` call below but we don't get the decision out, so we duplicate it here)
     let response_model_prefix = match (&params.function_name, &params.model_name) {
         (Some(function_name), None) => Ok::<String, Error>(format!(
-            "tensorzero::function_name::{}::variant_name::",
-            function_name,
+            "tensorzero::function_name::{function_name}::variant_name::",
         )),
         (None, Some(_model_name)) => Ok("tensorzero::model_name::".to_string()),
         (Some(_), Some(_)) => Err(ErrorDetails::InvalidInferenceTarget {
@@ -1023,7 +1022,7 @@ fn prepare_serialized_openai_compatible_events(
             for chunk in openai_compatible_chunks {
                 let mut chunk_json = serde_json::to_value(chunk).map_err(|e| {
                     Error::new(ErrorDetails::Inference {
-                        message: format!("Failed to convert chunk to JSON: {}", e),
+                        message: format!("Failed to convert chunk to JSON: {e}"),
                     })
                 })?;
                 if is_first_chunk {
@@ -1034,7 +1033,7 @@ fn prepare_serialized_openai_compatible_events(
 
                 yield Event::default().json_data(chunk_json).map_err(|e| {
                     Error::new(ErrorDetails::Inference {
-                        message: format!("Failed to convert Value to Event: {}", e),
+                        message: format!("Failed to convert Value to Event: {e}"),
                     })
                 })
             }
@@ -1060,7 +1059,7 @@ fn prepare_serialized_openai_compatible_events(
                 episode_id: episode_id.to_string(),
                 choices: vec![],
                 created: current_timestamp() as u32,
-                model: format!("{response_model_prefix}{}", variant_name),
+                model: format!("{response_model_prefix}{variant_name}"),
                 system_fingerprint: "".to_string(),
                 object: "chat.completion.chunk".to_string(),
                 service_tier: "".to_string(),
@@ -1074,7 +1073,7 @@ fn prepare_serialized_openai_compatible_events(
                 usage_chunk)
                 .map_err(|e| {
                     Error::new(ErrorDetails::Inference {
-                        message: format!("Failed to convert usage chunk to JSON: {}", e),
+                        message: format!("Failed to convert usage chunk to JSON: {e}"),
                     })
                 });
         }

--- a/tensorzero-internal/src/error.rs
+++ b/tensorzero-internal/src/error.rs
@@ -547,7 +547,7 @@ impl std::fmt::Display for ErrorDetails {
                     "All variants failed with errors: {}",
                     errors
                         .iter()
-                        .map(|(variant_name, error)| format!("{}: {}", variant_name, error))
+                        .map(|(variant_name, error)| format!("{variant_name}: {error}"))
                         .collect::<Vec<_>>()
                         .join("\n")
                 )
@@ -562,7 +562,7 @@ impl std::fmt::Display for ErrorDetails {
                 write!(f, "Invalid inference target: {message}")
             }
             ErrorDetails::BadImageFetch { url, message } => {
-                write!(f, "Error fetching image from {}: {message}", url)
+                write!(f, "Error fetching image from {url}: {message}")
             }
             ErrorDetails::ObjectStoreUnconfigured { block_type } => {
                 write!(f, "Object storage is not configured. You must configure `[object_storage]` before making requests containing a `{block_type}` content block")
@@ -583,59 +583,57 @@ impl std::fmt::Display for ErrorDetails {
                 )
             }
             ErrorDetails::ApiKeyMissing { provider_name } => {
-                write!(f, "API key missing for provider: {}", provider_name)
+                write!(f, "API key missing for provider: {provider_name}")
             }
             ErrorDetails::AppState { message } => {
-                write!(f, "Error initializing AppState: {}", message)
+                write!(f, "Error initializing AppState: {message}")
             }
             ErrorDetails::BadCredentialsPreInference { provider_name } => {
                 write!(
                     f,
-                    "Bad credentials at inference time for provider: {}. This should never happen. Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new",
-                    provider_name
+                    "Bad credentials at inference time for provider: {provider_name}. This should never happen. Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new"
                 )
             }
             ErrorDetails::BatchInputValidation { index, message } => {
-                write!(f, "Input at index {} failed validation: {}", index, message,)
+                write!(f, "Input at index {index} failed validation: {message}",)
             }
             ErrorDetails::BatchNotFound { id } => {
-                write!(f, "Batch request not found for id: {}", id)
+                write!(f, "Batch request not found for id: {id}")
             }
             ErrorDetails::Cache { message } => {
-                write!(f, "Error in cache: {}", message)
+                write!(f, "Error in cache: {message}")
             }
             ErrorDetails::ChannelWrite { message } => {
-                write!(f, "Error writing to channel: {}", message)
+                write!(f, "Error writing to channel: {message}")
             }
             ErrorDetails::ClickHouseConnection { message } => {
-                write!(f, "Error connecting to ClickHouse: {}", message)
+                write!(f, "Error connecting to ClickHouse: {message}")
             }
             ErrorDetails::ClickHouseDeserialization { message } => {
-                write!(f, "Error deserializing ClickHouse response: {}", message)
+                write!(f, "Error deserializing ClickHouse response: {message}")
             }
             ErrorDetails::ClickHouseMigration { id, message } => {
-                write!(f, "Error running ClickHouse migration {}: {}", id, message)
+                write!(f, "Error running ClickHouse migration {id}: {message}")
             }
             ErrorDetails::ClickHouseQuery { message } => {
-                write!(f, "Failed to run ClickHouse query: {}", message)
+                write!(f, "Failed to run ClickHouse query: {message}")
             }
             ErrorDetails::Config { message } => {
-                write!(f, "{}", message)
+                write!(f, "{message}")
             }
             ErrorDetails::DynamicJsonSchema { message } => {
                 write!(
                     f,
-                    "Error in compiling client-provided JSON schema: {}",
-                    message
+                    "Error in compiling client-provided JSON schema: {message}"
                 )
             }
             ErrorDetails::FileRead { message, file_path } => {
                 write!(f, "Error reading file {file_path}: {message}")
             }
             ErrorDetails::GCPCredentials { message } => {
-                write!(f, "Error in acquiring GCP credentials: {}", message)
+                write!(f, "Error in acquiring GCP credentials: {message}")
             }
-            ErrorDetails::Inference { message } => write!(f, "{}", message),
+            ErrorDetails::Inference { message } => write!(f, "{message}"),
             ErrorDetails::InferenceClient {
                 message,
                 provider_type,
@@ -652,23 +650,23 @@ impl std::fmt::Display for ErrorDetails {
                         message,
                         raw_request
                             .as_ref()
-                            .map_or("".to_string(), |r| format!("\nRaw request: {}", r)),
+                            .map_or("".to_string(), |r| format!("\nRaw request: {r}")),
                         raw_response
                             .as_ref()
-                            .map_or("".to_string(), |r| format!("\nRaw response: {}", r))
+                            .map_or("".to_string(), |r| format!("\nRaw response: {r}"))
                     )
                 } else {
                     write!(
                         f,
                         "Error{} from {} client: {}",
-                        status_code.map_or("".to_string(), |s| format!(" {}", s)),
+                        status_code.map_or("".to_string(), |s| format!(" {s}")),
                         provider_type,
                         message
                     )
                 }
             }
             ErrorDetails::InferenceNotFound { inference_id } => {
-                write!(f, "Inference not found for id: {}", inference_id)
+                write!(f, "Inference not found for id: {inference_id}")
             }
             ErrorDetails::InferenceServer {
                 message,
@@ -685,53 +683,50 @@ impl std::fmt::Display for ErrorDetails {
                         message,
                         raw_request
                             .as_ref()
-                            .map_or("".to_string(), |r| format!("\nRaw request: {}", r)),
+                            .map_or("".to_string(), |r| format!("\nRaw request: {r}")),
                         raw_response
                             .as_ref()
-                            .map_or("".to_string(), |r| format!("\nRaw response: {}", r))
+                            .map_or("".to_string(), |r| format!("\nRaw response: {r}"))
                     )
                 } else {
-                    write!(f, "Error from {} server: {}", provider_type, message)
+                    write!(f, "Error from {provider_type} server: {message}")
                 }
             }
             ErrorDetails::InferenceTimeout { variant_name } => {
-                write!(f, "Inference timed out for variant: {}", variant_name)
+                write!(f, "Inference timed out for variant: {variant_name}")
             }
             ErrorDetails::InputValidation { source } => {
-                write!(f, "Input validation failed with messages: {}", source)
+                write!(f, "Input validation failed with messages: {source}")
             }
             ErrorDetails::InternalError { message } => {
-                write!(f, "Internal error: {}", message)
+                write!(f, "Internal error: {message}")
             }
-            ErrorDetails::InvalidBaseUrl { message } => write!(
-                f,
-                "Invalid batch params retrieved from database: {}",
-                message
-            ),
-            ErrorDetails::InvalidBatchParams { message } => write!(f, "{}", message),
+            ErrorDetails::InvalidBaseUrl { message } => {
+                write!(f, "Invalid batch params retrieved from database: {message}")
+            }
+            ErrorDetails::InvalidBatchParams { message } => write!(f, "{message}"),
             ErrorDetails::InvalidCandidate {
                 variant_name,
                 message,
             } => {
                 write!(
                     f,
-                    "Invalid candidate variant as a component of variant {}: {}",
-                    variant_name, message
+                    "Invalid candidate variant as a component of variant {variant_name}: {message}"
                 )
             }
             ErrorDetails::InvalidDiclConfig { message } => {
-                write!(f, "Invalid dynamic in-context learning config: {}. This should never happen. Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new", message)
+                write!(f, "Invalid dynamic in-context learning config: {message}. This should never happen. Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new")
             }
             ErrorDetails::InvalidDatasetName { dataset_name } => {
-                write!(f, "Invalid dataset name: {}. Datasets cannot be named \"builder\" or begin with \"tensorzero::\"", dataset_name)
+                write!(f, "Invalid dataset name: {dataset_name}. Datasets cannot be named \"builder\" or begin with \"tensorzero::\"")
             }
-            ErrorDetails::InvalidFunctionVariants { message } => write!(f, "{}", message),
+            ErrorDetails::InvalidFunctionVariants { message } => write!(f, "{message}"),
             ErrorDetails::InvalidTensorzeroUuid { message, kind } => {
-                write!(f, "Invalid {kind} ID: {}", message)
+                write!(f, "Invalid {kind} ID: {message}")
             }
-            ErrorDetails::InvalidMessage { message } => write!(f, "{}", message),
+            ErrorDetails::InvalidMessage { message } => write!(f, "{message}"),
             ErrorDetails::InvalidModel { model_name } => {
-                write!(f, "Invalid model: {}", model_name)
+                write!(f, "Invalid model: {model_name}")
             }
             ErrorDetails::InvalidModelProvider {
                 model_name,
@@ -739,26 +734,24 @@ impl std::fmt::Display for ErrorDetails {
             } => {
                 write!(
                     f,
-                    "Invalid model provider: {} for model: {}",
-                    provider_name, model_name
+                    "Invalid model provider: {provider_name} for model: {model_name}"
                 )
             }
             ErrorDetails::InvalidOpenAICompatibleRequest { message } => write!(
                 f,
-                "Invalid request to OpenAI-compatible endpoint: {}",
-                message
+                "Invalid request to OpenAI-compatible endpoint: {message}"
             ),
-            ErrorDetails::InvalidProviderConfig { message } => write!(f, "{}", message),
-            ErrorDetails::InvalidRequest { message } => write!(f, "{}", message),
+            ErrorDetails::InvalidProviderConfig { message } => write!(f, "{message}"),
+            ErrorDetails::InvalidRequest { message } => write!(f, "{message}"),
             ErrorDetails::InvalidTemplatePath => {
                 write!(f, "Template path failed to convert to Rust string")
             }
-            ErrorDetails::InvalidTool { message } => write!(f, "{}", message),
+            ErrorDetails::InvalidTool { message } => write!(f, "{message}"),
             ErrorDetails::InvalidUuid { raw_uuid } => {
-                write!(f, "Failed to parse UUID as v7: {}", raw_uuid)
+                write!(f, "Failed to parse UUID as v7: {raw_uuid}")
             }
-            ErrorDetails::JsonRequest { message } => write!(f, "{}", message),
-            ErrorDetails::JsonSchema { message } => write!(f, "{}", message),
+            ErrorDetails::JsonRequest { message } => write!(f, "{message}"),
+            ErrorDetails::JsonSchema { message } => write!(f, "{message}"),
             ErrorDetails::JsonSchemaValidation {
                 messages,
                 data,
@@ -780,28 +773,27 @@ impl std::fmt::Display for ErrorDetails {
                 )
             }
             ErrorDetails::MiniJinjaEnvironment { message } => {
-                write!(f, "Error initializing MiniJinja environment: {}", message)
+                write!(f, "Error initializing MiniJinja environment: {message}")
             }
             ErrorDetails::MiniJinjaTemplate {
                 template_name,
                 message,
             } => {
-                write!(f, "Error rendering template {}: {}", template_name, message)
+                write!(f, "Error rendering template {template_name}: {message}")
             }
             ErrorDetails::MiniJinjaTemplateMissing { template_name } => {
-                write!(f, "Template not found: {}", template_name)
+                write!(f, "Template not found: {template_name}")
             }
             ErrorDetails::MiniJinjaTemplateRender {
                 template_name,
                 message,
             } => {
-                write!(f, "Error rendering template {}: {}", template_name, message)
+                write!(f, "Error rendering template {template_name}: {message}")
             }
             ErrorDetails::MissingBatchInferenceResponse { inference_id } => match inference_id {
                 Some(inference_id) => write!(
                     f,
-                    "Missing batch inference response for inference id: {}",
-                    inference_id
+                    "Missing batch inference response for inference id: {inference_id}"
                 ),
                 None => write!(f, "Missing batch inference response"),
             },
@@ -811,16 +803,16 @@ impl std::fmt::Display for ErrorDetails {
                     "All model providers failed to infer with errors: {}",
                     provider_errors
                         .iter()
-                        .map(|(provider_name, error)| format!("{}: {}", provider_name, error))
+                        .map(|(provider_name, error)| format!("{provider_name}: {error}"))
                         .collect::<Vec<_>>()
                         .join(", ")
                 )
             }
             ErrorDetails::ModelValidation { message } => {
-                write!(f, "Failed to validate model: {}", message)
+                write!(f, "Failed to validate model: {message}")
             }
             ErrorDetails::Observability { message } => {
-                write!(f, "{}", message)
+                write!(f, "{message}")
             }
             ErrorDetails::OutputParsing {
                 raw_output,
@@ -832,40 +824,37 @@ impl std::fmt::Display for ErrorDetails {
                 )
             }
             ErrorDetails::OutputValidation { source } => {
-                write!(f, "Output validation failed with messages: {}", source)
+                write!(f, "Output validation failed with messages: {source}")
             }
             ErrorDetails::ProviderNotFound { provider_name } => {
-                write!(f, "Provider not found: {}", provider_name)
+                write!(f, "Provider not found: {provider_name}")
             }
             ErrorDetails::StreamError { source } => {
                 write!(f, "Error in streaming response: {source}")
             }
-            ErrorDetails::Serialization { message } => write!(f, "{}", message),
-            ErrorDetails::TypeConversion { message } => write!(f, "{}", message),
-            ErrorDetails::ToolNotFound { name } => write!(f, "Tool not found: {}", name),
-            ErrorDetails::ToolNotLoaded { name } => write!(f, "Tool not loaded: {}", name),
+            ErrorDetails::Serialization { message } => write!(f, "{message}"),
+            ErrorDetails::TypeConversion { message } => write!(f, "{message}"),
+            ErrorDetails::ToolNotFound { name } => write!(f, "Tool not found: {name}"),
+            ErrorDetails::ToolNotLoaded { name } => write!(f, "Tool not loaded: {name}"),
             ErrorDetails::UnknownCandidate { name } => {
-                write!(f, "Unknown candidate variant: {}", name)
+                write!(f, "Unknown candidate variant: {name}")
             }
-            ErrorDetails::UnknownFunction { name } => write!(f, "Unknown function: {}", name),
-            ErrorDetails::UnknownModel { name } => write!(f, "Unknown model: {}", name),
-            ErrorDetails::UnknownTool { name } => write!(f, "Unknown tool: {}", name),
-            ErrorDetails::UnknownVariant { name } => write!(f, "Unknown variant: {}", name),
-            ErrorDetails::UnknownMetric { name } => write!(f, "Unknown metric: {}", name),
+            ErrorDetails::UnknownFunction { name } => write!(f, "Unknown function: {name}"),
+            ErrorDetails::UnknownModel { name } => write!(f, "Unknown model: {name}"),
+            ErrorDetails::UnknownTool { name } => write!(f, "Unknown tool: {name}"),
+            ErrorDetails::UnknownVariant { name } => write!(f, "Unknown variant: {name}"),
+            ErrorDetails::UnknownMetric { name } => write!(f, "Unknown metric: {name}"),
             ErrorDetails::UnsupportedModelProviderForBatchInference { provider_type } => {
                 write!(
                     f,
-                    "Unsupported model provider for batch inference: {}",
-                    provider_type
+                    "Unsupported model provider for batch inference: {provider_type}"
                 )
             }
             ErrorDetails::UnsupportedVariantForBatchInference { variant_name } => {
                 match variant_name {
-                    Some(variant_name) => write!(
-                        f,
-                        "Unsupported variant for batch inference: {}",
-                        variant_name
-                    ),
+                    Some(variant_name) => {
+                        write!(f, "Unsupported variant for batch inference: {variant_name}")
+                    }
                     None => write!(f, "Unsupported variant for batch inference"),
                 }
             }
@@ -876,14 +865,12 @@ impl std::fmt::Display for ErrorDetails {
                 if let Some(link) = issue_link {
                     write!(
                         f,
-                        "Unsupported variant for streaming inference of type {}. For more information, see: {}",
-                        variant_type, link
+                        "Unsupported variant for streaming inference of type {variant_type}. For more information, see: {link}"
                     )
                 } else {
                     write!(
                         f,
-                        "Unsupported variant for streaming inference of type {}",
-                        variant_type
+                        "Unsupported variant for streaming inference of type {variant_type}"
                     )
                 }
             }
@@ -896,10 +883,10 @@ impl std::fmt::Display for ErrorDetails {
                 write!(f, "Unsupported variant `{variant_name}` of type `{variant_type}` for function `{function_name}` of type `{function_type}`")
             }
             ErrorDetails::UuidInFuture { raw_uuid } => {
-                write!(f, "UUID is in the future: {}", raw_uuid)
+                write!(f, "UUID is in the future: {raw_uuid}")
             }
             ErrorDetails::RouteNotFound { path, method } => {
-                write!(f, "Route not found: {} {}", method, path)
+                write!(f, "Route not found: {method} {path}")
             }
         }
     }

--- a/tensorzero-internal/src/evaluations/mod.rs
+++ b/tensorzero-internal/src/evaluations/mod.rs
@@ -129,17 +129,11 @@ impl From<LLMJudgeOptimize> for MetricConfigOptimize {
 }
 
 pub fn get_llm_judge_function_name(evaluation_name: &str, evaluator_name: &str) -> String {
-    format!(
-        "tensorzero::llm_judge::{}::{}",
-        evaluation_name, evaluator_name
-    )
+    format!("tensorzero::llm_judge::{evaluation_name}::{evaluator_name}")
 }
 
 pub fn get_evaluator_metric_name(evaluation_name: &str, evaluator_name: &str) -> String {
-    format!(
-        "tensorzero::evaluation_name::{}::evaluator_name::{}",
-        evaluation_name, evaluator_name
-    )
+    format!("tensorzero::evaluation_name::{evaluation_name}::evaluator_name::{evaluator_name}")
 }
 
 #[derive(Debug, TensorZeroDeserialize)]

--- a/tensorzero-internal/src/function.rs
+++ b/tensorzero-internal/src/function.rs
@@ -575,7 +575,7 @@ mod tests {
         "#;
 
         let mut temp_file = NamedTempFile::new().expect("Failed to create temporary file");
-        write!(temp_file, "{}", schema).expect("Failed to write schema to temporary file");
+        write!(temp_file, "{schema}").expect("Failed to write schema to temporary file");
 
         StaticJSONSchema::from_path(temp_file.path().to_owned(), PathBuf::new())
             .expect("Failed to create schema")
@@ -1437,8 +1437,7 @@ mod tests {
 
                 assert!(
                     diff <= tolerance,
-                    "Probability for variant {} is outside the acceptable range",
-                    variant_name
+                    "Probability for variant {variant_name} is outside the acceptable range"
                 );
             }
         }
@@ -1483,11 +1482,7 @@ mod tests {
         for (variant_name, count) in counts {
             assert!(
                 (count as i32 - expected_count as i32).abs() <= tolerance as i32,
-                "Variant {} was not sampled uniformly. Expected {} +/- {}, got {}",
-                variant_name,
-                expected_count,
-                tolerance,
-                count
+                "Variant {variant_name} was not sampled uniformly. Expected {expected_count} +/- {tolerance}, got {count}"
             );
         }
     }

--- a/tensorzero-internal/src/gateway_util.rs
+++ b/tensorzero-internal/src/gateway_util.rs
@@ -152,7 +152,7 @@ pub fn setup_http_client() -> Result<Client, Error> {
             http_client_builder = http_client_builder
                 .proxy(Proxy::all(proxy_url).map_err(|e| {
                     Error::new(ErrorDetails::AppState {
-                        message: format!("Invalid proxy URL: {}", e),
+                        message: format!("Invalid proxy URL: {e}"),
                     })
                 })?)
                 // When running e2e tests, we use `provider-proxy` as an MITM proxy
@@ -163,7 +163,7 @@ pub fn setup_http_client() -> Result<Client, Error> {
 
     http_client_builder.build().map_err(|e| {
         Error::new(ErrorDetails::AppState {
-            message: format!("Failed to build HTTP client: {}", e),
+            message: format!("Failed to build HTTP client: {e}"),
         })
     })
 }
@@ -187,12 +187,12 @@ pub async fn start_openai_compatible_gateway(
         .await
         .map_err(|e| {
             Error::new(ErrorDetails::InternalError {
-                message: format!("Failed to bind to a port: {}", e),
+                message: format!("Failed to bind to a port: {e}"),
             })
         })?;
     let bind_addr = listener.local_addr().map_err(|e| {
         Error::new(ErrorDetails::InternalError {
-            message: format!("Failed to get local address: {}", e),
+            message: format!("Failed to get local address: {e}"),
         })
     })?;
 

--- a/tensorzero-internal/src/inference/providers/aws_bedrock.rs
+++ b/tensorzero-internal/src/inference/providers/aws_bedrock.rs
@@ -808,7 +808,7 @@ fn serialize_aws_bedrock_struct<T: std::fmt::Debug>(output: &T) -> Result<String
     serde_json::to_string(&serde_json::json!({"debug": format!("{:?}", output)})).map_err(|e| {
         Error::new(ErrorDetails::InferenceServer {
             raw_request: None,
-            raw_response: Some(format!("{:?}", output)),
+            raw_response: Some(format!("{output:?}")),
             message: format!(
                 "Error parsing response from AWS Bedrock: {}",
                 DisplayOrDebugGateway::new(e)

--- a/tensorzero-internal/src/inference/providers/aws_http_client.rs
+++ b/tensorzero-internal/src/inference/providers/aws_http_client.rs
@@ -93,7 +93,7 @@ impl std::fmt::Display for CallError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.message)?;
         if let Some(err) = self.source.as_ref() {
-            write!(f, ": {}", err)?;
+            write!(f, ": {err}")?;
         }
         Ok(())
     }

--- a/tensorzero-internal/src/inference/providers/aws_sagemaker.rs
+++ b/tensorzero-internal/src/inference/providers/aws_sagemaker.rs
@@ -114,7 +114,7 @@ impl InferenceProvider for AWSSagemakerProvider {
         })?;
         let raw_response_string = String::from_utf8(raw_response.into_inner()).map_err(|e| {
             Error::new(ErrorDetails::InferenceServer {
-                message: format!("Error converting raw response to string: {}", e),
+                message: format!("Error converting raw response to string: {e}"),
                 raw_request: Some(raw_request.clone()),
                 raw_response: None,
                 provider_type: PROVIDER_TYPE.to_string(),

--- a/tensorzero-internal/src/inference/providers/deepseek.rs
+++ b/tensorzero-internal/src/inference/providers/deepseek.rs
@@ -438,8 +438,7 @@ fn stream_deepseek(
                         let data: Result<DeepSeekChatChunk, Error> =
                             serde_json::from_str(&message.data).map_err(|e| Error::new(ErrorDetails::InferenceServer {
                                 message: format!(
-                                    "Error parsing chunk. Error: {}",
-                                    e,
+                                    "Error parsing chunk. Error: {e}",
                                 ),
                                 raw_request: None,
                                 raw_response: Some(message.data.clone()),

--- a/tensorzero-internal/src/inference/providers/fireworks.rs
+++ b/tensorzero-internal/src/inference/providers/fireworks.rs
@@ -585,7 +585,7 @@ fn stream_fireworks(
                         }
                         let data: Result<FireworksChatChunk, Error> =
                             serde_json::from_str(&message.data).map_err(|e| Error::new(ErrorDetails::InferenceServer {
-                                message: format!("Error parsing chunk. Error: {}", e),
+                                message: format!("Error parsing chunk. Error: {e}"),
                                 raw_request: None,
                                 raw_response: Some(message.data.clone()),
                                 provider_type: PROVIDER_TYPE.to_string(),

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
@@ -101,7 +101,7 @@ impl TryFrom<(Credential, &str)> for GCPVertexCredentials {
                 GCPServiceAccountCredentials::from_json_str(file_content.expose_secret()).map_err(
                     |e| {
                         Error::new(ErrorDetails::GCPCredentials {
-                            message: format!("Failed to load GCP credentials: {}", e),
+                            message: format!("Failed to load GCP credentials: {e}"),
                         })
                     },
                 )?,
@@ -109,7 +109,7 @@ impl TryFrom<(Credential, &str)> for GCPVertexCredentials {
             Credential::Dynamic(key_name) => Ok(GCPVertexCredentials::Dynamic(key_name)),
             Credential::Missing => Ok(GCPVertexCredentials::None),
             _ => Err(Error::new(ErrorDetails::GCPCredentials {
-                message: format!("Invalid credential_location for {} provider", model),
+                message: format!("Invalid credential_location for {model} provider"),
             }))?,
         }
     }

--- a/tensorzero-internal/src/inference/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/google_ai_studio_gemini.rs
@@ -65,7 +65,7 @@ impl GoogleAIStudioGeminiProvider {
         ))
         .map_err(|e| {
             Error::new(ErrorDetails::Config {
-                message: format!("Failed to parse request URL: {}", e),
+                message: format!("Failed to parse request URL: {e}"),
             })
         })?;
         let streaming_request_url = Url::parse(&format!(
@@ -73,7 +73,7 @@ impl GoogleAIStudioGeminiProvider {
         ))
         .map_err(|e| {
             Error::new(ErrorDetails::Config {
-                message: format!("Failed to parse streaming request URL: {}", e),
+                message: format!("Failed to parse streaming request URL: {e}"),
             })
         })?;
         Ok(GoogleAIStudioGeminiProvider {

--- a/tensorzero-internal/src/inference/providers/openai.rs
+++ b/tensorzero-internal/src/inference/providers/openai.rs
@@ -782,8 +782,7 @@ pub fn stream_openai(
                         let data: Result<OpenAIChatChunk, Error> =
                             serde_json::from_str(&message.data).map_err(|e| Error::new(ErrorDetails::InferenceServer {
                                 message: format!(
-                                    "Error parsing chunk. Error: {}",
-                                    e,
+                                    "Error parsing chunk. Error: {e}",
                                 ),
                                 raw_request: None,
                                 raw_response: Some(message.data.clone()),
@@ -927,7 +926,7 @@ fn get_file_url(base_url: &Url, file_id: Option<&str>) -> Result<Url, Error> {
         url.set_path(&format!("{}/", url.path()));
     }
     let path = if let Some(id) = file_id {
-        format!("files/{}/content", id)
+        format!("files/{id}/content")
     } else {
         "files".to_string()
     };

--- a/tensorzero-internal/src/inference/providers/tgi.rs
+++ b/tensorzero-internal/src/inference/providers/tgi.rs
@@ -344,8 +344,7 @@ fn stream_tgi(
                         let data: Result<TGIChatChunk, Error> =
                             serde_json::from_str(&message.data).map_err(|e| Error::new(ErrorDetails::InferenceServer {
                                 message: format!(
-                                    "Error parsing chunk. Error: {}",
-                                    e,
+                                    "Error parsing chunk. Error: {e}",
                                 ),
                                 raw_request: None,
                                 raw_response: Some(message.data.clone()),

--- a/tensorzero-internal/src/inference/providers/together.rs
+++ b/tensorzero-internal/src/inference/providers/together.rs
@@ -626,7 +626,7 @@ fn stream_together(
                         }
                         let data: Result<TogetherChatChunk, Error> =
                             serde_json::from_str(&message.data).map_err(|e| Error::new(ErrorDetails::InferenceServer {
-                                message: format!("Error parsing chunk. Error: {}", e),
+                                message: format!("Error parsing chunk. Error: {e}"),
                                 raw_request: None,
                                 raw_response: Some(message.data.clone()),
                                 provider_type: PROVIDER_TYPE.to_string(),

--- a/tensorzero-internal/src/inference/types/mod.rs
+++ b/tensorzero-internal/src/inference/types/mod.rs
@@ -228,8 +228,7 @@ impl<'de> Deserialize<'de> for TextKind {
             }),
             "value" => Ok(TextKind::LegacyValue { value }),
             _ => Err(serde::de::Error::custom(format!(
-                "Unknown key '{}' in text content",
-                key
+                "Unknown key '{key}' in text content"
             ))),
         }
     }
@@ -1647,7 +1646,7 @@ pub fn serialize_or_log<T: Serialize>(value: &T) -> String {
         Ok(serialized) => serialized,
         Err(e) => {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Failed to serialize value: {}", e),
+                message: format!("Failed to serialize value: {e}"),
             });
             String::new()
         }
@@ -2705,7 +2704,7 @@ mod tests {
             );
             assert_eq!(model_inference_result.raw_request, raw_request);
         } else {
-            panic!("Expected Ok(InferenceResult::Chat), got {:?}", result);
+            panic!("Expected Ok(InferenceResult::Chat), got {result:?}");
         }
 
         // Test Case 6: a JSON function with implicit tool call config

--- a/tensorzero-internal/src/jsonschema_util.rs
+++ b/tensorzero-internal/src/jsonschema_util.rs
@@ -96,7 +96,7 @@ impl StaticJSONSchema {
         let schema_boxed: &'static serde_json::Value = Box::leak(Box::new(value.clone()));
         let compiled_schema = jsonschema::validator_for(schema_boxed).map_err(|e| {
             Error::new(ErrorDetails::JsonSchema {
-                message: format!("Failed to compile JSON Schema: {}", e),
+                message: format!("Failed to compile JSON Schema: {e}"),
             })
         })?;
         Ok(Self {
@@ -184,7 +184,7 @@ impl DynamicJSONSchema {
                     .await
                     .map_err(|e| {
                         Error::new(ErrorDetails::JsonSchema {
-                            message: format!("Task join error in DynamicJSONSchema: {}", e),
+                            message: format!("Task join error in DynamicJSONSchema: {e}"),
                         })
                     })?
                 }
@@ -224,7 +224,7 @@ mod tests {
         "#;
 
         let mut temp_file = NamedTempFile::new().expect("Failed to create temporary file");
-        write!(temp_file, "{}", schema).expect("Failed to write schema to temporary file");
+        write!(temp_file, "{schema}").expect("Failed to write schema to temporary file");
 
         let schema = StaticJSONSchema::from_path(temp_file.path().to_owned(), PathBuf::from(""))
             .expect("Failed to load schema");
@@ -268,7 +268,7 @@ mod tests {
         "#;
 
         let mut temp_file = NamedTempFile::new().expect("Failed to create temporary file");
-        write!(temp_file, "{}", invalid_schema)
+        write!(temp_file, "{invalid_schema}")
             .expect("Failed to write invalid schema to temporary file");
 
         let result = StaticJSONSchema::from_path(temp_file.path().to_owned(), PathBuf::from(""));

--- a/tensorzero-internal/src/minijinja_util.rs
+++ b/tensorzero-internal/src/minijinja_util.rs
@@ -32,7 +32,7 @@ impl TemplateConfig<'_> {
                 .map_err(|e| {
                     Error::new(ErrorDetails::MiniJinjaTemplate {
                         template_name,
-                        message: format!("Failed to add template: {}", e),
+                        message: format!("Failed to add template: {e}"),
                     })
                 })?;
         }
@@ -60,7 +60,7 @@ impl TemplateConfig<'_> {
             .map_err(|e| {
                 Error::new(ErrorDetails::MiniJinjaTemplate {
                     template_name: template_name.to_string(),
-                    message: format!("Failed to add template: {}", e),
+                    message: format!("Failed to add template: {e}"),
                 })
             })
     }
@@ -76,10 +76,10 @@ impl TemplateConfig<'_> {
         match maybe_message {
             Ok(message) => Ok(message),
             Err(err) => {
-                let mut message = format!("Could not render template: {:#}", err);
+                let mut message = format!("Could not render template: {err:#}");
                 let mut err = &err as &dyn std::error::Error;
                 while let Some(next_err) = err.source() {
-                    message.push_str(&format!("\nCaused by: {:#}", next_err));
+                    message.push_str(&format!("\nCaused by: {next_err:#}"));
                     err = next_err;
                 }
                 Err(ErrorDetails::MiniJinjaTemplateRender {
@@ -110,7 +110,7 @@ impl TemplateConfig<'_> {
             .map_err(|e| {
                 Error::new(ErrorDetails::MiniJinjaTemplate {
                     template_name: "t0:best_of_n_evaluator_system".to_string(),
-                    message: format!("Failed to add template: {}", e),
+                    message: format!("Failed to add template: {e}"),
                 })
             })?;
         self.env
@@ -121,7 +121,7 @@ impl TemplateConfig<'_> {
             .map_err(|e| {
                 Error::new(ErrorDetails::MiniJinjaTemplate {
                     template_name: "t0:best_of_n_evaluator_candidates".to_string(),
-                    message: format!("Failed to add template: {}", e),
+                    message: format!("Failed to add template: {e}"),
                 })
             })?;
         self.env
@@ -129,7 +129,7 @@ impl TemplateConfig<'_> {
             .map_err(|e| {
                 Error::new(ErrorDetails::MiniJinjaTemplate {
                     template_name: "t0:mixture_of_n_fuser_system".to_string(),
-                    message: format!("Failed to add template: {}", e),
+                    message: format!("Failed to add template: {e}"),
                 })
             })?;
         self.env
@@ -140,7 +140,7 @@ impl TemplateConfig<'_> {
             .map_err(|e| {
                 Error::new(ErrorDetails::MiniJinjaTemplate {
                     template_name: "t0:mixture_of_n_fuser_candidates".to_string(),
-                    message: format!("Failed to add template: {}", e),
+                    message: format!("Failed to add template: {e}"),
                 })
             })?;
         Ok(())

--- a/tensorzero-internal/src/model.rs
+++ b/tensorzero-internal/src/model.rs
@@ -1200,8 +1200,7 @@ impl<'de> Deserialize<'de> for CredentialLocation {
             Ok(CredentialLocation::None)
         } else {
             Err(serde::de::Error::custom(format!(
-                "Invalid ApiKeyLocation format: {}",
-                s
+                "Invalid ApiKeyLocation format: {s}"
             )))
         }
     }
@@ -1320,8 +1319,7 @@ impl TryFrom<(CredentialLocation, &str)> for Credential {
                         } else {
                             return Err(Error::new(ErrorDetails::ApiKeyMissing {
                                 provider_name: format!(
-                                    "{}: Environment variable {} for credentials path is missing",
-                                    provider_type, env_key
+                                    "{provider_type}: Environment variable {env_key} for credentials path is missing"
                                 ),
                             }));
                         }
@@ -1343,8 +1341,7 @@ impl TryFrom<(CredentialLocation, &str)> for Credential {
                         } else {
                             Err(Error::new(ErrorDetails::ApiKeyMissing {
                                 provider_name: format!(
-                                    "{}: Failed to read credentials file - {}",
-                                    provider_type, e
+                                    "{provider_type}: Failed to read credentials file - {e}"
                                 ),
                             }))
                         }
@@ -1366,8 +1363,7 @@ impl TryFrom<(CredentialLocation, &str)> for Credential {
                     } else {
                         Err(Error::new(ErrorDetails::ApiKeyMissing {
                             provider_name: format!(
-                                "{}: Failed to read credentials file - {}",
-                                provider_type, e
+                                "{provider_type}: Failed to read credentials file - {e}"
                             ),
                         }))
                     }
@@ -1423,7 +1419,7 @@ impl ShorthandModelConfig for ModelConfig {
             "dummy" => ProviderConfig::Dummy(DummyProvider::new(model_name, None)?),
             _ => {
                 return Err(ErrorDetails::Config {
-                    message: format!("Invalid provider type: {}", provider_type),
+                    message: format!("Invalid provider type: {provider_type}"),
                 }
                 .into());
             }
@@ -2247,8 +2243,7 @@ mod tests {
         for &shorthand in SHORTHAND_MODEL_PREFIXES {
             assert!(
                 RESERVED_MODEL_PREFIXES.contains(&shorthand.to_string()),
-                "Shorthand prefix '{}' is not in RESERVED_MODEL_PREFIXES",
-                shorthand
+                "Shorthand prefix '{shorthand}' is not in RESERVED_MODEL_PREFIXES"
             );
         }
     }

--- a/tensorzero-internal/src/model_table.rs
+++ b/tensorzero-internal/src/model_table.rs
@@ -15,7 +15,7 @@ lazy_static! {
     pub static ref RESERVED_MODEL_PREFIXES: Vec<String> = {
         let mut prefixes: Vec<String> = ProviderConfigHelper::VARIANTS
             .iter()
-            .map(|&v| format!("{}::", v))
+            .map(|&v| format!("{v}::"))
             .collect();
         prefixes.push("tensorzero::".to_string());
         prefixes
@@ -133,7 +133,7 @@ impl<T: ShorthandModelConfig> BaseModelTable<T> {
         }
 
         Err(ErrorDetails::Config {
-            message: format!("Model name '{}' not found in model table", key),
+            message: format!("Model name '{key}' not found in model table"),
         }
         .into())
     }

--- a/tensorzero-internal/src/observability.rs
+++ b/tensorzero-internal/src/observability.rs
@@ -36,7 +36,7 @@ pub fn setup_logs(debug: bool, log_format: LogFormat) {
 pub fn setup_metrics() -> Result<PrometheusHandle, Error> {
     PrometheusBuilder::new().install_recorder().map_err(|e| {
         Error::new(ErrorDetails::Observability {
-            message: format!("Failed to install Prometheus exporter: {}", e),
+            message: format!("Failed to install Prometheus exporter: {e}"),
         })
     })
 }

--- a/tensorzero-internal/src/uuid_util.rs
+++ b/tensorzero-internal/src/uuid_util.rs
@@ -15,7 +15,7 @@ pub fn validate_tensorzero_uuid(uuid: Uuid, kind: &str) -> Result<(), Error> {
     if version != 7 {
         return Err(ErrorDetails::InvalidTensorzeroUuid {
             kind: kind.to_string(),
-            message: format!("Version must be 7, got {}", version),
+            message: format!("Version must be 7, got {version}"),
         }
         .into());
     }

--- a/tensorzero-internal/src/variant/chain_of_thought.rs
+++ b/tensorzero-internal/src/variant/chain_of_thought.rs
@@ -57,8 +57,7 @@ impl Variant for ChainOfThoughtConfig {
             // This should never happen, because we check this in `validate`
             return Err(ErrorDetails::Inference {
                 message: format!(
-                    "Can't use chain of thought variant type with non-JSON function. {}",
-                    IMPOSSIBLE_ERROR_MESSAGE
+                    "Can't use chain of thought variant type with non-JSON function. {IMPOSSIBLE_ERROR_MESSAGE}"
                 ),
             }
             .into());

--- a/tensorzero-internal/src/variant/chat_completion.rs
+++ b/tensorzero-internal/src/variant/chat_completion.rs
@@ -179,7 +179,7 @@ impl ChatCompletionConfig {
                 .as_str()
                 .ok_or_else(|| Error::new(ErrorDetails::InvalidMessage {
                     message:
-                        format!("System message content {} is not a string but there is no variant template", system)
+                        format!("System message content {system} is not a string but there is no variant template")
                             .to_string(),
                 }))?
                 .to_string()),

--- a/tensorzero-internal/src/variant/dicl.rs
+++ b/tensorzero-internal/src/variant/dicl.rs
@@ -314,8 +314,7 @@ impl DiclConfig {
         let serialized_input = serde_json::to_string(&input).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
                 message: format!(
-                    "Error in serializing Input in dynamic in-context learning variant: {}",
-                    e
+                    "Error in serializing Input in dynamic in-context learning variant: {e}"
                 ),
             })
         })?;
@@ -374,7 +373,7 @@ impl DiclConfig {
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| {
                 Error::new(ErrorDetails::Serialization {
-                    message: format!("Failed to parse raw examples: {}", e),
+                    message: format!("Failed to parse raw examples: {e}"),
                 })
             })?;
 
@@ -411,8 +410,7 @@ impl DiclConfig {
                 .map_err(|e| {
                     Error::new(ErrorDetails::Serialization {
                         message: format!(
-                            "Error in serializing Input in dynamic in-context learning variant: {}",
-                            e
+                            "Error in serializing Input in dynamic in-context learning variant: {e}"
                         ),
                     })
                 })?
@@ -445,8 +443,7 @@ impl DiclConfig {
             .map_err(|e| {
                 Error::new(ErrorDetails::Serialization {
                     message: format!(
-                        "Error in serializing Input in dynamic in-context learning variant: {}",
-                        e
+                        "Error in serializing Input in dynamic in-context learning variant: {e}"
                     ),
                 })
             })?
@@ -549,7 +546,7 @@ fn parse_raw_examples(
         // Parse the `input` string into `Input`
         let input: ResolvedInput = serde_json::from_str(&raw_example.input).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
-                message: format!("Failed to parse `input`: {}", e),
+                message: format!("Failed to parse `input`: {e}"),
             })
         })?;
 
@@ -571,8 +568,7 @@ fn parse_raw_examples(
                         .map_err(|e| {
                             Error::new(ErrorDetails::Serialization {
                                 message: format!(
-                                    "Failed to parse `output` in example `{:?}`: {}",
-                                    raw_example, e
+                                    "Failed to parse `output` in example `{raw_example:?}`: {e}"
                                 ),
                             })
                         })?;
@@ -584,8 +580,7 @@ fn parse_raw_examples(
                     .map_err(|e| {
                         Error::new(ErrorDetails::Serialization {
                             message: format!(
-                                "Failed to parse `output` in example `{:?}`: {}",
-                                raw_example, e
+                                "Failed to parse `output` in example `{raw_example:?}`: {e}"
                             ),
                         })
                     })?;
@@ -611,7 +606,7 @@ impl LoadableConfig<DiclConfig> for UninitializedDiclConfig {
                 let path = base_path.as_ref().join(path);
                 fs::read_to_string(path).map_err(|e| {
                     Error::new(ErrorDetails::Config {
-                        message: format!("Failed to read system instructions: {}", e),
+                        message: format!("Failed to read system instructions: {e}"),
                     })
                 })?
             }

--- a/tensorzero-internal/tests/e2e/clickhouse.rs
+++ b/tensorzero-internal/tests/e2e/clickhouse.rs
@@ -40,7 +40,7 @@ fn get_clean_clickhouse() -> ClickHouseConnectionInfo {
     );
     let mut clickhouse_url = url::Url::parse(&CLICKHOUSE_URL).unwrap();
     clickhouse_url.set_path("");
-    clickhouse_url.set_query(Some(format!("database={}", database).as_str()));
+    clickhouse_url.set_query(Some(format!("database={database}").as_str()));
 
     ClickHouseConnectionInfo::Production {
         database_url: SecretString::from(clickhouse_url.to_string()),

--- a/tensorzero-internal/tests/e2e/datasets.rs
+++ b/tensorzero-internal/tests/e2e/datasets.rs
@@ -42,7 +42,7 @@ async fn test_datapoint_insert_synthetic_chat() {
     let resp_json = resp.json::<Value>().await.unwrap();
 
     if !status.is_success() {
-        panic!("Bad request: {:?}", resp_json);
+        panic!("Bad request: {resp_json:?}");
     }
 
     let id: Uuid = resp_json
@@ -246,7 +246,7 @@ async fn test_datapoint_insert_synthetic_chat_with_tools() {
     // This should fail because the tool call is not in the tool_params
     assert_eq!(status, StatusCode::BAD_REQUEST);
     let err_msg = resp_json.get("error").unwrap().as_str().unwrap();
-    println!("Error: {}", err_msg);
+    println!("Error: {err_msg}");
     assert!(
         err_msg.contains("Demonstration contains invalid tool name"),
         "Unexpected error message: {err_msg}"
@@ -285,7 +285,7 @@ async fn test_datapoint_insert_synthetic_chat_with_tools() {
     // This request is correct
     assert_eq!(status, StatusCode::BAD_REQUEST);
     let err_msg = resp_json.get("error").unwrap().as_str().unwrap();
-    println!("Error: {}", err_msg);
+    println!("Error: {err_msg}");
     assert!(
         err_msg.contains("Demonstration contains invalid tool call arguments"),
         "Unexpected error message: {err_msg}"
@@ -397,7 +397,7 @@ async fn test_datapoint_insert_synthetic_json() {
     let resp_json = resp.json::<Value>().await.unwrap();
 
     if !status.is_success() {
-        panic!("Bad request: {:?}", resp_json);
+        panic!("Bad request: {resp_json:?}");
     }
 
     let id: Uuid = resp_json
@@ -591,7 +591,7 @@ async fn test_datapoint_insert_synthetic_json() {
 
     // Check that the datapoint was not inserted into clickhouse
     let datapoint = select_json_datapoint_clickhouse(&clickhouse, new_datapoint_id).await;
-    println!("datapoint: {:?}", datapoint);
+    println!("datapoint: {datapoint:?}");
     assert!(datapoint.is_none());
     // Let's stale the old datapoint and try again
     stale_datapoint_clickhouse(&clickhouse, datapoint_id).await;
@@ -1694,8 +1694,7 @@ async fn test_datapoint_insert_missing_output_chat() {
     let status = resp.status();
     assert!(
         status.is_success(),
-        "Expected successful response, got: {}",
-        status
+        "Expected successful response, got: {status}"
     );
 
     let resp_json = resp.json::<Value>().await.unwrap();
@@ -1758,8 +1757,7 @@ async fn test_datapoint_insert_null_output_chat() {
     let status = resp.status();
     assert!(
         status.is_success(),
-        "Expected successful response, got: {}",
-        status
+        "Expected successful response, got: {status}"
     );
 
     let resp_json = resp.json::<Value>().await.unwrap();
@@ -1823,8 +1821,7 @@ async fn test_datapoint_insert_missing_output_json() {
     let status = resp.status();
     assert!(
         status.is_success(),
-        "Expected successful response, got: {}",
-        status
+        "Expected successful response, got: {status}"
     );
 
     let resp_json = resp.json::<Value>().await.unwrap();
@@ -1888,8 +1885,7 @@ async fn test_datapoint_insert_null_output_json() {
     let status = resp.status();
     assert!(
         status.is_success(),
-        "Expected successful response, got: {}",
-        status
+        "Expected successful response, got: {status}"
     );
 
     let resp_json = resp.json::<Value>().await.unwrap();

--- a/tensorzero-internal/tests/e2e/dicl.rs
+++ b/tensorzero-internal/tests/e2e/dicl.rs
@@ -297,7 +297,7 @@ pub async fn test_dicl_inference_request_no_examples(dicl_variant_name: &str) {
                 assert!(model_inference.get("output_tokens").unwrap().is_null());
             }
             _ => {
-                panic!("Unexpected model: {}", model_name);
+                panic!("Unexpected model: {model_name}");
             }
         }
         let model_inference_id = model_inference.get("id").unwrap().as_str().unwrap();
@@ -404,8 +404,7 @@ pub async fn test_dicl_inference_request_simple() {
     let function_name = "basic_test";
     // Delete any existing examples for this function and variant
     let delete_query = format!(
-        "ALTER TABLE DynamicInContextLearningExample DELETE WHERE function_name = '{}' AND variant_name = '{}'",
-            function_name, variant_name
+        "ALTER TABLE DynamicInContextLearningExample DELETE WHERE function_name = '{function_name}' AND variant_name = '{variant_name}'"
         );
     clickhouse
         .run_query_synchronous(delete_query, None)
@@ -693,7 +692,7 @@ pub async fn test_dicl_inference_request_simple() {
                 assert_eq!(output.len(), 0);
             }
             _ => {
-                panic!("Unexpected model: {}", model_name);
+                panic!("Unexpected model: {model_name}");
             }
         }
         let model_inference_id = model_inference.get("id").unwrap().as_str().unwrap();
@@ -936,7 +935,7 @@ pub async fn test_dicl_inference_request_simple() {
                 assert_eq!(output.len(), 0);
             }
             _ => {
-                panic!("Unexpected model: {}", model_name);
+                panic!("Unexpected model: {model_name}");
             }
         }
         let model_inference_id = model_inference.get("id").unwrap().as_str().unwrap();
@@ -985,8 +984,7 @@ async fn test_dicl_json_request() {
     let function_name = "json_success";
     // Delete any existing examples for this function and variant
     let delete_query = format!(
-        "ALTER TABLE DynamicInContextLearningExample DELETE WHERE function_name = '{}' AND variant_name = '{}'",
-            function_name, variant_name
+        "ALTER TABLE DynamicInContextLearningExample DELETE WHERE function_name = '{function_name}' AND variant_name = '{variant_name}'"
         );
     clickhouse
         .run_query_synchronous(delete_query, None)
@@ -1263,7 +1261,7 @@ async fn test_dicl_json_request() {
                 assert_eq!(output.len(), 0);
             }
             _ => {
-                panic!("Unexpected model: {}", model_name);
+                panic!("Unexpected model: {model_name}");
             }
         }
         let model_inference_id = model_inference.get("id").unwrap().as_str().unwrap();

--- a/tensorzero-internal/tests/e2e/feedback.rs
+++ b/tensorzero-internal/tests/e2e/feedback.rs
@@ -1036,8 +1036,7 @@ async fn e2e_test_float_feedback() {
     let error_message = response_json.get("error").unwrap().as_str().unwrap();
     assert!(
         error_message.contains("Correct ID was not provided for feedback level"),
-        "Unexpected error message: {}",
-        error_message
+        "Unexpected error message: {error_message}"
     );
 
     // Running without valid inference_id. Should fail.
@@ -1208,8 +1207,7 @@ async fn e2e_test_boolean_feedback() {
     let error_message = response_json.get("error").unwrap().as_str().unwrap();
     assert!(
         error_message.contains("Correct ID was not provided for feedback level"),
-        "Unexpected error message: {}",
-        error_message
+        "Unexpected error message: {error_message}"
     );
 
     // Try string feedback (should fail)

--- a/tensorzero-internal/tests/e2e/inference.rs
+++ b/tensorzero-internal/tests/e2e/inference.rs
@@ -1848,7 +1848,7 @@ model_name = "json"
     let good_response = gateway.inference(params.clone()).await.unwrap();
     let InferenceOutput::NonStreaming(InferenceResponse::Chat(good_response)) = good_response
     else {
-        panic!("Expected non-streaming response, got {:?}", good_response);
+        panic!("Expected non-streaming response, got {good_response:?}");
     };
 
     assert_eq!(
@@ -1859,7 +1859,7 @@ model_name = "json"
     // Second request to the flaky judge should fail
     let bad_response = gateway.inference(params).await.unwrap();
     let InferenceOutput::NonStreaming(InferenceResponse::Chat(bad_response)) = bad_response else {
-        panic!("Expected non-streaming response, got {:?}", bad_response);
+        panic!("Expected non-streaming response, got {bad_response:?}");
     };
 
     assert!(
@@ -1914,7 +1914,7 @@ model = "dummy::flaky_model"
     let good_response = gateway.inference(params.clone()).await.unwrap();
     let InferenceOutput::NonStreaming(InferenceResponse::Chat(good_response)) = good_response
     else {
-        panic!("Expected non-streaming response, got {:?}", good_response);
+        panic!("Expected non-streaming response, got {good_response:?}");
     };
 
     assert_eq!(
@@ -1925,7 +1925,7 @@ model = "dummy::flaky_model"
     // Second request to the flaky judge should fail
     let bad_response = gateway.inference(params).await.unwrap();
     let InferenceOutput::NonStreaming(InferenceResponse::Chat(bad_response)) = bad_response else {
-        panic!("Expected non-streaming response, got {:?}", bad_response);
+        panic!("Expected non-streaming response, got {bad_response:?}");
     };
 
     assert!(

--- a/tensorzero-internal/tests/e2e/openai_compatible.rs
+++ b/tensorzero-internal/tests/e2e/openai_compatible.rs
@@ -59,7 +59,7 @@ async fn test_openai_compatible_route_with_function_name_asmodel(model: &str) {
     // Check Response is OK, then fields in order
     assert_eq!(response.status(), StatusCode::OK);
     let response_json = response.json::<Value>().await.unwrap();
-    println!("response: {:?}", response_json);
+    println!("response: {response_json:?}");
     let choices = response_json.get("choices").unwrap().as_array().unwrap();
     assert!(choices.len() == 1);
     let choice = choices.first().unwrap();
@@ -135,7 +135,7 @@ async fn test_openai_compatible_route_with_function_name_asmodel(model: &str) {
     let result = select_model_inference_clickhouse(&clickhouse, inference_id)
         .await
         .unwrap();
-    println!("ModelInference result: {:?}", result);
+    println!("ModelInference result: {result:?}");
     let inference_id_result = result.get("inference_id").unwrap().as_str().unwrap();
     let inference_id_result = Uuid::parse_str(inference_id_result).unwrap();
     assert_eq!(inference_id_result, inference_id);
@@ -216,8 +216,7 @@ async fn test_openai_compatible_matches_response_fields() {
     let missing_keys: Vec<_> = openai_keys.difference(&tensorzero_keys).collect();
     assert!(
         missing_keys.is_empty(),
-        "Missing keys in TensorZero response: {:?}",
-        missing_keys
+        "Missing keys in TensorZero response: {missing_keys:?}"
     );
 }
 
@@ -252,7 +251,7 @@ async fn test_openai_compatible_dryrun() {
     // Check Response is OK, then fields in order
     assert_eq!(response.status(), StatusCode::OK);
     let response_json = response.json::<Value>().await.unwrap();
-    println!("response_json: {:?}", response_json);
+    println!("response_json: {response_json:?}");
     let choices = response_json.get("choices").unwrap().as_array().unwrap();
     assert!(choices.len() == 1);
     let choice = choices.first().unwrap();
@@ -333,7 +332,7 @@ async fn test_openai_compatible_route_with_default_function(
     // Check Response is OK, then fields in order
     assert_eq!(response.status(), StatusCode::OK);
     let response_json = response.json::<Value>().await.unwrap();
-    println!("response_json: {:?}", response_json);
+    println!("response_json: {response_json:?}");
     let choices = response_json.get("choices").unwrap().as_array().unwrap();
     assert!(choices.len() == 1);
     let choice = choices.first().unwrap();
@@ -630,7 +629,7 @@ async fn test_openai_compatible_route_with_json_schema() {
     // Check Response is OK, then fields in order
     assert_eq!(response.status(), StatusCode::OK);
     let response_json = response.json::<Value>().await.unwrap();
-    println!("response_json: {:?}", response_json);
+    println!("response_json: {response_json:?}");
     let choices = response_json.get("choices").unwrap().as_array().unwrap();
     assert!(choices.len() == 1);
     let choice = choices.first().unwrap();
@@ -815,7 +814,7 @@ async fn test_openai_compatible_streaming_tool_call() {
         "assistant"
     );
     assert!(parsed_chunk["choices"][0]["delta"].get("content").is_none());
-    println!("parsed_chunk: {:?}", parsed_chunk);
+    println!("parsed_chunk: {parsed_chunk:?}");
     let tool_calls = parsed_chunk["choices"][0]["delta"]["tool_calls"]
         .as_array()
         .unwrap();

--- a/tensorzero-internal/tests/e2e/providers/anthropic.rs
+++ b/tensorzero-internal/tests/e2e/providers/anthropic.rs
@@ -211,8 +211,7 @@ async fn test_thinking_signature() {
     let mut tensorzero_content_blocks = content_blocks.clone();
     assert!(
         content_blocks.len() == 3,
-        "Unexpected content blocks: {:?}",
-        content_blocks
+        "Unexpected content blocks: {content_blocks:?}"
     );
     let first_block = &content_blocks[0];
     let first_block_type = first_block.get("type").unwrap().as_str().unwrap();
@@ -372,8 +371,7 @@ async fn test_thinking_signature() {
     let content_blocks = response_json.get("content").unwrap().as_array().unwrap();
     assert!(
         content_blocks.len() == 1,
-        "Unexpected content blocks: {:?}",
-        content_blocks
+        "Unexpected content blocks: {content_blocks:?}"
     );
     assert_eq!(content_blocks[0]["type"], "text");
     assert!(
@@ -419,8 +417,7 @@ async fn test_redacted_thinking() {
     let tensorzero_content_blocks = content_blocks.clone();
     assert!(
         content_blocks.len() == 2,
-        "Unexpected content blocks: {:?}",
-        content_blocks
+        "Unexpected content blocks: {content_blocks:?}"
     );
     let first_block = &content_blocks[0];
     let first_block_type = first_block.get("type").unwrap().as_str().unwrap();
@@ -560,8 +557,7 @@ async fn test_redacted_thinking() {
     let content_blocks = response_json.get("content").unwrap().as_array().unwrap();
     assert!(
         content_blocks.len() == 2,
-        "Unexpected content blocks: {:?}",
-        content_blocks
+        "Unexpected content blocks: {content_blocks:?}"
     );
     assert_eq!(content_blocks[1]["type"], "text");
 }

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -857,7 +857,7 @@ pub async fn test_url_image_inference_with_provider_and_store(
 
     // The '_shutdown_sender' will wake up the receiver on drop
     let (server_addr, _shutdown_sender) = make_temp_image_server().await;
-    let image_url = Url::parse(&format!("http://{}/ferris.png", server_addr)).unwrap();
+    let image_url = Url::parse(&format!("http://{server_addr}/ferris.png")).unwrap();
 
     let client = make_embedded_gateway_with_config(config_toml).await;
 
@@ -3493,7 +3493,7 @@ pub async fn test_tool_use_tool_choice_auto_used_streaming_inference_request_wit
                     // We mostly care about the tool call, so we'll ignore the text.
                 }
                 _ => {
-                    panic!("Unexpected block type: {}", block_type);
+                    panic!("Unexpected block type: {block_type}");
                 }
             }
         }
@@ -3978,7 +3978,7 @@ pub async fn check_tool_use_tool_choice_auto_unused_inference_response(
     match first {
         ContentBlock::Text(_text) => {}
         _ => {
-            panic!("Expected a text block, got {:?}", first);
+            panic!("Expected a text block, got {first:?}");
         }
     }
 }
@@ -4066,7 +4066,7 @@ pub async fn test_tool_use_tool_choice_auto_unused_streaming_inference_request_w
                     full_text.push_str(block.get("text").unwrap().as_str().unwrap());
                 }
                 _ => {
-                    panic!("Unexpected block type: {}", block_type);
+                    panic!("Unexpected block type: {block_type}");
                 }
             }
         }
@@ -4265,7 +4265,7 @@ pub async fn test_tool_use_tool_choice_auto_unused_streaming_inference_request_w
     match first {
         ContentBlock::Text(_text) => {}
         _ => {
-            panic!("Expected a text block, got {:?}", first);
+            panic!("Expected a text block, got {first:?}");
         }
     }
 }
@@ -4652,7 +4652,7 @@ pub async fn test_tool_use_tool_choice_required_streaming_inference_request_with
                     // We mostly care about the tool call, so we'll ignore the text.
                 }
                 _ => {
-                    panic!("Unexpected block type: {}", block_type);
+                    panic!("Unexpected block type: {block_type}");
                 }
             }
         }
@@ -5116,7 +5116,7 @@ pub async fn check_tool_use_tool_choice_none_inference_response(
     match first {
         ContentBlock::Text(_text) => {}
         _ => {
-            panic!("Expected a text block, got {:?}", first);
+            panic!("Expected a text block, got {first:?}");
         }
     }
 }
@@ -5212,7 +5212,7 @@ pub async fn test_tool_use_tool_choice_none_streaming_inference_request_with_pro
                     full_text.push_str(block.get("text").unwrap().as_str().unwrap());
                 }
                 _ => {
-                    panic!("Unexpected block type: {}", block_type);
+                    panic!("Unexpected block type: {block_type}");
                 }
             }
         }
@@ -5412,7 +5412,7 @@ pub async fn test_tool_use_tool_choice_none_streaming_inference_request_with_pro
     match first {
         ContentBlock::Text(_text) => {}
         _ => {
-            panic!("Expected a text block, got {:?}", first);
+            panic!("Expected a text block, got {first:?}");
         }
     }
 }
@@ -5879,7 +5879,7 @@ pub async fn test_tool_use_tool_choice_specific_streaming_inference_request_with
                     // We mostly care about the tool call, so we'll ignore the text.
                 }
                 _ => {
-                    panic!("Unexpected block type: {}", block_type);
+                    panic!("Unexpected block type: {block_type}");
                 }
             }
         }
@@ -6504,7 +6504,7 @@ pub async fn test_tool_use_allowed_tools_streaming_inference_request_with_provid
                     // We mostly care about the tool call, so we'll ignore the text.
                 }
                 _ => {
-                    panic!("Unexpected block type: {}", block_type);
+                    panic!("Unexpected block type: {block_type}");
                 }
             }
         }
@@ -7004,7 +7004,7 @@ pub async fn check_tool_use_multi_turn_inference_response(
             assert!(text.text.to_lowercase().contains("tokyo"));
         }
         _ => {
-            panic!("Expected a text block, got {:?}", first);
+            panic!("Expected a text block, got {first:?}");
         }
     }
 }
@@ -7323,7 +7323,7 @@ pub async fn test_tool_multi_turn_streaming_inference_request_with_provider(
             assert!(text.text.to_lowercase().contains("tokyo"));
         }
         _ => {
-            panic!("Expected a text block, got {:?}", first);
+            panic!("Expected a text block, got {first:?}");
         }
     }
 }
@@ -7743,7 +7743,7 @@ pub async fn test_dynamic_tool_use_streaming_inference_request_with_provider(
                     // We mostly care about the tool call, so we'll ignore the text.
                 }
                 _ => {
-                    panic!("Unexpected block type: {}", block_type);
+                    panic!("Unexpected block type: {block_type}");
                 }
             }
         }
@@ -8304,7 +8304,7 @@ pub async fn check_parallel_tool_use_inference_response(
                 serde_json::from_str::<Value>(&tool_call.arguments).unwrap();
             }
             _ => {
-                panic!("Expected a tool call, got {:?}", block);
+                panic!("Expected a tool call, got {block:?}");
             }
         }
     }
@@ -8407,7 +8407,7 @@ pub async fn test_parallel_tool_use_streaming_inference_request_with_provider(
                             get_humidity_arguments.push_str(chunk_arguments);
                         }
                         _ => {
-                            panic!("Unexpected tool name: {}", tool_name);
+                            panic!("Unexpected tool name: {tool_name}");
                         }
                     }
                 }
@@ -8417,7 +8417,7 @@ pub async fn test_parallel_tool_use_streaming_inference_request_with_provider(
                     // We mostly care about the tool call, so we'll ignore the text.
                 }
                 _ => {
-                    panic!("Unexpected block type: {}", block_type);
+                    panic!("Unexpected block type: {block_type}");
                 }
             }
         }
@@ -8708,7 +8708,7 @@ pub async fn test_parallel_tool_use_streaming_inference_request_with_provider(
                 serde_json::from_str::<Value>(&tool_call.arguments).unwrap();
             }
             _ => {
-                panic!("Expected a tool call, got {:?}", block);
+                panic!("Expected a tool call, got {block:?}");
             }
         }
     }
@@ -9998,7 +9998,7 @@ pub async fn check_multi_turn_parallel_tool_use_inference_response(
                 );
             }
             _ => {
-                panic!("Expected a tool call, got {:?}", tool_result);
+                panic!("Expected a tool call, got {tool_result:?}");
             }
         }
     }
@@ -10012,7 +10012,7 @@ pub async fn check_multi_turn_parallel_tool_use_inference_response(
             assert!(text.text.to_lowercase().contains("30"));
         }
         _ => {
-            panic!("Expected a text block, got {:?}", output_content);
+            panic!("Expected a text block, got {output_content:?}");
         }
     }
 }
@@ -10184,7 +10184,7 @@ pub async fn test_multi_turn_parallel_tool_use_streaming_inference_request_with_
                     output_content.push_str(block.get("text").unwrap().as_str().unwrap());
                 }
                 _ => {
-                    panic!("Unexpected block type: {}", block_type);
+                    panic!("Unexpected block type: {block_type}");
                 }
             }
         }
@@ -10333,7 +10333,7 @@ pub async fn test_multi_turn_parallel_tool_use_streaming_inference_request_with_
                 );
             }
             _ => {
-                panic!("Expected a tool call, got {:?}", tool_result);
+                panic!("Expected a tool call, got {tool_result:?}");
             }
         }
     }
@@ -10347,7 +10347,7 @@ pub async fn test_multi_turn_parallel_tool_use_streaming_inference_request_with_
             assert!(text.text.to_lowercase().contains("30"));
         }
         _ => {
-            panic!("Expected a text block, got {:?}", output_content);
+            panic!("Expected a text block, got {output_content:?}");
         }
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/openai.rs
+++ b/tensorzero-internal/tests/e2e/providers/openai.rs
@@ -984,7 +984,7 @@ async fn test_o3_mini_inference_with_reasoning_effort() {
     // Check Response is OK, then fields in order
     // assert_eq!(response.status(), StatusCode::OK);
     let response_json = response.json::<Value>().await.unwrap();
-    println!("Response JSON: {:?}", response_json);
+    println!("Response JSON: {response_json:?}");
 
     let content_blocks = response_json.get("content").unwrap().as_array().unwrap();
     assert!(content_blocks.len() == 1);
@@ -1136,8 +1136,7 @@ async fn test_embedding_request() {
     // Assert that the norm is approximately 1 (allowing for small floating-point errors)
     assert!(
         (norm - 1.0).abs() < 1e-6,
-        "The L2 norm of the embedding should be 1, but it is {}",
-        norm
+        "The L2 norm of the embedding should be 1, but it is {norm}"
     );
     // Check that the timestamp in created is within 1 second of the current time
     let created = response.created;
@@ -1147,8 +1146,7 @@ async fn test_embedding_request() {
         .as_secs() as i64;
     assert!(
         (created as i64 - now).abs() <= 1,
-        "The created timestamp should be within 1 second of the current time, but it is {}",
-        created
+        "The created timestamp should be within 1 second of the current time, but it is {created}"
     );
     let parsed_raw_response: Value = serde_json::from_str(&response.raw_response).unwrap();
     assert!(

--- a/tensorzero-internal/tests/e2e/providers/reasoning.rs
+++ b/tensorzero-internal/tests/e2e/providers/reasoning.rs
@@ -78,7 +78,7 @@ pub async fn test_reasoning_inference_request_simple_with_provider(provider: E2E
             "thought" => {
                 found_thought = true;
             }
-            _ => panic!("Unexpected content block type: {}", block_type),
+            _ => panic!("Unexpected content block type: {block_type}"),
         }
     }
 
@@ -147,7 +147,7 @@ pub async fn test_reasoning_inference_request_simple_with_provider(provider: E2E
             "thought" => {
                 found_thought = true;
             }
-            _ => panic!("Unexpected content block type: {}", block_type),
+            _ => panic!("Unexpected content block type: {block_type}"),
         }
     }
 
@@ -409,7 +409,7 @@ pub async fn test_streaming_reasoning_inference_request_simple_with_provider(
                 found_thought = true;
                 clickhouse_thought = block.get("text").unwrap().as_str().unwrap().to_string();
             }
-            _ => panic!("Unexpected content block type: {}", block_type),
+            _ => panic!("Unexpected content block type: {block_type}"),
         }
     }
 

--- a/ui/app/utils/minijinja/src/lib.rs
+++ b/ui/app/utils/minijinja/src/lib.rs
@@ -21,7 +21,7 @@ pub struct JsExposedEnv {
 }
 
 fn annotate_error(err: minijinja::Error) -> JsError {
-    JsError::new(&format!("{:#}", err))
+    JsError::new(&format!("{err:#}"))
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
Inlined format args are easier to read, and in some cases, improves perf (i.e. if an arg has a `&`, it causes 6% perf loss with the current compiler).

```sh
cargo clippy --fix --allow-dirty --workspace -- -A clippy::all -W clippy::uninlined_format_args && cargo fmt
```

P.S. It might be good to add a few more pedantic clippies.  Run this command to get overall lint statistics:

```sh
cargo clippy --all-targets --workspace --message-format=json --quiet -- -W clippy::pedantic    | jq -r '.message.code.code | select(. != null and startswith("clippy::"))'    | sort | uniq -c | sort -h -r
```

<details><summary>Results as a table</summary>
<p>

A slightly better formatted results with this:

```sh
echo '|count|lint|' && echo '|---|---|' && cargo clippy --all-targets --workspace --message-format=json --quiet -- -W clippy::pedantic | jq -r '.message.code.code | select(. != null and startswith("clippy::")) | "| [" + . + "](https://rust-lang.github.io/rust-clippy/master/index.html#" + .[8:] + ") |"'     | sort | uniq -c | sort -h -r | sed 's/^/|/'
```

|count|lint|
|---|---|
|   5596 | [clippy::match_same_arms](https://rust-lang.github.io/rust-clippy/master/index.html#match_same_arms) |
|    657 | [clippy::doc_markdown](https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown) |
|    471 | [clippy::uninlined_format_args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) |
|    301 | [clippy::needless_raw_string_hashes](https://rust-lang.github.io/rust-clippy/master/index.html#needless_raw_string_hashes) |
|    282 | [clippy::missing_errors_doc](https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc) |
|    246 | [clippy::default_trait_access](https://rust-lang.github.io/rust-clippy/master/index.html#default_trait_access) |
|    201 | [clippy::must_use_candidate](https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate) |
|    136 | [clippy::redundant_closure_for_method_calls](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure_for_method_calls) |
|    119 | [clippy::too_many_lines](https://rust-lang.github.io/rust-clippy/master/index.html#too_many_lines) |
|    105 | [clippy::manual_string_new](https://rust-lang.github.io/rust-clippy/master/index.html#manual_string_new) |
|     57 | [clippy::match_wildcard_for_single_variants](https://rust-lang.github.io/rust-clippy/master/index.html#match_wildcard_for_single_variants) |
|     52 | [clippy::needless_pass_by_value](https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_value) |
|     45 | [clippy::explicit_iter_loop](https://rust-lang.github.io/rust-clippy/master/index.html#explicit_iter_loop) |
|     42 | [clippy::semicolon_if_nothing_returned](https://rust-lang.github.io/rust-clippy/master/index.html#semicolon_if_nothing_returned) |
|     41 | [clippy::cast_possible_truncation](https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation) |
|     26 | [clippy::manual_let_else](https://rust-lang.github.io/rust-clippy/master/index.html#manual_let_else) |
|     25 | [clippy::non_std_lazy_statics](https://rust-lang.github.io/rust-clippy/master/index.html#non_std_lazy_statics) |
|     22 | [clippy::needless_continue](https://rust-lang.github.io/rust-clippy/master/index.html#needless_continue) |
|     19 | [clippy::missing_panics_doc](https://rust-lang.github.io/rust-clippy/master/index.html#missing_panics_doc) |
|     18 | [clippy::ignored_unit_patterns](https://rust-lang.github.io/rust-clippy/master/index.html#ignored_unit_patterns) |
|     17 | [clippy::large_futures](https://rust-lang.github.io/rust-clippy/master/index.html#large_futures) |
|     16 | [clippy::single_match_else](https://rust-lang.github.io/rust-clippy/master/index.html#single_match_else) |
|     16 | [clippy::match_bool](https://rust-lang.github.io/rust-clippy/master/index.html#match_bool) |
|     15 | [clippy::unused_async](https://rust-lang.github.io/rust-clippy/master/index.html#unused_async) |
|     14 | [clippy::unused_self](https://rust-lang.github.io/rust-clippy/master/index.html#unused_self) |
|     14 | [clippy::unreadable_literal](https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal) |
|     14 | [clippy::if_not_else](https://rust-lang.github.io/rust-clippy/master/index.html#if_not_else) |
|     12 | [clippy::unnecessary_wraps](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_wraps) |
|     12 | [clippy::unnecessary_semicolon](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_semicolon) |
|     12 | [clippy::trivially_copy_pass_by_ref](https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref) |
|     11 | [clippy::cast_sign_loss](https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss) |
|     11 | [clippy::cast_precision_loss](https://rust-lang.github.io/rust-clippy/master/index.html#cast_precision_loss) |
|     10 | [clippy::redundant_else](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_else) |
|     10 | [clippy::inconsistent_struct_constructor](https://rust-lang.github.io/rust-clippy/master/index.html#inconsistent_struct_constructor) |
|      9 | [clippy::similar_names](https://rust-lang.github.io/rust-clippy/master/index.html#similar_names) |
|      9 | [clippy::map_unwrap_or](https://rust-lang.github.io/rust-clippy/master/index.html#map_unwrap_or) |
|      8 | [clippy::struct_field_names](https://rust-lang.github.io/rust-clippy/master/index.html#struct_field_names) |
|      8 | [clippy::single_char_pattern](https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern) |
|      8 | [clippy::ref_option](https://rust-lang.github.io/rust-clippy/master/index.html#ref_option) |
|      8 | [clippy::explicit_into_iter_loop](https://rust-lang.github.io/rust-clippy/master/index.html#explicit_into_iter_loop) |
|      7 | [clippy::cast_possible_wrap](https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_wrap) |
|      6 | [clippy::items_after_statements](https://rust-lang.github.io/rust-clippy/master/index.html#items_after_statements) |
|      6 | [clippy::implicit_hasher](https://rust-lang.github.io/rust-clippy/master/index.html#implicit_hasher) |
|      6 | [clippy::cast_lossless](https://rust-lang.github.io/rust-clippy/master/index.html#cast_lossless) |
|      4 | [clippy::return_self_not_must_use](https://rust-lang.github.io/rust-clippy/master/index.html#return_self_not_must_use) |
|      4 | [clippy::implicit_clone](https://rust-lang.github.io/rust-clippy/master/index.html#implicit_clone) |
|      4 | [clippy::float_cmp](https://rust-lang.github.io/rust-clippy/master/index.html#float_cmp) |
|      3 | [clippy::flat_map_option](https://rust-lang.github.io/rust-clippy/master/index.html#flat_map_option) |
|      2 | [clippy::wildcard_imports](https://rust-lang.github.io/rust-clippy/master/index.html#wildcard_imports) |
|      2 | [clippy::unnecessary_literal_bound](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_literal_bound) |
|      2 | [clippy::struct_excessive_bools](https://rust-lang.github.io/rust-clippy/master/index.html#struct_excessive_bools) |
|      2 | [clippy::str_split_at_newline](https://rust-lang.github.io/rust-clippy/master/index.html#str_split_at_newline) |
|      2 | [clippy::manual_assert](https://rust-lang.github.io/rust-clippy/master/index.html#manual_assert) |
|      2 | [clippy::from_iter_instead_of_collect](https://rust-lang.github.io/rust-clippy/master/index.html#from_iter_instead_of_collect) |
|      2 | [clippy::format_push_string](https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string) |
|      2 | [clippy::cloned_instead_of_copied](https://rust-lang.github.io/rust-clippy/master/index.html#cloned_instead_of_copied) |

</p>
</details> 


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Inline format arguments in Rust code to improve readability and performance across multiple files.
> 
>   - **Behavior**:
>     - Inline format arguments in error messages and SQL queries across multiple files to improve readability and performance.
>     - Addresses performance loss when using certain characters with the current compiler.
>   - **Files Affected**:
>     - `internal.rs`: Inline format arguments in error messages and SQL queries.
>     - `lib.rs` (in `clients/python-pyo3` and `clients/rust`): Inline format arguments in error messages.
>     - `migration_0003.rs`, `migration_0004.rs`, `migration_0005.rs`, `migration_0008.rs`, `migration_0009.rs`, `migration_0013.rs`, `migration_0020.rs`, `migration_0021.rs`: Inline format arguments in SQL queries.
>   - **Misc**:
>     - Update `README.md` to reflect changes in code style.
>     - Minor logging changes in `app.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 65dd8108e9d339f1a3f74428dafdf95d0645b5e8. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->