### PR TITLE
Use 'cargo test-e2e' to avoid running batch tests in 'live-tests' job

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -148,14 +148,14 @@ jobs:
       # We run the tests without the flaky tests, and require them to pass
       - name: Run all tests (including E2E tests)
         run: |
-          TENSORZERO_E2E_PROXY="http://localhost:3003" cargo test-all --profile ci ${{ vars.CARGO_NEXTEST_EXTRA_ARGS }} -E "not (${{ vars.CARGO_NEXTEST_FLAKY_TESTS }})"
+          TENSORZERO_E2E_PROXY="http://localhost:3003" cargo test-e2e --profile ci ${{ vars.CARGO_NEXTEST_EXTRA_ARGS }} -E "not (${{ vars.CARGO_NEXTEST_FLAKY_TESTS }})"
 
       # As a separate step, we run just the flaky tests, and allow them to fail.
       # This lets us see if any flaky tests have started succeeding (by looking at the job output),
       # so that we can decide to mark them as non-flaky.
       # - name: Run flaky E2E tests
       #   run: |
-      #     TENSORZERO_E2E_PROXY="http://localhost:3003" cargo test-all --profile ci --no-fail-fast ${{ vars.CARGO_NEXTEST_EXTRA_ARGS }} -E "${{ vars.CARGO_NEXTEST_FLAKY_TESTS }}"
+      #     TENSORZERO_E2E_PROXY="http://localhost:3003" cargo test-e2e --profile ci --no-fail-fast ${{ vars.CARGO_NEXTEST_EXTRA_ARGS }} -E "${{ vars.CARGO_NEXTEST_FLAKY_TESTS }}"
       #   continue-on-error: true
 
       - name: Print e2e logs


### PR DESCRIPTION
We already test the batch tests in a separate 'batch-tests' job (which uses a persistent ClickHouse Cloud database), so stop running them in the live-tests job

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use `cargo test-e2e` in `live-tests` job to avoid redundant batch tests, which are covered in `batch-tests` job.
> 
>   - **Behavior**:
>     - Change `cargo test-all` to `cargo test-e2e` in `merge-queue.yml` to avoid running batch tests in `live-tests` job.
>     - Batch tests are already covered in the `batch-tests` job using a persistent ClickHouse Cloud database.
>   - **Misc**:
>     - Update comments in `merge-queue.yml` to reflect the change in test command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7a177e2be1792b043c7fb49a39482c4fd9f37fe4. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->