### PR TITLE
bumped version to 2025.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2025.5.1"
+version = "2025.5.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2025.5.1"
+version = "2025.5.2"
 dependencies = [
  "axum",
  "axum-tracing-opentelemetry",
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-bindings"
-version = "2025.5.1"
+version = "2025.5.2"
 dependencies = [
  "console_error_panic_hook",
  "minijinja",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-internal"
-version = "2025.5.1"
+version = "2025.5.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4210,7 +4210,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.5.1"
+version = "2025.5.2"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2025.5.1"
+version = "2025.5.2"
 
 [workspace.dependencies]
 reqwest = { version = "0.12.15", features = [

--- a/ui/app/utils/version.ts
+++ b/ui/app/utils/version.ts
@@ -5,4 +5,4 @@
  * It serves as the single source of truth for version information.
  */
 
-export const VERSION = "2025.5.1";
+export const VERSION = "2025.5.2";


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump version to `2025.5.2` across multiple packages and files.
> 
>   - **Version Bump**:
>     - Update version to `2025.5.2` in `Cargo.lock`, `Cargo.toml`, and `version.ts`.
>     - Affects packages: `evaluations`, `gateway`, `minijinja-bindings`, `tensorzero-internal`, `tensorzero-python`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 737f4acf806f65f09481ea85057a880becf5f31f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->