### PR TITLE
Use shared component dialog content for consistent styling

### DIFF
--- a/ui/app/components/ui/alert-dialog.tsx
+++ b/ui/app/components/ui/alert-dialog.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
-
+import { DialogContentBox } from "./dialog";
 import { cn } from "~/utils/common";
 import { buttonVariants } from "~/components/ui/button";
 
@@ -28,17 +28,12 @@ AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
 const AlertDialogContent = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
->(({ className, ...props }, ref) => (
+>(({ children, ...props }, ref) => (
   <AlertDialogPortal>
     <AlertDialogOverlay />
-    <AlertDialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
-        className,
-      )}
-      {...props}
-    />
+    <AlertDialogPrimitive.Content asChild ref={ref} {...props}>
+      <DialogContentBox>{children}</DialogContentBox>
+    </AlertDialogPrimitive.Content>
   </AlertDialogPortal>
 ));
 AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;

--- a/ui/app/components/ui/dialog.tsx
+++ b/ui/app/components/ui/dialog.tsx
@@ -27,25 +27,36 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
-const DialogContent = React.forwardRef<
-  React.ComponentRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
+function DialogContentBox({
+  className,
+  ...props
+}: React.ComponentPropsWithRef<"div">) {
+  return (
+    <div
+      {...props}
       className={cn(
         "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
         className,
       )}
       {...props}
-    >
-      {children}
-      <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+    />
+  );
+}
+
+const DialogContent = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content asChild ref={ref} {...props}>
+      <DialogContentBox>
+        {children}
+        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogContentBox>
     </DialogPrimitive.Content>
   </DialogPortal>
 ));
@@ -112,6 +123,7 @@ export {
   DialogOverlay,
   DialogTrigger,
   DialogClose,
+  DialogContentBox,
   DialogContent,
   DialogHeader,
   DialogFooter,


### PR DESCRIPTION
I noticed that the AlertDialog had the same jumpiness problem we fixed previously in the standard dialog. I fixed this by exposing a styled div container that can be used in both components to avoid consistency issues creeping in again if we make any changes in the future.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduced `DialogContentBox` for consistent styling between `AlertDialog` and `Dialog`, fixing jumpiness in `AlertDialog`.
> 
>   - **Styling Consistency**:
>     - Introduced `DialogContentBox` in `dialog.tsx` for shared styling.
>     - Replaced inline styles in `AlertDialogContent` in `alert-dialog.tsx` with `DialogContentBox`.
>   - **Behavior**:
>     - Fixes jumpiness issue in `AlertDialog` by using `DialogContentBox`.
>   - **Misc**:
>     - Minor refactoring in `dialog.tsx` to accommodate `DialogContentBox`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c4c3a4d03655d64f18a289147f7e5edd25d6499f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->