### PR TITLE
Exclude two more tool-call-streaming tests on Together

### DIFF
--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -4008,6 +4008,11 @@ pub async fn check_tool_use_tool_choice_auto_unused_inference_response(
 pub async fn test_tool_use_tool_choice_auto_unused_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    // Together doesn't correctly produce streaming tool call chunks (it produces text chunks with the raw tool call).
+    if provider.model_provider_name == "together" {
+        return;
+    }
+
     // OpenAI O1 doesn't support streaming responses
     if provider.model_provider_name == "openai" && provider.model_name.starts_with("o1") {
         return;
@@ -7036,6 +7041,11 @@ pub async fn check_tool_use_multi_turn_inference_response(
 pub async fn test_tool_multi_turn_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    // Together doesn't correctly produce streaming tool call chunks (it produces text chunks with the raw tool call).
+    if provider.model_provider_name == "together" {
+        return;
+    }
+
     // NOTE: The xAI API returns an error for multi-turn tool use when the assistant message only has tool_calls but no content.
     // The xAI team has acknowledged the issue and is working on a fix.
     // We skip this test for xAI until the fix is deployed.


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Exclude two tool-call-streaming tests for 'Together' provider due to incorrect behavior in `common.rs`.
> 
>   - **Tests**:
>     - Exclude `test_tool_use_tool_choice_auto_unused_streaming_inference_request_with_provider` for 'Together' in `common.rs` due to incorrect streaming tool call chunks.
>     - Exclude `test_tool_multi_turn_streaming_inference_request_with_provider` for 'Together' in `common.rs` for the same reason.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 775301b77aecf40becc2b320854fb271768c8476. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->