### PR TITLE
Don't make CLA Assistant lock PRs after merging

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -31,3 +31,4 @@ jobs:
           branch: "cla-signatures"
           allowlist: dependabot[bot]
           custom-pr-sign-comment: "I have read the Contributor License Agreement (CLA) and hereby sign the CLA."
+          lock-pullrequest-aftermerge: false


### PR DESCRIPTION
The original CLA signature will still be in the history of the signatures file, so it doesn't matter if users edit or add comments later

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevents CLA Assistant from locking pull requests after merging by updating `.github/workflows/cla.yml`.
> 
>   - **Behavior**:
>     - Prevents CLA Assistant from locking pull requests after merging by setting `lock-pullrequest-aftermerge: false` in `.github/workflows/cla.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 18cf283620f5fdc13726fa25f793eaee6686ced5. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->