### PR TITLE
Produce ContentBlock::Unknown in `gcp_vertex_anthropic`

### DIFF
--- a/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-internal/src/inference/providers/gcp_vertex_anthropic.rs
@@ -27,8 +27,8 @@ use crate::inference::types::{
     ProviderInferenceResponseArgs, ProviderInferenceResponseChunk,
     ProviderInferenceResponseStreamInner, RequestMessage, Usage,
 };
-use crate::model::ModelProvider;
 use crate::model::{build_creds_caching_default_with_fn, CredentialLocation};
+use crate::model::{fully_qualified_name, ModelProvider};
 use crate::tool::{ToolCall, ToolCallChunk, ToolChoice, ToolConfig};
 
 use super::anthropic::{
@@ -185,7 +185,7 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
         &'a self,
         ModelProviderRequest {
             request,
-            provider_name: _,
+            provider_name,
             model_name,
         }: ModelProviderRequest<'a>,
         http_client: &'a reqwest::Client,
@@ -262,6 +262,8 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
                 function_type: &request.function_type,
                 json_mode: &request.json_mode,
                 generic_request: request,
+                model_name,
+                provider_name,
             };
             Ok(response_with_latency.try_into()?)
         } else {
@@ -812,26 +814,31 @@ pub enum GCPVertexAnthropicContentBlock {
     },
 }
 
-impl TryFrom<GCPVertexAnthropicContentBlock> for ContentBlockOutput {
-    type Error = Error;
-    fn try_from(block: GCPVertexAnthropicContentBlock) -> Result<Self, Self::Error> {
-        match block {
-            GCPVertexAnthropicContentBlock::Text { text } => Ok(text.into()),
-            GCPVertexAnthropicContentBlock::ToolUse { id, name, input } => {
-                Ok(ContentBlockOutput::ToolCall(ToolCall {
-                    id,
-                    name,
-                    arguments: serde_json::to_string(&input).map_err(|e| {
-                        Error::new(ErrorDetails::Serialization {
-                            message: format!(
-                                "Error parsing input for tool call: {}",
-                                DisplayOrDebugGateway::new(e)
-                            ),
-                        })
-                    })?,
-                }))
-            }
+fn convert_to_output(
+    model_name: &str,
+    provider_name: &str,
+    block: FlattenUnknown<'static, GCPVertexAnthropicContentBlock>,
+) -> Result<ContentBlockOutput, Error> {
+    match block {
+        FlattenUnknown::Normal(GCPVertexAnthropicContentBlock::Text { text }) => Ok(text.into()),
+        FlattenUnknown::Normal(GCPVertexAnthropicContentBlock::ToolUse { id, name, input }) => {
+            Ok(ContentBlockOutput::ToolCall(ToolCall {
+                id,
+                name,
+                arguments: serde_json::to_string(&input).map_err(|e| {
+                    Error::new(ErrorDetails::Serialization {
+                        message: format!(
+                            "Error parsing input for tool call: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
+                    })
+                })?,
+            }))
         }
+        FlattenUnknown::Unknown(obj) => Ok(ContentBlockOutput::Unknown {
+            data: obj.into_owned(),
+            model_provider_name: Some(fully_qualified_name(model_name, provider_name)),
+        }),
     }
 }
 
@@ -855,7 +862,7 @@ struct GCPVertexAnthropicResponse {
     id: String,
     r#type: String, // this is always "message"
     role: String,   // this is always "assistant"
-    content: Vec<GCPVertexAnthropicContentBlock>,
+    content: Vec<FlattenUnknown<'static, GCPVertexAnthropicContentBlock>>,
     model: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     stop_reason: Option<AnthropicStopReason>,
@@ -873,6 +880,8 @@ struct GCPVertexAnthropicResponseWithMetadata<'a> {
     function_type: &'a FunctionType,
     json_mode: &'a ModelInferenceRequestJsonMode,
     generic_request: &'a ModelInferenceRequest<'a>,
+    model_name: &'a str,
+    provider_name: &'a str,
 }
 
 impl<'a> TryFrom<GCPVertexAnthropicResponseWithMetadata<'a>> for ProviderInferenceResponse {
@@ -886,12 +895,14 @@ impl<'a> TryFrom<GCPVertexAnthropicResponseWithMetadata<'a>> for ProviderInferen
             function_type,
             json_mode,
             generic_request,
+            model_name,
+            provider_name,
         } = value;
 
         let content: Vec<ContentBlockOutput> = response
             .content
             .into_iter()
-            .map(|block| block.try_into())
+            .map(|block| convert_to_output(model_name, provider_name, block))
             .collect::<Result<Vec<_>, _>>()?;
         let raw_request = serde_json::to_string(&request).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
@@ -1903,14 +1914,17 @@ mod tests {
 
     #[test]
     fn test_anthropic_response_conversion() {
-        // Test case 1: Text response
+        // Test case 1: Text response and unknown content
         let anthropic_response_body = GCPVertexAnthropicResponse {
             id: "1".to_string(),
             r#type: "message".to_string(),
             role: "assistant".to_string(),
-            content: vec![GCPVertexAnthropicContentBlock::Text {
-                text: "Response text".to_string(),
-            }],
+            content: vec![
+                FlattenUnknown::Normal(GCPVertexAnthropicContentBlock::Text {
+                    text: "Response text".to_string(),
+                }),
+                FlattenUnknown::Unknown(Cow::Owned(json!({"my_custom": "content"}))),
+            ],
             model: "model-name".into(),
             stop_reason: Some(AnthropicStopReason::EndTurn),
             stop_sequence: Some("stop sequence".to_string()),
@@ -1964,12 +1978,22 @@ mod tests {
             function_type: &FunctionType::Chat,
             json_mode: &ModelInferenceRequestJsonMode::Off,
             generic_request: &generic_request,
+            model_name: "my-model",
+            provider_name: "my-provider",
         };
 
         let inference_response = ProviderInferenceResponse::try_from(body_with_latency).unwrap();
         assert_eq!(
             inference_response.output,
-            vec!["Response text".to_string().into()]
+            vec![
+                "Response text".to_string().into(),
+                ContentBlockOutput::Unknown {
+                    data: serde_json::json!({"my_custom": "content"}),
+                    model_provider_name: Some(
+                        "tensorzero::model_name::my-model::provider_name::my-provider".to_string()
+                    )
+                }
+            ]
         );
 
         assert_eq!(raw_response, inference_response.raw_response);
@@ -1982,7 +2006,7 @@ mod tests {
             inference_response.input_messages,
             vec![RequestMessage {
                 role: Role::User,
-                content: vec!["Hello".to_string().into()],
+                content: vec!["Hello".to_string().into(),],
             }]
         );
         // Test case 2: Tool call response
@@ -1990,11 +2014,13 @@ mod tests {
             id: "2".to_string(),
             r#type: "message".to_string(),
             role: "assistant".to_string(),
-            content: vec![GCPVertexAnthropicContentBlock::ToolUse {
-                id: "tool_call_1".to_string(),
-                name: "get_temperature".to_string(),
-                input: json!({"location": "New York"}),
-            }],
+            content: vec![FlattenUnknown::Normal(
+                GCPVertexAnthropicContentBlock::ToolUse {
+                    id: "tool_call_1".to_string(),
+                    name: "get_temperature".to_string(),
+                    input: json!({"location": "New York"}),
+                },
+            )],
             model: "model-name".into(),
             stop_reason: Some(AnthropicStopReason::ToolUse),
             stop_sequence: None,
@@ -2044,6 +2070,8 @@ mod tests {
             function_type: &FunctionType::Chat,
             json_mode: &ModelInferenceRequestJsonMode::Off,
             generic_request: &generic_request,
+            model_name: "model-name",
+            provider_name: "provider-name",
         };
 
         let inference_response: ProviderInferenceResponse = body_with_latency.try_into().unwrap();
@@ -2076,14 +2104,14 @@ mod tests {
             r#type: "message".to_string(),
             role: "assistant".to_string(),
             content: vec![
-                GCPVertexAnthropicContentBlock::Text {
+                FlattenUnknown::Normal(GCPVertexAnthropicContentBlock::Text {
                     text: "Here's the weather:".to_string(),
-                },
-                GCPVertexAnthropicContentBlock::ToolUse {
+                }),
+                FlattenUnknown::Normal(GCPVertexAnthropicContentBlock::ToolUse {
                     id: "tool_call_2".to_string(),
                     name: "get_temperature".to_string(),
                     input: json!({"location": "London"}),
-                },
+                }),
             ],
             model: "model-name".into(),
             stop_reason: None,
@@ -2134,6 +2162,8 @@ mod tests {
             function_type: &FunctionType::Chat,
             json_mode: &ModelInferenceRequestJsonMode::Off,
             generic_request: &generic_request,
+            model_name: "model-name",
+            provider_name: "provider-name",
         };
         let inference_response = ProviderInferenceResponse::try_from(body_with_latency).unwrap();
         assert_eq!(


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Handle unknown content blocks in `gcp_vertex_anthropic` by converting them to `ContentBlockOutput::Unknown`.
> 
>   - **Behavior**:
>     - `convert_to_output` function now handles `FlattenUnknown::Unknown` to produce `ContentBlockOutput::Unknown` with `model_provider_name`.
>     - Updates `GCPVertexAnthropicResponse` to use `FlattenUnknown` for `content` field.
>   - **Tests**:
>     - Adds test cases in `test_anthropic_response_conversion` to verify handling of unknown content blocks.
>     - Updates existing tests to reflect changes in content handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 694cd98d07c1ebab0061eb18306c2135bbbb99fe. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->