### PR TITLE
Remove 'on: merge_group' for batch-test.yml

### DIFF
--- a/.github/workflows/batch-test.yml
+++ b/.github/workflows/batch-test.yml
@@ -27,7 +27,6 @@ env:
 
 on:
   workflow_dispatch:
-  merge_group:
   schedule:
     - cron: '0 0 * * *'  # Runs at 00:00 UTC every day
 


### PR DESCRIPTION
We now invoke this directly from merge-queue.yml

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove 'on: merge_group' trigger from `batch-test.yml`, now invoked from `merge-queue.yml`.
> 
>   - **Workflow Changes**:
>     - Remove `on: merge_group` trigger from `batch-test.yml`.
>     - `batch-test.yml` is now invoked directly from `merge-queue.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 93ca7feafba209b496cf48d1de1f0d0dc55749e6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->