### PR TITLE
Remove openssl-sys dependency from git2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1695,8 +1695,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
  "url",
 ]
 
@@ -2330,9 +2328,7 @@ checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -2354,20 +2350,6 @@ checksum = "ec9d6fac27761dabcd4ee73571cdb06b7022dc99089acbe5435691edffaac0f4"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2841,18 +2823,6 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.107"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ serde-untagged = "0.1.7"
 object_store = { version = "0.12.0", features = ["serde", "aws", "gcp"] }
 rand = "0.9.1"
 chrono = { version = "0.4.41", features = ["serde"] }
-git2 = "0.20.1"
+git2 = { version = "0.20.1", default-features = false }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,7 @@
 deny = [
     { name = "native-tls" },
     { name = "openssl" },
+    { name = "openssl-sys"}
 ]
 
 [advisories]


### PR DESCRIPTION
This is breaking the PyO3 build on linux (since we don't have OpenSSL available, and would have difficulty getting it for musl)

Fortunately, we don't actually need any of the 'git2' features (https, ssh) that use openssl

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `openssl-sys` dependency from `git2` to fix Linux build issues by disabling default features.
> 
>   - **Dependencies**:
>     - Remove `openssl-sys` and `openssl-probe` from `Cargo.lock` dependencies for `git2`.
>     - Update `git2` in `Cargo.toml` to disable default features, removing OpenSSL dependency.
>     - Add `openssl-sys` to deny list in `deny.toml`.
>   - **Behavior**:
>     - `git2` no longer requires OpenSSL, resolving build issues on Linux, especially for musl targets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2855381694bfd143855879e13d437f067828e4bc. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->