### PR TITLE
Add shorthand model support to gcp_vertex_gemini

### DIFF
--- a/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
@@ -187,7 +187,145 @@ fn make_gcp_object_store(
     })
 }
 
+#[derive(Debug, Eq, PartialEq)]
+enum ShorthandUrl<'a> {
+    // We enforce that the publisher is 'google' when parsing the url
+    Publisher {
+        location: &'a str,
+        model_id: &'a str,
+    },
+    Endpoint {
+        location: &'a str,
+        endpoint_id: &'a str,
+    },
+}
+
+// 'projects/<project_id>/locations/<location>/publishers/<publisher>/models/<model_id>'
+fn parse_shorthand_url(shorthand_url: &str) -> Result<ShorthandUrl, Error> {
+    let components: Vec<&str> = shorthand_url.split('/').collect_vec();
+    let [projects, _project_id, locations, location, publishers_or_endpoint, ..] = &components[..]
+    else {
+        return Err(Error::new(ErrorDetails::Config {
+            message: format!("GCP shorthand url is not in the expected format (should start with `projects/<project_id>/locations/<location>'): `{shorthand_url}`"),
+        }));
+    };
+
+    if projects != &"projects" {
+        return Err(Error::new(ErrorDetails::Config {
+            message: format!("GCP shorthand url does not start with 'projects': `{shorthand_url}`"),
+        }));
+    }
+    if locations != &"locations" {
+        return Err(Error::new(ErrorDetails::Config {
+            message: format!("GCP shorthand url does contain '/locations/': `{shorthand_url}`"),
+        }));
+    }
+
+    if publishers_or_endpoint == &"publishers" {
+        let publisher = components.get(5).ok_or_else(|| {
+            Error::new(ErrorDetails::Config {
+                message: format!(
+                    "GCP shorthand url does not contain a publisher: `{shorthand_url}`"
+                ),
+            })
+        })?;
+        if publisher != &"google" {
+            return Err(Error::new(ErrorDetails::Config {
+                message: format!(
+                    "GCP Vertex Geminishorthand url has non-`google` publisher: `{shorthand_url}`"
+                ),
+            }));
+        }
+        let models = components.get(6).ok_or_else(|| {
+            Error::new(ErrorDetails::Config {
+                message: format!(
+                    "GCP shorthand url does not contain a model or endpoint: `{shorthand_url}`"
+                ),
+            })
+        })?;
+        if models != &"models" {
+            return Err(Error::new(ErrorDetails::Config {
+                message: format!("GCP shorthand url does not contain a model: `{shorthand_url}`"),
+            }));
+        }
+        let model_id = components.get(7).ok_or_else(|| {
+            Error::new(ErrorDetails::Config {
+                message: format!(
+                    "GCP shorthand url does not contain a model id: `{shorthand_url}`"
+                ),
+            })
+        })?;
+        Ok(ShorthandUrl::Publisher { location, model_id })
+    } else if publishers_or_endpoint == &"endpoints" {
+        let endpoint = components.get(5).ok_or_else(|| {
+            Error::new(ErrorDetails::Config {
+                message: format!(
+                    "GCP shorthand url does not contain an endpoint: `{shorthand_url}`"
+                ),
+            })
+        })?;
+        Ok(ShorthandUrl::Endpoint {
+            endpoint_id: endpoint,
+            location,
+        })
+    } else {
+        Err(Error::new(ErrorDetails::Config {
+            message: format!(
+                "GCP shorthand url does not contain a publisher or endpoint: `{shorthand_url}`"
+            ),
+        }))
+    }
+}
+
 impl GCPVertexGeminiProvider {
+    // Constructs a provider from a shorthand string of the form:
+    // *
+    // * 'projects/<project_id>/locations/<location>/endpoints/XXX'
+    //
+    // This is *not* a full url - we append ':generateContent' or ':streamGenerateContent' to the end of the path as needed.
+    pub fn new_shorthand(project_url_path: String) -> Result<Self, Error> {
+        let credentials = build_creds_caching_default_with_fn(
+            None,
+            default_api_key_location(),
+            PROVIDER_TYPE,
+            &DEFAULT_CREDENTIALS,
+            |creds| GCPVertexCredentials::try_from((creds, PROVIDER_TYPE)),
+        )?;
+
+        let shorthand_url = parse_shorthand_url(&project_url_path)?;
+        let (location, model_id) = match shorthand_url {
+            ShorthandUrl::Publisher { location, model_id } => (location, model_id.to_string()),
+            ShorthandUrl::Endpoint {
+                location,
+                endpoint_id,
+            } => (location, format!("endpoints/{endpoint_id}")),
+        };
+
+        let request_url = format!(
+            "https://{location}-aiplatform.googleapis.com/v1/{project_url_path}:generateContent"
+        );
+        let streaming_request_url = format!("https://{location}-aiplatform.googleapis.com/v1/{project_url_path}:streamGenerateContent?alt=sse");
+        let audience = format!("https://{location}-aiplatform.googleapis.com/");
+        let api_v1_base_url = Url::parse(&format!(
+            "https://{location}-aiplatform.googleapis.com/v1/"
+        ))
+        .map_err(|e| {
+            Error::new(ErrorDetails::InternalError {
+                message: format!("Failed to parse base URL - this should never happen: {e}"),
+            })
+        })?;
+
+        Ok(GCPVertexGeminiProvider {
+            api_v1_base_url,
+            request_url,
+            streaming_request_url,
+            batch_config: None,
+            audience,
+            credentials,
+            model_id,
+        })
+    }
+
     pub fn new(
         model_id: String,
         location: String,
@@ -2887,6 +3025,46 @@ mod tests {
         let err = result.unwrap_err().get_owned_details();
         assert!(
             matches!(err, ErrorDetails::GCPCredentials { message } if message.contains("Invalid credential_location"))
+        );
+    }
+
+    #[test]
+    fn test_shorthand_url_parse() {
+        use super::parse_shorthand_url;
+
+        let err1 = parse_shorthand_url("bad-shor-hand-url")
+            .unwrap_err()
+            .to_string();
+        assert_eq!(err1, "GCP shorthand url is not in the expected format (should start with `projects/<project_id>/locations/<location>'): `bad-shor-hand-url`");
+
+        let missing_components =
+            parse_shorthand_url("projects/tensorzero-public/locations/us-central1/")
+                .unwrap_err()
+                .to_string();
+        assert_eq!(missing_components, "GCP shorthand url does not contain a publisher or endpoint: `projects/tensorzero-public/locations/us-central1/`");
+
+        let non_google_publisher = parse_shorthand_url("projects/tensorzero-public/locations/us-central1/publishers/not-google/models/gemini-2.0-flash-001").unwrap_err().to_string();
+        assert_eq!(non_google_publisher, "GCP Vertex Geminishorthand url has non-`google` publisher: `projects/tensorzero-public/locations/us-central1/publishers/not-google/models/gemini-2.0-flash-001`");
+
+        let valid_model_url = parse_shorthand_url("projects/tensorzero-public/locations/us-central1/publishers/google/models/gemini-2.0-flash-001").unwrap();
+        assert_eq!(
+            valid_model_url,
+            ShorthandUrl::Publisher {
+                location: "us-central1",
+                model_id: "gemini-2.0-flash-001"
+            }
+        );
+
+        let valid_endpoint_url = parse_shorthand_url(
+            "projects/tensorzero-public/locations/us-central1/endpoints/945488740422254592",
+        )
+        .unwrap();
+        assert_eq!(
+            valid_endpoint_url,
+            ShorthandUrl::Endpoint {
+                location: "us-central1",
+                endpoint_id: "945488740422254592"
+            }
         );
     }
 }

--- a/tensorzero-internal/src/model.rs
+++ b/tensorzero-internal/src/model.rs
@@ -1476,6 +1476,7 @@ const SHORTHAND_MODEL_PREFIXES: &[&str] = &[
     "deepseek::",
     "fireworks::",
     "google_ai_studio_gemini::",
+    "gcp_vertex_gemini::",
     "hyperbolic::",
     "mistral::",
     "openai::",
@@ -1503,6 +1504,9 @@ impl ShorthandModelConfig for ModelConfig {
             "google_ai_studio_gemini" => ProviderConfig::GoogleAIStudioGemini(
                 GoogleAIStudioGeminiProvider::new(model_name, None)?,
             ),
+            "gcp_vertex_gemini" => {
+                ProviderConfig::GCPVertexGemini(GCPVertexGeminiProvider::new_shorthand(model_name)?)
+            }
             "hyperbolic" => ProviderConfig::Hyperbolic(HyperbolicProvider::new(model_name, None)?),
             "mistral" => ProviderConfig::Mistral(MistralProvider::new(model_name, None)?),
             "openai" => ProviderConfig::OpenAI(OpenAIProvider::new(model_name, None, None)?),

--- a/tensorzero-internal/tests/e2e/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/tests/e2e/providers/gcp_vertex_gemini.rs
@@ -96,6 +96,20 @@ async fn get_providers() -> E2ETestProviders {
         credentials: HashMap::new(),
     }];
 
+    let shorthand_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
+        variant_name: "gcp_vertex_gemini_shorthand".to_string(),
+        model_name: "gcp_vertex_gemini::projects/tensorzero-public/locations/us-central1/publishers/google/models/gemini-2.0-flash-001".into(),
+        model_provider_name: "gcp_vertex_gemini".into(),
+        credentials: HashMap::new(),
+    }, E2ETestProvider {
+        supports_batch_inference: false,
+        variant_name: "gcp_vertex_gemini_shorthand_endpoint".to_string(),
+        model_name: "gcp_vertex_gemini::projects/tensorzero-public/locations/us-central1/endpoints/945488740422254592".into(),
+        model_provider_name: "gcp_vertex_gemini".into(),
+        credentials: HashMap::new(),
+    }];
+
     E2ETestProviders {
         simple_inference: standard_providers.clone(),
         extra_body_inference: extra_body_providers,
@@ -111,7 +125,7 @@ async fn get_providers() -> E2ETestProviders {
         json_mode_off_inference: json_mode_off_providers.clone(),
         image_inference: image_providers,
 
-        shorthand_inference: vec![],
+        shorthand_inference: shorthand_providers.clone(),
     }
 }
 

--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -940,6 +940,18 @@ model = "openai::gpt-4o-mini-2024-07-18"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 
+[functions.basic_test.variants.gcp_vertex_gemini_shorthand]
+type = "chat_completion"
+model = "gcp_vertex_gemini::projects/tensorzero-public/locations/us-central1/publishers/google/models/gemini-2.0-flash-001"
+system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
+max_tokens = 100
+
+[functions.basic_test.variants.gcp_vertex_gemini_shorthand_endpoint]
+type = "chat_completion"
+model = "gcp_vertex_gemini::projects/tensorzero-public/locations/us-central1/endpoints/945488740422254592"
+system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
+max_tokens = 100
+
 [functions.basic_test.variants.o4-mini]
 type = "chat_completion"
 model = "o4-mini"


### PR DESCRIPTION
The supported shorthand url formats are:
* `gcp_vertex_gemini::projects/<PROJECT_ID>/locations/<REGION>/publishers/google/models/<MODEL_ID>`
* `gcp_vertex_gemini::projects/<PROJECT_ID>/locations/<REGION>/endpoints/<ENDPOINT_ID>`

This allows invoking both Gemini models and deployed fine-tuned endpoints. We currently enforce that the publisher is 'google' when using the `/models/` form of the url

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for shorthand URL formats in `gcp_vertex_gemini.rs` for easier invocation of GCP Vertex Gemini models and endpoints.
> 
>   - **Behavior**:
>     - Adds support for shorthand URL formats in `gcp_vertex_gemini.rs` for models and endpoints.
>     - Enforces 'google' as the publisher for model URLs.
>   - **Functions**:
>     - `parse_shorthand_url()` added to parse shorthand URLs in `gcp_vertex_gemini.rs`.
>     - `new_shorthand()` added to `GCPVertexGeminiProvider` for provider initialization from shorthand URLs.
>   - **Tests**:
>     - Adds tests for shorthand URL parsing in `gcp_vertex_gemini.rs`.
>     - Updates `e2e/providers/gcp_vertex_gemini.rs` to include shorthand provider tests.
>   - **Config**:
>     - Updates `tensorzero.toml` to include shorthand model configurations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 70db0fdb6e2de8e755c8f96b283daace2e693dca. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->