### PR TITLE
Add 'tensorzero::extra_body' and 'tensorzero::extra_headers' to OpenAI

### DIFF
--- a/clients/openai-python/tests/test_openai_compatibility.py
+++ b/clients/openai-python/tests/test_openai_compatibility.py
@@ -774,6 +774,75 @@ async def test_async_json_invalid_system(async_client):
         in str(exc_info.value)
     )
 
+@pytest.mark.asyncio
+async def test_async_extra_headers_param(async_client):
+    messages = [
+        {"role": "user", "content": "Hello, world!"},
+    ]
+    result = await async_client.chat.completions.create(
+        extra_body={
+            "tensorzero::extra_headers": [
+                {
+                    "model_provider_name": "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
+                    "name": "x-my-extra-header",
+                    "value": "my-extra-header-value",
+                },
+            ]
+        },
+        messages=messages,
+        model="tensorzero::model_name::dummy::echo_extra_info",
+    )
+    assert result.model == "tensorzero::model_name::dummy::echo_extra_info"
+    assert json.loads(result.choices[0].message.content) == {
+        "extra_body": {"inference_extra_body": []},
+        "extra_headers": {
+            "inference_extra_headers": [
+                {
+                    "model_provider_name": "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
+                    "name": "x-my-extra-header",
+                    "value": "my-extra-header-value",
+                }
+            ],
+            "variant_extra_headers": None,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_extra_body_param(async_client):
+    messages = [
+        {"role": "user", "content": "Hello, world!"},
+    ]
+    result = await async_client.chat.completions.create(
+        extra_body={
+            "tensorzero::extra_body": [
+                {
+                    "model_provider_name": "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
+                    "pointer": "/thinking",
+                    "value": {
+                        "type": "enabled",
+                        "budget_tokens": 1024,
+                    },
+                },
+            ]
+        },
+        messages=messages,
+        model="tensorzero::model_name::dummy::echo_extra_info",
+    )
+    assert result.model == "tensorzero::model_name::dummy::echo_extra_info"
+    assert json.loads(result.choices[0].message.content) == {
+        "extra_body": {
+            "inference_extra_body": [
+                {
+                    "model_provider_name": "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
+                    "pointer": "/thinking",
+                    "value": {"type": "enabled", "budget_tokens": 1024},
+                }
+            ]
+        },
+        "extra_headers": {"variant_extra_headers": None, "inference_extra_headers": []},
+    }
+
 
 @pytest.mark.asyncio
 async def test_async_json_failure(async_client):

--- a/clients/openai-python/tests/test_openai_compatibility.py
+++ b/clients/openai-python/tests/test_openai_compatibility.py
@@ -774,6 +774,7 @@ async def test_async_json_invalid_system(async_client):
         in str(exc_info.value)
     )
 
+
 @pytest.mark.asyncio
 async def test_async_extra_headers_param(async_client):
     messages = [

--- a/tensorzero-internal/src/endpoints/openai_compatible.rs
+++ b/tensorzero-internal/src/endpoints/openai_compatible.rs
@@ -252,6 +252,10 @@ pub struct OpenAICompatibleParams {
     tensorzero_episode_id: Option<Uuid>,
     #[serde(rename = "tensorzero::cache_options")]
     tensorzero_cache_options: Option<CacheParamsOptions>,
+    #[serde(default, rename = "tensorzero::extra_body")]
+    tensorzero_extra_body: UnfilteredInferenceExtraBody,
+    #[serde(default, rename = "tensorzero::extra_headers")]
+    tensorzero_extra_headers: UnfilteredInferenceExtraHeaders,
     #[serde(flatten)]
     unknown_fields: HashMap<String, Value>,
 }
@@ -489,9 +493,8 @@ impl Params {
             tags: HashMap::new(),
             // OpenAI compatible endpoint does not support 'include_original_response'
             include_original_response: false,
-            // OpenAI compatible endpoint does not support 'extra_body'
-            extra_body: UnfilteredInferenceExtraBody::default(),
-            extra_headers: UnfilteredInferenceExtraHeaders::default(),
+            extra_body: openai_compatible_params.tensorzero_extra_body,
+            extra_headers: openai_compatible_params.tensorzero_extra_headers,
         })
     }
 }
@@ -1142,6 +1145,8 @@ mod tests {
                 tensorzero_variant_name: None,
                 tensorzero_dryrun: None,
                 tensorzero_cache_options: None,
+                tensorzero_extra_body: UnfilteredInferenceExtraBody::default(),
+                tensorzero_extra_headers: UnfilteredInferenceExtraHeaders::default(),
                 unknown_fields: Default::default(),
                 stream_options: None,
             },
@@ -1606,6 +1611,8 @@ mod tests {
                 tensorzero_dryrun: None,
                 tensorzero_episode_id: None,
                 tensorzero_cache_options: None,
+                tensorzero_extra_body: UnfilteredInferenceExtraBody::default(),
+                tensorzero_extra_headers: UnfilteredInferenceExtraHeaders::default(),
                 unknown_fields: Default::default(),
                 stream_options: None,
             },
@@ -1640,6 +1647,8 @@ mod tests {
                     max_age_s: Some(3600),
                     enabled: CacheEnabledMode::On,
                 }),
+                tensorzero_extra_body: UnfilteredInferenceExtraBody::default(),
+                tensorzero_extra_headers: UnfilteredInferenceExtraHeaders::default(),
                 unknown_fields: Default::default(),
                 stream_options: None,
             },
@@ -1680,6 +1689,8 @@ mod tests {
                     max_age_s: Some(3600),
                     enabled: CacheEnabledMode::On,
                 }),
+                tensorzero_extra_body: UnfilteredInferenceExtraBody::default(),
+                tensorzero_extra_headers: UnfilteredInferenceExtraHeaders::default(),
                 unknown_fields: Default::default(),
                 stream_options: None,
             },
@@ -1720,6 +1731,8 @@ mod tests {
                     max_age_s: None,
                     enabled: CacheEnabledMode::WriteOnly,
                 }),
+                tensorzero_extra_body: UnfilteredInferenceExtraBody::default(),
+                tensorzero_extra_headers: UnfilteredInferenceExtraHeaders::default(),
                 unknown_fields: Default::default(),
                 stream_options: None,
             },

--- a/tensorzero-internal/src/inference/providers/dummy.rs
+++ b/tensorzero-internal/src/inference/providers/dummy.rs
@@ -288,13 +288,21 @@ impl InferenceProvider for DummyProvider {
                 })]
             }
             "alternate" => vec![ALTERNATE_INFER_RESPONSE_CONTENT.to_string().into()],
-            #[expect(clippy::unwrap_used)]
+            "echo_extra_info" => {
+                vec![ContentBlockOutput::Text(Text {
+                    text: json!({
+                        "extra_body": request.extra_body,
+                        "extra_headers": request.extra_headers,
+                    })
+                    .to_string(),
+                })]
+            }
             "echo_request_messages" => vec![ContentBlockOutput::Text(Text {
-                text: serde_json::to_string(&json!({
+                text: json!({
                     "system": request.system,
                     "messages": request.messages,
-                }))
-                .unwrap(),
+                })
+                .to_string(),
             })],
             "extract_images" => {
                 let images: Vec<_> = request


### PR DESCRIPTION
These are passed as fields in the openai-compatible request body, and set the underyling 'extra_body' and 'extra_headers' request args

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for `tensorzero::extra_body` and `tensorzero::extra_headers` in OpenAI-compatible requests, with tests and provider updates.
> 
>   - **Behavior**:
>     - Add support for `tensorzero::extra_body` and `tensorzero::extra_headers` in OpenAI-compatible requests in `openai_compatible.rs`.
>     - These fields are set in `Params` and used in request handling.
>   - **Tests**:
>     - Add `test_async_extra_headers_param` and `test_async_extra_body_param` in `test_openai_compatibility.py` to verify handling of `extra_headers` and `extra_body`.
>   - **Providers**:
>     - Update `DummyProvider` in `dummy.rs` to echo `extra_body` and `extra_headers` in `echo_extra_info` model.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 83d8a30576077a4b6d1c9a09fd3af0cd1b852126. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->