### PR TITLE
Skip `test_concurrent_clickhouse_migrations` on ClickHouse Cloud

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -72,7 +72,10 @@ jobs:
           echo "GATEWAY_PID=$!" >> $GITHUB_ENV
 
       - name: Test (Rust)
-        run: cargo test-e2e-no-creds
+        # This test causes a huge slowdown on ClickHouse cloud, even though it uses a fresh database
+        # For now, let's skip it (we still run it in the local docker ClickHouse tests)
+        # See https://github.com/tensorzero/tensorzero/issues/2216
+        run: cargo test-e2e-no-creds -- --skip test_concurrent_clickhouse_migrations
 
       - name: Print e2e logs
         if: always()

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -75,7 +75,14 @@ jobs:
         # This test causes a huge slowdown on ClickHouse cloud, even though it uses a fresh database
         # For now, let's skip it (we still run it in the local docker ClickHouse tests)
         # See https://github.com/tensorzero/tensorzero/issues/2216
-        run: cargo test-e2e-no-creds -- --skip test_concurrent_clickhouse_migrations
+        # Also, `test_clickhouse_migration_manager` is consistently taking a very long time (and timing out)
+        # on the fast release channel, so we temporarily skip it
+        run: |
+          if [ "${{ matrix.cloud_instance.release_channel }}" = "fast" ]; then
+            cargo test-e2e-no-creds -- --skip test_concurrent_clickhouse_migrations --skip test_clickhouse_migration_manager
+          else
+            cargo test-e2e-no-creds -- --skip test_concurrent_clickhouse_migrations
+          fi
 
       - name: Print e2e logs
         if: always()

--- a/tensorzero-internal/src/error.rs
+++ b/tensorzero-internal/src/error.rs
@@ -19,9 +19,17 @@ use crate::inference::types::storage::StoragePath;
 ///
 /// WARNING: Setting this to true will expose potentially sensitive request/response
 /// data in logs and error responses. Use with caution.
-static DEBUG: OnceCell<bool> = OnceCell::const_new_with(cfg!(feature = "e2e_tests"));
+static DEBUG: OnceCell<bool> = if cfg!(feature = "e2e_tests") {
+    OnceCell::const_new_with(true)
+} else {
+    OnceCell::const_new()
+};
 
 pub fn set_debug(debug: bool) -> Result<(), Error> {
+    // We already initialized `DEBUG`, so do nothing
+    if cfg!(feature = "e2e_tests") {
+        return Ok(());
+    }
     DEBUG.set(debug).map_err(|_| {
         Error::new(ErrorDetails::Config {
             message: "Failed to set debug mode".to_string(),

--- a/tensorzero-internal/src/error.rs
+++ b/tensorzero-internal/src/error.rs
@@ -19,7 +19,7 @@ use crate::inference::types::storage::StoragePath;
 ///
 /// WARNING: Setting this to true will expose potentially sensitive request/response
 /// data in logs and error responses. Use with caution.
-static DEBUG: OnceCell<bool> = OnceCell::const_new();
+static DEBUG: OnceCell<bool> = OnceCell::const_new_with(cfg!(feature = "e2e_tests"));
 
 pub fn set_debug(debug: bool) -> Result<(), Error> {
     DEBUG.set(debug).map_err(|_| {

--- a/tensorzero-internal/tests/e2e/clickhouse.rs
+++ b/tensorzero-internal/tests/e2e/clickhouse.rs
@@ -39,7 +39,9 @@ fn get_clean_clickhouse() -> ClickHouseConnectionInfo {
     ClickHouseConnectionInfo::Production {
         database_url: SecretString::from(clickhouse_url.to_string()),
         database: database.clone(),
-        client: Client::new(),
+        // This works around an issue with ClickHouse Cloud where long-lived connections
+        // are abruptly closed by the server.
+        client: Client::builder().pool_max_idle_per_host(0).build().unwrap(),
     }
 }
 


### PR DESCRIPTION
This will unbreak CI while we figure out exactly how we want to handle this test.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Skip specific ClickHouse tests on cloud to resolve CI issues and adjust debug initialization in error handling.
> 
>   - **CI Changes**:
>     - Skip `test_concurrent_clickhouse_migrations` and `test_clickhouse_migration_manager` on ClickHouse Cloud in `general.yml` to avoid slowdowns and timeouts.
>     - Conditional skipping based on `release_channel` in `general.yml`.
>   - **Error Handling**:
>     - Modify `DEBUG` initialization in `error.rs` to set `true` if `e2e_tests` feature is enabled, preventing re-initialization in `set_debug()`.
>   - **ClickHouse Connection**:
>     - Adjust `client` in `get_clean_clickhouse()` in `clickhouse.rs` to handle ClickHouse Cloud connection issues by setting `pool_max_idle_per_host(0)`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 87013339a4c47df80ee775029695095a80ec4dea. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->