### PR TITLE
Support batch API for GCP Vertex Anthropic

### DIFF
--- a/tensorzero-internal/src/config_parser.rs
+++ b/tensorzero-internal/src/config_parser.rs
@@ -649,6 +649,8 @@ struct UninitializedConfig {
 pub struct ProviderTypesConfig {
     #[serde(default)]
     pub gcp_vertex_gemini: Option<GCPProviderTypeConfig>,
+    #[serde(default)]
+    pub gcp_vertex_anthropic: Option<GCPProviderTypeConfig>,
 }
 
 impl UninitializedConfig {

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
@@ -172,7 +172,7 @@ impl GCPVertexAnthropicProvider {
                         raw_response,
                         file_id: store_and_path.path.to_string(),
                     },
-                    |r| make_provider_batch_inference_output(r),
+                    make_provider_batch_inference_output,
                 )
                 .await
             }
@@ -874,7 +874,7 @@ fn join_cloud_paths(base: &str, suffix: &str) -> String {
 fn make_provider_batch_inference_output(
     line: GCPVertexAnthropicBatchResponseLine,
 ) -> Result<ProviderBatchInferenceOutput, Error> {
-    let request = GCPVertexAnthropicRequestMinimal::deserialize(&*line.request).map_err(|e| {
+    let request = GCPVertexAnthropicRequestMinimal::deserialize(&line.request).map_err(|e| {
         Error::new(ErrorDetails::Serialization {
             message: format!("Error deserializing batch request: {e}"),
         })

--- a/tensorzero-internal/src/model.rs
+++ b/tensorzero-internal/src/model.rs
@@ -792,6 +792,7 @@ impl UninitializedProviderConfig {
                 location,
                 project_id,
                 api_key_location,
+                provider_types,
             )?),
             UninitializedProviderConfig::GCPVertexGemini {
                 model_id,

--- a/tensorzero-internal/tests/e2e/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/tests/e2e/providers/gcp_vertex_anthropic.rs
@@ -6,13 +6,22 @@ crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
-    let standard_providers = vec![E2ETestProvider {
-        supports_batch_inference: true,
-        variant_name: "gcp-vertex-haiku".to_string(),
-        model_name: "claude-3-haiku-20240307-gcp-vertex".into(),
-        model_provider_name: "gcp_vertex_anthropic".into(),
-        credentials: HashMap::new(),
-    }];
+    let standard_providers = vec![
+        E2ETestProvider {
+            supports_batch_inference: true,
+            variant_name: "gcp-vertex-haiku".to_string(),
+            model_name: "claude-3-5-haiku-20241022-gcp-vertex".into(),
+            model_provider_name: "gcp_vertex_anthropic".into(),
+            credentials: HashMap::new(),
+        },
+        E2ETestProvider {
+            supports_batch_inference: false,
+            variant_name: "gcp-vertex-haiku".to_string(),
+            model_name: "claude-3-haiku-20240307-gcp-vertex".into(),
+            model_provider_name: "gcp_vertex_anthropic".into(),
+            credentials: HashMap::new(),
+        },
+    ];
 
     let image_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
@@ -39,6 +48,13 @@ async fn get_providers() -> E2ETestProviders {
     }];
 
     let json_providers = vec![
+        E2ETestProvider {
+            supports_batch_inference: true,
+            variant_name: "gcp-vertex-haiku".to_string(),
+            model_name: "claude-3-5-haiku-20241022-gcp-vertex".into(),
+            model_provider_name: "gcp_vertex_anthropic".into(),
+            credentials: HashMap::new(),
+        },
         E2ETestProvider {
             supports_batch_inference: false,
             variant_name: "gcp-vertex-haiku".to_string(),

--- a/tensorzero-internal/tests/e2e/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/tests/e2e/providers/gcp_vertex_anthropic.rs
@@ -7,7 +7,7 @@ crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
     let standard_providers = vec![E2ETestProvider {
-        supports_batch_inference: false,
+        supports_batch_inference: true,
         variant_name: "gcp-vertex-haiku".to_string(),
         model_name: "claude-3-haiku-20240307-gcp-vertex".into(),
         model_provider_name: "gcp_vertex_anthropic".into(),

--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -161,6 +161,15 @@ model_name = "gemma3:1b"
 # We actually host an ollama container, but we don't have an ollama provider yet
 hosted_provider = "openai"
 
+[models.claude-3-5-haiku-20241022-gcp-vertex]
+routing = ["gcp_vertex_anthropic"]
+
+[models.claude-3-5-haiku-20241022-gcp-vertex.providers.gcp_vertex_anthropic]
+type = "gcp_vertex_anthropic"
+model_id = "claude-3-5-haiku@20241022"
+location = "us-east5"
+project_id = "tensorzero-public"
+
 [models.claude-3-haiku-20240307-gcp-vertex]
 routing = ["gcp_vertex_anthropic"]
 
@@ -808,6 +817,12 @@ type = "chat_completion"
 model = "gemini-2.5-pro-dynamic"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 500
+
+[functions.basic_test.variants.gcp-vertex-haiku-3-5]
+type = "chat_completion"
+model = "claude-3-5-haiku-20241022-gcp-vertex"
+system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
+max_tokens = 100
 
 [functions.basic_test.variants.gcp-vertex-haiku]
 type = "chat_completion"

--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -347,6 +347,11 @@ storage_type = "cloud_storage"
 input_uri_prefix = "gs://tensorzero-batch-tests-input/input-prefix/"
 output_uri_prefix = "gs://tensorzero-batch-tests-output/output-prefix/"
 
+[provider_types.gcp_vertex_anthropic.batch]
+storage_type = "cloud_storage"
+input_uri_prefix = "gs://tensorzero-batch-tests-input/input-prefix/"
+output_uri_prefix = "gs://tensorzero-batch-tests-output/output-prefix/"
+
 [models."grok_2_1212-dynamic".providers.xai]
 type = "xai"
 model_name = "grok-2-1212"


### PR DESCRIPTION
Status: not able to manually test or run E2E tests locally, due to lack of access to Vertex API. 

After getting setup on Vertex, I got 429 Too Many Request errors when hitting their API, and learned that my quota for online prediction requests for Claude 3.5 haiku was zero. A request to increase it was refused by GCloud support, apparently personal accounts aren't accepted.

TODO
- [ ] waiting on quota update for Claude 3.5 haiku on Google Vertex*
- [x] fix error parsing

*Claude 3 haiku doesn't support batches

Closes #1938

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
