### PR TITLE
added a concurrency group for clickhouse cloud tests

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -14,6 +14,9 @@ jobs:
   clickhouse-tests-cloud:
     if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
+    concurrency:
+      group: clickhouse-cloud-tests
+      cancel-in-progress: false
     strategy:
       matrix:
         cloud_instance:


### PR DESCRIPTION
These tests seem to be choking on the memory usage of concurrent migrations. Here we limit the concurrency to avoid these limits.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add concurrency group `clickhouse-cloud-tests` to limit concurrent migrations in `clickhouse-tests-cloud` job.
> 
>   - **Concurrency Group**:
>     - Added `concurrency` group `clickhouse-cloud-tests` to `clickhouse-tests-cloud` job in `.github/workflows/general.yml`.
>     - Set `cancel-in-progress` to `false` to prevent canceling in-progress jobs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c6be7307528b02730787e1e17f0867ba9825b6b8. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->