### PR TITLE
Remove .git from dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,6 @@ target-rust-analyzer
 **/node_modules
 **/.env*
 **/.vscode
-.git
 /recipes
 /examples
 !/examples/integrations/cursor/experimental


### PR DESCRIPTION
This ensures that the gateway Docker build can compile the git hash into the binary

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `.git` from `.dockerignore` to allow Docker build to access git hash for compilation.
> 
>   - **Docker Build**:
>     - Removes `.git` from `.dockerignore` to allow Docker build to access git hash for compilation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ad02b8fdbf1d603d55bd0ac5a52c2d9e52fa251c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->