### PR TITLE
Preserve relative content block order in `collect_chunks`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4276,6 +4276,7 @@ dependencies = [
  "hex",
  "http 1.3.1",
  "image",
+ "indexmap 2.9.0",
  "init-tracing-opentelemetry",
  "itertools 0.14.0",
  "jsonschema",

--- a/tensorzero-internal/Cargo.toml
+++ b/tensorzero-internal/Cargo.toml
@@ -108,6 +108,7 @@ tower-http = { workspace = true }
 tower-layer = "0.3.3"
 pyo3 = { workspace = true, optional = true }
 google-cloud-auth = "0.20.0"
+indexmap = "2.9.0"
 
 
 [dev-dependencies]

--- a/tensorzero-internal/src/inference/types/mod.rs
+++ b/tensorzero-internal/src/inference/types/mod.rs
@@ -1409,7 +1409,7 @@ pub async fn collect_chunks(args: CollectChunksArgs<'_, '_>) -> Result<Inference
     // NOTE: We will eventually need this to be per-inference-response-type and sensitive to the type of variant and function being called.
     // We preserve the order of chunks in the stream when combining them into `ContentBlockOutput`, except when
     // the same id is used by non-adjacent blocks.
-    // For example, the follow chunks:
+    // For example, the following chunks:
     // `[TextChunk(id=0, content="Hello ""), ThoughtChunk(id=0, content=Something), TextChunk(id=0, content=World)]``
     // will be collected into the content block list: `[Text("Hello World"), Thought("Something"))]`
     //

--- a/tensorzero-internal/src/inference/types/mod.rs
+++ b/tensorzero-internal/src/inference/types/mod.rs
@@ -7,6 +7,7 @@ use file::sanitize_raw_request;
 pub use file::{Base64File, File, FileKind};
 use futures::stream::Peekable;
 use futures::Stream;
+use indexmap::IndexMap;
 use itertools::Itertools;
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
@@ -321,6 +322,14 @@ pub enum ContentBlock {
 pub enum FlattenUnknown<'a, T> {
     Normal(T),
     Unknown(Cow<'a, Value>),
+}
+
+/// Holds the variants types of `ContentBlockOutput` without any data
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum ContentBlockOutputType {
+    Text,
+    ToolCall,
+    Thought,
 }
 
 /// Defines the types of content block that can come out of a model provider
@@ -1398,9 +1407,18 @@ pub async fn collect_chunks(args: CollectChunksArgs<'_, '_>) -> Result<Inference
     } = args;
 
     // NOTE: We will eventually need this to be per-inference-response-type and sensitive to the type of variant and function being called.
-    let mut tool_call_blocks: HashMap<String, ContentBlockOutput> = HashMap::new();
-    let mut text_blocks: HashMap<String, ContentBlockOutput> = HashMap::new();
-    let mut thought_blocks: HashMap<String, ContentBlockOutput> = HashMap::new();
+    // We preserve the order of chunks in the stream when combining them into `ContentBlockOutput`, except when
+    // the same id is used by non-adjacent blocks.
+    // For example, the follow chunks:
+    // `[TextChunk(id=0, content="Hello ""), ThoughtChunk(id=0, content=Something), TextChunk(id=0, content=World)]``
+    // will be collected into the content block list: `[Text("Hello World"), Thought("Something"))]`
+    //
+    // All chunks with the same type and id (in this case, TextChunk id=0) are combined into a single content
+    // block at the first occurrence of that type and id.
+    // We use an 'IndexMap' to preserve the insertion order, so that newly-seen type/id combinations
+    // are not reordered.
+    let mut blocks: IndexMap<(ContentBlockOutputType, String), ContentBlockOutput> =
+        IndexMap::new();
     let raw_response: String = value
         .iter()
         .map(|chunk| chunk.raw_response())
@@ -1436,8 +1454,8 @@ pub async fn collect_chunks(args: CollectChunksArgs<'_, '_>) -> Result<Inference
                     match content {
                         ContentBlockChunk::Text(text) => {
                             handle_textual_content_block(
-                                &mut text_blocks,
-                                text.id,
+                                &mut blocks,
+                                (ContentBlockOutputType::Text, text.id),
                                 text.text,
                                 &mut ttft,
                                 chunk.latency,
@@ -1460,8 +1478,8 @@ pub async fn collect_chunks(args: CollectChunksArgs<'_, '_>) -> Result<Inference
                             // to a thought.
                             if let Some(text) = thought.text {
                                 handle_textual_content_block(
-                                    &mut thought_blocks,
-                                    thought.id.clone(),
+                                    &mut blocks,
+                                    (ContentBlockOutputType::Thought, thought.id.clone()),
                                     text,
                                     &mut ttft,
                                     chunk.latency,
@@ -1480,8 +1498,8 @@ pub async fn collect_chunks(args: CollectChunksArgs<'_, '_>) -> Result<Inference
                             }
                             if let Some(signature) = thought.signature {
                                 handle_textual_content_block(
-                                    &mut thought_blocks,
-                                    thought.id,
+                                    &mut blocks,
+                                    (ContentBlockOutputType::Thought, thought.id),
                                     signature,
                                     &mut ttft,
                                     chunk.latency,
@@ -1505,7 +1523,9 @@ pub async fn collect_chunks(args: CollectChunksArgs<'_, '_>) -> Result<Inference
                             }
                         }
                         ContentBlockChunk::ToolCall(tool_call) => {
-                            match tool_call_blocks.get_mut(&tool_call.id) {
+                            match blocks
+                                .get_mut(&(ContentBlockOutputType::ToolCall, tool_call.id.clone()))
+                            {
                                 // If there is already a tool call block with this id, append to it
                                 Some(ContentBlockOutput::ToolCall(existing_tool_call)) => {
                                     // We assume that the name and ID are present and complete in the first chunk
@@ -1518,8 +1538,8 @@ pub async fn collect_chunks(args: CollectChunksArgs<'_, '_>) -> Result<Inference
                                     if ttft.is_none() {
                                         ttft = Some(chunk.latency);
                                     }
-                                    tool_call_blocks.insert(
-                                        tool_call.id.clone(),
+                                    blocks.insert(
+                                        (ContentBlockOutputType::ToolCall, tool_call.id.clone()),
                                         ContentBlockOutput::ToolCall(tool_call.into()),
                                     );
                                 }
@@ -1532,7 +1552,7 @@ pub async fn collect_chunks(args: CollectChunksArgs<'_, '_>) -> Result<Inference
                 if let Some(chunk_finish_reason) = chunk.finish_reason {
                     finish_reason = Some(chunk_finish_reason);
                 }
-                match text_blocks.get_mut("") {
+                match blocks.get_mut(&(ContentBlockOutputType::Text, "".to_string())) {
                     // If there is already a text block, append to it
                     Some(ContentBlockOutput::Text(Text {
                         text: existing_text,
@@ -1549,20 +1569,21 @@ pub async fn collect_chunks(args: CollectChunksArgs<'_, '_>) -> Result<Inference
                             ttft = Some(chunk.latency);
                         }
                         if let Some(raw) = chunk.raw {
-                            text_blocks.insert(String::new(), raw.into());
+                            blocks
+                                .insert((ContentBlockOutputType::Text, "".to_string()), raw.into());
                         }
                     }
                 }
                 if let Some(thought) = chunk.thought {
-                    match thought_blocks.get_mut("") {
+                    match blocks.get_mut(&(ContentBlockOutputType::Thought, "".to_string())) {
                         // If there is already a thought block, append to it
                         Some(ContentBlockOutput::Thought(existing_thought)) => {
                             existing_thought.text.push_str(&thought);
                         }
                         // If there is no thought block, create one
                         _ => {
-                            thought_blocks.insert(
-                                String::new(),
+                            blocks.insert(
+                                (ContentBlockOutputType::Thought, "".to_string()),
                                 ContentBlockOutput::Thought(Thought {
                                     text: thought,
                                     signature: None,
@@ -1583,9 +1604,7 @@ pub async fn collect_chunks(args: CollectChunksArgs<'_, '_>) -> Result<Inference
         ttft,
         response_time,
     };
-    let mut content_blocks: Vec<ContentBlockOutput> = tool_call_blocks.into_values().collect();
-    content_blocks.extend(thought_blocks.into_values());
-    content_blocks.extend(text_blocks.into_values());
+    let content_blocks: Vec<_> = blocks.into_values().collect();
     let model_response = ProviderInferenceResponse::new(ProviderInferenceResponseArgs {
         output: content_blocks.clone(),
         system,
@@ -1722,8 +1741,8 @@ pub fn serialize_or_log<T: Serialize>(value: &T) -> String {
 /// Otherwise, it creates a new block and inserts it into the map.
 /// It also updates the TTFT if it hasn't been set
 fn handle_textual_content_block<F, A>(
-    blocks: &mut HashMap<String, ContentBlockOutput>,
-    id: String,
+    blocks: &mut IndexMap<(ContentBlockOutputType, String), ContentBlockOutput>,
+    key: (ContentBlockOutputType, String),
     text: String,
     ttft: &mut Option<Duration>,
     chunk_latency: Duration,
@@ -1733,7 +1752,7 @@ fn handle_textual_content_block<F, A>(
     F: FnOnce(String) -> ContentBlockOutput,
     A: FnOnce(&mut ContentBlockOutput, &str),
 {
-    match blocks.get_mut(&id) {
+    match blocks.get_mut(&key) {
         // If there is already a block, append to it
         Some(existing_block) => append_text(existing_block, &text),
         // If there is no block, create one
@@ -1743,7 +1762,7 @@ fn handle_textual_content_block<F, A>(
                 *ttft = Some(chunk_latency);
             }
             if !text.is_empty() {
-                blocks.insert(id, create_block(text));
+                blocks.insert(key, create_block(text));
             }
         }
     }
@@ -2749,12 +2768,12 @@ mod tests {
             assert_eq!(
                 chat_response.content,
                 vec![
+                    ContentBlockChatOutput::Text(Text {
+                        text: "{\"name\":\"John\",\"age\":30}".to_string()
+                    }),
                     ContentBlockChatOutput::Thought(Thought {
                         text: "Thought 2".to_string(),
                         signature: None,
-                    }),
-                    ContentBlockChatOutput::Text(Text {
-                        text: "{\"name\":\"John\",\"age\":30}".to_string()
                     }),
                 ]
             );
@@ -2988,6 +3007,150 @@ mod tests {
             }
             _ => panic!("Expected Json inference response"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_collect_interleaved_chunks() {
+        let templates = TemplateConfig::default();
+        let function_config = Arc::new(FunctionConfig::Chat(FunctionConfigChat::default()));
+        let model_name = "test_model";
+        let model_provider_name = "test_provider";
+        let raw_request = "raw request".to_string();
+        let inference_id = Uuid::now_v7();
+        let episode_id = Uuid::now_v7();
+        let created = current_timestamp();
+        let latency = Duration::from_millis(150);
+        let chunks = vec![
+            InferenceResultChunk::Chat(ChatInferenceResultChunk {
+                content: vec![
+                    ContentBlockChunk::Text(TextChunk {
+                        text: "Hello ".to_string(),
+                        id: "0".to_string(),
+                    }),
+                    ContentBlockChunk::ToolCall(ToolCallChunk {
+                        id: "0".to_string(),
+                        raw_name: "my_tool_call".to_string(),
+                        raw_arguments: "true".to_string(),
+                    }),
+                ],
+                created,
+                usage: None,
+                raw_response: "{\"message\": \"Hello}".to_string(),
+                latency,
+                finish_reason: None,
+            }),
+            InferenceResultChunk::Chat(ChatInferenceResultChunk {
+                content: vec![
+                    ContentBlockChunk::Thought(ThoughtChunk {
+                        text: Some("Some thou".to_string()),
+                        id: "0".to_string(),
+                        signature: None,
+                    }),
+                    ContentBlockChunk::Thought(ThoughtChunk {
+                        text: Some("My other interleaved thought".to_string()),
+                        id: "1".to_string(),
+                        signature: None,
+                    }),
+                ],
+                created,
+                usage: None,
+                raw_response: "my raw thought".to_string(),
+                latency,
+                finish_reason: None,
+            }),
+            InferenceResultChunk::Chat(ChatInferenceResultChunk {
+                content: vec![ContentBlockChunk::Text(TextChunk {
+                    text: "world!".to_string(),
+                    id: "0".to_string(),
+                })],
+                created,
+                usage: Some(Usage {
+                    input_tokens: 2,
+                    output_tokens: 4,
+                }),
+                raw_response: ", world!\"}".to_string(),
+                latency: Duration::from_millis(250),
+                finish_reason: Some(FinishReason::Stop),
+            }),
+            InferenceResultChunk::Chat(ChatInferenceResultChunk {
+                content: vec![ContentBlockChunk::Thought(ThoughtChunk {
+                    text: Some("ght".to_string()),
+                    id: "0".to_string(),
+                    signature: None,
+                })],
+                created,
+                usage: None,
+                raw_response: "my other raw thought".to_string(),
+                latency,
+                finish_reason: None,
+            }),
+        ];
+        let collect_chunks_args = CollectChunksArgs {
+            inference_id,
+            episode_id,
+            value: chunks,
+            system: None,
+            input_messages: vec![],
+            function: function_config.clone(),
+            model_name: model_name.into(),
+            model_provider_name: model_provider_name.into(),
+            raw_request: raw_request.clone(),
+            inference_params: InferenceParams::default(),
+            function_name: "",
+            variant_name: "",
+            dynamic_output_schema: None,
+            templates: &templates,
+            tool_config: None,
+            cached: false,
+            extra_body: Default::default(),
+            extra_headers: Default::default(),
+        };
+        let result = collect_chunks(collect_chunks_args).await.unwrap();
+        let chat_result = match result {
+            InferenceResult::Chat(chat_result) => chat_result,
+            _ => panic!("Expected Chat inference response"),
+        };
+        assert_eq!(chat_result.inference_id, inference_id);
+        assert_eq!(chat_result.created, created);
+        assert_eq!(chat_result.finish_reason, Some(FinishReason::Stop));
+        assert_eq!(
+            chat_result.usage,
+            Usage {
+                input_tokens: 2,
+                output_tokens: 4,
+            }
+        );
+
+        let expected_content = vec![
+            ContentBlockChatOutput::Text(Text {
+                text: "Hello world!".to_string(),
+            }),
+            ContentBlockChatOutput::ToolCall(ToolCallOutput {
+                name: None,
+                raw_name: "my_tool_call".to_string(),
+                raw_arguments: "true".to_string(),
+                arguments: None,
+                id: "0".to_string(),
+            }),
+            ContentBlockChatOutput::Thought(Thought {
+                text: "Some thought".to_string(),
+                signature: None,
+            }),
+            ContentBlockChatOutput::Thought(Thought {
+                text: "My other interleaved thought".to_string(),
+                signature: None,
+            }),
+        ];
+        assert_eq!(chat_result.content, expected_content);
+
+        assert_eq!(chat_result.model_inference_results.len(), 1);
+        let model_inference_result = chat_result.model_inference_results.first().unwrap();
+        assert_eq!(&*model_inference_result.model_name, model_name);
+        assert_eq!(
+            &*model_inference_result.model_provider_name,
+            model_provider_name
+        );
+        assert_eq!(model_inference_result.raw_request, raw_request);
     }
 
     #[test]
@@ -3229,14 +3392,15 @@ mod tests {
 
     #[test]
     fn test_handle_textual_content_block() {
-        let mut blocks: HashMap<String, ContentBlockOutput> = HashMap::new();
+        let mut blocks: IndexMap<(ContentBlockOutputType, String), ContentBlockOutput> =
+            IndexMap::new();
         let mut ttft: Option<Duration> = None;
         let chunk_latency = Duration::from_millis(100);
 
         // Test case 1: Create new text block
         handle_textual_content_block(
             &mut blocks,
-            "1".to_string(),
+            (ContentBlockOutputType::Text, "1".to_string()),
             "Hello".to_string(),
             &mut ttft,
             chunk_latency,
@@ -3253,7 +3417,10 @@ mod tests {
 
         assert_eq!(blocks.len(), 1);
         assert_eq!(ttft, Some(chunk_latency));
-        match blocks.get("1").unwrap() {
+        match blocks
+            .get(&(ContentBlockOutputType::Text, "1".to_string()))
+            .unwrap()
+        {
             ContentBlockOutput::Text(Text { text }) => assert_eq!(text, "Hello"),
             _ => panic!("Expected text block"),
         }
@@ -3261,7 +3428,7 @@ mod tests {
         // Test case 2: Append to existing text block
         handle_textual_content_block(
             &mut blocks,
-            "1".to_string(),
+            (ContentBlockOutputType::Text, "1".to_string()),
             " World".to_string(),
             &mut ttft,
             chunk_latency,
@@ -3277,7 +3444,10 @@ mod tests {
         );
 
         assert_eq!(blocks.len(), 1);
-        match blocks.get("1").unwrap() {
+        match blocks
+            .get(&(ContentBlockOutputType::Text, "1".to_string()))
+            .unwrap()
+        {
             ContentBlockOutput::Text(Text { text }) => assert_eq!(text, "Hello World"),
             _ => panic!("Expected text block"),
         }
@@ -3285,7 +3455,7 @@ mod tests {
         // Test case 3: Empty text should not create block
         handle_textual_content_block(
             &mut blocks,
-            "2".to_string(),
+            (ContentBlockOutputType::Text, "2".to_string()),
             "".to_string(),
             &mut ttft,
             chunk_latency,
@@ -3305,7 +3475,7 @@ mod tests {
         // Test case 4: Create thought block
         handle_textual_content_block(
             &mut blocks,
-            "3".to_string(),
+            (ContentBlockOutputType::Thought, "3".to_string()),
             "Thinking...".to_string(),
             &mut ttft,
             chunk_latency,
@@ -3323,7 +3493,10 @@ mod tests {
         );
 
         assert_eq!(blocks.len(), 2);
-        match blocks.get("3").unwrap() {
+        match blocks
+            .get(&(ContentBlockOutputType::Thought, "3".to_string()))
+            .unwrap()
+        {
             ContentBlockOutput::Thought(Thought { text, signature: _ }) => {
                 assert_eq!(text, "Thinking...")
             }

--- a/tensorzero-internal/tests/e2e/providers/anthropic.rs
+++ b/tensorzero-internal/tests/e2e/providers/anthropic.rs
@@ -829,23 +829,22 @@ async fn test_streaming_thinking() {
         serde_json::from_str(clickhouse_content_blocks).unwrap();
     println!("Got content blocks: {clickhouse_content_blocks:?}");
     // We should reconstruct thee blocks - a thought block, tool call, and text block
-    // Note that we currently always store the tool call first in ClickHouse
     assert_eq!(clickhouse_content_blocks.len(), 3);
-    assert_eq!(clickhouse_content_blocks[0]["type"], "tool_call");
-    assert_eq!(clickhouse_content_blocks[1]["type"], "thought");
-    assert_eq!(clickhouse_content_blocks[2]["type"], "text");
+    assert_eq!(clickhouse_content_blocks[0]["type"], "thought");
+    assert_eq!(clickhouse_content_blocks[1]["type"], "text");
+    assert_eq!(clickhouse_content_blocks[2]["type"], "tool_call");
 
-    assert_eq!(clickhouse_content_blocks[1]["text"], content_blocks["0"]);
+    assert_eq!(clickhouse_content_blocks[0]["text"], content_blocks["0"]);
     assert_eq!(
-        clickhouse_content_blocks[1]["signature"],
+        clickhouse_content_blocks[0]["signature"],
         content_block_signatures["0"]
     );
-    assert_eq!(clickhouse_content_blocks[2]["text"], content_blocks["1"]);
+    assert_eq!(clickhouse_content_blocks[1]["text"], content_blocks["1"]);
 
-    let tool_call_id = clickhouse_content_blocks[0]["id"].as_str().unwrap();
+    let tool_call_id = clickhouse_content_blocks[2]["id"].as_str().unwrap();
 
     assert_eq!(
-        clickhouse_content_blocks[0]["raw_arguments"],
+        clickhouse_content_blocks[2]["raw_arguments"],
         content_blocks[tool_call_id]
     );
 

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -8288,7 +8288,12 @@ pub async fn test_dynamic_tool_use_streaming_inference_request_with_provider(
     let output_clickhouse: Vec<Value> =
         serde_json::from_str(result.get("output").unwrap().as_str().unwrap()).unwrap();
     assert!(!output_clickhouse.is_empty()); // could be > 1 if the model returns text as well
-    let content_block = output_clickhouse.first().unwrap();
+
+    // Ignore other content blocks
+    let content_block = output_clickhouse
+        .iter()
+        .find(|b| b["type"] == "tool_call")
+        .unwrap();
     let content_block_type = content_block.get("type").unwrap().as_str().unwrap();
     assert_eq!(content_block_type, "tool_call");
     assert_eq!(content_block.get("id").unwrap().as_str().unwrap(), tool_id);

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -3936,7 +3936,11 @@ pub async fn test_tool_use_tool_choice_auto_used_streaming_inference_request_wit
     let output_clickhouse: Vec<Value> =
         serde_json::from_str(result.get("output").unwrap().as_str().unwrap()).unwrap();
     assert!(!output_clickhouse.is_empty()); // could be > 1 if the model returns text as well
-    let content_block = output_clickhouse.first().unwrap();
+                                            // Ignore other content blocks
+    let content_block = output_clickhouse
+        .iter()
+        .find(|b| b["type"] == "tool_call")
+        .unwrap();
     let content_block_type = content_block.get("type").unwrap().as_str().unwrap();
     assert_eq!(content_block_type, "tool_call");
     assert_eq!(content_block.get("id").unwrap().as_str().unwrap(), tool_id);
@@ -5126,7 +5130,11 @@ pub async fn test_tool_use_tool_choice_required_streaming_inference_request_with
     let output_clickhouse: Vec<Value> =
         serde_json::from_str(result.get("output").unwrap().as_str().unwrap()).unwrap();
     assert!(!output_clickhouse.is_empty()); // could be > 1 if the model returns text as well
-    let content_block = output_clickhouse.first().unwrap();
+                                            // Ignore other content blocks
+    let content_block = output_clickhouse
+        .iter()
+        .find(|b| b["type"] == "tool_call")
+        .unwrap();
     let content_block_type = content_block.get("type").unwrap().as_str().unwrap();
     assert_eq!(content_block_type, "tool_call");
     assert_eq!(content_block.get("id").unwrap().as_str().unwrap(), tool_id);

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -7029,7 +7029,12 @@ pub async fn test_tool_use_allowed_tools_streaming_inference_request_with_provid
     let output_clickhouse: Vec<Value> =
         serde_json::from_str(result.get("output").unwrap().as_str().unwrap()).unwrap();
     assert!(!output_clickhouse.is_empty()); // could be > 1 if the model returns text as well
-    let content_block = output_clickhouse.first().unwrap();
+
+    // Ignore other content blocks
+    let content_block = output_clickhouse
+        .iter()
+        .find(|b| b["type"] == "tool_call")
+        .unwrap();
     let content_block_type = content_block.get("type").unwrap().as_str().unwrap();
     assert_eq!(content_block_type, "tool_call");
     assert_eq!(content_block.get("id").unwrap().as_str().unwrap(), tool_id);


### PR DESCRIPTION
Previously, we always produced content blocks in the order `[tool_call, thought, text]`, regardless of the original order of chunks.

We now preserve the relative order of chunks (except for merging chunks with the same kind and id).

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> `collect_chunks` now preserves the relative order of content blocks using `IndexMap`, merging chunks with the same type and id.
> 
>   - **Behavior**:
>     - `collect_chunks` now preserves the relative order of content blocks using `IndexMap`.
>     - Merges chunks with the same type and id, maintaining the first occurrence order.
>   - **Dependencies**:
>     - Adds `indexmap 2.9.0` to `Cargo.toml` and `Cargo.lock`.
>   - **Tests**:
>     - Adds `test_collect_interleaved_chunks` in `mod.rs` to verify order preservation.
>     - Updates existing tests in `common.rs` and `anthropic.rs` to reflect new order behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 152780095e5524aeb2f1db6f9c3ee6bf5ab74d76. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->