### PR TITLE
Use shared cache mount for /sccache directory

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -52,7 +52,7 @@ ARG CARGO_BUILD_FLAGS=""
 
 RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/registry \
     --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/git \
-    --mount=type=cache,id=tensorzero-evaluations-release,sharing=locked,target=/sccache \
+    --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/sccache \
     cargo build --release -p evaluations $CARGO_BUILD_FLAGS && \
     sccache --show-stats && \
     cp -r /tensorzero/target/release /release


### PR DESCRIPTION
This should allow concurrent Python and Node ui-tests-e2e jobs to both use the same cache volume

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify cache mount for `/sccache` in `ui/Dockerfile` to use shared cache for concurrent job efficiency.
> 
>   - **Dockerfile Changes**:
>     - Modify cache mount for `/sccache` directory in `ui/Dockerfile` to use `sharing=shared` instead of `sharing=locked`.
>     - Affects the `RUN` command for building evaluations in the `evaluations-build-env` stage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 88bff2c400edd980fad5b0d40629126a727f1f43. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->