### PR TITLE
Fix deprecation warnings in openai-compat e2e tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4272,6 +4272,7 @@ dependencies = [
  "google-cloud-auth",
  "hex",
  "http 1.3.1",
+ "http-body-util",
  "image",
  "indexmap 2.9.0",
  "init-tracing-opentelemetry",

--- a/tensorzero-internal/Cargo.toml
+++ b/tensorzero-internal/Cargo.toml
@@ -128,6 +128,7 @@ aws-sdk-s3 = { version = "1.91.0", default-features = false, features = [
 aws-credential-types = { version = "1.2.2", features = [
     "hardcoded-credentials",
 ] }
+http-body-util = "0.1.3"
 
 [build-dependencies]
 built = { version = "0.8.0", features = ["git2"] }

--- a/tensorzero-internal/tests/e2e/openai_compatible.rs
+++ b/tensorzero-internal/tests/e2e/openai_compatible.rs
@@ -3,11 +3,17 @@
 use std::collections::HashSet;
 
 use axum::{extract::State, http::HeaderMap};
+use http::{HeaderName, HeaderValue};
+use http_body_util::BodyExt;
 use reqwest::{Client, StatusCode};
 use serde_json::{json, Value};
+use tracing_test::traced_test;
 use uuid::Uuid;
 
-use crate::{common::get_gateway_endpoint, providers::common::make_embedded_gateway_no_config};
+use crate::{
+    common::get_gateway_endpoint,
+    providers::common::{make_embedded_gateway, make_embedded_gateway_no_config},
+};
 use tensorzero_internal::{
     clickhouse::test_helpers::{
         get_clickhouse, select_chat_inference_clickhouse, select_json_inference_clickhouse,
@@ -16,52 +22,63 @@ use tensorzero_internal::{
     gateway_util::StructuredJson,
 };
 
-#[tokio::test]
-async fn test_openai_compatible_route() {
-    // Test that both the old and new formats work.
-    test_openai_compatible_route_with_function_name_asmodel(
+#[tokio::test(flavor = "multi_thread")]
+async fn test_openai_compatible_route_new_format() {
+    test_openai_compatible_route_with_function_name_as_model(
         "tensorzero::function_name::basic_test_no_system_schema",
-    )
-    .await;
-    test_openai_compatible_route_with_function_name_asmodel(
-        "tensorzero::basic_test_no_system_schema",
     )
     .await;
 }
 
-async fn test_openai_compatible_route_with_function_name_asmodel(model: &str) {
-    let client = Client::new();
+#[tokio::test(flavor = "multi_thread")]
+#[traced_test]
+async fn test_openai_compatible_route_old_format() {
+    test_openai_compatible_route_with_function_name_as_model(
+        "tensorzero::basic_test_no_system_schema",
+    )
+    .await;
+    assert!(logs_contain(
+        "Please set the `model` parameter to `tensorzero::function_name::your_function` instead of `tensorzero::your_function.`"
+    ));
+}
+
+async fn test_openai_compatible_route_with_function_name_as_model(model: &str) {
+    let client = make_embedded_gateway().await;
+    let state = client.get_app_state_data().unwrap().clone();
     let episode_id = Uuid::now_v7();
 
-    let payload = json!({
-        "model": model,
-        "messages": [
-            {
-                "role": "system",
-                "content": "TensorBot"
-            },
-            {
-                "role": "user",
-                "content": "What is the capital of Japan?"
-            }
-        ],
-        "stream": false,
-        "tensorzero::tags": {
-            "foo": "bar"
-        }
-    });
-
-    let response = client
-        .post(get_gateway_endpoint("/openai/v1/chat/completions"))
-        .header("episode_id", episode_id.to_string())
-        .json(&payload)
-        .send()
-        .await
-        .unwrap();
+    let response = tensorzero_internal::endpoints::openai_compatible::inference_handler(
+        State(state),
+        HeaderMap::default(),
+        StructuredJson(
+            serde_json::from_value(serde_json::json!({
+                "model": model,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "TensorBot"
+                    },
+                    {
+                        "role": "user",
+                        "content": "What is the capital of Japan?"
+                    }
+                ],
+                "stream": false,
+                "tensorzero::tags": {
+                    "foo": "bar"
+                },
+                "tensorzero::episode_id": episode_id.to_string(),
+            }))
+            .unwrap(),
+        ),
+    )
+    .await
+    .unwrap();
 
     // Check Response is OK, then fields in order
     assert_eq!(response.status(), StatusCode::OK);
-    let response_json = response.json::<Value>().await.unwrap();
+    let response_json = response.into_body().collect().await.unwrap().to_bytes();
+    let response_json: Value = serde_json::from_slice(&response_json).unwrap();
     println!("response: {response_json:?}");
     let choices = response_json.get("choices").unwrap().as_array().unwrap();
     assert!(choices.len() == 1);
@@ -325,12 +342,12 @@ async fn test_openai_compatible_route_with_default_function(
                 "content": "What is the capital of Japan?"
             }
         ],
+        "tensorzero::episode_id": episode_id.to_string(),
         "stream": false,
     });
 
     let response = client
         .post(get_gateway_endpoint("/openai/v1/chat/completions"))
-        .header("episode_id", episode_id.to_string())
         .json(&payload)
         .send()
         .await
@@ -451,11 +468,11 @@ async fn test_openai_compatible_route_bad_model_name() {
             }
         ],
         "stream": false,
+        "tensorzero::episode_id": episode_id.to_string(),
     });
 
     let response = client
         .post(get_gateway_endpoint("/openai/v1/chat/completions"))
-        .header("episode_id", episode_id.to_string())
         .json(&payload)
         .send()
         .await
@@ -488,12 +505,12 @@ async fn test_openai_compatible_route_with_json_mode_on() {
             }
         ],
         "stream": false,
-        "response_format":{"type":"json_object"}
+        "response_format":{"type":"json_object"},
+        "tensorzero::episode_id": episode_id.to_string(),
     });
 
     let response = client
         .post(get_gateway_endpoint("/openai/v1/chat/completions"))
-        .header("episode_id", episode_id.to_string())
         .json(&payload)
         .send()
         .await
@@ -622,12 +639,12 @@ async fn test_openai_compatible_route_with_json_schema() {
             }
         ],
         "stream": false,
+        "tensorzero::episode_id": episode_id.to_string(),
         "response_format":{"type":"json_schema", "json_schema":{"name":"test", "strict":true, "schema":{}}}
     });
 
     let response = client
         .post(get_gateway_endpoint("/openai/v1/chat/completions"))
-        .header("episode_id", episode_id.to_string())
         .json(&payload)
         .send()
         .await
@@ -783,13 +800,13 @@ async fn test_openai_compatible_streaming_tool_call() {
                 }
             }
         ],
-        "tool_choice": "auto"
+        "tool_choice": "auto",
+        "tensorzero::episode_id": episode_id.to_string(),
     });
 
     let mut response = client
         .post(get_gateway_endpoint("/openai/v1/chat/completions"))
         .header("Content-Type", "application/json")
-        .header("X-Episode-Id", episode_id.to_string())
         .json(&body)
         .eventsource()
         .unwrap();
@@ -861,7 +878,50 @@ async fn test_openai_compatible_streaming_tool_call() {
 }
 
 #[tokio::test]
-#[tracing_test::traced_test]
+#[traced_test]
+async fn test_openai_compatible_warn_headers() {
+    let client = make_embedded_gateway_no_config().await;
+    let state = client.get_app_state_data().unwrap().clone();
+    let episode_id = Uuid::now_v7();
+    let _ = tensorzero_internal::endpoints::openai_compatible::inference_handler(
+        State(state),
+        HeaderMap::from_iter(vec![
+            (
+                HeaderName::from_static("episode_id"),
+                HeaderValue::from_str(&episode_id.to_string()).unwrap(),
+            ),
+            (
+                HeaderName::from_static("variant_name"),
+                HeaderValue::from_str("test").unwrap(),
+            ),
+            (
+                HeaderName::from_static("dryrun"),
+                HeaderValue::from_str("true").unwrap(),
+            ),
+        ]),
+        StructuredJson(
+            serde_json::from_value(serde_json::json!({
+                "messages": [],
+                "model": "tensorzero::model_name::dummy::good",
+            }))
+            .unwrap(),
+        ),
+    )
+    .await;
+
+    assert!(logs_contain(
+        "Deprecation Warning: Please use the `tensorzero::episode_id` field instead of the `episode_id` header."
+    ));
+    assert!(logs_contain(
+        "Deprecation Warning: Please use the `tensorzero::variant_name` field instead of the `variant_name` header."
+    ));
+    assert!(logs_contain(
+        "Deprecation Warning: Please use the `tensorzero::dryrun` field instead of the `dryrun` header."
+    ));
+}
+
+#[tokio::test]
+#[traced_test]
 async fn test_openai_compatible_warn_unknown_fields() {
     let client = make_embedded_gateway_no_config().await;
     let state = client.get_app_state_data().unwrap().clone();
@@ -926,13 +986,13 @@ async fn test_openai_compatible_streaming() {
                 "role": "user",
                 "content": "What's the reason for why we use AC not DC?"
             }
-        ]
+        ],
+        "tensorzero::episode_id": episode_id.to_string(),
     });
 
     let mut response = client
         .post(get_gateway_endpoint("/openai/v1/chat/completions"))
         .header("Content-Type", "application/json")
-        .header("X-Episode-Id", episode_id.to_string())
         .json(&body)
         .eventsource()
         .unwrap();


### PR DESCRIPTION
I modified a test that was intentionally trigger depreations warnings to use an embedded gateway

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
