### PR TITLE
Remove payload from gateway logs when inserting datapoints

### DIFF
--- a/tensorzero-internal/src/endpoints/datasets.rs
+++ b/tensorzero-internal/src/endpoints/datasets.rs
@@ -260,7 +260,7 @@ struct WithFunctionName {
 ///
 /// The inference is mostly copied as-is, except for the 'output' field.
 /// Based on the 'output' parameter, the output is copied, ignored, or fetched from a demonstration.
-#[instrument(name = "create_datapoint", skip(app_state))]
+#[instrument(name = "create_datapoint", skip(app_state, existing_inference))]
 pub async fn create_from_existing_datapoint_handler(
     State(app_state): AppState,
     Path(path_params): Path<CreatePathParams>,
@@ -451,7 +451,7 @@ pub struct CreateDatapointPathParams {
 
 // The handler for the POST `/datasets/:dataset_name/datapoints/bulk` endpoint.
 /// This inserts a new datapoint into `ChatInferenceDatapoint`/`JsonInferenceDatapoint`/
-#[tracing::instrument(name = "create_datapoint_handler", skip(app_state))]
+#[tracing::instrument(name = "create_datapoint_handler", skip(app_state, params))]
 pub async fn create_datapoint_handler(
     State(app_state): AppState,
     Path(path_params): Path<CreateDatapointPathParams>,

--- a/tensorzero-internal/src/endpoints/datasets.rs
+++ b/tensorzero-internal/src/endpoints/datasets.rs
@@ -165,7 +165,7 @@ FORMAT JSONEachRow;"#
 async fn insert_from_existing(
     clickhouse: &ClickHouseConnectionInfo,
     path_params: CreatePathParams,
-    existing: &ExistingInference,
+    existing: &ExistingInferenceInfo,
 ) -> Result<Uuid, Error> {
     let inference_data = query_inference_for_datapoint(clickhouse, existing.inference_id).await?;
     let datapoint_id = Uuid::now_v7();
@@ -264,13 +264,13 @@ struct WithFunctionName {
 pub async fn create_from_existing_datapoint_handler(
     State(app_state): AppState,
     Path(path_params): Path<CreatePathParams>,
-    StructuredJson(existing_inference): StructuredJson<ExistingInference>,
+    StructuredJson(existing_inference_info): StructuredJson<ExistingInferenceInfo>,
 ) -> Result<Json<CreateDatapointResponse>, Error> {
     validate_dataset_name(&path_params.dataset_name)?;
     let datapoint_id = insert_from_existing(
         &app_state.clickhouse_connection_info,
         path_params,
-        &existing_inference,
+        &existing_inference_info,
     )
     .await?;
     Ok(Json(CreateDatapointResponse { id: datapoint_id }))
@@ -1001,7 +1001,7 @@ pub struct DeletePathParams {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct ExistingInference {
+pub struct ExistingInferenceInfo {
     pub output: OutputKind,
     pub inference_id: Uuid,
 }

--- a/tensorzero-internal/src/endpoints/datasets.rs
+++ b/tensorzero-internal/src/endpoints/datasets.rs
@@ -260,7 +260,7 @@ struct WithFunctionName {
 ///
 /// The inference is mostly copied as-is, except for the 'output' field.
 /// Based on the 'output' parameter, the output is copied, ignored, or fetched from a demonstration.
-#[instrument(name = "create_datapoint", skip(app_state, existing_inference))]
+#[instrument(name = "create_datapoint", skip(app_state))]
 pub async fn create_from_existing_datapoint_handler(
     State(app_state): AppState,
     Path(path_params): Path<CreatePathParams>,


### PR DESCRIPTION
Closes #2173

New log:

```
2025-05-19T18:00:37.651572Z  WARN request{method=POST uri=/datasets/test-dataset-0196e9b4-6c10-7ab1-9c08-2666711aaf60/datapoints/bulk version=HTTP/1.1}:create_datapoint_handler{path_params=CreateDatapointPathParams { dataset_name: "test-dataset-0196e9b4-6c10-7ab1-9c08-2666711aaf60" }}: tensorzero_internal::error: Failed to validate chat output for datapoint 0: Demonstration contains invalid tool name
```

~~Also removed it from `create_from_existing_datapoint_handler`.~~

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove payload from logs in `create_datapoint_handler` and `create_from_existing_datapoint_handler` in `datasets.rs`.
> 
>   - **Logging**:
>     - Remove payload from logs in `create_datapoint_handler` by skipping `params`.
>     - Remove payload from logs in `create_from_existing_datapoint_handler` by skipping `existing_inference`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for cc044b5b3cf06f8f5b544781818e0486fef36453. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->