### PR TITLE
updated clickhouse query to handle double feedbacks and users

### DIFF
--- a/examples/integrations/cursor/experimental/post-commit.example
+++ b/examples/integrations/cursor/experimental/post-commit.example
@@ -6,7 +6,17 @@ cd "$(git rev-parse --show-toplevel)"
 
 echo "Running cursorzero.."
 
+# Optional: Configure user for feedback attribution
+# Uncomment and set your preferred user identifier:
+# CURSORZERO_USER="your-username"
+
+# Build cursorzero command with optional user parameter
+CURSORZERO_CMD="cursorzero"
+if [ -n "${CURSORZERO_USER:-}" ]; then
+    CURSORZERO_CMD="$CURSORZERO_CMD --user $CURSORZERO_USER"
+fi
+
 # run the installed build of cursorzero
-cursorzero "$@"
+$CURSORZERO_CMD "$@"
 
 echo "done!"

--- a/examples/integrations/cursor/experimental/src/clickhouse.rs
+++ b/examples/integrations/cursor/experimental/src/clickhouse.rs
@@ -11,6 +11,7 @@ use tensorzero_internal::{
 use uuid::Uuid;
 
 use crate::git::CommitInterval;
+use crate::util::{get_max_uuidv7, get_min_uuidv7};
 
 #[derive(Debug, Deserialize)]
 pub struct InferenceInfo {
@@ -21,41 +22,59 @@ pub struct InferenceInfo {
     pub output: Vec<ContentBlockChatOutput>,
 }
 
+/// Gets the inferences which are relevant to a particular commit's interval.
+/// For an inference to be relevant, it must satisfy 4 conditions:
+/// 1. The function_name must be 'cursorzero'
+/// 2. The inference must have happened in between the previous commit and the current commit's timestamps
+/// 3. The inference must not have been given a float metric feedback
+/// 4. The inference must be from the user specified in the user argument (if provided)
 pub async fn get_inferences_in_time_range(
     clickhouse: &ClickHouseConnectionInfo,
     commit_interval: CommitInterval,
+    user: Option<String>,
 ) -> Result<Vec<InferenceInfo>> {
     // If start_time is None, set to 1 day ago
-    let start_time_str = commit_interval
-        .parent_timestamp
-        .unwrap_or(Utc::now() - chrono::Duration::days(1))
-        .format("%Y-%m-%d %H:%M:%S")
-        .to_string();
-    let end_time_str = commit_interval
-        .commit_timestamp
-        .format("%Y-%m-%d %H:%M:%S")
-        .to_string();
+    let lower_bound = get_min_uuidv7(
+        commit_interval
+            .parent_timestamp
+            .unwrap_or(Utc::now() - chrono::Duration::days(1)),
+    )
+    .to_string();
+    let upper_bound = get_max_uuidv7(commit_interval.commit_timestamp).to_string();
 
-    let query = r#"
+    // Create the parameter map with string slices (&str)
+    let mut parameters = HashMap::from([
+        ("lower_bound", lower_bound.as_str()),
+        ("upper_bound", upper_bound.as_str()),
+    ]);
+
+    let user_where_clause = if let Some(ref user) = user {
+        parameters.insert("user", user);
+        "AND ci.tags['user'] = {user:String}".to_string()
+    } else {
+        "".to_string()
+    };
+
+    let mut query = r#"
+    WITH inference_ids AS (
+        SELECT uint_to_uuid(id_uint) as id
+        FROM InferenceById
+        WHERE id_uint >= toUInt128({lower_bound:UUID})
+        AND id_uint <= toUInt128({upper_bound:UUID})
+    )
     SELECT
         ci.id as id,
         ci.input as input,
         ci.output as output
-    FROM InferenceById AS inferences
-    JOIN ChatInference AS ci ON inferences.id_uint = toUInt128(ci.id)
-         AND ci.function_name = inferences.function_name
-         AND ci.variant_name = inferences.variant_name
-         AND ci.episode_id = inferences.episode_id
-         AND UUIDv7ToDateTime(uint_to_uuid(inferences.id_uint)) < {end_time:DateTime}
-         AND UUIDv7ToDateTime(uint_to_uuid(inferences.id_uint)) >= {start_time:DateTime}
-    FORMAT JSONEachRow
-    "#;
-
-    // Create the parameter map with string slices (&str)
-    let parameters = HashMap::from([
-        ("start_time", start_time_str.as_str()),
-        ("end_time", end_time_str.as_str()),
-    ]);
+    FROM ChatInference AS ci
+    LEFT ANTI JOIN FloatMetricFeedbackByTargetId AS fmf ON fmf.target_id = ci.id
+    WHERE
+        ci.function_name = 'cursorzero'
+        AND ci.id IN (SELECT id FROM inference_ids)
+        "#
+    .to_string();
+    query.push_str(&user_where_clause);
+    query.push_str("FORMAT JSONEachRow");
 
     // Pass the owned query string and the map of string slices
     let results = clickhouse

--- a/examples/integrations/cursor/experimental/src/lib.rs
+++ b/examples/integrations/cursor/experimental/src/lib.rs
@@ -3,3 +3,4 @@ pub mod cursor;
 pub mod git;
 pub mod parsing;
 pub mod ted;
+mod util;

--- a/examples/integrations/cursor/experimental/src/main.rs
+++ b/examples/integrations/cursor/experimental/src/main.rs
@@ -44,6 +44,8 @@ struct Cli {
     path: String,
     #[clap(long, default_value = "http://localhost:6900")]
     gateway_url: Url,
+    #[clap(long, default_value = None)]
+    user: Option<String>,
 }
 
 #[tokio::main]
@@ -88,7 +90,7 @@ async fn main() -> Result<()> {
 
     let clickhouse_url = std::env::var("CURSORZERO_CLICKHOUSE_URL")?;
     let clickhouse = ClickHouseConnectionInfo::new(&clickhouse_url).await?;
-    let inferences = get_inferences_in_time_range(&clickhouse, commit_interval).await?;
+    let inferences = get_inferences_in_time_range(&clickhouse, commit_interval, args.user).await?;
     let inferences_by_id: HashMap<Uuid, &InferenceInfo> =
         inferences.iter().map(|i| (i.id, i)).collect();
     let mut inference_trees: HashMap<Uuid, Vec<TreeInfo>> = HashMap::new();

--- a/examples/integrations/cursor/experimental/src/util.rs
+++ b/examples/integrations/cursor/experimental/src/util.rs
@@ -1,0 +1,26 @@
+use chrono::{DateTime, Utc};
+use uuid::{Builder, Uuid};
+
+/// Generates the maximum UUIDv7 for a given timestamp.
+pub fn get_max_uuidv7(timestamp: DateTime<Utc>) -> Uuid {
+    // Create a byte array of 255s
+    let bytes: [u8; 10] = [255; 10];
+    // Get the unix timestamp in milliseconds as a u64
+    let timestamp_ms = timestamp.timestamp_millis() as u64;
+    // Create a builder
+    let builder = Builder::from_unix_timestamp_millis(timestamp_ms, &bytes);
+    // Build the UUID
+    builder.into_uuid()
+}
+
+/// Generates the minimum UUIDv7 for a given timestamp.
+pub fn get_min_uuidv7(timestamp: DateTime<Utc>) -> Uuid {
+    // Create a byte array of 0s
+    let bytes: [u8; 10] = [0; 10];
+    // Get the unix timestamp in milliseconds as a u64
+    let timestamp_ms = timestamp.timestamp_millis() as u64;
+    // Create a builder
+    let builder = Builder::from_unix_timestamp_millis(timestamp_ms, &bytes);
+    // Build the UUID
+    builder.into_uuid()
+}


### PR DESCRIPTION
After we made the changes in #2401 we should only query the inferences for which:
* the user tag is present (if set)
* there is no feedback in the table already