### PR TITLE
Remove 'sccache' from maturin action invocation

### DIFF
--- a/.github/workflows/python-client-build.yml
+++ b/.github/workflows/python-client-build.yml
@@ -27,7 +27,7 @@ jobs:
           working-directory: ./clients/python
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
-          sccache: "true"
+          #sccache: "true"
           manylinux: auto
       - name: Upload wheels
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -60,7 +60,7 @@ jobs:
           working-directory: ./clients/python
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
-          sccache: "true"
+          #sccache: "true"
           manylinux: musllinux_1_2
       - name: Upload wheels
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -93,7 +93,7 @@ jobs:
           working-directory: ./clients/python
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
-          sccache: "true"
+          #sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
@@ -128,7 +128,7 @@ jobs:
           working-directory: ./clients/python
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
-          sccache: "true"
+          #sccache: "true"
 
       - name: Upload wheels
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02


### PR DESCRIPTION
This is causing a weird failure: https://github.com/tensorzero/tensorzero/actions/runs/15031110837/job/42244252554?pr=2137

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Comments out `sccache` in `maturin-action` steps in `python-client-build.yml` to fix a failure issue.
> 
>   - **GitHub Actions**:
>     - Comments out `sccache: "true"` in `maturin-action` steps in `python-client-build.yml` for `linux`, `musllinux`, `windows`, and `macos` jobs.
>     - Aimed to fix a failure issue as referenced in the PR description link.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f3921309140446534bdd1b7599dadf3c0635c3f9. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->