### PR TITLE
Fix a couple of deprecation warnings in our e2e tests

### DIFF
--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -2082,7 +2082,7 @@ def test_sync_basic_inference_with_content_block_plain_dict(
                             "type": "tool_call",
                             "id": "1",
                             "name": "test",
-                            "arguments": json.dumps({"arg": "value"}),
+                            "arguments": {"arg": "value"},
                         },
                         {
                             "type": "tool_result",

--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -2319,6 +2319,7 @@ max_tokens = 500
 [functions.dynamic_json.variants.gcp-vertex-gemini-flash-lite-tuned]
 type = "chat_completion"
 model = "gemini-2.0-flash-lite-tuned"
+json_mode = "strict"
 system_template = "../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 max_tokens = 100


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix deprecation warnings in e2e tests by updating JSON handling in `test_client.py` and `tensorzero.toml`.
> 
>   - **Deprecation Warning Fixes**:
>     - In `test_client.py`, change `"arguments": json.dumps({"arg": "value"})` to `"arguments": {"arg": "value"}` in `test_sync_basic_inference_with_content_block_plain_dict()`.
>     - In `tensorzero.toml`, add `json_mode = "strict"` to `[functions.dynamic_json.variants.gcp-vertex-gemini-flash-lite-tuned]` to enforce strict JSON handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3267c3415c5ca274f178eda9a04c34726261bb8f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->