### PR TITLE
Log tower-http failed request messages at DEBUG level

### DIFF
--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -12,7 +12,8 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::signal;
-use tower_http::trace::TraceLayer;
+use tower_http::trace::{DefaultOnFailure, TraceLayer};
+use tracing::Level;
 
 use tensorzero_internal::clickhouse::ClickHouseConnectionInfo;
 use tensorzero_internal::config_parser::Config;
@@ -255,7 +256,8 @@ async fn main() {
         // Note - this is intentionally *not* used by our OTEL exporter (it creates a span without any `http.` or `otel.` fields)
         // This is only used to output request/response information to our logs
         // OTEL exporting is done by the `OtelAxumLayer` above, which is only enabled for certain routes (and includes much more information)
-        .layer(TraceLayer::new_for_http())
+        // We log failed requests messages at 'DEBUG', since we already have our own error-logging code,
+        .layer(TraceLayer::new_for_http().on_failure(DefaultOnFailure::new().level(Level::DEBUG)))
         .with_state(app_state);
 
     // Bind to the socket address specified in the config, or default to 0.0.0.0:3000


### PR DESCRIPTION
We already have our own error-loging logic, so we don't need to log an additional ERROR-level message.

Fixes #2248

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change logging level for failed HTTP requests to DEBUG in `main.rs` to avoid duplicate ERROR logs.
> 
>   - **Logging**:
>     - Change logging level for failed HTTP requests to `DEBUG` in `main.rs` using `TraceLayer` and `DefaultOnFailure`.
>     - Avoids duplicate ERROR-level logs for failed requests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6fac71ec2d135cf671c7aa78ec8361e935023c50. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->