### PR TITLE
Correctly use downloaded gateway and ui images on CI

### DIFF
--- a/.github/workflows/build-gateway-container.yml
+++ b/.github/workflows/build-gateway-container.yml
@@ -12,10 +12,10 @@ jobs:
 
       - name: Build `gateway` container
         run: |
-          docker build -f gateway/Dockerfile . -t tensorzero/gateway
+          docker build -f gateway/Dockerfile . -t tensorzero/gateway:sha-${{ github.sha }}
 
       - name: Save `gateway` container
-        run: docker save tensorzero/gateway > gateway-container.tar
+        run: docker save tensorzero/gateway:sha-${{ github.sha }} > gateway-container.tar
 
       - name: Upload `gateway` container as an artifact
         uses: namespace-actions/upload-artifact@9a78c62e083914789d908952f9773e42744b9f68

--- a/.github/workflows/build-ui-container.yml
+++ b/.github/workflows/build-ui-container.yml
@@ -12,10 +12,10 @@ jobs:
 
       - name: Build `ui` container
         run: |
-          docker build -f ui/Dockerfile . -t tensorzero/ui
+          docker build -f ui/Dockerfile . -t tensorzero/ui:sha-${{ github.sha }}
 
       - name: Save `ui` container
-        run: docker save tensorzero/ui > ui-container.tar
+        run: docker save tensorzero/ui:sha-${{ github.sha }} > ui-container.tar
 
       - name: Upload `ui` container as an artifact
         uses: namespace-actions/upload-artifact@9a78c62e083914789d908952f9773e42744b9f68

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -59,6 +59,12 @@ jobs:
           docker load < gateway-container.tar
           docker load < ui-container.tar
 
+      # This allows us to use 'no-build' on subsequent steps
+      - name: Build needed docker images
+        working-directory: ui
+        run: |
+          docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml build fixtures mock-inference-provider
+
       - name: Start Docker containers and apply fixtures
         working-directory: ui
         run: |
@@ -71,7 +77,9 @@ jobs:
           echo "S3_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> fixtures/.env
           echo "TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero_ui_fixtures" >> fixtures/.env
           echo "TENSORZERO_GATEWAY_URL=http://gateway:3000" >> fixtures/.env
-          docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml up --wait
+          echo "TENSORZERO_GATEWAY_TAG=sha-${{ github.sha }}" >> fixtures/.env
+          echo "TENSORZERO_UI_TAG=sha-${{ github.sha }}" >> fixtures/.env
+          docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml up --no-build --wait
 
       - name: Run UI E2E tests
         id: e2e_tests

--- a/ui/fixtures/docker-compose.e2e.yml
+++ b/ui/fixtures/docker-compose.e2e.yml
@@ -37,6 +37,7 @@ services:
       timeout: 1s
 
   gateway:
+    image: tensorzero/gateway:${TENSORZERO_GATEWAY_TAG:-latest}
     build:
       context: ../..
       dockerfile: gateway/Dockerfile

--- a/ui/fixtures/docker-compose.ui.yml
+++ b/ui/fixtures/docker-compose.ui.yml
@@ -1,5 +1,6 @@
 services:
   ui:
+    image: tensorzero/ui:${TENSORZERO_UI_TAG:-latest}
     build:
       context: ../..
       dockerfile: ui/Dockerfile

--- a/ui/fixtures/docker-compose.yml
+++ b/ui/fixtures/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       timeout: 1s
 
   gateway:
+    image: tensorzero/gateway:${TENSORZERO_GATEWAY_TAG:-latest}
     build:
       context: ../..
       dockerfile: gateway/Dockerfile


### PR DESCRIPTION
We were missing an 'image:' field in our docker-compose.yml files. As a result, the images loaded by 'docker load' were being ignored in favor of whatever image happened to be in the Namespace cache

We now build the image with a specific sha tag, and use that tag when starting the containers. This should result in an error if the image export ever breaks, rather than silently falling back to the latest published image

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add SHA-specific tags to Docker images and update `docker-compose` files to ensure correct image usage in CI.
> 
>   - **Docker Image Tagging**:
>     - Add SHA-specific tags to `gateway` and `ui` images in `build-gateway-container.yml` and `build-ui-container.yml`.
>     - Save images with SHA tags to ensure correct versioning.
>   - **Docker Compose Configuration**:
>     - Add `image:` field with SHA tag for `gateway` in `docker-compose.e2e.yml` and `docker-compose.yml`.
>     - Add `image:` field with SHA tag for `ui` in `docker-compose.ui.yml`.
>   - **CI Workflow Changes**:
>     - Update `ui-tests-e2e.yml` to use SHA tags for `gateway` and `ui` images, ensuring correct images are loaded and used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 49de5128edec6c54079432481d4f37381995df2a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->