### PR TITLE
changed the node / filter types

### DIFF
--- a/clients/python/tensorzero/__init__.py
+++ b/clients/python/tensorzero/__init__.py
@@ -14,9 +14,11 @@ from .tensorzero import (
     _start_http_gateway as _start_http_gateway,
 )
 from .types import (
-    AndNode,
+    AndFilter,
+    AndNode,  # DEPRECATED
     BaseTensorZeroError,
-    BooleanMetricNode,
+    BooleanMetricFilter,
+    BooleanMetricNode,  # DEPRECATED
     ChatDatapointInsert,
     ChatInferenceDatapointInput,  # DEPRECATED
     ChatInferenceResponse,
@@ -29,7 +31,8 @@ from .types import (
     FileBase64,
     FileUrl,
     FinishReason,
-    FloatMetricNode,
+    FloatMetricFilter,
+    FloatMetricNode,  # DEPRECATED
     ImageBase64,
     ImageUrl,
     InferenceChunk,
@@ -40,8 +43,10 @@ from .types import (
     JsonInferenceOutput,
     JsonInferenceResponse,
     Message,
-    NotNode,
-    OrNode,
+    NotFilter,
+    NotNode,  # DEPRECATED
+    OrFilter,
+    OrNode,  # DEPRECATED
     RawText,
     System,
     TensorZeroError,
@@ -61,11 +66,13 @@ from .types import (
 )
 
 __all__ = [
-    "AndNode",
+    "AndFilter",
+    "AndNode",  # DEPRECATED
     "AsyncTensorZeroGateway",
     "BaseTensorZeroError",
     "BaseTensorZeroGateway",
-    "BooleanMetricNode",
+    "BooleanMetricFilter",
+    "BooleanMetricNode",  # DEPRECATED
     "ChatDatapointInsert",
     "ChatInferenceDatapointInput",  # DEPRECATED
     "ChatInferenceResponse",
@@ -78,7 +85,8 @@ __all__ = [
     "FileBase64",
     "FileUrl",
     "FinishReason",
-    "FloatMetricNode",
+    "FloatMetricFilter",
+    "FloatMetricNode",  # DEPRECATED
     "ImageBase64",
     "ImageUrl",
     "InferenceChunk",
@@ -92,8 +100,10 @@ __all__ = [
     "JsonInferenceOutput",
     "JsonInferenceResponse",
     "Message",
-    "NotNode",
-    "OrNode",
+    "NotFilter",
+    "NotNode",  # DEPRECATED
+    "OrFilter",
+    "OrNode",  # DEPRECATED
     "patch_openai_client",
     "RawText",
     "RenderedStoredInference",

--- a/clients/python/tensorzero/types.py
+++ b/clients/python/tensorzero/types.py
@@ -550,33 +550,88 @@ class InferenceFilterTreeNode(ABC, HasTypeField):
 
 
 @dataclass
-class FloatMetricNode(InferenceFilterTreeNode):
+class FloatMetricFilter(InferenceFilterTreeNode):
     metric_name: str
     value: float
     comparison_operator: Literal["<", "<=", "=", ">", ">=", "!="]
     type: str = "float_metric"
 
 
+# CAREFUL: deprecated
+class FloatMetricNode(FloatMetricFilter):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        warnings.warn(
+            "Please use `FloatMetricFilter` instead of `FloatMetricNode`. In a future release, `FloatMetricNode` will be removed.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
+
 @dataclass
-class BooleanMetricNode(InferenceFilterTreeNode):
+class BooleanMetricFilter(InferenceFilterTreeNode):
     metric_name: str
     value: bool
     type: str = "boolean_metric"
 
 
+# CAREFUL: deprecated
+class BooleanMetricNode(BooleanMetricFilter):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        warnings.warn(
+            "Please use `BooleanMetricFilter` instead of `BooleanMetricNode`. In a future release, `BooleanMetricNode` will be removed.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
+
 @dataclass
-class AndNode(InferenceFilterTreeNode):
+class AndFilter(InferenceFilterTreeNode):
     children: List[InferenceFilterTreeNode]
     type: str = "and"
 
 
+# CAREFUL: deprecated
+class AndNode(AndFilter):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        warnings.warn(
+            "Please use `AndFilter` instead of `AndNode`. In a future release, `AndNode` will be removed.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
+
 @dataclass
-class OrNode(InferenceFilterTreeNode):
+class OrFilter(InferenceFilterTreeNode):
     children: List[InferenceFilterTreeNode]
     type: str = "or"
 
 
+# CAREFUL: deprecated
+class OrNode(OrFilter):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        warnings.warn(
+            "Please use `OrFilter` instead of `OrNode`. In a future release, `OrNode` will be removed.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
+
 @dataclass
-class NotNode(InferenceFilterTreeNode):
+class NotFilter(InferenceFilterTreeNode):
     child: InferenceFilterTreeNode
     type: str = "not"
+
+
+# CAREFUL: deprecated
+class NotNode(NotFilter):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        warnings.warn(
+            "Please use `NotFilter` instead of `NotNode`. In a future release, `NotNode` will be removed.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/clients/python/tests/test_list_inferences.py
+++ b/clients/python/tests/test_list_inferences.py
@@ -2,12 +2,12 @@ from uuid import UUID
 
 import pytest
 from tensorzero import (
-    AndNode,
+    AndFilter,
     AsyncTensorZeroGateway,
-    BooleanMetricNode,
-    FloatMetricNode,
-    NotNode,
-    OrNode,
+    BooleanMetricFilter,
+    FloatMetricFilter,
+    NotFilter,
+    OrFilter,
     TensorZeroGateway,
     Text,
     ToolCall,
@@ -49,7 +49,7 @@ def test_simple_list_json_inferences(embedded_sync_client: TensorZeroGateway):
 
 
 def test_simple_query_with_float_filter(embedded_sync_client: TensorZeroGateway):
-    filters = FloatMetricNode(
+    filters = FloatMetricFilter(
         metric_name="jaccard_similarity",
         value=0.5,
         comparison_operator=">",
@@ -202,7 +202,7 @@ def test_demonstration_output_source(embedded_sync_client: TensorZeroGateway):
 
 
 def test_boolean_metric_filter(embedded_sync_client: TensorZeroGateway):
-    filters = BooleanMetricNode(
+    filters = BooleanMetricFilter(
         metric_name="exact_match",
         value=True,
     )
@@ -220,14 +220,14 @@ def test_boolean_metric_filter(embedded_sync_client: TensorZeroGateway):
 
 
 def test_and_filter_multiple_float_metrics(embedded_sync_client: TensorZeroGateway):
-    filters = AndNode(
+    filters = AndFilter(
         children=[
-            FloatMetricNode(
+            FloatMetricFilter(
                 metric_name="jaccard_similarity",
                 value=0.5,
                 comparison_operator=">",
             ),
-            FloatMetricNode(
+            FloatMetricFilter(
                 metric_name="jaccard_similarity",
                 value=0.8,
                 comparison_operator="<",
@@ -248,18 +248,18 @@ def test_and_filter_multiple_float_metrics(embedded_sync_client: TensorZeroGatew
 
 
 def test_or_filter_mixed_metrics(embedded_sync_client: TensorZeroGateway):
-    filters = OrNode(
+    filters = OrFilter(
         children=[
-            FloatMetricNode(
+            FloatMetricFilter(
                 metric_name="jaccard_similarity",
                 value=0.8,
                 comparison_operator=">=",
             ),
-            BooleanMetricNode(
+            BooleanMetricFilter(
                 metric_name="exact_match",
                 value=True,
             ),
-            BooleanMetricNode(
+            BooleanMetricFilter(
                 metric_name="goal_achieved",
                 value=True,
             ),
@@ -279,14 +279,14 @@ def test_or_filter_mixed_metrics(embedded_sync_client: TensorZeroGateway):
 
 
 def test_not_filter(embedded_sync_client: TensorZeroGateway):
-    filters = NotNode(
-        child=OrNode(
+    filters = NotFilter(
+        child=OrFilter(
             children=[
-                BooleanMetricNode(
+                BooleanMetricFilter(
                     metric_name="exact_match",
                     value=True,
                 ),
-                BooleanMetricNode(
+                BooleanMetricFilter(
                     metric_name="exact_match",
                     value=False,
                 ),
@@ -378,7 +378,7 @@ async def test_simple_list_json_inferences_async(
 async def test_simple_query_with_float_filter_async(
     embedded_async_client: AsyncTensorZeroGateway,
 ):
-    filters = FloatMetricNode(
+    filters = FloatMetricFilter(
         metric_name="jaccard_similarity",
         value=0.5,
         comparison_operator=">",
@@ -454,7 +454,7 @@ async def test_demonstration_output_source_async(
 async def test_boolean_metric_filter_async(
     embedded_async_client: AsyncTensorZeroGateway,
 ):
-    filters = BooleanMetricNode(
+    filters = BooleanMetricFilter(
         metric_name="exact_match",
         value=True,
     )
@@ -475,14 +475,14 @@ async def test_boolean_metric_filter_async(
 async def test_and_filter_multiple_float_metrics_async(
     embedded_async_client: AsyncTensorZeroGateway,
 ):
-    filters = AndNode(
+    filters = AndFilter(
         children=[
-            FloatMetricNode(
+            FloatMetricFilter(
                 metric_name="jaccard_similarity",
                 value=0.5,
                 comparison_operator=">",
             ),
-            FloatMetricNode(
+            FloatMetricFilter(
                 metric_name="jaccard_similarity",
                 value=0.8,
                 comparison_operator="<",
@@ -506,18 +506,18 @@ async def test_and_filter_multiple_float_metrics_async(
 async def test_or_filter_mixed_metrics_async(
     embedded_async_client: AsyncTensorZeroGateway,
 ):
-    filters = OrNode(
+    filters = OrFilter(
         children=[
-            FloatMetricNode(
+            FloatMetricFilter(
                 metric_name="jaccard_similarity",
                 value=0.8,
                 comparison_operator=">=",
             ),
-            BooleanMetricNode(
+            BooleanMetricFilter(
                 metric_name="exact_match",
                 value=True,
             ),
-            BooleanMetricNode(
+            BooleanMetricFilter(
                 metric_name="goal_achieved",
                 value=True,
             ),
@@ -538,14 +538,14 @@ async def test_or_filter_mixed_metrics_async(
 
 @pytest.mark.asyncio
 async def test_not_filter_async(embedded_async_client: AsyncTensorZeroGateway):
-    filters = NotNode(
-        child=OrNode(
+    filters = NotFilter(
+        child=OrFilter(
             children=[
-                BooleanMetricNode(
+                BooleanMetricFilter(
                     metric_name="exact_match",
                     value=True,
                 ),
-                BooleanMetricNode(
+                BooleanMetricFilter(
                     metric_name="exact_match",
                     value=False,
                 ),


### PR DESCRIPTION
Closes #2414, opened #2433 to track deprecation.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Renamed node types to filter types in `tensorzero`, deprecated old node classes, and updated tests accordingly.
> 
>   - **Types**:
>     - Rename `AndNode` to `AndFilter`, `BooleanMetricNode` to `BooleanMetricFilter`, `FloatMetricNode` to `FloatMetricFilter`, `NotNode` to `NotFilter`, and `OrNode` to `OrFilter` in `types.py`.
>     - Deprecated old node classes with warnings in `types.py`.
>   - **Imports**:
>     - Update imports in `__init__.py` to use new filter types and mark old node types as deprecated.
>   - **Tests**:
>     - Update `test_list_inferences.py` to use new filter types in test cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8a149e54f4702cb5001b92f0d2dd9e6c4b3298e1. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->