### PR TITLE
Include explicit 'context: .' in docker-hub-publish workflow

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -69,6 +69,9 @@ jobs:
         with:
           platforms: ${{ matrix.platform.target }}
           file: ./${{ matrix.container.path }}/Dockerfile
+          # This is required to make '.git' available in the build context:
+          # https://github.com/docker/build-push-action/issues/513#issuecomment-987951050
+          context: .
           push: true
           provenance: mode=max
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `context: .` to `docker-hub-publish.yml` to include `.git` in Docker build context.
> 
>   - **Workflow Update**:
>     - Adds `context: .` to the `docker-hub-publish.yml` workflow in the `Build and push Docker image` step to include `.git` in the build context.
>     - Addresses issue from docker/build-push-action regarding missing `.git` directory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 676f8e608efcf7c9150c6ade2b568695821dc9d6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->