### PR TITLE
refactor datapoint insert endpoint; add client methods

### DIFF
--- a/clients/python-pyo3/src/lib.rs
+++ b/clients/python-pyo3/src/lib.rs
@@ -26,7 +26,9 @@ use python_helpers::{
     parse_inference_response, parse_tool, python_uuid_to_uuid, serialize_to_dict,
 };
 use tensorzero_internal::{
-    endpoints::dynamic_evaluation_run::DynamicEvaluationRunEpisodeParams,
+    endpoints::{
+        datasets::CreateDatapointParams, dynamic_evaluation_run::DynamicEvaluationRunEpisodeParams,
+    },
     gateway_util::ShutdownHandle,
     inference::types::{
         extra_body::UnfilteredInferenceExtraBody, extra_headers::UnfilteredInferenceExtraHeaders,
@@ -784,6 +786,50 @@ impl TensorZeroGateway {
             Err(e) => Err(convert_error(this.py(), e)),
         }
     }
+
+    ///  Make a POST request to the /datasets/{dataset_name}/datapoints/bulk endpoint.
+    ///
+    /// :param dataset_name: The name of the dataset to insert the datapoints into.
+    /// :param datapoints: A list of datapoints to insert.
+    /// :return: None.
+    fn bulk_insert_datapoints(
+        this: PyRef<'_, Self>,
+        dataset_name: String,
+        datapoints: Vec<Bound<'_, PyAny>>,
+    ) -> PyResult<Py<PyList>> {
+        let client = this.as_super().client.clone();
+        let datapoints = datapoints
+            .iter()
+            .map(|dp| deserialize_from_pyobj(this.py(), dp))
+            .collect::<Result<Vec<_>, _>>()?;
+        let params = CreateDatapointParams { datapoints };
+        let fut = client.bulk_insert_datapoints(dataset_name, params);
+        let self_module = PyModule::import(this.py(), "uuid")?;
+        let uuid = self_module.getattr("UUID")?.unbind();
+        let res =
+            tokio_block_on_without_gil(this.py(), fut).map_err(|e| convert_error(this.py(), e))?;
+        let uuids = res
+            .iter()
+            .map(|x| uuid.call(this.py(), (x.to_string(),), None))
+            .collect::<Result<Vec<_>, _>>()?;
+        PyList::new(this.py(), uuids).map(|x| x.unbind())
+    }
+
+    /// Make a DELETE request to the /datasets/{dataset_name}/datapoints/{datapoint_id} endpoint.
+    ///
+    /// :param dataset_name: The name of the dataset to delete the datapoint from.
+    /// :param datapoint_id: The ID of the datapoint to delete.
+    /// :return: None.
+    fn delete_datapoint(
+        this: PyRef<'_, Self>,
+        dataset_name: String,
+        datapoint_id: Bound<'_, PyAny>,
+    ) -> PyResult<()> {
+        let client = this.as_super().client.clone();
+        let datapoint_id = python_uuid_to_uuid("datapoint_id", datapoint_id)?;
+        let fut = client.delete_datapoint(dataset_name, datapoint_id);
+        tokio_block_on_without_gil(this.py(), fut).map_err(|e| convert_error(this.py(), e))
+    }
 }
 
 #[pyclass(extends=BaseTensorZeroGateway)]
@@ -1177,6 +1223,61 @@ impl AsyncTensorZeroGateway {
             let res = client.dynamic_evaluation_run_episode(run_id, params).await;
             Python::with_gil(|py| match res {
                 Ok(resp) => parse_dynamic_evaluation_run_episode_response(py, resp),
+                Err(e) => Err(convert_error(py, e)),
+            })
+        })
+    }
+
+    ///  Make a POST request to the /datasets/{dataset_name}/datapoints/bulk endpoint.
+    ///
+    /// :param dataset_name: The name of the dataset to insert the datapoints into.
+    /// :param datapoints: A list of datapoints to insert.
+    /// :return: None.
+    fn bulk_insert_datapoints<'a>(
+        this: PyRef<'a, Self>,
+        dataset_name: String,
+        datapoints: Vec<Bound<'a, PyAny>>,
+    ) -> PyResult<Bound<'a, PyAny>> {
+        let client = this.as_super().client.clone();
+        let datapoints = datapoints
+            .iter()
+            .map(|dp| deserialize_from_pyobj(this.py(), dp))
+            .collect::<Result<Vec<_>, _>>()?;
+        let params = CreateDatapointParams { datapoints };
+        let self_module = PyModule::import(this.py(), "uuid")?;
+        let uuid = self_module.getattr("UUID")?.unbind();
+        pyo3_async_runtimes::tokio::future_into_py(this.py(), async move {
+            let res = client.bulk_insert_datapoints(dataset_name, params).await;
+            Python::with_gil(|py| match res {
+                Ok(uuids) => Ok(PyList::new(
+                    py,
+                    uuids
+                        .iter()
+                        .map(|id| uuid.call(py, (id.to_string(),), None))
+                        .collect::<Result<Vec<_>, _>>()?,
+                )?
+                .unbind()),
+                Err(e) => Err(convert_error(py, e)),
+            })
+        })
+    }
+
+    /// Make a DELETE request to the /datasets/{dataset_name}/datapoints/{datapoint_id} endpoint.
+    ///
+    /// :param dataset_name: The name of the dataset to delete the datapoint from.
+    /// :param datapoint_id: The ID of the datapoint to delete.
+    /// :return: None.
+    fn delete_datapoint<'a>(
+        this: PyRef<'a, Self>,
+        dataset_name: String,
+        datapoint_id: Bound<'a, PyAny>,
+    ) -> PyResult<Bound<'a, PyAny>> {
+        let client = this.as_super().client.clone();
+        let datapoint_id = python_uuid_to_uuid("datapoint_id", datapoint_id)?;
+        pyo3_async_runtimes::tokio::future_into_py(this.py(), async move {
+            let res = client.delete_datapoint(dataset_name, datapoint_id).await;
+            Python::with_gil(|py| match res {
+                Ok(_) => Ok(()),
                 Err(e) => Err(convert_error(py, e)),
             })
         })

--- a/clients/python-pyo3/tensorzero/__init__.py
+++ b/clients/python-pyo3/tensorzero/__init__.py
@@ -7,6 +7,7 @@ from .client import AsyncTensorZeroGateway, BaseTensorZeroGateway, TensorZeroGat
 from .tensorzero import _start_http_gateway as _start_http_gateway
 from .types import (
     BaseTensorZeroError,
+    ChatInferenceDatapointInput,
     ChatInferenceResponse,
     ContentBlock,
     DynamicEvaluationRunEpisodeResponse,
@@ -19,6 +20,7 @@ from .types import (
     InferenceChunk,
     InferenceInput,
     InferenceResponse,
+    JsonInferenceDatapointInput,
     JsonInferenceOutput,
     JsonInferenceResponse,
     Message,
@@ -40,6 +42,7 @@ __all__ = [
     "BaseTensorZeroError",
     "BaseTensorZeroGateway",
     "ChatInferenceResponse",
+    "ChatInferenceDatapointInput",
     "ContentBlock",
     "DynamicEvaluationRunEpisodeResponse",
     "DynamicEvaluationRunResponse",
@@ -53,6 +56,7 @@ __all__ = [
     "InferenceResponse",
     "JsonInferenceOutput",
     "JsonInferenceResponse",
+    "JsonInferenceDatapointInput",
     "Message",
     "patch_openai_client",
     "RawText",

--- a/clients/python-pyo3/tensorzero/tensorzero.pyi
+++ b/clients/python-pyo3/tensorzero/tensorzero.pyi
@@ -200,9 +200,9 @@ class TensorZeroGateway(BaseTensorZeroGateway):
         datapoints: List[
             Union[ChatInferenceDatapointInput, JsonInferenceDatapointInput]
         ],
-    ) -> None:
+    ) -> List[UUID]:
         """
-        Make a POST request to the /bulk_insert_datapoints endpoint.
+        Make a POST request to the /datasets/{dataset_name}/datapoints/bulk endpoint.
 
         :param dataset_name: The name of the dataset to insert the datapoints into.
         :param datapoints: A list of datapoints to insert.
@@ -215,7 +215,7 @@ class TensorZeroGateway(BaseTensorZeroGateway):
         datapoint_id: str,
     ) -> None:
         """
-        Make a POST request to the /delete_datapoint endpoint.
+        Make a DELETE request to the /datasets/{dataset_name}/datapoints/{datapoint_id} endpoint.
 
         :param dataset_name: The name of the dataset to delete the datapoint from.
         :param datapoint_id: The ID of the datapoint to delete.
@@ -408,9 +408,9 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         datapoints: List[
             Union[ChatInferenceDatapointInput, JsonInferenceDatapointInput]
         ],
-    ) -> None:
+    ) -> List[UUID]:
         """
-        Make a POST request to the /bulk_insert_datapoints endpoint.
+        Make a POST request to the /datasets/{dataset_name}/datapoints/bulk endpoint.
 
         :param dataset_name: The name of the dataset to insert the datapoints into.
         :param datapoints: A list of datapoints to insert.
@@ -423,7 +423,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         datapoint_id: str,
     ) -> None:
         """
-        Make a POST request to the /delete_datapoint endpoint.
+        Make a DELETE request to the /datasets/{dataset_name}/datapoints/{datapoint_id} endpoint.
 
         :param dataset_name: The name of the dataset to delete the datapoint from.
         :param datapoint_id: The ID of the datapoint to delete.

--- a/clients/python-pyo3/tensorzero/tensorzero.pyi
+++ b/clients/python-pyo3/tensorzero/tensorzero.pyi
@@ -16,6 +16,7 @@ import uuid_utils
 
 import tensorzero.internal_optimizations_server_types as iost
 from tensorzero import (
+    ChatInferenceDatapointInput,
     DynamicEvaluationRunEpisodeResponse,
     DynamicEvaluationRunResponse,
     ExtraBody,
@@ -23,6 +24,7 @@ from tensorzero import (
     InferenceChunk,
     InferenceInput,
     InferenceResponse,
+    JsonInferenceDatapointInput,
 )
 
 class BaseTensorZeroGateway:
@@ -189,6 +191,34 @@ class TensorZeroGateway(BaseTensorZeroGateway):
                     Deprecated: use `task_name` instead.
         :param tags: A dictionary of tags to add to the dynamic evaluation run.
         :return: A `DynamicEvaluationRunEpisodeResponse` instance ({"episode_id": str}).
+        """
+
+    def bulk_insert_datapoints(
+        self,
+        *,
+        dataset_name: str,
+        datapoints: List[
+            Union[ChatInferenceDatapointInput, JsonInferenceDatapointInput]
+        ],
+    ) -> None:
+        """
+        Make a POST request to the /bulk_insert_datapoints endpoint.
+
+        :param dataset_name: The name of the dataset to insert the datapoints into.
+        :param datapoints: A list of datapoints to insert.
+        """
+
+    def delete_datapoint(
+        self,
+        *,
+        dataset_name: str,
+        datapoint_id: str,
+    ) -> None:
+        """
+        Make a POST request to the /delete_datapoint endpoint.
+
+        :param dataset_name: The name of the dataset to delete the datapoint from.
+        :param datapoint_id: The ID of the datapoint to delete.
         """
 
     def close(self) -> None:
@@ -369,6 +399,34 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
                     Deprecated: use `task_name` instead.
         :param tags: A dictionary of tags to add to the dynamic evaluation run.
         :return: A `DynamicEvaluationRunEpisodeResponse` instance ({"episode_id": str}).
+        """
+
+    async def bulk_insert_datapoints(
+        self,
+        *,
+        dataset_name: str,
+        datapoints: List[
+            Union[ChatInferenceDatapointInput, JsonInferenceDatapointInput]
+        ],
+    ) -> None:
+        """
+        Make a POST request to the /bulk_insert_datapoints endpoint.
+
+        :param dataset_name: The name of the dataset to insert the datapoints into.
+        :param datapoints: A list of datapoints to insert.
+        """
+
+    async def delete_datapoint(
+        self,
+        *,
+        dataset_name: str,
+        datapoint_id: str,
+    ) -> None:
+        """
+        Make a POST request to the /delete_datapoint endpoint.
+
+        :param dataset_name: The name of the dataset to delete the datapoint from.
+        :param datapoint_id: The ID of the datapoint to delete.
         """
 
     async def close(self) -> None:

--- a/clients/python-pyo3/tensorzero/types.py
+++ b/clients/python-pyo3/tensorzero/types.py
@@ -404,3 +404,24 @@ def parse_dynamic_evaluation_run_episode_response(
     data: Dict[str, Any],
 ) -> DynamicEvaluationRunEpisodeResponse:
     return DynamicEvaluationRunEpisodeResponse(episode_id=UUID(data["episode_id"]))
+
+
+@dataclass
+class ChatInferenceDatapointInput:
+    function_name: str
+    input: InferenceInput
+    output: Optional[Any]
+    allowed_tools: Optional[List[str]]
+    additional_tools: Optional[List[Any]]
+    tool_choice: Optional[str]
+    parallel_tool_calls: Optional[bool]
+    tags: Optional[Dict[str, str]]
+
+
+@dataclass
+class JsonInferenceDatapointInput:
+    function_name: str
+    input: InferenceInput
+    output: Optional[Any]
+    output_schema: Optional[Any]
+    tags: Optional[Dict[str, str]]

--- a/clients/python-pyo3/tensorzero/types.py
+++ b/clients/python-pyo3/tensorzero/types.py
@@ -410,18 +410,39 @@ def parse_dynamic_evaluation_run_episode_response(
 class ChatInferenceDatapointInput:
     function_name: str
     input: InferenceInput
-    output: Optional[Any]
-    allowed_tools: Optional[List[str]]
-    additional_tools: Optional[List[Any]]
-    tool_choice: Optional[str]
-    parallel_tool_calls: Optional[bool]
-    tags: Optional[Dict[str, str]]
+    output: Optional[Any] = None
+    allowed_tools: Optional[List[str]] = None
+    additional_tools: Optional[List[Any]] = None
+    tool_choice: Optional[str] = None
+    parallel_tool_calls: Optional[bool] = None
+    tags: Optional[Dict[str, str]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "function_name": self.function_name,
+            "input": self.input,
+            "output": self.output,
+            "allowed_tools": self.allowed_tools,
+            "additional_tools": self.additional_tools,
+            "tool_choice": self.tool_choice,
+            "parallel_tool_calls": self.parallel_tool_calls,
+            "tags": self.tags,
+        }
 
 
 @dataclass
 class JsonInferenceDatapointInput:
     function_name: str
     input: InferenceInput
-    output: Optional[Any]
-    output_schema: Optional[Any]
-    tags: Optional[Dict[str, str]]
+    output: Optional[Any] = None
+    output_schema: Optional[Any] = None
+    tags: Optional[Dict[str, str]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "function_name": self.function_name,
+            "input": self.input,
+            "output": self.output,
+            "output_schema": self.output_schema,
+            "tags": self.tags,
+        }

--- a/clients/python-pyo3/tests/test_client.py
+++ b/clients/python-pyo3/tests/test_client.py
@@ -37,6 +37,7 @@ from openai import AsyncOpenAI, OpenAI
 from pytest import FixtureRequest
 from tensorzero import (
     AsyncTensorZeroGateway,
+    ChatInferenceDatapointInput,
     ChatInferenceResponse,
     DynamicEvaluationRunResponse,
     FeedbackResponse,
@@ -44,6 +45,7 @@ from tensorzero import (
     ImageBase64,
     ImageUrl,
     InferenceChunk,
+    JsonInferenceDatapointInput,
     JsonInferenceResponse,
     RawText,
     TensorZeroError,
@@ -2871,3 +2873,240 @@ def test_sync_json_function_null_response(sync_client: TensorZeroGateway):
     assert isinstance(result, JsonInferenceResponse)
     assert result.output.raw is None
     assert result.output.parsed is None
+
+
+def test_sync_bulk_insert_delete_datapoints(sync_client: TensorZeroGateway):
+    datapoints = [
+        ChatInferenceDatapointInput(
+            function_name="basic_test",
+            input={
+                "system": {"assistant_name": "foo"},
+                "messages": [
+                    {"role": "user", "content": [{"type": "text", "text": "bar"}]}
+                ],
+            },
+            output=[{"type": "text", "text": "foobar"}],
+            allowed_tools=None,
+            additional_tools=None,
+            tool_choice="auto",
+            parallel_tool_calls=False,
+            tags=None,
+        ),
+        ChatInferenceDatapointInput(
+            function_name="basic_test",
+            input={
+                "system": {"assistant_name": "Dummy"},
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "My synthetic input"}],
+                    }
+                ],
+            },
+            output=[
+                {
+                    "type": "tool_call",
+                    "name": "get_temperature",
+                    "arguments": {"location": "New York", "units": "fahrenheit"},
+                }
+            ],
+            additional_tools=[
+                {
+                    "description": "Get the current temperature in a given location",
+                    "parameters": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "type": "object",
+                        "properties": {
+                            "location": {
+                                "type": "string",
+                                "description": 'The location to get the temperature for (e.g. "New York")',
+                            },
+                            "units": {
+                                "type": "string",
+                                "description": 'The units to get the temperature in (must be "fahrenheit" or "celsius")',
+                                "enum": ["fahrenheit", "celsius"],
+                            },
+                        },
+                        "required": ["location"],
+                        "additionalProperties": False,
+                    },
+                    "name": "get_temperature",
+                    "strict": False,
+                }
+            ],
+            tool_choice="auto",
+            parallel_tool_calls=False,
+            allowed_tools=None,
+            tags=None,
+        ),
+        JsonInferenceDatapointInput(
+            function_name="json_success",
+            input={
+                "system": {"assistant_name": "foo"},
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "arguments": {"country": "US"}}],
+                    }
+                ],
+            },
+            output={"answer": "Hello"},
+            output_schema=None,
+            tags=None,
+        ),
+        JsonInferenceDatapointInput(
+            function_name="json_success",
+            input={
+                "system": {"assistant_name": "foo"},
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "arguments": {"country": "US"}}],
+                    }
+                ],
+            },
+            output={"response": "Hello"},
+            output_schema={
+                "type": "object",
+                "properties": {"response": {"type": "string"}},
+            },
+            tags=None,
+        ),
+    ]
+    datapoint_ids = sync_client.bulk_insert_datapoints(
+        dataset_name="test", datapoints=datapoints
+    )
+    assert len(datapoint_ids) == 4
+    assert isinstance(datapoint_ids[0], UUID)
+    assert isinstance(datapoint_ids[1], UUID)
+    assert isinstance(datapoint_ids[2], UUID)
+    assert isinstance(datapoint_ids[3], UUID)
+
+    sync_client.delete_datapoint(dataset_name="test", datapoint_id=datapoint_ids[0])
+    sync_client.delete_datapoint(dataset_name="test", datapoint_id=datapoint_ids[1])
+    sync_client.delete_datapoint(dataset_name="test", datapoint_id=datapoint_ids[2])
+    sync_client.delete_datapoint(dataset_name="test", datapoint_id=datapoint_ids[3])
+
+
+@pytest.mark.asyncio
+async def test_async_bulk_insert_delete_datapoints(
+    async_client: AsyncTensorZeroGateway,
+):
+    datapoints = [
+        ChatInferenceDatapointInput(
+            function_name="basic_test",
+            input={
+                "system": {"assistant_name": "foo"},
+                "messages": [
+                    {"role": "user", "content": [{"type": "text", "text": "bar"}]}
+                ],
+            },
+            output=[{"type": "text", "text": "foobar"}],
+            allowed_tools=None,
+            additional_tools=None,
+            tool_choice="auto",
+            parallel_tool_calls=False,
+            tags=None,
+        ),
+        ChatInferenceDatapointInput(
+            function_name="basic_test",
+            input={
+                "system": {"assistant_name": "Dummy"},
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "My synthetic input"}],
+                    }
+                ],
+            },
+            output=[
+                {
+                    "type": "tool_call",
+                    "name": "get_temperature",
+                    "arguments": {"location": "New York", "units": "fahrenheit"},
+                }
+            ],
+            additional_tools=[
+                {
+                    "description": "Get the current temperature in a given location",
+                    "parameters": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "type": "object",
+                        "properties": {
+                            "location": {
+                                "type": "string",
+                                "description": 'The location to get the temperature for (e.g. "New York")',
+                            },
+                            "units": {
+                                "type": "string",
+                                "description": 'The units to get the temperature in (must be "fahrenheit" or "celsius")',
+                                "enum": ["fahrenheit", "celsius"],
+                            },
+                        },
+                        "required": ["location"],
+                        "additionalProperties": False,
+                    },
+                    "name": "get_temperature",
+                    "strict": False,
+                }
+            ],
+            tool_choice="auto",
+            parallel_tool_calls=False,
+            allowed_tools=None,
+            tags=None,
+        ),
+        JsonInferenceDatapointInput(
+            function_name="json_success",
+            input={
+                "system": {"assistant_name": "foo"},
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "arguments": {"country": "US"}}],
+                    }
+                ],
+            },
+            output={"answer": "Hello"},
+            output_schema=None,
+            tags=None,
+        ),
+        JsonInferenceDatapointInput(
+            function_name="json_success",
+            input={
+                "system": {"assistant_name": "foo"},
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "arguments": {"country": "US"}}],
+                    }
+                ],
+            },
+            output={"response": "Hello"},
+            output_schema={
+                "type": "object",
+                "properties": {"response": {"type": "string"}},
+            },
+            tags=None,
+        ),
+    ]
+    datapoint_ids = await async_client.bulk_insert_datapoints(
+        dataset_name="test", datapoints=datapoints
+    )
+    assert len(datapoint_ids) == 4
+    assert isinstance(datapoint_ids[0], UUID)
+    assert isinstance(datapoint_ids[1], UUID)
+    assert isinstance(datapoint_ids[2], UUID)
+    assert isinstance(datapoint_ids[3], UUID)
+
+    await async_client.delete_datapoint(
+        dataset_name="test", datapoint_id=datapoint_ids[0]
+    )
+    await async_client.delete_datapoint(
+        dataset_name="test", datapoint_id=datapoint_ids[1]
+    )
+    await async_client.delete_datapoint(
+        dataset_name="test", datapoint_id=datapoint_ids[2]
+    )
+    await async_client.delete_datapoint(
+        dataset_name="test", datapoint_id=datapoint_ids[3]
+    )

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -10,6 +10,7 @@ use std::fmt::Debug;
 use tensorzero_internal::{
     config_parser::Config,
     endpoints::{
+        datasets::CreateDatapointParams,
         dynamic_evaluation_run::{
             DynamicEvaluationRunEpisodeParams, DynamicEvaluationRunEpisodeResponse,
         },
@@ -574,6 +575,70 @@ impl Client {
                         gateway.state.clone(),
                         run_id,
                         params,
+                    )
+                    .await
+                    .map_err(err_to_http)
+                })
+                .await?)
+            }
+        }
+    }
+
+    pub async fn bulk_insert_datapoints(
+        &self,
+        dataset_name: String,
+        params: CreateDatapointParams,
+    ) -> Result<(), TensorZeroError> {
+        match &self.mode {
+            ClientMode::HTTPGateway(client) => {
+                let url = client.base_url.join(&format!("datasets/{dataset_name}/datapoints/bulk")).map_err(|e| TensorZeroError::Other {
+                    source: tensorzero_internal::error::Error::new(ErrorDetails::InvalidBaseUrl {
+                        message: format!("Failed to join base URL with /datasets/{dataset_name}/datapoints/bulk endpoint: {e}"),
+                    })
+                    .into(),
+                })?;
+                let builder = client.http_client.post(url).json(&params);
+                self.parse_http_response(builder.send().await).await
+            }
+            ClientMode::EmbeddedGateway { gateway, timeout } => {
+                Ok(with_embedded_timeout(*timeout, async {
+                    tensorzero_internal::endpoints::datasets::create_datapoint(
+                        dataset_name,
+                        params,
+                        &gateway.state.config,
+                        &gateway.state.http_client,
+                        &gateway.state.clickhouse_connection_info,
+                    )
+                    .await
+                    .map_err(err_to_http)
+                })
+                .await?)
+            }
+        }
+    }
+
+    pub async fn delete_datapoint(
+        &self,
+        dataset_name: String,
+        datapoint_id: Uuid,
+    ) -> Result<(), TensorZeroError> {
+        match &self.mode {
+            ClientMode::HTTPGateway(client) => {
+                let url = client.base_url.join(&format!("datasets/{dataset_name}/datapoints/{datapoint_id}")).map_err(|e| TensorZeroError::Other {
+                    source: tensorzero_internal::error::Error::new(ErrorDetails::InvalidBaseUrl {
+                        message: format!("Failed to join base URL with /datasets/{dataset_name}/datapoints/{datapoint_id} endpoint: {e}"),
+                    })
+                    .into(),
+                })?;
+                let builder = client.http_client.delete(url);
+                self.parse_http_response(builder.send().await).await
+            }
+            ClientMode::EmbeddedGateway { gateway, timeout } => {
+                Ok(with_embedded_timeout(*timeout, async {
+                    tensorzero_internal::endpoints::datasets::delete_datapoint(
+                        dataset_name,
+                        datapoint_id,
+                        &gateway.state.clickhouse_connection_info,
                     )
                     .await
                     .map_err(err_to_http)

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -198,7 +198,7 @@ async fn main() {
         .route("/status", get(endpoints::status::status_handler))
         .route("/health", get(endpoints::status::health_handler))
         .route(
-            "/datasets/{dataset_name}/datapoints/batch",
+            "/datasets/{dataset_name}/datapoints/bulk",
             post(endpoints::datasets::create_datapoint_handler),
         )
         .route(

--- a/tensorzero-internal/src/endpoints/datasets.rs
+++ b/tensorzero-internal/src/endpoints/datasets.rs
@@ -442,7 +442,7 @@ pub async fn update_datapoint_handler(
     }))
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CreateDatapointParams {
     // the function name

--- a/tensorzero-internal/src/endpoints/datasets.rs
+++ b/tensorzero-internal/src/endpoints/datasets.rs
@@ -864,13 +864,6 @@ pub struct JsonInferenceDatapointInput {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum DatapointInput {
-    Chat(ChatInferenceDatapointInput),
-    Json(JsonInferenceDatapointInput),
-}
-
-#[derive(Debug, Deserialize, Serialize)]
 pub struct ChatInferenceDatapoint {
     pub dataset_name: String,
     pub function_name: String,

--- a/tensorzero-internal/tests/e2e/datasets.rs
+++ b/tensorzero-internal/tests/e2e/datasets.rs
@@ -212,7 +212,7 @@ async fn test_create_delete_datapoint_chat() {
 
     let resp = client
         .post(get_gateway_endpoint(&format!(
-            "/datasets/{dataset_name}/datapoints/batch",
+            "/datasets/{dataset_name}/datapoints/bulk",
         )))
         .json(&json!({
             "function_name": "basic_test",
@@ -360,7 +360,7 @@ async fn test_create_datapoint_chat_bad_request() {
 
     let resp = client
         .post(get_gateway_endpoint(&format!(
-            "/datasets/{dataset_name}/datapoints/batch",
+            "/datasets/{dataset_name}/datapoints/bulk",
         )))
         .json(&json!({
             "function_name": "basic_test",
@@ -892,7 +892,7 @@ async fn test_create_delete_datapoint_json() {
     });
     let resp = client
         .post(get_gateway_endpoint(&format!(
-            "/datasets/{dataset_name}/datapoints/batch",
+            "/datasets/{dataset_name}/datapoints/bulk",
         )))
         .json(&json!({
             "function_name": "json_success",
@@ -989,7 +989,7 @@ async fn test_create_datapoint_json_bad_output() {
 
     let resp = client
         .post(get_gateway_endpoint(&format!(
-            "/datasets/{dataset_name}/datapoints/batch",
+            "/datasets/{dataset_name}/datapoints/bulk",
         )))
         .json(&json!({
             "function_name": "json_success",


### PR DESCRIPTION
Previously we had been using a columnar (struct-of-lists) design for the datapoint bulk insert API. Now we're instead using list-of-structs since we need that anyway and it's easier to deal with for the clients. 

Made the changes for that and refactored all tests.
Also added the equivalent methods to the Rust and Python clients. 

@GabrielBianconi also moved the endpoint from .../batch to .../bulk since we have batch inference and this is unrelated. 