### PR TITLE
Disregard #86

### DIFF
--- a/tensorzero-internal/src/endpoints/inference.rs
+++ b/tensorzero-internal/src/endpoints/inference.rs
@@ -1185,10 +1185,6 @@ mod tests {
             }
         }
 
-        // TODO (#86): You could get the values of the private members using unsafe Rust.
-        // For now, we won't and will rely on E2E testing here.
-        // This test doesn't do much so consider deleting or doing more.
-
         // Test case 2: Valid JSON ProviderInferenceResponseChunk
         let chunk = InferenceResultChunk::Json(JsonInferenceResultChunk {
             raw: Some("Test content".to_string()),


### PR DESCRIPTION
This is sufficiently tested at this point.