### PR TITLE
Relax tool-call arguments check

### DIFF
--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -4747,8 +4747,11 @@ pub async fn check_tool_use_tool_choice_required_inference_response(
 
     let arguments = content_block.get("arguments").unwrap();
     let arguments = arguments.as_object().unwrap();
-    assert!(arguments.len() == 1 || arguments.len() == 2);
-    assert!(arguments.get("location").unwrap().as_str().is_some());
+    // OpenAI occasionally emits a tool call with an empty object for `arguments`
+    assert!(arguments.len() <= 2);
+    if let Some(location) = arguments.get("location") {
+        assert!(location.as_str().is_some())
+    }
     if arguments.len() == 2 {
         let units = arguments.get("units").unwrap().as_str().unwrap();
         assert!(units == "celsius" || units == "fahrenheit");


### PR DESCRIPTION
OpenAI sometimes gives us back an empty object for 'arguments', despite the tool definition requiring arguments. There's not really anything we can do about that, so let's just relax the test to accept an empty object.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Relax argument check in `common.rs` to accept empty `arguments` object from OpenAI.
> 
>   - **Behavior**:
>     - Relaxed argument check in `check_tool_use_tool_choice_required_inference_response()` in `common.rs` to accept empty `arguments` object.
>     - Now asserts `arguments.len() <= 2` instead of `arguments.len() == 1 || arguments.len() == 2`.
>     - Checks `location` key only if present in `arguments`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b4bf58bd27ef687e86a003d0abf4068ffdd5a741. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->