### PR TITLE
Only upload provider-proxy cache from merge queue

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -232,6 +232,7 @@ jobs:
           kill $GATEWAY_PID
 
       - name: Upload provider-proxy cache
+        if: github.event_name == 'merge_group'
         run: |
           AWS_ACCESS_KEY_ID=$R2_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$R2_SECRET_ACCESS_KEY ./ci/upload-provider-proxy-cache.sh
 


### PR DESCRIPTION
This allows us to manually trigger the live-tests job for a branch without polluting the cache

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Upload provider-proxy cache only on `merge_group` events to prevent cache pollution.
> 
>   - **Behavior**:
>     - Modify `merge-queue.yml` to upload provider-proxy cache only when `github.event_name` is `merge_group`.
>     - Prevents cache pollution when manually triggering live-tests for branches.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 553026234da2fdb8b64be990738812b059d666c7. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->