### PR TITLE
fixed issue with openai response format

### DIFF
--- a/clients/openai-node/tests/openai-compatibility.test.ts
+++ b/clients/openai-node/tests/openai-compatibility.test.ts
@@ -1006,6 +1006,15 @@ describe("OpenAI Compatibility", () => {
       required: ["response"],
       additionalProperties: false,
     };
+    const response_format = {
+      type: "json_schema" as const,
+      json_schema: {
+        name: "test",
+        description: "test",
+        schema: outputSchema,
+        strict: true,
+      },
+    };
 
     const serializedOutputSchema = JSON.stringify(outputSchema);
     const messages: ChatCompletionMessageParam[] = [
@@ -1033,10 +1042,7 @@ describe("OpenAI Compatibility", () => {
     const result = await client.chat.completions.create({
       messages,
       model: "tensorzero::function_name::dynamic_json",
-      response_format: {
-        type: "json_schema",
-        json_schema: { name: "json_schema", ...outputSchema }, // the Node client requires a `name` field here...?
-      },
+      response_format,
       // @ts-expect-error - custom TensorZero property
       "tensorzero::episode_id": episodeId,
       "tensorzero::variant_name": "openai",

--- a/clients/openai-python/tests/test_openai_compatibility.py
+++ b/clients/openai-python/tests/test_openai_compatibility.py
@@ -730,6 +730,77 @@ async def test_async_json_success(async_client):
 
 
 @pytest.mark.asyncio
+async def test_async_json_success_strict(async_client):
+    messages = [
+        {"role": "system", "content": [{"assistant_name": "Alfred Pennyworth"}]},
+        {"role": "user", "content": [{"country": "Japan"}]},
+    ]
+    episode_id = str(uuid7())
+    response_format = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "test",
+            "description": "test",
+            "schema": {
+                "type": "object",
+                "properties": {"response": {"type": "string"}},
+                "required": ["response"],
+                "additionalProperties": False,
+                "strict": True,
+            },
+        },
+    }
+    result = await async_client.chat.completions.create(
+        extra_body={
+            "tensorzero::episode_id": episode_id,
+            "tensorzero::variant_name": "test-diff-schema",
+        },
+        messages=messages,
+        model="tensorzero::function_name::json_success",
+        response_format=response_format,
+    )
+    assert (
+        result.model
+        == "tensorzero::function_name::json_success::variant_name::test-diff-schema"
+    )
+    assert result.episode_id == episode_id
+    assert result.choices[0].message.content == '{"response":"Hello"}'
+    assert result.choices[0].message.tool_calls is None
+    assert result.usage.prompt_tokens == 10
+    assert result.usage.completion_tokens == 10
+
+
+@pytest.mark.asyncio
+async def test_async_json_success_json_object(async_client):
+    messages = [
+        {"role": "system", "content": [{"assistant_name": "Alfred Pennyworth"}]},
+        {"role": "user", "content": [{"country": "Japan"}]},
+    ]
+    episode_id = str(uuid7())
+    response_format = {
+        "type": "json_object",
+    }
+    result = await async_client.chat.completions.create(
+        extra_body={
+            "tensorzero::episode_id": episode_id,
+            "tensorzero::variant_name": "test-diff-schema",
+        },
+        messages=messages,
+        model="tensorzero::function_name::json_success",
+        response_format=response_format,
+    )
+    assert (
+        result.model
+        == "tensorzero::function_name::json_success::variant_name::test-diff-schema"
+    )
+    assert result.episode_id == episode_id
+    assert result.choices[0].message.content == '{"response":"Hello"}'
+    assert result.choices[0].message.tool_calls is None
+    assert result.usage.prompt_tokens == 10
+    assert result.usage.completion_tokens == 10
+
+
+@pytest.mark.asyncio
 async def test_async_json_success_override(async_client):
     # Check that if we pass a string to a function with an input schema it is 400
     # We will add explicit support for raw text in the OpenAI API later
@@ -933,6 +1004,14 @@ async def test_dynamic_json_mode_inference_body_param_openai(async_client):
         "required": ["response"],
         "additionalProperties": False,
     }
+    response_format = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "test",
+            "description": "test",
+            "schema": output_schema,
+        },
+    }
     serialized_output_schema = json.dumps(output_schema)
     messages = [
         {
@@ -953,7 +1032,7 @@ async def test_dynamic_json_mode_inference_body_param_openai(async_client):
         },
         messages=messages,
         model="tensorzero::function_name::dynamic_json",
-        response_format={"type": "json_schema", "json_schema": output_schema},
+        response_format=response_format,
     )
     assert (
         result.model == "tensorzero::function_name::dynamic_json::variant_name::openai"
@@ -976,6 +1055,14 @@ async def test_dynamic_json_mode_inference_openai(async_client):
         "additionalProperties": False,
     }
     serialized_output_schema = json.dumps(output_schema)
+    response_format = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "test",
+            "description": "test",
+            "schema": output_schema,
+        },
+    }
     messages = [
         {
             "role": "system",
@@ -992,7 +1079,7 @@ async def test_dynamic_json_mode_inference_openai(async_client):
         },
         messages=messages,
         model="tensorzero::function_name::dynamic_json",
-        response_format={"type": "json_schema", "json_schema": output_schema},
+        response_format=response_format,
     )
     assert (
         result.model == "tensorzero::function_name::dynamic_json::variant_name::openai"

--- a/tensorzero-internal/src/endpoints/openai_compatible.rs
+++ b/tensorzero-internal/src/endpoints/openai_compatible.rs
@@ -173,8 +173,16 @@ enum OpenAICompatibleMessage {
 #[serde(rename_all = "snake_case")]
 enum OpenAICompatibleResponseFormat {
     Text,
-    JsonSchema { json_schema: Value },
+    JsonSchema { json_schema: JsonSchemaInfo },
     JsonObject,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+struct JsonSchemaInfo {
+    name: String,
+    description: Option<String>,
+    schema: Option<Value>,
+    strict: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
@@ -465,7 +473,7 @@ impl Params {
             parallel_tool_calls: openai_compatible_params.parallel_tool_calls,
         };
         let output_schema = match openai_compatible_params.response_format {
-            Some(OpenAICompatibleResponseFormat::JsonSchema { json_schema }) => Some(json_schema),
+            Some(OpenAICompatibleResponseFormat::JsonSchema { json_schema }) => json_schema.schema,
             _ => None,
         };
         Ok(Params {

--- a/tensorzero-internal/src/inference/providers/dummy.rs
+++ b/tensorzero-internal/src/inference/providers/dummy.rs
@@ -120,6 +120,7 @@ lazy_static! {
 }
 pub static DUMMY_JSON_RESPONSE_RAW: &str = r#"{"answer":"Hello"}"#;
 pub static DUMMY_JSON_GOODBYE_RESPONSE_RAW: &str = r#"{"answer":"Goodbye"}"#;
+pub static DUMMY_JSON_RESPONSE_RAW_DIFF_SCHEMA: &str = r#"{"response":"Hello"}"#;
 pub static DUMMY_JSON_COT_RESPONSE_RAW: &str =
     r#"{"thinking":"hmmm", "response": {"answer":"tokyo!"}}"#;
 pub static DUMMY_INFER_USAGE: Usage = Usage {
@@ -265,6 +266,7 @@ impl InferenceProvider for DummyProvider {
             "json" => vec![DUMMY_JSON_RESPONSE_RAW.to_string().into()],
             "json_goodbye" => vec![DUMMY_JSON_GOODBYE_RESPONSE_RAW.to_string().into()],
             "json_cot" => vec![DUMMY_JSON_COT_RESPONSE_RAW.to_string().into()],
+            "json_diff_schema" => vec![DUMMY_JSON_RESPONSE_RAW_DIFF_SCHEMA.to_string().into()],
             "json_beatles_1" => vec![r#"{"names":["John", "George"]}"#.to_string().into()],
             "json_beatles_2" => vec![r#"{"names":["Paul", "Ringo"]}"#.to_string().into()],
             "best_of_n_0" => {

--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -1222,6 +1222,15 @@ user_template = "../../fixtures/config/functions/json_success/prompt/user_templa
 max_tokens = 100
 json_mode = "strict"
 
+[functions.json_success.variants.test-diff-schema]
+type = "chat_completion"
+weight = 0
+model = "dummy::json_diff_schema"
+system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
+user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
+max_tokens = 100
+json_mode = "strict"
+
 [functions.json_success.variants.anthropic]
 type = "chat_completion"
 model = "claude-3-haiku-20240307-anthropic"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes OpenAI response format issue by introducing a new `response_format` structure and updating related tests.
> 
>   - **Behavior**:
>     - Introduces `response_format` structure in `openai-compatibility.test.ts` and `test_openai_compatibility.py` to handle OpenAI response format.
>     - Updates tests to use `response_format` for JSON schema validation.
>   - **Implementation**:
>     - Adds `JsonSchemaInfo` struct in `openai_compatible.rs` to encapsulate JSON schema details.
>     - Modifies `OpenAICompatibleResponseFormat` to include `JsonSchemaInfo`.
>     - Updates `Params::try_from_openai` to handle new `response_format` structure.
>   - **Tests**:
>     - Adds `test_async_json_success_strict` and `test_async_json_success_json_object` in `test_openai_compatibility.py`.
>     - Updates existing tests in `openai-compatibility.test.ts` to use `response_format`.
>     - Adds `DUMMY_JSON_RESPONSE_RAW_DIFF_SCHEMA` in `dummy.rs` for testing different JSON schema responses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for fe24dac91db69f8f222d613f2c098039bf55eab6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->