### PR TITLE
removed full ClickHouse URL from UI entrypoint

### DIFF
--- a/ui/entrypoint.sh
+++ b/ui/entrypoint.sh
@@ -6,13 +6,21 @@ if [ -z "$TENSORZERO_CLICKHOUSE_URL" ]; then
   echo "Error: TENSORZERO_CLICKHOUSE_URL environment variable is not set."
   exit 1
 fi
+
 # Extract the base URL without path from TENSORZERO_CLICKHOUSE_URL
 BASE_URL=$(echo "$TENSORZERO_CLICKHOUSE_URL" | sed -E 's#(https?://[^/]+).*#\1#')
+# Extract the base URL without path and credentials from TENSORZERO_CLICKHOUSE_URL
+# This is used for display purposes only
+DISPLAY_BASE_URL=$(
+  echo "$TENSORZERO_CLICKHOUSE_URL" |
+  sed -E 's#(https?://)[^@/]*@?([^/?]+).*#\1\2#'
+)
+
 
 # Attempt to ping ClickHouse and check for OK response
-echo "Pinging ClickHouse at /ping to verify connectivity..."
+echo "Pinging ClickHouse at $DISPLAY_BASE_URL/ping to verify connectivity..."
 if ! curl -s --connect-timeout 5 "$BASE_URL/ping" > /dev/null; then
-  echo "Error: Failed to connect to ClickHouse at /ping"
+  echo "Error: Failed to connect to ClickHouse at $DISPLAY_BASE_URL/ping"
   exit 1
 fi
 

--- a/ui/entrypoint.sh
+++ b/ui/entrypoint.sh
@@ -10,9 +10,9 @@ fi
 BASE_URL=$(echo "$TENSORZERO_CLICKHOUSE_URL" | sed -E 's#(https?://[^/]+).*#\1#')
 
 # Attempt to ping ClickHouse and check for OK response
-echo "Pinging ClickHouse at $BASE_URL/ping to verify connectivity..."
+echo "Pinging ClickHouse at /ping to verify connectivity..."
 if ! curl -s --connect-timeout 5 "$BASE_URL/ping" > /dev/null; then
-  echo "Error: Failed to connect to ClickHouse at $BASE_URL/ping"
+  echo "Error: Failed to connect to ClickHouse at /ping"
   exit 1
 fi
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove credentials from ClickHouse URL in logs in `ui/entrypoint.sh`.
> 
>   - **Security**:
>     - In `ui/entrypoint.sh`, extract `DISPLAY_BASE_URL` from `TENSORZERO_CLICKHOUSE_URL` to exclude credentials for display purposes.
>     - Update ping command and error messages to use `DISPLAY_BASE_URL` instead of `BASE_URL`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 94fa592f7a24af5d8997f912f5d37c9fa723efc4. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->