### PR TITLE
Add large json inference fixture to S3 and use them in ui fixtures

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -548,11 +548,11 @@ jobs:
         working-directory: ui
         run: pnpm install --frozen-lockfile
 
-      - name: Cache s3-fixtures
-        uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          path: |
-            ./ui/fixtures/s3-fixtures
+      #- name: Cache s3-fixtures
+      #  uses: namespacelabs/nscloud-cache-action@v1
+      #  with:
+      #    path: |
+      #      ./ui/fixtures/s3-fixtures
 
       - name: Build ui container
         # Enable feedback in the UI for this job so the playwright tests can use it

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -459,11 +459,11 @@ jobs:
         with:
           node-version: "22.9.0"
 
-      - name: Cache s3-fixtures
-        uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          path: |
-            ./ui/fixtures/s3-fixtures
+      # - name: Cache s3-fixtures
+      #   uses: namespacelabs/nscloud-cache-action@v1
+      #   with:
+      #     path: |
+      #       ./ui/fixtures/s3-fixtures
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -498,6 +498,14 @@ jobs:
         working-directory: ui
         run: docker compose -f fixtures/docker-compose.yml logs -t
 
+      - name: Print ClickHouse error logs
+        if: always()
+        run: docker exec fixtures-clickhouse-1 cat /var/log/clickhouse-server/clickhouse-server.err.log
+
+      - name: Print ClickHouse trace logs
+        if: always()
+        run: docker exec fixtures-clickhouse-1 cat /var/log/clickhouse-server/clickhouse-server.log
+
   ui-tests-e2e:
     runs-on: namespace-profile-tensorzero-8x16
     # We currently only run this job when we have secrets available, since we need to use an S3 object_store

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -412,8 +412,8 @@ jobs:
 
   ui-tests:
     # We run on Namespace so that we have cache volumes for our s3-fixtures directory
-    #runs-on: namespace-profile-tensorzero-2x8
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-tensorzero-2x8
+    #runs-on: ubuntu-latest
     permissions:
       # Permission to checkout the repository
       contents: read

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -412,7 +412,8 @@ jobs:
 
   ui-tests:
     # We run on Namespace so that we have cache volumes for our s3-fixtures directory
-    runs-on: namespace-profile-tensorzero-2x8
+    #runs-on: namespace-profile-tensorzero-2x8
+    runs-on: ubuntu-latest
     permissions:
       # Permission to checkout the repository
       contents: read

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -412,8 +412,7 @@ jobs:
 
   ui-tests:
     # We run on Namespace so that we have cache volumes for our s3-fixtures directory
-    runs-on: namespace-profile-tensorzero-2x8
-    #runs-on: ubuntu-latest
+    runs-on: namespace-profile-tensorzero-4x16
     permissions:
       # Permission to checkout the repository
       contents: read
@@ -459,11 +458,11 @@ jobs:
         with:
           node-version: "22.9.0"
 
-      # - name: Cache s3-fixtures
-      #   uses: namespacelabs/nscloud-cache-action@v1
-      #   with:
-      #     path: |
-      #       ./ui/fixtures/s3-fixtures
+      - name: Cache s3-fixtures
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          path: |
+            ./ui/fixtures/s3-fixtures
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -548,11 +547,11 @@ jobs:
         working-directory: ui
         run: pnpm install --frozen-lockfile
 
-      #- name: Cache s3-fixtures
-      #  uses: namespacelabs/nscloud-cache-action@v1
-      #  with:
-      #    path: |
-      #      ./ui/fixtures/s3-fixtures
+      - name: Cache s3-fixtures
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          path: |
+            ./ui/fixtures/s3-fixtures
 
       - name: Build ui container
         # Enable feedback in the UI for this job so the playwright tests can use it

--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -1205,6 +1205,19 @@ system_template = "../../fixtures/config/functions/basic_test/prompt/system_temp
 max_tokens = 100
 json_mode = "strict"
 
+[functions.json_success_no_input_schema]
+type = "json"
+system_schema = "../../fixtures/config/functions/basic_test/system_schema.json"
+output_schema = "../../fixtures/config/functions/basic_test/output_schema.json"
+
+[functions.json_success_no_input_schema.variants.test]
+type = "chat_completion"
+weight = 1
+model = "json"
+system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
+max_tokens = 100
+json_mode = "strict"
+
 [functions.json_success]
 type = "json"
 system_schema = "../../fixtures/config/functions/basic_test/system_schema.json"

--- a/ui/app/utils/clickhouse/inference.test.ts
+++ b/ui/app/utils/clickhouse/inference.test.ts
@@ -301,13 +301,13 @@ test("queryInferenceTableByEpisodeId pages through a sample of results correctly
 test("queryInferenceTableBounds", async () => {
   const bounds = await queryInferenceTableBounds();
   expect(bounds.first_id).toBe("01934c9a-be70-74e2-8e6d-8eb19531638c");
-  expect(bounds.last_id).toBe("0196c682-72e0-7c83-a92b-9d1a3c7630f2");
+  expect(bounds.last_id).toBe("0196ca1e-2a1f-73f3-8ea6-d95d3f9b8645");
 });
 
 test("queryEpisodeTableBounds", async () => {
   const bounds = await queryEpisodeTableBounds();
   expect(bounds.first_id).toBe("01934c9a-be70-74e2-8e6d-8eb19531638c");
-  expect(bounds.last_id).toBe("0196c682-72e0-7c83-a92b-9d1a3c7630f2");
+  expect(bounds.last_id).toBe("0196ca1e-2a1f-73f3-8ea6-d95d3f9b8645");
 });
 
 test("queryInferenceTableBounds with episode_id", async () => {

--- a/ui/fixtures/check-fixtures.sh
+++ b/ui/fixtures/check-fixtures.sh
@@ -7,7 +7,7 @@ echo "==============================================="
 
 # Define tables and their corresponding files
 declare -A all_tables
-all_tables["JsonInference"]="json_inference_examples.jsonl"
+all_tables["JsonInference"]="json_inference_examples.jsonl ./s3-fixtures/large_json_inference.parquet"
 all_tables["BooleanMetricFeedback"]="boolean_metric_feedback_examples.jsonl"
 all_tables["BooleanMetricFeedbackByTargetId"]="boolean_metric_feedback_examples.jsonl"
 all_tables["FloatMetricFeedback"]="float_metric_feedback_examples.jsonl"
@@ -15,7 +15,7 @@ all_tables["FloatMetricFeedbackByTargetId"]="float_metric_feedback_examples.json
 all_tables["CommentFeedback"]="comment_feedback_examples.jsonl"
 all_tables["DemonstrationFeedback"]="demonstration_feedback_examples.jsonl"
 all_tables["ChatInference"]="chat_inference_examples.jsonl ./s3-fixtures/large_chat_inference.parquet"
-all_tables["ModelInference"]="model_inference_examples.jsonl ./s3-fixtures/large_model_inference.parquet"
+all_tables["ModelInference"]="model_inference_examples.jsonl ./s3-fixtures/large_model_inference.parquet ./s3-fixtures/large_json_model_inference.parquet"
 all_tables["ChatInferenceDatapoint FINAL"]="chat_inference_datapoint_examples.jsonl"
 all_tables["JsonInferenceDatapoint FINAL"]="json_inference_datapoint_examples.jsonl"
 all_tables["ModelInferenceCache"]="model_inference_cache_examples.jsonl"

--- a/ui/fixtures/download-fixtures.py
+++ b/ui/fixtures/download-fixtures.py
@@ -13,7 +13,12 @@ import requests
 
 # Constants
 PART_SIZE = 8388608
-FIXTURES = ["large_chat_inference.parquet", "large_model_inference.parquet", "large_json_inference.parquet", "large_json_model_inference.parquet"]
+FIXTURES = [
+    "large_chat_inference.parquet",
+    "large_model_inference.parquet",
+    "large_json_inference.parquet",
+    "large_json_model_inference.parquet",
+]
 R2_BUCKET = "https://pub-147e9850a60643208c411e70b636e956.r2.dev"
 S3_FIXTURES_DIR = Path("./s3-fixtures")
 

--- a/ui/fixtures/download-fixtures.py
+++ b/ui/fixtures/download-fixtures.py
@@ -13,7 +13,7 @@ import requests
 
 # Constants
 PART_SIZE = 8388608
-FIXTURES = ["large_chat_inference.parquet", "large_model_inference.parquet"]
+FIXTURES = ["large_chat_inference.parquet", "large_model_inference.parquet", "large_json_inference.parquet", "large_json_model_inference.parquet"]
 R2_BUCKET = "https://pub-147e9850a60643208c411e70b636e956.r2.dev"
 S3_FIXTURES_DIR = Path("./s3-fixtures")
 

--- a/ui/fixtures/load_fixtures.sh
+++ b/ui/fixtures/load_fixtures.sh
@@ -20,6 +20,10 @@ clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --
 df -h
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO JsonInference FROM INFILE './s3-fixtures/large_json_inference.parquet' FORMAT Parquet"
 df -h
+clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "OPTIMIZE TABLE ChatInference"
+df -h
+clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "OPTIMIZE TABLE JsonInference"
+df -h
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO ModelInference FROM INFILE './s3-fixtures/large_model_inference.parquet' FORMAT Parquet"
 df -h
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO ModelInference FROM INFILE './s3-fixtures/large_json_model_inference.parquet' FORMAT Parquet"

--- a/ui/fixtures/load_fixtures.sh
+++ b/ui/fixtures/load_fixtures.sh
@@ -22,10 +22,6 @@ clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --
 df -h
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO JsonInference FROM INFILE './s3-fixtures/large_json_inference.parquet' FORMAT Parquet"
 df -h
-clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "OPTIMIZE TABLE ChatInference"
-df -h
-clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "OPTIMIZE TABLE JsonInference"
-df -h
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO ModelInference FROM INFILE './s3-fixtures/large_model_inference.parquet' FORMAT Parquet"
 df -h
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO ModelInference FROM INFILE './s3-fixtures/large_json_model_inference.parquet' FORMAT Parquet"

--- a/ui/fixtures/load_fixtures.sh
+++ b/ui/fixtures/load_fixtures.sh
@@ -16,7 +16,9 @@ clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --
 
 uv run ./download-fixtures.py
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO ChatInference FROM INFILE './s3-fixtures/large_chat_inference.parquet' FORMAT Parquet"
+clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO JsonInference FROM INFILE './s3-fixtures/large_json_inference.parquet' FORMAT Parquet"
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO ModelInference FROM INFILE './s3-fixtures/large_model_inference.parquet' FORMAT Parquet"
+clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO ModelInference FROM INFILE './s3-fixtures/large_json_model_inference.parquet' FORMAT Parquet"
 
 # Give ClickHouse some time to make the writes visible
 sleep 2

--- a/ui/fixtures/load_fixtures.sh
+++ b/ui/fixtures/load_fixtures.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-clickhouse-client --user chuser --password chpassword "SELECT * FROM system.disks;"
+clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword "SELECT * FROM system.disks;"
 
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO JsonInference FORMAT JSONEachRow" < json_inference_examples.jsonl
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO BooleanMetricFeedback FORMAT JSONEachRow" < boolean_metric_feedback_examples.jsonl

--- a/ui/fixtures/load_fixtures.sh
+++ b/ui/fixtures/load_fixtures.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euxo pipefail
 
+clickhouse-client --user chuser --password chpassword "SELECT * FROM system.disks;"
+
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO JsonInference FORMAT JSONEachRow" < json_inference_examples.jsonl
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO BooleanMetricFeedback FORMAT JSONEachRow" < boolean_metric_feedback_examples.jsonl
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO FloatMetricFeedback FORMAT JSONEachRow" < float_metric_feedback_examples.jsonl

--- a/ui/fixtures/load_fixtures.sh
+++ b/ui/fixtures/load_fixtures.sh
@@ -15,10 +15,15 @@ clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO DynamicEvaluationRunEpisode FORMAT JSONEachRow" < dynamic_evaluation_run_episode_examples.jsonl
 
 uv run ./download-fixtures.py
+df -h
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO ChatInference FROM INFILE './s3-fixtures/large_chat_inference.parquet' FORMAT Parquet"
+df -h
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO JsonInference FROM INFILE './s3-fixtures/large_json_inference.parquet' FORMAT Parquet"
+df -h
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO ModelInference FROM INFILE './s3-fixtures/large_model_inference.parquet' FORMAT Parquet"
+df -h
 clickhouse-client --host $CLICKHOUSE_HOST --user chuser --password chpassword --database tensorzero_ui_fixtures --query "INSERT INTO ModelInference FROM INFILE './s3-fixtures/large_json_model_inference.parquet' FORMAT Parquet"
+df -h
 
 # Give ClickHouse some time to make the writes visible
 sleep 2


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add large JSON inference fixtures to S3 and update scripts and tests to utilize them.
> 
>   - **Fixtures**:
>     - Add `large_json_inference.parquet` and `large_json_model_inference.parquet` to `download-fixtures.py` and `check-fixtures.sh`.
>     - Update `load_fixtures.sh` to load new parquet files into `JsonInference` and `ModelInference` tables.
>   - **Tests**:
>     - Update `queryInferenceTableBounds` and `queryEpisodeTableBounds` tests in `inference.test.ts` to expect new last ID `0196ca1e-2a1f-73f3-8ea6-d95d3f9b8645`.
>   - **CI/CD**:
>     - Change `runs-on` for `ui-tests` in `general.yml` from `namespace-profile-tensorzero-2x8` to `namespace-profile-tensorzero-4x16`.
>     - Add steps to print ClickHouse error and trace logs in `general.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 9b7b933f3eeec46b2ef5700fb63fbc3a3ca5cbca. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->