### PR TITLE
added migration 29 that drops bad MVs

### DIFF
--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0003.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0003.rs
@@ -239,10 +239,10 @@ impl Migration for Migration0003<'_> {
     fn rollback_instructions(&self) -> String {
         "\
             -- Drop the materialized views\n\
-            DROP MATERIALIZED VIEW IF EXISTS BooleanMetricFeedbackTagView;\n\
-            DROP MATERIALIZED VIEW IF EXISTS CommentFeedbackTagView;\n\
-            DROP MATERIALIZED VIEW IF EXISTS DemonstrationFeedbackTagView;\n\
-            DROP MATERIALIZED VIEW IF EXISTS FloatMetricFeedbackTagView;\n\
+            DROP VIEW IF EXISTS BooleanMetricFeedbackTagView;\n\
+            DROP VIEW IF EXISTS CommentFeedbackTagView;\n\
+            DROP VIEW IF EXISTS DemonstrationFeedbackTagView;\n\
+            DROP VIEW IF EXISTS FloatMetricFeedbackTagView;\n\
             \n\
             -- Drop the table\n\
             DROP TABLE IF EXISTS FeedbackTag;\n\

--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0005.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0005.rs
@@ -170,8 +170,8 @@ impl Migration for Migration0005<'_> {
     fn rollback_instructions(&self) -> String {
         "\
             -- Drop the materialized views\n\
-            DROP MATERIALIZED VIEW IF EXISTS ChatInferenceTagView;\n\
-            DROP MATERIALIZED VIEW IF EXISTS JsonInferenceTagView;\n\
+            DROP VIEW IF EXISTS ChatInferenceTagView;\n\
+            DROP VIEW IF EXISTS JsonInferenceTagView;\n\
             \n
             -- Drop the `InferenceTag` table\n\
             DROP TABLE IF EXISTS InferenceTag;\n\

--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0006.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0006.rs
@@ -133,7 +133,7 @@ impl Migration for Migration0006<'_> {
     fn rollback_instructions(&self) -> String {
         "\
             -- Drop the materialized views\n\
-            DROP MATERIALIZED VIEW IF EXISTS BatchIdByInferenceIdView;\n\
+            DROP VIEW IF EXISTS BatchIdByInferenceIdView;\n\
             \n\
             -- Drop the tables\n\
             DROP TABLE IF EXISTS BatchIdByInferenceId;\n\

--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0021.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0021.rs
@@ -274,8 +274,8 @@ impl Migration for Migration0021<'_> {
     fn rollback_instructions(&self) -> String {
         "\
         -- Drop the materialized views\n\
-        DROP MATERIALIZED VIEW IF EXISTS TagChatInferenceView;\n\
-        DROP MATERIALIZED VIEW IF EXISTS TagJsonInferenceView;\n\
+        DROP VIEW IF EXISTS TagChatInferenceView;\n\
+        DROP VIEW IF EXISTS TagJsonInferenceView;\n\
         \n
         -- Drop the `TagInference` table\n\
         DROP TABLE IF EXISTS TagInference;

--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0023.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0023.rs
@@ -161,8 +161,8 @@ impl Migration for Migration0023<'_> {
 
     fn rollback_instructions(&self) -> String {
         r#"DROP TABLE IF EXISTS StaticEvaluationHumanFeedback;
-        DROP MATERIALIZED VIEW IF EXISTS StaticEvaluationHumanFeedbackFloatView;
-        DROP MATERIALIZED VIEW IF EXISTS StaticEvaluationHumanFeedbackBooleanView;
+        DROP VIEW IF EXISTS StaticEvaluationHumanFeedbackFloatView;
+        DROP VIEW IF EXISTS StaticEvaluationHumanFeedbackBooleanView;
         "#
         .to_string()
     }

--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0026.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0026.rs
@@ -138,8 +138,8 @@ impl Migration for Migration0026<'_> {
     fn rollback_instructions(&self) -> String {
         "\
         -- Drop the materialized views\n\
-        DROP MATERIALIZED VIEW IF EXISTS DynamicEvaluationRunEpisodeByRunIdView;\n\
-        DROP MATERIALIZED VIEW IF EXISTS DynamicEvaluationRunByProjectNameView;\n\
+        DROP VIEW IF EXISTS DynamicEvaluationRunEpisodeByRunIdView;\n\
+        DROP VIEW IF EXISTS DynamicEvaluationRunByProjectNameView;\n\
         -- Drop the tables\n\
         DROP TABLE IF EXISTS DynamicEvaluationRunEpisodeByRunId;\n\
         DROP TABLE IF EXISTS DynamicEvaluationRunByProjectName;

--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0028.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0028.rs
@@ -153,14 +153,14 @@ impl Migration for Migration0028<'_> {
                 chat_inference AS (
                     SELECT function_name, variant_name, episode_id, id, output FROM ChatInference
                     WHERE (function_name, variant_name, episode_id) IN (
-                        SELECT function_name, variant_name, episode_id 
+                        SELECT function_name, variant_name, episode_id
                         FROM inference_by_id
                     )
                 ),
                 json_inference AS (
                     SELECT function_name, variant_name, episode_id, id, output FROM JsonInference
                     WHERE (function_name, variant_name, episode_id) IN (
-                        SELECT function_name, variant_name, episode_id 
+                        SELECT function_name, variant_name, episode_id
                         FROM inference_by_id
                     )
                 )
@@ -226,14 +226,14 @@ impl Migration for Migration0028<'_> {
                 chat_inference AS (
                     SELECT function_name, variant_name, episode_id, id, output FROM ChatInference
                     WHERE (function_name, variant_name, episode_id) IN (
-                        SELECT function_name, variant_name, episode_id 
+                        SELECT function_name, variant_name, episode_id
                         FROM inference_by_id
                     )
                 ),
                 json_inference AS (
                     SELECT function_name, variant_name, episode_id, id, output FROM JsonInference
                     WHERE (function_name, variant_name, episode_id) IN (
-                        SELECT function_name, variant_name, episode_id 
+                        SELECT function_name, variant_name, episode_id
                         FROM inference_by_id
                     )
                 )
@@ -330,14 +330,14 @@ impl Migration for Migration0028<'_> {
                 chat_inference AS (
                     SELECT function_name, variant_name, episode_id, id, output FROM ChatInference
                     WHERE (function_name, variant_name, episode_id) IN (
-                        SELECT function_name, variant_name, episode_id 
+                        SELECT function_name, variant_name, episode_id
                         FROM inference_by_id
                     )
                 ),
                 json_inference AS (
                     SELECT function_name, variant_name, episode_id, id, output FROM JsonInference
                     WHERE (function_name, variant_name, episode_id) IN (
-                        SELECT function_name, variant_name, episode_id 
+                        SELECT function_name, variant_name, episode_id
                         FROM inference_by_id
                     )
                 )
@@ -377,8 +377,8 @@ impl Migration for Migration0028<'_> {
 
     fn rollback_instructions(&self) -> String {
         r#"
-        DROP MATERIALIZED VIEW IF EXISTS StaticEvaluationFloatHumanFeedbackView;
-        DROP MATERIALIZED VIEW IF EXISTS StaticEvaluationBooleanHumanFeedbackView;
+        DROP VIEW IF EXISTS StaticEvaluationFloatHumanFeedbackView;
+        DROP VIEW IF EXISTS StaticEvaluationBooleanHumanFeedbackView;
         DROP TABLE IF EXISTS StaticEvaluationHumanFeedback;
         "#
         .to_string()

--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0029.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/migration_0029.rs
@@ -1,0 +1,64 @@
+use crate::clickhouse::migration_manager::migration_trait::Migration;
+use crate::clickhouse::ClickHouseConnectionInfo;
+use crate::error::Error;
+use async_trait::async_trait;
+
+use super::check_table_exists;
+
+/// This migration completes the process started by migration_0028 of migrating away from 0023. We drop the old view
+/// StaticEvaluationHumanFeedbackFloatView and StaticEvaluationHumanFeedbackBooleanView, which were subsumed in 0028.
+pub struct Migration0029<'a> {
+    pub clickhouse: &'a ClickHouseConnectionInfo,
+}
+
+const MIGRATION_ID: &str = "0029";
+
+#[async_trait]
+impl Migration for Migration0029<'_> {
+    async fn can_apply(&self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn should_apply(&self) -> Result<bool, Error> {
+        let float_materialized_view_exists = check_table_exists(
+            self.clickhouse,
+            "StaticEvaluationHumanFeedbackFloatView",
+            MIGRATION_ID,
+        )
+        .await?;
+        let boolean_materialized_view_exists = check_table_exists(
+            self.clickhouse,
+            "StaticEvaluationHumanFeedbackBooleanView",
+            MIGRATION_ID,
+        )
+        .await?;
+        // We need to run this migration if either the float or boolean materialized views exist.
+        Ok(float_materialized_view_exists || boolean_materialized_view_exists)
+    }
+
+    async fn apply(&self, _clean_start: bool) -> Result<(), Error> {
+        self.clickhouse
+            .run_query_synchronous(
+                r#"DROP VIEW IF EXISTS StaticEvaluationHumanFeedbackFloatView;"#.to_string(),
+                None,
+            )
+            .await?;
+        self.clickhouse
+            .run_query_synchronous(
+                r#"DROP VIEW IF EXISTS StaticEvaluationHumanFeedbackBooleanView;"#.to_string(),
+                None,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    fn rollback_instructions(&self) -> String {
+        r#"no action required"#.to_string()
+    }
+
+    async fn has_succeeded(&self) -> Result<bool, Error> {
+        let should_apply = self.should_apply().await?;
+        Ok(!should_apply)
+    }
+}

--- a/tensorzero-internal/src/clickhouse/migration_manager/migrations/mod.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/migrations/mod.rs
@@ -26,6 +26,7 @@ pub mod migration_0025;
 pub mod migration_0026;
 pub mod migration_0027;
 pub mod migration_0028;
+pub mod migration_0029;
 
 /// Returns true if the table exists, false if it does not
 /// Errors if the query fails

--- a/tensorzero-internal/src/clickhouse/migration_manager/mod.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/mod.rs
@@ -27,6 +27,7 @@ use migrations::migration_0025::Migration0025;
 use migrations::migration_0026::Migration0026;
 use migrations::migration_0027::Migration0027;
 use migrations::migration_0028::Migration0028;
+use migrations::migration_0029::Migration0029;
 
 /// Constructs (but does not run) a vector of all our database migrations.
 /// This is the single source of truth for all migration - it's used during startup to migrate
@@ -70,6 +71,7 @@ pub fn make_all_migrations(
         Box::new(Migration0026 { clickhouse }),
         Box::new(Migration0027 { clickhouse }),
         Box::new(Migration0028 { clickhouse }),
+        Box::new(Migration0029 { clickhouse }),
     ]
 }
 

--- a/tensorzero-internal/tests/e2e/clickhouse.rs
+++ b/tensorzero-internal/tests/e2e/clickhouse.rs
@@ -113,8 +113,11 @@ async fn test_clickhouse_migration_manager() {
 
             // The latest migration should get applied, since we haven't run it before
             let name = migrations[migration_num].name();
-            assert!(logs_contain(&format!("Applying migration: {name}")));
-            assert!(logs_contain(&format!("Migration succeeded: {name}")));
+            // Migration 0029 will not be applied since 0023 is turned off.
+            if name != "Migration0029" {
+                assert!(logs_contain(&format!("Applying migration: {name}")));
+                assert!(logs_contain(&format!("Migration succeeded: {name}")));
+            }
             assert!(!logs_contain("Failed to apply migration"));
             assert!(!logs_contain("Failed migration success check"));
             assert!(!logs_contain("Failed to verify migration"));
@@ -151,7 +154,7 @@ async fn test_clickhouse_migration_manager() {
         // will throw an error if it doesn't.
         // This must be an array literal, so that the macro can generate a function
         // for each element in the array.
-        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
     );
     run_all(&migrations).await;
 


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add migration 0029 to drop outdated materialized views from the database schema.
> 
>   - **Migration 0029**:
>     - Adds `Migration0029` to drop `StaticEvaluationHumanFeedbackFloatView` and `StaticEvaluationHumanFeedbackBooleanView`.
>     - Checks if these views exist before attempting to drop them.
>     - No rollback action required.
>   - **Migration Manager**:
>     - Registers `Migration0029` in `mod.rs` and `migration_manager/mod.rs`.
>   - **Tests**:
>     - Updates `test_clickhouse_migration_manager()` in `clickhouse.rs` to skip applying `Migration0029` since `Migration0023` is turned off.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d3b9ce1c77c704d7d8d5a68fa1b0796fc6561b69. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->