### PR TITLE
Add 'original_chunk' field when 'include_original_response' is set

### DIFF
--- a/tensorzero-internal/src/endpoints/inference.rs
+++ b/tensorzero-internal/src/endpoints/inference.rs
@@ -129,6 +129,7 @@ struct InferenceMetadata {
     pub cached: bool,
     pub extra_body: UnfilteredInferenceExtraBody,
     pub extra_headers: UnfilteredInferenceExtraHeaders,
+    pub include_original_response: bool,
 }
 
 pub type InferenceCredentials = HashMap<String, SecretString>;
@@ -218,14 +219,6 @@ pub async fn inference(
     let inference_id = Uuid::now_v7();
     span.record("inference_id", inference_id.to_string());
     validate_tags(&params.tags, params.internal)?;
-
-    if params.include_original_response && params.stream.unwrap_or(false) {
-        return Err(ErrorDetails::InvalidRequest {
-            message: "Cannot set both `include_original_response` and `stream` to `true`"
-                .to_string(),
-        }
-        .into());
-    }
 
     // Retrieve or generate the episode ID
     let episode_id = params.episode_id.unwrap_or(Uuid::now_v7());
@@ -408,6 +401,7 @@ pub async fn inference(
                 cached: model_used_info.cached,
                 extra_body,
                 extra_headers,
+                include_original_response: params.include_original_response,
             };
 
             let stream = create_stream(
@@ -609,6 +603,7 @@ fn create_stream(
                 cached,
                 extra_body,
                 extra_headers,
+                include_original_response: _,
             } = metadata;
 
             let config = config.clone();
@@ -685,6 +680,7 @@ fn prepare_response_chunk(
         metadata.episode_id,
         metadata.variant_name.clone(),
         metadata.cached,
+        metadata.include_original_response,
     )
 }
 
@@ -960,6 +956,8 @@ pub struct ChatInferenceResponseChunk {
     pub usage: Option<Usage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub finish_reason: Option<FinishReason>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original_chunk: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -972,6 +970,8 @@ pub struct JsonInferenceResponseChunk {
     pub usage: Option<Usage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub finish_reason: Option<FinishReason>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original_chunk: Option<String>,
 }
 
 const ZERO_USAGE: Usage = Usage {
@@ -986,6 +986,7 @@ impl InferenceResponseChunk {
         episode_id: Uuid,
         variant_name: String,
         cached: bool,
+        include_original_response: bool,
     ) -> Option<Self> {
         Some(match inference_result {
             InferenceResultChunk::Chat(result) => {
@@ -1002,6 +1003,7 @@ impl InferenceResponseChunk {
                         result.usage
                     },
                     finish_reason: result.finish_reason,
+                    original_chunk: include_original_response.then_some(result.raw_response),
                 })
             }
             InferenceResultChunk::Json(result) => {
@@ -1021,6 +1023,7 @@ impl InferenceResponseChunk {
                         result.usage
                     },
                     finish_reason: result.finish_reason,
+                    original_chunk: include_original_response.then_some(result.raw_response),
                 })
             }
         })
@@ -1172,6 +1175,7 @@ mod tests {
             cached: false,
             extra_body: Default::default(),
             extra_headers: Default::default(),
+            include_original_response: false,
         };
 
         let result = prepare_response_chunk(&inference_metadata, chunk).unwrap();
@@ -1223,6 +1227,7 @@ mod tests {
             cached: false,
             extra_body: Default::default(),
             extra_headers: Default::default(),
+            include_original_response: false,
         };
 
         let result = prepare_response_chunk(&inference_metadata, chunk).unwrap();

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -203,6 +203,7 @@ macro_rules! generate_provider_tests {
         use $crate::providers::common::test_streaming_invalid_request_with_provider;
         use $crate::providers::common::test_json_mode_off_inference_request_with_provider;
         use $crate::providers::common::test_multiple_text_blocks_in_message_with_provider;
+        use $crate::providers::common::test_streaming_include_original_response_with_provider;
 
         #[tokio::test]
         async fn test_simple_inference_request() {
@@ -245,6 +246,14 @@ macro_rules! generate_provider_tests {
             let providers = $func().await.shorthand_inference;
             for provider in providers {
                 test_simple_inference_request_with_provider(provider).await;
+            }
+        }
+
+        #[tokio::test]
+        async fn test_streaming_include_original_response() {
+            let providers = $func().await.simple_inference;
+            for provider in providers {
+                test_streaming_include_original_response_with_provider(provider).await;
             }
         }
 
@@ -2380,12 +2389,34 @@ pub async fn test_simple_streaming_inference_request_with_provider(provider: E2E
     let seed = rand::rng().random_range(0..u32::MAX);
 
     let original_content = test_simple_streaming_inference_request_with_provider_cache(
-        &provider, episode_id, seed, &tag_value, false,
+        &provider, episode_id, seed, &tag_value, false, false,
     )
     .await;
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     let cached_content = test_simple_streaming_inference_request_with_provider_cache(
-        &provider, episode_id, seed, &tag_value, true,
+        &provider, episode_id, seed, &tag_value, true, false,
+    )
+    .await;
+    assert_eq!(original_content, cached_content);
+}
+
+pub async fn test_streaming_include_original_response_with_provider(provider: E2ETestProvider) {
+    // We use a serverless Sagemaker endpoint, which doesn't support streaming
+    if provider.variant_name == "aws-sagemaker-tgi" {
+        return;
+    }
+    let episode_id = Uuid::now_v7();
+    let tag_value = Uuid::now_v7().to_string();
+    // Generate random u32
+    let seed = rand::rng().random_range(0..u32::MAX);
+
+    let original_content = test_simple_streaming_inference_request_with_provider_cache(
+        &provider, episode_id, seed, &tag_value, false, true,
+    )
+    .await;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    let cached_content = test_simple_streaming_inference_request_with_provider_cache(
+        &provider, episode_id, seed, &tag_value, true, true,
     )
     .await;
     assert_eq!(original_content, cached_content);
@@ -2397,6 +2428,7 @@ pub async fn test_simple_streaming_inference_request_with_provider_cache(
     seed: u32,
     tag_value: &str,
     check_cache: bool,
+    include_original_response: bool,
 ) -> String {
     let extra_headers = get_extra_headers();
     let payload = json!({
@@ -2413,6 +2445,7 @@ pub async fn test_simple_streaming_inference_request_with_provider_cache(
                 }
             ]},
         "stream": true,
+        "include_original_response": include_original_response,
         "tags": {"key": tag_value},
         "cache_options": {"enabled": "on", "lookback_s": 10},
         "extra_headers": extra_headers.headers,
@@ -2450,6 +2483,13 @@ pub async fn test_simple_streaming_inference_request_with_provider_cache(
         let chunk_json: Value = serde_json::from_str(&chunk).unwrap();
 
         println!("API response chunk: {chunk_json:#?}");
+
+        // The `original_chunk` field shouuld only be set if we enable the `include_original_response` flag
+        if include_original_response {
+            assert!(chunk_json.get("original_chunk").is_some());
+        } else {
+            assert_eq!(chunk_json.get("original_chunk"), None);
+        }
 
         let chunk_inference_id = chunk_json.get("inference_id").unwrap().as_str().unwrap();
         let chunk_inference_id = Uuid::parse_str(chunk_inference_id).unwrap();


### PR DESCRIPTION
Fixes #1335

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
