### PR TITLE
Always overwrite existing headers with extra-headers

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -43,6 +43,14 @@ filter = 'binary(e2e) and test(providers::fireworks::)'
 test-group = 'e2e_fireworks'
 
 [[profile.default.overrides]]
+filter = 'binary(e2e) and test(providers::vllm::)'
+slow-timeout = { period = "60s", terminate-after = 2 }
+
+[[profile.default.overrides]]
+filter = 'binary(e2e) and test(providers::sglang::)'
+slow-timeout = { period = "60s", terminate-after = 2 }
+
+[[profile.default.overrides]]
 filter = 'test(test_concurrent_clickhouse_migrations)'
 # the test fails if migrations > 60s so we can kill it at 65
 slow-timeout = { period = "65s" }

--- a/tensorzero-internal/src/inference/providers/deepseek.rs
+++ b/tensorzero-internal/src/inference/providers/deepseek.rs
@@ -158,11 +158,11 @@ impl InferenceProvider for DeepSeekProvider {
         let request_builder = http_client
             .post(request_url)
             .header("Content-Type", "application/json")
-            .bearer_auth(api_key.expose_secret())
-            .headers(headers);
+            .bearer_auth(api_key.expose_secret());
 
         let res = request_builder
             .json(&request_body)
+            .headers(headers)
             .send()
             .await
             .map_err(|e| {
@@ -284,8 +284,8 @@ impl InferenceProvider for DeepSeekProvider {
             .post(request_url)
             .header("Content-Type", "application/json")
             .bearer_auth(api_key.expose_secret())
-            .headers(headers)
             .json(&request_body)
+            .headers(headers)
             .eventsource()
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {

--- a/tensorzero-internal/src/inference/providers/fireworks.rs
+++ b/tensorzero-internal/src/inference/providers/fireworks.rs
@@ -175,8 +175,8 @@ impl InferenceProvider for FireworksProvider {
             .post(request_url)
             .header("Content-Type", "application/json")
             .bearer_auth(api_key.expose_secret())
-            .headers(headers)
             .json(&request_body)
+            .headers(headers)
             .send()
             .await
             .map_err(|e| {

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
@@ -232,8 +232,8 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
             .post(&self.streaming_request_url)
             .bearer_auth(api_key.expose_secret())
             .header("content-type", "application/json")
-            .headers(headers)
             .json(&request_body)
+            .headers(headers)
             .eventsource()
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {

--- a/tensorzero-internal/src/inference/providers/hyperbolic.rs
+++ b/tensorzero-internal/src/inference/providers/hyperbolic.rs
@@ -150,11 +150,11 @@ impl InferenceProvider for HyperbolicProvider {
         let request_builder = http_client
             .post(request_url)
             .header("Content-Type", "application/json")
-            .headers(headers)
             .bearer_auth(api_key.expose_secret());
 
         let res = request_builder
             .json(&request_body)
+            .headers(headers)
             .send()
             .await
             .map_err(|e| {
@@ -270,8 +270,8 @@ impl InferenceProvider for HyperbolicProvider {
             .post(request_url)
             .header("Content-Type", "application/json")
             .bearer_auth(api_key.expose_secret())
-            .headers(headers)
             .json(&request_body)
+            .headers(headers)
             .eventsource()
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {

--- a/tensorzero-internal/src/inference/providers/openai.rs
+++ b/tensorzero-internal/src/inference/providers/openai.rs
@@ -346,13 +346,15 @@ impl InferenceProvider for OpenAIProvider {
         let start_time = Instant::now();
         let mut request_builder = http_client
             .post(request_url)
-            .header("Content-Type", "application/json")
-            .headers(headers);
+            .header("Content-Type", "application/json");
         if let Some(api_key) = api_key {
             request_builder = request_builder.bearer_auth(api_key.expose_secret());
         }
         let event_source = request_builder
             .json(&request_body)
+            // Important - the 'headers' call should come just before we sent the request with '.eventsource()',
+            // so that users can override any of the headers that we set.
+            .headers(headers)
             .eventsource()
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {

--- a/tensorzero-internal/src/inference/providers/xai.rs
+++ b/tensorzero-internal/src/inference/providers/xai.rs
@@ -276,8 +276,8 @@ impl InferenceProvider for XAIProvider {
             .post(request_url)
             .header("Content-Type", "application/json")
             .bearer_auth(api_key.expose_secret())
-            .headers(headers)
             .json(&request_body)
+            .headers(headers)
             .eventsource()
             .map_err(|e| {
                 Error::new(ErrorDetails::InferenceClient {

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -1431,7 +1431,10 @@ pub async fn test_bad_auth_extra_headers_with_provider_and_stream(
         }
         "hyperbolic" => {
             assert!(
-                res["error"].as_str().unwrap().contains("Bad Request")
+                res["error"]
+                    .as_str()
+                    .unwrap()
+                    .contains("Could not validate credentials")
                     || res["error"].as_str().unwrap().contains("401 Unauthorized"),
                 "Unexpected error: {res}"
             );


### PR DESCRIPTION
In some providers, we were calling '.header' with our headers (e.g. 'Authorization') after setting the user-supplied extra-headers with '.headers'. This could result in duplicate headers getting sent (since '.header' will append to any existing headers)

We now call '.headers' as the last method call before making the request
- this causes extra-headers to completely replace any existing headers with the same name.

To catch this kind of issue, I've modified provider-proxy to produce a failure response when duplicate headers are present in the request.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure user-supplied headers overwrite existing ones and detect duplicate headers in requests.
> 
>   - **Behavior**:
>     - Adjusted order of `.headers()` calls in `deepseek.rs`, `fireworks.rs`, `gcp_vertex_anthropic.rs`, `hyperbolic.rs`, `openai.rs`, and `xai.rs` to ensure user-supplied headers overwrite existing ones.
>     - Modified `provider-proxy/src/lib.rs` to return a failure response when duplicate headers are detected using `find_duplicate_header()`.
>   - **Functions**:
>     - Added `find_duplicate_header()` in `provider-proxy/src/lib.rs` to identify duplicate headers.
>   - **Tests**:
>     - Updated `common.rs` to check for specific error messages related to authentication failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2f8144d418aaa1b035777cdda071b46d4840b835. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->