### PR TITLE
Set 'GH_TOKEN' env var when running 'gh' command

### DIFF
--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -18,6 +18,8 @@ jobs:
         run: |
           MEMBER=$((gh api 'orgs/tensorzero/members/${{ github.actor }}' && echo 1) || echo 0)
           echo "ACTOR_MEMBER=$MEMBER" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Slash Command Dispatch
         if: ${{ steps.check-permission.outputs.ACTOR_MEMBER == '1' }}
         uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `GH_TOKEN` environment variable in `slash-command-dispatch.yml` for authentication in `Check permission` step.
> 
>   - **Environment Variables**:
>     - Set `GH_TOKEN` environment variable in `slash-command-dispatch.yml` for the `Check permission` step to use `${{ secrets.GITHUB_TOKEN }}`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e07f86407a0d27a1592e331763872f292f852656. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->