### PR TITLE
Add sleep to openai-compatible cache test

### DIFF
--- a/clients/openai-python/tests/test_openai_compatibility.py
+++ b/clients/openai-python/tests/test_openai_compatibility.py
@@ -19,6 +19,7 @@ uv run pytest
 ```
 """
 
+import asyncio
 import base64
 import json
 import os
@@ -220,11 +221,14 @@ async def test_async_inference_streaming_with_cache(async_client):
     assert final_chunk.usage.prompt_tokens == 10
     assert final_chunk.usage.completion_tokens == 16
 
+    # Wait for trailing cache write to ClickHouse
+    await asyncio.sleep(1)
+
     # Second request with cache
     stream = await async_client.chat.completions.create(
         extra_body={
             "tensorzero::episode_id": str(uuid7()),
-            "tensorzero::cache_options": {"max_age_s": 10, "enabled": "on"},
+            "tensorzero::cache_options": {"max_age_s": None, "enabled": "on"},
         },
         messages=messages,
         model="tensorzero::function_name::basic_test",


### PR DESCRIPTION
I've seen this test flake several times on CI, which I suspect is caused by the second request running before the ClickHouse trailing write completes.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add delay in `test_async_inference_streaming_with_cache` to ensure ClickHouse write completion before second request.
> 
>   - **Tests**:
>     - Add `asyncio.sleep(1)` in `test_async_inference_streaming_with_cache` in `test_openai_compatibility.py` to ensure ClickHouse trailing write completes before the second request.
>     - Modify `tensorzero::cache_options` in the second request to set `max_age_s` to `None` in `test_async_inference_streaming_with_cache`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0f4c12950c8ad4118a0574cb7c366c31c032306d. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->