### PR TITLE
Fix double-build when running pyo3 tests

### DIFF
--- a/clients/python-pyo3/test.sh
+++ b/clients/python-pyo3/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 set -euxo pipefail
-uv run maturin develop --uv --features e2e_tests
-uv run pytest -n auto $@
+# Avoid using 'uv run maturin develop', as this will build twice (once from uv when making the venv, and once from maturin)
+uv run --config-setting 'build-args=--profile=dev --features e2e_tests' pytest -n auto $@


### PR DESCRIPTION
Running 'uv run maturin develop' builds the package twice - once in release mode when uv makes the venv, and once in debug mode when 'maturin develop' runs inside the freshly created venv.

By customizing the uv build args, we can just build the client once with 'e2e_tests' enabled

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `test.sh` to prevent double-build by customizing `uv run` command with specific build arguments.
> 
>   - **Behavior**:
>     - Modify `test.sh` to prevent double-build by customizing `uv run` command.
>     - Use `--config-setting 'build-args=--profile=dev --features e2e_tests'` to build once in dev mode with `e2e_tests` enabled.
>   - **Misc**:
>     - Remove redundant `maturin develop` call in `test.sh`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1f8685946f32565a986f706726b860dd90cfc14e. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->