### PR TITLE
Update Zod to prep for v4 migration

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
     dependencies:
       openai:
         specifier: ^4.91.1
-        version: 4.103.0(ws@8.18.2)(zod@3.25.27)
+        version: 4.103.0(ws@8.18.2)(zod@3.25.51)
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -52,7 +52,7 @@ importers:
     dependencies:
       openai:
         specifier: ^4.87.1
-        version: 4.103.0(ws@8.18.2)(zod@3.25.27)
+        version: 4.103.0(ws@8.18.2)(zod@3.25.51)
       process:
         specifier: ^0.11.10
         version: 0.11.10
@@ -65,7 +65,7 @@ importers:
     dependencies:
       openai:
         specifier: ^4.87.1
-        version: 4.103.0(ws@8.18.2)(zod@3.25.27)
+        version: 4.103.0(ws@8.18.2)(zod@3.25.51)
       process:
         specifier: ^0.11.10
         version: 0.11.10
@@ -78,7 +78,7 @@ importers:
     dependencies:
       openai:
         specifier: ^4.87.1
-        version: 4.103.0(ws@8.18.2)(zod@3.25.27)
+        version: 4.103.0(ws@8.18.2)(zod@3.25.51)
     devDependencies:
       tsx:
         specifier: ^4.0.0
@@ -181,7 +181,7 @@ importers:
         version: 0.487.0(react@19.1.0)
       openai:
         specifier: ^4.91.1
-        version: 4.103.0(ws@8.18.2)(zod@3.25.27)
+        version: 4.103.0(ws@8.18.2)(zod@3.25.51)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -219,8 +219,8 @@ importers:
         specifier: ^3.4.1
         version: 3.4.1(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4))
       zod:
-        specifier: ^3.24.2
-        version: 3.25.27
+        specifier: ^3.25.51
+        version: 3.25.51
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^4.0.0
@@ -4151,8 +4151,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod@3.25.27:
-    resolution: {integrity: sha512-xkYsE+ztNLzBeoAG8Ipd2ICr86gyMpovQlB+Vid1LT7V16/Dj0z+Up1u1qxNX58cmJ/AtG2mvGw/7+jK48xEYw==}
+  zod@3.25.51:
+    resolution: {integrity: sha512-TQSnBldh+XSGL+opiSIq0575wvDPqu09AqWe1F7JhUMKY+M91/aGlK4MhpVNO7MgYfHcVCB1ffwAUTJzllKJqg==}
 
 snapshots:
 
@@ -7206,7 +7206,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@4.103.0(ws@8.18.2)(zod@3.25.27):
+  openai@4.103.0(ws@8.18.2)(zod@3.25.51):
     dependencies:
       '@types/node': 18.19.103
       '@types/node-fetch': 2.6.12
@@ -7217,7 +7217,7 @@ snapshots:
       node-fetch: 2.7.0
     optionalDependencies:
       ws: 8.18.2
-      zod: 3.25.27
+      zod: 3.25.51
     transitivePeerDependencies:
       - encoding
 
@@ -8243,4 +8243,4 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod@3.25.27: {}
+  zod@3.25.51: {}

--- a/ui/package.json
+++ b/ui/package.json
@@ -61,7 +61,7 @@
     "typescript-eslint": "^8.29.0",
     "uuid": "^11.1.0",
     "vite-plugin-wasm": "^3.4.1",
-    "zod": "^3.24.2"
+    "zod": "^3.25.51"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.0.0",


### PR DESCRIPTION
Migrating to Zod v4 will bring lots of benefits, but first we need to get on the latest v3 to start incrementally migrating to new APIs per the [migration guide](https://zod.dev/v4/changelog).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `zod` dependency in `package.json` to version `^3.25.51` for v4 migration preparation.
> 
>   - **Dependencies**:
>     - Update `zod` version in `package.json` from `^3.24.2` to `^3.25.51` to prepare for v4 migration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 626b039e4c17bc81478594070617da742cd51eee. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->