### PR TITLE
Fix more tool-call deprecation warnings in e2e tests

### DIFF
--- a/tensorzero-internal/tests/e2e/providers/anthropic.rs
+++ b/tensorzero-internal/tests/e2e/providers/anthropic.rs
@@ -347,7 +347,7 @@ async fn test_thinking_signature() {
     assert_eq!(response.status(), StatusCode::OK);
     let response_json = response.json::<Value>().await.unwrap();
     let content_blocks = response_json.get("content").unwrap().as_array().unwrap();
-    let mut tensorzero_content_blocks = content_blocks.clone();
+    let tensorzero_content_blocks = content_blocks.clone();
     assert!(
         content_blocks.len() == 3,
         "Unexpected content blocks: {content_blocks:?}"
@@ -457,19 +457,6 @@ async fn test_thinking_signature() {
     let _raw_response_json: Value = serde_json::from_str(raw_response).unwrap();
 
     println!("Original tensorzero_content_blocks: {tensorzero_content_blocks:?}");
-
-    // TODO - support passing tool call in directly (https://github.com/tensorzero/tensorzero/issues/1366)
-    tensorzero_content_blocks[2]["arguments"] =
-        Value::String(serde_json::to_string(&tensorzero_content_blocks[2]["arguments"]).unwrap());
-    tensorzero_content_blocks[2]
-        .as_object_mut()
-        .unwrap()
-        .remove("raw_arguments");
-    tensorzero_content_blocks[2]
-        .as_object_mut()
-        .unwrap()
-        .remove("raw_name");
-
     // Feed content blocks back in
     let mut new_messages = vec![
         serde_json::json!({

--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -7664,7 +7664,7 @@ pub async fn test_tool_multi_turn_streaming_inference_request_with_provider(
                             "type": "tool_call",
                             "id": "123456789",
                             "name": "get_temperature",
-                            "arguments": "{\"location\": \"Tokyo\", \"units\": \"celsius\"}"
+                            "arguments": {"location": "Tokyo", "units": "celsius"}
                         }
                     ]
                 },
@@ -7797,7 +7797,7 @@ pub async fn test_tool_multi_turn_streaming_inference_request_with_provider(
                         "type": "tool_call",
                         "id": "123456789",
                         "name": "get_temperature",
-                        "arguments": "{\"location\": \"Tokyo\", \"units\": \"celsius\"}"
+                        "arguments": "{\"location\":\"Tokyo\",\"units\":\"celsius\"}"
                     }
                 ]
             },
@@ -7926,7 +7926,7 @@ pub async fn test_tool_multi_turn_streaming_inference_request_with_provider(
             content: vec![ContentBlock::ToolCall(ToolCall {
                 id: "123456789".to_string(),
                 name: "get_temperature".to_string(),
-                arguments: "{\"location\": \"Tokyo\", \"units\": \"celsius\"}".to_string(),
+                arguments: "{\"location\":\"Tokyo\",\"units\":\"celsius\"}".to_string(),
             })],
         },
         RequestMessage {
@@ -11053,18 +11053,7 @@ pub async fn test_multi_turn_parallel_tool_use_streaming_inference_request_with_
             );
         }
 
-        let mut redacted_content_block = content_block.clone();
-        redacted_content_block
-            .as_object_mut()
-            .unwrap()
-            .remove("raw_name");
-        redacted_content_block
-            .as_object_mut()
-            .unwrap()
-            .remove("raw_arguments");
-        redacted_content_block["arguments"] =
-            Value::String(redacted_content_block.get("arguments").unwrap().to_string());
-        redacted_tool_calls.push(redacted_content_block);
+        redacted_tool_calls.push(content_block);
     }
 
     // Build the payload for the second inference request


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix deprecation warnings in e2e tests by updating tool-call argument handling and JSON formatting.
> 
>   - **Deprecation Warning Fixes**:
>     - Remove code handling deprecated tool-call formats in `test_thinking_signature()` in `anthropic.rs`.
>     - Update JSON argument formatting in `test_tool_multi_turn_streaming_inference_request_with_provider()` and `test_multi_turn_parallel_tool_use_streaming_inference_request_with_provider()` in `common.rs`.
>   - **JSON Formatting**:
>     - Change `"arguments": {"location": "Tokyo", "units": "celsius"}` to `"arguments": {"location":"Tokyo","units":"celsius"}` in `common.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 550fa597223aaf77c5217d4ba184d965d20336f1. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->