### PR TITLE
Re-add sccache (with correct architecture for downloaded binary)

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -8,7 +8,11 @@ on:
     types: [released]
   push:
     branches: ["main"]
-
+  pull_request:
+    paths:
+      - '.github/workflows/docker-hub-publish.yml'
+      - '**/Dockerfile'
+  
 env:
   DOCKERHUB_USER: tensorzero
 

--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -28,14 +28,14 @@ jobs:
           - runner: ubuntu-24.04-arm
             target: linux/arm64
         container:
-          # Set the container name to a '-dev' name when this workflow is invoked by a push event
-          # Otherwise, use the unsuffixed name (which will be invoked by a release or manual dispatch)
+          # Give the container name to a '-dev' normally - only use the unsuffixed name when we're releasing,
+          # or when this workflow is invoked by a manual dispatch
           # Unfortunately, we can't use 'env' in 'strategy.matrix'
-          - name: ${{ github.event_name == 'push' && 'ui-dev' || 'ui' }}
+          - name: ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch') && 'ui' || 'ui-dev' }}
             path: ui
-          - name: ${{ github.event_name == 'push' && 'gateway-dev' || 'gateway' }}
+          - name: ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch') && 'gateway' || 'gateway-dev' }}
             path: gateway
-          - name: ${{ github.event_name == 'push' && 'evaluations-dev' || 'evaluations' }}
+          - name: ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch') && 'evaluations' || 'evaluations-dev' }}
             path: evaluations
 
     permissions:

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -26,19 +26,32 @@ WORKDIR /app
 
 RUN pnpm install --frozen-lockfile --prod
 
+# ========== rust-sccache-env ==========
+
+FROM rust:latest AS rust-sccache-env
+ENV SCCACHE_VERSION=v0.10.0
+RUN SCCACHE_PLATFORM=$(uname -m)-unknown-linux-musl && \
+wget https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-${SCCACHE_PLATFORM}.tar.gz && \
+    tar -xzf sccache-${SCCACHE_VERSION}-${SCCACHE_PLATFORM}.tar.gz && \
+    mv sccache-${SCCACHE_VERSION}-${SCCACHE_PLATFORM}/sccache /usr/local/bin/ && \
+    chmod +x /usr/local/bin/sccache && \
+    rm -rf sccache-${SCCACHE_VERSION}-${SCCACHE_PLATFORM} sccache-${SCCACHE_VERSION}-${SCCACHE_PLATFORM}.tar.gz
+ENV RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache
+
 # ========== minijinja-build-env ==========
 
-FROM rust:latest AS minijinja-build-env
+FROM rust-sccache-env AS minijinja-build-env
 
 COPY . /build
 
 WORKDIR /build/ui/app/utils/minijinja
 RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-RUN wasm-pack build --features console_error_panic_hook
+RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/sccache \
+    wasm-pack build --features console_error_panic_hook
 
 # ========== evaluations-build-env ==========
 
-FROM rust:latest AS evaluations-build-env
+FROM rust-sccache-env AS evaluations-build-env
 
 RUN apt-get update && apt-get install -y clang libc++-dev && rm -rf /var/lib/apt/lists/*
 
@@ -48,10 +61,9 @@ WORKDIR /tensorzero
 
 ARG CARGO_BUILD_FLAGS=""
 
-RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/registry \
-    --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/git \
-    --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/sccache \
+RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/sccache \
     cargo build --release -p evaluations $CARGO_BUILD_FLAGS && \
+    sccache --show-stats && \
     cp -r /tensorzero/target/release /release
 
 
@@ -71,7 +83,7 @@ RUN pnpm run build
 
 # ========== python-build-env ==========
 
-FROM rust:latest AS python-build-env
+FROM rust-sccache-env AS python-build-env
 RUN apt-get update && apt-get install -y python3
 COPY --from=ghcr.io/astral-sh/uv:0.6.6 /uv /uvx /bin/
 COPY . /build
@@ -80,7 +92,8 @@ WORKDIR /build/optimization-server
 # UV_PYTHON_DOWNLOADS=never
 # https://hynek.me/articles/docker-uv/
 ENV UV_COMPILE_BYTECODE=1
-RUN uv  --verbose sync --locked --no-dev
+RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/sccache \
+    uv --verbose sync --locked --no-dev
 
 # ========== ui ==========
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -36,7 +36,8 @@ wget https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/scc
     mv sccache-${SCCACHE_VERSION}-${SCCACHE_PLATFORM}/sccache /usr/local/bin/ && \
     chmod +x /usr/local/bin/sccache && \
     rm -rf sccache-${SCCACHE_VERSION}-${SCCACHE_PLATFORM} sccache-${SCCACHE_VERSION}-${SCCACHE_PLATFORM}.tar.gz
-ENV RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache
+# Set enormous cache size to prevent eviction (which breaks concurrent sccache builds)
+ENV RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache SCCACHE_CACHE_SIZE=100000000GB
 
 # ========== minijinja-build-env ==========
 


### PR DESCRIPTION
We were unconditionally using the x86_64 binary, which broke the aarch64 runners

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Re-adds `sccache` with architecture-specific binary in Dockerfile to support aarch64 runners.
> 
>   - **Dockerfile Changes**:
>     - Introduced `rust-sccache-env` stage to download architecture-specific `sccache` binary.
>     - Updated `minijinja-build-env`, `evaluations-build-env`, and `python-build-env` to use `rust-sccache-env` for Rust builds.
>     - Added `sccache --show-stats` in `evaluations-build-env` to display cache statistics.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 47034d902ee7e3b56e17a0cbf1c2d94f324238d0. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->