### PR TITLE
Implement correct permission check for slash-commands

### DIFF
--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -8,13 +8,22 @@ permissions:
 on:
   issue_comment:
     types: [created]
+  workflow_dispatch:
 jobs:
   slashCommandDispatch:
     runs-on: ubuntu-latest
     steps:
+      - name: "Check permission"
+        id: check-permission
+        run: |
+          PERM=$(gh api repos/tensorzero/tensorzero/collaborators/${{ github.actor }}/permission | jq .permission -r)
+          echo "ACTOR_PERM=$PERM" >> $GITHUB_OUTPUT
       - name: Slash Command Dispatch
+        if: ${{ steps.check-permission.outputs.ACTOR_PERM && steps.check-permission.outputs.ACTOR_PERM != 'read' }}
         uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commands: |
             regen-fixtures
+          # Use our custom permission check above, since `peter-evans/slash-command-dispatch` doesn't handle organizations 
+          permission: none


### PR DESCRIPTION
We manually check that the actor permission level is not 'read' (which should allow anyone in the 'tensorzero' organization to use the commands)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
