### PR TITLE
Update table id items to use ShortUuid

### DIFF
--- a/ui/app/components/ui/TableItems.tsx
+++ b/ui/app/components/ui/TableItems.tsx
@@ -8,11 +8,15 @@ import {
 import { formatDate } from "~/utils/date";
 
 interface TableItemShortUuidProps {
-  id: string;
+  id: string | null;
   link?: string;
 }
 
 function TableItemShortUuid({ id, link }: TableItemShortUuidProps) {
+  if (id === null) {
+    return <span className="text-fg-muted">—</span>;
+  }
+
   const content = (
     <span
       className="inline-block max-w-[80px] overflow-hidden align-middle font-mono whitespace-nowrap"

--- a/ui/app/routes/datasets/$dataset_name/DatasetRowTable.tsx
+++ b/ui/app/routes/datasets/$dataset_name/DatasetRowTable.tsx
@@ -9,9 +9,8 @@ import {
 } from "~/components/ui/table";
 import type { DatasetDetailRow } from "~/utils/clickhouse/datasets";
 import { Badge } from "~/components/ui/badge";
-import { Link } from "react-router";
 import { FunctionLink } from "~/components/function/FunctionLink";
-import { TableItemTime } from "~/components/ui/TableItems";
+import { TableItemShortUuid, TableItemTime } from "~/components/ui/TableItems";
 
 export default function DatasetRowTable({
   rows,
@@ -39,27 +38,19 @@ export default function DatasetRowTable({
             rows.map((row) => (
               <TableRow key={row.id} id={row.id}>
                 <TableCell className="max-w-[200px]">
-                  <Link
-                    to={`/datasets/${dataset_name}/datapoint/${row.id}`}
-                    className="block no-underline"
-                  >
-                    <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-                      {row.id}
-                    </code>
-                  </Link>
+                  <TableItemShortUuid
+                    id={row.id}
+                    link={`/datasets/${dataset_name}/datapoint/${row.id}`}
+                  />
                 </TableCell>
                 <TableCell className="max-w-[200px]">
                   <Badge variant="outline">{row.type}</Badge>
                 </TableCell>
                 <TableCell>
-                  <Link
-                    to={`/observability/episodes/${row.episode_id}`}
-                    className="block no-underline"
-                  >
-                    <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-                      {row.episode_id}
-                    </code>
-                  </Link>
+                  <TableItemShortUuid
+                    id={row.episode_id}
+                    link={`/observability/episodes/${row.episode_id}`}
+                  />
                 </TableCell>
                 <TableCell>
                   <FunctionLink functionName={row.function_name}>

--- a/ui/app/routes/evaluations/EvaluationRunsTable.tsx
+++ b/ui/app/routes/evaluations/EvaluationRunsTable.tsx
@@ -11,7 +11,7 @@ import {
 import { FunctionLink } from "~/components/function/FunctionLink";
 import { VariantLink } from "~/components/function/variant/VariantLink";
 import type { EvaluationInfoResult } from "~/utils/clickhouse/evaluations";
-import { TableItemTime } from "~/components/ui/TableItems";
+import { TableItemShortUuid, TableItemTime } from "~/components/ui/TableItems";
 
 export default function EvaluationRunsTable({
   evaluationRuns,
@@ -41,14 +41,10 @@ export default function EvaluationRunsTable({
                 id={evaluationRun.evaluation_run_id}
               >
                 <TableCell className="max-w-[200px]">
-                  <Link
-                    to={`/evaluations/${evaluationRun.evaluation_name}?evaluation_run_ids=${evaluationRun.evaluation_run_id}`}
-                    className="block no-underline"
-                  >
-                    <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-                      {evaluationRun.evaluation_run_id}
-                    </code>
-                  </Link>
+                  <TableItemShortUuid
+                    id={evaluationRun.evaluation_run_id}
+                    link={`/evaluations/${evaluationRun.evaluation_name}?evaluation_run_ids=${evaluationRun.evaluation_run_id}`}
+                  />
                 </TableCell>
                 <TableCell className="max-w-[200px]">
                   <Link

--- a/ui/app/routes/observability/episodes/$episode_id/EpisodeInferenceTable.tsx
+++ b/ui/app/routes/observability/episodes/$episode_id/EpisodeInferenceTable.tsx
@@ -8,10 +8,9 @@ import {
   TableEmptyState,
 } from "~/components/ui/table";
 import type { InferenceByIdRow } from "~/utils/clickhouse/inference";
-import { Link } from "react-router";
 import { FunctionLink } from "~/components/function/FunctionLink";
 import { VariantLink } from "~/components/function/variant/VariantLink";
-import { TableItemTime } from "~/components/ui/TableItems";
+import { TableItemShortUuid, TableItemTime } from "~/components/ui/TableItems";
 
 export default function EpisodeInferenceTable({
   inferences,
@@ -35,14 +34,10 @@ export default function EpisodeInferenceTable({
           inferences.map((inference) => (
             <TableRow key={inference.id} id={inference.id}>
               <TableCell className="max-w-[200px]">
-                <Link
-                  to={`/observability/inferences/${inference.id}`}
-                  className="block no-underline"
-                >
-                  <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-                    {inference.id}
-                  </code>
-                </Link>
+                <TableItemShortUuid
+                  id={inference.id}
+                  link={`/observability/inferences/${inference.id}`}
+                />
               </TableCell>
               <TableCell>
                 <FunctionLink functionName={inference.function_name}>

--- a/ui/app/routes/observability/episodes/EpisodesTable.tsx
+++ b/ui/app/routes/observability/episodes/EpisodesTable.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router";
 import {
   Table,
   TableBody,
@@ -9,6 +8,7 @@ import {
   TableEmptyState,
 } from "~/components/ui/table";
 import type { EpisodeByIdRow } from "~/utils/clickhouse/inference";
+import { TableItemShortUuid } from "~/components/ui/TableItems";
 
 export default function EpisodesTable({
   episodes,
@@ -49,14 +49,10 @@ export default function EpisodesTable({
             episodes.map((episode) => (
               <TableRow key={episode.episode_id} id={episode.episode_id}>
                 <TableCell className="max-w-[200px] lg:max-w-none">
-                  <Link
-                    to={`/observability/episodes/${episode.episode_id}`}
-                    className="block no-underline"
-                  >
-                    <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-                      {episode.episode_id}
-                    </code>
-                  </Link>
+                  <TableItemShortUuid
+                    id={episode.episode_id}
+                    link={`/observability/episodes/${episode.episode_id}`}
+                  />
                 </TableCell>
                 <TableCell>{episode.count}</TableCell>
                 <TableCell className="max-w-[200px] lg:max-w-none">

--- a/ui/app/routes/observability/functions/$function_name/FunctionInferenceTable.tsx
+++ b/ui/app/routes/observability/functions/$function_name/FunctionInferenceTable.tsx
@@ -8,9 +8,8 @@ import {
   TableEmptyState,
 } from "~/components/ui/table";
 import type { InferenceByIdRow } from "~/utils/clickhouse/inference";
-import { Link } from "react-router";
 import { VariantLink } from "~/components/function/variant/VariantLink";
-import { TableItemTime } from "~/components/ui/TableItems";
+import { TableItemShortUuid, TableItemTime } from "~/components/ui/TableItems";
 
 export default function FunctionInferenceTable({
   inferences,
@@ -34,24 +33,16 @@ export default function FunctionInferenceTable({
           inferences.map((inference) => (
             <TableRow key={inference.id} id={inference.id}>
               <TableCell className="max-w-[200px]">
-                <Link
-                  to={`/observability/inferences/${inference.id}`}
-                  className="block no-underline"
-                >
-                  <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-                    {inference.id}
-                  </code>
-                </Link>
+                <TableItemShortUuid
+                  id={inference.id}
+                  link={`/observability/inferences/${inference.id}`}
+                />
               </TableCell>
               <TableCell>
-                <Link
-                  to={`/observability/episodes/${inference.episode_id}`}
-                  className="block no-underline"
-                >
-                  <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-                    {inference.episode_id}
-                  </code>
-                </Link>
+                <TableItemShortUuid
+                  id={inference.episode_id}
+                  link={`/observability/episodes/${inference.episode_id}`}
+                />
               </TableCell>
               <TableCell>
                 <VariantLink

--- a/ui/app/routes/observability/functions/$function_name/variants/VariantInferenceTable.tsx
+++ b/ui/app/routes/observability/functions/$function_name/variants/VariantInferenceTable.tsx
@@ -8,8 +8,8 @@ import {
   TableEmptyState,
 } from "~/components/ui/table";
 import type { InferenceByIdRow } from "~/utils/clickhouse/inference";
-import { Link } from "react-router";
-import { TableItemTime } from "~/components/ui/TableItems";
+import { TableItemShortUuid, TableItemTime } from "~/components/ui/TableItems";
+
 export default function VariantInferenceTable({
   inferences,
 }: {
@@ -31,24 +31,16 @@ export default function VariantInferenceTable({
           inferences.map((inference) => (
             <TableRow key={inference.id} id={inference.id}>
               <TableCell className="max-w-[200px]">
-                <Link
-                  to={`/observability/inferences/${inference.id}`}
-                  className="block no-underline"
-                >
-                  <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-                    {inference.id}
-                  </code>
-                </Link>
+                <TableItemShortUuid
+                  id={inference.id}
+                  link={`/observability/inferences/${inference.id}`}
+                />
               </TableCell>
               <TableCell>
-                <Link
-                  to={`/observability/episodes/${inference.episode_id}`}
-                  className="block no-underline"
-                >
-                  <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-                    {inference.episode_id}
-                  </code>
-                </Link>
+                <TableItemShortUuid
+                  id={inference.episode_id}
+                  link={`/observability/episodes/${inference.episode_id}`}
+                />
               </TableCell>
               <TableCell>
                 <TableItemTime timestamp={inference.timestamp} />

--- a/ui/app/routes/observability/inferences/$inference_id/ModelInferencesTable.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/ModelInferencesTable.tsx
@@ -11,6 +11,7 @@ import {
 import { Sheet, SheetContent } from "~/components/ui/sheet";
 import type { ParsedModelInferenceRow } from "~/utils/clickhouse/inference";
 import { ModelInferenceItem } from "./ModelInferenceItem";
+import { TableItemShortUuid } from "~/components/ui/TableItems";
 
 interface ModelInferencesTableProps {
   modelInferences: ParsedModelInferenceRow[];
@@ -48,9 +49,7 @@ export function ModelInferencesTable({
                 onClick={() => handleRowClick(inference)}
               >
                 <TableCell className="max-w-[200px]">
-                  <span className="block overflow-hidden font-mono text-ellipsis whitespace-nowrap">
-                    {inference.id}
-                  </span>
+                  <TableItemShortUuid id={inference.id} />
                 </TableCell>
                 <TableCell className="max-w-[200px]">
                   <span className="block overflow-hidden font-mono text-ellipsis whitespace-nowrap">


### PR DESCRIPTION
- updated table id items to use `TableItemShortUuid`
- added null check to the `TableItemShortUuid` as `DatasetDetailRow` type explicitly defines `episode_id` as nullable, used in `DatasetRowTable`, and potentially other components in the future.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update ID display in tables to use `TableItemShortUuid`, handling null IDs and ensuring consistent formatting across components.
> 
>   - **Behavior**:
>     - Updated ID display in tables to use `TableItemShortUuid` in `DatasetRowTable.tsx`, `EvaluationRunsTable.tsx`, and `EpisodeInferenceTable.tsx`.
>     - Handles null `id` by displaying a dash in `TableItemShortUuid`.
>   - **Components**:
>     - Added null check in `TableItemShortUuid` in `TableItems.tsx`.
>     - Replaced `Link` components with `TableItemShortUuid` for ID display in `EpisodesTable.tsx`, `FunctionInferenceTable.tsx`, and `VariantInferenceTable.tsx`.
>   - **Misc**:
>     - Removed unused `Link` imports from several files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 78d5f4d679a52dfe706408139c8c55dfc51cf017. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->