### PR TITLE
Re-run the pyo3 build on push to 'main' to repopulate cache

### DIFF
--- a/.github/workflows/caching-hack.yml
+++ b/.github/workflows/caching-hack.yml
@@ -1,0 +1,17 @@
+# Unfortunately, writing to the Github Actions cache from a merge queue doesn't work correctly.
+# The `merge_group` event runs on a temporary branch, which prevents it from being used from
+# any other branches: https://github.com/orgs/community/discussions/47349
+#
+# The hacky solution is to re-run certain workflows on pushes to `main`,
+# as caches written from `main` are accessible from all other branches.
+#
+# To avoid wasting money, we should only use the standard (free) Github Actions runners.
+name: Caching Hack (re-runs actions on 'main' to update the cache)
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  check-python-client-build:
+    uses: ./.github/workflows/python-client-build.yml

--- a/.github/workflows/python-client-build.yml
+++ b/.github/workflows/python-client-build.yml
@@ -1,3 +1,6 @@
+# NOTE - this workflow is run on every push to 'main' in order to populate the cache
+# If you ever switch this to a non-free runner (e.g. a Namespace runner), be aware that
+# this might end up costing us much more than expected.
 on:
   workflow_call:
 
@@ -21,6 +24,10 @@ jobs:
           python-version: 3.x
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
+      - run: rustup toolchain install stable --profile minimal
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Build wheels
         uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
         with:


### PR DESCRIPTION
This is a hacky way of getting the normal PR/merge-queue pyo3 build jobs to use a GitHub Actions cache. See the comments in the workflow for more details

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
