### PR TITLE
Show human feedback form errors in modal

### DIFF
--- a/ui/app/components/feedback/HumanFeedbackForm.tsx
+++ b/ui/app/components/feedback/HumanFeedbackForm.tsx
@@ -16,7 +16,8 @@ import CommentFeedbackInput from "./CommentFeedbackInput";
 
 export interface HumanFeedbackFormSharedProps {
   inferenceOutput?: ContentBlockOutput[] | JsonInferenceOutput;
-  formError?: string;
+  formError?: string | null;
+  isSubmitting?: boolean;
 }
 
 type HumanFeedbackFormProps = HumanFeedbackFormSharedProps &
@@ -30,6 +31,7 @@ export function HumanFeedbackForm({
   episodeId,
   inferenceId,
   formError,
+  isSubmitting,
 }: HumanFeedbackFormProps) {
   const config = useConfig();
   // If there is no inference output this is likely an episode-level feedback and
@@ -144,18 +146,22 @@ export function HumanFeedbackForm({
       )}
 
       {selectedMetricName && (
-        <div className="flex items-start justify-between gap-4">
+        <div className="mt-4 flex items-start justify-between gap-4">
           <div aria-live="polite">
-            {!!formError && <p className="text-destructive">{formError}</p>}
+            {!!formError && (
+              <p className="text-destructive text-sm font-bold">{formError}</p>
+            )}
           </div>
           <Button
             type="submit"
             disabled={
-              !selectedMetricName || isInputMissing || !demonstrationIsValid
+              isSubmitting ||
+              !selectedMetricName ||
+              isInputMissing ||
+              !demonstrationIsValid
             }
-            className="mt-2"
           >
-            Submit Feedback
+            {isSubmitting ? "Submitting…" : "Submit Feedback"}
           </Button>
         </div>
       )}

--- a/ui/app/hooks/use-fetcher-with-reset.ts
+++ b/ui/app/hooks/use-fetcher-with-reset.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useFetcher } from "react-router";
+
+type FetcherType<T> = ReturnType<typeof useFetcher<T>>;
+
+export type FetcherWithComponentsReset<T> = FetcherType<T> & {
+  reset: () => void;
+};
+
+/**
+ * `useFetcher` does not provide a way to reset its data. This would be useful
+ * in cases where the fetcher's state is used to update the UI and some
+ * unrelated interaction want to update the UI back to its initial state, e.g.
+ * showing messages in a modal that are cleared when the modal is closed so that
+ * the previous submission's data is not shown when the modal is opened again.
+ */
+export function useFetcherWithReset<T = unknown>(
+  opts?: Parameters<typeof useFetcher>[0],
+): FetcherWithComponentsReset<T> {
+  const fetcher = useFetcher<T>(opts);
+  const [isReset, setIsReset] = useState(false);
+
+  const reset = useCallback(() => {
+    if (fetcher.state === "idle") {
+      setIsReset(true);
+    }
+  }, [fetcher.state]);
+
+  useEffect(() => {
+    if (fetcher.state === "idle") {
+      setIsReset(false);
+    }
+  }, [fetcher.state]);
+
+  const data = isReset ? undefined : fetcher.data;
+
+  return useMemo(
+    () => ({
+      ...fetcher,
+      data,
+      reset,
+    }),
+    [fetcher, reset, data],
+  );
+}

--- a/ui/app/routes/observability/episodes/$episode_id/route.tsx
+++ b/ui/app/routes/observability/episodes/$episode_id/route.tsx
@@ -10,13 +10,7 @@ import {
   queryFeedbackByTargetId,
 } from "~/utils/clickhouse/feedback";
 import type { Route } from "./+types/route";
-import {
-  data,
-  Form,
-  isRouteErrorResponse,
-  redirect,
-  useNavigate,
-} from "react-router";
+import { data, isRouteErrorResponse, useNavigate } from "react-router";
 import EpisodeInferenceTable from "./EpisodeInferenceTable";
 import FeedbackTable from "~/components/feedback/FeedbackTable";
 import PageButtons from "~/components/utils/PageButtons";
@@ -35,6 +29,8 @@ import { ActionBar } from "~/components/layout/ActionBar";
 import { HumanFeedbackButton } from "~/components/feedback/HumanFeedbackButton";
 import { HumanFeedbackModal } from "~/components/feedback/HumanFeedbackModal";
 import { HumanFeedbackForm } from "~/components/feedback/HumanFeedbackForm";
+import { isServerRequestError } from "~/utils/common";
+import { useFetcherWithReset } from "~/hooks/use-fetcher-with-reset";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
   const { episode_id } = params;
@@ -103,18 +99,31 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   };
 }
 
+type ActionData =
+  | { redirectTo: string; error?: never }
+  | { error: string; redirectTo?: never };
+
 export async function action({ request }: Route.ActionArgs) {
   const formData = await request.formData();
-  const _action = formData.get("_action");
-  switch (_action) {
-    case "addFeedback": {
-      const response = await addHumanFeedback(formData);
-      const url = new URL(request.url);
-      url.searchParams.delete("beforeFeedback");
-      url.searchParams.delete("afterFeedback");
-      url.searchParams.set("newFeedbackId", response.feedback_id);
-      return redirect(url.toString());
+
+  try {
+    const response = await addHumanFeedback(formData);
+    const url = new URL(request.url);
+    url.searchParams.delete("beforeFeedback");
+    url.searchParams.delete("afterFeedback");
+    url.searchParams.set("newFeedbackId", response.feedback_id);
+    return data<ActionData>({ redirectTo: url.toString() });
+  } catch (error) {
+    if (isServerRequestError(error)) {
+      return data<ActionData>(
+        { error: error.message },
+        { status: error.statusCode },
+      );
     }
+    return data<ActionData>(
+      { error: "Unknown server error. Try again." },
+      { status: 500 },
+    );
   }
 }
 
@@ -193,19 +202,48 @@ export default function InferencesPage({ loaderData }: Route.ComponentProps) {
     !feedback_bounds.first_id ||
     feedback_bounds.first_id === bottomFeedback.id;
 
+  const humanFeedbackFetcher = useFetcherWithReset<typeof action>();
+  const formError =
+    humanFeedbackFetcher.state === "idle"
+      ? (humanFeedbackFetcher.data?.error ?? null)
+      : null;
+  useEffect(() => {
+    const currentState = humanFeedbackFetcher.state;
+    const data = humanFeedbackFetcher.data;
+    if (currentState === "idle" && data?.redirectTo) {
+      navigate(data.redirectTo);
+      setIsModalOpen(false);
+    }
+  }, [humanFeedbackFetcher.data, humanFeedbackFetcher.state, navigate]);
+
   return (
     <PageLayout>
       <PageHeader label="Episode" name={episode_id}>
         <ActionBar>
           <HumanFeedbackModal
             isOpen={isModalOpen}
-            onOpenChange={setIsModalOpen}
+            onOpenChange={(isOpen) => {
+              if (humanFeedbackFetcher.state !== "idle") {
+                return;
+              }
+
+              if (!isOpen) {
+                humanFeedbackFetcher.reset();
+              }
+              setIsModalOpen(isOpen);
+            }}
             trigger={<HumanFeedbackButton />}
           >
-            <Form method="post" onSubmit={() => setIsModalOpen(false)}>
-              <input type="hidden" name="_action" value="addFeedback" />
-              <HumanFeedbackForm episodeId={episode_id} />
-            </Form>
+            <humanFeedbackFetcher.Form method="post">
+              <HumanFeedbackForm
+                episodeId={episode_id}
+                formError={formError}
+                isSubmitting={
+                  humanFeedbackFetcher.state === "submitting" ||
+                  humanFeedbackFetcher.state === "loading"
+                }
+              />
+            </humanFeedbackFetcher.Form>
           </HumanFeedbackModal>
         </ActionBar>
       </PageHeader>

--- a/ui/app/utils/common.ts
+++ b/ui/app/utils/common.ts
@@ -30,4 +30,38 @@ export function extractTimestampFromUUIDv7(uuid: string): Date {
   return date;
 }
 
+interface ErrorLike {
+  message: string;
+  name: string;
+  stack?: string;
+  cause?: unknown;
+}
+
+export function isErrorLike(error: unknown): error is ErrorLike {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string" &&
+    "name" in error &&
+    typeof error.name === "string" &&
+    ("stack" in error ? typeof error.stack === "string" : true)
+  );
+}
+
 export class JSONParseError extends SyntaxError {}
+
+export class ServerRequestError extends Error {
+  statusCode: number;
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = "ServerRequestError";
+    this.statusCode = statusCode;
+  }
+}
+
+export function isServerRequestError(
+  error: unknown,
+): error is ServerRequestError {
+  return isErrorLike(error) && error.name === "ServerRequestError";
+}


### PR DESCRIPTION
This PR makes a few changes to facilitate inline error handling in the human feedback form dialog.

- Replace `Form` with `fetcher.Form` so that submission doesn't trigger a navigation right away, letting us read the submission's state while the dialog is open
- Reset the fetcher's error when the dialog is closed so that it doesn't show up again when the user re-opens the dialog

Closes https://github.com/tensorzero/tensorzero/issues/1764