### PR TITLE
Increase model inference modal width

### DIFF
--- a/ui/app/components/ui/sheet.tsx
+++ b/ui/app/components/ui/sheet.tsx
@@ -38,7 +38,7 @@ const sheetVariants = cva(
           "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
         left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
-          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          "inset-y-0 right-0 h-full w-full md:w-5/6 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
       },
     },
     defaultVariants: {

--- a/ui/app/routes/observability/inferences/$inference_id/ModelInferencesTable.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/ModelInferencesTable.tsx
@@ -63,7 +63,7 @@ export function ModelInferencesTable({
       </Table>
 
       <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
-        <SheetContent className="bg-bg-secondary w-full overflow-y-auto p-0 sm:max-w-xl md:max-w-2xl lg:max-w-3xl">
+        <SheetContent className="bg-bg-secondary w-full min-w-[85vw] overflow-y-auto p-0">
           {selectedInference && (
             <ModelInferenceItem inference={selectedInference} />
           )}

--- a/ui/app/routes/observability/inferences/$inference_id/ModelInferencesTable.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/ModelInferencesTable.tsx
@@ -63,7 +63,7 @@ export function ModelInferencesTable({
       </Table>
 
       <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
-        <SheetContent className="bg-bg-secondary w-full min-w-[85vw] overflow-y-auto p-0">
+        <SheetContent className="bg-bg-secondary overflow-y-auto p-0">
           {selectedInference && (
             <ModelInferenceItem inference={selectedInference} />
           )}


### PR DESCRIPTION
Increasing modal width for Model Inference view per feedback.
- Changed the sheet component width to be w-5/6 on desktop and w-full on mobile by default;

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Increase modal width for Model Inference view to full width on mobile and 85% on larger screens.
> 
>   - **UI Changes**:
>     - In `sheet.tsx`, updated `right` variant to `w-full md:w-5/6` for full width on mobile and 85% width on larger screens.
>     - In `ModelInferencesTable.tsx`, removed width constraints from `SheetContent` to allow full width usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for cc1a2bc6f1bfd7afa47c61a5b7ec5591b76e922b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->