### PR TITLE
decouple input validation and deserialization of Tool calls

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -63,4 +63,4 @@ dev = [
 [tool.maturin]
 features = ["pyo3/extension-module"]
 include = [".cargo/*"]
-strip = true
+# strip = true

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -63,4 +63,4 @@ dev = [
 [tool.maturin]
 features = ["pyo3/extension-module"]
 include = [".cargo/*"]
-# strip = true
+strip = true

--- a/clients/python/tests/test_rendering.py
+++ b/clients/python/tests/test_rendering.py
@@ -36,7 +36,7 @@ def test_sync_render_inferences_success(embedded_sync_client: TensorZeroGateway)
                                 {
                                     "type": "tool_call",
                                     "id": "123",
-                                    "arguments": {"foo": "bar"},
+                                    "arguments": '{"foo": "bar"}',
                                     "name": "test_tool",
                                 },
                             ],
@@ -143,7 +143,7 @@ def test_sync_render_inferences_success(embedded_sync_client: TensorZeroGateway)
     assert isinstance(content[2], ToolCall)
     assert content[2].type == "tool_call"
     assert content[2].id == "123"
-    assert content[2].arguments == '{"foo":"bar"}'
+    assert content[2].arguments == '{"foo": "bar"}'
     assert content[2].name == "test_tool"
     message = messages[1]
     assert message.role == "assistant"
@@ -401,7 +401,7 @@ async def test_async_render_inferences_success(
                                 {
                                     "type": "tool_call",
                                     "id": "123",
-                                    "arguments": {"foo": "bar"},
+                                    "arguments": '{"foo": "bar"}',
                                     "name": "test_tool",
                                 },
                             ],
@@ -511,7 +511,7 @@ async def test_async_render_inferences_success(
     assert isinstance(content[2], ToolCall)
     assert content[2].type == "tool_call"
     assert content[2].id == "123"
-    assert content[2].arguments == """{"foo":"bar"}"""
+    assert content[2].arguments == """{"foo": "bar"}"""
     assert content[2].name == "test_tool"
     message = messages[1]
     assert message.role == "assistant"

--- a/clients/rust/src/client_input.rs
+++ b/clients/rust/src/client_input.rs
@@ -5,7 +5,7 @@ use tensorzero_derive::TensorZeroDeserialize;
 use tensorzero_internal::{
     error::Error,
     inference::types::{File, InputMessageContent, Role, TextKind, Thought},
-    tool::{ToolCall, ToolCallInput, ToolResult},
+    tool::{ToolCallInput, ToolResult},
 };
 
 // Like the normal `Input` type, but with `ClientInputMessage` instead of `InputMessage`.
@@ -58,7 +58,7 @@ impl TryFrom<ClientInputMessageContent> for InputMessageContent {
         Ok(match this {
             ClientInputMessageContent::Text(text) => InputMessageContent::Text(text),
             ClientInputMessageContent::ToolCall(tool_call) => {
-                InputMessageContent::ToolCall(tool_call.try_into()?)
+                InputMessageContent::ToolCall(tool_call)
             }
             ClientInputMessageContent::ToolResult(tool_result) => {
                 InputMessageContent::ToolResult(tool_result)
@@ -128,13 +128,15 @@ pub(super) fn test_client_to_message_content(
         ClientInputMessageContent::ToolCall(ToolCallInput {
             id,
             name,
-            raw_name: _,
+            raw_name,
             arguments,
-            raw_arguments: _,
-        }) => InputMessageContent::ToolCall(ToolCall {
+            raw_arguments,
+        }) => InputMessageContent::ToolCall(ToolCallInput {
             id,
-            name: name.unwrap_or_default(),
-            arguments: arguments.unwrap_or_default().to_string(),
+            name,
+            raw_name,
+            raw_arguments,
+            arguments,
         }),
         ClientInputMessageContent::ToolResult(tool_result) => {
             InputMessageContent::ToolResult(tool_result)

--- a/tensorzero-internal/src/endpoints/openai_compatible.rs
+++ b/tensorzero-internal/src/endpoints/openai_compatible.rs
@@ -38,7 +38,7 @@ use crate::inference::types::{
     current_timestamp, ContentBlockChatOutput, ContentBlockChunk, File, FinishReason, Input,
     InputMessage, InputMessageContent, Role, TextKind, Usage,
 };
-use crate::tool::{DynamicToolParams, Tool, ToolCall, ToolCallOutput, ToolChoice, ToolResult};
+use crate::tool::{DynamicToolParams, Tool, ToolCallInput, ToolCallOutput, ToolChoice, ToolResult};
 use crate::variant::JsonMode;
 
 use super::inference::{
@@ -770,12 +770,14 @@ impl From<ChatCompletionToolChoiceOption> for ToolChoice {
     }
 }
 
-impl From<OpenAICompatibleToolCall> for ToolCall {
+impl From<OpenAICompatibleToolCall> for ToolCallInput {
     fn from(tool_call: OpenAICompatibleToolCall) -> Self {
-        ToolCall {
+        ToolCallInput {
             id: tool_call.id,
-            name: tool_call.function.name,
-            arguments: tool_call.function.arguments,
+            raw_name: Some(tool_call.function.name),
+            raw_arguments: Some(tool_call.function.arguments),
+            name: None,
+            arguments: None,
         }
     }
 }
@@ -1314,10 +1316,12 @@ mod tests {
         let expected_text = InputMessageContent::Text(TextKind::Text {
             text: "Hello, world!".to_string(),
         });
-        let expected_tool_call = InputMessageContent::ToolCall(ToolCall {
+        let expected_tool_call = InputMessageContent::ToolCall(ToolCallInput {
             id: "1".to_string(),
-            name: "test_tool".to_string(),
-            arguments: "{}".to_string(),
+            raw_name: Some("test_tool".to_string()),
+            raw_arguments: Some("{}".to_string()),
+            name: None,
+            arguments: None,
         });
 
         assert!(


### PR DESCRIPTION
We had implemented a deserializer for the `ToolCall` struct that automatically called a `TryFrom<ToolCallInput>` in order to handle the deprecation of an arguments field that was a string vs an object. This led to a warning being printed when deserializing `ToolCall`s from the database in the `experimental_list_inferences` function. 

In order to handle the deserialization separately from the ToolCall handling, we changed the input type to ToolCallInput in Rust and then do the `.try_from` in the input resolution step of an inference. 

We then derived `Deserialize` in `ToolCall` and directly use that impl in the list_inferences function.

There was one small change to the public interface:
- `ToolCall`s that get passed into `experimental_render_inference` need their arguments to be strings rather than parsed JSON. This is due to the change in deserialization for the `ToolCall` type.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Decouple `ToolCall` input validation and deserialization in Rust, requiring string arguments for `experimental_render_inference`.
> 
>   - **Behavior**:
>     - Change `ToolCall` deserialization to use `ToolCallInput` in Rust, converting to `ToolCall` during input resolution.
>     - `ToolCall` arguments in `experimental_render_inference` must be strings due to deserialization changes.
>   - **Code Changes**:
>     - Modify `client_input.rs` to use `ToolCallInput` for deserialization and conversion.
>     - Update `openai_compatible.rs` to reflect changes in `ToolCall` handling.
>     - Adjust `mod.rs` in `inference/types` to handle `ToolCallInput`.
>   - **Tests**:
>     - Update `test_rendering.py` to reflect changes in `ToolCall` argument handling.
>     - Modify tests in `tool.rs` to ensure compatibility with new deserialization logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1e5de303bb3017118130f52fd789fa6be136bda6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->