### PR TITLE
added additional tool call testing for vLLM

### DIFF
--- a/tensorzero-internal/tests/e2e/providers/vllm.rs
+++ b/tensorzero-internal/tests/e2e/providers/vllm.rs
@@ -68,7 +68,6 @@ async fn get_providers() -> E2ETestProviders {
         credentials: HashMap::new(),
     }];
 
-    // TODOs (#169): Implement a solution for vLLM tool use
     E2ETestProviders {
         simple_inference: providers.clone(),
         extra_body_inference: extra_body_providers,
@@ -77,9 +76,9 @@ async fn get_providers() -> E2ETestProviders {
         inference_params_inference: providers.clone(),
         inference_params_dynamic_credentials: inference_params_dynamic_providers,
         tool_use_inference: tool_providers.clone(),
-        tool_multi_turn_inference: vec![],
-        dynamic_tool_use_inference: vec![],
-        parallel_tool_use_inference: vec![],
+        tool_multi_turn_inference: tool_providers.clone(),
+        dynamic_tool_use_inference: tool_providers.clone(),
+        parallel_tool_use_inference: tool_providers.clone(),
         json_mode_inference: json_providers.clone(),
         json_mode_off_inference: vec![],
         image_inference: vec![],

--- a/tensorzero-internal/tests/e2e/tensorzero.toml
+++ b/tensorzero-internal/tests/e2e/tensorzero.toml
@@ -2941,6 +2941,13 @@ weight = 1
 model = "llama3.1-405b-instruct-turbo-together"
 system_template = "../../fixtures/config/functions/weather_helper_parallel/prompt/system_template.minijinja"
 
+[functions.weather_helper_parallel.variants.vllm]
+type = "chat_completion"
+weight = 1
+model = "qwen2.5-0.5b-instruct-vllm"
+system_template = "../../fixtures/config/functions/weather_helper_parallel/prompt/system_template.minijinja"
+
+
 [functions.required_tool]
 type = "chat"
 tool_choice = "required"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhanced vLLM testing by adding extra headers in multiple test functions and updating configuration for tool use inference.
> 
>   - **Testing Enhancements**:
>     - Added `extra_headers` using `get_extra_headers()` in `test_tool_multi_turn_inference_request_with_provider`, `test_tool_multi_turn_streaming_inference_request_with_provider`, `test_dynamic_tool_use_inference_request_with_provider`, `test_dynamic_tool_use_streaming_inference_request_with_provider`, `test_parallel_tool_use_inference_request_with_provider`, `test_parallel_tool_use_streaming_inference_request_with_provider`, `test_multi_turn_parallel_tool_use_inference_request_with_provider`, and `test_multi_turn_parallel_tool_use_streaming_inference_request_with_provider` in `common.rs`.
>     - Updated assertion in `test_parallel_tool_use_streaming_inference_request_with_provider` to allow `output.len() >= 2`.
>     - Modified panic message to include text block in `test_parallel_tool_use_streaming_inference_request_with_provider`.
>   - **Configuration Updates**:
>     - Added `vllm` variant to `functions.weather_helper_parallel.variants` in `tensorzero.toml`.
>     - Updated `get_providers()` in `vllm.rs` to include `tool_multi_turn_inference`, `dynamic_tool_use_inference`, and `parallel_tool_use_inference` for `vllm`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f39e86bc733d5ed9e69d86a1b0571429d5b42d7f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->