### PR TITLE
Add `[timeouts]` section to variant config

### DIFF
--- a/clients/python/src/internal.rs
+++ b/clients/python/src/internal.rs
@@ -40,7 +40,7 @@ pub fn get_template_config(
                 "Variant {variant_name} not found in function {function_name}",
             ))
         })?;
-    let VariantConfig::ChatCompletion(config) = variant_config else {
+    let VariantConfig::ChatCompletion(config) = &variant_config.inner else {
         return Err(PyValueError::new_err(format!(
             "Variant {variant_name} is not a ChatCompletion variant"
         )));

--- a/clients/rust/src/stored_inference.rs
+++ b/clients/rust/src/stored_inference.rs
@@ -109,7 +109,7 @@ fn render_model_input(
                 name: variant_name.clone(),
             })
         })?;
-    let VariantConfig::ChatCompletion(chat_completion_config) = variant_config else {
+    let VariantConfig::ChatCompletion(chat_completion_config) = &variant_config.inner else {
         return Err(Error::new(ErrorDetails::InvalidVariantForOptimization {
             function_name: inference_example.function_name().to_string(),
             variant_name: variant_name.clone(),

--- a/tensorzero-internal/src/error.rs
+++ b/tensorzero-internal/src/error.rs
@@ -205,6 +205,11 @@ pub enum ErrorDetails {
     InferenceTimeout {
         variant_name: String,
     },
+    VariantTimeout {
+        variant_name: Option<String>,
+        timeout: Duration,
+        streaming: bool,
+    },
     ModelProviderTimeout {
         provider_name: String,
         timeout: Duration,
@@ -427,6 +432,7 @@ impl ErrorDetails {
             ErrorDetails::InferenceServer { .. } => tracing::Level::ERROR,
             ErrorDetails::InferenceTimeout { .. } => tracing::Level::WARN,
             ErrorDetails::ModelProviderTimeout { .. } => tracing::Level::WARN,
+            ErrorDetails::VariantTimeout { .. } => tracing::Level::WARN,
             ErrorDetails::InputValidation { .. } => tracing::Level::WARN,
             ErrorDetails::InternalError { .. } => tracing::Level::ERROR,
             ErrorDetails::InvalidBaseUrl { .. } => tracing::Level::ERROR,
@@ -519,6 +525,7 @@ impl ErrorDetails {
             ErrorDetails::InferenceServer { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::InferenceTimeout { .. } => StatusCode::REQUEST_TIMEOUT,
             ErrorDetails::ModelProviderTimeout { .. } => StatusCode::REQUEST_TIMEOUT,
+            ErrorDetails::VariantTimeout { .. } => StatusCode::REQUEST_TIMEOUT,
             ErrorDetails::InvalidClientMode { .. } => StatusCode::BAD_REQUEST,
             ErrorDetails::InvalidTensorzeroUuid { .. } => StatusCode::BAD_REQUEST,
             ErrorDetails::InvalidUuid { .. } => StatusCode::BAD_REQUEST,
@@ -626,6 +633,22 @@ impl std::fmt::Display for ErrorDetails {
                         f,
                         "Model provider {provider_name} timed out due to configured `non_streaming.total_ms` timeout ({timeout:?})"
                     )
+                }
+            }
+            ErrorDetails::VariantTimeout {
+                variant_name,
+                timeout,
+                streaming,
+            } => {
+                let variant_description = if let Some(variant_name) = variant_name {
+                    format!("Variant `{variant_name}`")
+                } else {
+                    "Unknown variant".to_string()
+                };
+                if *streaming {
+                    write!(f, "{variant_description} timed out due to configured `streaming.ttft_ms` timeout ({timeout:?})")
+                } else {
+                    write!(f, "{variant_description} timed out due to configured `non_streaming.total_ms` timeout ({timeout:?})")
                 }
             }
             ErrorDetails::ObjectStoreWrite { message, path } => {

--- a/tensorzero-internal/src/function.rs
+++ b/tensorzero-internal/src/function.rs
@@ -18,7 +18,7 @@ use crate::minijinja_util::TemplateConfig;
 use crate::model::ModelTable;
 use crate::tool::{DynamicToolParams, StaticToolConfig, ToolCallConfig, ToolChoice};
 use crate::variant::chat_completion::TemplateSchemaInfo;
-use crate::variant::{InferenceConfig, JsonMode, Variant, VariantConfig};
+use crate::variant::{InferenceConfig, JsonMode, Variant, VariantInfo};
 
 #[derive(Debug)]
 pub enum FunctionConfig {
@@ -50,7 +50,7 @@ impl FunctionConfig {
 
 #[derive(Debug, Default)]
 pub struct FunctionConfigChat {
-    pub variants: HashMap<String, VariantConfig>, // variant name => variant config
+    pub variants: HashMap<String, VariantInfo>, // variant name => variant config
     pub system_schema: Option<StaticJSONSchema>,
     pub user_schema: Option<StaticJSONSchema>,
     pub assistant_schema: Option<StaticJSONSchema>,
@@ -62,7 +62,7 @@ pub struct FunctionConfigChat {
 
 #[derive(Debug, Default)]
 pub struct FunctionConfigJson {
-    pub variants: HashMap<String, VariantConfig>, // variant name => variant config
+    pub variants: HashMap<String, VariantInfo>, // variant name => variant config
     pub system_schema: Option<StaticJSONSchema>,
     pub user_schema: Option<StaticJSONSchema>,
     pub assistant_schema: Option<StaticJSONSchema>,
@@ -72,7 +72,7 @@ pub struct FunctionConfigJson {
 }
 
 impl FunctionConfig {
-    pub fn variants(&self) -> &HashMap<String, VariantConfig> {
+    pub fn variants(&self) -> &HashMap<String, VariantInfo> {
         match self {
             FunctionConfig::Chat(params) => &params.variants,
             FunctionConfig::Json(params) => &params.variants,
@@ -433,15 +433,15 @@ fn validate_single_message(
 /// Sample a variant from the function based on variant weights (uniform random selection)
 pub fn sample_variant<'a>(
     candidate_variant_names: &mut Vec<&'a str>,
-    variants: &'a HashMap<String, VariantConfig>,
+    variants: &'a HashMap<String, VariantInfo>,
     function_name: &str,
     episode_id: &Uuid,
-) -> Result<(&'a str, &'a VariantConfig), Error> {
+) -> Result<(&'a str, &'a VariantInfo), Error> {
     // Compute the total weight of variants present in variant_names
     let total_weight = candidate_variant_names
         .iter()
         .filter_map(|name| variants.get(*name))
-        .map(|variant| variant.weight().unwrap_or(0.0))
+        .map(|variant| variant.inner.weight().unwrap_or(0.0))
         .sum::<f64>();
 
     // If the total weight is non-positive, perform uniform sampling
@@ -495,7 +495,7 @@ pub fn sample_variant<'a>(
                 message: format!("Function `{function_name}` has no variant `{variant_name}`"),
             })
         })?;
-        cumulative_weight += variant.weight().unwrap_or(0.0);
+        cumulative_weight += variant.inner.weight().unwrap_or(0.0);
         if cumulative_weight > random_threshold {
             sampled_variant_name = candidate_variant_names.swap_remove(i);
             break;
@@ -540,6 +540,7 @@ mod tests {
     use crate::minijinja_util::TemplateConfig;
     use crate::tool::ToolCall;
     use crate::variant::chat_completion::ChatCompletionConfig;
+    use crate::variant::VariantConfig;
 
     use super::*;
     use serde_json::json;
@@ -1374,17 +1375,20 @@ mod tests {
     #[test]
     fn test_sample_variant() {
         // Helper function to create a HashMap of variant names to their weights
-        fn create_variants(variant_weights: &[(&str, f64)]) -> HashMap<String, VariantConfig> {
+        fn create_variants(variant_weights: &[(&str, f64)]) -> HashMap<String, VariantInfo> {
             variant_weights
                 .iter()
                 .map(|&(name, weight)| {
                     (
                         name.to_string(),
-                        VariantConfig::ChatCompletion(ChatCompletionConfig {
-                            weight: Some(weight),
-                            model: "model-name".into(),
-                            ..Default::default()
-                        }),
+                        VariantInfo {
+                            inner: VariantConfig::ChatCompletion(ChatCompletionConfig {
+                                weight: Some(weight),
+                                model: "model-name".into(),
+                                ..Default::default()
+                            }),
+                            timeouts: Default::default(),
+                        },
                     )
                 })
                 .collect()
@@ -1393,11 +1397,14 @@ mod tests {
         // Helper function to test the distribution of variant weights by sampling them many times
         // and checking if the observed distribution is close to the expected distribution
         fn test_variant_distribution(
-            variants: &HashMap<String, VariantConfig>,
+            variants: &HashMap<String, VariantInfo>,
             sample_size: usize,
             tolerance: f64,
         ) {
-            let total_weight: f64 = variants.values().map(|v| v.weight().unwrap_or(0.0)).sum();
+            let total_weight: f64 = variants
+                .values()
+                .map(|v| v.inner.weight().unwrap_or(0.0))
+                .sum();
             let mut counts: HashMap<String, usize> = HashMap::new();
 
             for _ in 0..sample_size {
@@ -1413,7 +1420,7 @@ mod tests {
             }
 
             for (variant_name, variant) in variants {
-                let expected_prob = variant.weight().unwrap_or(0.0) / total_weight;
+                let expected_prob = variant.inner.weight().unwrap_or(0.0) / total_weight;
                 let actual_prob =
                     *counts.get(variant_name).unwrap_or(&0) as f64 / sample_size as f64;
                 let diff = (expected_prob - actual_prob).abs();

--- a/tensorzero-internal/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-internal/src/variant/best_of_n_sampling.rs
@@ -756,7 +756,7 @@ mod tests {
         },
         minijinja_util::tests::get_test_template_config,
         model::{ModelConfig, ModelProvider, ProviderConfig},
-        variant::VariantConfig,
+        variant::{VariantConfig, VariantInfo},
     };
 
     use super::*;
@@ -1263,14 +1263,17 @@ mod tests {
         let function = FunctionConfig::Chat(FunctionConfigChat {
             variants: HashMap::from([(
                 "best_of_n_1".into(),
-                VariantConfig::BestOfNSampling(BestOfNSamplingConfig {
-                    candidates: vec![],
-                    weight: None,
-                    timeout_s: 0.0,
-                    evaluator: EvaluatorConfig {
-                        inner: Default::default(),
-                    },
-                }),
+                VariantInfo {
+                    inner: VariantConfig::BestOfNSampling(BestOfNSamplingConfig {
+                        candidates: vec![],
+                        weight: None,
+                        timeout_s: 0.0,
+                        evaluator: EvaluatorConfig {
+                            inner: Default::default(),
+                        },
+                    }),
+                    timeouts: Default::default(),
+                },
             )]),
             ..Default::default()
         });

--- a/tensorzero-internal/src/variant/mod.rs
+++ b/tensorzero-internal/src/variant/mod.rs
@@ -6,11 +6,13 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::sync::Arc;
+use tokio::time::error::Elapsed;
 use tokio::time::Duration;
 use tracing::instrument;
 use uuid::Uuid;
 
 use crate::config_parser::PathWithContents;
+use crate::config_parser::TimeoutsConfig;
 use crate::embeddings::EmbeddingModelTable;
 use crate::endpoints::inference::InferenceIds;
 use crate::endpoints::inference::{InferenceClients, InferenceModels, InferenceParams};
@@ -40,6 +42,14 @@ pub mod chain_of_thought;
 pub mod chat_completion;
 pub mod dicl;
 pub mod mixture_of_n;
+
+/// Holds a particular variant implementation, plus additional top-level configuration
+/// that is applicable to any variant type.
+#[derive(Debug)]
+pub struct VariantInfo {
+    pub inner: VariantConfig,
+    pub timeouts: TimeoutsConfig,
+}
 
 #[derive(Debug)]
 pub enum VariantConfig {
@@ -191,7 +201,7 @@ impl VariantConfig {
     }
 }
 
-impl Variant for VariantConfig {
+impl Variant for VariantInfo {
     #[instrument(
         fields(function_name = %inference_config.function_name, variant_name = %inference_config.variant_name.unwrap_or(""), otel.name="variant_inference", stream=false),
         skip_all
@@ -205,68 +215,86 @@ impl Variant for VariantConfig {
         clients: &'request InferenceClients<'request>,
         inference_params: InferenceParams,
     ) -> Result<InferenceResult, Error> {
-        match self {
-            VariantConfig::ChatCompletion(params) => {
-                params
-                    .infer(
-                        input,
-                        models,
-                        function,
-                        inference_config,
-                        clients,
-                        inference_params,
-                    )
-                    .await
-            }
-            VariantConfig::BestOfNSampling(params) => {
-                params
-                    .infer(
-                        input,
-                        models,
-                        function,
-                        inference_config,
-                        clients,
-                        inference_params,
-                    )
-                    .await
-            }
+        let fut = async {
+            match &self.inner {
+                VariantConfig::ChatCompletion(params) => {
+                    params
+                        .infer(
+                            input,
+                            models,
+                            function,
+                            inference_config,
+                            clients,
+                            inference_params,
+                        )
+                        .await
+                }
+                VariantConfig::BestOfNSampling(params) => {
+                    params
+                        .infer(
+                            input,
+                            models,
+                            function,
+                            inference_config,
+                            clients,
+                            inference_params,
+                        )
+                        .await
+                }
 
-            VariantConfig::Dicl(params) => {
-                params
-                    .infer(
-                        input,
-                        models,
-                        function,
-                        inference_config,
-                        clients,
-                        inference_params,
-                    )
-                    .await
+                VariantConfig::Dicl(params) => {
+                    params
+                        .infer(
+                            input,
+                            models,
+                            function,
+                            inference_config,
+                            clients,
+                            inference_params,
+                        )
+                        .await
+                }
+                VariantConfig::MixtureOfN(params) => {
+                    params
+                        .infer(
+                            input,
+                            models,
+                            function,
+                            inference_config,
+                            clients,
+                            inference_params,
+                        )
+                        .await
+                }
+                VariantConfig::ChainOfThought(params) => {
+                    params
+                        .infer(
+                            input,
+                            models,
+                            function,
+                            inference_config,
+                            clients,
+                            inference_params,
+                        )
+                        .await
+                }
             }
-            VariantConfig::MixtureOfN(params) => {
-                params
-                    .infer(
-                        input,
-                        models,
-                        function,
-                        inference_config,
-                        clients,
-                        inference_params,
-                    )
-                    .await
-            }
-            VariantConfig::ChainOfThought(params) => {
-                params
-                    .infer(
-                        input,
-                        models,
-                        function,
-                        inference_config,
-                        clients,
-                        inference_params,
-                    )
-                    .await
-            }
+        };
+        if let Some(timeout) = self.timeouts.non_streaming.total_ms {
+            let timeout = Duration::from_millis(timeout);
+            tokio::time::timeout(timeout, fut)
+                .await
+                // Convert the outer `Elapsed` error into a TensorZero error,
+                // so that it can be handled by the `match response` block below
+                .unwrap_or_else(|_: Elapsed| {
+                    Err(Error::new(ErrorDetails::VariantTimeout {
+                        variant_name: inference_config.variant_name.map(|v| v.to_string()),
+                        timeout,
+                        streaming: false,
+                    }))
+                })
+        } else {
+            fut.await
         }
     }
 
@@ -283,67 +311,86 @@ impl Variant for VariantConfig {
         clients: &'request InferenceClients<'request>,
         inference_params: InferenceParams,
     ) -> Result<(InferenceResultStream, ModelUsedInfo), Error> {
-        match self {
-            VariantConfig::ChatCompletion(params) => {
-                params
-                    .infer_stream(
-                        input,
-                        models,
-                        function,
-                        inference_config,
-                        clients,
-                        inference_params,
-                    )
-                    .await
+        let fut = async {
+            match &self.inner {
+                VariantConfig::ChatCompletion(params) => {
+                    params
+                        .infer_stream(
+                            input,
+                            models,
+                            function,
+                            inference_config,
+                            clients,
+                            inference_params,
+                        )
+                        .await
+                }
+                VariantConfig::BestOfNSampling(params) => {
+                    params
+                        .infer_stream(
+                            input,
+                            models,
+                            function,
+                            inference_config,
+                            clients,
+                            inference_params,
+                        )
+                        .await
+                }
+                VariantConfig::Dicl(params) => {
+                    params
+                        .infer_stream(
+                            input,
+                            models,
+                            function,
+                            inference_config,
+                            clients,
+                            inference_params,
+                        )
+                        .await
+                }
+                VariantConfig::MixtureOfN(params) => {
+                    params
+                        .infer_stream(
+                            input,
+                            models,
+                            function,
+                            inference_config,
+                            clients,
+                            inference_params,
+                        )
+                        .await
+                }
+                VariantConfig::ChainOfThought(params) => {
+                    params
+                        .infer_stream(
+                            input,
+                            models,
+                            function,
+                            inference_config,
+                            clients,
+                            inference_params,
+                        )
+                        .await
+                }
             }
-            VariantConfig::BestOfNSampling(params) => {
-                params
-                    .infer_stream(
-                        input,
-                        models,
-                        function,
-                        inference_config,
-                        clients,
-                        inference_params,
-                    )
-                    .await
-            }
-            VariantConfig::Dicl(params) => {
-                params
-                    .infer_stream(
-                        input,
-                        models,
-                        function,
-                        inference_config,
-                        clients,
-                        inference_params,
-                    )
-                    .await
-            }
-            VariantConfig::MixtureOfN(params) => {
-                params
-                    .infer_stream(
-                        input,
-                        models,
-                        function,
-                        inference_config,
-                        clients,
-                        inference_params,
-                    )
-                    .await
-            }
-            VariantConfig::ChainOfThought(params) => {
-                params
-                    .infer_stream(
-                        input,
-                        models,
-                        function,
-                        inference_config,
-                        clients,
-                        inference_params,
-                    )
-                    .await
-            }
+        };
+
+        // This future includes a call to `peek_first_chunk`, so applying
+        // `streaming_ttft_timeout` is correct.
+        if let Some(timeout) = self.timeouts.streaming.ttft_ms {
+            let timeout = Duration::from_millis(timeout);
+            tokio::time::timeout(timeout, fut)
+                .await
+                .unwrap_or_else(|_: Elapsed| {
+                    Err(Error::new(ErrorDetails::VariantTimeout {
+                        variant_name: inference_config.variant_name.map(|v| v.to_string()),
+                        timeout,
+                        streaming: true,
+                    }))
+                })
+        } else {
+            fut.await
         }
     }
 
@@ -357,7 +404,7 @@ impl Variant for VariantConfig {
         clients: &'a InferenceClients<'a>,
         inference_params: Vec<InferenceParams>,
     ) -> Result<StartBatchModelInferenceWithMetadata<'a>, Error> {
-        match self {
+        match &self.inner {
             VariantConfig::ChatCompletion(params) => {
                 params
                     .start_batch_inference(
@@ -386,7 +433,7 @@ impl Variant for VariantConfig {
         function_name: &str,
         variant_name: &str,
     ) -> Result<(), Error> {
-        match self {
+        match &self.inner {
             VariantConfig::ChatCompletion(params) => {
                 params
                     .validate(
@@ -451,7 +498,7 @@ impl Variant for VariantConfig {
     }
 
     fn get_all_template_paths(&self) -> Vec<&PathWithContents> {
-        match self {
+        match &self.inner {
             VariantConfig::ChatCompletion(params) => params.get_all_template_paths(),
             VariantConfig::BestOfNSampling(params) => params.get_all_template_paths(),
             VariantConfig::Dicl(params) => params.get_all_template_paths(),

--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -632,6 +632,44 @@ model_name = "text-embedding-3-small"
 # │                                 FUNCTIONS                                  │
 # └────────────────────────────────────────────────────────────────────────────┘
 
+# Variant timeout tests
+
+[functions.basic_test_variant_timeout]
+type = "chat"
+
+[functions.basic_test_variant_timeout.variants.slow_timeout]
+type = "chat_completion"
+model = "slow"
+
+[functions.basic_test_variant_timeout.variants.slow_timeout.timeouts]
+non_streaming = { total_ms = 400 }
+streaming = { ttft_ms = 500 }
+
+[functions.basic_test_variant_timeout.variants.slow_second_chunk]
+type = "chat_completion"
+model = "slow_second_chunk"
+
+[functions.basic_test_variant_timeout.variants.slow_second_chunk.timeouts]
+non_streaming = { total_ms = 400 }
+streaming = { ttft_ms = 500 }
+
+[functions.basic_test_variant_timeout.variants.best_of_n]
+type = "experimental_best_of_n_sampling"
+candidates = ["good", "slow_timeout", "reasoner"]
+
+[functions.basic_test_variant_timeout.variants.best_of_n.evaluator]
+model = "dummy::best_of_n_0"
+
+[functions.basic_test_variant_timeout.variants.good]
+type = "chat_completion"
+model = "dummy::good"
+
+[functions.basic_test_variant_timeout.variants.reasoner]
+type = "chat_completion"
+model = "dummy::reasoner"
+
+# Model provider timeout tests
+
 [functions.basic_test_timeout]
 type = "chat"
 
@@ -664,6 +702,7 @@ candidates = ["good", "reasoner"]
 
 [functions.basic_test_timeout.variants.best_of_n_judge_timeout.evaluator]
 model = "slow_with_timeout"
+
 [functions.basic_test_template_no_schema]
 type = "chat"
 

--- a/tensorzero-internal/tests/e2e/timeouts.rs
+++ b/tensorzero-internal/tests/e2e/timeouts.rs
@@ -381,7 +381,7 @@ async fn slow_second_chunk_streaming(payload: Value) {
         }
     }
 
-    // The overall stream duration should be at least 2 seconds, becaues we used the 'slow_second_chunk' model
+    // The overall stream duration should be at least 2 seconds, because we used the 'slow_second_chunk' model
     let elapsed = start.elapsed();
     assert!(
         elapsed >= Duration::from_millis(2000),

--- a/tensorzero-internal/tests/e2e/timeouts.rs
+++ b/tensorzero-internal/tests/e2e/timeouts.rs
@@ -14,6 +14,118 @@ use uuid::Uuid;
 
 use crate::common::get_gateway_endpoint;
 
+// Variant timeout tests
+
+#[tokio::test]
+async fn test_variant_timeout_non_streaming() {
+    let payload = json!({
+        "function_name": "basic_test_variant_timeout",
+        "variant_name": "slow_timeout",
+        "episode_id": Uuid::now_v7(),
+        "input": {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Hello, world!"
+                }
+            ]
+        },
+    });
+
+    let response = Client::new()
+        .post(get_gateway_endpoint("/inference"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+
+    let response_json = response.json::<Value>().await.unwrap();
+    assert_eq!(
+        response_json,
+        json!({
+            "error":"All variants failed with errors: slow_timeout: Variant `slow_timeout` timed out due to configured `non_streaming.total_ms` timeout (400ms)"
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_variant_timeout_streaming() {
+    let payload = json!({
+        "function_name": "basic_test_variant_timeout",
+        "variant_name": "slow_timeout",
+        "episode_id": Uuid::now_v7(),
+        "input": {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Hello, world!"
+                }
+            ]
+        },
+        "stream": true,
+    });
+
+    let response = Client::new()
+        .post(get_gateway_endpoint("/inference"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let response_json = response.json::<Value>().await.unwrap();
+    assert_eq!(
+        response_json,
+        json!({
+            "error":"All variants failed with errors: slow_timeout: Variant `slow_timeout` timed out due to configured `streaming.ttft_ms` timeout (500ms)"
+        })
+    );
+    assert_eq!(status, StatusCode::BAD_GATEWAY);
+}
+
+#[tokio::test]
+async fn test_variant_timeout_slow_second_chunk_streaming() {
+    slow_second_chunk_streaming(json!({
+        "function_name": "basic_test_variant_timeout",
+        "variant_name": "slow_second_chunk",
+        "episode_id": Uuid::now_v7(),
+        "input": {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Hello, world!"
+                }
+            ]
+        },
+        "stream": true,
+    }))
+    .await;
+}
+
+// We don't currently support setting an actual variant as the judge,
+// so we can't apply a variant timeout to the judge itself.
+
+// Test that if a candidate times out, the evaluator can still see the other candidates
+#[tokio::test]
+async fn test_variant_timeout_best_of_n_other_candidate() {
+    best_of_n_other_candidate(json!({
+        "function_name": "basic_test_variant_timeout",
+        "variant_name": "best_of_n",
+        "episode_id": Uuid::now_v7(),
+        "input": {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Hello, world!"
+                }
+            ]
+        },
+    }))
+    .await;
+}
+
+// Model provider timeout tests
+
 #[tokio::test]
 async fn test_model_provider_timeout_non_streaming() {
     let payload = json!({
@@ -83,7 +195,7 @@ async fn test_model_provider_timeout_streaming() {
 
 #[tokio::test]
 async fn test_model_provider_timeout_slow_second_chunk_streaming() {
-    let payload = json!({
+    slow_second_chunk_streaming(json!({
         "function_name": "basic_test_timeout",
         "variant_name": "slow_second_chunk",
         "episode_id": Uuid::now_v7(),
@@ -96,58 +208,14 @@ async fn test_model_provider_timeout_slow_second_chunk_streaming() {
             ]
         },
         "stream": true,
-    });
-
-    let start = Instant::now();
-    let mut response = Client::new()
-        .post(get_gateway_endpoint("/inference"))
-        .json(&payload)
-        .eventsource()
-        .unwrap();
-
-    let mut inference_id = None;
-
-    while let Some(event) = response.next().await {
-        let chunk = event.unwrap();
-        println!("chunk: {chunk:?}");
-        if let Event::Message(event) = chunk {
-            if event.data == "[DONE]" {
-                break;
-            }
-            let event = serde_json::from_str::<Value>(&event.data).unwrap();
-            inference_id = Some(event["inference_id"].as_str().unwrap().parse().unwrap());
-        }
-    }
-
-    // The overall stream duration should be at least 2 seconds, becaues we used the 'slow_second_chunk' model
-    let elapsed = start.elapsed();
-    assert!(
-        elapsed >= Duration::from_millis(2000),
-        "slow_second_chunk should take at least 2 seconds, but took {elapsed:?}"
-    );
-
-    // Wait 100ms to allow time for data to be inserted into ClickHouse (trailing writes from API)
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-
-    let clickhouse = get_clickhouse().await;
-
-    let model_inference = select_model_inference_clickhouse(&clickhouse, inference_id.unwrap())
-        .await
-        .unwrap();
-
-    // The TTFT should be under 400ms (it should really be instant, but we give some buffer in case CI is overloaded)
-    // As a result, the 'streaming.ttft_ms' timeout was not hit.
-    let ttft_ms = model_inference["ttft_ms"].as_u64().unwrap();
-    assert!(
-        ttft_ms <= 400,
-        "ttft_ms should be less than 400ms, but was {ttft_ms}"
-    );
+    }))
+    .await;
 }
 
 // Test that if a candidate times out, the evaluator can still see the other candidates
 #[tokio::test]
 async fn test_model_provider_timeout_best_of_n_other_candidate() {
-    let payload = json!({
+    best_of_n_other_candidate(json!({
         "function_name": "basic_test_timeout",
         "variant_name": "best_of_n",
         "episode_id": Uuid::now_v7(),
@@ -159,8 +227,11 @@ async fn test_model_provider_timeout_best_of_n_other_candidate() {
                 }
             ]
         },
-    });
+    }))
+    .await;
+}
 
+async fn best_of_n_other_candidate(payload: Value) {
     let response = Client::new()
         .post(get_gateway_endpoint("/inference"))
         .json(&payload)
@@ -223,7 +294,7 @@ async fn test_model_provider_timeout_best_of_n_other_candidate() {
 
 #[tokio::test]
 async fn test_model_provider_timeout_best_of_n_judge_timeout() {
-    let payload = json!({
+    best_of_n_judge_timeout(json!({
         "function_name": "basic_test_timeout",
         "variant_name": "best_of_n_judge_timeout",
         "episode_id": Uuid::now_v7(),
@@ -235,8 +306,11 @@ async fn test_model_provider_timeout_best_of_n_judge_timeout() {
                 }
             ]
         },
-    });
+    }))
+    .await;
+}
 
+async fn best_of_n_judge_timeout(payload: Value) {
     let response = Client::new()
         .post(get_gateway_endpoint("/inference"))
         .json(&payload)
@@ -283,4 +357,51 @@ async fn test_model_provider_timeout_best_of_n_judge_timeout() {
     }
     model_names.sort();
     assert_eq!(model_names, ["dummy::good", "dummy::reasoner"]);
+}
+
+async fn slow_second_chunk_streaming(payload: Value) {
+    let start = Instant::now();
+    let mut response = Client::new()
+        .post(get_gateway_endpoint("/inference"))
+        .json(&payload)
+        .eventsource()
+        .unwrap();
+
+    let mut inference_id = None;
+
+    while let Some(event) = response.next().await {
+        let chunk = event.unwrap();
+        println!("chunk: {chunk:?}");
+        if let Event::Message(event) = chunk {
+            if event.data == "[DONE]" {
+                break;
+            }
+            let event = serde_json::from_str::<Value>(&event.data).unwrap();
+            inference_id = Some(event["inference_id"].as_str().unwrap().parse().unwrap());
+        }
+    }
+
+    // The overall stream duration should be at least 2 seconds, becaues we used the 'slow_second_chunk' model
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed >= Duration::from_millis(2000),
+        "slow_second_chunk should take at least 2 seconds, but took {elapsed:?}"
+    );
+
+    // Wait 100ms to allow time for data to be inserted into ClickHouse (trailing writes from API)
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let clickhouse = get_clickhouse().await;
+
+    let model_inference = select_model_inference_clickhouse(&clickhouse, inference_id.unwrap())
+        .await
+        .unwrap();
+
+    // The TTFT should be under 400ms (it should really be instant, but we give some buffer in case CI is overloaded)
+    // As a result, the 'streaming.ttft_ms' timeout was not hit.
+    let ttft_ms = model_inference["ttft_ms"].as_u64().unwrap();
+    assert!(
+        ttft_ms <= 400,
+        "ttft_ms should be less than 400ms, but was {ttft_ms}"
+    );
 }


### PR DESCRIPTION
Most of this PR just refactors our variant-handling code to add a wrapper 'VariantInfo' struct, which holds both a 'VariantConfig' and the 'TimeoutsConfig'. The `Variant` trait is now implemented on `VariantInfo`, which calls the wrapped `VariantInfo` with the timeout applied.

The config section looks like this:

```toml
[functions.basic_test_variant_timeout.variants.slow_timeout.timeouts]
non_streaming = { total_ms = 400 }
streaming = { ttft_ms = 500 }
```

The `timeouts` values are the same as for model provider timeouts.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR adds timeout handling to variant configurations by introducing a `VariantInfo` struct and updating relevant functions and tests.
> 
>   - **Behavior**:
>     - Introduces `VariantInfo` struct to encapsulate `VariantConfig` and `TimeoutsConfig`.
>     - Applies timeouts to variants using `timeouts` section in config, e.g., `non_streaming` and `streaming` timeouts.
>     - Updates `infer()` and `infer_stream()` in `variant/mod.rs` to handle timeouts.
>   - **Config**:
>     - Adds `[timeouts]` section to variant configurations in `tensorzero.toml`.
>     - Example config: `non_streaming = { total_ms = 400 }`, `streaming = { ttft_ms = 500 }`.
>   - **Tests**:
>     - Adds tests for variant timeouts in `timeouts.rs`.
>     - Tests include `test_variant_timeout_non_streaming`, `test_variant_timeout_streaming`, and others.
>     - Validates that timeouts are correctly applied and handled in different scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5aba9335c1dbc1dbe5d60e7d7f2be145ea35c153. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->