### PR TITLE
Start downloading/uploading provider-proxy cache to R2

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -133,6 +133,10 @@ jobs:
         run: |
           echo "TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@localhost:8123/tensorzero_e2e_tests" >> $GITHUB_ENV
 
+      - name: Download provider-proxy cache
+        run: |
+          AWS_ACCESS_KEY_ID=$R2_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$R2_SECRET_ACCESS_KEY ./ci/download-provider-proxy-cache.sh
+
       - name: Launch ClickHouse container for E2E tests
         run: |
           # 'docker compose' will exit with status code 1 if any container exits, even if the container exits with status code 0
@@ -231,6 +235,10 @@ jobs:
         run: |
           echo "Killing gateway with pid $GATEWAY_PID"
           kill $GATEWAY_PID
+
+      - name: Upload provider-proxy cache
+        run: |
+          AWS_ACCESS_KEY_ID=$R2_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$R2_SECRET_ACCESS_KEY ./ci/upload-provider-proxy-cache.sh
 
   check-production-docker-container:
     runs-on: ubuntu-latest

--- a/ci/download-provider-proxy-cache.sh
+++ b/ci/download-provider-proxy-cache.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euxo pipefail
+cd $(dirname $0)/provider-proxy-cache
+aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync s3://provider-proxy-cache .

--- a/ci/upload-provider-proxy-cache.sh
+++ b/ci/upload-provider-proxy-cache.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euxo pipefail
+cd $(dirname $0)/provider-proxy-cache
+aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync . s3://provider-proxy-cache --checksum-algorithm CRC32


### PR DESCRIPTION
We download at the start of the live-tests job, and upload if the job succeeded. For now, this will do nothing, since we're currently running the provider-proxy in read-only mode

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add download/upload steps for provider-proxy cache to R2 in CI workflow, with upload inactive.
> 
>   - **CI Workflow**:
>     - Adds a step to download provider-proxy cache in `merge-queue.yml` using `ci/download-provider-proxy-cache.sh`.
>     - Adds a step to upload provider-proxy cache in `merge-queue.yml` using `ci/upload-provider-proxy-cache.sh`, but it is currently inactive.
>   - **Scripts**:
>     - New script `ci/download-provider-proxy-cache.sh` to sync cache from R2 storage.
>     - New script `ci/upload-provider-proxy-cache.sh` to sync cache to R2 storage with CRC32 checksum.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 12407f4c93231ffae1e53d688f8e47609fb8c604. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->