### PR TITLE
Add image/file support to AWS Bedrock

### DIFF
--- a/tensorzero-internal/tests/e2e/providers/aws_bedrock.rs
+++ b/tensorzero-internal/tests/e2e/providers/aws_bedrock.rs
@@ -87,8 +87,8 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: vec![],
         json_mode_inference: json_providers.clone(),
         json_mode_off_inference: json_mode_off_providers.clone(),
-        image_inference: vec![],
-        pdf_inference: vec![],
+        image_inference: standard_providers.clone(),
+        pdf_inference: standard_providers.clone(),
 
         shorthand_inference: vec![],
     }

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -612,6 +612,18 @@ model = "gcp_vertex_gemini::projects/tensorzero-public/locations/us-central1/pub
 [functions.pdf_test.variants.anthropic]
 type = "chat_completion"
 model = "anthropic::claude-3-5-sonnet-20241022"
+
+[functions.pdf_test.variants.aws-bedrock]
+type = "chat_completion"
+model = "claude-3-haiku-20240307-aws-bedrock"
+
+[models.claude-3-haiku-20240307-aws-bedrock]
+routing = ["aws_bedrock"]
+
+[models.claude-3-haiku-20240307-aws-bedrock.providers.aws_bedrock]
+type = "aws_bedrock"
+model_id = "us.anthropic.claude-3-haiku-20240307-v1:0"
+region = "us-east-1"
 "#;
 
 pub static FERRIS_PNG: &[u8] = include_bytes!("./ferris.png");
@@ -658,6 +670,18 @@ type = "gcp_vertex_anthropic"
 model_id = "claude-3-haiku@20240307"
 location = "us-central1"
 project_id = "tensorzero-public"
+
+[functions.image_test.variants.aws-bedrock]
+type = "chat_completion"
+model = "claude-3-haiku-20240307-aws-bedrock"
+
+[models.claude-3-haiku-20240307-aws-bedrock]
+routing = ["aws_bedrock"]
+
+[models.claude-3-haiku-20240307-aws-bedrock.providers.aws_bedrock]
+type = "aws_bedrock"
+model_id = "us.anthropic.claude-3-haiku-20240307-v1:0"
+region = "us-east-1"
 "#;
 
 pub async fn test_image_url_inference_with_provider_filesystem(provider: E2ETestProvider) {


### PR DESCRIPTION
We test against both images and PDFs

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds image and PDF file support to AWS Bedrock with updated inference logic and tests.
> 
>   - **Behavior**:
>     - Adds support for image and PDF files in `aws_bedrock.rs` by decoding base64 data and creating `ImageBlock` or `DocumentBlock` based on MIME type.
>     - Handles errors for invalid base64 data and unsupported MIME types.
>   - **Tests**:
>     - Updates `aws_bedrock.rs` and `common.rs` in `tests/e2e/providers` to include image and PDF inference tests.
>     - Adds configuration for `aws-bedrock` model variants for image and PDF tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0a6fdfa8133260e92b6ba4a641d83c6f5fbce0e2. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->