### PR TITLE
Always use original text for 'raw_response' in streaming

### DIFF
--- a/tensorzero-internal/src/inference/providers/anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/anthropic.rs
@@ -373,6 +373,7 @@ fn stream_anthropic(
 
                         let response = data.and_then(|data| {
                             anthropic_to_tensorzero_stream_message(
+                                message.data,
                                 data,
                                 start_time.elapsed(),
                                 &mut current_tool_id,
@@ -1090,19 +1091,12 @@ enum AnthropicStreamMessage {
 /// There is no need to do the same bookkeeping for TextDelta chunks since they come with an index (which we use as an ID for a text chunk).
 /// See the Anthropic [docs](https://docs.anthropic.com/en/api/messages-streaming) on streaming messages for details on the types of events and their semantics.
 fn anthropic_to_tensorzero_stream_message(
+    raw_message: String,
     message: AnthropicStreamMessage,
     message_latency: Duration,
     current_tool_id: &mut Option<String>,
     current_tool_name: &mut Option<String>,
 ) -> Result<Option<ProviderInferenceResponseChunk>, Error> {
-    let raw_message = serde_json::to_string(&message).map_err(|e| {
-        Error::new(ErrorDetails::Serialization {
-            message: format!(
-                "Error serializing stream message from Anthropic: {}",
-                DisplayOrDebugGateway::new(e)
-            ),
-        })
-    })?;
     match message {
         AnthropicStreamMessage::ContentBlockDelta { delta, index } => match delta {
             AnthropicMessageBlock::TextDelta { text } => {
@@ -2217,6 +2211,7 @@ mod tests {
         };
         let latency = Duration::from_millis(100);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             content_block_delta,
             latency,
             &mut current_tool_id,
@@ -2245,6 +2240,7 @@ mod tests {
         };
         let latency = Duration::from_millis(100);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             content_block_delta,
             latency,
             &mut current_tool_id,
@@ -2272,6 +2268,7 @@ mod tests {
         };
         let latency = Duration::from_millis(100);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             content_block_delta,
             latency,
             &mut current_tool_id,
@@ -2302,6 +2299,7 @@ mod tests {
         };
         let latency = Duration::from_millis(110);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             content_block_start,
             latency,
             &mut current_tool_id,
@@ -2332,6 +2330,7 @@ mod tests {
         };
         let latency = Duration::from_millis(120);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             content_block_start,
             latency,
             &mut current_tool_id,
@@ -2359,6 +2358,7 @@ mod tests {
         };
         let latency = Duration::from_millis(130);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             content_block_start,
             latency,
             &mut current_tool_id,
@@ -2381,6 +2381,7 @@ mod tests {
         let content_block_stop = AnthropicStreamMessage::ContentBlockStop { index: 2 };
         let latency = Duration::from_millis(120);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             content_block_stop,
             latency,
             &mut current_tool_id,
@@ -2395,6 +2396,7 @@ mod tests {
         };
         let latency = Duration::from_millis(130);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             error_message,
             latency,
             &mut current_tool_id,
@@ -2421,6 +2423,7 @@ mod tests {
         };
         let latency = Duration::from_millis(140);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             message_delta,
             latency,
             &mut current_tool_id,
@@ -2442,6 +2445,7 @@ mod tests {
         };
         let latency = Duration::from_millis(150);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             message_start,
             latency,
             &mut current_tool_id,
@@ -2460,6 +2464,7 @@ mod tests {
         let message_stop = AnthropicStreamMessage::MessageStop;
         let latency = Duration::from_millis(160);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             message_stop,
             latency,
             &mut current_tool_id,
@@ -2472,6 +2477,7 @@ mod tests {
         let ping = AnthropicStreamMessage::Ping {};
         let latency = Duration::from_millis(170);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             ping,
             latency,
             &mut current_tool_id,

--- a/tensorzero-internal/src/inference/providers/deepseek.rs
+++ b/tensorzero-internal/src/inference/providers/deepseek.rs
@@ -458,7 +458,7 @@ fn stream_deepseek(
 
                         let latency = start_time.elapsed();
                         let stream_message = data.and_then(|d| {
-                            deepseek_to_tensorzero_chunk(d, latency, &mut tool_call_ids, &mut tool_call_names)
+                            deepseek_to_tensorzero_chunk(message.data, d, latency, &mut tool_call_ids, &mut tool_call_names)
                         });
                         yield stream_message;
                     }
@@ -515,22 +515,12 @@ struct DeepSeekChatChunk {
 
 /// Maps a DeepSeek chunk to a TensorZero chunk for streaming inferences
 fn deepseek_to_tensorzero_chunk(
+    raw_message: String,
     mut chunk: DeepSeekChatChunk,
     latency: Duration,
     tool_call_ids: &mut Vec<String>,
     tool_names: &mut Vec<String>,
 ) -> Result<ProviderInferenceResponseChunk, Error> {
-    let raw_message = serde_json::to_string(&chunk).map_err(|e| {
-        Error::new(ErrorDetails::InferenceServer {
-            message: format!(
-                "Error parsing response from DeepSeek: {}",
-                DisplayOrDebugGateway::new(e)
-            ),
-            raw_request: None,
-            raw_response: Some(serde_json::to_string(&chunk).unwrap_or_default()),
-            provider_type: PROVIDER_TYPE.to_string(),
-        })
-    })?;
     if chunk.choices.len() > 1 {
         return Err(ErrorDetails::InferenceServer {
             message: "Response has invalid number of choices: {}. Expected 1.".to_string(),

--- a/tensorzero-internal/src/inference/providers/fireworks.rs
+++ b/tensorzero-internal/src/inference/providers/fireworks.rs
@@ -600,7 +600,7 @@ fn stream_fireworks(
 
                         let latency = start_time.elapsed();
                         let stream_message = data.and_then(|d| {
-                            fireworks_to_tensorzero_chunk(d, latency, &mut tool_call_ids, &mut tool_call_names, &mut thinking_state, parse_think_blocks)
+                            fireworks_to_tensorzero_chunk(message.data, d, latency, &mut tool_call_ids, &mut tool_call_names, &mut thinking_state, parse_think_blocks)
                         });
                         yield stream_message;
                     }
@@ -618,6 +618,7 @@ fn stream_fireworks(
 /// It processes the content and tool calls from the Fireworks response, updating the tool call IDs and names.
 /// If parsing think blocks is enabled, it also processes the thinking state and extracts reasoning.
 fn fireworks_to_tensorzero_chunk(
+    raw_message: String,
     mut chunk: FireworksChatChunk,
     latency: Duration,
     tool_call_ids: &mut Vec<String>,
@@ -625,17 +626,6 @@ fn fireworks_to_tensorzero_chunk(
     thinking_state: &mut ThinkingState,
     parse_think_blocks: bool,
 ) -> Result<ProviderInferenceResponseChunk, Error> {
-    let raw_message = serde_json::to_string(&chunk).map_err(|e| {
-        Error::new(ErrorDetails::InferenceServer {
-            message: format!(
-                "Error parsing response from Fireworks: {}",
-                DisplayOrDebugGateway::new(e)
-            ),
-            raw_request: None,
-            raw_response: Some(serde_json::to_string(&chunk).unwrap_or_default()),
-            provider_type: PROVIDER_TYPE.to_string(),
-        })
-    })?;
     if chunk.choices.len() > 1 {
         return Err(ErrorDetails::InferenceServer {
             message: "Response has invalid number of choices: {}. Expected 1.".to_string(),
@@ -1131,6 +1121,7 @@ mod tests {
         let mut tool_call_names = vec!["name1".to_string()];
         let mut thinking_state = ThinkingState::Normal;
         let message = fireworks_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -1168,6 +1159,7 @@ mod tests {
             usage: None,
         };
         let message = fireworks_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -1197,6 +1189,7 @@ mod tests {
             }),
         };
         let message = fireworks_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -1236,6 +1229,7 @@ mod tests {
 
         // With parsing enabled
         let result = fireworks_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(100),
             &mut tool_call_ids,
@@ -1263,6 +1257,7 @@ mod tests {
         };
 
         let result = fireworks_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk,
             Duration::from_millis(100),
             &mut tool_call_ids,
@@ -1295,6 +1290,7 @@ mod tests {
         };
 
         let result = fireworks_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk,
             Duration::from_millis(100),
             &mut tool_call_ids,
@@ -1322,6 +1318,7 @@ mod tests {
         };
 
         let result = fireworks_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk,
             Duration::from_millis(100),
             &mut tool_call_ids,
@@ -1358,6 +1355,7 @@ mod tests {
         let mut tool_call_names = vec![];
         let mut thinking_state = ThinkingState::Normal;
         let message = fireworks_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk,
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -1401,6 +1399,7 @@ mod tests {
         let mut thinking_state = ThinkingState::Normal;
 
         let result = fireworks_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk,
             Duration::from_millis(100),
             &mut tool_call_ids,
@@ -1443,6 +1442,7 @@ mod tests {
         };
 
         let result = fireworks_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk,
             Duration::from_millis(100),
             &mut tool_call_ids,

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
@@ -316,6 +316,7 @@ fn stream_anthropic(
 
                         let response = data.and_then(|data| {
                             anthropic_to_tensorzero_stream_message(
+                                message.data,
                                 data,
                                 start_time.elapsed(),
                                 &mut current_tool_id,
@@ -917,19 +918,12 @@ enum GCPVertexAnthropicStreamMessage {
 /// There is no need to do the same bookkeeping for TextDelta chunks since they come with an index (which we use as an ID for a text chunk).
 /// See the Anthropic [docs](https://docs.anthropic.com/en/api/messages-streaming) on streaming messages for details on the types of events and their semantics.
 fn anthropic_to_tensorzero_stream_message(
+    raw_message: String,
     message: GCPVertexAnthropicStreamMessage,
     message_latency: Duration,
     current_tool_id: &mut Option<String>,
     current_tool_name: &mut Option<String>,
 ) -> Result<Option<ProviderInferenceResponseChunk>, Error> {
-    let raw_message = serde_json::to_string(&message).map_err(|e| {
-        Error::new(ErrorDetails::Serialization {
-            message: format!(
-                "Error parsing response from Anthropic: {}",
-                DisplayOrDebugGateway::new(e)
-            ),
-        })
-    })?;
     match message {
         GCPVertexAnthropicStreamMessage::ContentBlockDelta { delta, index } => match delta {
             GCPVertexAnthropicMessageBlock::TextDelta { text } => {
@@ -2093,6 +2087,7 @@ mod tests {
         };
         let latency = Duration::from_millis(100);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             content_block_delta,
             latency,
             &mut current_tool_id,
@@ -2121,6 +2116,7 @@ mod tests {
         };
         let latency = Duration::from_millis(100);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             content_block_delta,
             latency,
             &mut current_tool_id,
@@ -2148,6 +2144,7 @@ mod tests {
         };
         let latency = Duration::from_millis(100);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             content_block_delta,
             latency,
             &mut current_tool_id,
@@ -2178,6 +2175,7 @@ mod tests {
         };
         let latency = Duration::from_millis(110);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             content_block_start,
             latency,
             &mut current_tool_id,
@@ -2208,6 +2206,7 @@ mod tests {
         };
         let latency = Duration::from_millis(120);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             content_block_start,
             latency,
             &mut current_tool_id,
@@ -2235,6 +2234,7 @@ mod tests {
         };
         let latency = Duration::from_millis(130);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             content_block_start,
             latency,
             &mut current_tool_id,
@@ -2255,6 +2255,7 @@ mod tests {
         let content_block_stop = GCPVertexAnthropicStreamMessage::ContentBlockStop { index: 2 };
         let latency = Duration::from_millis(120);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             content_block_stop,
             latency,
             &mut current_tool_id,
@@ -2269,6 +2270,7 @@ mod tests {
         };
         let latency = Duration::from_millis(130);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             error_message,
             latency,
             &mut current_tool_id,
@@ -2295,6 +2297,7 @@ mod tests {
         };
         let latency = Duration::from_millis(140);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             message_delta,
             latency,
             &mut current_tool_id,
@@ -2315,6 +2318,7 @@ mod tests {
         };
         let latency = Duration::from_millis(150);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             message_start,
             latency,
             &mut current_tool_id,
@@ -2333,6 +2337,7 @@ mod tests {
         let message_stop = GCPVertexAnthropicStreamMessage::MessageStop;
         let latency = Duration::from_millis(160);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             message_stop,
             latency,
             &mut current_tool_id,
@@ -2345,6 +2350,7 @@ mod tests {
         let ping = GCPVertexAnthropicStreamMessage::Ping {};
         let latency = Duration::from_millis(170);
         let result = anthropic_to_tensorzero_stream_message(
+            "my_raw_chunk".to_string(),
             ping,
             latency,
             &mut current_tool_id,

--- a/tensorzero-internal/src/inference/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/google_ai_studio_gemini.rs
@@ -357,6 +357,7 @@ fn stream_google_ai_studio_gemini(
                             }
                         };
                         yield GoogleAIStudioGeminiResponseWithMetadata {
+                            raw_response: message.data,
                             response: data,
                             latency: start_time.elapsed(),
                         }.try_into();
@@ -949,26 +950,23 @@ impl<'a> TryFrom<GeminiResponseWithMetadata<'a>> for ProviderInferenceResponse {
 struct GoogleAIStudioGeminiResponseWithMetadata {
     response: GeminiResponse,
     latency: Duration,
+    raw_response: String,
 }
 
 impl TryFrom<GoogleAIStudioGeminiResponseWithMetadata> for ProviderInferenceResponseChunk {
     type Error = Error;
     fn try_from(response: GoogleAIStudioGeminiResponseWithMetadata) -> Result<Self, Self::Error> {
-        let GoogleAIStudioGeminiResponseWithMetadata { response, latency } = response;
-
-        let raw = serde_json::to_string(&response).map_err(|e| {
-            Error::new(ErrorDetails::Serialization {
-                message: format!(
-                    "Error serializing streaming response from Google AI Studio Gemini: {e}"
-                ),
-            })
-        })?;
+        let GoogleAIStudioGeminiResponseWithMetadata {
+            response,
+            latency,
+            raw_response,
+        } = response;
 
         let first_candidate = response.candidates.into_iter().next().ok_or_else(|| {
             Error::new(ErrorDetails::InferenceServer {
                 message: "Google AI Studio Gemini response has no candidates".to_string(),
                 raw_request: None,
-                raw_response: Some(raw.clone()),
+                raw_response: Some(raw_response.clone()),
                 provider_type: PROVIDER_TYPE.to_string(),
             })
         })?;
@@ -997,7 +995,7 @@ impl TryFrom<GoogleAIStudioGeminiResponseWithMetadata> for ProviderInferenceResp
         Ok(ProviderInferenceResponseChunk::new(
             content,
             usage,
-            raw,
+            raw_response,
             latency,
             first_candidate
                 .finish_reason
@@ -1897,6 +1895,7 @@ mod tests {
         };
 
         let response_with_metadata = GoogleAIStudioGeminiResponseWithMetadata {
+            raw_response: "my_raw_chunk".to_string(),
             response,
             latency: Duration::from_millis(100),
         };
@@ -1943,6 +1942,7 @@ mod tests {
         };
 
         let response_with_metadata = GoogleAIStudioGeminiResponseWithMetadata {
+            raw_response: "my_raw_chunk".to_string(),
             response,
             latency: Duration::from_millis(50),
         };
@@ -1986,6 +1986,7 @@ mod tests {
         };
 
         let response_with_metadata = GoogleAIStudioGeminiResponseWithMetadata {
+            raw_response: "my_raw_chunk".to_string(),
             response,
             latency: Duration::from_millis(75),
         };
@@ -2025,6 +2026,7 @@ mod tests {
         };
 
         let response_with_metadata = GoogleAIStudioGeminiResponseWithMetadata {
+            raw_response: "my_raw_chunk".to_string(),
             response,
             latency: Duration::from_millis(120),
         };
@@ -2065,6 +2067,7 @@ mod tests {
         };
 
         let response_with_metadata = GoogleAIStudioGeminiResponseWithMetadata {
+            raw_response: "my_raw_chunk".to_string(),
             response,
             latency: Duration::from_millis(60),
         };
@@ -2097,6 +2100,7 @@ mod tests {
         };
 
         let response_with_metadata = GoogleAIStudioGeminiResponseWithMetadata {
+            raw_response: "my_raw_chunk".to_string(),
             response,
             latency: Duration::from_millis(30),
         };
@@ -2159,6 +2163,7 @@ mod tests {
             };
 
             let response_with_metadata = GoogleAIStudioGeminiResponseWithMetadata {
+                raw_response: "my_raw_chunk".to_string(),
                 response,
                 latency: Duration::from_millis(10),
             };

--- a/tensorzero-internal/src/inference/providers/openai.rs
+++ b/tensorzero-internal/src/inference/providers/openai.rs
@@ -825,7 +825,7 @@ pub fn stream_openai(
 
                         let latency = start_time.elapsed();
                         let stream_message = data.and_then(|d| {
-                            openai_to_tensorzero_chunk(d, latency, &mut tool_call_ids, &mut tool_call_names)
+                            openai_to_tensorzero_chunk(message.data, d, latency, &mut tool_call_ids, &mut tool_call_names)
                         });
                         yield stream_message;
                     }
@@ -1909,22 +1909,12 @@ struct OpenAIChatChunk {
 
 /// Maps an OpenAI chunk to a TensorZero chunk for streaming inferences
 fn openai_to_tensorzero_chunk(
+    raw_message: String,
     mut chunk: OpenAIChatChunk,
     latency: Duration,
     tool_call_ids: &mut Vec<String>,
     tool_names: &mut Vec<String>,
 ) -> Result<ProviderInferenceResponseChunk, Error> {
-    let raw_message = serde_json::to_string(&chunk).map_err(|e| {
-        Error::new(ErrorDetails::InferenceServer {
-            message: format!(
-                "Error parsing response from OpenAI: {}",
-                DisplayOrDebugGateway::new(e)
-            ),
-            raw_request: None,
-            raw_response: Some(serde_json::to_string(&chunk).unwrap_or_default()),
-            provider_type: PROVIDER_TYPE.to_string(),
-        })
-    })?;
     if chunk.choices.len() > 1 {
         return Err(ErrorDetails::InferenceServer {
             message: "Response has invalid number of choices: {}. Expected 1.".to_string(),
@@ -3098,6 +3088,7 @@ mod tests {
         let mut tool_call_ids = vec!["id1".to_string()];
         let mut tool_call_names = vec!["name1".to_string()];
         let message = openai_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -3131,6 +3122,7 @@ mod tests {
             usage: None,
         };
         let message = openai_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -3165,6 +3157,7 @@ mod tests {
             usage: None,
         };
         let error = openai_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -3200,6 +3193,7 @@ mod tests {
             usage: None,
         };
         let message = openai_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -3233,6 +3227,7 @@ mod tests {
             }),
         };
         let message = openai_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,

--- a/tensorzero-internal/src/inference/providers/openrouter.rs
+++ b/tensorzero-internal/src/inference/providers/openrouter.rs
@@ -414,7 +414,7 @@ pub fn stream_openrouter(
 
                         let latency = start_time.elapsed();
                         let stream_message = data.and_then(|d| {
-                            openrouter_to_tensorzero_chunk(d, latency, &mut tool_call_ids, &mut tool_call_names)
+                            openrouter_to_tensorzero_chunk(message.data, d, latency, &mut tool_call_ids, &mut tool_call_names)
                         });
                         yield stream_message;
                     }
@@ -1378,22 +1378,12 @@ struct OpenRouterChatChunk {
 
 /// Maps an OpenRouter chunk to a TensorZero chunk for streaming inferences
 fn openrouter_to_tensorzero_chunk(
+    raw_message: String,
     mut chunk: OpenRouterChatChunk,
     latency: Duration,
     tool_call_ids: &mut Vec<String>,
     tool_names: &mut Vec<String>,
 ) -> Result<ProviderInferenceResponseChunk, Error> {
-    let raw_message = serde_json::to_string(&chunk).map_err(|e| {
-        Error::new(ErrorDetails::InferenceServer {
-            message: format!(
-                "Error parsing response from OpenRouter: {}",
-                DisplayOrDebugGateway::new(e)
-            ),
-            raw_request: None,
-            raw_response: Some(serde_json::to_string(&chunk).unwrap_or_default()),
-            provider_type: PROVIDER_TYPE.to_string(),
-        })
-    })?;
     if chunk.choices.len() > 1 {
         return Err(ErrorDetails::InferenceServer {
             message: "Response has invalid number of choices: {}. Expected 1.".to_string(),
@@ -2339,6 +2329,7 @@ mod tests {
         let mut tool_call_ids = vec!["id1".to_string()];
         let mut tool_call_names = vec!["name1".to_string()];
         let message = openrouter_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -2372,6 +2363,7 @@ mod tests {
             usage: None,
         };
         let message = openrouter_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -2406,6 +2398,7 @@ mod tests {
             usage: None,
         };
         let error = openrouter_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -2441,6 +2434,7 @@ mod tests {
             usage: None,
         };
         let message = openrouter_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -2474,6 +2468,7 @@ mod tests {
             }),
         };
         let message = openrouter_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,

--- a/tensorzero-internal/src/inference/providers/together.rs
+++ b/tensorzero-internal/src/inference/providers/together.rs
@@ -645,7 +645,7 @@ fn stream_together(
 
                         let latency = start_time.elapsed();
                         let stream_message = data.and_then(|d| {
-                            together_to_tensorzero_chunk(d, latency, &mut tool_call_ids, &mut tool_call_names, &mut thinking_state, parse_think_blocks)
+                            together_to_tensorzero_chunk(message.data, d, latency, &mut tool_call_ids, &mut tool_call_names, &mut thinking_state, parse_think_blocks)
                         });
                         yield stream_message;
                     }
@@ -663,6 +663,7 @@ fn stream_together(
 /// It processes the content and tool calls from the Together response, updating the tool call IDs and names.
 /// If parsing think blocks is enabled, it also processes the thinking state and extracts reasoning.
 fn together_to_tensorzero_chunk(
+    raw_message: String,
     mut chunk: TogetherChatChunk,
     latency: Duration,
     tool_call_ids: &mut Vec<String>,
@@ -670,17 +671,6 @@ fn together_to_tensorzero_chunk(
     thinking_state: &mut ThinkingState,
     parse_think_blocks: bool,
 ) -> Result<ProviderInferenceResponseChunk, Error> {
-    let raw_message = serde_json::to_string(&chunk).map_err(|e| {
-        Error::new(ErrorDetails::InferenceServer {
-            message: format!(
-                "Error parsing response from Together: {}",
-                DisplayOrDebugGateway::new(e)
-            ),
-            raw_request: None,
-            raw_response: Some(serde_json::to_string(&chunk).unwrap_or_default()),
-            provider_type: PROVIDER_TYPE.to_string(),
-        })
-    })?;
     if chunk.choices.len() > 1 {
         return Err(ErrorDetails::InferenceServer {
             message: "Response has invalid number of choices: {}. Expected 1.".to_string(),
@@ -1209,6 +1199,7 @@ mod tests {
 
         // With parsing enabled
         let result = together_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(100),
             &mut tool_call_ids,
@@ -1236,6 +1227,7 @@ mod tests {
         };
 
         let result = together_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk,
             Duration::from_millis(100),
             &mut tool_call_ids,
@@ -1268,6 +1260,7 @@ mod tests {
         };
 
         let result = together_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk,
             Duration::from_millis(100),
             &mut tool_call_ids,
@@ -1295,6 +1288,7 @@ mod tests {
         };
 
         let result = together_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk,
             Duration::from_millis(100),
             &mut tool_call_ids,
@@ -1331,6 +1325,7 @@ mod tests {
         let mut tool_call_names = vec!["name1".to_string()];
         let mut thinking_state = ThinkingState::Normal;
         let message = together_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -1366,6 +1361,7 @@ mod tests {
             usage: None,
         };
         let message = together_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -1402,6 +1398,7 @@ mod tests {
             usage: None,
         };
         let error = together_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -1439,6 +1436,7 @@ mod tests {
             usage: None,
         };
         let message = together_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -1472,6 +1470,7 @@ mod tests {
             }),
         };
         let message = together_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -1501,6 +1500,7 @@ mod tests {
             usage: None,
         };
         let message = together_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -1524,6 +1524,7 @@ mod tests {
             usage: None,
         };
         let message = together_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -1554,6 +1555,7 @@ mod tests {
             usage: None,
         };
         let message = together_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk.clone(),
             Duration::from_millis(50),
             &mut tool_call_ids,
@@ -1582,6 +1584,7 @@ mod tests {
         let mut tool_call_names = vec![];
         let mut thinking_state = ThinkingState::Normal;
         let message = together_to_tensorzero_chunk(
+            "my_raw_chunk".to_string(),
             chunk,
             Duration::from_millis(50),
             &mut tool_call_ids,


### PR DESCRIPTION
We were sometimes parsing and stringifying the provider chunk, which will lose information like whitespace. Since we're going to start directly exposing 'original_chunk' to users, let's make sure that we preserve the exact response from the provider.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Preserve original `raw_response` in streaming by passing `message.data` directly to processing functions, removing unnecessary serialization across multiple provider files.
> 
>   - **Behavior**:
>     - Preserve original `raw_response` in streaming by passing `message.data` directly to functions like `openrouter_to_tensorzero_chunk()` and `sglang_to_tensorzero_chunk()`.
>     - Remove unnecessary serialization of messages in `anthropic.rs`, `deepseek.rs`, `fireworks.rs`, `gcp_vertex_anthropic.rs`, `gcp_vertex_gemini.rs`, `google_ai_studio_gemini.rs`, `mistral.rs`, `openai.rs`, `openrouter.rs`, `sglang.rs`, `tgi.rs`, and `together.rs`.
>   - **Functions**:
>     - Update `openrouter_to_tensorzero_chunk()`, `sglang_to_tensorzero_chunk()`, `tgi_to_tensorzero_chunk()`, and `together_to_tensorzero_chunk()` to accept `raw_message` as a parameter.
>   - **Tests**:
>     - Update tests in `openrouter.rs`, `sglang.rs`, `tgi.rs`, and `together.rs` to pass `raw_message` directly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7a9666c1063a2d57925af73c34bca75870ff1a60. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->