### PR TITLE
Inspect fixtures with parquet-tools after downloading

### DIFF
--- a/ui/fixtures/download-fixtures.py
+++ b/ui/fixtures/download-fixtures.py
@@ -106,6 +106,10 @@ def main():
     with concurrent.futures.ThreadPoolExecutor() as executor:
         executor.map(process_fixture, FIXTURES)
 
+    for fixture in FIXTURES:
+        print(f"Fixture {fixture}:")
+        os.system(f"parquet-tools inspect {S3_FIXTURES_DIR / fixture}")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
We saw a very concerning spurious failure in
https://github.com/tensorzero/tensorzero/actions/runs/15309390301/job/43070144785

Our `download-fixtures.py` script checks the ETag on the on-disk file after downloading, but ClickHouse gave us the following error when './s3-fixtures/large_chat_demonstration_feedback.parquet' was loaded:

```
 fixtures-1    | + clickhouse-client --host clickhouse --user chuser --password chpassword --database tensorzero_ui_fixtures --query 'INSERT INTO DemonstrationFeedback FROM INFILE '\''./s3-fixtures/large_chat_demonstration_feedback.parquet'\'' FORMAT Parquet'
fixtures-1    | Error on processing query: std::exception. Code: 1001, type: parquet::ParquetInvalidOrCorruptedFileException, e.what() = Invalid: Parquet magic bytes not found in footer. Either the file is corrupted or this is not a parquet file. (version 24.12.6.70 (official build))
```

Let's use `parquet-tools inspect` to print out our downloaded files - if this issue ever happens again, it should give us more information about exactly what happened.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
