### PR TITLE
Always display the tags table in the UI

### DIFF
--- a/ui/app/routes/observability/inferences/$inference_id/route.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/route.tsx
@@ -368,12 +368,10 @@ export default function InferencePage({ loaderData }: Route.ComponentProps) {
           </SectionLayout>
         )}
 
-        {Object.keys(inference.tags).length > 0 && (
-          <SectionLayout>
-            <SectionHeader heading="Tags" />
-            <TagsTable tags={inference.tags} />
-          </SectionLayout>
-        )}
+        <SectionLayout>
+          <SectionHeader heading="Tags" />
+          <TagsTable tags={inference.tags} />
+        </SectionLayout>
 
         <SectionLayout>
           <SectionHeader heading="Model Inferences" />


### PR DESCRIPTION
![CleanShot 2025-05-13 at 15 50 40@2x](https://github.com/user-attachments/assets/fd1d80bb-40eb-4231-a6ed-19dbec1a23f8)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Always display the `TagsTable` in `InferencePage` in `route.tsx`, even if `inference.tags` is empty.
> 
>   - **UI Change**:
>     - In `InferencePage` in `route.tsx`, the `TagsTable` is now always displayed, regardless of whether `inference.tags` is empty or not.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5eb9545abcaf4c8d31a085fea263ab5002961eb3. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->