### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 <p><picture><img src="https://www.tensorzero.com/github-trending-badge.svg" alt="#1 Repository Of The Day"></picture></p>
 
+<!-- Keep these links. Translations will automatically update with the README. -->
+[Deutsch](https://www.readme-i18n.com/tensorzero/tensorzero?lang=de) | 
+[Español](https://www.readme-i18n.com/tensorzero/tensorzero?lang=es) | 
+[français](https://www.readme-i18n.com/tensorzero/tensorzero?lang=fr) | 
+[日本語](https://www.readme-i18n.com/tensorzero/tensorzero?lang=ja) | 
+[한국어](https://www.readme-i18n.com/tensorzero/tensorzero?lang=ko) | 
+[Português](https://www.readme-i18n.com/tensorzero/tensorzero?lang=pt) | 
+[Русский](https://www.readme-i18n.com/tensorzero/tensorzero?lang=ru) | 
+[中文](https://www.readme-i18n.com/tensorzero/tensorzero?lang=zh)
+
 **TensorZero is an open-source stack for _industrial-grade LLM applications_:**
 
 - [x] **Gateway**


### PR DESCRIPTION
Added language selection links to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese.

After the README was updated, my previous pull request (https://github.com/tensorzero/tensorzero/pull/2413) had merge conflicts. I resolved the conflicts, synchronized the translation content with the latest README, and am now submitting this updated PR.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
