### PR TITLE
Extend duration of 'model_provider_inference' span for streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4195,6 +4195,7 @@ dependencies = [
  "tokio-stream",
  "toml",
  "tracing",
+ "tracing-futures",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tracing-test",
@@ -4561,6 +4562,18 @@ checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/tensorzero-internal/Cargo.toml
+++ b/tensorzero-internal/Cargo.toml
@@ -98,6 +98,7 @@ tracing-opentelemetry = "0.30.0"
 opentelemetry-otlp = { version = "0.29.0", features = ["grpc-tonic"] }
 opentelemetry-semantic-conventions = "0.29.0"
 init-tracing-opentelemetry = "0.28.0"
+tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 
 
 [dev-dependencies]

--- a/tensorzero-internal/src/model.rs
+++ b/tensorzero-internal/src/model.rs
@@ -8,7 +8,8 @@ use std::time::Duration;
 use std::{env, fs};
 use strum::VariantNames;
 use tensorzero_derive::TensorZeroDeserialize;
-use tracing::{span, Instrument, Level};
+use tracing::{span, Level, Span};
+use tracing_futures::{Instrument, Instrumented};
 use url::Url;
 
 use crate::cache::{
@@ -103,7 +104,7 @@ impl UninitializedModelConfig {
 }
 
 pub struct StreamResponse {
-    pub stream: PeekableProviderInferenceResponseStream,
+    pub stream: Instrumented<PeekableProviderInferenceResponseStream>,
     pub raw_request: String,
     pub model_provider_name: Arc<str>,
     pub cached: bool,
@@ -148,7 +149,11 @@ impl StreamResponse {
                     })
                 },
             ))) as ProviderInferenceResponseStreamInner)
-                .peekable(),
+                .peekable()
+                .instrument(tracing::info_span!(
+                    "stream_from_cache",
+                    otel.name = "stream_from_cache"
+                )),
             raw_request: cache_lookup.raw_request,
             model_provider_name,
             cached: true,
@@ -339,11 +344,6 @@ impl ModelConfig {
                     clients.http_client,
                     clients.credentials,
                 )
-                .instrument(span!(
-                    Level::INFO,
-                    "infer_stream",
-                    provider_name = &**provider_name
-                ))
                 .await;
             match response {
                 Ok(response) => {
@@ -352,19 +352,21 @@ impl ModelConfig {
                     // in the cache. We don't want this logic in `collect_chunks`, which would cause us to cache the result
                     // of higher-level transformations (e.g. dicl)
                     let mut stream = if clients.cache_options.enabled.write() {
+                        let span = stream.span().clone();
                         stream_with_cache_write(
                             raw_request.clone(),
                             model_provider_request,
                             clients,
-                            stream,
+                            stream.into_inner(),
                         )
                         .await?
+                        .instrument(span)
                     } else {
                         stream
                     };
                     // Get a single chunk from the stream and make sure it is OK then send to client.
                     // We want to do this here so that we can tell that the request is working.
-                    peek_first_chunk(&mut stream, &raw_request, provider_name).await?;
+                    peek_first_chunk(stream.inner_mut(), &raw_request, provider_name).await?;
                     return Ok((
                         StreamResponse {
                             stream,
@@ -944,8 +946,14 @@ impl ModelProvider {
         request: ModelProviderRequest<'_>,
         client: &Client,
         api_keys: &InferenceCredentials,
-    ) -> Result<(PeekableProviderInferenceResponseStream, String), Error> {
-        match &self.config {
+    ) -> Result<
+        (
+            tracing_futures::Instrumented<PeekableProviderInferenceResponseStream>,
+            String,
+        ),
+        Error,
+    > {
+        let (stream, raw_request) = match &self.config {
             ProviderConfig::Anthropic(provider) => {
                 provider.infer_stream(request, client, api_keys, self).await
             }
@@ -1001,7 +1009,13 @@ impl ModelProvider {
             ProviderConfig::Dummy(provider) => {
                 provider.infer_stream(request, client, api_keys, self).await
             }
-        }
+        }?;
+
+        // Attach the current `model_provider_inference` span to the stream.
+        // This will cause the span to be entered every time the stream is polled,
+        // extending the lifetime of the span in OpenTelemetry to include the entire
+        // duration of the response stream.
+        Ok((stream.instrument(Span::current()), raw_request))
     }
 
     async fn start_batch_inference<'a>(

--- a/tensorzero-internal/src/variant/mod.rs
+++ b/tensorzero-internal/src/variant/mod.rs
@@ -1632,7 +1632,7 @@ mod tests {
         assert_eq!(full_response, expected_response);
 
         assert!(logs_contain(
-            r#"ERROR test_infer_model_request_errors_stream:infer_model_request_stream{model_name=dummy_chat_model}:infer_stream{model_name="dummy_chat_model" otel.name="model_inference" stream=true}:infer_stream{provider_name="error"}:infer_stream{provider_name="error" otel.name="model_provider_inference" gen_ai.operation.name="chat" gen_ai.system="dummy" gen_ai.request.model="error" stream=true}: tensorzero_internal::error: Error from dummy client: Error sending request to Dummy provider for model 'error'."#
+            r#"ERROR test_infer_model_request_errors_stream:infer_model_request_stream{model_name=dummy_chat_model}:infer_stream{model_name="dummy_chat_model" otel.name="model_inference" stream=true}:infer_stream{provider_name="error" otel.name="model_provider_inference" gen_ai.operation.name="chat" gen_ai.system="dummy" gen_ai.request.model="error" stream=true}: tensorzero_internal::error: Error from dummy client: Error sending request to Dummy provider for model 'error'."#
         ));
     }
 }


### PR DESCRIPTION
We now use `tracing_futures` to instrument the stream using our existing span. Previously, a streaming `model_provider_inference` span would end as soon as the `infer_stream` (causing the OpenTelemetry span to exclude almost all of the time spend streaming the response).

The `model_provider_inference` span now includes the entire duration of the model response. When a cached stream is read from ClickHouse, we emit a new `stream_from_cache` span

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Extend `model_provider_inference` span to cover full streaming duration and add `stream_from_cache` span for cached streams.
> 
>   - **Behavior**:
>     - Extends `model_provider_inference` span to cover entire streaming duration using `tracing_futures` in `model.rs`.
>     - Adds `stream_from_cache` span for cached streams from ClickHouse in `StreamResponse::from_cache()`.
>   - **Dependencies**:
>     - Adds `tracing-futures` to `Cargo.toml` and `Cargo.lock` for stream instrumentation.
>   - **Instrumentation**:
>     - Updates `infer_stream()` in `ModelProvider` to instrument streams with the current span.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7828683657329bd4e7cdb545f0a87b2ee2421b7f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->