### PR TITLE
Use 'list' and 'github' pnpm reporters on CI

### DIFF
--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
   /* Fail immediately while we're debugging the CI issue */
   maxFailures: process.env.TENSORZERO_CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.TENSORZERO_CI ? [['list', 'github']] : [['dot']],
+  reporter: process.env.TENSORZERO_CI ? [['list'], ['github']] : [['dot']],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -11,6 +11,7 @@ import { defineConfig, devices } from "@playwright/test";
 const useUIDocker =
   process.env.TENSORZERO_PLAYWRIGHT_NO_WEBSERVER || process.env.TENSORZERO_CI;
 
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -27,7 +28,7 @@ export default defineConfig({
   /* Fail immediately while we're debugging the CI issue */
   maxFailures: process.env.TENSORZERO_CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
+  reporter: process.env.TENSORZERO_CI ? [['list', 'github']] : [['dot']],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
This should give us more useful output while the e2e tests are running, and nicer annotations when errors occur

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change reporter configuration in `playwright.config.ts` to use 'list' and 'github' reporters on CI for better output and annotations.
> 
>   - **Configuration**:
>     - In `playwright.config.ts`, change reporter configuration to `[['list', 'github']]` for CI environments, providing more detailed output and annotations.
>     - Retain `[['dot']]` reporter for non-CI environments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for cf1dd72b40ce8b7e885b7c1d760000e02af5fe14. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->