### PR TITLE
Persist evaluation runs in local storage

### DIFF
--- a/ui/app/routes/evaluations/AdvancedParametersAccordion.tsx
+++ b/ui/app/routes/evaluations/AdvancedParametersAccordion.tsx
@@ -10,16 +10,17 @@ import { RadioGroup, RadioGroupItem } from "~/components/ui/radio-group";
 import type { InferenceCacheSetting } from "~/utils/evaluations.server";
 
 export interface AdvancedParametersAccordionProps {
-  inference_cache: InferenceCacheSetting;
+  inferenceCache: InferenceCacheSetting;
   setInferenceCache: (inference_cache: InferenceCacheSetting) => void;
+  defaultOpen?: boolean;
 }
 
 export function AdvancedParametersAccordion({
-  inference_cache,
+  inferenceCache,
   setInferenceCache,
+  defaultOpen,
 }: AdvancedParametersAccordionProps) {
-  const [isOpen, setIsOpen] = useState(false);
-
+  const [isOpen, setIsOpen] = useState(defaultOpen ?? false);
   return (
     <Accordion
       type="single"
@@ -38,7 +39,7 @@ export function AdvancedParametersAccordion({
           <div className="space-y-6 px-3 pt-3">
             <Label>Inference Cache</Label>
             <RadioGroup
-              value={inference_cache}
+              value={inferenceCache}
               onValueChange={setInferenceCache}
               className="mt-2 flex gap-4"
             >

--- a/ui/app/routes/evaluations/LaunchEvaluationModal.tsx
+++ b/ui/app/routes/evaluations/LaunchEvaluationModal.tsx
@@ -374,7 +374,11 @@ function persistToLocalStorage(formData: FormData) {
     if (typeof value !== "string") continue;
     formObject[key] = value;
   }
-  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(formObject));
+  try {
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(formObject));
+  } catch {
+    // silently ignore errors, e.g. if localStorage is full
+  }
 }
 
 function getFromLocalStorage() {

--- a/ui/app/routes/evaluations/LaunchEvaluationModal.tsx
+++ b/ui/app/routes/evaluations/LaunchEvaluationModal.tsx
@@ -327,13 +327,11 @@ export default function LaunchEvaluationModal({
   useLayoutEffect(() => {
     const storedValues = getFromLocalStorage();
     if (storedValues) {
-      const advancedParamsOpen = storedValues.inference_cache !== "on";
       setInitialFormState({
         ...storedValues,
         // generate a key that we'll use to force re-render the form so that all
         // internal state values are reset when given new data
         renderKey: Date.now().toString(),
-        advancedParamsOpen,
       });
     }
   }, []);
@@ -362,7 +360,6 @@ interface EvaluationsFormValues {
 }
 
 interface EvaluationsFormState extends Partial<EvaluationsFormValues> {
-  advancedParamsOpen: boolean;
   renderKey: string;
 }
 

--- a/ui/app/routes/evaluations/LaunchEvaluationModal.tsx
+++ b/ui/app/routes/evaluations/LaunchEvaluationModal.tsx
@@ -319,7 +319,7 @@ function EvaluationForm({
 export default function LaunchEvaluationModal({
   isOpen,
   onClose,
-  datasetNames: dataset_names,
+  datasetNames,
 }: LaunchEvaluationModalProps) {
   const [initialFormState, setInitialFormState] =
     useState<EvaluationsFormState | null>(null);
@@ -345,7 +345,7 @@ export default function LaunchEvaluationModal({
         </DialogHeader>
         <EvaluationForm
           key={initialFormState?.renderKey}
-          datasetNames={dataset_names}
+          datasetNames={datasetNames}
           initialFormState={initialFormState}
         />
       </DialogContent>

--- a/ui/app/routes/evaluations/LaunchEvaluationModal.tsx
+++ b/ui/app/routes/evaluations/LaunchEvaluationModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import { useFetcher, Link } from "react-router";
 import { Button } from "~/components/ui/button";
 import {
@@ -39,7 +39,7 @@ import type { InferenceCacheSetting } from "~/utils/evaluations.server";
 interface LaunchEvaluationModalProps {
   isOpen: boolean;
   onClose: () => void;
-  dataset_names: string[];
+  datasetNames: string[];
 }
 
 interface DatasetSelectorProps {
@@ -127,22 +127,31 @@ function DatasetSelector({
   );
 }
 
-function EvaluationForm({ dataset_names }: { dataset_names: string[] }) {
+function EvaluationForm({
+  datasetNames,
+  initialFormState,
+}: {
+  datasetNames: string[];
+  initialFormState: Partial<EvaluationsFormValues> | null;
+}) {
   const fetcher = useFetcher();
   const config = useConfig();
   const evaluation_names = Object.keys(config.evaluations);
   const [selectedEvaluationName, setSelectedEvaluationName] = useState<
     string | null
-  >(null);
+  >(initialFormState?.evaluation_name ?? null);
   const [selectedDatasetName, setSelectedDatasetName] = useState<string | null>(
-    null,
+    initialFormState?.dataset_name ?? null,
   );
   const [selectedVariantName, setSelectedVariantName] = useState<string | null>(
-    null,
+    initialFormState?.variant_name ?? null,
   );
-  const [concurrencyLimit, setConcurrencyLimit] = useState<string>("5");
-  const [inferenceCache, setInferenceCache] =
-    useState<InferenceCacheSetting>("on");
+  const [concurrencyLimit, setConcurrencyLimit] = useState<string>(
+    initialFormState?.concurrency_limit ?? "5",
+  );
+  const [inferenceCache, setInferenceCache] = useState<InferenceCacheSetting>(
+    initialFormState?.inference_cache ?? "on",
+  );
 
   let count = null;
   let isLoading = false;
@@ -166,7 +175,13 @@ function EvaluationForm({ dataset_names }: { dataset_names: string[] }) {
     concurrencyLimit !== "";
 
   return (
-    <fetcher.Form method="post">
+    <fetcher.Form
+      method="post"
+      onSubmit={(event) => {
+        const formData = new FormData(event.currentTarget);
+        persistToLocalStorage(formData);
+      }}
+    >
       <div className="mt-4">
         <label
           htmlFor="evaluation_name"
@@ -177,6 +192,7 @@ function EvaluationForm({ dataset_names }: { dataset_names: string[] }) {
       </div>
       <Select
         name="evaluation_name"
+        defaultValue={initialFormState?.evaluation_name ?? undefined}
         onValueChange={(value) => {
           setSelectedEvaluationName(value);
           setSelectedVariantName(null); // Reset variant selection when evaluation changes
@@ -203,7 +219,7 @@ function EvaluationForm({ dataset_names }: { dataset_names: string[] }) {
       </div>
 
       <DatasetSelector
-        dataset_names={dataset_names}
+        dataset_names={datasetNames}
         selectedDatasetName={selectedDatasetName}
         setSelectedDatasetName={setSelectedDatasetName}
       />
@@ -240,6 +256,7 @@ function EvaluationForm({ dataset_names }: { dataset_names: string[] }) {
       </div>
       <Select
         name="variant_name"
+        defaultValue={initialFormState?.variant_name ?? undefined}
         disabled={!selectedEvaluationName}
         onValueChange={(value) => setSelectedVariantName(value)}
       >
@@ -284,8 +301,9 @@ function EvaluationForm({ dataset_names }: { dataset_names: string[] }) {
       </div>
       <div className="mt-4">
         <AdvancedParametersAccordion
-          inference_cache={inferenceCache}
+          inferenceCache={inferenceCache}
           setInferenceCache={setInferenceCache}
+          defaultOpen={inferenceCache !== "on"}
         />
         <input type="hidden" name="inference_cache" value={inferenceCache} />
       </div>
@@ -301,17 +319,79 @@ function EvaluationForm({ dataset_names }: { dataset_names: string[] }) {
 export default function LaunchEvaluationModal({
   isOpen,
   onClose,
-  dataset_names,
+  datasetNames: dataset_names,
 }: LaunchEvaluationModalProps) {
+  const [initialFormState, setInitialFormState] =
+    useState<EvaluationsFormState | null>(null);
+  // useLayoutEffect to update fields before paint to avoid flicker of old state
+  useLayoutEffect(() => {
+    const storedValues = getFromLocalStorage();
+    if (storedValues) {
+      const advancedParamsOpen = storedValues.inference_cache !== "on";
+      setInitialFormState({
+        ...storedValues,
+        // generate a key that we'll use to force re-render the form so that all
+        // internal state values are reset when given new data
+        renderKey: Date.now().toString(),
+        advancedParamsOpen,
+      });
+    }
+  }, []);
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Launch Evaluation</DialogTitle>
         </DialogHeader>
-
-        <EvaluationForm dataset_names={dataset_names} />
+        <EvaluationForm
+          key={initialFormState?.renderKey}
+          datasetNames={dataset_names}
+          initialFormState={initialFormState}
+        />
       </DialogContent>
     </Dialog>
   );
+}
+
+interface EvaluationsFormValues {
+  dataset_name: string | null;
+  evaluation_name: string | null;
+  variant_name: string | null;
+  concurrency_limit: string;
+  inference_cache: InferenceCacheSetting;
+}
+
+interface EvaluationsFormState extends Partial<EvaluationsFormValues> {
+  advancedParamsOpen: boolean;
+  renderKey: string;
+}
+
+const LOCAL_STORAGE_KEY = "tensorzero:evaluationForm";
+
+function persistToLocalStorage(formData: FormData) {
+  const formObject: Record<string, string> = {};
+  for (const [key, value] of formData.entries()) {
+    if (typeof value !== "string") continue;
+    formObject[key] = value;
+  }
+  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(formObject));
+}
+
+function getFromLocalStorage() {
+  const values = localStorage.getItem(LOCAL_STORAGE_KEY);
+  if (!values) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(values);
+    if (parsed == null || typeof parsed !== "object") {
+      localStorage.removeItem(LOCAL_STORAGE_KEY);
+      return null;
+    }
+  } catch {
+    localStorage.removeItem(LOCAL_STORAGE_KEY);
+    return null;
+  }
+
+  // TODO: add validation
+  return parsed as Partial<EvaluationsFormValues>;
 }

--- a/ui/app/routes/evaluations/route.tsx
+++ b/ui/app/routes/evaluations/route.tsx
@@ -111,7 +111,7 @@ export default function EvaluationSummaryPage({
       <LaunchEvaluationModal
         isOpen={launchEvaluationModalIsOpen}
         onClose={() => setLaunchEvaluationModalIsOpen(false)}
-        dataset_names={dataset_names}
+        datasetNames={dataset_names}
       />
     </PageLayout>
   );


### PR DESCRIPTION
Simpler implementation of https://github.com/tensorzero/tensorzero/pull/2238 that avoids refactoring internal form state (and removes the need for that gross Radix hack)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Persist evaluation form data in local storage to maintain state across sessions and update UI components accordingly.
> 
>   - **Behavior**:
>     - Persist evaluation form data to local storage in `LaunchEvaluationModal.tsx` using `persistToLocalStorage()` and `getFromLocalStorage()`.
>     - Initialize form fields with stored values in `EvaluationForm` using `initialFormState`.
>     - Form submission updates local storage with current form data.
>   - **UI Components**:
>     - Add `defaultOpen` prop to `AdvancedParametersAccordion` to control initial open state.
>     - Use `useLayoutEffect` in `LaunchEvaluationModal` to set initial form state from local storage.
>   - **Renames**:
>     - Rename `inference_cache` to `inferenceCache` and `dataset_names` to `datasetNames` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 710aa9634f65cbbe4f664683478448c85410c1c6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->