### PR TITLE
Exclude clickhouse tests from test-e2e

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,10 +8,10 @@ rustflags = [
 [alias]
 test-unit = "nextest run --lib --bins"
 test-all = "nextest run --features e2e_tests"
-# Note - these two commands should only differ by the 'not' clause wrapping 'test(batch)'
-# This ensures that running 'test-batch' and 'test-e2e' will cover all tests, and not miss any
+# Note - 'test-batch', 'test-e2e', and 'test-e2e-no-creds' must be kept in sync
+# Running all of them should cover all of our tests, and not miss any
 test-batch = ["nextest", "run", "--features", "e2e_tests", "-E",      "test(batch)"]
-test-e2e   = ["nextest", "run", "--features", "e2e_tests", "-E", "not (test(batch))"]
+test-e2e   = ["nextest", "run", "--features", "e2e_tests", "-E", "not (test(batch)) and not (test(test_dummy_only) | test(clickhouse))"]
 
 # Runs e2e tests that don't require any credentials available.
 # This is useful for both running on PR CI (where we don't have creds at all),


### PR DESCRIPTION
We already run these tests via 'test-e2e-no-creds' on CI. Excluding them from 'test-e2e' saves both time and disk space on the live-tests runner

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
