### PR TITLE
Fixed tool call handling in input snippet 

### DIFF
--- a/ui/app/components/inference/InputSnippet.tsx
+++ b/ui/app/components/inference/InputSnippet.tsx
@@ -27,7 +27,14 @@ function renderContentBlock(block: ResolvedInputMessageContent, index: number) {
   switch (block.type) {
     case "text": {
       if (typeof block.value === "object") {
-        return <TextMessage key={index} label="Text (Arguments)" content={JSON.stringify(block.value, null, 2)} type="structured" />;
+        return (
+          <TextMessage
+            key={index}
+            label="Text (Arguments)"
+            content={JSON.stringify(block.value, null, 2)}
+            type="structured"
+          />
+        );
       }
 
       // Try to parse JSON strings
@@ -36,7 +43,12 @@ function renderContentBlock(block: ResolvedInputMessageContent, index: number) {
           const parsedJson = JSON.parse(block.value);
           if (typeof parsedJson === "object") {
             return (
-              <TextMessage key={index} label="Text (Arguments)" content={JSON.stringify(parsedJson, null, 2)} type="structured" />
+              <TextMessage
+                key={index}
+                label="Text (Arguments)"
+                content={JSON.stringify(parsedJson, null, 2)}
+                type="structured"
+              />
             );
           }
         } catch {
@@ -48,18 +60,34 @@ function renderContentBlock(block: ResolvedInputMessageContent, index: number) {
     }
 
     case "raw_text":
-      return <TextMessage key={index} label="Text (Raw)" content={block.value} type="structured" />;
+      return (
+        <TextMessage
+          key={index}
+          label="Text (Raw)"
+          content={block.value}
+          type="structured"
+        />
+      );
 
-    case "tool_call":
+    case "tool_call": {
+      // NOTE: since tool calls are stored as a string in ResolvedInput and therefore the database
+      // and we are not guaranteed that they are valid JSON, we try to parse them as JSON
+      // and if they are not valid JSON, we display the raw string
+      const parsedArguments = block.arguments
+        ? JSON.parse(block.arguments)
+        : null;
+      const prettyArguments = parsedArguments
+        ? JSON.stringify(parsedArguments, null, 2)
+        : block.arguments;
       return (
         <ToolCallMessage
           key={index}
           toolName={block.name}
-          toolArguments={JSON.stringify(JSON.parse(block.arguments), null, 2)}
-          // TODO: if arguments is null, display raw arguments without parsing
+          toolArguments={prettyArguments}
           toolCallId={block.id}
         />
       );
+    }
 
     case "tool_result":
       return (

--- a/ui/app/components/layout/SnippetContent.tsx
+++ b/ui/app/components/layout/SnippetContent.tsx
@@ -115,9 +115,11 @@ export function TextMessage({
         icon={<AlignLeft className="text-fg-muted h-3 w-3" />}
       />
       {type === "structured" ? (
-        <pre className="w-full whitespace-pre-wrap break-words font-mono text-sm">{content}</pre>
+        <pre className="w-full font-mono text-sm break-words whitespace-pre-wrap">
+          {content}
+        </pre>
       ) : (
-        <span className="w-full text-fg-primary text-sm">{content}</span>
+        <span className="text-fg-primary w-full text-sm">{content}</span>
       )}
     </div>
   );

--- a/ui/app/components/layout/SnippetLayout.tsx
+++ b/ui/app/components/layout/SnippetLayout.tsx
@@ -10,7 +10,7 @@ interface SnippetLayoutProps {
 
 export function SnippetLayout({ children }: SnippetLayoutProps) {
   return (
-    <div className="w-full bg-bg-primary rounded-lg border border-border">
+    <div className="bg-bg-primary border-border w-full rounded-lg border">
       {children}
     </div>
   );
@@ -80,7 +80,7 @@ export function SnippetContent({
       </div>
 
       {needsExpansion && !expanded && maxHeight !== "Content" && (
-        <div className="from-bg-primary absolute right-0 bottom-0 left-0 flex justify-center bg-gradient-to-t to-transparent pt-8 pb-4 rounded-b-lg">
+        <div className="from-bg-primary absolute right-0 bottom-0 left-0 flex justify-center rounded-b-lg bg-gradient-to-t to-transparent pt-8 pb-4">
           <Button variant="outline" size="sm" onClick={() => setExpanded(true)}>
             Show more
           </Button>
@@ -109,7 +109,9 @@ export function SnippetMessage({
         <div className="text-sm font-medium text-purple-600 capitalize">
           {role}
         </div>
-        <div className="flex w-full flex-col gap-4 border-l border-border pl-4">{children}</div>
+        <div className="border-border flex w-full flex-col gap-4 border-l pl-4">
+          {children}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
Closes #2359. As I mention in the comment in `InputSnippet.tsx` the issue was actually wrong so the right handling is to do this conditional rendering based on whether the JSON parses. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves tool call argument handling in `InputSnippet.tsx` by conditionally parsing JSON and displaying raw strings if parsing fails, with minor formatting updates.
> 
>   - **Behavior**:
>     - In `InputSnippet.tsx`, `tool_call` arguments are now conditionally parsed as JSON. If parsing fails, the raw string is displayed.
>     - Ensures `TextMessage` and `ToolCallMessage` components handle structured and raw content appropriately.
>   - **Formatting**:
>     - Reformatted JSX in `InputSnippet.tsx` for better readability.
>     - Minor class reordering in `SnippetLayout.tsx` and `SnippetContent.tsx` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d57bc986406027211cc000c1ec7120934b4a7f4c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->