### PR TITLE
Cache gateway build on CI for clickhouse tests

### DIFF
--- a/.github/workflows/caching-hack.yml
+++ b/.github/workflows/caching-hack.yml
@@ -15,3 +15,20 @@ on:
 jobs:
   check-python-client-build:
     uses: ./.github/workflows/python-client-build.yml
+
+  build-gateway:
+    strategy:
+      matrix:
+        runner:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
+        with:
+          cache-provider: "buildjet"
+          # We use this cache key from other jobs that need to build the gateway
+          shared-key: "build-gateway-cache"
+      - run: cargo build-e2e

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -27,7 +27,8 @@ jobs:
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
         with:
           cache-provider: "buildjet"
-          save-if: ${{ github.event_name == 'merge_group' }}
+          shared-key: "build-gateway-cache"
+          save-if: false
       - name: Install cargo-nextest
         uses: taiki-e/install-action@37bdc826eaedac215f638a96472df572feab0f9b
         with:
@@ -387,7 +388,8 @@ jobs:
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
         with:
           cache-provider: "buildjet"
-          save-if: ${{ github.event_name == 'merge_group' }}
+          shared-key: "build-gateway-cache"
+          save-if: false
       - run: df -h
       # ClickHouse intermittently runs out of disk space on the `ubuntu-latest` runner
       # I'm using the commands from https://carlosbecker.com/posts/github-actions-disk-space/ to try to get more disk space


### PR DESCRIPTION
The hacky build-on-push-to-main strategy is working correctly for PyO3 builds, so let's start using it for gateway builds as well

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
