### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,22 +3,36 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
-    labels: []
+      interval: "weekly"
+    labels: [ ]
+    open-pull-requests-limit: 0 # only send security updates
+
+  - package-ecosystem: "pnpm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels: [ ]
     open-pull-requests-limit: 0 # only send security updates
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "daily"
-    labels: []
+      interval: "weekly"
+    labels: [ ]
     open-pull-requests-limit: 0 # only send security updates
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
-    labels: []
+      interval: "weekly"
+    labels: [ ]
+    open-pull-requests-limit: 0 # only send security updates
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels: [ ]
     open-pull-requests-limit: 0 # only send security updates
 
   - package-ecosystem: "cargo"
@@ -26,8 +40,9 @@ updates:
     schedule:
       # This schedule does not affect security updates: https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/customizing-dependabot-security-prs#about-customizing-pull-requests-for-security-updates
       interval: "weekly"
+    labels: [ ]
     groups:
       rust-dependencies:
         patterns:
           - "*"
-    open-pull-requests-limit: 1 # This does not affect the security update pr limit
+    open-pull-requests-limit: 1 # This does not affect the security update PR limit


### PR DESCRIPTION
We were missing `uv` and `pnpm`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `.github/dependabot.yml` to include `pnpm` and `uv`, and set weekly update intervals with security-only PRs.
> 
>   - **Dependabot Configuration**:
>     - Adds `pnpm` and `uv` package ecosystems to `.github/dependabot.yml`.
>     - Changes update interval to `weekly` for all ecosystems.
>     - Sets `open-pull-requests-limit` to 0 for `npm`, `pnpm`, `docker`, `pip`, and `uv` to only send security updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ce561da0b96f1b354825abd40b858e5a5b55f4db. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->