### PR TITLE
Use workspace lints for 'evaluations' crate

### DIFF
--- a/evaluations/Cargo.toml
+++ b/evaluations/Cargo.toml
@@ -26,18 +26,8 @@ indicatif = "0.17.11"
 [dev-dependencies]
 tensorzero = { path = "../clients/rust" }
 
-[lints.rust]
-unsafe_code = "forbid"
-[lints.clippy]
-panic = "deny"
-print_stderr = "deny"
-print_stdout = "deny"
-todo = "deny"
-unimplemented = "deny"
-unreachable = "deny"
-unwrap_used = "deny"
-dbg_macro = "deny"
-
+[lints]
+workspace = true
 
 [features]
 default = []

--- a/evaluations/src/evaluators/llm_judge/mod.rs
+++ b/evaluations/src/evaluators/llm_judge/mod.rs
@@ -190,6 +190,7 @@ fn prepare_llm_judge_input(
                 messages: vec![ClientInputMessage {
                     role: Role::User,
                     content: vec![ClientInputMessageContent::Text(TextKind::Arguments{
+                        #[allow(clippy::expect_used)]
                         arguments: json!({"input": serialized_input, "generated_output": generated_output, "reference_output": reference_output})
                             .as_object()
                             .expect("Arguments should be an object")


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch 'evaluations' crate to use workspace-wide lints and allow specific Clippy lint in `prepare_llm_judge_input`.
> 
>   - **Lint Configuration**:
>     - In `Cargo.toml`, replace specific lint rules with `workspace = true` under `[lints]`.
>   - **Code Changes**:
>     - Allow `clippy::expect_used` in `prepare_llm_judge_input` in `mod.rs` to suppress Clippy warning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 32dd757c53c1121abdab90f4f1e29b5d475fd850. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->