### PR TITLE
Retry downloading fixtures from Cloudflare

### DIFF
--- a/ui/fixtures/download-fixtures.py
+++ b/ui/fixtures/download-fixtures.py
@@ -87,6 +87,7 @@ def download_file(filename, remote_etag):
                 raise Exception(
                     f"ETag mismatch after downloading: {local_etag} != {remote_etag}"
                 )
+            return
         except Exception as e:
             print(
                 f"Error downloading `{filename}` (attempt {i + 1} of {RETRIES}): {e}",


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds retry logic to `download_file()` in `download-fixtures.py` with 3 attempts and error logging.
> 
>   - **Behavior**:
>     - Adds retry logic to `download_file()` in `download-fixtures.py` with 3 attempts and 1-second delay between retries.
>     - Raises exception if download fails after 3 attempts.
>   - **Logging**:
>     - Logs error message with attempt count on download failure in `download_file()`.
>   - **Misc**:
>     - Imports `time` module in `download-fixtures.py` for retry delay.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5cb32257a5e6e8b4d83d7eb51a9a4304e9213883. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->