### PR TITLE
Implement 'read-old-write-new' mode for provider-proxy

### DIFF
--- a/ci/run-provider-proxy.sh
+++ b/ci/run-provider-proxy.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 cargo build --bin provider-proxy
 if [[ "${1:-}" = "ci" ]]; then
-  cargo run --bin provider-proxy -- --cache-path ./ci/provider-proxy-cache --write false > provider_proxy_logs.txt 2>&1 &
+  cargo run --bin provider-proxy -- --cache-path ./ci/provider-proxy-cache --mode read-old-write-new > provider_proxy_logs.txt 2>&1 &
 else
-  cargo run --bin provider-proxy -- --cache-path ./ci/provider-proxy-cache
+  cargo run --bin provider-proxy -- --cache-path ./ci/provider-proxy-cache --mode read-old-write-new
 fi

--- a/provider-proxy/Cargo.toml
+++ b/provider-proxy/Cargo.toml
@@ -31,6 +31,7 @@ tokio.workspace = true
 tokio-rustls = "0.26.1"
 tracing = "0.1.41"
 tracing-subscriber.workspace = true
+tempfile = "3.20.0"
 
 
 [lints]
@@ -39,4 +40,3 @@ workspace = true
 [dev-dependencies]
 axum.workspace = true
 rand = "0.9.1"
-tempfile = "3.20.0"

--- a/provider-proxy/src/lib.rs
+++ b/provider-proxy/src/lib.rs
@@ -319,7 +319,7 @@ fn is_openrouter_request(uri: &http::Uri) -> bool {
 pub async fn run_server(args: Args, server_started: oneshot::Sender<SocketAddr>) {
     use tracing_subscriber::EnvFilter;
 
-    #[allow(clippy::print_stderr)]
+    #[expect(clippy::print_stderr)]
     let _ = tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::builder()

--- a/provider-proxy/src/lib.rs
+++ b/provider-proxy/src/lib.rs
@@ -7,15 +7,15 @@ mod mitm_server;
 mod streaming_body_collector;
 mod tls;
 
+use std::future::Future;
 use std::io::Write;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::{fs::OpenOptions, future::Future};
 
 use anyhow::Context as _;
 use bytes::{Bytes, BytesMut};
-use clap::{ArgAction, Parser};
+use clap::{Parser, ValueEnum};
 use http::{HeaderName, HeaderValue};
 use http_body_util::{combinators::BoxBody, BodyExt, Full};
 use hyper::service::service_fn;
@@ -82,31 +82,25 @@ fn save_cache_body(
             .with_context(|| format!("Failed to serialize response for path {path_str}"))?;
     let json_str = serde_json::to_string(&json_response)
         .with_context(|| format!("Failed to stringify response for path {path_str}"))?;
-    // Open the file after we've constructed our json string, to avoid creating an empty
-    // file if we fail to serialize the response
-    match OpenOptions::new().write(true).create_new(true).open(&path) {
-        Ok(mut file) => {
-            file.write_all(json_str.as_bytes())
-                .with_context(|| format!("Failed to write to file for path {path_str}"))?;
-            file.write_all(b"\n").with_context(|| {
-                format!("Failed to write EOL newline to file for path {path_str}")
-            })?;
-            tracing::info!(path = path_str, "Wrote response to cache");
-            Ok(())
-        }
-        Err(e) => {
-            if e.kind() == std::io::ErrorKind::AlreadyExists {
-                // Log the error but otherwise continue on, as it's the client's fault
-                tracing::error!(
-                    path = path_str,
-                    "Cache file already exists - two duplicate requests were likely made in parallel"
-                );
-                Ok(())
-            } else {
-                Err(e).with_context(|| format!("Failed to open cache file for path {path_str}"))
-            }
-        }
-    }
+
+    // Write the cache response to a temporary file, and then atomically rename it to the final path.
+    // If we have multiple concurrent requests to the same path, one of them will win the race.
+    // This is fine for our use case, as it shouldn't matter which successful (by HTTP status code)
+    // response is cached.
+    let mut tmpfile = tempfile::NamedTempFile::new()
+        .with_context(|| format!("Failed to create tempfile for path {path_str}"))?;
+    tmpfile
+        .write_all(json_str.as_bytes())
+        .with_context(|| format!("Failed to write to file for path {path_str}"))?;
+    tmpfile
+        .write_all(b"\n")
+        .with_context(|| format!("Failed to write EOL newline to file for path {path_str}"))?;
+    tmpfile
+        .persist(&path)
+        .with_context(|| format!("Failed to rename tempfile to {path_str}"))?;
+
+    tracing::info!(path = path_str, "Wrote response to cache");
+    Ok(())
 }
 
 const HEADER_TRUE: HeaderValue = HeaderValue::from_static("true");
@@ -117,6 +111,7 @@ async fn check_cache<
     T: Future<Output = Result<hyper::Response<BoxBody<Bytes, E>>, anyhow::Error>>,
     F: FnOnce() -> T,
 >(
+    start_time: std::time::SystemTime,
     args: &Args,
     request: &hyper::Request<Bytes>,
     missing: F,
@@ -177,7 +172,20 @@ async fn check_cache<
 
     let path = args.cache_path.join(filename);
     let path_str = path.to_string_lossy().into_owned();
-    let (mut resp, cache_hit) = if path.exists() {
+
+    let use_cache = || match args.mode {
+        CacheMode::ReadOnly => Ok::<_, anyhow::Error>(true),
+        CacheMode::ReadWrite => Ok(true),
+        CacheMode::ReadOldWriteNew => {
+            let file_mtime = std::fs::metadata(&path)
+                .with_context(|| format!("Failed to read cache file metadata for {path_str}"))?
+                .modified()
+                .with_context(|| format!("Failed to read cache file mtime for {path_str}"))?;
+            Ok(file_mtime <= start_time)
+        }
+    };
+
+    let (mut resp, cache_hit) = if path.exists() && use_cache()? {
         tracing::info!(sanitized_header, "Cache hit: {}", path_str);
         let path_str_clone = path_str.clone();
         let resp = tokio::task::spawn_blocking(move || {
@@ -217,7 +225,11 @@ async fn check_cache<
             // We need to clear the extensions in order to be able to serialize the response
             hyper_response.extensions_mut().clear();
 
-            let write = args.write;
+            let write = match args.mode {
+                CacheMode::ReadOnly => false,
+                CacheMode::ReadWrite => true,
+                CacheMode::ReadOldWriteNew => true,
+            };
 
             // Start streaming the response to the client, running the provided callback once the whole body has been received
             // This lets us forward streaming responses without needing to wait for the entire response, while
@@ -254,6 +266,20 @@ async fn check_cache<
     Ok(resp)
 }
 
+#[derive(ValueEnum, Clone, Debug)]
+pub enum CacheMode {
+    /// Only read from the cache, never write to it.
+    ReadOnly,
+    /// Read from the cache, and write to it when a cache miss occurs.
+    ReadWrite,
+    /// Read entries from the cache that were created before the provider-proxy start time.
+    /// Writes to the cache when a miss occurs, or if the cache entry was written after the provider-proxy start time
+    /// (e.g. by this instance)
+    /// This allows our e2e tests to retry when they get a bad response from the provider,
+    /// without provider-proxy serving the cached bad response.
+    ReadOldWriteNew,
+}
+
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct Args {
@@ -271,10 +297,8 @@ pub struct Args {
     pub sanitize_aws_sigv4: bool,
     #[arg(long, default_value = "true")]
     pub sanitize_model_headers: bool,
-    /// Whether to write to the cache when a cache miss occurs.
-    /// If false, the proxy will still read existing entries from the cache, but not write new ones.
-    #[arg(long, action = ArgAction::Set, default_value_t = true, num_args = 1)]
-    pub write: bool,
+    #[arg(long, default_value = "ReadOldWriteNew")]
+    pub mode: CacheMode,
 }
 
 fn find_duplicate_header(headers: &http::HeaderMap) -> Option<HeaderName> {
@@ -295,22 +319,25 @@ fn is_openrouter_request(uri: &http::Uri) -> bool {
 pub async fn run_server(args: Args, server_started: oneshot::Sender<SocketAddr>) {
     use tracing_subscriber::EnvFilter;
 
-    tracing_subscriber::fmt()
+    #[allow(clippy::print_stderr)]
+    let _ = tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::builder()
                 .with_default_directive(LevelFilter::INFO.into())
                 .from_env_lossy(),
         )
         .try_init()
-        .unwrap();
+        .inspect_err(|e| eprintln!("Failed to initialize tracing: {e}"));
+
+    let start_time = std::time::SystemTime::now();
 
     let args = Arc::new(args);
 
     std::fs::create_dir_all(&args.cache_path).expect("Failed to create cache directory");
 
-    rustls::crypto::ring::default_provider()
+    let _ = rustls::crypto::ring::default_provider()
         .install_default()
-        .expect("Failed to install rustls ring provider");
+        .inspect_err(|e| tracing::error!("Failed to install rustls ring provider: {e:?}"));
 
     let root_cert = make_root_cert();
 
@@ -375,7 +402,7 @@ pub async fn run_server(args: Args, server_started: oneshot::Sender<SocketAddr>)
                         .with_context(|| "Failed to collect body")?
                         .to_bytes();
                     let bytes_request = hyper::Request::from_parts(parts, body_bytes);
-                    let response = check_cache(&args, &bytes_request, || async {
+                    let response = check_cache(start_time, &args, &bytes_request, || async {
                         let request: reqwest::Request =
                             bytes_request.clone().try_into().with_context(|| {
                                 "Failed to convert Request from `hyper` to `reqwest`"

--- a/provider-proxy/tests/e2e/tests.rs
+++ b/provider-proxy/tests/e2e/tests.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use axum::{routing::post, Router};
-use provider_proxy::{run_server, Args};
+use provider_proxy::{run_server, Args, CacheMode};
 use rand::Rng;
 use tokio::{sync::oneshot, task::JoinHandle};
 
@@ -65,7 +65,7 @@ async fn test_provider_proxy() {
             sanitize_bearer_auth: true,
             sanitize_aws_sigv4: true,
             sanitize_model_headers: true,
-            write: true,
+            mode: CacheMode::ReadWrite,
         },
         server_started_tx,
     ));
@@ -172,4 +172,128 @@ async fn test_provider_proxy() {
         .await
         .unwrap();
     assert_eq!(bad_gateway_response.status(), 502);
+}
+
+#[tokio::test]
+async fn test_read_old_write_new() {
+    let (server_started_tx, server_started_rx) = oneshot::channel();
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let _proxy_handle = tokio::spawn(run_server(
+        Args {
+            cache_path: temp_dir.path().to_path_buf(),
+            port: 0,
+            sanitize_bearer_auth: true,
+            sanitize_aws_sigv4: true,
+            sanitize_model_headers: true,
+            mode: CacheMode::ReadOldWriteNew,
+        },
+        server_started_tx,
+    ));
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let shutdown_fut = async {
+        shutdown_rx.await.unwrap();
+    };
+
+    let (target_server_addr, _) = start_target_server(shutdown_fut).await;
+
+    let proxy_addr = server_started_rx.await.unwrap();
+
+    let client = reqwest::Client::builder()
+        .proxy(reqwest::Proxy::all(format!("http://{proxy_addr}")).unwrap())
+        .danger_accept_invalid_certs(true)
+        .build()
+        .unwrap();
+
+    let first_local_response = client
+        .post(format!("http://{target_server_addr}/timestamp-good"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(first_local_response.status(), 200);
+    let mut first_local_headers = first_local_response.headers().clone();
+    assert!(first_local_headers.contains_key("x-my-custom-header"));
+    // Remove this header so that we can compare the remaining headers between requests
+    let cached = first_local_headers
+        .remove("x-tensorzero-provider-proxy-cache")
+        .unwrap();
+    assert_eq!(cached, "false");
+
+    // Wait for a file to show up on disk
+    loop {
+        let temp_path = temp_dir.path().to_path_buf();
+        let found_file = tokio::task::spawn_blocking(move || {
+            let files = std::fs::read_dir(temp_path).unwrap();
+            for file in files {
+                if file.unwrap().path().to_string_lossy().contains("127.0.0.1") {
+                    return true;
+                }
+            }
+            false
+        })
+        .await
+        .unwrap();
+        if found_file {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    // The cache file was written after the proxy started, so we should get a cache miss
+    let second_local_response = client
+        .post(format!("http://{target_server_addr}/timestamp-good"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(second_local_response.status(), 200);
+    let mut second_local_headers = second_local_response.headers().clone();
+    let cached = second_local_headers
+        .remove("x-tensorzero-provider-proxy-cache")
+        .unwrap();
+    assert_eq!(cached, "false");
+    let second_local_response_body = second_local_response.text().await.unwrap();
+
+    shutdown_tx.send(()).unwrap();
+
+    // Start a new proxy server with the same settings
+    let (server_started_tx, server_started_rx) = oneshot::channel();
+
+    let _proxy_handle = tokio::spawn(run_server(
+        Args {
+            cache_path: temp_dir.path().to_path_buf(),
+            port: 0,
+            sanitize_bearer_auth: true,
+            sanitize_aws_sigv4: true,
+            sanitize_model_headers: true,
+            mode: CacheMode::ReadOldWriteNew,
+        },
+        server_started_tx,
+    ));
+
+    let proxy_addr = server_started_rx.await.unwrap();
+
+    let client = reqwest::Client::builder()
+        .proxy(reqwest::Proxy::all(format!("http://{proxy_addr}")).unwrap())
+        .danger_accept_invalid_certs(true)
+        .build()
+        .unwrap();
+
+    let third_local_response = client
+        .post(format!("http://{target_server_addr}/timestamp-good"))
+        .send()
+        .await
+        .unwrap();
+
+    // We should now get a cache hit, because the cache file was written before the proxy started
+    assert_eq!(third_local_response.status(), 200);
+    let mut third_local_headers = third_local_response.headers().clone();
+    let cached = third_local_headers
+        .remove("x-tensorzero-provider-proxy-cache")
+        .unwrap();
+    assert_eq!(cached, "true");
+    let third_local_response_body = third_local_response.text().await.unwrap();
+    // We should use the second response body (from the original run of provider-proxy), which
+    // should have overwritten the first response body on disk.
+    assert_eq!(second_local_response_body, third_local_response_body);
 }


### PR DESCRIPTION
In this mode, we read any cache files that were modified before the provider-proxy instance started. Cache files modified after startup (which includes files that we wrote during execution) are ignored and overwritten by subsequent requests to the same URL.

This will allow us to implement automatic provider-proxy cache regeneration on CI. Tests without cache entries to begin with can get correctly retried by 'cargo nextest', as each retry will overwrite the existing cache entry (which might have been a bad response from the provider). Tests with cache entries will always be served from the cache

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Implement 'read-old-write-new' cache mode in provider-proxy for improved cache handling in CI environments.
> 
>   - **Behavior**:
>     - Introduces `read-old-write-new` mode in `provider-proxy` to read cache files modified before startup and overwrite them with new requests.
>     - Updates `run_provider_proxy.sh` to use `--mode read-old-write-new`.
>   - **Cache Handling**:
>     - Modifies `check_cache()` in `lib.rs` to handle `read-old-write-new` mode by checking file modification times.
>     - Uses `tempfile` for atomic cache writes in `save_cache_body()`.
>   - **Command-Line Interface**:
>     - Replaces `--write` flag with `--mode` in `Args` struct in `lib.rs`.
>     - Adds `CacheMode` enum to define cache behavior modes.
>   - **Testing**:
>     - Adds `test_read_old_write_new()` in `tests.rs` to verify new cache mode behavior.
>     - Updates existing tests to use `CacheMode` enum.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 13fbfa89670c130b689ee208f9b322152319279f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->