### PR TITLE
Add nodejs openai client tests for extra_body/extra_headers

### DIFF
--- a/clients/openai-node/tests/openai-compatibility.test.ts
+++ b/clients/openai-node/tests/openai-compatibility.test.ts
@@ -1376,3 +1376,70 @@ it("should handle json function null response", async () => {
   );
   expect(result.choices[0].message.content).toBeNull();
 });
+
+it("should handle extra headers parameter", async () => {
+  const result = await client.chat.completions.create({
+    // @ts-expect-error - custom TensorZero property
+    "tensorzero::extra_headers": [
+      {
+        "model_provider_name": "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
+        "name": "x-my-extra-header",
+        "value": "my-extra-header-value",
+      },
+    ],
+    messages: [
+      { role: "user", content: "Hello, world!" },
+    ],
+    model: "tensorzero::model_name::dummy::echo_extra_info",
+  });
+
+  expect(result.model).toBe("tensorzero::model_name::dummy::echo_extra_info");
+  expect(JSON.parse(result.choices[0].message.content!)).toEqual({
+    "extra_body": { "inference_extra_body": [] },
+    "extra_headers": {
+      "inference_extra_headers": [
+        {
+          "model_provider_name": "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
+          "name": "x-my-extra-header",
+          "value": "my-extra-header-value",
+        }
+      ],
+      "variant_extra_headers": null,
+    },
+  });
+});
+
+it("should handle extra body parameter", async () => {
+  const result = await client.chat.completions.create({
+    // @ts-expect-error - custom TensorZero property
+    "tensorzero::extra_body": [
+      {
+        "model_provider_name": "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
+        "pointer": "/thinking",
+        "value": {
+          "type": "enabled",
+          "budget_tokens": 1024,
+        },
+      },
+    ],
+    messages: [
+      { role: "user", content: "Hello, world!" },
+    ],
+    model: "tensorzero::model_name::dummy::echo_extra_info",
+  });
+
+  expect(result.model).toBe("tensorzero::model_name::dummy::echo_extra_info");
+  expect(JSON.parse(result.choices[0].message.content!)).toEqual({
+    "extra_body": {
+      "inference_extra_body": [
+        {
+          "model_provider_name": "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
+          "pointer": "/thinking",
+          "value": { "type": "enabled", "budget_tokens": 1024 },
+        }
+      ]
+    },
+    "extra_headers": { "variant_extra_headers": null, "inference_extra_headers": [] },
+  });
+});
+


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add tests for handling `extra_headers` and `extra_body` parameters in Node.js OpenAI client for TensorZero model.
> 
>   - **Tests**:
>     - Add test for `extra_headers` parameter in `openai-compatibility.test.ts` to verify correct handling and response structure.
>     - Add test for `extra_body` parameter in `openai-compatibility.test.ts` to ensure proper processing and expected output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8cfb3275b6af9b2a778c16bca1e766afacc05111. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->