### PR TITLE
removed failure on a bad CursorZero inference and now warn and continue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,6 +1202,7 @@ dependencies = [
  "tensorzero-internal",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-md",
  "tree-sitter-python",

--- a/examples/integrations/cursor/experimental/Cargo.toml
+++ b/examples/integrations/cursor/experimental/Cargo.toml
@@ -12,6 +12,7 @@ tokio = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 tree-sitter = "0.25.3"
 tree-sitter-rust = "0.24.0"
 tree-sitter-typescript = "0.23.2"


### PR DESCRIPTION
Cursorzero was bailing if it failed to parse any inference but I think it would be better to just warn and keep going as there may be other inferences that parse.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `main.rs` to log warnings and skip bad inferences, adding `tracing-subscriber` for logging support.
> 
>   - **Behavior**:
>     - Modify `main.rs` to log a warning and skip bad inferences instead of failing.
>     - Add `tracing-subscriber` to `Cargo.toml` and `Cargo.lock` for logging support.
>   - **Logging**:
>     - Initialize `FmtSubscriber` in `main.rs` to set up logging with environment filter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e29cf9e58930a96a403eda70b1c811d12a02e80d. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->