### PR TITLE
Start running 'cargo deny' license check in CI

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -251,7 +251,7 @@ jobs:
           cargo hack clippy --all-targets --each-feature -- -D warnings
 
       - name: Run cargo-deny
-        run: cargo deny check advisories bans
+        run: cargo deny check
 
       - name: Test (Rust)
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
 
       - id: cargo-deny
         name: cargo deny
-        entry: cargo deny check advisories bans
+        entry: cargo deny check
         language: system
         types: [rust]
         pass_filenames: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ resolver = "2"
 [workspace.package]
 version = "2025.5.7"
 rust-version = "1.85.0"
+license = "Apache-2.0"
 
 [workspace.dependencies]
 reqwest = { version = "0.12.15", features = [

--- a/clients/python/Cargo.toml
+++ b/clients/python/Cargo.toml
@@ -6,7 +6,7 @@ name = "tensorzero-python"
 version.workspace = true
 rust-version.workspace = true
 edition = "2021"
-license = "Apache-2.0"
+license.workspace = true
 
 [lints]
 workspace = true

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -3,6 +3,7 @@ name = "tensorzero"
 version = "0.1.0"
 edition = "2021"
 rust-version.workspace = true
+license.workspace = true
 
 [[test]]
 name = "client_tests"

--- a/deny.toml
+++ b/deny.toml
@@ -11,3 +11,7 @@ deny = [
 ignore = [
     "RUSTSEC-2024-0436" # We don't care that 'paste' is unmaintained
 ]
+
+[licenses]
+version = 2
+allow = ["Unicode-3.0", "Apache-2.0", "MIT", "CDLA-Permissive-2.0", "ISC", "CC0-1.0", "Apache-2.0 WITH LLVM-exception", "BSD-3-Clause", "Zlib", "MIT-0", "OpenSSL", "BSD-2-Clause"]

--- a/evaluations/Cargo.toml
+++ b/evaluations/Cargo.toml
@@ -3,6 +3,7 @@ name = "evaluations"
 version.workspace = true
 edition = "2021"
 rust-version.workspace = true
+license.workspace = true
 
 [[test]]
 name = "e2e"

--- a/examples/integrations/cursor/experimental/Cargo.toml
+++ b/examples/integrations/cursor/experimental/Cargo.toml
@@ -3,6 +3,7 @@ name = "cursorzero"
 version = "0.1.0"
 edition = "2021"
 rust-version.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -3,6 +3,7 @@ name = "gateway"
 version.workspace = true
 rust-version.workspace = true
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 tensorzero-internal = { path = "../tensorzero-internal" }

--- a/provider-proxy/Cargo.toml
+++ b/provider-proxy/Cargo.toml
@@ -3,6 +3,7 @@ name = "provider-proxy"
 version = "0.1.0"
 rust-version.workspace = true
 edition = "2021"
+license.workspace = true
 
 [[test]]
 name = "e2e"

--- a/tensorzero-derive/Cargo.toml
+++ b/tensorzero-derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "tensorzero-derive"
 version = "0.1.0"
 rust-version.workspace = true
 edition = "2021"
+license.workspace = true
 
 [lib]
 proc-macro = true

--- a/tensorzero-internal/Cargo.toml
+++ b/tensorzero-internal/Cargo.toml
@@ -3,6 +3,7 @@ name = "tensorzero-internal"
 version.workspace = true
 rust-version.workspace = true
 edition = "2021"
+license.workspace = true
 
 
 [features]

--- a/tensorzero-internal/tests/mock-inference-provider/Cargo.toml
+++ b/tensorzero-internal/tests/mock-inference-provider/Cargo.toml
@@ -3,6 +3,7 @@ name = "mock-inference-provider"
 version = "0.1.0"
 rust-version.workspace = true
 edition = "2021"
+license.workspace = true
 
 [lints]
 workspace = true

--- a/ui/app/utils/minijinja/Cargo.toml
+++ b/ui/app/utils/minijinja/Cargo.toml
@@ -3,6 +3,7 @@ name = "minijinja-bindings"
 version.workspace = true
 rust-version.workspace = true
 edition = "2021"
+license.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
This will make sure that we don't accidentally start depending on any GPL-licensed dependencies. I've added all of the license of our current dependnecies to the 'allow' list

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `cargo deny` license check to CI and update `Cargo.toml` files for consistent license management.
> 
>   - **CI Configuration**:
>     - Modify `.github/workflows/general.yml` to run `cargo deny check` instead of `cargo deny check advisories bans`.
>     - Update `.pre-commit-config.yaml` to use `cargo deny check` for pre-commit hook.
>   - **License Management**:
>     - Add `license = "Apache-2.0"` to `Cargo.toml` in the root and set `license.workspace = true` in various `Cargo.toml` files to ensure consistent license declaration across the workspace.
>     - Update `deny.toml` to include a list of allowed licenses, preventing GPL-licensed dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d7954a4d1e7c0e7b969e0d45a6817e7a146e6d9e. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->