### PR TITLE
Add unknown/thinking content block support to Gemini providers

### DIFF
--- a/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_gemini.rs
@@ -42,7 +42,7 @@ use crate::inference::types::{
 use crate::inference::types::{
     ContentBlock, ContentBlockChunk, ContentBlockOutput, FileKind, FinishReason, FlattenUnknown,
     Latency, ModelInferenceRequestJsonMode, ProviderInferenceResponseArgs,
-    ProviderInferenceResponseStreamInner, Role, Text, TextChunk,
+    ProviderInferenceResponseStreamInner, Role, Text, TextChunk, Thought, ThoughtChunk,
 };
 use crate::model::{
     build_creds_caching_default_with_fn, fully_qualified_name, Credential, CredentialLocation,
@@ -1824,7 +1824,18 @@ struct GCPVertexGeminiResponseFunctionCall {
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-enum GCPVertexGeminiResponseContentPart {
+struct GCPVertexGeminiResponseContentPart {
+    #[serde(default)]
+    thought: bool,
+    #[serde(default)]
+    thought_signature: Option<String>,
+    #[serde(flatten)]
+    data: FlattenUnknown<'static, GCPVertexGeminiResponseContentPartData>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+enum GCPVertexGeminiResponseContentPartData {
     Text(String),
     // TODO (if needed): InlineData { inline_data: Blob },
     // TODO (if needed): FileData { file_data: FileData },
@@ -1840,12 +1851,44 @@ impl TryFrom<GCPVertexGeminiResponseContentPart> for ContentBlockChunk {
     /// So there is no issue with bookkeeping IDs for content blocks.
     /// We should revisit this if they begin to support it.
     fn try_from(part: GCPVertexGeminiResponseContentPart) -> Result<Self, Self::Error> {
-        match part {
-            GCPVertexGeminiResponseContentPart::Text(text) => Ok(ContentBlockChunk::Text(TextChunk {
-                text,
-                id: "0".to_string(),
-            })),
-            GCPVertexGeminiResponseContentPart::FunctionCall(function_call) => {
+        if part.thought {
+            match part.data {
+                FlattenUnknown::Normal(GCPVertexGeminiResponseContentPartData::Text(text)) => {
+                    return Ok(ContentBlockChunk::Thought(ThoughtChunk {
+                        id: "0".to_string(),
+                        text: Some(text),
+                        signature: part.thought_signature,
+                    }));
+                }
+                // Handle 'thought/thoughtSignature' with no other fields
+                FlattenUnknown::Unknown(obj) if obj.as_object().is_some_and(|m| m.is_empty()) => {
+                    return Ok(ContentBlockChunk::Thought(ThoughtChunk {
+                        id: "0".to_string(),
+                        text: None,
+                        signature: part.thought_signature,
+                    }));
+                }
+                _ => {
+                    return Err(Error::new(ErrorDetails::InferenceServer {
+                        message: "Thought part in GCP Vertex Gemini response must be a text block"
+                            .to_string(),
+                        provider_type: PROVIDER_TYPE.to_string(),
+                        raw_request: None,
+                        raw_response: Some(serde_json::to_string(&part).unwrap_or_default()),
+                    }));
+                }
+            }
+        }
+        match part.data {
+            FlattenUnknown::Normal(GCPVertexGeminiResponseContentPartData::Text(text)) => {
+                Ok(ContentBlockChunk::Text(TextChunk {
+                    text,
+                    id: "0".to_string(),
+                }))
+            }
+            FlattenUnknown::Normal(GCPVertexGeminiResponseContentPartData::FunctionCall(
+                function_call,
+            )) => {
                 let arguments = serialize_or_log(&function_call.args);
                 Ok(ContentBlockChunk::ToolCall(ToolCallChunk {
                     raw_name: function_call.name,
@@ -1853,14 +1896,22 @@ impl TryFrom<GCPVertexGeminiResponseContentPart> for ContentBlockChunk {
                     id: "0".to_string(),
                 }))
             }
-            GCPVertexGeminiResponseContentPart::ExecutableCode(_) => {
-                Err(Error::new(ErrorDetails::InferenceServer {
-                    message: "executableCode is not supported in streaming response for GCP Vertex Gemini".to_string(),
-                    provider_type: PROVIDER_TYPE.to_string(),
-                    raw_request: None,
-                    raw_response: Some(serde_json::to_string(&part).unwrap_or_default()),
-                }))
-            }
+            FlattenUnknown::Normal(
+                GCPVertexGeminiResponseContentPartData::ExecutableCode(_),
+            ) => Err(Error::new(ErrorDetails::InferenceServer {
+                message:
+                    "executableCode is not supported in streaming response for GCP Vertex Gemini"
+                        .to_string(),
+                provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: None,
+                raw_response: Some(serde_json::to_string(&part).unwrap_or_default()),
+            })),
+            FlattenUnknown::Unknown(part) => Err(Error::new(ErrorDetails::InferenceServer {
+                message: "Unknown content part in GCP Vertex Gemini response".to_string(),
+                provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: None,
+                raw_response: Some(part.to_string()),
+            })),
         }
     }
 }
@@ -1870,9 +1921,44 @@ fn convert_to_output(
     provider_name: &str,
     part: GCPVertexGeminiResponseContentPart,
 ) -> Result<ContentBlockOutput, Error> {
-    match part {
-        GCPVertexGeminiResponseContentPart::Text(text) => Ok(text.into()),
-        GCPVertexGeminiResponseContentPart::FunctionCall(function_call) => {
+    // We currently only support text thoughts - if we get anything else, turn it into
+    // an `unknown` block
+    if part.thought {
+        match part.data {
+            FlattenUnknown::Normal(GCPVertexGeminiResponseContentPartData::Text(text)) => {
+                return Ok(ContentBlockOutput::Thought(Thought {
+                    signature: part.thought_signature,
+                    text,
+                }));
+            }
+            // Handle 'thought/thoughtSignature' with no other fields
+            FlattenUnknown::Unknown(obj) if obj.as_object().is_some_and(|m| m.is_empty()) => {
+                return Ok(ContentBlockOutput::Thought(Thought {
+                    signature: part.thought_signature,
+                    text: "".to_string(),
+                }));
+            }
+            _ => {
+                return Ok(ContentBlockOutput::Unknown {
+                    data: serde_json::to_value(part).map_err(|e| {
+                        Error::new(ErrorDetails::Serialization {
+                            message: format!(
+                                "Error serializing thought part returned from GCP: {e}"
+                            ),
+                        })
+                    })?,
+                    model_provider_name: Some(fully_qualified_name(model_name, provider_name)),
+                });
+            }
+        }
+    }
+    match part.data {
+        FlattenUnknown::Normal(GCPVertexGeminiResponseContentPartData::Text(text)) => {
+            Ok(text.into())
+        }
+        FlattenUnknown::Normal(GCPVertexGeminiResponseContentPartData::FunctionCall(
+            function_call,
+        )) => {
             Ok(ContentBlockOutput::ToolCall(ToolCall {
                 name: function_call.name,
                 arguments: serde_json::to_string(&function_call.args).map_err(|e| {
@@ -1886,7 +1972,7 @@ fn convert_to_output(
                 id: Uuid::now_v7().to_string(),
             }))
         }
-        GCPVertexGeminiResponseContentPart::ExecutableCode(data) => {
+        FlattenUnknown::Normal(GCPVertexGeminiResponseContentPartData::ExecutableCode(data)) => {
             Ok(ContentBlockOutput::Unknown {
                 data: serde_json::json!({
                     "executableCode": data,
@@ -1894,6 +1980,10 @@ fn convert_to_output(
                 model_provider_name: Some(fully_qualified_name(model_name, provider_name)),
             })
         }
+        FlattenUnknown::Unknown(data) => Ok(ContentBlockOutput::Unknown {
+            data: data.into_owned(),
+            model_provider_name: Some(fully_qualified_name(model_name, provider_name)),
+        }),
     }
 }
 
@@ -2576,8 +2666,14 @@ mod tests {
 
     #[test]
     fn test_gcp_to_t0_response() {
-        let part = GCPVertexGeminiResponseContentPart::Text("test_assistant".to_string());
-        let content = GCPVertexGeminiResponseContent { parts: vec![part] };
+        let part = GCPVertexGeminiResponseContentPartData::Text("test_assistant".to_string());
+        let content = GCPVertexGeminiResponseContent {
+            parts: vec![GCPVertexGeminiResponseContentPart {
+                thought: false,
+                thought_signature: None,
+                data: FlattenUnknown::Normal(part),
+            }],
+        };
         let candidate = GCPVertexGeminiResponseCandidate {
             content: Some(content),
             finish_reason: Some(GCPVertexGeminiFinishReason::Stop),
@@ -2654,15 +2750,28 @@ mod tests {
             Some("test_system".to_string())
         );
         assert_eq!(model_inference_response.input_messages, vec![]);
-        let text_part =
-            GCPVertexGeminiResponseContentPart::Text("Here's the weather information:".to_string());
-        let function_call_part =
-            GCPVertexGeminiResponseContentPart::FunctionCall(GCPVertexGeminiResponseFunctionCall {
+        let text_part = GCPVertexGeminiResponseContentPartData::Text(
+            "Here's the weather information:".to_string(),
+        );
+        let function_call_part = GCPVertexGeminiResponseContentPartData::FunctionCall(
+            GCPVertexGeminiResponseFunctionCall {
                 name: "get_temperature".to_string(),
                 args: json!({"location": "New York", "unit": "celsius"}),
-            });
+            },
+        );
         let content = GCPVertexGeminiResponseContent {
-            parts: vec![text_part, function_call_part],
+            parts: vec![
+                GCPVertexGeminiResponseContentPart {
+                    thought: false,
+                    thought_signature: None,
+                    data: FlattenUnknown::Normal(text_part),
+                },
+                GCPVertexGeminiResponseContentPart {
+                    thought: false,
+                    thought_signature: None,
+                    data: FlattenUnknown::Normal(function_call_part),
+                },
+            ],
         };
         let candidate = GCPVertexGeminiResponseCandidate {
             content: Some(content),
@@ -2756,27 +2865,46 @@ mod tests {
             }]
         );
 
-        let text_part1 =
-            GCPVertexGeminiResponseContentPart::Text("Here's the weather information:".to_string());
-        let function_call_part =
-            GCPVertexGeminiResponseContentPart::FunctionCall(GCPVertexGeminiResponseFunctionCall {
+        let text_part1 = GCPVertexGeminiResponseContentPartData::Text(
+            "Here's the weather information:".to_string(),
+        );
+        let function_call_part = GCPVertexGeminiResponseContentPartData::FunctionCall(
+            GCPVertexGeminiResponseFunctionCall {
                 name: "get_temperature".to_string(),
                 args: json!({"location": "New York", "unit": "celsius"}),
-            });
-        let text_part2 = GCPVertexGeminiResponseContentPart::Text(
+            },
+        );
+        let text_part2 = GCPVertexGeminiResponseContentPartData::Text(
             "And here's a restaurant recommendation:".to_string(),
         );
-        let function_call_part2 =
-            GCPVertexGeminiResponseContentPart::FunctionCall(GCPVertexGeminiResponseFunctionCall {
+        let function_call_part2 = GCPVertexGeminiResponseContentPartData::FunctionCall(
+            GCPVertexGeminiResponseFunctionCall {
                 name: "get_restaurant".to_string(),
                 args: json!({"cuisine": "Italian", "price_range": "moderate"}),
-            });
+            },
+        );
         let content = GCPVertexGeminiResponseContent {
             parts: vec![
-                text_part1,
-                function_call_part,
-                text_part2,
-                function_call_part2,
+                GCPVertexGeminiResponseContentPart {
+                    thought: false,
+                    thought_signature: None,
+                    data: FlattenUnknown::Normal(text_part1),
+                },
+                GCPVertexGeminiResponseContentPart {
+                    thought: false,
+                    thought_signature: None,
+                    data: FlattenUnknown::Normal(function_call_part),
+                },
+                GCPVertexGeminiResponseContentPart {
+                    thought: false,
+                    thought_signature: None,
+                    data: FlattenUnknown::Normal(text_part2),
+                },
+                GCPVertexGeminiResponseContentPart {
+                    thought: false,
+                    thought_signature: None,
+                    data: FlattenUnknown::Normal(function_call_part2),
+                },
             ],
         };
         let candidate = GCPVertexGeminiResponseCandidate {

--- a/tensorzero-internal/src/inference/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-internal/src/inference/providers/google_ai_studio_gemini.rs
@@ -26,9 +26,13 @@ use crate::inference::types::{
 use crate::inference::types::{
     ContentBlock, ContentBlockChunk, ContentBlockOutput, Latency, ModelInferenceRequestJsonMode,
     ProviderInferenceResponseArgs, ProviderInferenceResponseStreamInner, Role, Text, TextChunk,
+    Thought, ThoughtChunk,
 };
 use crate::inference::types::{FinishReason, FlattenUnknown};
-use crate::model::{build_creds_caching_default, Credential, CredentialLocation, ModelProvider};
+use crate::model::{
+    build_creds_caching_default, fully_qualified_name, Credential, CredentialLocation,
+    ModelProvider,
+};
 use crate::tool::{ToolCall, ToolCallChunk, ToolChoice, ToolConfig};
 
 use super::gcp_vertex_gemini::process_output_schema;
@@ -145,7 +149,7 @@ impl InferenceProvider for GoogleAIStudioGeminiProvider {
         &'a self,
         ModelProviderRequest {
             request,
-            provider_name: _,
+            provider_name,
             model_name,
         }: ModelProviderRequest<'a>,
         http_client: &'a reqwest::Client,
@@ -220,6 +224,8 @@ impl InferenceProvider for GoogleAIStudioGeminiProvider {
                 raw_response,
                 request: request_body,
                 generic_request: request,
+                model_name,
+                provider_name,
             };
             Ok(response_with_latency.try_into()?)
         } else {
@@ -740,7 +746,19 @@ struct GeminiResponseFunctionCall {
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-enum GeminiResponseContentPart {
+struct GeminiResponseContentPart {
+    #[serde(default)]
+    thought: bool,
+    #[serde(default)]
+    thought_signature: Option<String>,
+    #[serde(flatten)]
+    #[serde(default)]
+    data: FlattenUnknown<'static, GeminiResponseContentPartData>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+enum GeminiResponseContentPartData {
     Text(String),
     // TODO (if needed): InlineData { inline_data: Blob },
     // TODO (if needed): FileData { file_data: FileData },
@@ -749,48 +767,121 @@ enum GeminiResponseContentPart {
     // TODO (if needed): VideoMetadata { video_metadata: VideoMetadata },
 }
 
-impl From<GeminiResponseContentPart> for ContentBlockChunk {
+impl TryFrom<GeminiResponseContentPart> for ContentBlockChunk {
+    type Error = Error;
     /// Google AI Studio Gemini does not support parallel tool calling or multiple content blocks as far as I can tell.
     /// So there is no issue with bookkeeping IDs for content blocks.
     /// We should revisit this if they begin to support it.
-    fn from(part: GeminiResponseContentPart) -> Self {
-        match part {
-            GeminiResponseContentPart::Text(text) => ContentBlockChunk::Text(TextChunk {
-                text,
-                id: "0".to_string(),
-            }),
-            GeminiResponseContentPart::FunctionCall(function_call) => {
+    fn try_from(part: GeminiResponseContentPart) -> Result<Self, Self::Error> {
+        if part.thought {
+            match part.data {
+                FlattenUnknown::Normal(GeminiResponseContentPartData::Text(text)) => {
+                    return Ok(ContentBlockChunk::Thought(ThoughtChunk {
+                        id: "0".to_string(),
+                        text: Some(text),
+                        signature: part.thought_signature,
+                    }));
+                }
+                // Handle 'thought/thoughtSignature' with no other fields
+                FlattenUnknown::Unknown(obj) if obj.as_object().is_some_and(|m| m.is_empty()) => {
+                    return Ok(ContentBlockChunk::Thought(ThoughtChunk {
+                        id: "0".to_string(),
+                        text: None,
+                        signature: part.thought_signature,
+                    }));
+                }
+                _ => {
+                    return Err(Error::new(ErrorDetails::InferenceServer {
+                        message:
+                            format!(
+                                "Thought part in Google AI Studio Gemini response must be a text block: {part:?}"
+                            ),
+                        provider_type: PROVIDER_TYPE.to_string(),
+                        raw_request: None,
+                        raw_response: Some(serde_json::to_string(&part).unwrap_or_default()),
+                    }));
+                }
+            }
+        }
+        match part.data {
+            FlattenUnknown::Normal(GeminiResponseContentPartData::Text(text)) => {
+                Ok(ContentBlockChunk::Text(TextChunk {
+                    text,
+                    id: "0".to_string(),
+                }))
+            }
+            FlattenUnknown::Normal(GeminiResponseContentPartData::FunctionCall(function_call)) => {
                 let arguments = serialize_or_log(&function_call.args);
-                ContentBlockChunk::ToolCall(ToolCallChunk {
+                Ok(ContentBlockChunk::ToolCall(ToolCallChunk {
                     raw_name: function_call.name,
                     raw_arguments: arguments,
                     id: "0".to_string(),
-                })
+                }))
             }
+            FlattenUnknown::Unknown(part) => Err(Error::new(ErrorDetails::InferenceServer {
+                message: "Unknown content part in Google AI Studio Gemini response".to_string(),
+                provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: None,
+                raw_response: Some(part.to_string()),
+            })),
         }
     }
 }
 
-impl TryFrom<GeminiResponseContentPart> for ContentBlockOutput {
-    type Error = Error;
-    fn try_from(part: GeminiResponseContentPart) -> Result<Self, Self::Error> {
-        match part {
-            GeminiResponseContentPart::Text(text) => Ok(text.into()),
-            GeminiResponseContentPart::FunctionCall(function_call) => {
-                Ok(ContentBlockOutput::ToolCall(ToolCall {
-                    name: function_call.name,
-                    arguments: serde_json::to_string(&function_call.args).map_err(|e| {
+fn convert_part_to_output(
+    model_name: &str,
+    provider_name: &str,
+    part: GeminiResponseContentPart,
+) -> Result<ContentBlockOutput, Error> {
+    if part.thought {
+        match part.data {
+            FlattenUnknown::Normal(GeminiResponseContentPartData::Text(text)) => {
+                return Ok(ContentBlockOutput::Thought(Thought {
+                    signature: part.thought_signature,
+                    text,
+                }));
+            }
+            // Handle 'thought/thoughtSignature' with no other fields
+            FlattenUnknown::Unknown(obj) if obj.as_object().is_some_and(|m| m.is_empty()) => {
+                return Ok(ContentBlockOutput::Thought(Thought {
+                    signature: part.thought_signature,
+                    text: "".to_string(),
+                }));
+            }
+            _ => {
+                return Ok(ContentBlockOutput::Unknown {
+                    data: serde_json::to_value(part).map_err(|e| {
                         Error::new(ErrorDetails::Serialization {
                             message: format!(
-                                "Error serializing function call arguments returned from Gemini: {e}"
+                                "Error serializing thought part returned from GCP: {e}"
                             ),
                         })
                     })?,
-                    // Gemini doesn't have the concept of tool call ID so we generate one for our bookkeeping
-                    id: Uuid::now_v7().to_string(),
-                }))
+                    model_provider_name: Some(fully_qualified_name(model_name, provider_name)),
+                });
             }
         }
+    }
+    match part.data {
+        FlattenUnknown::Normal(GeminiResponseContentPartData::Text(text)) => Ok(text.into()),
+        FlattenUnknown::Normal(GeminiResponseContentPartData::FunctionCall(function_call)) => {
+            Ok(ContentBlockOutput::ToolCall(ToolCall {
+                name: function_call.name,
+                arguments: serde_json::to_string(&function_call.args).map_err(|e| {
+                    Error::new(ErrorDetails::Serialization {
+                        message: format!(
+                            "Error serializing function call arguments returned from Gemini: {e}"
+                        ),
+                    })
+                })?,
+                // Gemini doesn't have the concept of tool call ID so we generate one for our bookkeeping
+                id: Uuid::now_v7().to_string(),
+            }))
+        }
+        FlattenUnknown::Unknown(part) => Ok(ContentBlockOutput::Unknown {
+            data: part.into_owned(),
+            model_provider_name: Some(fully_qualified_name(model_name, provider_name)),
+        }),
     }
 }
 
@@ -872,6 +963,8 @@ struct GeminiResponse {
 }
 
 struct GeminiResponseWithMetadata<'a> {
+    model_name: &'a str,
+    provider_name: &'a str,
     response: GeminiResponse,
     raw_response: String,
     latency: Latency,
@@ -888,6 +981,8 @@ impl<'a> TryFrom<GeminiResponseWithMetadata<'a>> for ProviderInferenceResponse {
             latency,
             request: request_body,
             generic_request,
+            model_name,
+            provider_name,
         } = response;
 
         // Google AI Studio Gemini response can contain multiple candidates and each of these can contain
@@ -906,7 +1001,7 @@ impl<'a> TryFrom<GeminiResponseWithMetadata<'a>> for ProviderInferenceResponse {
             Some(content) => content
                 .parts
                 .into_iter()
-                .map(|part| part.try_into())
+                .map(|part| convert_part_to_output(model_name, provider_name, part))
                 .collect::<Result<Vec<ContentBlockOutput>, Error>>()?,
             None => vec![],
         };
@@ -976,7 +1071,11 @@ impl TryFrom<GoogleAIStudioGeminiResponseWithMetadata> for ProviderInferenceResp
 
         // Gemini sometimes returns chunks without content (e.g. they might have usage only).
         let mut content: Vec<ContentBlockChunk> = match first_candidate.content {
-            Some(content) => content.parts.into_iter().map(|part| part.into()).collect(),
+            Some(content) => content
+                .parts
+                .into_iter()
+                .map(|part| part.try_into())
+                .collect::<Result<Vec<ContentBlockChunk>, Error>>()?,
             None => vec![],
         };
 
@@ -1384,8 +1483,14 @@ mod tests {
 
     #[test]
     fn test_google_ai_studio_gemini_to_t0_response() {
-        let part = GeminiResponseContentPart::Text("test_assistant".to_string());
-        let content = GeminiResponseContent { parts: vec![part] };
+        let part = GeminiResponseContentPartData::Text("test_assistant".to_string());
+        let content = GeminiResponseContent {
+            parts: vec![GeminiResponseContentPart {
+                thought: false,
+                thought_signature: None,
+                data: FlattenUnknown::Normal(part),
+            }],
+        };
         let candidate = GeminiResponseCandidate {
             content: Some(content),
             finish_reason: Some(GeminiFinishReason::Stop),
@@ -1431,6 +1536,8 @@ mod tests {
         let raw_request = serde_json::to_string(&request_body).unwrap();
         let raw_response = "test response".to_string();
         let response_with_latency = GeminiResponseWithMetadata {
+            model_name: "test_model",
+            provider_name: "test_provider",
             response,
             latency: latency.clone(),
             request: serde_json::to_value(&request_body).unwrap(),
@@ -1466,14 +1573,25 @@ mod tests {
             }]
         );
         let text_part =
-            GeminiResponseContentPart::Text("Here's the weather information:".to_string());
+            GeminiResponseContentPartData::Text("Here's the weather information:".to_string());
         let function_call_part =
-            GeminiResponseContentPart::FunctionCall(GeminiResponseFunctionCall {
+            GeminiResponseContentPartData::FunctionCall(GeminiResponseFunctionCall {
                 name: "get_temperature".to_string(),
                 args: json!({"location": "New York", "unit": "celsius"}),
             });
         let content = GeminiResponseContent {
-            parts: vec![text_part, function_call_part],
+            parts: vec![
+                GeminiResponseContentPart {
+                    thought: false,
+                    thought_signature: None,
+                    data: FlattenUnknown::Normal(text_part),
+                },
+                GeminiResponseContentPart {
+                    thought: false,
+                    thought_signature: None,
+                    data: FlattenUnknown::Normal(function_call_part),
+                },
+            ],
         };
         let candidate = GeminiResponseCandidate {
             content: Some(content),
@@ -1519,6 +1637,8 @@ mod tests {
         };
         let raw_request = serde_json::to_string(&request_body).unwrap();
         let response_with_latency = GeminiResponseWithMetadata {
+            model_name: "test_model",
+            provider_name: "test_provider",
             response,
             latency: latency.clone(),
             request: serde_json::to_value(&request_body).unwrap(),
@@ -1567,25 +1687,42 @@ mod tests {
         );
 
         let text_part1 =
-            GeminiResponseContentPart::Text("Here's the weather information:".to_string());
+            GeminiResponseContentPartData::Text("Here's the weather information:".to_string());
         let function_call_part =
-            GeminiResponseContentPart::FunctionCall(GeminiResponseFunctionCall {
+            GeminiResponseContentPartData::FunctionCall(GeminiResponseFunctionCall {
                 name: "get_temperature".to_string(),
                 args: json!({"location": "New York", "unit": "celsius"}),
             });
-        let text_part2 =
-            GeminiResponseContentPart::Text("And here's a restaurant recommendation:".to_string());
+        let text_part2 = GeminiResponseContentPartData::Text(
+            "And here's a restaurant recommendation:".to_string(),
+        );
         let function_call_part2 =
-            GeminiResponseContentPart::FunctionCall(GeminiResponseFunctionCall {
+            GeminiResponseContentPartData::FunctionCall(GeminiResponseFunctionCall {
                 name: "get_restaurant".to_string(),
                 args: json!({"cuisine": "Italian", "price_range": "moderate"}),
             });
         let content = GeminiResponseContent {
             parts: vec![
-                text_part1,
-                function_call_part,
-                text_part2,
-                function_call_part2,
+                GeminiResponseContentPart {
+                    thought: false,
+                    thought_signature: None,
+                    data: FlattenUnknown::Normal(text_part1),
+                },
+                GeminiResponseContentPart {
+                    thought: false,
+                    thought_signature: None,
+                    data: FlattenUnknown::Normal(function_call_part),
+                },
+                GeminiResponseContentPart {
+                    thought: false,
+                    thought_signature: None,
+                    data: FlattenUnknown::Normal(text_part2),
+                },
+                GeminiResponseContentPart {
+                    thought: false,
+                    thought_signature: None,
+                    data: FlattenUnknown::Normal(function_call_part2),
+                },
             ],
         };
         let candidate = GeminiResponseCandidate {
@@ -1611,6 +1748,8 @@ mod tests {
         };
         let raw_request = serde_json::to_string(&request_body).unwrap();
         let response_with_latency = GeminiResponseWithMetadata {
+            model_name: "test_model",
+            provider_name: "test_provider",
             response,
             latency: latency.clone(),
             request: serde_json::to_value(&request_body).unwrap(),
@@ -1881,9 +2020,13 @@ mod tests {
     #[test]
     fn test_try_from_with_content_and_finish_reason() {
         // Setup a response with content and finish reason
-        let text_part = GeminiResponseContentPart::Text("Hello, world!".to_string());
+        let text_part = GeminiResponseContentPartData::Text("Hello, world!".to_string());
         let content = GeminiResponseContent {
-            parts: vec![text_part],
+            parts: vec![GeminiResponseContentPart {
+                thought: false,
+                thought_signature: None,
+                data: FlattenUnknown::Normal(text_part),
+            }],
         };
         let candidate = GeminiResponseCandidate {
             content: Some(content),
@@ -1928,9 +2071,13 @@ mod tests {
     #[test]
     fn test_try_from_without_finish_reason() {
         // Setup a response without finish reason (streaming chunk)
-        let text_part = GeminiResponseContentPart::Text("Partial response".to_string());
+        let text_part = GeminiResponseContentPartData::Text("Partial response".to_string());
         let content = GeminiResponseContent {
-            parts: vec![text_part],
+            parts: vec![GeminiResponseContentPart {
+                thought: false,
+                thought_signature: None,
+                data: FlattenUnknown::Normal(text_part),
+            }],
         };
         let candidate = GeminiResponseCandidate {
             content: Some(content),
@@ -1971,10 +2118,21 @@ mod tests {
     #[test]
     fn test_try_from_with_empty_text_chunks() {
         // Setup a response with empty text chunks that should be filtered out
-        let empty_text = GeminiResponseContentPart::Text("".to_string());
-        let non_empty_text = GeminiResponseContentPart::Text("Non-empty text".to_string());
+        let empty_text = GeminiResponseContentPartData::Text("".to_string());
+        let non_empty_text = GeminiResponseContentPartData::Text("Non-empty text".to_string());
         let content = GeminiResponseContent {
-            parts: vec![empty_text, non_empty_text],
+            parts: vec![
+                GeminiResponseContentPart {
+                    thought: false,
+                    thought_signature: None,
+                    data: FlattenUnknown::Normal(empty_text),
+                },
+                GeminiResponseContentPart {
+                    thought: false,
+                    thought_signature: None,
+                    data: FlattenUnknown::Normal(non_empty_text),
+                },
+            ],
         };
         let candidate = GeminiResponseCandidate {
             content: Some(content),
@@ -2009,12 +2167,17 @@ mod tests {
     #[test]
     fn test_try_from_with_function_call() {
         // Setup a response with a function call
-        let function_call = GeminiResponseContentPart::FunctionCall(GeminiResponseFunctionCall {
-            name: "get_weather".to_string(),
-            args: json!({"location": "New York", "unit": "celsius"}),
-        });
+        let function_call =
+            GeminiResponseContentPartData::FunctionCall(GeminiResponseFunctionCall {
+                name: "get_weather".to_string(),
+                args: json!({"location": "New York", "unit": "celsius"}),
+            });
         let content = GeminiResponseContent {
-            parts: vec![function_call],
+            parts: vec![GeminiResponseContentPart {
+                thought: false,
+                thought_signature: None,
+                data: FlattenUnknown::Normal(function_call),
+            }],
         };
         let candidate = GeminiResponseCandidate {
             content: Some(content),
@@ -2149,9 +2312,13 @@ mod tests {
         ];
 
         for (gemini_reason, expected_reason) in finish_reasons {
-            let text_part = GeminiResponseContentPart::Text("Test".to_string());
+            let text_part = GeminiResponseContentPartData::Text("Test".to_string());
             let content = GeminiResponseContent {
-                parts: vec![text_part],
+                parts: vec![GeminiResponseContentPart {
+                    thought: false,
+                    thought_signature: None,
+                    data: FlattenUnknown::Normal(text_part),
+                }],
             };
             let candidate = GeminiResponseCandidate {
                 content: Some(content),

--- a/tensorzero-internal/tests/e2e/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-internal/tests/e2e/providers/gcp_vertex_gemini.rs
@@ -137,9 +137,11 @@ async fn get_providers() -> E2ETestProviders {
     }
 }
 
-// Specifying `tool_choice: none` causes Gemini 2.5 Pro to produce an 'executableCode' block.
-// We test that we properly construct an 'unknown' content block in this case.
+// Specifying `tool_choice: none` causes Gemini 2.5 to emit an 'UNEXPECTED_TOOL_CALL'
+// error. For now, we disable this test until we decide how to handle this:
+// https://github.com/tensorzero/tensorzero/issues/2329
 #[tokio::test]
+#[ignore]
 async fn test_gcp_pro_tool_choice_none() {
     let episode_id = Uuid::now_v7();
     let payload = json!({


### PR DESCRIPTION
This unbreaks the tests, as Gemini models recently started producing 'thought' content blocks by default

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
