### PR TITLE
Use 'cargo chef' when building evaluations binary in ui Dockerfile

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -6,6 +6,14 @@ COPY --from=ghcr.io/astral-sh/uv:0.6.6 /uv /uvx /bin/
 
 RUN npm install -g pnpm
 
+# ========== cargo-chef-planner ==========
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
 # ========== development-dependencies-env ==========
 
 FROM base AS development-dependencies-env
@@ -38,20 +46,17 @@ RUN wasm-pack build --features console_error_panic_hook
 
 # ========== evaluations-build-env ==========
 
-FROM rust:latest AS evaluations-build-env
+FROM chef AS evaluations-build-env
 
 RUN apt-get update && apt-get install -y clang libc++-dev && rm -rf /var/lib/apt/lists/*
-
-COPY . /tensorzero
-
 WORKDIR /tensorzero
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release -p evaluations --recipe-path recipe.json
+COPY . /tensorzero
 
 ARG CARGO_BUILD_FLAGS=""
 
-RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/registry \
-    --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/git \
-    --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/sccache \
-    cargo build --release -p evaluations $CARGO_BUILD_FLAGS && \
+RUN cargo build --release -p evaluations $CARGO_BUILD_FLAGS && \
     cp -r /tensorzero/target/release /release
 
 


### PR DESCRIPTION
We've tried several alternatives:
* Using docker cache mounts ('RUN --mount=type=cache') on Namespace can cause cross-job (!!) cache pollution - cargo can skip rebuilding the target directly if it sees a build timestamp from another job that's newer than the file modification time
* Using sccache doesn't work correctly with multiple concurrent docker stage builders (unless we want to use an S3 backend instead of the filesystem backend)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use `cargo chef` in `ui/Dockerfile` to build `evaluations` binary, replacing Docker cache mounts for improved build reliability.
> 
>   - **Dockerfile Changes**:
>     - Use `cargo chef` in `ui/Dockerfile` for building `evaluations` binary.
>     - Add `cargo-chef-planner` stage to prepare build recipe with `cargo chef prepare`.
>     - Use `cargo chef cook` in `evaluations-build-env` stage to build `evaluations` binary.
>   - **Removed**:
>     - Removed Docker cache mounts for `cargo build` in `evaluations-build-env` stage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ae2a6f97b7e93ad4d8497a9194ee439796ccd572. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->