### PR TITLE
Max/fix snippet messages

### DIFF
--- a/ui/app/components/inference/InputSnippet.tsx
+++ b/ui/app/components/inference/InputSnippet.tsx
@@ -59,7 +59,7 @@ function renderContentBlock(block: ResolvedInputMessageContent, index: number) {
         <ToolCallMessage
           key={index}
           toolName={block.name}
-          toolArguments={JSON.stringify(block.arguments, null, 2)}
+          toolArguments={block.arguments}
           toolCallId={block.id}
         />
       );

--- a/ui/app/components/inference/NewOutput.tsx
+++ b/ui/app/components/inference/NewOutput.tsx
@@ -9,7 +9,12 @@ import {
   SnippetMessage,
   type SnippetTab,
 } from "~/components/layout/SnippetLayout";
-import { CodeMessage, TextMessage } from "~/components/layout/SnippetContent";
+import {
+  CodeMessage,
+  EmptyMessage,
+  TextMessage,
+  ToolCallMessage,
+} from "~/components/layout/SnippetContent";
 
 /*
 NOTE: This is the new output component but it is not editable yet so we are rolling
@@ -32,83 +37,88 @@ function isJsonInferenceOutput(
   return "raw" in output;
 }
 
-function renderContentBlock(block: ContentBlockOutput, index: number) {
-  switch (block.type) {
-    case "text":
-      return <TextMessage key={index} label="Text" content={block.text} />;
-    case "tool_call":
-      return (
-        <TextMessage
-          key={index}
-          label={`Tool: ${block.name}`}
-          content={JSON.stringify(block.arguments, null, 2)}
-        />
-      );
+function renderJsonInferenceOutput(output: JsonInferenceOutputRenderingData) {
+  const tabs: SnippetTab[] = [
+    {
+      id: "parsed",
+      label: "Parsed Output",
+      indicator: output.parsed ? "content" : "fail",
+    },
+    {
+      id: "raw",
+      label: "Raw Output",
+    },
+  ];
+
+  // Add Output Schema tab if available
+  if (output.schema) {
+    tabs.push({
+      id: "schema",
+      label: "Output Schema",
+    });
   }
+
+  // Set default tab to Parsed if it has content, otherwise Raw
+  const defaultTab = output.parsed ? "parsed" : "raw";
+
+  return (
+    <SnippetTabs tabs={tabs} defaultTab={defaultTab}>
+      {(activeTab) => (
+        <SnippetContent>
+          {activeTab === "parsed" ? (
+            <SnippetMessage>
+              {output.parsed ? (
+                <CodeMessage
+                  content={JSON.stringify(output.parsed, null, 2)}
+                  showLineNumbers={true}
+                />
+              ) : (
+                <EmptyMessage message="The inference output failed to parse against the schema." />
+              )}
+            </SnippetMessage>
+          ) : activeTab === "raw" ? (
+            <SnippetMessage>
+              <CodeMessage content={output.raw} showLineNumbers={true} />
+            </SnippetMessage>
+          ) : (
+            <SnippetMessage>
+              <CodeMessage
+                content={JSON.stringify(output.schema, null, 2)}
+                showLineNumbers={true}
+              />
+            </SnippetMessage>
+          )}
+        </SnippetContent>
+      )}
+    </SnippetTabs>
+  );
 }
 
-export function OutputContent({ output }: OutputProps) {
-  if (isJsonInferenceOutput(output)) {
-    const tabs: SnippetTab[] = [
-      {
-        id: "parsed",
-        label: "Parsed Output",
-        indicator: output.parsed ? "content" : "fail",
-      },
-      {
-        id: "raw",
-        label: "Raw Output",
-      },
-    ];
-
-    // Add Output Schema tab if available
-    if (output.schema) {
-      tabs.push({
-        id: "schema",
-        label: "Output Schema",
-      });
-    }
-
-    // Set default tab to Parsed if it has content, otherwise Raw
-    const defaultTab = output.parsed ? "parsed" : "raw";
-
-    return (
-      <SnippetTabs tabs={tabs} defaultTab={defaultTab}>
-        {(activeTab) => (
-          <SnippetContent>
-            {activeTab === "parsed" ? (
-              <SnippetMessage>
-                <CodeMessage
-                  content={
-                    output.parsed
-                      ? JSON.stringify(output.parsed, null, 2)
-                      : "The inference output failed to parse against the schema."
-                  }
-                  showLineNumbers={true}
-                />
-              </SnippetMessage>
-            ) : activeTab === "raw" ? (
-              <SnippetMessage>
-                <CodeMessage content={output.raw} showLineNumbers={true} />
-              </SnippetMessage>
-            ) : (
-              <SnippetMessage>
-                <CodeMessage
-                  content={JSON.stringify(output.schema, null, 2)}
-                  showLineNumbers={true}
-                />
-              </SnippetMessage>
-            )}
-          </SnippetContent>
-        )}
-      </SnippetTabs>
-    );
-  }
-
+function renderChatInferenceOutput(output: ChatInferenceOutputRenderingData) {
   return (
     <SnippetContent>
       <SnippetMessage>
-        {output.map((block, index) => renderContentBlock(block, index))}
+        {output.length === 0 ? (
+          <EmptyMessage message="No output messages found" />
+        ) : (
+          output.map((block, index) => {
+            switch (block.type) {
+              case "text":
+                return (
+                  <TextMessage key={index} label="Text" content={block.text} />
+                );
+              case "tool_call":
+                return (
+                  <ToolCallMessage
+                    key={index}
+                    toolName={block.name ?? ""}
+                    toolArguments={JSON.stringify(block.arguments, null, 2)}
+                    toolCallId={block.id}
+                  />
+                );
+            }
+          })
+        )}
       </SnippetMessage>
     </SnippetContent>
   );
@@ -117,7 +127,9 @@ export function OutputContent({ output }: OutputProps) {
 export default function Output({ output }: OutputProps) {
   return (
     <SnippetLayout>
-      <OutputContent output={output} />
+      {isJsonInferenceOutput(output)
+        ? renderJsonInferenceOutput(output)
+        : renderChatInferenceOutput(output)}
     </SnippetLayout>
   );
 }

--- a/ui/app/components/layout/SnippetContent.tsx
+++ b/ui/app/components/layout/SnippetContent.tsx
@@ -107,7 +107,7 @@ export function TextMessage({
   }
 
   return (
-    <div className="relative flex max-w-200 min-w-80 flex-col gap-2">
+    <div className="relative flex min-w-80 flex-col gap-2">
       <Label
         text={label}
         icon={<AlignLeft className="text-fg-muted h-3 w-3" />}
@@ -129,7 +129,7 @@ interface InputTextMessageProps {
 
 export function InputTextMessage({ content }: InputTextMessageProps) {
   return (
-    <div className="flex max-w-200 min-w-80 flex-col gap-1">
+    <div className="flex min-w-80 flex-col gap-1">
       <Label
         text="Text"
         icon={<AlignLeft className="text-fg-muted h-3 w-3" />}
@@ -149,7 +149,7 @@ export function TextMessageWithArguments({
   content,
 }: TextMessageWithArgumentsProps) {
   return (
-    <div className="flex max-w-200 min-w-80 flex-col gap-1.5">
+    <div className="flex min-w-80 flex-col gap-1.5">
       <Label
         text="Text (Arguments)"
         icon={<AlignLeft className="text-fg-muted h-3 w-3" />}
@@ -174,7 +174,7 @@ export function ToolCallMessage({
   toolCallId,
 }: ToolCallMessageProps) {
   return (
-    <div className="flex max-w-200 min-w-80 flex-col gap-1 overflow-x-auto">
+    <div className="flex min-w-80 flex-col gap-1 overflow-x-auto">
       <Label
         text="Tool Call"
         icon={<Terminal className="text-fg-muted h-3 w-3" />}
@@ -212,7 +212,7 @@ export function ToolResultMessage({
   toolResultId,
 }: ToolResultMessageProps) {
   return (
-    <div className="flex max-w-200 min-w-80 flex-col gap-1 overflow-x-auto">
+    <div className="flex min-w-80 flex-col gap-1 overflow-x-auto">
       <Label
         text="Tool Result"
         icon={<ArrowRight className="text-fg-muted h-3 w-3" />}

--- a/ui/app/components/layout/SnippetLayout.tsx
+++ b/ui/app/components/layout/SnippetLayout.tsx
@@ -122,7 +122,7 @@ export function SnippetMessage({
   // Default variant - simple wrapper with padding
   return (
     <div className="relative w-full">
-      <div className="bg-bg-primary w-full overflow-hidden rounded-lg p-5">
+      <div className="bg-bg-primary flex w-full flex-col gap-4 overflow-hidden rounded-lg p-5">
         {children}
       </div>
     </div>


### PR DESCRIPTION
WIP

- Added gap between content blocks in the default SnippetMessage (text function output);
- Cleaned up the NewOutput structure so it has to render blocks one for chat function and one for json function;
- Added missing empty state for chat function output;
- Removed max width limit on snippet content messages per feedback;

---

temporarily removed json parsing on tool calls and results, to be fixed.
