### PR TITLE
Relax 'raw_arguments' check in tool calling test

### DIFF
--- a/tensorzero-internal/tests/e2e/providers/common.rs
+++ b/tensorzero-internal/tests/e2e/providers/common.rs
@@ -4862,8 +4862,11 @@ pub async fn check_tool_use_tool_choice_required_inference_response(
         .unwrap();
     let raw_arguments: Value = serde_json::from_str(raw_arguments).unwrap();
     let raw_arguments = raw_arguments.as_object().unwrap();
-    assert!(raw_arguments.len() == 1 || raw_arguments.len() == 2);
-    assert!(raw_arguments.get("location").unwrap().as_str().is_some());
+    // OpenAI occasionally emits a tool call with an empty object for `arguments`
+    assert!(raw_arguments.len() <= 2);
+    if let Some(location) = raw_arguments.get("location") {
+        assert!(location.as_str().is_some());
+    }
     if raw_arguments.len() == 2 {
         let units = raw_arguments.get("units").unwrap().as_str().unwrap();
         assert!(units == "celsius" || units == "fahrenheit");


### PR DESCRIPTION
We already relaxed the check for 'arguments', so let's relax the check for 'raw_arguments' as well

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Relaxed 'raw_arguments' check in `check_tool_use_tool_choice_required_inference_response()` to allow empty objects and conditional 'location' checks.
> 
>   - **Behavior**:
>     - Relaxed check for `raw_arguments` in `check_tool_use_tool_choice_required_inference_response()` in `common.rs`.
>     - Allows `raw_arguments` to be empty or have up to 2 elements.
>     - Conditional check for `location` key in `raw_arguments` to ensure it is a string if present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6541465f7aec1a086d93a85c42940d514c18c3b8. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->