### PR TITLE
Verify that Migration0009 correctly updates metric feedback tables

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -372,6 +372,15 @@ jobs:
         with:
           cache-provider: "buildjet"
           save-if: ${{ github.event_name == 'merge_group' }}
+      - run: df -h
+      # ClickHouse intermittently runs out of disk space on the `ubuntu-latest` runner
+      # I'm using the commands from https://carlosbecker.com/posts/github-actions-disk-space/ to try to get more disk space
+      - name: "Free up disk space"
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+      - run: df -h
       - name: Install cargo-nextest
         uses: taiki-e/install-action@37bdc826eaedac215f638a96472df572feab0f9b
         with:

--- a/tensorzero-internal/src/clickhouse/migration_manager/mod.rs
+++ b/tensorzero-internal/src/clickhouse/migration_manager/mod.rs
@@ -104,7 +104,7 @@ pub async fn run_migration(
         // Get the migration name (e.g. `Migration0000`)
         let migration_name = migration.name();
 
-        tracing::info!("Applying migration: {migration_name}");
+        tracing::info!("Applying migration: {migration_name} with clean_start: {clean_start}");
 
         if let Err(e) = migration.apply(clean_start).await {
             tracing::error!(

--- a/tensorzero-internal/tests/e2e/clickhouse.rs
+++ b/tensorzero-internal/tests/e2e/clickhouse.rs
@@ -74,10 +74,17 @@ macro_rules! invoke_all {
 
 const MANIFEST_PATH: &str = env!("CARGO_MANIFEST_DIR");
 
-async fn run_migration_0020_with_data<R: Future<Output = bool>, F: FnOnce() -> R>(
-    clickhouse: &ClickHouseConnectionInfo,
-    run_migration: F,
-) -> bool {
+async fn count_table_rows(clickhouse: &ClickHouseConnectionInfo, table: &str) -> u64 {
+    clickhouse
+        .run_query_synchronous(format!("SELECT count(*) FROM {table}"), None)
+        .await
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap()
+}
+
+async fn insert_large_fixtures(clickhouse: &ClickHouseConnectionInfo) {
     // Insert data so that we test the migration re-creates the tables properly.
     let s3_fixtures_path: String = format!("{MANIFEST_PATH}/../ui/fixtures/s3-fixtures");
 
@@ -102,6 +109,16 @@ async fn run_migration_0020_with_data<R: Future<Output = bool>, F: FnOnce() -> R
     for (file, table) in [
         ("large_chat_inference_v2.parquet", "ChatInference"),
         ("large_json_inference.parquet", "JsonInference"),
+        (
+            "large_chat_boolean_feedback.parquet",
+            "BooleanMetricFeedback",
+        ),
+        ("large_chat_comment_feedback.parquet", "CommentFeedback"),
+        (
+            "large_chat_demonstration_feedback.parquet",
+            "DemonstrationFeedback",
+        ),
+        ("large_chat_float_feedback.parquet", "FloatMetricFeedback"),
     ] {
         let mut command = tokio::process::Command::new("docker");
         command.args([
@@ -131,41 +148,56 @@ async fn run_migration_0020_with_data<R: Future<Output = bool>, F: FnOnce() -> R
             "Failed to insert {table}"
         );
     }
+}
 
-    // Check that the same number of rows are in the tables before and after the migration
-
-    let initial_chat_count: u64 = clickhouse
-        .run_query_synchronous("SELECT count() FROM ChatInference".to_string(), None)
-        .await
-        .unwrap()
-        .trim()
-        .parse()
-        .unwrap();
-    let initial_json_count: u64 = clickhouse
-        .run_query_synchronous("SELECT count() FROM JsonInference".to_string(), None)
-        .await
-        .unwrap()
-        .trim()
-        .parse()
-        .unwrap();
+async fn run_migration_0009_with_data<R: Future<Output = bool>, F: FnOnce() -> R>(
+    clickhouse: &ClickHouseConnectionInfo,
+    run_migration: F,
+) -> bool {
+    let initial_boolean_feedback_count: u64 =
+        count_table_rows(clickhouse, "BooleanMetricFeedback").await;
+    let initial_comment_feedback_count: u64 = count_table_rows(clickhouse, "CommentFeedback").await;
+    let initial_demonstration_feedback_count: u64 =
+        count_table_rows(clickhouse, "DemonstrationFeedback").await;
+    let initial_float_metric_feedback_count: u64 =
+        count_table_rows(clickhouse, "FloatMetricFeedback").await;
 
     let clean_start = run_migration().await;
 
-    let final_chat_count: u64 = clickhouse
-        .run_query_synchronous("SELECT count() FROM ChatInference".to_string(), None)
-        .await
-        .unwrap()
-        .trim()
-        .parse()
-        .unwrap();
-    let final_json_count: u64 = clickhouse
-        .run_query_synchronous("SELECT count() FROM JsonInference".to_string(), None)
-        .await
-        .unwrap()
-        .trim()
-        .parse()
-        .unwrap();
+    let final_boolean_feedback_count: u64 =
+        count_table_rows(clickhouse, "BooleanMetricFeedback").await;
+    let final_comment_feedback_count: u64 = count_table_rows(clickhouse, "CommentFeedback").await;
+    let final_demonstration_feedback_count: u64 =
+        count_table_rows(clickhouse, "DemonstrationFeedback").await;
+    let final_float_metric_feedback_count: u64 =
+        count_table_rows(clickhouse, "FloatMetricFeedback").await;
 
+    assert_eq!(initial_boolean_feedback_count, final_boolean_feedback_count);
+    assert_eq!(initial_comment_feedback_count, final_comment_feedback_count);
+    assert_eq!(
+        initial_demonstration_feedback_count,
+        final_demonstration_feedback_count
+    );
+    assert_eq!(
+        initial_float_metric_feedback_count,
+        final_float_metric_feedback_count
+    );
+
+    clean_start
+}
+
+async fn run_migration_0020_with_data<R: Future<Output = bool>, F: FnOnce() -> R>(
+    clickhouse: &ClickHouseConnectionInfo,
+    run_migration: F,
+) -> bool {
+    // Check that the same number of rows are in the tables before and after the migration
+    let initial_chat_count: u64 = count_table_rows(clickhouse, "ChatInference").await;
+    let initial_json_count: u64 = count_table_rows(clickhouse, "JsonInference").await;
+
+    let clean_start = run_migration().await;
+
+    let final_chat_count: u64 = count_table_rows(clickhouse, "ChatInference").await;
+    let final_json_count: u64 = count_table_rows(clickhouse, "JsonInference").await;
     assert_eq!(
         initial_chat_count, final_chat_count,
         "Lost data from ChatInference"
@@ -178,24 +210,10 @@ async fn run_migration_0020_with_data<R: Future<Output = bool>, F: FnOnce() -> R
     // Check that existing rows are inserted into InferenceById and InferenceByEpisodeId,
     // and check an individual row from ChatInference and JsonInference.
 
-    let final_inference_by_id_count: u64 = clickhouse
-        .run_query_synchronous("SELECT count() FROM InferenceById FINAL".to_string(), None)
-        .await
-        .unwrap()
-        .trim()
-        .parse()
-        .unwrap();
-
-    let final_inference_by_episode_id_count: u64 = clickhouse
-        .run_query_synchronous(
-            "SELECT count() FROM InferenceByEpisodeId FINAL".to_string(),
-            None,
-        )
-        .await
-        .unwrap()
-        .trim()
-        .parse()
-        .unwrap();
+    let final_inference_by_id_count: u64 =
+        count_table_rows(clickhouse, "InferenceById FINAL").await;
+    let final_inference_by_episode_id_count: u64 =
+        count_table_rows(clickhouse, "InferenceByEpisodeId FINAL").await;
 
     assert_eq!(
         final_inference_by_id_count,
@@ -313,14 +331,14 @@ async fn test_clickhouse_migration_manager() {
     // Run it twice to test that it is a no-op the second time
     clickhouse.create_database().await.unwrap();
     let migrations = make_all_migrations(&clickhouse);
-
+    let initial_clean_start = Cell::new(true);
     // This runs all migrations up to and including the given migration number,
     // verifying that only the most recent migration is actually applied.
     let run_migrations_up_to = |migration_num: usize, logs_contain: fn(&str) -> bool| {
         let migrations = &migrations;
         let clickhouse = &clickhouse;
+        let initial_clean_start = &initial_clean_start;
         async move {
-            let initial_clean_start = Cell::new(true);
             // All of the previous migrations should have already been run
             for (i, migration) in migrations.iter().enumerate().take(migration_num) {
                 let clean_start = migration_manager::run_migration(migration.as_ref(), false)
@@ -353,13 +371,17 @@ async fn test_clickhouse_migration_manager() {
             // The latest migration should get applied, since we haven't run it before
             let name = migrations[migration_num].name();
 
-            let clean_start = if name == "Migration0020" {
-                // We're going to be inserting data into the tables, so run all subsequent
-                // migrations in non-clean-start mode.
-                initial_clean_start.set(false);
-                run_migration_0020_with_data(clickhouse, run_migration).await
-            } else {
-                run_migration().await
+            let clean_start = match name.as_str() {
+                "Migration0009" => {
+                    // Insert our large fixtures - these will be used for Migration0009 all subsequent migrations
+                    insert_large_fixtures(clickhouse).await;
+                    // We're going to be inserting data into the tables, so run all subsequent
+                    // migrations in non-clean-start mode.
+                    initial_clean_start.set(false);
+                    run_migration_0009_with_data(clickhouse, run_migration).await
+                }
+                "Migration0020" => run_migration_0020_with_data(clickhouse, run_migration).await,
+                _ => run_migration().await,
             };
 
             if migration_num == 0 {


### PR DESCRIPTION
We now insert our large fixtures before running the Migration0009 test, and verify that it correctly copies over data in non-clean-start mode

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add tests to verify `Migration0009` correctly updates metric feedback tables by inserting large fixtures and checking data consistency.
> 
>   - **Behavior**:
>     - Insert large fixtures before running `Migration0009` test in `clickhouse.rs` to verify data consistency in non-clean-start mode.
>     - Verify that `Migration0009` correctly updates `BooleanMetricFeedback`, `CommentFeedback`, `DemonstrationFeedback`, and `FloatMetricFeedback` tables.
>   - **Functions**:
>     - Add `insert_large_fixtures()` to insert data for testing migrations.
>     - Add `run_migration_0009_with_data()` to test `Migration0009` with data verification.
>     - Modify `run_migration()` in `mod.rs` to log `clean_start` status.
>   - **Misc**:
>     - Free up disk space in `general.yml` to prevent ClickHouse from running out of space during tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2f4f53b1dd7324be8dd1f1e2cfba5d2e2dfb6e7b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->