### PR TITLE
Rename internal `Image` content block to `File`

### DIFF
--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -32,7 +32,7 @@ use tensorzero_internal::{
     gateway_util::ShutdownHandle,
     inference::types::{
         extra_body::UnfilteredInferenceExtraBody, extra_headers::UnfilteredInferenceExtraHeaders,
-        image::serialize_with_image_data,
+        image::serialize_with_file_data,
     },
 };
 use tensorzero_rust::{
@@ -1440,7 +1440,7 @@ impl AsyncTensorZeroGateway {
                     for inference in inferences {
                         dict_inferences.push(serialize_to_dict(
                             py,
-                            serialize_with_image_data(&inference).map_err(|e| {
+                            serialize_with_file_data(&inference).map_err(|e| {
                                 convert_error(py, TensorZeroError::Other { source: e.into() })
                             })?,
                         )?);

--- a/clients/rust/src/client_input.rs
+++ b/clients/rust/src/client_input.rs
@@ -4,7 +4,7 @@ use serde_untagged::UntaggedEnumVisitor;
 use tensorzero_derive::TensorZeroDeserialize;
 use tensorzero_internal::{
     error::Error,
-    inference::types::{Image, InputMessageContent, Role, TextKind, Thought},
+    inference::types::{File, InputMessageContent, Role, TextKind, Thought},
     tool::{ToolCall, ToolCallInput, ToolResult},
 };
 
@@ -38,7 +38,7 @@ pub enum ClientInputMessageContent {
         value: String,
     },
     Thought(Thought),
-    Image(Image),
+    Image(File),
     /// An unknown content block type, used to allow passing provider-specific
     /// content blocks (e.g. Anthropic's "redacted_thinking") in and out
     /// of TensorZero.
@@ -64,7 +64,7 @@ impl TryFrom<ClientInputMessageContent> for InputMessageContent {
             }
             ClientInputMessageContent::RawText { value } => InputMessageContent::RawText { value },
             ClientInputMessageContent::Thought(thought) => InputMessageContent::Thought(thought),
-            ClientInputMessageContent::Image(image) => InputMessageContent::Image(image),
+            ClientInputMessageContent::Image(image) => InputMessageContent::File(image),
             ClientInputMessageContent::Unknown {
                 data,
                 model_provider_name,
@@ -140,7 +140,7 @@ pub(super) fn test_client_to_message_content(
         }
         ClientInputMessageContent::RawText { value } => InputMessageContent::RawText { value },
         ClientInputMessageContent::Thought(thought) => InputMessageContent::Thought(thought),
-        ClientInputMessageContent::Image(image) => InputMessageContent::Image(image),
+        ClientInputMessageContent::Image(image) => InputMessageContent::File(image),
         ClientInputMessageContent::Unknown {
             data,
             model_provider_name,

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -47,7 +47,7 @@ pub use tensorzero_internal::endpoints::inference::{
 };
 pub use tensorzero_internal::endpoints::object_storage::ObjectResponse;
 pub use tensorzero_internal::inference::types::storage::{StorageKind, StoragePath};
-pub use tensorzero_internal::inference::types::Image;
+pub use tensorzero_internal::inference::types::File;
 pub use tensorzero_internal::inference::types::{
     ContentBlockChunk, Input, InputMessage, InputMessageContent, Role,
 };

--- a/clients/rust/tests/tests.rs
+++ b/clients/rust/tests/tests.rs
@@ -3,11 +3,11 @@
 use serde_json::json;
 use tensorzero::{
     input_handling::resolved_input_to_client_input, ClientBuilder, ClientBuilderMode,
-    ClientInferenceParams, ClientInput, ClientInputMessageContent, Image,
+    ClientInferenceParams, ClientInput, ClientInputMessageContent, File,
 };
 
 use reqwest::Url;
-use tensorzero_internal::inference::types::{ImageKind, ResolvedInput};
+use tensorzero_internal::inference::types::{FileKind, ResolvedInput};
 
 lazy_static::lazy_static! {
     static ref GATEWAY_URL: String = std::env::var("GATEWAY_URL").unwrap_or("http://localhost:3000".to_string());

--- a/evaluations/src/evaluators/llm_judge/mod.rs
+++ b/evaluations/src/evaluators/llm_judge/mod.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use serde_json::{json, Value};
 use tensorzero::{
     ClientInferenceParams, ClientInput, ClientInputMessage, ClientInputMessageContent,
-    DynamicToolParams, Image, InferenceOutput, InferenceParams, InferenceResponse, Role,
+    DynamicToolParams, File, InferenceOutput, InferenceParams, InferenceResponse, Role,
 };
 use tensorzero_internal::cache::CacheEnabledMode;
 use tensorzero_internal::endpoints::datasets::Datapoint;
@@ -312,7 +312,7 @@ fn serialize_content_for_messages_input(
         match content_block {
             ClientInputMessageContent::Image(image) => {
                 // The image was already converted from a ResolvedImage to a Base64Image before this.
-                if let Image::Url { .. } = image {
+                if let File::Url { .. } = image {
                     bail!("URL images not supported for LLM judge evaluations. This should never happen. Please file a bug report at https://github.com/tensorzero/tensorzero/discussions/new?category=bug-reports.")
                 }
                 serialized_content.push(ClientInputMessageContent::Image(image.clone()));
@@ -415,7 +415,7 @@ mod tests {
     use super::*;
 
     use serde_json::json;
-    use tensorzero::Image;
+    use tensorzero::File;
     use tensorzero::Role;
     use tensorzero_internal::endpoints::datasets::ChatInferenceDatapoint;
     use tensorzero_internal::endpoints::datasets::JsonInferenceDatapoint;
@@ -478,7 +478,7 @@ mod tests {
             system: None,
             messages: vec![ClientInputMessage {
                 role: Role::User,
-                content: vec![ClientInputMessageContent::Image(Image::Url {
+                content: vec![ClientInputMessageContent::Image(File::Url {
                     url: Url::parse("https://example.com/image.png").unwrap(),
                 })],
             }],

--- a/tensorzero-internal/src/inference/providers/anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/anthropic.rs
@@ -17,13 +17,13 @@ use crate::error::{DisplayOrDebugGateway, Error, ErrorDetails};
 use crate::inference::providers::provider_trait::InferenceProvider;
 use crate::inference::types::batch::BatchRequestRow;
 use crate::inference::types::batch::PollBatchInferenceResponse;
-use crate::inference::types::resolved_input::ImageWithPath;
+use crate::inference::types::resolved_input::FileWithPath;
 use crate::inference::types::{
     batch::StartBatchProviderInferenceResponse, ContentBlock, ContentBlockChunk, FinishReason,
     FunctionType, Latency, ModelInferenceRequestJsonMode, Role, Text,
 };
 use crate::inference::types::{
-    ContentBlockOutput, FlattenUnknown, ImageKind, ModelInferenceRequest,
+    ContentBlockOutput, FileKind, FlattenUnknown, ModelInferenceRequest,
     PeekableProviderInferenceResponseStream, ProviderInferenceResponse,
     ProviderInferenceResponseArgs, ProviderInferenceResponseChunk,
     ProviderInferenceResponseStreamInner, RequestMessage, TextChunk, Thought, ThoughtChunk, Usage,
@@ -505,7 +505,7 @@ enum AnthropicMessageContent<'a> {
 #[serde(rename_all = "snake_case")]
 pub struct AnthropicImageSource {
     pub r#type: AnthropicImageType,
-    pub media_type: ImageKind,
+    pub media_type: FileKind,
     pub data: String,
 }
 
@@ -564,7 +564,7 @@ impl<'a> TryFrom<&'a ContentBlock> for Option<FlattenUnknown<'a, AnthropicMessag
                     }],
                 },
             ))),
-            ContentBlock::Image(ImageWithPath {
+            ContentBlock::File(FileWithPath {
                 image,
                 storage_path: _,
             }) => Ok(Some(FlattenUnknown::Normal(

--- a/tensorzero-internal/src/inference/providers/aws_bedrock.rs
+++ b/tensorzero-internal/src/inference/providers/aws_bedrock.rs
@@ -611,7 +611,7 @@ impl TryFrom<&ContentBlock> for Option<BedrockContentBlock> {
 
                 Ok(Some(BedrockContentBlock::ToolResult(tool_result_block)))
             }
-            ContentBlock::Image(_) => Err(Error::new(ErrorDetails::UnsupportedContentBlockType {
+            ContentBlock::File(_) => Err(Error::new(ErrorDetails::UnsupportedContentBlockType {
                 content_block_type: "image".to_string(),
                 provider_type: PROVIDER_TYPE.to_string(),
             })),

--- a/tensorzero-internal/src/inference/providers/dummy.rs
+++ b/tensorzero-internal/src/inference/providers/dummy.rs
@@ -331,7 +331,7 @@ impl InferenceProvider for DummyProvider {
                     .iter()
                     .flat_map(|m| {
                         m.content.iter().flat_map(|block| {
-                            if let ContentBlock::Image(image) = block {
+                            if let ContentBlock::File(image) = block {
                                 Some(image.clone())
                             } else {
                                 None

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
@@ -16,7 +16,7 @@ use crate::error::{DisplayOrDebugGateway, Error, ErrorDetails};
 use crate::inference::providers::provider_trait::InferenceProvider;
 use crate::inference::types::batch::BatchRequestRow;
 use crate::inference::types::batch::PollBatchInferenceResponse;
-use crate::inference::types::resolved_input::ImageWithPath;
+use crate::inference::types::resolved_input::FileWithPath;
 use crate::inference::types::{
     batch::StartBatchProviderInferenceResponse, ContentBlock, ContentBlockChunk, FunctionType,
     Latency, ModelInferenceRequestJsonMode, Role, Text, TextChunk,
@@ -476,7 +476,7 @@ impl<'a> TryFrom<&'a ContentBlock>
                     }],
                 },
             ))),
-            ContentBlock::Image(ImageWithPath {
+            ContentBlock::File(FileWithPath {
                 image,
                 storage_path: _,
             }) => Ok(Some(FlattenUnknown::Normal(

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
@@ -31,7 +31,7 @@ use crate::inference::types::batch::{
     BatchRequestRow, BatchStatus, PollBatchInferenceResponse, ProviderBatchInferenceOutput,
     ProviderBatchInferenceResponse,
 };
-use crate::inference::types::resolved_input::ImageWithPath;
+use crate::inference::types::resolved_input::FileWithPath;
 use crate::inference::types::{
     batch::StartBatchProviderInferenceResponse, serialize_or_log, ModelInferenceRequest,
     PeekableProviderInferenceResponseStream, ProviderInferenceResponse,
@@ -1246,7 +1246,7 @@ impl<'a> TryFrom<&'a ContentBlock> for Option<FlattenUnknown<'a, GCPVertexGemini
                     },
                 )))
             }
-            ContentBlock::Image(ImageWithPath {
+            ContentBlock::File(FileWithPath {
                 image,
                 storage_path: _,
             }) => Ok(Some(FlattenUnknown::Normal(

--- a/tensorzero-internal/src/inference/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/google_ai_studio_gemini.rs
@@ -17,7 +17,7 @@ use crate::endpoints::inference::InferenceCredentials;
 use crate::error::{DisplayOrDebugGateway, Error, ErrorDetails};
 use crate::inference::providers::provider_trait::InferenceProvider;
 use crate::inference::types::batch::{BatchRequestRow, PollBatchInferenceResponse};
-use crate::inference::types::resolved_input::ImageWithPath;
+use crate::inference::types::resolved_input::FileWithPath;
 use crate::inference::types::{
     batch::StartBatchProviderInferenceResponse, serialize_or_log, ModelInferenceRequest,
     PeekableProviderInferenceResponseStream, ProviderInferenceResponse,
@@ -477,7 +477,7 @@ impl<'a> TryFrom<&'a ContentBlock> for Option<FlattenUnknown<'a, GeminiPart<'a>>
                     },
                 })))
             }
-            ContentBlock::Image(ImageWithPath {
+            ContentBlock::File(FileWithPath {
                 image,
                 storage_path: _,
             }) => Ok(Some(FlattenUnknown::Normal(GeminiPart::InlineData {

--- a/tensorzero-internal/src/inference/providers/openai.rs
+++ b/tensorzero-internal/src/inference/providers/openai.rs
@@ -26,7 +26,7 @@ use crate::inference::types::batch::{BatchRequestRow, PollBatchInferenceResponse
 use crate::inference::types::batch::{
     ProviderBatchInferenceOutput, ProviderBatchInferenceResponse,
 };
-use crate::inference::types::resolved_input::ImageWithPath;
+use crate::inference::types::resolved_input::FileWithPath;
 use crate::inference::types::{
     batch::{BatchStatus, StartBatchProviderInferenceResponse},
     ContentBlock, ContentBlockChunk, ContentBlockOutput, Latency, ModelInferenceRequest,
@@ -1264,7 +1264,7 @@ fn tensorzero_to_openai_user_messages(
                     tool_call_id: &tool_result.id,
                 }));
             }
-            ContentBlock::Image(ImageWithPath {
+            ContentBlock::File(FileWithPath {
                 image,
                 storage_path: _,
             }) => {
@@ -1339,7 +1339,7 @@ fn tensorzero_to_openai_assistant_messages(
                     message: "Tool results are not supported in assistant messages".to_string(),
                 }));
             }
-            ContentBlock::Image(ImageWithPath {
+            ContentBlock::File(FileWithPath {
                 image,
                 storage_path: _,
             }) => {

--- a/tensorzero-internal/src/inference/types/image.rs
+++ b/tensorzero-internal/src/inference/types/image.rs
@@ -8,19 +8,19 @@ use url::Url;
 use crate::error::{Error, ErrorDetails};
 use aws_smithy_types::base64;
 
-use super::{resolved_input::ImageWithPath, ContentBlock, RequestMessage};
+use super::{resolved_input::FileWithPath, ContentBlock, RequestMessage};
 
-scoped_thread_local!(static SERIALIZE_IMAGE_DATA: ());
+scoped_thread_local!(static SERIALIZE_FILE_DATA: ());
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ImageEncoding {
+pub enum FileEncoding {
     Base64,
     Url,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
-pub enum ImageKind {
+pub enum FileKind {
     #[serde(rename = "image/jpeg")]
     Jpeg,
     #[serde(rename = "image/png")]
@@ -29,25 +29,25 @@ pub enum ImageKind {
     WebP,
 }
 
-impl Display for ImageKind {
+impl Display for FileKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ImageKind::Jpeg => write!(f, "image/jpeg"),
-            ImageKind::Png => write!(f, "image/png"),
-            ImageKind::WebP => write!(f, "image/webp"),
+            FileKind::Jpeg => write!(f, "image/jpeg"),
+            FileKind::Png => write!(f, "image/png"),
+            FileKind::WebP => write!(f, "image/webp"),
         }
     }
 }
 
-fn skip_serialize_image_data(_: &Option<String>) -> bool {
-    !SERIALIZE_IMAGE_DATA.is_set()
+fn skip_serialize_file_data(_: &Option<String>) -> bool {
+    !SERIALIZE_FILE_DATA.is_set()
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-pub struct Base64Image {
-    // The original url we used to download the image
+pub struct Base64File {
+    // The original url we used to download the file
     pub url: Option<Url>,
-    pub mime_type: ImageKind,
+    pub mime_type: FileKind,
     // TODO - should we add a wrapper type to enforce base64?
     #[serde(skip_serializing_if = "skip_serialize_image_data")]
     #[serde(default)]
@@ -56,7 +56,7 @@ pub struct Base64Image {
     pub data: Option<String>,
 }
 
-impl Base64Image {
+impl Base64File {
     pub fn data(&self) -> Result<&String, Error> {
         self.data.as_ref().ok_or_else(|| {
             Error::new(ErrorDetails::InternalError {
@@ -66,8 +66,8 @@ impl Base64Image {
     }
 }
 
-pub fn serialize_with_image_data<T: Serialize>(value: &T) -> Result<Value, Error> {
-    SERIALIZE_IMAGE_DATA.set(&(), || {
+pub fn serialize_with_file_data<T: Serialize>(value: &T) -> Result<Value, Error> {
+    SERIALIZE_FILE_DATA.set(&(), || {
         serde_json::to_value(value).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
                 message: format!("Error serializing value: {e}"),
@@ -78,15 +78,15 @@ pub fn serialize_with_image_data<T: Serialize>(value: &T) -> Result<Value, Error
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(untagged, deny_unknown_fields)]
-pub enum Image {
+pub enum File {
     Url { url: Url },
-    Base64 { mime_type: ImageKind, data: String },
+    Base64 { mime_type: FileKind, data: String },
 }
 
-impl Image {
-    pub async fn take_or_fetch(self, client: &reqwest::Client) -> Result<Base64Image, Error> {
+impl File {
+    pub async fn take_or_fetch(self, client: &reqwest::Client) -> Result<Base64File, Error> {
         match self {
-            Image::Url { url } => {
+            File::Url { url } => {
                 let response = client.get(url.clone()).send().await.map_err(|e| {
                     Error::new(ErrorDetails::BadImageFetch {
                         url: url.clone(),
@@ -100,9 +100,9 @@ impl Image {
                     })
                 })?;
                 let kind = match image::guess_format(&bytes) {
-                    Ok(image::ImageFormat::Jpeg) => ImageKind::Jpeg,
-                    Ok(image::ImageFormat::Png) => ImageKind::Png,
-                    Ok(image::ImageFormat::WebP) => ImageKind::WebP,
+                    Ok(image::ImageFormat::Jpeg) => FileKind::Jpeg,
+                    Ok(image::ImageFormat::Png) => FileKind::Png,
+                    Ok(image::ImageFormat::WebP) => FileKind::WebP,
                     Ok(format) => {
                         return Err(Error::new(ErrorDetails::BadImageFetch {
                             url: url.clone(),
@@ -117,16 +117,16 @@ impl Image {
                     }
                 };
                 let data = base64::encode(bytes);
-                Ok(Base64Image {
+                Ok(Base64File {
                     url: Some(url.clone()),
                     mime_type: kind,
                     data: Some(data),
                 })
             }
-            Image::Base64 {
+            File::Base64 {
                 mime_type: kind,
                 data,
-            } => Ok(Base64Image {
+            } => Ok(Base64File {
                 url: None,
                 mime_type: kind,
                 data: Some(data),
@@ -141,7 +141,7 @@ pub fn sanitize_raw_request(input_messages: &[RequestMessage], mut raw_request: 
     let mut i = 0;
     for message in input_messages {
         for content in &message.content {
-            if let ContentBlock::Image(ImageWithPath {
+            if let ContentBlock::File(FileWithPath {
                 image,
                 storage_path: _,
             }) = content
@@ -160,9 +160,9 @@ pub fn sanitize_raw_request(input_messages: &[RequestMessage], mut raw_request: 
 mod tests {
     use crate::inference::types::{
         image::sanitize_raw_request,
-        resolved_input::ImageWithPath,
+        resolved_input::FileWithPath,
         storage::{StorageKind, StoragePath},
-        Base64Image, ContentBlock, ImageKind, RequestMessage, Role,
+        Base64File, ContentBlock, FileKind, RequestMessage, Role,
     };
 
     #[test]
@@ -178,10 +178,10 @@ mod tests {
                     RequestMessage {
                         role: Role::User,
                         content: vec![
-                            ContentBlock::Image(ImageWithPath {
-                                image: Base64Image {
+                            ContentBlock::File(FileWithPath {
+                                image: Base64File {
                                     url: None,
-                                    mime_type: ImageKind::Jpeg,
+                                    mime_type: FileKind::Jpeg,
                                     data: Some("my-image-1-data".to_string()),
                                 },
                                 storage_path: StoragePath {
@@ -190,10 +190,10 @@ mod tests {
                                         .unwrap(),
                                 },
                             }),
-                            ContentBlock::Image(ImageWithPath {
-                                image: Base64Image {
+                            ContentBlock::File(FileWithPath {
+                                image: Base64File {
                                     url: None,
-                                    mime_type: ImageKind::Jpeg,
+                                    mime_type: FileKind::Jpeg,
                                     data: Some("my-image-2-data".to_string()),
                                 },
                                 storage_path: StoragePath {
@@ -202,10 +202,10 @@ mod tests {
                                         .unwrap(),
                                 },
                             }),
-                            ContentBlock::Image(ImageWithPath {
-                                image: Base64Image {
+                            ContentBlock::File(FileWithPath {
+                                image: Base64File {
                                     url: None,
-                                    mime_type: ImageKind::Jpeg,
+                                    mime_type: FileKind::Jpeg,
                                     data: Some("my-image-1-data".to_string()),
                                 },
                                 storage_path: StoragePath {
@@ -219,10 +219,10 @@ mod tests {
                     RequestMessage {
                         role: Role::User,
                         content: vec![
-                            ContentBlock::Image(ImageWithPath {
-                                image: Base64Image {
+                            ContentBlock::File(FileWithPath {
+                                image: Base64File {
                                     url: None,
-                                    mime_type: ImageKind::Jpeg,
+                                    mime_type: FileKind::Jpeg,
                                     data: Some("my-image-3-data".to_string()),
                                 },
                                 storage_path: StoragePath {
@@ -231,10 +231,10 @@ mod tests {
                                         .unwrap(),
                                 },
                             }),
-                            ContentBlock::Image(ImageWithPath {
-                                image: Base64Image {
+                            ContentBlock::File(FileWithPath {
+                                image: Base64File {
                                     url: None,
-                                    mime_type: ImageKind::Jpeg,
+                                    mime_type: FileKind::Jpeg,
                                     data: Some("my-image-1-data".to_string()),
                                 },
                                 storage_path: StoragePath {

--- a/tensorzero-internal/src/inference/types/mod.rs
+++ b/tensorzero-internal/src/inference/types/mod.rs
@@ -6,9 +6,9 @@ use extra_headers::{FullExtraHeadersConfig, UnfilteredInferenceExtraHeaders};
 use futures::stream::Peekable;
 use futures::Stream;
 use image::sanitize_raw_request;
-pub use image::{Base64Image, Image, ImageKind};
+pub use image::{Base64File, File, FileKind};
 use itertools::Itertools;
-use resolved_input::ImageWithPath;
+use resolved_input::FileWithPath;
 pub use resolved_input::{ResolvedInput, ResolvedInputMessage, ResolvedInputMessageContent};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
@@ -131,7 +131,7 @@ impl InputMessageContent {
                 );
                 ResolvedInputMessageContent::Text { value }
             }
-            InputMessageContent::Image(image) => {
+            InputMessageContent::File(image) => {
                 let storage_kind = context
                     .object_store_info
                     .as_ref()
@@ -144,7 +144,7 @@ impl InputMessageContent {
                     .clone();
                 let image = image.take_or_fetch(context.client).await?;
                 let path = storage_kind.image_path(&image)?;
-                ResolvedInputMessageContent::Image(ImageWithPath {
+                ResolvedInputMessageContent::File(FileWithPath {
                     image,
                     storage_path: path,
                 })
@@ -180,7 +180,8 @@ pub enum InputMessageContent {
         value: String,
     },
     Thought(Thought),
-    Image(Image),
+    #[serde(alias = "image")]
+    File(File),
     /// An unknown content block type, used to allow passing provider-specific
     /// content blocks (e.g. Anthropic's "redacted_thinking") in and out
     /// of TensorZero.
@@ -273,7 +274,8 @@ pub enum ContentBlock {
     Text(Text),
     ToolCall(ToolCall),
     ToolResult(ToolResult),
-    Image(ImageWithPath),
+    #[serde(alias = "image")]
+    File(FileWithPath),
     Thought(Thought),
     /// Represents an unknown provider-specific content block.
     /// We pass this along as-is without any validation or transformation.

--- a/tensorzero-internal/src/inference/types/resolved_input.rs
+++ b/tensorzero-internal/src/inference/types/resolved_input.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 
 use crate::tool::{ToolCall, ToolResult};
 
-use super::{storage::StoragePath, Base64Image, Role, Thought};
+use super::{storage::StoragePath, Base64File, Role, Thought};
 
 /// Like `Input`, but with all network resources resolved.
 /// Currently, this is just used to fetch image URLs in the image input,
@@ -37,7 +37,8 @@ pub enum ResolvedInputMessageContent {
         value: String,
     },
     Thought(Thought),
-    Image(ImageWithPath),
+    #[serde(alias = "image")]
+    File(FileWithPath),
     Unknown {
         data: Value,
         model_provider_name: Option<String>,
@@ -46,7 +47,8 @@ pub enum ResolvedInputMessageContent {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-pub struct ImageWithPath {
-    pub image: Base64Image,
+pub struct FileWithPath {
+    #[serde(alias = "image")]
+    pub file: Base64File,
     pub storage_path: StoragePath,
 }

--- a/tensorzero-internal/src/inference/types/storage.rs
+++ b/tensorzero-internal/src/inference/types/storage.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::error::{Error, ErrorDetails};
 
-use super::{Base64Image, ImageKind};
+use super::{Base64File, FileKind};
 
 /// Configuration for the object storage backend
 /// Currently, we only support S3-compatible object storage and local filesystem storage
@@ -46,7 +46,7 @@ impl StorageKind {
     fn prefix(&self) -> &str {
         ""
     }
-    pub fn image_path(self, image: &Base64Image) -> Result<StoragePath, Error> {
+    pub fn image_path(self, image: &Base64File) -> Result<StoragePath, Error> {
         let hash = blake3::hash(
             image
                 .data
@@ -60,9 +60,9 @@ impl StorageKind {
                 .as_bytes(),
         );
         let suffix = match image.mime_type {
-            ImageKind::Jpeg => "jpg",
-            ImageKind::Png => "png",
-            ImageKind::WebP => "webp",
+            FileKind::Jpeg => "jpg",
+            FileKind::Png => "png",
+            FileKind::WebP => "webp",
         };
         let path = Path::parse(format!(
             "{}observability/images/{hash}.{suffix}",

--- a/tensorzero-internal/src/variant/chat_completion.rs
+++ b/tensorzero-internal/src/variant/chat_completion.rs
@@ -250,8 +250,8 @@ fn prepare_request_message(
             ResolvedInputMessageContent::ToolResult(tool_result) => {
                 content.push(ContentBlock::ToolResult(tool_result.clone()));
             }
-            ResolvedInputMessageContent::Image(image) => {
-                content.push(ContentBlock::Image(image.clone()));
+            ResolvedInputMessageContent::File(image) => {
+                content.push(ContentBlock::File(image.clone()));
             }
             ResolvedInputMessageContent::Thought(thought) => {
                 content.push(ContentBlock::Thought(thought.clone()));

--- a/tensorzero-internal/src/variant/dicl.rs
+++ b/tensorzero-internal/src/variant/dicl.rs
@@ -470,7 +470,7 @@ impl DiclConfig {
             for content in &message.content {
                 match content {
                     // We cannot meaningfully embed images into dicl inputs, so reject the request.
-                    ResolvedInputMessageContent::Image(..) => {
+                    ResolvedInputMessageContent::File(..) => {
                         return Err(Error::new(ErrorDetails::UnsupportedContentBlockType {
                             content_block_type: "image".to_string(),
                             provider_type: "dicl".to_string(),
@@ -559,7 +559,7 @@ fn parse_raw_examples(
 
         for messages in &input.messages {
             for content in &messages.content {
-                if let ResolvedInputMessageContent::Image(_) = content {
+                if let ResolvedInputMessageContent::File(_) = content {
                     return Err(Error::new(ErrorDetails::Serialization {
                         message: "Failed to deserialize raw_example - images are not supported in dynamic in-context learning".to_string(),
                     }));
@@ -646,9 +646,9 @@ mod tests {
     use crate::{
         function::{FunctionConfigChat, FunctionConfigJson},
         inference::types::{
-            resolved_input::ImageWithPath,
+            resolved_input::FileWithPath,
             storage::{StorageKind, StoragePath},
-            Base64Image, ImageKind, ResolvedInputMessage, ResolvedInputMessageContent, Role, Text,
+            Base64File, FileKind, ResolvedInputMessage, ResolvedInputMessageContent, Role, Text,
         },
         tool::{ToolCall, ToolCallOutput},
     };
@@ -830,10 +830,10 @@ mod tests {
                             ResolvedInputMessageContent::Text {
                                 value: json!("What is the name of the capital city of Japan?"),
                             },
-                            ResolvedInputMessageContent::Image(ImageWithPath {
-                                image: Base64Image {
+                            ResolvedInputMessageContent::File(FileWithPath {
+                                image: Base64File {
                                     url: None,
-                                    mime_type: ImageKind::Png,
+                                    mime_type: FileKind::Png,
                                     data: Some("ABC".to_string()),
                                 },
                                 storage_path: StoragePath {

--- a/tensorzero-internal/tests/e2e/inference.rs
+++ b/tensorzero-internal/tests/e2e/inference.rs
@@ -25,7 +25,7 @@ use tensorzero_internal::{
             DUMMY_STREAMING_TOOL_RESPONSE, DUMMY_TOOL_RESPONSE,
         },
         types::{
-            ContentBlock, ContentBlockOutput, Image, ImageKind, RequestMessage, ResolvedInput,
+            ContentBlock, ContentBlockOutput, File, FileKind, RequestMessage, ResolvedInput,
             ResolvedInputMessageContent, Role, Text, TextKind,
         },
     },
@@ -2851,8 +2851,8 @@ async fn test_image_inference_without_object_store() {
                         ClientInputMessageContent::Text(TextKind::Text {
                             text: "Describe the contents of the image".to_string(),
                         }),
-                        ClientInputMessageContent::Image(Image::Base64 {
-                            mime_type: ImageKind::Png,
+                        ClientInputMessageContent::Image(File::Base64 {
+                            mime_type: FileKind::Png,
                             data: BASE64_STANDARD.encode(FERRIS_PNG),
                         }),
                     ],

--- a/tensorzero-internal/tests/e2e/providers/batch.rs
+++ b/tensorzero-internal/tests/e2e/providers/batch.rs
@@ -759,7 +759,7 @@ pub async fn test_start_simple_image_batch_inference_request_with_provider(
         "What kind of animal is in this image?".to_string().into()
     );
     assert!(
-        matches!(input_messages[0].content[1], ContentBlock::Image(_)),
+        matches!(input_messages[0].content[1], ContentBlock::File(_)),
         "Unexpected input: {input_messages:?}"
     );
     assert_eq!(input_messages[0].content.len(), 2);

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -32,9 +32,9 @@ use tensorzero_internal::inference::types::TextKind;
 use tensorzero_internal::{
     cache::CacheEnabledMode,
     inference::types::{
-        resolved_input::ImageWithPath,
+        resolved_input::FileWithPath,
         storage::{StorageKind, StoragePath},
-        Base64Image, ContentBlock, ContentBlockChatOutput, Image, ImageKind, RequestMessage, Role,
+        Base64File, ContentBlock, ContentBlockChatOutput, File, FileKind, RequestMessage, Role,
         Text,
     },
     tool::{ToolCall, ToolResult},
@@ -883,7 +883,7 @@ pub async fn test_url_image_inference_with_provider_and_store(
                             ClientInputMessageContent::Text(TextKind::Text {
                                 text: "Describe the contents of the image".to_string(),
                             }),
-                            ClientInputMessageContent::Image(Image::Url {
+                            ClientInputMessageContent::Image(File::Url {
                                 url: image_url.clone(),
                             }),
                         ],
@@ -943,8 +943,8 @@ pub async fn test_base64_image_inference_with_provider_and_store(
                             ClientInputMessageContent::Text(TextKind::Text {
                                 text: "Describe the contents of the image".to_string(),
                             }),
-                            ClientInputMessageContent::Image(Image::Base64 {
-                                mime_type: ImageKind::Png,
+                            ClientInputMessageContent::Image(File::Base64 {
+                                mime_type: FileKind::Png,
                                 data: image_data.clone(),
                             }),
                         ],
@@ -1686,11 +1686,11 @@ pub async fn check_base64_image_response(
                 ContentBlock::Text(Text {
                     text: "Describe the contents of the image".to_string(),
                 }),
-                ContentBlock::Image(ImageWithPath {
-                    image: Base64Image {
+                ContentBlock::File(FileWithPath {
+                    image: Base64File {
                         url: None,
                         data: None,
-                        mime_type: ImageKind::Png,
+                        mime_type: FileKind::Png,
                     },
                     storage_path: expected_storage_path.clone(),
                 })
@@ -1836,11 +1836,11 @@ pub async fn check_url_image_response(
                 role: Role::User,
                 content: vec![ContentBlock::Text(Text {
                     text: "Describe the contents of the image".to_string(),
-                }), ContentBlock::Image(ImageWithPath {
-                    image: Base64Image {
+                }), ContentBlock::File(FileWithPath {
+                    image: Base64File {
                         url: Some(image_url.clone()),
                         data: None,
-                        mime_type: ImageKind::Png,
+                        mime_type: FileKind::Png,
                     },
                     storage_path: StoragePath {
                         kind: kind.clone(),

--- a/ui/app/components/inference/ImageBlock.tsx
+++ b/ui/app/components/inference/ImageBlock.tsx
@@ -1,16 +1,16 @@
-import type { ResolvedImageContent } from "~/utils/clickhouse/common";
+import type { ResolvedFileContent } from "~/utils/clickhouse/common";
 
-export default function ImageBlock({ image }: { image: ResolvedImageContent }) {
+export default function ImageBlock({ image }: { image: ResolvedFileContent }) {
   return (
     <div className="w-60 rounded bg-slate-100 p-2 text-xs text-slate-300">
       <div className="mb-2">Image</div>
       <a
-        href={image.image.url}
+        href={image.file.url}
         target="_blank"
         rel="noopener noreferrer"
         download={"tensorzero_" + image.storage_path.path}
       >
-        <img src={image.image.url} alt="Image" />
+        <img src={image.file.url} alt="Image" />
       </a>
     </div>
   );

--- a/ui/app/components/inference/Input.tsx
+++ b/ui/app/components/inference/Input.tsx
@@ -185,12 +185,20 @@ function MessageContent({
                 }
               />
             );
-          case "image":
-            return <ImageBlock key={index} image={block} />;
-          case "image_error":
+          case "file":
+            if (block.file.mime_type.startsWith("image/")) {
+              return <ImageBlock key={index} image={block} />;
+            } else {
+              return (
+                <div key={index}>
+                  <SkeletonImage error={`Unsupported file type: ${block.file.mime_type}`} />
+                </div>
+              )
+            }
+          case "file_error":
             return (
               <div key={index}>
-                <SkeletonImage error={true} />
+                <SkeletonImage error="Failed to retrieve image." />
               </div>
             );
           default:

--- a/ui/app/components/inference/InputSnippet.stories.tsx
+++ b/ui/app/components/inference/InputSnippet.stories.tsx
@@ -366,8 +366,8 @@ export const ImageInput: Story = {
               value: "Do the images share any common features?",
             },
             {
-              type: "image",
-              image: {
+              type: "file",
+              file: {
                 url: await getBase64Image(
                   "https://raw.githubusercontent.com/tensorzero/tensorzero/ff3e17bbd3e32f483b027cf81b54404788c90dc1/tensorzero-internal/tests/e2e/providers/ferris.png",
                 ),
@@ -385,8 +385,8 @@ export const ImageInput: Story = {
               },
             },
             {
-              type: "image",
-              image: {
+              type: "file",
+              file: {
                 // This is a one pixel by one pixel orange image
                 url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdj+O/P8B8ABe0CTsv8mHgAAAAASUVORK5CYII=",
                 mime_type: "image/png",
@@ -418,11 +418,11 @@ export const ImageInputError: Story = {
               value: "Do the images share any common features?",
             },
             {
-              type: "image_error",
+              type: "file_error",
               error: "Failed to get object: Internal Server Error",
             },
             {
-              type: "image_error",
+              type: "file_error",
               error: "Failed to get object: Timeout",
             },
           ],

--- a/ui/app/components/inference/InputSnippet.tsx
+++ b/ui/app/components/inference/InputSnippet.tsx
@@ -74,17 +74,24 @@ function renderContentBlock(block: ResolvedInputMessageContent, index: number) {
         />
       );
 
-    case "image":
-      return (
-        <ImageMessage
-          key={index}
-          url={block.image.url}
-          downloadName={`tensorzero_${block.storage_path.path}`}
-        />
-      );
-
-    case "image_error":
-      return <ImageErrorMessage key={index} />;
+    case "file":
+      if (block.file.mime_type.startsWith("image/")) {
+        return (
+          <ImageMessage
+            key={index}
+            url={block.file.url}
+              downloadName={`tensorzero_${block.storage_path.path}`}
+            />
+        );
+      } else {
+        return (
+          <div key={index}>
+            <ImageErrorMessage key={index} error={`Unsupported file type: ${block.file.mime_type}`} />
+          </div>
+        )
+      }
+    case "file_error":
+      return <ImageErrorMessage key={index} error="Failed to retrieve image" />;
 
     default:
       return null;

--- a/ui/app/components/inference/SkeletonImage.tsx
+++ b/ui/app/components/inference/SkeletonImage.tsx
@@ -2,17 +2,17 @@ import { Skeleton } from "~/components/ui/skeleton";
 
 export function SkeletonImage({
   className = "w-[150px]",
-  error = false,
+  error = undefined,
 }: {
   className?: string;
-  error?: boolean;
+  error?: string;
 }) {
   if (error) {
     return (
       <Skeleton className={`relative aspect-square ${className}`}>
         <div className="absolute inset-0 flex flex-col items-center justify-center p-2">
           <span className="text-center text-sm text-balance text-red-500/40">
-            Failed to retrieve image.
+            {error}
           </span>
         </div>
       </Skeleton>

--- a/ui/app/components/layout/SnippetContent.tsx
+++ b/ui/app/components/layout/SnippetContent.tsx
@@ -267,8 +267,12 @@ export function ImageMessage({ url, downloadName }: ImageMessageProps) {
   );
 }
 
+interface ImageErrorMessageProps {  
+  error: string;
+}
+
 // Image Error Message component
-export function ImageErrorMessage() {
+export function ImageErrorMessage({ error }: ImageErrorMessageProps) {
   return (
     <div className="flex flex-col gap-1.5">
       <Label
@@ -279,7 +283,7 @@ export function ImageErrorMessage() {
         <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 p-2">
           <ImageOff className="text-fg-muted h-4 w-4" />
           <span className="text-fg-tertiary text-center text-xs font-medium">
-            Failed to retrieve image
+            {error}
           </span>
         </div>
       </div>

--- a/ui/app/components/model/ModelInput.tsx
+++ b/ui/app/components/model/ModelInput.tsx
@@ -51,12 +51,20 @@ function MessageContent({
                 <pre className="mt-1 text-sm">{block.result}</pre>
               </div>
             );
-          case "image":
-            return <ImageBlock key={blockIndex} image={block} />;
-          case "image_error":
+          case "file":
+            if (block.file.mime_type.startsWith("image/")) {
+              return <ImageBlock key={blockIndex} image={block} />;
+            } else {
+              return (
+                <div key={blockIndex}>
+                  <SkeletonImage error={`Unsupported file type: ${block.file.mime_type}`} />
+                </div>
+              )
+            }
+          case "file_error":
             return (
               <div key={blockIndex}>
-                <SkeletonImage error={true} />
+                <SkeletonImage error="Failed to retrieve image." />
               </div>
             );
         }

--- a/ui/app/routes/api/tensorzero/inference.ts
+++ b/ui/app/routes/api/tensorzero/inference.ts
@@ -2,7 +2,7 @@ import { ZodError } from "zod";
 import { InferenceRequestSchema } from "~/utils/tensorzero";
 import { tensorZeroClient } from "~/utils/tensorzero.server";
 import type {
-  ResolvedImageContent,
+  ResolvedFileContent,
   ResolvedInput,
   ResolvedInputMessageContent,
 } from "~/utils/clickhouse/common";
@@ -99,20 +99,20 @@ function resolvedInputMessageContentToTensorZeroContent(
     case "tool_call":
     case "tool_result":
       return content;
-    case "image":
-      return resolvedImageContentToTensorZeroImage(content);
-    case "image_error":
+    case "file":
+      return resolvedFileContentToTensorZeroFile(content);
+    case "file_error":
       throw new Error("Can't convert image error to tensorzero content");
   }
 }
 
-function resolvedImageContentToTensorZeroImage(
-  content: ResolvedImageContent,
+function resolvedFileContentToTensorZeroFile(
+  content: ResolvedFileContent,
 ): TensorZeroImage {
-  const data = content.image.url.split(",")[1];
+  const data = content.file.url.split(",")[1];
   return {
     type: "image",
-    mime_type: content.image.mime_type,
+    mime_type: content.file.mime_type,
     data,
   };
 }

--- a/ui/app/utils/clickhouse/common.ts
+++ b/ui/app/utils/clickhouse/common.ts
@@ -58,17 +58,17 @@ export const toolResultContentSchema = z
   .strict();
 export type ToolResultContent = z.infer<typeof toolResultContentSchema>;
 
-export const base64ImageSchema = z.object({
+export const base64FileSchema = z.object({
   url: z.string().nullable(),
   mime_type: z.string(),
 });
-export type Base64Image = z.infer<typeof base64ImageSchema>;
+export type Base64File = z.infer<typeof base64FileSchema>;
 
-export const resolvedBase64ImageSchema = z.object({
+export const resolvedBase64FileSchema = z.object({
   url: z.string(),
   mime_type: z.string(),
 });
-export type ResolvedBase64Image = z.infer<typeof resolvedBase64ImageSchema>;
+export type ResolvedBase64File = z.infer<typeof resolvedBase64FileSchema>;
 
 export const storageKindSchema = z.discriminatedUnion("type", [
   z
@@ -102,24 +102,33 @@ export type StoragePath = z.infer<typeof storagePathSchema>;
 
 export const imageContentSchema = z.object({
   type: z.literal("image"),
-  image: base64ImageSchema,
+  image: base64FileSchema,
   storage_path: storagePathSchema,
 });
+// Legacy 'image' content block stored in the database
+// All new images are written out with the 'file' content block type
 export type ImageContent = z.infer<typeof imageContentSchema>;
 
-export const resolvedImageContentSchema = z.object({
-  type: z.literal("image"),
-  image: resolvedBase64ImageSchema,
+export const fileContentSchema = z.object({
+  type: z.literal("file"),
+  file: base64FileSchema,
   storage_path: storagePathSchema,
 });
-export type ResolvedImageContent = z.infer<typeof resolvedImageContentSchema>;
+export type FileContent = z.infer<typeof fileContentSchema>;
 
-export const resolvedImageContentErrorSchema = z.object({
-  type: z.literal("image_error"),
+export const resolvedFileContentSchema = z.object({
+  type: z.literal("file"),
+  file: resolvedBase64FileSchema,
+  storage_path: storagePathSchema,
+});
+export type ResolvedFileContent = z.infer<typeof resolvedFileContentSchema>;
+
+export const resolvedFileContentErrorSchema = z.object({
+  type: z.literal("file_error"),
   error: z.string(),
 });
 export type ResolvedImageContentError = z.infer<
-  typeof resolvedImageContentErrorSchema
+  typeof resolvedFileContentErrorSchema
 >;
 
 // Types for input to TensorZero
@@ -128,6 +137,7 @@ export const inputMessageContentSchema = z.discriminatedUnion("type", [
   toolCallContentSchema,
   toolResultContentSchema,
   imageContentSchema,
+  fileContentSchema,
   rawTextInputSchema,
 ]);
 export type InputMessageContent = z.infer<typeof inputMessageContentSchema>;
@@ -139,6 +149,7 @@ export const modelInferenceInputMessageContentSchema = z.discriminatedUnion(
     toolCallContentSchema,
     toolResultContentSchema,
     imageContentSchema,
+    fileContentSchema,
     rawTextInputSchema,
   ],
 );
@@ -150,8 +161,8 @@ export const resolvedInputMessageContentSchema = z.discriminatedUnion("type", [
   textInputSchema,
   toolCallContentSchema,
   toolResultContentSchema,
-  resolvedImageContentSchema,
-  resolvedImageContentErrorSchema,
+  resolvedFileContentSchema,
+  resolvedFileContentErrorSchema,
   rawTextInputSchema,
 ]);
 
@@ -221,6 +232,7 @@ export const contentBlockSchema = z.discriminatedUnion("type", [
   toolCallContentSchema,
   toolResultContentSchema,
   imageContentSchema,
+  fileContentSchema,
   rawTextInputSchema,
 ]);
 export type ContentBlock = z.infer<typeof contentBlockSchema>;

--- a/ui/app/utils/resolve.server.ts
+++ b/ui/app/utils/resolve.server.ts
@@ -1,9 +1,9 @@
 import type {
-  ImageContent,
+  FileContent,
   ModelInferenceInput,
   ModelInferenceInputMessage,
   ModelInferenceInputMessageContent,
-  ResolvedBase64Image,
+  ResolvedBase64File,
   ResolvedInputMessageContent,
 } from "./clickhouse/common";
 import type { InputMessageContent } from "./clickhouse/common";
@@ -90,12 +90,29 @@ async function resolveContent(
     case "image":
       try {
         return {
-          ...content,
-          image: await resolveImage(content as ImageContent),
+          type: "file",
+          file: await resolveFile({
+            type: "file",
+            file: content.image,
+            storage_path: content.storage_path
+          }),
+          storage_path: content.storage_path,
         };
       } catch (error) {
         return {
-          type: "image_error",
+          type: "file_error",
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }      
+    case "file":
+      try {
+        return {
+          ...content,
+          file: await resolveFile(content as FileContent),
+        };
+      } catch (error) {
+        return {
+          type: "file_error",
           error: error instanceof Error ? error.message : String(error),
         };
       }
@@ -115,28 +132,46 @@ async function resolveModelInferenceContent(
     case "tool_result":
     case "raw_text":
       return content;
+    // Convert legacy 'image' content block to 'file' when resolving input
     case "image":
       try {
         return {
-          ...content,
-          image: await resolveImage(content as ImageContent),
+          type: "file",
+          file: await resolveFile({
+            type: "file",
+            file: content.image,
+            storage_path: content.storage_path
+          }),
+          storage_path: content.storage_path,
         };
       } catch (error) {
         return {
-          type: "image_error",
+          type: "file_error",
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    case "file":
+      try {
+        return {
+          ...content,
+          file: await resolveFile(content as FileContent),
+        };
+      } catch (error) {
+        return {
+          type: "file_error",
           error: error instanceof Error ? error.message : String(error),
         };
       }
   }
 }
-async function resolveImage(
-  content: ImageContent,
-): Promise<ResolvedBase64Image> {
+async function resolveFile(
+  content: FileContent,
+): Promise<ResolvedBase64File> {
   const object = await tensorZeroClient.getObject(content.storage_path);
   const json = JSON.parse(object);
-  const dataURL = `data:${content.image.mime_type};base64,${json.data}`;
+  const dataURL = `data:${content.file.mime_type};base64,${json.data}`;
   return {
     url: dataURL,
-    mime_type: content.image.mime_type,
+    mime_type: content.file.mime_type,
   };
 }

--- a/ui/app/utils/supervised_fine_tuning/openai.ts
+++ b/ui/app/utils/supervised_fine_tuning/openai.ts
@@ -279,8 +279,9 @@ export function content_block_to_openai_message(
         content: content.result,
       };
     case "image":
+    case "file":
       throw new Error(
-        "Image content is not supported for OpenAI fine-tuning. We have an open issue for this feature at https://github.com/tensorzero/tensorzero/issues/1132.",
+        "File content is not supported for OpenAI fine-tuning. We have an open issue for this feature at https://github.com/tensorzero/tensorzero/issues/1132.",
       );
     case "raw_text":
       return {


### PR DESCRIPTION
We still need to be able to deserialize old 'image' content blocks from the database, so we now have `#[serde(alias = "image")]` on some fields. The UI server ClickHouse code also handles deserializing "image" content blocks.

In the frontend codebase, we now display an error when trying to render a file with a mime-type that does not start with `image/`

This is preparation for supporting additional file types (e.g. PDF)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
