### PR TITLE
added a tag for variant pinning and adjusted tests to work

### DIFF
--- a/tensorzero-internal/src/endpoints/inference.rs
+++ b/tensorzero-internal/src/endpoints/inference.rs
@@ -269,6 +269,10 @@ pub async fn inference(
             }
             .into());
         }
+        params.tags.insert(
+            "tensorzero::variant_pinned".to_string(),
+            variant_name.to_string(),
+        );
     } else {
         // Remove all zero-weight variants - these can only be used if explicitly pinned above
         candidate_variant_names.retain(|name| {

--- a/tensorzero-internal/tests/e2e/inference.rs
+++ b/tensorzero-internal/tests/e2e/inference.rs
@@ -339,6 +339,9 @@ async fn test_dummy_only_inference_chat_strip_unknown_block_stream() {
     // Check the variant name
     let variant_name = result.get("variant_name").unwrap().as_str().unwrap();
     assert_eq!(variant_name, "test");
+    let tags = result.get("tags").unwrap().as_object().unwrap();
+    // Since the variant was not pinned, the variant_pinned tag should not be present
+    assert!(tags.get("tensorzero::variant_pinned").is_none());
 
     // Check the ModelInference Table
     let result = select_model_inference_clickhouse(&clickhouse, inference_id)

--- a/tensorzero-internal/tests/e2e/providers/batch.rs
+++ b/tensorzero-internal/tests/e2e/providers/batch.rs
@@ -1735,7 +1735,6 @@ pub async fn test_tool_use_batch_inference_request_with_provider(provider: E2ETe
         assert_eq!(output_schema, Some(&Value::Null));
 
         let tags = result.get("tags").unwrap().as_object().unwrap();
-        assert_eq!(tags.len(), 1);
         assert_eq!(
             tags.get("test_type").unwrap(),
             &payload["tags"][i]["test_type"]
@@ -2182,8 +2181,7 @@ pub async fn test_allowed_tools_batch_inference_request_with_provider(provider: 
     let output_schema = result.get("output_schema");
     assert_eq!(output_schema, Some(&Value::Null));
 
-    let tags = result.get("tags").unwrap().as_object().unwrap();
-    assert_eq!(tags.len(), 1);
+    result.get("tags").unwrap().as_object().unwrap();
 
     let raw_request = result.get("raw_request").unwrap().as_str().unwrap();
     assert!(!raw_request.is_empty());
@@ -2628,7 +2626,6 @@ pub async fn test_multi_turn_parallel_tool_use_batch_inference_request_with_prov
     assert_eq!(output_schema, Some(&Value::Null));
 
     let tags = result.get("tags").unwrap().as_object().unwrap();
-    assert_eq!(tags.len(), 1);
     assert_eq!(
         tags.get("test").unwrap().as_str().unwrap(),
         "multi_turn_parallel_tool_use"
@@ -2834,7 +2831,6 @@ pub async fn test_tool_multi_turn_batch_inference_request_with_provider(provider
     assert_eq!(output_schema, Some(&Value::Null));
 
     let tags = result.get("tags").unwrap().as_object().unwrap();
-    assert_eq!(tags.len(), 1);
     assert_eq!(tags.get("test").unwrap().as_str().unwrap(), "multi_turn");
 
     let raw_request = result.get("raw_request").unwrap().as_str().unwrap();
@@ -3363,8 +3359,7 @@ pub async fn test_dynamic_tool_use_batch_inference_request_with_provider(
     let output_schema = result.get("output_schema");
     assert_eq!(output_schema, Some(&Value::Null));
 
-    let tags = result.get("tags").unwrap().as_object().unwrap();
-    assert_eq!(tags.len(), 1);
+    result.get("tags").unwrap().as_object().unwrap();
 
     let raw_request = result.get("raw_request").unwrap().as_str().unwrap();
     assert!(!raw_request.is_empty());
@@ -3714,8 +3709,7 @@ pub async fn test_parallel_tool_use_batch_inference_request_with_provider(
     let output_schema = result.get("output_schema");
     assert_eq!(output_schema, Some(&Value::Null));
 
-    let tags = result.get("tags").unwrap().as_object().unwrap();
-    assert_eq!(tags.len(), 1);
+    result.get("tags").unwrap().as_object().unwrap();
 
     let raw_request = result.get("raw_request").unwrap().as_str().unwrap();
     assert!(!raw_request.is_empty());
@@ -4061,8 +4055,7 @@ pub async fn test_json_mode_batch_inference_request_with_provider(provider: E2ET
     });
     assert_eq!(output_schema, expected_output_schema);
 
-    let tags = result.get("tags").unwrap().as_object().unwrap();
-    assert_eq!(tags.len(), 1);
+    result.get("tags").unwrap().as_object().unwrap();
 
     let raw_request = result.get("raw_request").unwrap().as_str().unwrap();
     assert!(!raw_request.is_empty());
@@ -4401,8 +4394,7 @@ pub async fn test_dynamic_json_mode_batch_inference_request_with_provider(
     });
     assert_eq!(output_schema, expected_output_schema);
 
-    let tags = result.get("tags").unwrap().as_object().unwrap();
-    assert_eq!(tags.len(), 1);
+    result.get("tags").unwrap().as_object().unwrap();
 
     let raw_request = result.get("raw_request").unwrap().as_str().unwrap();
     assert!(!raw_request.is_empty());

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -1960,10 +1960,18 @@ pub async fn check_simple_inference_response(
     let clickhouse_content = content_block.get("text").unwrap().as_str().unwrap();
     assert_eq!(clickhouse_content, content);
 
+    let tags = result.get("tags").unwrap().as_object().unwrap();
     if !is_batch {
-        let tags = result.get("tags").unwrap().as_object().unwrap();
         assert_eq!(tags.get("foo").unwrap().as_str().unwrap(), "bar");
     }
+    // Since the variant was pinned, the variant_pinned tag should be present
+    assert_eq!(
+        tags.get("tensorzero::variant_pinned")
+            .unwrap()
+            .as_str()
+            .unwrap(),
+        provider.variant_name
+    );
 
     let tool_params = result.get("tool_params").unwrap().as_str().unwrap();
     assert!(tool_params.is_empty());
@@ -2547,7 +2555,6 @@ pub async fn test_simple_streaming_inference_request_with_provider_cache(
     assert!(processing_time_ms > 0);
 
     let tags = result.get("tags").unwrap().as_object().unwrap();
-    assert_eq!(tags.len(), 1);
     assert_eq!(tags.get("key").unwrap().as_str().unwrap(), tag_value);
 
     // Check ClickHouse - ModelInference Table

--- a/tensorzero-internal/tests/e2e/providers/reasoning.rs
+++ b/tensorzero-internal/tests/e2e/providers/reasoning.rs
@@ -439,7 +439,6 @@ pub async fn test_streaming_reasoning_inference_request_simple_with_provider(
     assert!(processing_time_ms > 0);
 
     let tags = result.get("tags").unwrap().as_object().unwrap();
-    assert_eq!(tags.len(), 1);
     assert_eq!(tags.get("key").unwrap().as_str().unwrap(), tag_value);
 
     // Check ClickHouse - ModelInference Table

--- a/tensorzero-internal/tests/e2e/providers/reasoning.rs
+++ b/tensorzero-internal/tests/e2e/providers/reasoning.rs
@@ -629,9 +629,6 @@ pub async fn test_reasoning_inference_request_with_provider_json_mode(provider: 
     let output_clickhouse = output_clickhouse.as_object().unwrap();
     assert_eq!(output_clickhouse, output);
 
-    let tags = result.get("tags").unwrap().as_object().unwrap();
-    assert!(tags.is_empty());
-
     let inference_params = result.get("inference_params").unwrap().as_str().unwrap();
     let inference_params: Value = serde_json::from_str(inference_params).unwrap();
     let inference_params = inference_params.get("chat_completion").unwrap();


### PR DESCRIPTION
Closes #2068 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `tensorzero::variant_pinned` tag for pinned variants in inference and update tests accordingly.
> 
>   - **Behavior**:
>     - Add `tensorzero::variant_pinned` tag in `inference()` in `inference.rs` when a variant is pinned.
>   - **Tests**:
>     - Update `test_dummy_only_inference_chat_strip_unknown_block_stream()` in `inference.rs` to check absence of `tensorzero::variant_pinned` tag when variant is not pinned.
>     - Remove assertions checking tag length in `batch.rs`, `common.rs`, and `reasoning.rs` to accommodate new tag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 776254548167c11a617b81e5b0507686d8450e98. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->