### PR TITLE
Remove explicit 'maturin' step from PR CI

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -204,14 +204,7 @@ jobs:
           uvx ruff@0.9.0 check --output-format=github --extend-select I .
           uvx ruff@0.9.0 format --check .
 
-      - name: "TensorZero PyO3 Client: Build"
-        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
-        with:
-          working-directory: clients/python-pyo3
-          args: --find-interpreter
-          container: off
-
-      - name: "Python: Pyo3 Client: Install dependencies"
+      - name: "Python: Pyo3 Client: Build and install dependencies"
         working-directory: clients/python-pyo3
         run: |
           uv venv


### PR DESCRIPTION
Running 'uv venv' already builds the pyo3 client
(via the `pyproject.toml`), so we're just building it twice in CI.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove redundant `maturin` build step for PyO3 client in CI workflow, consolidating into `uv venv`.
> 
>   - **CI Workflow**:
>     - Removes explicit `maturin` build step for PyO3 client in `.github/workflows/general.yml`.
>     - Consolidates build and dependency installation into a single step using `uv venv` in the `validate` job.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 85a7a2f8045d0994e66d27c2d638c2ad4fb8542a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->