### PR TITLE
Adjust tests to use o4-mini instead of o1-mini

### DIFF
--- a/tensorzero-internal/tests/e2e/providers/openai.rs
+++ b/tensorzero-internal/tests/e2e/providers/openai.rs
@@ -357,7 +357,7 @@ async fn test_default_function_model_name_shorthand() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
-        "model_name": "openai::o1-mini",
+        "model_name": "openai::o4-mini",
         "episode_id": episode_id,
         "input": {
             "messages": [
@@ -432,7 +432,7 @@ async fn test_default_function_model_name_shorthand() {
     assert_eq!(retrieved_episode_id, episode_id);
     // Check the variant name
     let variant_name = result.get("variant_name").unwrap().as_str().unwrap();
-    assert_eq!(variant_name, "openai::o1-mini");
+    assert_eq!(variant_name, "openai::o4-mini");
     // Check the processing time
     let processing_time_ms = result.get("processing_time_ms").unwrap().as_u64().unwrap();
     assert!(processing_time_ms > 0);
@@ -445,7 +445,7 @@ async fn test_default_function_model_name_shorthand() {
     let inference_id_result = Uuid::parse_str(inference_id_result).unwrap();
     assert_eq!(inference_id_result, inference_id);
     let model_name = result.get("model_name").unwrap().as_str().unwrap();
-    assert_eq!(model_name, "openai::o1-mini");
+    assert_eq!(model_name, "openai::o4-mini");
     let model_provider_name = result.get("model_provider_name").unwrap().as_str().unwrap();
     assert_eq!(model_provider_name, "openai");
     let raw_request = result.get("raw_request").unwrap().as_str().unwrap();
@@ -471,7 +471,7 @@ async fn test_default_function_model_name_non_shorthand() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
-        "model_name": "o1-mini",
+        "model_name": "o4-mini",
         "episode_id": episode_id,
         "input": {
             "messages": [
@@ -546,7 +546,7 @@ async fn test_default_function_model_name_non_shorthand() {
     assert_eq!(retrieved_episode_id, episode_id);
     // Check the variant name
     let variant_name = result.get("variant_name").unwrap().as_str().unwrap();
-    assert_eq!(variant_name, "o1-mini");
+    assert_eq!(variant_name, "o4-mini");
     // Check the processing time
     let processing_time_ms = result.get("processing_time_ms").unwrap().as_u64().unwrap();
     assert!(processing_time_ms > 0);
@@ -559,7 +559,7 @@ async fn test_default_function_model_name_non_shorthand() {
     let inference_id_result = Uuid::parse_str(inference_id_result).unwrap();
     assert_eq!(inference_id_result, inference_id);
     let model_name = result.get("model_name").unwrap().as_str().unwrap();
-    assert_eq!(model_name, "o1-mini");
+    assert_eq!(model_name, "o4-mini");
     let model_provider_name = result.get("model_provider_name").unwrap().as_str().unwrap();
     assert_eq!(model_provider_name, "openai");
     let raw_request = result.get("raw_request").unwrap().as_str().unwrap();
@@ -835,13 +835,13 @@ async fn test_chat_function_json_override_with_mode(json_mode: ModelInferenceReq
 }
 
 #[tokio::test]
-async fn test_o1_mini_inference() {
+async fn test_o4_mini_inference() {
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
         "function_name": "basic_test",
-        "variant_name": "o1-mini",
+        "variant_name": "o4-mini",
         "episode_id": episode_id,
         "input":
             {"system": {"assistant_name": "AskJeeves"},
@@ -916,7 +916,7 @@ async fn test_o1_mini_inference() {
     assert_eq!(retrieved_episode_id, episode_id);
     // Check the variant name
     let variant_name = result.get("variant_name").unwrap().as_str().unwrap();
-    assert_eq!(variant_name, "o1-mini");
+    assert_eq!(variant_name, "o4-mini");
     // Check the processing time
     let processing_time_ms = result.get("processing_time_ms").unwrap().as_u64().unwrap();
     assert!(processing_time_ms > 0);
@@ -929,7 +929,7 @@ async fn test_o1_mini_inference() {
     let inference_id_result = Uuid::parse_str(inference_id_result).unwrap();
     assert_eq!(inference_id_result, inference_id);
     let model_name = result.get("model_name").unwrap().as_str().unwrap();
-    assert_eq!(model_name, "o1-mini");
+    assert_eq!(model_name, "o4-mini");
     let model_provider_name = result.get("model_provider_name").unwrap().as_str().unwrap();
     assert_eq!(model_provider_name, "openai");
     let raw_request = result.get("raw_request").unwrap().as_str().unwrap();
@@ -1335,7 +1335,7 @@ async fn test_content_block_text_field() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
-        "model_name": "openai::o1-mini",
+        "model_name": "openai::o4-mini",
         "episode_id": episode_id,
         "input": {
             "messages": [
@@ -1410,7 +1410,7 @@ async fn test_content_block_text_field() {
     assert_eq!(retrieved_episode_id, episode_id);
     // Check the variant name
     let variant_name = result.get("variant_name").unwrap().as_str().unwrap();
-    assert_eq!(variant_name, "openai::o1-mini");
+    assert_eq!(variant_name, "openai::o4-mini");
     // Check the processing time
     let processing_time_ms = result.get("processing_time_ms").unwrap().as_u64().unwrap();
     assert!(processing_time_ms > 0);
@@ -1423,7 +1423,7 @@ async fn test_content_block_text_field() {
     let inference_id_result = Uuid::parse_str(inference_id_result).unwrap();
     assert_eq!(inference_id_result, inference_id);
     let model_name = result.get("model_name").unwrap().as_str().unwrap();
-    assert_eq!(model_name, "openai::o1-mini");
+    assert_eq!(model_name, "openai::o4-mini");
     let model_provider_name = result.get("model_provider_name").unwrap().as_str().unwrap();
     assert_eq!(model_provider_name, "openai");
     let raw_request = result.get("raw_request").unwrap().as_str().unwrap();

--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -318,12 +318,12 @@ type = "mistral"
 model_name = "open-mistral-nemo-2407"
 api_key_location = "dynamic::mistral_api_key"
 
-[models.o1-mini]
+[models.o4-mini]
 routing = ["openai"]
 
-[models.o1-mini.providers.openai]
+[models.o4-mini.providers.openai]
 type = "openai"
-model_name = "o1-mini"
+model_name = "o4-mini"
 
 [models.o3-mini]
 routing = ["openai"]
@@ -897,9 +897,9 @@ model = "openai::gpt-4o-mini-2024-07-18"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 
-[functions.basic_test.variants.o1-mini]
+[functions.basic_test.variants.o4-mini]
 type = "chat_completion"
-model = "o1-mini"
+model = "o4-mini"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 
 [functions.basic_test.variants.o3-mini]


### PR DESCRIPTION
o1-mini has been deprecated
Fixes https://github.com/tensorzero/tensorzero/issues/1967

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace deprecated `o1-mini` model with `o4-mini` in test configurations and code.
> 
>   - **Tests**:
>     - Replace `o1-mini` with `o4-mini` in `openai.rs` for model name and variant checks.
>     - Update test function `test_o1_mini_inference` to `test_o4_mini_inference`.
>   - **Configuration**:
>     - Update `tensorzero.toml` to replace `[models.o1-mini]` with `[models.o4-mini]` and adjust provider configurations accordingly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f92c34414fbe1d616cb24e53f9f5bbb0f2ac2820. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->