### PR TITLE
Re-enable connection pooling in ClickHouse tests

### DIFF
--- a/tensorzero-internal/tests/e2e/clickhouse.rs
+++ b/tensorzero-internal/tests/e2e/clickhouse.rs
@@ -77,9 +77,11 @@ fn get_clean_clickhouse(allow_db_missing: bool) -> (ClickHouseConnectionInfo, De
     let clickhouse = ClickHouseConnectionInfo::Production {
         database_url: SecretString::from(clickhouse_url.to_string()),
         database: database.clone(),
-        // This works around an issue with ClickHouse Cloud where long-lived connections
+        // This is a hack to work around an issue with ClickHouse Cloud where long-lived connections
         // are abruptly closed by the server.
-        client: Client::builder().pool_max_idle_per_host(0).build().unwrap(),
+        // If it occurs again, re-enable this line.
+        // client: Client::builder().pool_max_idle_per_host(0).build().unwrap(),
+        client: Client::new(),
     };
     (
         clickhouse.clone(),

--- a/tensorzero-internal/tests/e2e/clickhouse.rs
+++ b/tensorzero-internal/tests/e2e/clickhouse.rs
@@ -81,7 +81,8 @@ fn get_clean_clickhouse(allow_db_missing: bool) -> (ClickHouseConnectionInfo, De
         // are abruptly closed by the server.
         // If it occurs again, re-enable this line.
         // client: Client::builder().pool_max_idle_per_host(0).build().unwrap(),
-        client: Client::new(),
+        // See https://github.com/ClickHouse/clickhouse-rs/blob/abf7448e54261c586be849c48291b9321f506b2f/src/http_client.rs#L45
+        client: Client::new().pool_idle_timeout(Duration::from_secs(3)),
     };
     (
         clickhouse.clone(),

--- a/tensorzero-internal/tests/e2e/clickhouse.rs
+++ b/tensorzero-internal/tests/e2e/clickhouse.rs
@@ -3,6 +3,7 @@
 use std::cell::Cell;
 use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
 
 use paste::paste;
 use reqwest::Client;
@@ -82,7 +83,10 @@ fn get_clean_clickhouse(allow_db_missing: bool) -> (ClickHouseConnectionInfo, De
         // If it occurs again, re-enable this line.
         // client: Client::builder().pool_max_idle_per_host(0).build().unwrap(),
         // See https://github.com/ClickHouse/clickhouse-rs/blob/abf7448e54261c586be849c48291b9321f506b2f/src/http_client.rs#L45
-        client: Client::new().pool_idle_timeout(Duration::from_secs(3)),
+        client: Client::builder()
+            .pool_idle_timeout(Duration::from_secs(3))
+            .build()
+            .unwrap(),
     };
     (
         clickhouse.clone(),


### PR DESCRIPTION
The issue with ClickHouse Cloud has hopefully gone away, so this should speed up our tests

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Re-enables connection pooling in ClickHouse tests by setting a 3-second idle timeout in `get_clean_clickhouse()`.
> 
>   - **Behavior**:
>     - Re-enables connection pooling in ClickHouse tests by modifying `client` configuration in `get_clean_clickhouse()`.
>     - Sets `pool_idle_timeout` to 3 seconds instead of disabling pooling.
>   - **Comments**:
>     - Adds comments explaining the change and providing a link to relevant documentation in `clickhouse-rs` repository.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c3556bb217c8550814ab3629023824b440067f94. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->