### PR TITLE
Use 'wasm-pack build --dev' in PR CI

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -276,7 +276,7 @@ jobs:
 
       - name: Build minijinja WASM bindings
         working-directory: ui/app/utils/minijinja
-        run: wasm-pack build --features console_error_panic_hook
+        run: wasm-pack build --dev --features console_error_panic_hook
 
       - name: Run minijinja WASM tests
         working-directory: ui/app/utils/minijinja


### PR DESCRIPTION
This will slightly speed up CI

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use `wasm-pack build --dev` in CI to speed up WASM bindings build.
> 
>   - **CI Optimization**:
>     - Change `wasm-pack build` to `wasm-pack build --dev` in `.github/workflows/general.yml` for building minijinja WASM bindings.
>     - This change is intended to slightly speed up the CI process.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 92a2bac8438c48904ac3a617528fb8071e3d6132. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->