### PR TITLE
Use a concurrency group for 'clickhouse-tests-cloud' jobs

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -14,6 +14,13 @@ jobs:
   clickhouse-tests-cloud:
     if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
+    # Note - a concurrency group only allows at most one job to be pending at a time - additional
+    # pending jobs will cause existing pending jobs to be cancelled.
+    # This setting required a merge group concurrency limit of at most 2 - if it's any higher,
+    # jobs will get cancelled, causing spurious failures in the merge queue.
+    concurrency:
+      group: clickhouse-tests-cloud-${{ matrix.cloud_instance.release_channel }}
+      cancel-in-progress: false
     strategy:
       matrix:
         cloud_instance:


### PR DESCRIPTION
By setting our merg queue concurrency limit to 2, we can make this work even with the 'cancel pending jobs' limitation (https://github.com/orgs/community/discussions/32376)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
