### PR TITLE
Add PDF support to gcp_vertex_gemini and anthropic providers

### DIFF
--- a/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
@@ -32,8 +32,8 @@ use crate::model::{build_creds_caching_default_with_fn, CredentialLocation};
 use crate::tool::{ToolCall, ToolCallChunk, ToolChoice, ToolConfig};
 
 use super::anthropic::{
-    prefill_json_chunk_response, prefill_json_response, AnthropicImageSource, AnthropicImageType,
-    AnthropicMessageDelta, AnthropicStopReason,
+    prefill_json_chunk_response, prefill_json_response, AnthropicDocumentSource,
+    AnthropicDocumentType, AnthropicMessageDelta, AnthropicStopReason,
 };
 use super::gcp_vertex_gemini::{default_api_key_location, GCPVertexCredentials};
 use super::helpers::{inject_extra_request_data, peek_first_chunk};
@@ -460,7 +460,7 @@ enum GCPVertexAnthropicMessageContent<'a> {
         text: &'a str,
     },
     Image {
-        source: AnthropicImageSource,
+        source: AnthropicDocumentSource,
     },
     ToolResult {
         tool_use_id: &'a str,
@@ -532,8 +532,8 @@ impl<'a> TryFrom<&'a ContentBlock>
                 file.mime_type.require_image(PROVIDER_TYPE)?;
                 Ok(Some(FlattenUnknown::Normal(
                     GCPVertexAnthropicMessageContent::Image {
-                        source: AnthropicImageSource {
-                            r#type: AnthropicImageType::Base64,
+                        source: AnthropicDocumentSource {
+                            r#type: AnthropicDocumentType::Base64,
                             media_type: file.mime_type,
                             data: file.data()?.clone(),
                         },

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
@@ -40,8 +40,8 @@ use crate::inference::types::{
     ProviderInferenceResponseChunk, RequestMessage, Usage,
 };
 use crate::inference::types::{
-    ContentBlock, ContentBlockChunk, ContentBlockOutput, FinishReason, FlattenUnknown, Latency,
-    ModelInferenceRequestJsonMode, ProviderInferenceResponseArgs,
+    ContentBlock, ContentBlockChunk, ContentBlockOutput, FileKind, FinishReason, FlattenUnknown,
+    Latency, ModelInferenceRequestJsonMode, ProviderInferenceResponseArgs,
     ProviderInferenceResponseStreamInner, Role, Text, TextChunk,
 };
 use crate::model::{
@@ -1487,7 +1487,11 @@ impl<'a> TryFrom<&'a ContentBlock> for Option<FlattenUnknown<'a, GCPVertexGemini
                 file,
                 storage_path: _,
             }) => {
-                file.mime_type.require_image(PROVIDER_TYPE)?;
+                // All of our FileKinds are supported by GCP Vertex Gemini
+                // If we add more, make sure to check their docs to see if they support it.
+                match file.mime_type {
+                    FileKind::Png | FileKind::Jpeg | FileKind::WebP | FileKind::Pdf => {}
+                }
                 Ok(Some(FlattenUnknown::Normal(
                     GCPVertexGeminiContentPart::InlineData {
                         inline_data: GCPVertexInlineData {

--- a/tensorzero-internal/tests/e2e/providers/anthropic.rs
+++ b/tensorzero-internal/tests/e2e/providers/anthropic.rs
@@ -40,6 +40,14 @@ async fn get_providers() -> E2ETestProviders {
         credentials: HashMap::new(),
     }];
 
+    let pdf_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
+        variant_name: "anthropic".to_string(),
+        model_name: "anthropic::claude-3-5-sonnet-20241022".into(),
+        model_provider_name: "anthropic".into(),
+        credentials: HashMap::new(),
+    }];
+
     let extra_body_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "anthropic-extra-body".to_string(),
@@ -118,8 +126,7 @@ async fn get_providers() -> E2ETestProviders {
         json_mode_inference: json_providers.clone(),
         json_mode_off_inference: json_mode_off_providers.clone(),
         image_inference: image_providers,
-        pdf_inference: vec![],
-
+        pdf_inference: pdf_providers,
         shorthand_inference: shorthand_providers.clone(),
     }
 }

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -488,7 +488,7 @@ macro_rules! generate_provider_tests {
             }
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread")]
         async fn test_pdf_inference_store_filesystem() {
             let providers = $func().await.pdf_inference;
             for provider in providers {
@@ -594,6 +594,14 @@ type = "chat"
 [functions.pdf_test.variants.openai]
 type = "chat_completion"
 model = "openai::gpt-4o-mini-2024-07-18"
+
+[functions.pdf_test.variants.gcp_vertex_gemini]
+type = "chat_completion"
+model = "gcp_vertex_gemini::projects/tensorzero-public/locations/us-central1/publishers/google/models/gemini-2.0-flash-lite"
+
+[functions.pdf_test.variants.anthropic]
+type = "chat_completion"
+model = "anthropic::claude-3-5-sonnet-20241022"
 "#;
 
 pub static FERRIS_PNG: &[u8] = include_bytes!("./ferris.png");

--- a/tensorzero-internal/tests/e2e/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/tests/e2e/providers/gcp_vertex_gemini.rs
@@ -41,6 +41,14 @@ async fn get_providers() -> E2ETestProviders {
         credentials: HashMap::new(),
     }];
 
+    let pdf_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
+        variant_name: "gcp_vertex_gemini".to_string(),
+        model_name: "gcp_vertex_gemini::projects/tensorzero-public/locations/us-central1/publishers/google/models/gemini-2.0-flash-lite".into(),
+        model_provider_name: "gcp_vertex_gemini".into(),
+        credentials: HashMap::new(),
+    }];
+
     let extra_body_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "gcp-vertex-gemini-flash-extra-body".to_string(),
@@ -123,8 +131,8 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: vec![],
         json_mode_inference: json_providers.clone(),
         json_mode_off_inference: json_mode_off_providers.clone(),
-        image_inference: image_providers,
-        pdf_inference: vec![],
+        image_inference: image_providers.clone(),
+        pdf_inference: pdf_providers,
         shorthand_inference: shorthand_providers.clone(),
     }
 }


### PR DESCRIPTION
gcp_vertex_anthropic doesn't support PDFs, so I've left it unchanged for now

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add PDF support to `gcp_vertex_gemini` and `anthropic` providers, updating structures and tests accordingly.
> 
>   - **Behavior**:
>     - Add PDF support to `gcp_vertex_gemini` and `anthropic` providers by updating `TryFrom<&ContentBlock>` implementations in `gcp_vertex_gemini.rs` and `anthropic.rs`.
>     - `gcp_vertex_anthropic` provider remains unchanged due to lack of PDF support.
>   - **Structures**:
>     - Rename `AnthropicImageSource` to `AnthropicDocumentSource` and `AnthropicImageType` to `AnthropicDocumentType` in `anthropic.rs` and `gcp_vertex_anthropic.rs`.
>     - Add `Document` variant to `AnthropicMessageContent` in `anthropic.rs`.
>   - **Tests**:
>     - Update `e2e` tests in `anthropic.rs` and `gcp_vertex_gemini.rs` to include PDF inference tests.
>     - Modify `test_pdf_inference_store_filesystem` in `common.rs` to support multi-threading.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e6e2d28c64e952410879cc956f97a6278662107c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->