### PR TITLE
Allow publish to TestPyPI to fail when making releases

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -48,3 +48,7 @@ jobs:
       - name: Publish to TestPyPI
         run: |
           ./ci/upload-python-client.sh testpypi
+        # TestPyPI is frequently down for maintenance, so don't fail the workflow
+        # when making actual releases. We still fail on the job when running the
+        # workflow manually, as that's the only reason we'd want to run it.
+        continue-on-error: ${{ github.event_name == 'release' }}


### PR DESCRIPTION
Fixes https://github.com/tensorzero/tensorzero/issues/2294
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allow TestPyPI publish step to continue on error during release events in `pypi-publish.yml`.
> 
>   - **Behavior**:
>     - In `.github/workflows/pypi-publish.yml`, the `Publish to TestPyPI` step now uses `continue-on-error` for `release` events.
>     - This change prevents workflow failure due to TestPyPI downtime during actual releases.
>   - **Misc**:
>     - The workflow still fails on manual runs, ensuring errors are caught when intended.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ffac3e33e555584f244e2fe032c35a56c4269654. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->