### PR TITLE
Try sccache again for ui Dockerfile

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -26,19 +26,33 @@ WORKDIR /app
 
 RUN pnpm install --frozen-lockfile --prod
 
+# ========== rust-sccache-env ==========
+
+FROM rust:latest AS rust-sccache-env
+ENV SCCACHE_VERSION=v0.10.0
+RUN wget https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz && \
+    tar -xzf sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz && \
+    mv sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache /usr/local/bin/ && \
+    chmod +x /usr/local/bin/sccache && \
+    rm -rf sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz
+ENV RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache
+
 # ========== minijinja-build-env ==========
 
-FROM rust:latest AS minijinja-build-env
+FROM rust-sccache-env AS minijinja-build-env
 
 COPY . /build
 
 WORKDIR /build/ui/app/utils/minijinja
 RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-RUN wasm-pack build --features console_error_panic_hook
+RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/git \
+    --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/sccache \
+    wasm-pack build --features console_error_panic_hook
 
 # ========== evaluations-build-env ==========
 
-FROM rust:latest AS evaluations-build-env
+FROM rust-sccache-env AS evaluations-build-env
 
 RUN apt-get update && apt-get install -y clang libc++-dev && rm -rf /var/lib/apt/lists/*
 
@@ -52,6 +66,7 @@ RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/
     --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/git \
     --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/sccache \
     cargo build --release -p evaluations $CARGO_BUILD_FLAGS && \
+    sccache --show-stats && \
     cp -r /tensorzero/target/release /release
 
 
@@ -69,7 +84,7 @@ WORKDIR /app
 
 RUN pnpm run build
 
-FROM rust:latest AS python-build-env
+FROM rust-sccache-env AS python-build-env
 RUN apt-get update && apt-get install -y python3
 COPY --from=ghcr.io/astral-sh/uv:0.6.6 /uv /uvx /bin/
 COPY . /build
@@ -78,7 +93,10 @@ WORKDIR /build/optimizations-server
 # UV_PYTHON_DOWNLOADS=never
 # https://hynek.me/articles/docker-uv/
 ENV UV_COMPILE_BYTECODE=1
-RUN uv  --verbose sync --locked --no-dev
+RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/git \
+    --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/sccache \
+    uv --verbose sync --locked --no-dev
 
 # ========== ui ==========
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -45,9 +45,7 @@ COPY . /build
 
 WORKDIR /build/ui/app/utils/minijinja
 RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/registry \
-    --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/git \
-    --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/sccache \
+RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/sccache \
     wasm-pack build --features console_error_panic_hook
 
 # ========== evaluations-build-env ==========
@@ -62,9 +60,7 @@ WORKDIR /tensorzero
 
 ARG CARGO_BUILD_FLAGS=""
 
-RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/registry \
-    --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/git \
-    --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/sccache \
+RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/sccache \
     cargo build --release -p evaluations $CARGO_BUILD_FLAGS && \
     sccache --show-stats && \
     cp -r /tensorzero/target/release /release
@@ -93,9 +89,7 @@ WORKDIR /build/optimizations-server
 # UV_PYTHON_DOWNLOADS=never
 # https://hynek.me/articles/docker-uv/
 ENV UV_COMPILE_BYTECODE=1
-RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/registry \
-    --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/git \
-    --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/sccache \
+RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/sccache \
     uv --verbose sync --locked --no-dev
 
 # ========== ui ==========


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Integrates `sccache` in `ui/Dockerfile` to optimize Rust build caching and performance.
> 
>   - **Dockerfile Changes**:
>     - Introduces `rust-sccache-env` stage in `ui/Dockerfile` to set up `sccache` for Rust builds.
>     - Updates `minijinja-build-env`, `evaluations-build-env`, and `python-build-env` to use `rust-sccache-env` for caching.
>     - Adds `sccache --show-stats` in `evaluations-build-env` to display cache statistics after build.
>     - Removes redundant cache mounts for `/usr/local/cargo/registry` and `/usr/local/cargo/git` in `evaluations-build-env`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4fd90ebfdd7f926d02aabac526406a933b2c66c4. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->