### PR TITLE
Persist evaluation runs in local storage

### DIFF
--- a/ui/app/routes/evaluations/AdvancedParametersAccordion.tsx
+++ b/ui/app/routes/evaluations/AdvancedParametersAccordion.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import {
   Accordion,
   AccordionContent,
@@ -12,14 +11,16 @@ import type { InferenceCacheSetting } from "~/utils/evaluations.server";
 export interface AdvancedParametersAccordionProps {
   inference_cache: InferenceCacheSetting;
   setInferenceCache: (inference_cache: InferenceCacheSetting) => void;
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
 }
 
 export function AdvancedParametersAccordion({
   inference_cache,
   setInferenceCache,
+  isOpen,
+  setIsOpen,
 }: AdvancedParametersAccordionProps) {
-  const [isOpen, setIsOpen] = useState(false);
-
   return (
     <Accordion
       type="single"

--- a/ui/app/routes/evaluations/route.tsx
+++ b/ui/app/routes/evaluations/route.tsx
@@ -111,7 +111,7 @@ export default function EvaluationSummaryPage({
       <LaunchEvaluationModal
         isOpen={launchEvaluationModalIsOpen}
         onClose={() => setLaunchEvaluationModalIsOpen(false)}
-        dataset_names={dataset_names}
+        datasetNames={dataset_names}
       />
     </PageLayout>
   );


### PR DESCRIPTION
Found a Radix bug in this one, so dirty hack within!

This PR persists the form fields for each evaluation run in local storage so that the form fields are initialized with the same values when the user returns to run a new evaluation. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Persist evaluation form fields in local storage to retain user input across sessions.
> 
>   - **Behavior**:
>     - Persist evaluation form fields in local storage in `LaunchEvaluationModal.tsx`.
>     - On form submission, save form data to local storage using `persistToLocalStorage()`.
>     - On component mount, load form data from local storage using `getFromLocalStorage()`.
>   - **State Management**:
>     - Replace individual `useState` hooks with `useReducer` in `EvaluationForm` for managing form state.
>     - Add `EvaluationsFormState` and `FormUpdateAction` types to handle form state updates.
>     - Introduce `_lastAction` to track state synchronization and user actions.
>   - **Props and Components**:
>     - Pass `isOpen` and `setIsOpen` props to `AdvancedParametersAccordion` to control accordion state externally.
>     - Rename `dataset_names` to `datasetNames` in `LaunchEvaluationModal` and `EvaluationForm` for consistency.
>   - **Misc**:
>     - Add `LOCAL_STORAGE_KEY` constant for local storage operations.
>     - Add TODO comments for potential improvements using `zod` for data validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4059556bfa3a51f7a61f94ad2bd20fd8f568593c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->