### PR TITLE
Use reuseable workflow to build PyO3 wheels

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -99,32 +99,7 @@ jobs:
         run: ./ci/check-all-docker-compose.sh
 
   check-pyo3-build:
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        # We don't test on linux x86_64, because our main 'validate' step already does that
-        # For now, we just check that the build works on our other supported platforms -
-        # we don't run any tests.
-        platform:
-          - runner: ubuntu-22.04-arm
-            target: aarch64
-          - runner: windows-latest
-            target: x64
-          - runner: macos-13
-            target: x86_64
-          - runner: macos-14
-            target: aarch64
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
-        with:
-          cache-provider: "buildjet"
-          save-if: ${{ github.event_name == 'merge_group' }}
-      - name: "TensorZero PyO3 Client: Build"
-        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
-        with:
-          working-directory: clients/python-pyo3
-          args: --find-interpreter
+    uses: ./.github/workflows/pyo3-build-reusable.yml
 
   build-windows:
     runs-on: windows-latest

--- a/.github/workflows/pyo3-build-reusable.yml
+++ b/.github/workflows/pyo3-build-reusable.yml
@@ -1,0 +1,162 @@
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  linux:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: ubuntu-24.04
+            target: x86_64
+          - runner: ubuntu-24.04-arm
+            target: aarch64
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        with:
+          python-version: 3.x
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
+      - name: Build wheels
+        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
+        with:
+          working-directory: ./clients/python-pyo3
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          sccache: "true"
+          manylinux: auto
+      - name: Upload wheels
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: wheels-linux-${{ matrix.platform.target }}
+          path: ./clients/python-pyo3/dist
+      - name: Check built wheel
+        run: |
+          ./ci/check-local-wheel.sh ./clients/python-pyo3/dist/tensorzero*.whl
+
+  musllinux:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: ubuntu-24.04
+            target: x86_64
+          - runner: ubuntu-24.04-arm
+            target: aarch64
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        with:
+          python-version: 3.x
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
+      - name: Build wheels
+        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
+        with:
+          working-directory: ./clients/python-pyo3
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          sccache: "true"
+          manylinux: musllinux_1_2
+      - name: Upload wheels
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: wheels-musllinux-${{ matrix.platform.target }}
+          path: ./clients/python-pyo3/dist
+      - name: Check built musl wheel
+        run: |
+          ./ci/check-musl-wheel.sh ./clients/python-pyo3/dist/tensorzero*.whl
+
+  windows:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: windows-latest
+            target: x64
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        with:
+          python-version: 3.x
+          architecture: ${{ matrix.platform.target }}
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
+        shell: bash
+      - name: Build wheels
+        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
+        with:
+          working-directory: ./clients/python-pyo3
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          sccache: "true"
+      - name: Upload wheels
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: wheels-windows-${{ matrix.platform.target }}
+          path: ./clients/python-pyo3/dist
+      - name: Check built wheel
+        run: |
+          ./ci/check-local-wheel.sh ./clients/python-pyo3/dist/tensorzero*.whl
+        shell: bash
+
+  macos:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: macos-13
+            target: x86_64
+          - runner: macos-14
+            target: aarch64
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        with:
+          python-version: 3.x
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
+        with:
+          working-directory: ./clients/python-pyo3
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          sccache: "true"
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: wheels-macos-${{ matrix.platform.target }}
+          path: ./clients/python-pyo3/dist
+      - name: Check built wheel
+        run: |
+          ./ci/check-local-wheel.sh ./clients/python-pyo3/dist/tensorzero*.whl
+
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Build sdist
+        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
+        with:
+          working-directory: ./clients/python-pyo3
+          command: sdist
+          args: --out dist
+      - name: Upload sdist
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: wheels-sdist
+          path: ./clients/python-pyo3/dist
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
+      - name: Check local sdist
+        run: |
+          ./ci/check-local-wheel.sh ./clients/python-pyo3/dist/tensorzero-*.tar.gz

--- a/.github/workflows/pyo3-build-reusable.yml
+++ b/.github/workflows/pyo3-build-reusable.yml
@@ -3,7 +3,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   linux:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build-wheels:
-    uses: ./.github/workflows/pypi-publish-reusable.yml
+    uses: ./.github/workflows/pyo3-build-reusable.yml
     permissions:
       id-token: write
 

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -16,6 +16,8 @@ permissions:
 jobs:
   build-wheels:
     uses: ./.github/workflows/pypi-publish-reusable.yml
+    permissions:
+      id-token: write
 
   release:
     name: Release

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -4,8 +4,6 @@ name: Publish PyO3 client to PyPI
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: ["main"]    
   release:
     types: [published]
 

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -4,6 +4,8 @@ name: Publish PyO3 client to PyPI
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: ["main"]    
   release:
     types: [published]
 
@@ -12,165 +14,13 @@ permissions:
   id-token: write
 
 jobs:
-  linux:
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: ubuntu-24.04
-            target: x86_64
-          - runner: ubuntu-24.04-arm
-            target: aarch64
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
-        with:
-          python-version: 3.x
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
-      - name: Build wheels
-        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
-        with:
-          working-directory: ./clients/python-pyo3
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
-          sccache: "true"
-          manylinux: auto
-      - name: Upload wheels
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: wheels-linux-${{ matrix.platform.target }}
-          path: ./clients/python-pyo3/dist
-      - name: Check built wheel
-        run: |
-          ./ci/check-local-wheel.sh ./clients/python-pyo3/dist/tensorzero*.whl
-
-  musllinux:
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: ubuntu-24.04
-            target: x86_64
-          - runner: ubuntu-24.04-arm
-            target: aarch64
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
-        with:
-          python-version: 3.x
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
-      - name: Build wheels
-        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
-        with:
-          working-directory: ./clients/python-pyo3
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
-          sccache: "true"
-          manylinux: musllinux_1_2
-      - name: Upload wheels
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: wheels-musllinux-${{ matrix.platform.target }}
-          path: ./clients/python-pyo3/dist
-      - name: Check built musl wheel
-        run: |
-          ./ci/check-musl-wheel.sh ./clients/python-pyo3/dist/tensorzero*.whl
-
-  windows:
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: windows-latest
-            target: x64
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
-        with:
-          python-version: 3.x
-          architecture: ${{ matrix.platform.target }}
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
-        shell: bash
-      - name: Build wheels
-        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
-        with:
-          working-directory: ./clients/python-pyo3
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
-          sccache: "true"
-      - name: Upload wheels
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: wheels-windows-${{ matrix.platform.target }}
-          path: ./clients/python-pyo3/dist
-      - name: Check built wheel
-        run: |
-          ./ci/check-local-wheel.sh ./clients/python-pyo3/dist/tensorzero*.whl
-        shell: bash
-
-  macos:
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: macos-13
-            target: x86_64
-          - runner: macos-14
-            target: aarch64
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
-        with:
-          python-version: 3.x
-
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
-
-      - name: Build wheels
-        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
-        with:
-          working-directory: ./clients/python-pyo3
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
-          sccache: "true"
-
-      - name: Upload wheels
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: wheels-macos-${{ matrix.platform.target }}
-          path: ./clients/python-pyo3/dist
-      - name: Check built wheel
-        run: |
-          ./ci/check-local-wheel.sh ./clients/python-pyo3/dist/tensorzero*.whl
-
-  sdist:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Build sdist
-        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
-        with:
-          working-directory: ./clients/python-pyo3
-          command: sdist
-          args: --out dist
-      - name: Upload sdist
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: wheels-sdist
-          path: ./clients/python-pyo3/dist
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
-      - name: Check local sdist
-        run: |
-          ./ci/check-local-wheel.sh ./clients/python-pyo3/dist/tensorzero-*.tar.gz
+  build-wheels:
+    uses: ./.github/workflows/pypi-publish-reusable.yml
 
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [linux, musllinux, windows, macos, sdist]
+    needs: [build-wheels]
     environment: pypi-publish
     permissions:
       # Use to sign the release artifacts

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -17,6 +17,7 @@ jobs:
   build-wheels:
     uses: ./.github/workflows/pyo3-build-reusable.yml
     permissions:
+      contents: read
       id-token: write
 
   release:


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor GitHub Actions workflows to use a reusable workflow for building PyO3 wheels across multiple platforms.
> 
>   - **Workflows**:
>     - Refactor `general.yml` and `pypi-publish.yml` to use `pyo3-build-reusable.yml` for building PyO3 wheels.
>     - Remove platform-specific build steps from `general.yml` and `pypi-publish.yml`.
>   - **Reusable Workflow**:
>     - Add `pyo3-build-reusable.yml` to handle building PyO3 wheels for Linux, musllinux, Windows, and macOS.
>     - Includes steps for building, uploading, and checking wheels for each platform.
>   - **Misc**:
>     - Update `pypi-publish.yml` to use the reusable workflow for the `build-wheels` job.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ab12bf31e8a51f6c9f7a0273a87db80e2aeb5431. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->