### PR TITLE
Allow arbitrary mime-types for 'file' input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,7 +664,7 @@ dependencies = [
  "itoa",
  "matchit",
  "memchr",
- "mime",
+ "mime 0.3.17",
  "multer",
  "percent-encoding",
  "pin-project-lite",
@@ -692,7 +692,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "mime",
+ "mime 0.3.17",
  "pin-project-lite",
  "rustversion",
  "sync_wrapper",
@@ -2616,12 +2616,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime"
+version = "0.4.0-a.0"
+source = "git+https://github.com/hyperium/mime?rev=1ef137c7358fc64e07c8a640e4e9ba2a784b7f7d#1ef137c7358fc64e07c8a640e4e9ba2a784b7f7d"
+dependencies = [
+ "mime-parse",
+ "quoted-string",
+ "serde",
+]
+
+[[package]]
+name = "mime-parse"
+version = "0.0.0"
+source = "git+https://github.com/hyperium/mime?rev=1ef137c7358fc64e07c8a640e4e9ba2a784b7f7d#1ef137c7358fc64e07c8a640e4e9ba2a784b7f7d"
+
+[[package]]
 name = "mime_guess"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
- "mime",
+ "mime 0.3.17",
  "unicase",
 ]
 
@@ -2740,7 +2755,7 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "memchr",
- "mime",
+ "mime 0.3.17",
  "spin",
  "version_check",
 ]
@@ -3301,6 +3316,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3371,6 +3392,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "quoted-string"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9586f8867f39941d8e796c18340a9cb5221a018df021169dc3e61c87d9f5f567"
+dependencies = [
+ "quick-error",
 ]
 
 [[package]]
@@ -3583,7 +3613,7 @@ dependencies = [
  "ipnet",
  "js-sys",
  "log",
- "mime",
+ "mime 0.3.17",
  "mime_guess",
  "once_cell",
  "percent-encoding",
@@ -3620,7 +3650,7 @@ dependencies = [
  "eventsource-stream",
  "futures-core",
  "futures-timer",
- "mime",
+ "mime 0.3.17",
  "nom",
  "pin-project-lite",
  "reqwest",
@@ -4212,6 +4242,7 @@ dependencies = [
  "futures",
  "git2",
  "lazy_static",
+ "mime 0.4.0-a.0",
  "object_store",
  "pyo3",
  "reqwest",
@@ -4283,6 +4314,8 @@ dependencies = [
  "lazy_static",
  "metrics",
  "metrics-exporter-prometheus",
+ "mime 0.4.0-a.0",
+ "mime_guess",
  "minijinja",
  "object_store",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ tracing-opentelemetry-instrumentation-sdk = { version = "0.28.0", features = [
     "tracing_level_info",
 ] }
 tower-http = { version = "0.6.4", features = ["trace"] }
+mime = { git = "https://github.com/hyperium/mime", rev = "1ef137c7358fc64e07c8a640e4e9ba2a784b7f7d", features = ["serde1"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/clients/python/tensorzero/types.py
+++ b/clients/python/tensorzero/types.py
@@ -85,6 +85,7 @@ class FileBase64(ContentBlock):
 @dataclass
 class ImageUrl(ContentBlock):
     url: str
+    mime_type: Optional[str] = None
     type: str = "image"
 
 

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -30,6 +30,7 @@ serde-untagged = { workspace = true }
 git2 = { workspace = true }
 serde_path_to_error = { workspace = true }
 tensorzero-derive = { path = "../../tensorzero-derive" }
+mime = { workspace = true }
 
 [lints]
 workspace = true

--- a/clients/rust/src/input_handling.rs
+++ b/clients/rust/src/input_handling.rs
@@ -176,7 +176,7 @@ mod tests {
     use object_store::path::Path;
 
     use tensorzero_internal::inference::types::{
-        resolved_input::FileWithPath, storage::StorageKind, Base64File, FileKind,
+        resolved_input::FileWithPath, storage::StorageKind, Base64File,
     };
     use url::Url;
 
@@ -237,7 +237,7 @@ mod tests {
         let resolved_content = ResolvedInputMessageContent::File(FileWithPath {
             file: Base64File {
                 url: Some(Url::parse("http://notaurl.com").unwrap()),
-                mime_type: FileKind::Jpeg,
+                mime_type: mime::IMAGE_JPEG,
                 data: Some(image_data.to_string()),
             },
             storage_path: storage_path.clone(),
@@ -257,7 +257,7 @@ mod tests {
                 mime_type: result_mime_type,
                 data: result_data,
             }) => {
-                assert_eq!(result_mime_type, FileKind::Jpeg);
+                assert_eq!(result_mime_type, mime::IMAGE_JPEG);
                 assert_eq!(result_data, image_data);
             }
             _ => panic!("Expected ClientInputMessageContent::Image, got something else"),

--- a/clients/rust/tests/tests.rs
+++ b/clients/rust/tests/tests.rs
@@ -7,7 +7,7 @@ use tensorzero::{
 };
 
 use reqwest::Url;
-use tensorzero_internal::inference::types::{FileKind, ResolvedInput};
+use tensorzero_internal::inference::types::ResolvedInput;
 
 lazy_static::lazy_static! {
     static ref GATEWAY_URL: String = std::env::var("GATEWAY_URL").unwrap_or("http://localhost:3000".to_string());
@@ -82,6 +82,6 @@ async fn test_conversion() {
     else {
         panic!("Expected file");
     };
-    assert_eq!(mime_type, &FileKind::Png);
+    assert_eq!(mime_type, mime::IMAGE_PNG);
     assert!(!data.is_empty());
 }

--- a/evaluations/src/evaluators/llm_judge/mod.rs
+++ b/evaluations/src/evaluators/llm_judge/mod.rs
@@ -480,6 +480,7 @@ mod tests {
                 role: Role::User,
                 content: vec![ClientInputMessageContent::File(File::Url {
                     url: Url::parse("https://example.com/image.png").unwrap(),
+                    mime_type: None,
                 })],
             }],
         };

--- a/tensorzero-internal/Cargo.toml
+++ b/tensorzero-internal/Cargo.toml
@@ -108,6 +108,8 @@ tower-http = { workspace = true }
 tower-layer = "0.3.3"
 pyo3 = { workspace = true, optional = true }
 google-cloud-auth = "0.20.0"
+mime = { workspace = true }
+mime_guess = "2.0.5"
 
 
 [dev-dependencies]

--- a/tensorzero-internal/src/endpoints/inference.rs
+++ b/tensorzero-internal/src/endpoints/inference.rs
@@ -1130,7 +1130,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::inference::types::{
-        ChatInferenceResultChunk, ContentBlockChunk, File, FileKind, InputMessageContent,
+        ChatInferenceResultChunk, ContentBlockChunk, File, InputMessageContent,
         JsonInferenceResultChunk, Role, TextChunk,
     };
 
@@ -1358,6 +1358,7 @@ mod tests {
             input_with_url.messages[0].content[0],
             InputMessageContent::File(File::Url {
                 url: "https://example.com/file.txt".parse().unwrap(),
+                mime_type: None,
             })
         );
 
@@ -1383,7 +1384,7 @@ mod tests {
         assert_eq!(
             input_with_base64.messages[0].content[0],
             InputMessageContent::File(File::Base64 {
-                mime_type: FileKind::Png,
+                mime_type: mime::IMAGE_PNG,
                 data: "fake_base64_data".to_string(),
             })
         );

--- a/tensorzero-internal/src/endpoints/openai_compatible.rs
+++ b/tensorzero-internal/src/endpoints/openai_compatible.rs
@@ -18,6 +18,7 @@ use axum::response::sse::{Event, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use futures::Stream;
+use mime::MediaType;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use tokio_stream::StreamExt;
@@ -30,11 +31,12 @@ use crate::endpoints::inference::{
 };
 use crate::error::{Error, ErrorDetails};
 use crate::gateway_util::{AppState, AppStateData, StructuredJson};
+use crate::inference::providers::openai::filename_to_mime_type;
 use crate::inference::types::extra_body::UnfilteredInferenceExtraBody;
 use crate::inference::types::extra_headers::UnfilteredInferenceExtraHeaders;
 use crate::inference::types::{
-    current_timestamp, ContentBlockChatOutput, ContentBlockChunk, File, FileKind, FinishReason,
-    Input, InputMessage, InputMessageContent, Role, TextKind, Usage,
+    current_timestamp, ContentBlockChatOutput, ContentBlockChunk, File, FinishReason, Input,
+    InputMessage, InputMessageContent, Role, TextKind, Usage,
 };
 use crate::tool::{
     DynamicToolParams, Tool, ToolCall, ToolCallChunk, ToolCallOutput, ToolChoice, ToolResult,
@@ -669,7 +671,7 @@ pub enum TextContent {
     },
 }
 
-fn parse_base64_image_data_url(url: &str) -> Result<(FileKind, &str), Error> {
+fn parse_base64_image_data_url(url: &str) -> Result<(MediaType, &str), Error> {
     let Some(url) = url.strip_prefix("data:") else {
         return Err(Error::new(ErrorDetails::InvalidOpenAICompatibleRequest {
             message: "Image data URL must start with `data:`".to_string(),
@@ -680,16 +682,11 @@ fn parse_base64_image_data_url(url: &str) -> Result<(FileKind, &str), Error> {
             message: "Image data URL must contain a base64-encoded data part".to_string(),
         }));
     };
-    let image_type = match mime_type {
-        "image/jpeg" => FileKind::Jpeg,
-        "image/png" => FileKind::Png,
-        "image/webp" => FileKind::WebP,
-        _ => {
-            return Err(Error::new(ErrorDetails::InvalidOpenAICompatibleRequest {
-                message: format!("Unsupported content type `{mime_type}`: - only `image/jpeg`, `image/png``, and `image/webp` image data URLs are supported"),
-            }))
-        }
-    };
+    let image_type: MediaType = mime_type.parse().map_err(|_| {
+        Error::new(ErrorDetails::InvalidOpenAICompatibleRequest {
+            message: format!("Unknown content type `{mime_type}`"),
+        })
+    })?;
     Ok((image_type, data))
 }
 
@@ -709,11 +706,11 @@ fn convert_openai_message_content(content: Value) -> Result<Vec<InputMessageCont
                             let (mime_type, data) = parse_base64_image_data_url(&url_str)?;
                             InputMessageContent::File(File::Base64 { mime_type, data: data.to_string() })
                         } else {
-                            InputMessageContent::File(File::Url { url: image_url.url })
+                            InputMessageContent::File(File::Url { url: image_url.url, mime_type: None })
                         }
                     }
                     Ok(OpenAICompatibleContentBlock::File { file }) => {
-                        InputMessageContent::File(File::Base64 { mime_type: file.filename.as_str().try_into()?, data: file.file_data })
+                        InputMessageContent::File(File::Base64 { mime_type: filename_to_mime_type(&file.filename)?, data: file.file_data })
                     }
                     Err(e) => {
                         tracing::warn!(r#"Content block `{val}` was not a valid OpenAI content block. This is deprecated - please use `{{"type": "text", "tensorzero::arguments": {{"custom": "data"}}` to pass arbitrary JSON values to TensorZero: {e}"#);
@@ -1597,23 +1594,20 @@ mod tests {
     #[test]
     fn test_parse_base64() {
         assert_eq!(
-            (FileKind::Jpeg, "YWJjCg=="),
+            (mime::IMAGE_JPEG, "YWJjCg=="),
             parse_base64_image_data_url("data:image/jpeg;base64,YWJjCg==").unwrap()
         );
         assert_eq!(
-            (FileKind::Png, "YWJjCg=="),
+            (mime::IMAGE_PNG, "YWJjCg=="),
             parse_base64_image_data_url("data:image/png;base64,YWJjCg==").unwrap()
         );
         assert_eq!(
-            (FileKind::WebP, "YWJjCg=="),
+            ("image/webp".parse().unwrap(), "YWJjCg=="),
             parse_base64_image_data_url("data:image/webp;base64,YWJjCg==").unwrap()
         );
-        let err = parse_base64_image_data_url("data:image/svg;base64,YWJjCg==")
-            .unwrap_err()
-            .to_string();
-        assert!(
-            err.contains("Unsupported content type `image/svg`"),
-            "Unexpected error message: {err}"
+        assert_eq!(
+            ("image/svg".parse().unwrap(), "YWJjCg=="),
+            parse_base64_image_data_url("data:image/svg;base64,YWJjCg==").unwrap()
         );
     }
 
@@ -1779,5 +1773,33 @@ mod tests {
                 enabled: CacheEnabledMode::WriteOnly
             }
         );
+    }
+
+    #[test]
+    #[traced_test]
+    fn test_filename_to_mime_type() {
+        assert_eq!(filename_to_mime_type("test.png").unwrap(), mime::IMAGE_PNG);
+        assert_eq!(filename_to_mime_type("test.jpg").unwrap(), mime::IMAGE_JPEG);
+        assert_eq!(
+            filename_to_mime_type("test.jpeg").unwrap(),
+            mime::IMAGE_JPEG
+        );
+        assert_eq!(filename_to_mime_type("test.gif").unwrap(), mime::IMAGE_GIF);
+        assert_eq!(filename_to_mime_type("test.webp").unwrap(), "image/webp");
+        assert_eq!(
+            filename_to_mime_type("test.pdf").unwrap(),
+            mime::APPLICATION_PDF
+        );
+        assert!(!logs_contain("Guessed"))
+    }
+
+    #[test]
+    #[traced_test]
+    fn test_guessed_mime_type_warning() {
+        assert_eq!(
+            filename_to_mime_type("my_file.txt").unwrap(),
+            mime::TEXT_PLAIN
+        );
+        assert!(logs_contain("Guessed"))
     }
 }

--- a/tensorzero-internal/src/inference/providers/dummy.rs
+++ b/tensorzero-internal/src/inference/providers/dummy.rs
@@ -21,9 +21,7 @@ use crate::inference::types::{
     ContentBlockOutput, Latency, ModelInferenceRequest, PeekableProviderInferenceResponseStream,
     ProviderInferenceResponse, ProviderInferenceResponseChunk, Usage,
 };
-use crate::inference::types::{
-    ContentBlock, FileKind, FinishReason, ProviderInferenceResponseStreamInner,
-};
+use crate::inference::types::{ContentBlock, FinishReason, ProviderInferenceResponseStreamInner};
 use crate::inference::types::{Text, TextChunk, Thought, ThoughtChunk};
 use crate::model::{CredentialLocation, ModelProvider};
 use crate::tool::{ToolCall, ToolCallChunk};
@@ -365,7 +363,7 @@ impl InferenceProvider for DummyProvider {
                     .collect();
                 let mut found_pdf = false;
                 for file in &files {
-                    if file.file.mime_type == FileKind::Pdf {
+                    if file.file.mime_type == mime::APPLICATION_PDF {
                         found_pdf = true;
                     }
                 }

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
@@ -16,6 +16,7 @@ use crate::error::{DisplayOrDebugGateway, Error, ErrorDetails};
 use crate::inference::providers::provider_trait::InferenceProvider;
 use crate::inference::types::batch::BatchRequestRow;
 use crate::inference::types::batch::PollBatchInferenceResponse;
+use crate::inference::types::file::require_image;
 use crate::inference::types::resolved_input::FileWithPath;
 use crate::inference::types::{
     batch::StartBatchProviderInferenceResponse, ContentBlock, ContentBlockChunk, FunctionType,
@@ -572,12 +573,12 @@ impl<'a> TryFrom<&'a ContentBlock>
                 file,
                 storage_path: _,
             }) => {
-                file.mime_type.require_image(PROVIDER_TYPE)?;
+                require_image(&file.mime_type, PROVIDER_TYPE)?;
                 Ok(Some(FlattenUnknown::Normal(
                     GCPVertexAnthropicMessageContent::Image {
                         source: AnthropicDocumentSource {
                             r#type: AnthropicDocumentType::Base64,
-                            media_type: file.mime_type,
+                            media_type: file.mime_type.to_string(),
                             data: file.data()?.clone(),
                         },
                     },

--- a/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
@@ -40,8 +40,8 @@ use crate::inference::types::{
     ProviderInferenceResponseChunk, RequestMessage, Usage,
 };
 use crate::inference::types::{
-    ContentBlock, ContentBlockChunk, ContentBlockOutput, FileKind, FinishReason, FlattenUnknown,
-    Latency, ModelInferenceRequestJsonMode, ProviderInferenceResponseArgs,
+    ContentBlock, ContentBlockChunk, ContentBlockOutput, FinishReason, FlattenUnknown, Latency,
+    ModelInferenceRequestJsonMode, ProviderInferenceResponseArgs,
     ProviderInferenceResponseStreamInner, Role, Text, TextChunk,
 };
 use crate::model::{
@@ -1493,21 +1493,14 @@ impl<'a> TryFrom<&'a ContentBlock> for Option<FlattenUnknown<'a, GCPVertexGemini
             ContentBlock::File(FileWithPath {
                 file,
                 storage_path: _,
-            }) => {
-                // All of our FileKinds are supported by GCP Vertex Gemini
-                // If we add more, make sure to check their docs to see if they support it.
-                match file.mime_type {
-                    FileKind::Png | FileKind::Jpeg | FileKind::WebP | FileKind::Pdf => {}
-                }
-                Ok(Some(FlattenUnknown::Normal(
-                    GCPVertexGeminiContentPart::InlineData {
-                        inline_data: GCPVertexInlineData {
-                            mime_type: file.mime_type.to_string(),
-                            data: file.data()?.as_str(),
-                        },
+            }) => Ok(Some(FlattenUnknown::Normal(
+                GCPVertexGeminiContentPart::InlineData {
+                    inline_data: GCPVertexInlineData {
+                        mime_type: file.mime_type.to_string(),
+                        data: file.data()?.as_str(),
                     },
-                )))
-            }
+                },
+            ))),
             // We don't support thought blocks being passed in from a request.
             // These are only possible to be passed in in the scenario where the
             // output of a chat completion is used as an input to another model inference,

--- a/tensorzero-internal/src/inference/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/google_ai_studio_gemini.rs
@@ -17,6 +17,7 @@ use crate::endpoints::inference::InferenceCredentials;
 use crate::error::{DisplayOrDebugGateway, Error, ErrorDetails};
 use crate::inference::providers::provider_trait::InferenceProvider;
 use crate::inference::types::batch::{BatchRequestRow, PollBatchInferenceResponse};
+use crate::inference::types::file::require_image;
 use crate::inference::types::resolved_input::FileWithPath;
 use crate::inference::types::{
     batch::StartBatchProviderInferenceResponse, serialize_or_log, ModelInferenceRequest,
@@ -482,7 +483,7 @@ impl<'a> TryFrom<&'a ContentBlock> for Option<FlattenUnknown<'a, GeminiPart<'a>>
                 file,
                 storage_path: _,
             }) => {
-                file.mime_type.require_image(PROVIDER_TYPE)?;
+                require_image(&file.mime_type, PROVIDER_TYPE)?;
                 Ok(Some(FlattenUnknown::Normal(GeminiPart::InlineData {
                     inline_data: GeminiInlineData {
                         mime_type: file.mime_type.to_string(),

--- a/tensorzero-internal/src/inference/providers/openrouter.rs
+++ b/tensorzero-internal/src/inference/providers/openrouter.rs
@@ -21,6 +21,7 @@ use crate::error::{DisplayOrDebugGateway, Error, ErrorDetails};
 use crate::inference::providers::provider_trait::InferenceProvider;
 use crate::inference::types::batch::StartBatchProviderInferenceResponse;
 use crate::inference::types::batch::{BatchRequestRow, PollBatchInferenceResponse};
+use crate::inference::types::file::require_image;
 use crate::inference::types::resolved_input::FileWithPath;
 use crate::inference::types::{
     ContentBlock, ContentBlockChunk, ContentBlockOutput, Latency, ModelInferenceRequest,
@@ -775,7 +776,7 @@ fn tensorzero_to_openrouter_user_messages(
                 file,
                 storage_path: _,
             }) => {
-                file.mime_type.require_image(PROVIDER_TYPE)?;
+                require_image(&file.mime_type, PROVIDER_TYPE)?;
                 user_content_blocks.push(OpenRouterContentBlock::ImageUrl {
                     image_url: OpenRouterImageUrl {
                         // This will only produce an error if we pass in a bad
@@ -853,7 +854,7 @@ fn tensorzero_to_openrouter_assistant_messages(
                 file,
                 storage_path: _,
             }) => {
-                file.mime_type.require_image(PROVIDER_TYPE)?;
+                require_image(&file.mime_type, PROVIDER_TYPE)?;
                 assistant_content_blocks.push(OpenRouterContentBlock::ImageUrl {
                     image_url: OpenRouterImageUrl {
                         // This will only produce an error if we pass in a bad

--- a/tensorzero-internal/src/inference/types/mod.rs
+++ b/tensorzero-internal/src/inference/types/mod.rs
@@ -4,7 +4,7 @@ use derive_builder::Builder;
 use extra_body::{FullExtraBodyConfig, UnfilteredInferenceExtraBody};
 use extra_headers::{FullExtraHeadersConfig, UnfilteredInferenceExtraHeaders};
 use file::sanitize_raw_request;
-pub use file::{Base64File, File, FileKind};
+pub use file::{Base64File, File};
 use futures::stream::Peekable;
 use futures::Stream;
 use itertools::Itertools;

--- a/tensorzero-internal/src/variant/dicl.rs
+++ b/tensorzero-internal/src/variant/dicl.rs
@@ -649,7 +649,7 @@ mod tests {
         inference::types::{
             resolved_input::FileWithPath,
             storage::{StorageKind, StoragePath},
-            Base64File, FileKind, ResolvedInputMessage, ResolvedInputMessageContent, Role, Text,
+            Base64File, ResolvedInputMessage, ResolvedInputMessageContent, Role, Text,
         },
         tool::{ToolCall, ToolCallOutput},
     };
@@ -834,7 +834,7 @@ mod tests {
                             ResolvedInputMessageContent::File(FileWithPath {
                                 file: Base64File {
                                     url: None,
-                                    mime_type: FileKind::Png,
+                                    mime_type: mime::IMAGE_PNG,
                                     data: Some("ABC".to_string()),
                                 },
                                 storage_path: StoragePath {

--- a/tensorzero-internal/tests/e2e/inference.rs
+++ b/tensorzero-internal/tests/e2e/inference.rs
@@ -25,7 +25,7 @@ use tensorzero_internal::{
             DUMMY_STREAMING_TOOL_RESPONSE, DUMMY_TOOL_RESPONSE,
         },
         types::{
-            ContentBlock, ContentBlockOutput, File, FileKind, RequestMessage, ResolvedInput,
+            ContentBlock, ContentBlockOutput, File, RequestMessage, ResolvedInput,
             ResolvedInputMessageContent, Role, Text, TextKind,
         },
     },
@@ -2852,7 +2852,7 @@ async fn test_image_inference_without_object_store() {
                             text: "Describe the contents of the image".to_string(),
                         }),
                         ClientInputMessageContent::File(File::Base64 {
-                            mime_type: FileKind::Png,
+                            mime_type: mime::IMAGE_PNG,
                             data: BASE64_STANDARD.encode(FERRIS_PNG),
                         }),
                     ],

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -34,8 +34,7 @@ use tensorzero_internal::{
     inference::types::{
         resolved_input::FileWithPath,
         storage::{StorageKind, StoragePath},
-        Base64File, ContentBlock, ContentBlockChatOutput, File, FileKind, RequestMessage, Role,
-        Text,
+        Base64File, ContentBlock, ContentBlockChatOutput, File, RequestMessage, Role, Text,
     },
     tool::{ToolCall, ToolResult},
 };
@@ -1025,7 +1024,7 @@ pub async fn test_base64_pdf_inference_with_provider_and_store(
                                 text: "Describe the contents of the PDF".to_string(),
                             }),
                             ClientInputMessageContent::File(File::Base64 {
-                                mime_type: FileKind::Pdf,
+                                mime_type: mime::APPLICATION_PDF,
                                 data: pdf_data.clone(),
                             }),
                         ],
@@ -1087,7 +1086,7 @@ pub async fn test_base64_image_inference_with_provider_and_store(
                                 text: "Describe the contents of the image".to_string(),
                             }),
                             ClientInputMessageContent::File(File::Base64 {
-                                mime_type: FileKind::Png,
+                                mime_type: mime::IMAGE_PNG,
                                 data: image_data.clone(),
                             }),
                         ],
@@ -1844,7 +1843,7 @@ pub async fn check_base64_pdf_response(
                     file: Base64File {
                         url: None,
                         data: None,
-                        mime_type: FileKind::Pdf,
+                        mime_type: mime::APPLICATION_PDF,
                     },
                     storage_path: expected_storage_path.clone(),
                 })
@@ -2000,7 +1999,7 @@ pub async fn check_base64_image_response(
                     file: Base64File {
                         url: None,
                         data: None,
-                        mime_type: FileKind::Png,
+                        mime_type: mime::IMAGE_PNG,
                     },
                     storage_path: expected_storage_path.clone(),
                 })
@@ -2150,7 +2149,7 @@ pub async fn check_url_image_response(
                     file: Base64File {
                         url: Some(image_url.clone()),
                         data: None,
-                        mime_type: FileKind::Png,
+                        mime_type: mime::IMAGE_PNG,
                     },
                     storage_path: StoragePath {
                         kind: kind.clone(),

--- a/tensorzero-internal/tests/e2e/render_inferences.rs
+++ b/tensorzero-internal/tests/e2e/render_inferences.rs
@@ -7,7 +7,7 @@ use tensorzero::{
 use tensorzero_internal::{
     inference::types::{
         resolved_input::FileWithPath, Base64File, ContentBlock, ContentBlockChatOutput,
-        ContentBlockOutput, FileKind, JsonInferenceOutput, ResolvedInput, ResolvedInputMessage,
+        ContentBlockOutput, JsonInferenceOutput, ResolvedInput, ResolvedInputMessage,
         ResolvedInputMessageContent,
     },
     tool::{ToolCallConfigDatabaseInsert, ToolCallOutput, ToolChoice},
@@ -231,7 +231,7 @@ pub async fn test_render_inferences_normal() {
                         ResolvedInputMessageContent::File(FileWithPath {
                             file: Base64File {
                                 url: None,
-                                mime_type: FileKind::Png,
+                                mime_type: mime::IMAGE_PNG,
                                 data: None,
                             },
                             storage_path: StoragePath {


### PR DESCRIPTION
Unfortunately, the OpenAI apis require us to convert between mime-types and file extensions (when guessing the mime-type for the openai-compatible endpoint, and when generating a file name when invoking an openai provider).

When the mime-type is not a 'known good' mime type (current 'image/webp', 'image/png', 'image/jpeg', or 'application/pdf'), we log a warning when we attempt to convert between mime-types/extensions in either direction.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
