### PR TITLE
Increase delay to 2 seconds before checking inserted fixtures

### DIFF
--- a/ui/fixtures/load_fixtures.sh
+++ b/ui/fixtures/load_fixtures.sh
@@ -16,7 +16,7 @@ clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --
 
 
 # Give ClickHouse some time to make the writes visible
-sleep 1
+sleep 2
 
 ./check-fixtures.sh
 


### PR DESCRIPTION
We saw a mismatch error in https://github.com/tensorzero/tensorzero/actions/runs/14887087465/job/41809479747?pr=2061 FloatMetricFeedbackByTargetId had excepted 1546, actual 0.

Let's give ClickHouse more time

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase sleep duration in `load_fixtures.sh` to 2 seconds to address ClickHouse write visibility issue.
> 
>   - **Behavior**:
>     - Increase sleep duration from 1 to 2 seconds in `load_fixtures.sh` to allow ClickHouse more time to process writes before checking fixtures.
>     - Addresses mismatch error observed in GitHub Actions run 14887087465.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 96d80d5b87c4bf30c405efe07c9f3ab001bd6fa0. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->