### PR TITLE
Fix detail page 404 error for partial evals and bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2025.5.6"
+version = "2025.5.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2025.5.6"
+version = "2025.5.7"
 dependencies = [
  "axum",
  "axum-tracing-opentelemetry",
@@ -2565,7 +2565,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-bindings"
-version = "2025.5.6"
+version = "2025.5.7"
 dependencies = [
  "console_error_panic_hook",
  "minijinja",
@@ -4146,7 +4146,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-internal"
-version = "2025.5.6"
+version = "2025.5.7"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.5.6"
+version = "2025.5.7"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2025.5.6"
+version = "2025.5.7"
 
 [workspace.dependencies]
 reqwest = { version = "0.12.15", features = [

--- a/ui/app/utils/clickhouse/evaluations.server.ts
+++ b/ui/app/utils/clickhouse/evaluations.server.ts
@@ -552,7 +552,7 @@ export async function getEvaluationsForDatapoint(
     FROM filtered_inference
     INNER JOIN filtered_datapoint
       ON filtered_datapoint.id = toUUIDOrNull(filtered_inference.tags['tensorzero::datapoint_id'])
-    INNER JOIN filtered_feedback
+    LEFT JOIN filtered_feedback
       ON filtered_feedback.target_id = filtered_inference.id
 
   `;

--- a/ui/app/utils/version.ts
+++ b/ui/app/utils/version.ts
@@ -5,4 +5,4 @@
  * It serves as the single source of truth for version information.
  */
 
-export const VERSION = "7";
+export const VERSION = "2025.5.7";

--- a/ui/app/utils/version.ts
+++ b/ui/app/utils/version.ts
@@ -5,4 +5,4 @@
  * It serves as the single source of truth for version information.
  */
 
-export const VERSION = "2025.5.6";
+export const VERSION = "7";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix 404 error for partial evaluations by changing `INNER JOIN` to `LEFT JOIN` and bump version to `2025.5.7`.
> 
>   - **Behavior**:
>     - Fix 404 error for partial evaluations by changing `INNER JOIN` to `LEFT JOIN` in `getEvaluationsForDatapoint` in `evaluations.server.ts`.
>   - **Versioning**:
>     - Bump version to `2025.5.7` in `Cargo.toml`, `Cargo.lock`, and `version.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 48f22f3f5ac268b6ac6b8eafc0b2851dde810a38. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->