### PR TITLE
removed disable_observability config option

### DIFF
--- a/tensorzero-internal/src/config_parser.rs
+++ b/tensorzero-internal/src/config_parser.rs
@@ -45,14 +45,18 @@ pub struct Config<'c> {
     pub provider_types: ProviderTypesConfig,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Deserialize)]
 pub struct GatewayConfig {
     pub bind_address: Option<std::net::SocketAddr>,
+    #[serde(default)]
     pub observability: ObservabilityConfig,
+    #[serde(default)]
     pub debug: bool,
     /// If `true`, allow minijinja to read from the filesystem (within the tree of the config file) for '{% include %}'
     /// Defaults to `false`
+    #[serde(default)]
     pub enable_template_filesystem_access: bool,
+    #[serde(default)]
     pub export: ExportConfig,
 }
 
@@ -206,39 +210,9 @@ fn contains_bad_scheme_err(e: &impl StdError) -> bool {
     format!("{e:?}").contains("BadScheme")
 }
 
-/// Note: This struct and the impl below can be removed in favor of a derived impl for Deserialize once we have removed the `disable_observability` flag
-/// TODO (#797): Remove this once we have removed the `disable_observability` flag
-#[derive(Debug, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct UninitializedGatewayConfig {
-    pub bind_address: Option<std::net::SocketAddr>,
-    #[serde(default)]
-    pub observability: ObservabilityConfig,
-    #[serde(default)]
-    pub debug: bool,
-    #[serde(default)]
-    pub enable_template_filesystem_access: bool,
-    #[serde(default)]
-    pub export: ExportConfig,
-}
-
-impl TryFrom<UninitializedGatewayConfig> for GatewayConfig {
-    type Error = Error;
-    fn try_from(config: UninitializedGatewayConfig) -> Result<Self, Self::Error> {
-        Ok(Self {
-            bind_address: config.bind_address,
-            observability: config.observability,
-            export: config.export,
-            debug: config.debug,
-            enable_template_filesystem_access: config.enable_template_filesystem_access,
-        })
-    }
-}
-
 #[derive(Debug, Default, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct ObservabilityConfig {
-    #[serde(default)]
     pub enabled: Option<bool>,
     #[serde(default)]
     pub async_writes: bool,
@@ -350,11 +324,6 @@ impl<'c> Config<'c> {
         }
         let uninitialized_config = UninitializedConfig::try_from(table)?;
 
-        let gateway = uninitialized_config
-            .gateway
-            .unwrap_or_default()
-            .try_into()?;
-
         let templates = TemplateConfig::new();
 
         let functions = uninitialized_config
@@ -396,7 +365,7 @@ impl<'c> Config<'c> {
         let object_store_info = ObjectStoreInfo::new(uninitialized_config.object_storage)?;
 
         let mut config = Config {
-            gateway,
+            gateway: uninitialized_config.gateway,
             models: models.try_into().map_err(|e| {
                 Error::new(ErrorDetails::Config {
                     message: format!("Failed to load models: {e}"),
@@ -656,7 +625,8 @@ pub trait LoadableConfig<T> {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct UninitializedConfig {
-    pub gateway: Option<UninitializedGatewayConfig>,
+    #[serde(default)]
+    pub gateway: GatewayConfig,
     #[serde(default)]
     pub models: HashMap<Arc<str>, UninitializedModelConfig>, // model name => model config
     #[serde(default)]

--- a/ui/app/components/feedback/FeedbackTable.stories.tsx
+++ b/ui/app/components/feedback/FeedbackTable.stories.tsx
@@ -6,7 +6,19 @@ import type { Config } from "~/utils/config";
 
 const config: Config = {
   gateway: {
-    disable_observability: false,
+    observability: {
+      enabled: true,
+      async_writes: false,
+    },
+    export: {
+      otlp: {
+        traces: {
+          enabled: false,
+        },
+      },
+    },
+    debug: false,
+    enable_template_filesystem_access: false,
   },
   models: {},
   embedding_models: {},

--- a/ui/app/utils/config/index.server.ts
+++ b/ui/app/utils/config/index.server.ts
@@ -70,7 +70,21 @@ export async function loadConfig(config_path?: string): Promise<Config> {
       );
       // Return a blank config if no file is available.
       return {
-        gateway: { disable_observability: false },
+        gateway: {
+          observability: {
+            enabled: true,
+            async_writes: false,
+          },
+          export: {
+            otlp: {
+              traces: {
+                enabled: true,
+              },
+            },
+          },
+          debug: false,
+          enable_template_filesystem_access: false,
+        },
         models: {},
         embedding_models: {},
         functions: {},
@@ -137,7 +151,7 @@ export async function getConfig() {
 
 export const RawConfig = z
   .object({
-    gateway: GatewayConfig.optional().default({}),
+    gateway: GatewayConfig.optional(),
     models: z.record(z.string(), ModelConfigSchema).optional().default({}),
     embedding_models: z
       .record(z.string(), EmbeddingModelConfigSchema)

--- a/ui/app/utils/config/index.test.ts
+++ b/ui/app/utils/config/index.test.ts
@@ -7,7 +7,7 @@ test("parse e2e config", async () => {
   );
   expect(validatedConfig).toBeDefined();
   // Test something in the gateway config
-  expect(validatedConfig.gateway.bind_address).toBe("0.0.0.0:3000");
+  expect(validatedConfig.gateway?.bind_address).toBe("0.0.0.0:3000");
 
   // Test something in the model config
   const azureProvider =

--- a/ui/app/utils/config/index.ts
+++ b/ui/app/utils/config/index.ts
@@ -5,14 +5,33 @@ import { MetricConfigSchema } from "./metric";
 import { ToolConfigSchema } from "./tool";
 import { EvaluationConfigSchema } from "./evaluations";
 
-export const GatewayConfig = z.object({
-  bind_address: z.string().optional(), // Socket address as string
-  disable_observability: z.boolean().default(false),
+export const ObservabilityConfigSchema = z.object({
+  enabled: z.boolean().optional(),
+  async_writes: z.boolean().default(false),
 });
+
+export const OtlpConfigSchema = z.object({
+  traces: z.object({
+    enabled: z.boolean().optional(),
+  }),
+});
+
+export const ExportConfigSchema = z.object({
+  otlp: OtlpConfigSchema,
+});
+
+export const GatewayConfig = z.object({
+  bind_address: z.string().optional(),
+  observability: ObservabilityConfigSchema.optional(),
+  debug: z.boolean().default(false),
+  enable_template_filesystem_access: z.boolean().default(false),
+  export: ExportConfigSchema.optional(),
+});
+
 export type GatewayConfig = z.infer<typeof GatewayConfig>;
 
 export const Config = z.object({
-  gateway: GatewayConfig.optional().default({}),
+  gateway: GatewayConfig.optional(),
   models: z.record(z.string(), ModelConfigSchema),
   embedding_models: z
     .record(z.string(), EmbeddingModelConfigSchema)


### PR DESCRIPTION
Deprecated months ago and closes #1243
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove deprecated `disable_observability` config option from codebase and update related files.
> 
>   - **Config Changes**:
>     - Remove `disable_observability` from `GatewayConfig` in `config_parser.rs`.
>     - Update `GatewayConfig` in `index.ts` and `index.server.ts` to remove `disable_observability`.
>   - **Code Removal**:
>     - Remove `UninitializedGatewayConfig` and its usage in `config_parser.rs`.
>   - **Test Updates**:
>     - Update `FeedbackTable.stories.tsx` and `index.test.ts` to reflect removal of `disable_observability`.
>   - **Misc**:
>     - Remove related comments and error handling in `config_parser.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for fd32b9b22ce89ad5a59293386b8dde7db9275e47. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->