### PR TITLE
Make 'GCPVertexGeminiProvider::new_shorthand' an async fn

### DIFF
--- a/tensorzero-internal/src/embeddings.rs
+++ b/tensorzero-internal/src/embeddings.rs
@@ -36,7 +36,7 @@ pub type EmbeddingModelTable = BaseModelTable<EmbeddingModelConfig>;
 impl ShorthandModelConfig for EmbeddingModelConfig {
     const SHORTHAND_MODEL_PREFIXES: &[&str] = &["openai::"];
     const MODEL_TYPE: &str = "Embedding model";
-    fn from_shorthand(provider_type: &str, model_name: &str) -> Result<Self, Error> {
+    async fn from_shorthand(provider_type: &str, model_name: &str) -> Result<Self, Error> {
         let model_name = model_name.to_string();
         let provider_config = match provider_type {
             "openai" => {

--- a/tensorzero-internal/src/endpoints/batch_inference.rs
+++ b/tensorzero-internal/src/endpoints/batch_inference.rs
@@ -520,7 +520,8 @@ async fn poll_batch_inference(
     // Retrieve the relevant model provider
     // Call model.poll_batch_inference on it
     let model_config = models
-        .get(batch_request.model_name.as_ref())?
+        .get(batch_request.model_name.as_ref())
+        .await?
         .ok_or_else(|| {
             Error::new(ErrorDetails::InvalidModel {
                 model_name: batch_request.model_name.to_string(),

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
@@ -283,7 +283,7 @@ impl GCPVertexGeminiProvider {
     // * 'projects/<project_id>/locations/<location>/endpoints/XXX'
     //
     // This is *not* a full url - we append ':generateContent' or ':streamGenerateContent' to the end of the path as needed.
-    pub fn new_shorthand(project_url_path: String) -> Result<Self, Error> {
+    pub async fn new_shorthand(project_url_path: String) -> Result<Self, Error> {
         let credentials = build_creds_caching_default_with_fn(
             None,
             default_api_key_location(),

--- a/tensorzero-internal/src/model.rs
+++ b/tensorzero-internal/src/model.rs
@@ -16,7 +16,7 @@ use crate::cache::{
     cache_lookup, cache_lookup_streaming, start_cache_write, start_cache_write_streaming,
     CacheData, ModelProviderRequest, NonStreamingCacheData, StreamingCacheData,
 };
-use crate::config_parser::{ProviderTypesConfig, SKIP_CREDENTIAL_VALIDATION};
+use crate::config_parser::{skip_credential_validation, ProviderTypesConfig};
 use crate::endpoints::inference::InferenceClients;
 use crate::inference::providers::aws_sagemaker::AWSSagemakerProvider;
 #[cfg(any(test, feature = "e2e_tests"))]
@@ -1381,7 +1381,7 @@ impl TryFrom<(CredentialLocation, &str)> for Credential {
             CredentialLocation::Env(key_name) => match env::var(key_name) {
                 Ok(value) => Ok(Credential::Static(SecretString::from(value))),
                 Err(_) => {
-                    if SKIP_CREDENTIAL_VALIDATION.is_set() {
+                    if skip_credential_validation() {
                         #[cfg(any(test, feature = "e2e_tests"))]
                         {
                             tracing::warn!(
@@ -1402,7 +1402,7 @@ impl TryFrom<(CredentialLocation, &str)> for Credential {
                 let path = match env::var(&env_key) {
                     Ok(path) => path,
                     Err(_) => {
-                        if SKIP_CREDENTIAL_VALIDATION.is_set() {
+                        if skip_credential_validation() {
                             #[cfg(any(test, feature = "e2e_tests"))]
                             {
                                 tracing::warn!(
@@ -1425,7 +1425,7 @@ impl TryFrom<(CredentialLocation, &str)> for Credential {
                 match fs::read_to_string(path) {
                     Ok(contents) => Ok(Credential::FileContents(SecretString::from(contents))),
                     Err(e) => {
-                        if SKIP_CREDENTIAL_VALIDATION.is_set() {
+                        if skip_credential_validation() {
                             #[cfg(any(test, feature = "e2e_tests"))]
                             {
                                 tracing::warn!(
@@ -1447,7 +1447,7 @@ impl TryFrom<(CredentialLocation, &str)> for Credential {
             CredentialLocation::Path(path) => match fs::read_to_string(path) {
                 Ok(contents) => Ok(Credential::FileContents(SecretString::from(contents))),
                 Err(e) => {
-                    if SKIP_CREDENTIAL_VALIDATION.is_set() {
+                    if skip_credential_validation() {
                         #[cfg(any(test, feature = "e2e_tests"))]
                         {
                             tracing::warn!(
@@ -1491,7 +1491,7 @@ pub type ModelTable = BaseModelTable<ModelConfig>;
 impl ShorthandModelConfig for ModelConfig {
     const SHORTHAND_MODEL_PREFIXES: &[&str] = SHORTHAND_MODEL_PREFIXES;
     const MODEL_TYPE: &str = "Model";
-    fn from_shorthand(provider_type: &str, model_name: &str) -> Result<Self, Error> {
+    async fn from_shorthand(provider_type: &str, model_name: &str) -> Result<Self, Error> {
         let model_name = model_name.to_string();
         let provider_config = match provider_type {
             "anthropic" => ProviderConfig::Anthropic(AnthropicProvider::new(model_name, None)?),
@@ -1504,9 +1504,9 @@ impl ShorthandModelConfig for ModelConfig {
             "google_ai_studio_gemini" => ProviderConfig::GoogleAIStudioGemini(
                 GoogleAIStudioGeminiProvider::new(model_name, None)?,
             ),
-            "gcp_vertex_gemini" => {
-                ProviderConfig::GCPVertexGemini(GCPVertexGeminiProvider::new_shorthand(model_name)?)
-            }
+            "gcp_vertex_gemini" => ProviderConfig::GCPVertexGemini(
+                GCPVertexGeminiProvider::new_shorthand(model_name).await?,
+            ),
             "hyperbolic" => ProviderConfig::Hyperbolic(HyperbolicProvider::new(model_name, None)?),
             "mistral" => ProviderConfig::Mistral(MistralProvider::new(model_name, None)?),
             "openai" => ProviderConfig::OpenAI(OpenAIProvider::new(model_name, None, None)?),
@@ -1594,6 +1594,7 @@ mod tests {
     use std::{borrow::Cow, cell::Cell};
 
     use crate::cache::CacheEnabledMode;
+    use crate::config_parser::SKIP_CREDENTIAL_VALIDATION;
     use crate::tool::{ToolCallConfig, ToolChoice};
     use crate::{
         cache::CacheOptions,
@@ -2288,8 +2289,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_validate_or_create_model_config() {
+    #[tokio::test]
+    async fn test_validate_or_create_model_config() {
         let model_table = ModelTable::default();
         // Test that we can get or create a model config
         model_table.validate("dummy::gpt-4o").unwrap();
@@ -2297,6 +2298,7 @@ mod tests {
         assert_eq!(model_table.static_model_len(), 0);
         let model_config = model_table
             .get("dummy::gpt-4o")
+            .await
             .unwrap()
             .expect("Missing dummy model");
         assert_eq!(model_config.routing, vec!["dummy".into()]);
@@ -2317,7 +2319,7 @@ mod tests {
             .into()
         );
         // Test that it works with an initialized model
-        let anthropic_provider_config = SKIP_CREDENTIAL_VALIDATION.set(&(), || {
+        let anthropic_provider_config = SKIP_CREDENTIAL_VALIDATION.sync_scope((), || {
             ProviderConfig::Anthropic(AnthropicProvider::new("claude".to_string(), None).unwrap())
         });
         let anthropic_model_config = ModelConfig {

--- a/tensorzero-internal/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-internal/src/variant/best_of_n_sampling.rs
@@ -144,12 +144,12 @@ impl Variant for BestOfNSamplingConfig {
         .into())
     }
 
-    fn validate(
+    async fn validate(
         &self,
         function: &FunctionConfig,
         models: &mut ModelTable,
         embedding_models: &EmbeddingModelTable,
-        templates: &TemplateConfig,
+        templates: &TemplateConfig<'_>,
         function_name: &str,
         variant_name: &str,
     ) -> Result<(), Error> {
@@ -160,31 +160,34 @@ impl Variant for BestOfNSamplingConfig {
                     name: candidate.to_string(),
                 })
             })?;
-            variant
-                .validate(
-                    function,
-                    models,
-                    embedding_models,
-                    templates,
-                    function_name,
-                    candidate,
-                )
-                .map_err(|e| {
-                    Error::new(ErrorDetails::InvalidCandidate {
-                        variant_name: variant_name.to_string(),
-                        message: e.to_string(),
-                    })
-                })?;
+            Box::pin(variant.validate(
+                function,
+                models,
+                embedding_models,
+                templates,
+                function_name,
+                candidate,
+            ))
+            .await
+            .map_err(|e| {
+                Error::new(ErrorDetails::InvalidCandidate {
+                    variant_name: variant_name.to_string(),
+                    message: e.to_string(),
+                })
+            })?
         }
         // Validate the evaluator variant
-        self.evaluator.inner.validate(
-            function,
-            models,
-            embedding_models,
-            templates,
-            function_name,
-            variant_name,
-        )?;
+        self.evaluator
+            .inner
+            .validate(
+                function,
+                models,
+                embedding_models,
+                templates,
+                function_name,
+                variant_name,
+            )
+            .await?;
         Ok(())
     }
 
@@ -425,7 +428,7 @@ async fn inner_select_best_candidate<'a, 'request>(
         // Return the selected index and None for the model inference result
         return Ok((Some(selected_index), None));
     }
-    let model_config = models.get(&evaluator.inner.model)?.ok_or_else(|| {
+    let model_config = models.get(&evaluator.inner.model).await?.ok_or_else(|| {
         Error::new(ErrorDetails::UnknownModel {
             name: evaluator.inner.model.to_string(),
         })

--- a/tensorzero-internal/src/variant/chain_of_thought.rs
+++ b/tensorzero-internal/src/variant/chain_of_thought.rs
@@ -127,12 +127,12 @@ impl Variant for ChainOfThoughtConfig {
         .into())
     }
 
-    fn validate(
+    async fn validate(
         &self,
         function: &FunctionConfig,
         models: &mut ModelTable,
         embedding_models: &EmbeddingModelTable,
-        templates: &TemplateConfig,
+        templates: &TemplateConfig<'_>,
         function_name: &str,
         variant_name: &str,
     ) -> Result<(), Error> {
@@ -145,14 +145,16 @@ impl Variant for ChainOfThoughtConfig {
             }
             .into());
         }
-        self.inner.validate(
-            function,
-            models,
-            embedding_models,
-            templates,
-            function_name,
-            variant_name,
-        )
+        self.inner
+            .validate(
+                function,
+                models,
+                embedding_models,
+                templates,
+                function_name,
+                variant_name,
+            )
+            .await
     }
 
     fn get_all_template_paths(&self) -> Vec<&PathWithContents> {

--- a/tensorzero-internal/src/variant/chat_completion.rs
+++ b/tensorzero-internal/src/variant/chat_completion.rs
@@ -292,7 +292,7 @@ impl Variant for ChatCompletionConfig {
             false,
             &mut inference_params,
         )?;
-        let model_config = models.models.get(&self.model)?.ok_or_else(|| {
+        let model_config = models.models.get(&self.model).await?.ok_or_else(|| {
             Error::new(ErrorDetails::UnknownModel {
                 name: self.model.to_string(),
             })
@@ -327,7 +327,7 @@ impl Variant for ChatCompletionConfig {
             true,
             &mut inference_params,
         )?;
-        let model_config = models.models.get(&self.model)?.ok_or_else(|| {
+        let model_config = models.models.get(&self.model).await?.ok_or_else(|| {
             Error::new(ErrorDetails::UnknownModel {
                 name: self.model.to_string(),
             })
@@ -351,12 +351,12 @@ impl Variant for ChatCompletionConfig {
     ///    - If the template requires variables, the schema is provided.
     ///  - That the model name is a valid model
     ///  - That the weight is non-negative
-    fn validate(
+    async fn validate(
         &self,
         function: &FunctionConfig,
         models: &mut ModelTable,
         _embedding_models: &EmbeddingModelTable,
-        templates: &TemplateConfig,
+        templates: &TemplateConfig<'_>,
         function_name: &str,
         variant_name: &str,
     ) -> Result<(), Error> {
@@ -451,7 +451,7 @@ impl Variant for ChatCompletionConfig {
                 self.prepare_request(input, function, inference_config, false, inference_param)?;
             inference_requests.push(request);
         }
-        let model_config = models.models.get(&self.model)?.ok_or_else(|| {
+        let model_config = models.models.get(&self.model).await?.ok_or_else(|| {
             Error::new(ErrorDetails::UnknownModel {
                 name: self.model.to_string(),
             })

--- a/tensorzero-internal/src/variant/dicl.rs
+++ b/tensorzero-internal/src/variant/dicl.rs
@@ -121,7 +121,7 @@ impl Variant for DiclConfig {
             &mut inference_params,
         )?;
 
-        let model_config = models.models.get(&self.model)?.ok_or_else(|| {
+        let model_config = models.models.get(&self.model).await?.ok_or_else(|| {
             Error::new(ErrorDetails::UnknownModel {
                 name: self.model.to_string(),
             })
@@ -186,7 +186,7 @@ impl Variant for DiclConfig {
             &mut inference_params,
         )?;
 
-        let model_config = models.models.get(&self.model)?.ok_or_else(|| {
+        let model_config = models.models.get(&self.model).await?.ok_or_else(|| {
             Error::new(ErrorDetails::UnknownModel {
                 name: self.model.to_string(),
             })
@@ -211,12 +211,12 @@ impl Variant for DiclConfig {
         Ok((inference_result_stream, model_used_info))
     }
 
-    fn validate(
+    async fn validate(
         &self,
         _function: &FunctionConfig,
         models: &mut ModelTable,
         embedding_models: &EmbeddingModelTable,
-        _templates: &TemplateConfig,
+        _templates: &TemplateConfig<'_>,
         function_name: &str,
         variant_name: &str,
     ) -> Result<(), Error> {
@@ -237,7 +237,7 @@ impl Variant for DiclConfig {
         // Validate that the generation model and embedding model are valid
         models.validate(&self.model)?;
         let embedding_model = embedding_models
-            .get(&self.embedding_model)?
+            .get(&self.embedding_model).await?
             .ok_or_else(|| Error::new(ErrorDetails::Config {
                 message: format!(
                     "`functions.{function_name}.variants.{variant_name}`: `embedding_model` must be a valid embedding model name"
@@ -320,7 +320,8 @@ impl DiclConfig {
         })?;
 
         let embedding_model = embedding_models
-            .get(&self.embedding_model)?
+            .get(&self.embedding_model)
+            .await?
             .ok_or_else(|| {
                 Error::new(ErrorDetails::Inference {
                     message: format!("Embedding model {} not found", self.embedding_model),

--- a/tensorzero-internal/src/variant/mod.rs
+++ b/tensorzero-internal/src/variant/mod.rs
@@ -155,7 +155,7 @@ pub trait Variant {
         inference_params: InferenceParams,
     ) -> Result<(InferenceResultStream, ModelUsedInfo), Error>;
 
-    fn validate(
+    async fn validate(
         &self,
         function: &FunctionConfig,
         models: &mut ModelTable,
@@ -376,56 +376,76 @@ impl Variant for VariantConfig {
     }
 
     #[instrument(skip_all, fields(variant_name = %variant_name))]
-    fn validate(
+    async fn validate(
         &self,
         function: &FunctionConfig,
         models: &mut ModelTable,
         embedding_models: &EmbeddingModelTable,
-        templates: &TemplateConfig,
+        templates: &TemplateConfig<'_>,
         function_name: &str,
         variant_name: &str,
     ) -> Result<(), Error> {
         match self {
-            VariantConfig::ChatCompletion(params) => params.validate(
-                function,
-                models,
-                embedding_models,
-                templates,
-                function_name,
-                variant_name,
-            ),
-            VariantConfig::BestOfNSampling(params) => params.validate(
-                function,
-                models,
-                embedding_models,
-                templates,
-                function_name,
-                variant_name,
-            ),
-            VariantConfig::Dicl(params) => params.validate(
-                function,
-                models,
-                embedding_models,
-                templates,
-                function_name,
-                variant_name,
-            ),
-            VariantConfig::MixtureOfN(params) => params.validate(
-                function,
-                models,
-                embedding_models,
-                templates,
-                function_name,
-                variant_name,
-            ),
-            VariantConfig::ChainOfThought(params) => params.validate(
-                function,
-                models,
-                embedding_models,
-                templates,
-                function_name,
-                variant_name,
-            ),
+            VariantConfig::ChatCompletion(params) => {
+                params
+                    .validate(
+                        function,
+                        models,
+                        embedding_models,
+                        templates,
+                        function_name,
+                        variant_name,
+                    )
+                    .await
+            }
+            VariantConfig::BestOfNSampling(params) => {
+                params
+                    .validate(
+                        function,
+                        models,
+                        embedding_models,
+                        templates,
+                        function_name,
+                        variant_name,
+                    )
+                    .await
+            }
+            VariantConfig::Dicl(params) => {
+                params
+                    .validate(
+                        function,
+                        models,
+                        embedding_models,
+                        templates,
+                        function_name,
+                        variant_name,
+                    )
+                    .await
+            }
+            VariantConfig::MixtureOfN(params) => {
+                params
+                    .validate(
+                        function,
+                        models,
+                        embedding_models,
+                        templates,
+                        function_name,
+                        variant_name,
+                    )
+                    .await
+            }
+            VariantConfig::ChainOfThought(params) => {
+                params
+                    .validate(
+                        function,
+                        models,
+                        embedding_models,
+                        templates,
+                        function_name,
+                        variant_name,
+                    )
+                    .await
+            }
         }
     }
 


### PR DESCRIPTION
This is not currently used, but will be once we start supporting GCP SDK credentials from shorthand models (which require calling an `async fn`).

As a result, many functions up the call stack need to become `async`. This is mostly straightforward, with two notable exceptions:
* We now call `Box::pin` in some of the `validate` functions, as the compiler will otherwise reject the recursive calls from best_of_n/mixture_of_n
* The SKIP_CREDENTIAL_VALIDATION thread-local is now a Tokio task-local, since we need to set it for the duration of a future (which can be moved between threads by the Tokio runtime)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
