### PR TITLE
Add initial OpenTelemetry OTLP export to gateway

### DIFF
--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -3411,6 +3411,11 @@ pub async fn check_tool_use_tool_choice_auto_used_inference_response(
 pub async fn test_tool_use_tool_choice_auto_used_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    // Together doesn't correctly produce streaming tool call chunks (it produces text chunks with the raw tool call).
+    if provider.model_provider_name == "together" {
+        return;
+    }
+
     // OpenAI O1 doesn't support streaming responses
     if provider.model_provider_name == "openai" && provider.model_name.starts_with("o1") {
         return;
@@ -6420,6 +6425,10 @@ pub async fn check_tool_use_tool_choice_allowed_tools_inference_response(
 pub async fn test_tool_use_allowed_tools_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    // Together doesn't correctly produce streaming tool call chunks (it produces text chunks with the raw tool call).
+    if provider.model_provider_name == "together" {
+        return;
+    }
     // OpenAI O1 doesn't support streaming responses
     if provider.model_provider_name == "openai" && provider.model_name.starts_with("o1") {
         return;
@@ -8327,6 +8336,11 @@ pub async fn check_parallel_tool_use_inference_response(
 pub async fn test_parallel_tool_use_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    // Together doesn't correctly produce streaming tool call chunks (it produces text chunks with the raw tool call).
+    if provider.model_provider_name == "together" {
+        return;
+    }
+
     let episode_id = Uuid::now_v7();
 
     let payload = json!({


### PR DESCRIPTION
This feature is off by default, and must be explicitly enabled
via a newly-added `export` config:

```toml
[gateway.export.otlp.traces]
enabled = true
```

The actual export url is configured via the standard OpenTelemetry
environment variables (e.g. `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`).

For now, we don't allow configuring OTLP export in the Python client
(this is a global setting, so it will be tricky to make it work with
multiple independent embedded gateways).

When enabled, we create OpenTelemetry spans for several HTTP endpoints:
* /inference
* /batch_inference/*
* /openai/v1/chat/completions
* /feedback

For inference endpoints, we emit several nested spans corresponding
to the inference request flow:
* `tensorzero_function_call` - covers the overall function call, and
  is emitted for both `/inference` and `/openai/v1/chat/completions`
  This allows consumers to easily configure monitoring/alerts for
  all function calls, regardless of which inference endpoint they use
  * `tensorzero_variant_infer` - covers each variant inference, nested
    under the 'tensorzero_function_call' span
    * `tensorzero_model_infer` - covers the model inference request.
      * `tensorzero_model_provider_request` - covers the actual HTTP
	request to the model providers. This has standard OpenTelemetry
        GenAI attributes set on the span.

We only emit specifically-taggged spans (currently, any span with an
`http.` or `otel.` tracing-level field name). This ensures that we don't
accidentally start exporting internal spans to customers (which we may
want to break over time as the codebase changes).

During e2e tests, we now start a Jaeger instance, and verify that we can
query an exported span after submitting an inference request to the
gateway. Other tests install a custom in-process OTEL span exporter,
and verify that we export the expected spans (and that the total count
matches exactly).

Future extensions:
* Add support for OTEL metric export
* Attach more attributes to our exported spans (error information, more
  GenAI attributes, etc.)<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
