### PR TITLE
Temporarily switch Groq to Llama 3

### DIFF
--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -75,9 +75,12 @@ api_key_location = "dynamic::azure_openai_api_key"
 [models."llama-scout-groq"]
 routing = ["groq"]
 
+# The llama-scout-groq model is temporary set to Llama 3 instead
+# of Llama 4 scout, since Groq is having issues with Scout
+
 [models."llama-scout-groq".providers.groq]
 type = "groq"
-model_name = "meta-llama/llama-4-scout-17b-16e-instruct"
+model_name = "llama-3.3-70b-versatile"
 
 
 [models."llama-scout-groq-dynamic"]
@@ -85,7 +88,7 @@ routing = ["groq"]
 
 [models."llama-scout-groq-dynamic".providers.groq]
 type = "groq"
-model_name = "meta-llama/llama-4-scout-17b-16e-instruct"
+model_name = "llama-3.3-70b-versatile"
 api_key_location = "dynamic::groq_api_key"
 
 


### PR DESCRIPTION
meta-llama/llama-4-scout-17b-16e-instruct is down on Groq, so let's switch models to unblock CI

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
