### PR TITLE
Cancel 'general.yml' workflow on job failure

### DIFF
--- a/.github/actions/cancel-on-failure/action.yml
+++ b/.github/actions/cancel-on-failure/action.yml
@@ -2,8 +2,7 @@ name: 'Cancel on Failure'
 description: 'Cancel the workflow run if this step is reached due to failure'
 runs:
   using: 'composite'
-  post: gh run cancel ${{ github.run_id }}
+  post: 'bash -c "gh run cancel ${{ github.run_id }}"'
   post-if: failure()
   steps:
-    - name: Cancel workflow on failure
-      run: echo "Enabling cancel on failure"
+    - run: echo "Enabling cancel on failure"

--- a/.github/actions/cancel-on-failure/action.yml
+++ b/.github/actions/cancel-on-failure/action.yml
@@ -7,4 +7,4 @@ runs:
       uses: gacts/run-and-post-run@d803f6920adc9a47eeac4cb6c93dbc2e2890c684
       with:
         post: |
-          gh run cancel ${{ github.run_id }}
+          GH_TOKEN=${{ github.token }} gh run cancel ${{ github.run_id }}

--- a/.github/actions/cancel-on-failure/action.yml
+++ b/.github/actions/cancel-on-failure/action.yml
@@ -2,10 +2,5 @@ name: 'Cancel on Failure'
 description: 'Cancel the workflow run if this step is reached due to failure'
 runs:
   using: 'composite'
-  steps:
-    - name: Cancel workflow on failure
-      if: failure()
-      run: gh run cancel ${{ github.run_id }}
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+  post: gh run cancel ${{ github.run_id }}
+  post-if: failure()

--- a/.github/actions/cancel-on-failure/action.yml
+++ b/.github/actions/cancel-on-failure/action.yml
@@ -4,3 +4,6 @@ runs:
   using: 'composite'
   post: gh run cancel ${{ github.run_id }}
   post-if: failure()
+  steps:
+    - name: Cancel workflow on failure
+      run: echo "Enabling cancel on failure"

--- a/.github/actions/cancel-on-failure/action.yml
+++ b/.github/actions/cancel-on-failure/action.yml
@@ -1,0 +1,11 @@
+name: 'Cancel on Failure'
+description: 'Cancel the workflow run if this step is reached due to failure'
+runs:
+  using: 'composite'
+  steps:
+    - name: Cancel workflow on failure
+      if: failure()
+      run: gh run cancel ${{ github.run_id }}
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/.github/actions/cancel-on-failure/action.yml
+++ b/.github/actions/cancel-on-failure/action.yml
@@ -2,7 +2,9 @@ name: 'Cancel on Failure'
 description: 'Cancel the workflow run if this step is reached due to failure'
 runs:
   using: 'composite'
-  post: 'bash -c "gh run cancel ${{ github.run_id }}"'
-  post-if: failure()
   steps:
-    - run: echo "Enabling cancel on failure"
+    - name: Run this action
+      uses: gacts/run-and-post-run@d803f6920adc9a47eeac4cb6c93dbc2e2890c684
+      with:
+        post: |
+          gh run cancel ${{ github.run_id }}

--- a/.github/workflows/build-gateway-container.yml
+++ b/.github/workflows/build-gateway-container.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - uses: namespacelabs/nscloud-checkout-action@953fed31a6113cc2347ca69c9d823743c65bc84b
-
+      - uses: ./.github/actions/cancel-on-failure
       - name: Build `gateway` container
         run: |
           docker build -f gateway/Dockerfile . -t tensorzero/gateway:sha-${{ github.sha }}
@@ -25,4 +25,3 @@ jobs:
           retention-days: 1
           if-no-files-found: error
           overwrite: false
-      - uses: ./.github/actions/cancel-on-failure

--- a/.github/workflows/build-gateway-container.yml
+++ b/.github/workflows/build-gateway-container.yml
@@ -25,3 +25,4 @@ jobs:
           retention-days: 1
           if-no-files-found: error
           overwrite: false
+      - uses: ./.github/actions/cancel-on-failure

--- a/.github/workflows/build-ui-container.yml
+++ b/.github/workflows/build-ui-container.yml
@@ -9,6 +9,7 @@ jobs:
 
     steps:
       - uses: namespacelabs/nscloud-checkout-action@953fed31a6113cc2347ca69c9d823743c65bc84b
+      - uses: ./.github/actions/cancel-on-failure
 
       - name: Build `ui` container
         run: |
@@ -25,4 +26,3 @@ jobs:
           retention-days: 1
           if-no-files-found: error
           overwrite: false
-      - uses: ./.github/actions/cancel-on-failure

--- a/.github/workflows/build-ui-container.yml
+++ b/.github/workflows/build-ui-container.yml
@@ -25,3 +25,4 @@ jobs:
           retention-days: 1
           if-no-files-found: error
           overwrite: false
+      - uses: ./.github/actions/cancel-on-failure

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1,6 +1,9 @@
 name: General Checks
 run-name: "General Checks for: ${{ github.event.pull_request.title || github.ref }}"
 
+permissions:
+  actions: write
+
 on:
   merge_group:
   pull_request:

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -95,6 +95,7 @@ jobs:
       - name: Print e2e logs
         if: always()
         run: cat e2e_logs.txt
+      - uses: ./.github/actions/cancel-on-failure
 
   check-docker-compose:
     permissions:
@@ -122,6 +123,8 @@ jobs:
       - name: Check all docker-compose.yml files
         run: ./ci/check-all-docker-compose.sh
 
+      - uses: ./.github/actions/cancel-on-failure
+
   check-python-client-build:
     uses: ./.github/workflows/python-client-build.yml
 
@@ -136,6 +139,7 @@ jobs:
           save-if: ${{ github.event_name == 'merge_group' }}
       - name: Build Rust
         run: cargo build --workspace
+      - uses: ./.github/actions/cancel-on-failure
 
   validate:
     runs-on: namespace-profile-tensorzero-8x16
@@ -175,6 +179,8 @@ jobs:
 
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh
+
+      - run: intentional-missing-command
 
       - name: Configure Namespace cache for Rust, Python (pip), and pnpm
         uses: namespacelabs/nscloud-cache-action@2f50e7d0f70475e6f59a55ba0f05eec9108e77cc
@@ -351,6 +357,7 @@ jobs:
 
       - name: Compile / validate notebooks
         run: ci/compile-check-notebooks.sh
+      - uses: ./.github/actions/cancel-on-failure
 
   clickhouse-tests:
     # We don't run many tests here, so use a normal runner with Github Actions caching
@@ -441,6 +448,7 @@ jobs:
       - name: Print e2e logs
         if: always()
         run: cat e2e_logs.txt
+      - uses: ./.github/actions/cancel-on-failure
 
   build-gateway-container:
     uses: ./.github/workflows/build-gateway-container.yml

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -30,6 +30,7 @@ jobs:
             url_secret: CLICKHOUSE_CLOUD_FAST_CHANNEL_URL
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/cancel-on-failure
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
         with:
@@ -95,7 +96,6 @@ jobs:
       - name: Print e2e logs
         if: always()
         run: cat e2e_logs.txt
-      - uses: ./.github/actions/cancel-on-failure
 
   check-docker-compose:
     permissions:
@@ -108,6 +108,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/cancel-on-failure
 
       # We allow the namespace builder setup to fail on Dependabot PRs and PRs from forks
       # (where the oidc token is not available)
@@ -123,8 +124,6 @@ jobs:
       - name: Check all docker-compose.yml files
         run: ./ci/check-all-docker-compose.sh
 
-      - uses: ./.github/actions/cancel-on-failure
-
   check-python-client-build:
     uses: ./.github/workflows/python-client-build.yml
 
@@ -132,6 +131,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/cancel-on-failure
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
         with:
@@ -139,7 +139,6 @@ jobs:
           save-if: ${{ github.event_name == 'merge_group' }}
       - name: Build Rust
         run: cargo build --workspace
-      - uses: ./.github/actions/cancel-on-failure
 
   validate:
     runs-on: namespace-profile-tensorzero-8x16
@@ -148,7 +147,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-
+      - uses: ./.github/actions/cancel-on-failure
       # We allow the namespace builder setup to fail on Dependabot PRs and PRs from forks
       # (where the oidc token is not available)
 
@@ -180,7 +179,7 @@ jobs:
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh
 
-      - run: intentional-missing-command
+      - run: intentional-missing-command  
 
       - name: Configure Namespace cache for Rust, Python (pip), and pnpm
         uses: namespacelabs/nscloud-cache-action@2f50e7d0f70475e6f59a55ba0f05eec9108e77cc
@@ -357,7 +356,6 @@ jobs:
 
       - name: Compile / validate notebooks
         run: ci/compile-check-notebooks.sh
-      - uses: ./.github/actions/cancel-on-failure
 
   clickhouse-tests:
     # We don't run many tests here, so use a normal runner with Github Actions caching
@@ -383,6 +381,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/cancel-on-failure
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
         with:
@@ -448,7 +447,6 @@ jobs:
       - name: Print e2e logs
         if: always()
         run: cat e2e_logs.txt
-      - uses: ./.github/actions/cancel-on-failure
 
   build-gateway-container:
     uses: ./.github/workflows/build-gateway-container.yml

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -3,6 +3,7 @@ run-name: "General Checks for: ${{ github.event.pull_request.title || github.ref
 
 permissions:
   actions: write
+  contents: read
 
 on:
   merge_group:

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -111,3 +111,4 @@ jobs:
       - name: Exit if tests failed
         if: steps.e2e_tests.outcome == 'failure'
         run: exit 1
+      - uses: ./.github/actions/cancel-on-failure

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - uses: namespacelabs/nscloud-checkout-action@953fed31a6113cc2347ca69c9d823743c65bc84b
-
+      - uses: ./.github/actions/cancel-on-failure
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
@@ -111,4 +111,3 @@ jobs:
       - name: Exit if tests failed
         if: steps.e2e_tests.outcome == 'failure'
         run: exit 1
-      - uses: ./.github/actions/cancel-on-failure

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -79,3 +79,4 @@ jobs:
       - name: Print ClickHouse trace logs
         if: always()
         run: docker exec fixtures-clickhouse-1 cat /var/log/clickhouse-server/clickhouse-server.log
+      - uses: ./.github/actions/cancel-on-failure

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -13,6 +13,7 @@ jobs:
 
     steps:
       - uses: namespacelabs/nscloud-checkout-action@953fed31a6113cc2347ca69c9d823743c65bc84b
+      - uses: ./.github/actions/cancel-on-failure
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -79,4 +80,3 @@ jobs:
       - name: Print ClickHouse trace logs
         if: always()
         run: docker exec fixtures-clickhouse-1 cat /var/log/clickhouse-server/clickhouse-server.log
-      - uses: ./.github/actions/cancel-on-failure


### PR DESCRIPTION
This should prevent the workflow from continuing to run after the PR gets removed the merge queue (which was causing ClickHouse cloud tests to get cancelled due to the concurrency limit)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces `cancel-on-failure` action to stop workflows on job failure, integrated across multiple workflow files for improved resource management.
> 
>   - **New Action**:
>     - Adds `cancel-on-failure` action in `.github/actions/cancel-on-failure/action.yml` to cancel workflows on job failure.
>   - **Workflow Changes**:
>     - Integrates `cancel-on-failure` action into `build-gateway-container.yml`, `build-ui-container.yml`, and `general.yml` to stop workflows on failure.
>     - Updates `ui-tests-e2e.yml` and `ui-tests.yml` to include `cancel-on-failure` action for better resource management.
>   - **Permissions**:
>     - Adds `actions: write` and `contents: read` permissions in `general.yml` to support the new action.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for cb4681b7fdc0a15cd48e9e3d65b7d8f63f33d961. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->