### PR TITLE
bumped version to 2025.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2025.5.3"
+version = "2025.5.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2025.5.3"
+version = "2025.5.4"
 dependencies = [
  "axum",
  "axum-tracing-opentelemetry",
@@ -2565,7 +2565,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-bindings"
-version = "2025.5.3"
+version = "2025.5.4"
 dependencies = [
  "console_error_panic_hook",
  "minijinja",
@@ -4146,7 +4146,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-internal"
-version = "2025.5.3"
+version = "2025.5.4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.5.3"
+version = "2025.5.4"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2025.5.3"
+version = "2025.5.4"
 
 [workspace.dependencies]
 reqwest = { version = "0.12.15", features = [

--- a/ui/app/utils/version.ts
+++ b/ui/app/utils/version.ts
@@ -5,4 +5,4 @@
  * It serves as the single source of truth for version information.
  */
 
-export const VERSION = "2025.5.3";
+export const VERSION = "2025.5.4";


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump version from 2025.5.3 to 2025.5.4 across multiple components including `Cargo.lock`, `Cargo.toml`, and `version.ts`.
> 
>   - **Version Bump**:
>     - Update version from `2025.5.3` to `2025.5.4` in `Cargo.lock` for packages `evaluations`, `gateway`, `minijinja-bindings`, `tensorzero-internal`, and `tensorzero-python`.
>     - Update version in `Cargo.toml` to `2025.5.4`.
>     - Update version in `version.ts` to `2025.5.4`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c64ad11f9c413b03c59367750c59d39a12f14a9f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->