### PR TITLE
Use 'released' instead of 'published' in Github Actions

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -5,7 +5,7 @@ name: Publish docker images
 on:
   workflow_dispatch:
   release:
-    types: [published]
+    types: [released]
   push:
     branches: ["main"]
 

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -5,7 +5,7 @@ name: Publish PyO3 client to PyPI
 on:
   workflow_dispatch:
   release:
-    types: [published]
+    types: [released]
 
 permissions:
   contents: read


### PR DESCRIPTION
According to https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=released#release 'published' will fire for drafts, while 'released' will only fire for actual releases

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change GitHub Actions trigger type from 'published' to 'released' in two workflow files to trigger only on actual releases.
> 
>   - **Behavior**:
>     - Change trigger type from `published` to `released` in `.github/workflows/docker-hub-publish.yml` and `.github/workflows/pypi-publish.yml`.
>     - Ensures workflows trigger only on actual releases, not drafts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 671e61493d524199df6d95614fa146b75589b565. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->