### PR TITLE
fixed issue where storagekinds with no region failed to parse

### DIFF
--- a/clients/openai-node/tests/openai-compatibility.test.ts
+++ b/clients/openai-node/tests/openai-compatibility.test.ts
@@ -1382,29 +1382,29 @@ it("should handle extra headers parameter", async () => {
     // @ts-expect-error - custom TensorZero property
     "tensorzero::extra_headers": [
       {
-        "model_provider_name": "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
-        "name": "x-my-extra-header",
-        "value": "my-extra-header-value",
+        model_provider_name:
+          "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
+        name: "x-my-extra-header",
+        value: "my-extra-header-value",
       },
     ],
-    messages: [
-      { role: "user", content: "Hello, world!" },
-    ],
+    messages: [{ role: "user", content: "Hello, world!" }],
     model: "tensorzero::model_name::dummy::echo_extra_info",
   });
 
   expect(result.model).toBe("tensorzero::model_name::dummy::echo_extra_info");
   expect(JSON.parse(result.choices[0].message.content!)).toEqual({
-    "extra_body": { "inference_extra_body": [] },
-    "extra_headers": {
-      "inference_extra_headers": [
+    extra_body: { inference_extra_body: [] },
+    extra_headers: {
+      inference_extra_headers: [
         {
-          "model_provider_name": "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
-          "name": "x-my-extra-header",
-          "value": "my-extra-header-value",
-        }
+          model_provider_name:
+            "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
+          name: "x-my-extra-header",
+          value: "my-extra-header-value",
+        },
       ],
-      "variant_extra_headers": null,
+      variant_extra_headers: null,
     },
   });
 });
@@ -1414,32 +1414,31 @@ it("should handle extra body parameter", async () => {
     // @ts-expect-error - custom TensorZero property
     "tensorzero::extra_body": [
       {
-        "model_provider_name": "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
-        "pointer": "/thinking",
-        "value": {
-          "type": "enabled",
-          "budget_tokens": 1024,
+        model_provider_name:
+          "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
+        pointer: "/thinking",
+        value: {
+          type: "enabled",
+          budget_tokens: 1024,
         },
       },
     ],
-    messages: [
-      { role: "user", content: "Hello, world!" },
-    ],
+    messages: [{ role: "user", content: "Hello, world!" }],
     model: "tensorzero::model_name::dummy::echo_extra_info",
   });
 
   expect(result.model).toBe("tensorzero::model_name::dummy::echo_extra_info");
   expect(JSON.parse(result.choices[0].message.content!)).toEqual({
-    "extra_body": {
-      "inference_extra_body": [
+    extra_body: {
+      inference_extra_body: [
         {
-          "model_provider_name": "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
-          "pointer": "/thinking",
-          "value": { "type": "enabled", "budget_tokens": 1024 },
-        }
-      ]
+          model_provider_name:
+            "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
+          pointer: "/thinking",
+          value: { type: "enabled", budget_tokens: 1024 },
+        },
+      ],
     },
-    "extra_headers": { "variant_extra_headers": null, "inference_extra_headers": [] },
+    extra_headers: { variant_extra_headers: null, inference_extra_headers: [] },
   });
 });
-

--- a/ui/app/utils/clickhouse/common.test.ts
+++ b/ui/app/utils/clickhouse/common.test.ts
@@ -1,7 +1,21 @@
-import { expect, test } from "vitest";
+import { expect, describe, test } from "vitest";
 import { checkClickHouseConnection } from "./client.server";
+import { storageKindSchema } from "./common";
 
 test("checkClickHouseConnection", async () => {
   const result = await checkClickHouseConnection();
   expect(result).toBe(true);
+});
+
+describe("parsing storageKind", () => {
+  test("storagekind with null region", () => {
+    const storageKind = {
+      type: "s3_compatible",
+      bucket_name: "tensorzero",
+      region: null,
+      endpoint: "http://minio:9000",
+      allow_http: true,
+    };
+    storageKindSchema.parse(storageKind);
+  });
 });

--- a/ui/app/utils/clickhouse/common.ts
+++ b/ui/app/utils/clickhouse/common.ts
@@ -75,7 +75,7 @@ export const storageKindSchema = z.discriminatedUnion("type", [
     .object({
       type: z.literal("s3_compatible"),
       bucket_name: z.string(),
-      region: z.string(),
+      region: z.string().nullable(),
       endpoint: z.string().nullable(),
       allow_http: z.boolean().nullable(),
     })


### PR DESCRIPTION
separately my linter picked up some issues with OpenAI tests worth fixing

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix parsing issue for storage kinds with null regions by updating schema and adding a test.
> 
>   - **Schema Update**:
>     - In `common.ts`, update `storageKindSchema` to allow `region` to be `nullable` for `s3_compatible` type.
>   - **Testing**:
>     - Add test in `common.test.ts` to verify parsing of `storageKind` with `null` region.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 17ec3790351aa3a8292ea7d28440a33dca519956. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->