### PR TITLE
Remove `demonstration` from curation metric selector

### DIFF
--- a/ui/app/components/metric/CurationMetricSelector.tsx
+++ b/ui/app/components/metric/CurationMetricSelector.tsx
@@ -131,6 +131,10 @@ export default function CurationMetricSelector<
                     </div>
                   </SelectItem>
                   {Object.entries(config.metrics).map(([name, metric]) => {
+                    if (removeDemonstrations && name === "demonstration") {
+                      return null;
+                    }
+
                     const metricFeedback = metricsFetcher.data?.metrics.find(
                       (m) => m.metric_name === name,
                     );


### PR DESCRIPTION
Closes https://github.com/tensorzero/tensorzero/issues/2220
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Exclude `demonstration` metrics from `CurationMetricSelector` when `removeDemonstrations` is true.
> 
>   - **Behavior**:
>     - In `CurationMetricSelector.tsx`, exclude metrics named `demonstration` from rendering when `removeDemonstrations` is true.
>     - Affects metric selection dropdown by not displaying `demonstration` metrics.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ef59d1d9282a26fa2a371bbbaff3b8b5781b7ec7. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->