### PR TITLE
Increase the maximum body limit to 100mb

### DIFF
--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -1,4 +1,4 @@
-use axum::extract::Request;
+use axum::extract::{DefaultBodyLimit, Request};
 use axum::http::HeaderValue;
 use axum::middleware::Next;
 use axum::response::Response;
@@ -223,6 +223,7 @@ async fn main() {
         )
         .fallback(endpoints::fallback::handle_404)
         .layer(axum::middleware::from_fn(add_version_header))
+        .layer(DefaultBodyLimit::max(100 * 1024 * 1024)) // increase the default body limit from 2MB to 100MB
         .with_state(app_state);
 
     // Bind to the socket address specified in the config, or default to 0.0.0.0:3000


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase default body limit to 100MB in `main.rs`.
> 
>   - **Behavior**:
>     - Increase default body limit to 100MB in `main.rs` using `DefaultBodyLimit::max(100 * 1024 * 1024)`.
>   - **Imports**:
>     - Add `DefaultBodyLimit` to imports in `main.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ea01a7cbee45995ee60f6422d76f8a82f5fe8e3b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->