### PR TITLE
Add 'TENSORZERO_SKIP_BUILD_INFO' to speed up local development

### DIFF
--- a/tensorzero-internal/build.rs
+++ b/tensorzero-internal/build.rs
@@ -1,5 +1,12 @@
 #![expect(clippy::expect_used)]
 
 fn main() {
+    // If this env var is set, emit a 'cargo:rerun-if-env-changed', which will disable
+    // all of Cargo's default build.rs change detection logic. This is useful for local development,
+    // where we don't want to force unnecessary rebuilds of the build.rs file (e.g. when changing
+    // config files that happen to be inside the 'tensorzero-internal' directory)
+    if std::env::var("TENSORZERO_SKIP_BUILD_INFO").is_ok() {
+        println!("cargo:rerun-if-env-changed=TENSORZERO_SKIP_BUILD_INFO");
+    }
     built::write_built_file().expect("Failed to acquire build-time information")
 }


### PR DESCRIPTION
This reduces the number of times that 'build.rs' (and hence the entire tensorzero-internal crate) is rerun. It has no effect on CI, where we don't set 'TENSORZERO_SKIP_BUILD_INFO'

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `TENSORZERO_SKIP_BUILD_INFO` to `build.rs` to reduce unnecessary rebuilds during local development.
> 
>   - **Behavior**:
>     - Adds `TENSORZERO_SKIP_BUILD_INFO` environment variable check in `build.rs` to prevent unnecessary rebuilds during local development.
>     - No effect on CI builds as the variable is not set there.
>   - **Code**:
>     - Modifies `main()` in `build.rs` to include a check for `TENSORZERO_SKIP_BUILD_INFO` and emit `cargo:rerun-if-env-changed` if set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2a33a411a9a7ae304511b155a0ac702ad49351cd. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->