### PR TITLE
Add 'delete = true' option to extra_body config

### DIFF
--- a/tensorzero-core/src/config_parser.rs
+++ b/tensorzero-core/src/config_parser.rs
@@ -2362,6 +2362,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_load_bad_extra_body_delete() {
+        let config_str = r#"
+        [functions.bash_assistant]
+        type = "chat"
+        
+        [functions.bash_assistant.variants.anthropic_claude_3_7_sonnet_20250219]
+        type = "chat_completion"
+        model = "anthropic::claude-3-7-sonnet-20250219"
+        max_tokens = 2048
+        extra_body = [{ pointer = "/invalid-field-should-be-deleted", delete = false }]
+        "#;
+        let config = toml::from_str(config_str).expect("Failed to parse sample config");
+        let base_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let err = Config::load_from_toml(config, base_path.clone())
+            .await
+            .expect_err("Config loading should fail")
+            .to_string();
+        assert_eq!(err, "functions.bash_assistant: variants.anthropic_claude_3_7_sonnet_20250219: extra_body.[0]: Error deserializing extra body replacement: 'delete' must be 'true', or not set");
+    }
+
+    #[tokio::test]
     async fn test_load_bad_config_error_path() {
         let config_str = r#"
 [functions.bash_assistant]

--- a/tensorzero-core/src/providers/helpers.rs
+++ b/tensorzero-core/src/providers/helpers.rs
@@ -12,7 +12,7 @@ use crate::{
     error::{DisplayOrDebugGateway, Error, ErrorDetails},
     inference::types::{
         batch::{ProviderBatchInferenceOutput, ProviderBatchInferenceResponse},
-        extra_body::{FullExtraBodyConfig, InferenceExtraBody},
+        extra_body::{ExtraBodyReplacementKind, FullExtraBodyConfig, InferenceExtraBody},
         extra_headers::{ExtraHeader, FullExtraHeadersConfig, InferenceExtraHeader},
         ProviderInferenceResponseChunk,
     },
@@ -207,11 +207,14 @@ pub fn inject_extra_request_data(
         .flat_map(|c| &c.data)
         .chain(model_provider.extra_body.iter().flat_map(|c| &c.data))
     {
-        write_json_pointer_with_parent_creation(
-            body,
-            &replacement.pointer,
-            replacement.value.clone(),
-        )?;
+        match &replacement.kind {
+            ExtraBodyReplacementKind::Value(value) => {
+                write_json_pointer_with_parent_creation(body, &replacement.pointer, value.clone())?;
+            }
+            ExtraBodyReplacementKind::Delete => {
+                delete_json_pointer(body, &replacement.pointer)?;
+            }
+        }
     }
 
     let expected_provider_name = fully_qualified_name(model_name, &model_provider.provider_name);
@@ -224,17 +227,29 @@ pub fn inject_extra_request_data(
                 // Any remaining `InferenceExtraBody::Variant` values should be applied to the current request
                 variant_name: _,
                 pointer,
-                value,
-            } => {
-                write_json_pointer_with_parent_creation(body, pointer, value.clone())?;
-            }
+                kind,
+            } => match kind {
+                ExtraBodyReplacementKind::Value(value) => {
+                    write_json_pointer_with_parent_creation(body, pointer, value.clone())?;
+                }
+                ExtraBodyReplacementKind::Delete => {
+                    delete_json_pointer(body, pointer)?;
+                }
+            },
             InferenceExtraBody::Provider {
                 model_provider_name,
                 pointer,
-                value,
+                kind,
             } => {
                 if *model_provider_name == expected_provider_name {
-                    write_json_pointer_with_parent_creation(body, pointer, value.clone())?;
+                    match kind {
+                        ExtraBodyReplacementKind::Value(value) => {
+                            write_json_pointer_with_parent_creation(body, pointer, value.clone())?;
+                        }
+                        ExtraBodyReplacementKind::Delete => {
+                            delete_json_pointer(body, pointer)?;
+                        }
+                    }
                 }
             }
         }
@@ -342,6 +357,109 @@ fn parse_index(s: &str) -> Option<usize> {
         return None;
     }
     s.parse().ok()
+}
+
+fn delete_json_pointer(mut value: &mut serde_json::Value, pointer: &str) -> Result<(), Error> {
+    if pointer.is_empty() {
+        return Err(Error::new(ErrorDetails::ExtraBodyReplacement {
+            message: "Pointer cannot be empty".to_string(),
+            pointer: pointer.to_string(),
+        }));
+    }
+    if !pointer.starts_with('/') {
+        return Err(Error::new(ErrorDetails::ExtraBodyReplacement {
+            message: "Pointer must start with '/'".to_string(),
+            pointer: pointer.to_string(),
+        }));
+    }
+
+    if pointer.ends_with('/') {
+        return Err(Error::new(ErrorDetails::ExtraBodyReplacement {
+            message: "Pointer cannot end with '/'".to_string(),
+            pointer: pointer.to_string(),
+        }));
+    }
+
+    let mut components = pointer
+        .split('/')
+        .skip(1)
+        .map(|x| x.replace("~1", "/").replace("~0", "~"))
+        .peekable();
+    while let Some(token) = components.next() {
+        // This isn't the last component, so navigate deeper
+        if components.peek().is_some() {
+            match value {
+                Value::Object(map) => match map.entry(token.clone()) {
+                    // Move inside an object if the current pointer component is a valid key
+                    Entry::Occupied(occupied) => value = occupied.into_mut(),
+                    Entry::Vacant(_) => {
+                        tracing::warn!("Skipping deletion of extra_body pointer `{pointer}` - parent of pointer doesn't exist");
+                        // If a parent of our target pointer doesn't exist, then do nothing,
+                        // since `value`` is already an object where the target pointer doesn't exist
+                        return Ok(());
+                    }
+                },
+                Value::Array(list) => {
+                    match parse_index(&token) {
+                        Some(index) => {
+                            if let Some(target) = list.get_mut(index) {
+                                value = target;
+                            } else {
+                                tracing::warn!("Skipping deletion of extra_body pointer `{pointer}` - index `{token}` out of bounds");
+                                // If a parent of our target pointer doesn't exist, then do nothing,
+                                // since `value`` is already an object where the target pointer doesn't exist
+                                return Ok(());
+                            }
+                        }
+                        None => {
+                            tracing::warn!("Skipping deletion of extra_body pointer `{pointer}` - non-numeric array index `{token}`");
+                            // If a parent of our target pointer doesn't exist, then do nothing,
+                            // since `value`` is already an object where the target pointer doesn't exist
+                            return Ok(());
+                        }
+                    }
+                }
+                other => {
+                    return Err(Error::new(ErrorDetails::ExtraBodyReplacement {
+                        message: format!(
+                            "Can only index into object or array - found target {other}"
+                        ),
+                        pointer: pointer.to_string(),
+                    }))
+                }
+            }
+        } else {
+            match value {
+                Value::Object(map) => {
+                    if map.remove(&token).is_none() {
+                        tracing::warn!("Skipping deletion of extra_body pointer `{pointer}` - key `{token}` doesn't exist");
+                    }
+                }
+                Value::Array(list) => match parse_index(&token) {
+                    Some(index) => {
+                        if index < list.len() {
+                            list.remove(index);
+                        } else {
+                            tracing::warn!("Skipping deletion of extra_body pointer `{pointer}` - index `{token}` out of bounds");
+                        }
+                    }
+                    None => {
+                        tracing::warn!("Skipping deletion of extra_body pointer `{pointer}` - non-numeric array index `{token}`");
+                    }
+                },
+                other => {
+                    return Err(Error::new(ErrorDetails::ExtraBodyReplacement {
+                        message: format!(
+                            "Can only index into object or array - found target {other}"
+                        ),
+                        pointer: pointer.to_string(),
+                    }))
+                }
+            }
+            return Ok(());
+        }
+    }
+    Ok(())
 }
 
 // Based on https://github.com/serde-rs/json/blob/400eaa977f1f0a1c9ad5e35d634ed2226bf1218c/src/value/mod.rs#L834
@@ -502,6 +620,7 @@ mod tests {
     use std::time::Duration;
 
     use futures::{stream, StreamExt};
+    use tracing_test::traced_test;
 
     use crate::inference::types::{
         extra_body::{ExtraBodyConfig, ExtraBodyReplacement, FilteredInferenceExtraBody},
@@ -598,7 +717,9 @@ mod tests {
                     data: vec![InferenceExtraBody::Provider {
                         model_provider_name: "wrong_provider".to_string(),
                         pointer: "/my_key".to_string(),
-                        value: "My Value".to_string().into(),
+                        kind: ExtraBodyReplacementKind::Value(Value::String(
+                            "My Value".to_string(),
+                        )),
                     }],
                 },
             },
@@ -741,13 +862,13 @@ mod tests {
                     data: vec![
                         ExtraBodyReplacement {
                             pointer: "/generationConfig".to_string(),
-                            value: serde_json::json!({
+                            kind: ExtraBodyReplacementKind::Value(serde_json::json!({
                                 "otherNestedKey": "otherNestedValue"
-                            }),
+                            })),
                         },
                         ExtraBodyReplacement {
                             pointer: "/generationConfig/temperature".to_string(),
-                            value: serde_json::json!(0.123),
+                            kind: ExtraBodyReplacementKind::Value(serde_json::json!(0.123)),
                         },
                     ],
                 }),
@@ -757,7 +878,9 @@ mod tests {
                             "tensorzero::model_name::dummy_model::provider_name::dummy_provider"
                                 .to_string(),
                         pointer: "/generationConfig/valueFromInference".to_string(),
-                        value: "inferenceValue".to_string().into(),
+                        kind: ExtraBodyReplacementKind::Value(Value::String(
+                            "inferenceValue".to_string(),
+                        )),
                     }],
                 },
             },
@@ -794,7 +917,8 @@ mod tests {
             "otherKey": "otherValue",
             "generationConfig": {
                 "temperature": 123
-            }
+            },
+            "delete_me": {"some": "value"}
         });
         inject_extra_request_data(
             &FullExtraBodyConfig {
@@ -802,15 +926,25 @@ mod tests {
                     data: vec![
                         ExtraBodyReplacement {
                             pointer: "/generationConfig/otherNestedKey".to_string(),
-                            value: Value::String("otherNestedValue".to_string()),
+                            kind: ExtraBodyReplacementKind::Value(Value::String(
+                                "otherNestedValue".to_string(),
+                            )),
                         },
                         ExtraBodyReplacement {
                             pointer: "/variantKey".to_string(),
-                            value: Value::String("variantValue".to_string()),
+                            kind: ExtraBodyReplacementKind::Value(Value::String(
+                                "variantValue".to_string(),
+                            )),
                         },
                         ExtraBodyReplacement {
                             pointer: "/multiOverride".to_string(),
-                            value: Value::String("from variant".to_string()),
+                            kind: ExtraBodyReplacementKind::Value(Value::String(
+                                "from variant".to_string(),
+                            )),
+                        },
+                        ExtraBodyReplacement {
+                            pointer: "/delete_me".to_string(),
+                            kind: ExtraBodyReplacementKind::Delete,
                         },
                     ],
                 }),
@@ -820,7 +954,9 @@ mod tests {
                             "tensorzero::model_name::dummy_model::provider_name::dummy_provider"
                                 .to_string(),
                         pointer: "/multiOverride".to_string(),
-                        value: Value::String("from inference".to_string()),
+                        kind: ExtraBodyReplacementKind::Value(Value::String(
+                            "from inference".to_string(),
+                        )),
                     }],
                 },
             },
@@ -831,15 +967,21 @@ mod tests {
                     data: vec![
                         ExtraBodyReplacement {
                             pointer: "/variantKey".to_string(),
-                            value: Value::String("modelProviderOverride".to_string()),
+                            kind: ExtraBodyReplacementKind::Value(Value::String(
+                                "modelProviderOverride".to_string(),
+                            )),
                         },
                         ExtraBodyReplacement {
                             pointer: "/modelProviderKey".to_string(),
-                            value: Value::String("modelProviderValue".to_string()),
+                            kind: ExtraBodyReplacementKind::Value(Value::String(
+                                "modelProviderValue".to_string(),
+                            )),
                         },
                         ExtraBodyReplacement {
                             pointer: "/multiOverride".to_string(),
-                            value: Value::String("from model provider".to_string()),
+                            kind: ExtraBodyReplacementKind::Value(Value::String(
+                                "from model provider".to_string(),
+                            )),
                         },
                     ],
                 }),
@@ -1039,6 +1181,103 @@ mod tests {
         assert!(
             err.contains("TensorZero doesn't support pointing an index (0) if its container doesn't exist. We'd love to hear about your use case (& help)! Please open a GitHub Discussion: https://github.com/tensorzero/tensorzero/discussions/new` with pointer: `/new-key/0`"),
             "Unexpected error message: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_delete_json_pointer_simple() {
+        let mut obj = serde_json::json!({
+            "object1": "value1",
+            "my_array": ["value1", true],
+            "object2": {
+                "key1": "value1",
+            }
+        });
+        delete_json_pointer(&mut obj, "/object1").unwrap();
+        assert_eq!(
+            obj,
+            serde_json::json!({
+                "my_array": ["value1", true],
+                "object2": {
+                    "key1": "value1",
+                }
+            })
+        );
+
+        delete_json_pointer(&mut obj, "/object2/key1").unwrap();
+        assert_eq!(
+            obj,
+            serde_json::json!({
+                "my_array": ["value1", true],
+                "object2": {
+                }
+            })
+        );
+
+        delete_json_pointer(&mut obj, "/object2").unwrap();
+        assert_eq!(
+            obj,
+            serde_json::json!({
+                "my_array": ["value1", true],
+            })
+        );
+
+        delete_json_pointer(&mut obj, "/my_array/0").unwrap();
+        assert_eq!(
+            obj,
+            serde_json::json!({
+                "my_array": [true],
+            })
+        );
+
+        delete_json_pointer(&mut obj, "/my_array").unwrap();
+        assert_eq!(obj, serde_json::json!({}));
+    }
+
+    #[test]
+    #[traced_test]
+    fn test_delete_json_pointer_errors() {
+        let mut obj = serde_json::json!({"other": "value"});
+        delete_json_pointer(&mut obj, "/object1").unwrap();
+        assert!(logs_contain(
+            "Skipping deletion of extra_body pointer `/object1` - key `object1` doesn't exist"
+        ));
+        assert_eq!(obj, serde_json::json!({"other": "value"}));
+
+        let mut obj = serde_json::json!({
+            "my_array": ["value1", true],
+        });
+        delete_json_pointer(&mut obj, "/my_array/2").unwrap();
+        assert!(logs_contain(
+            "Skipping deletion of extra_body pointer `/my_array/2` - index `2` out of bounds"
+        ));
+        assert_eq!(
+            obj,
+            serde_json::json!({
+                "my_array": ["value1", true],
+            })
+        );
+
+        delete_json_pointer(&mut obj, "/fake/pointer").unwrap();
+        assert!(logs_contain(
+            "Skipping deletion of extra_body pointer `/fake/pointer` - parent of pointer doesn't exist"
+        ));
+        assert_eq!(
+            obj,
+            serde_json::json!({
+                "my_array": ["value1", true],
+            })
+        );
+
+        delete_json_pointer(&mut obj, "/my_array/non-int-index").unwrap();
+        assert!(logs_contain(
+            "Skipping deletion of extra_body pointer `/my_array/non-int-index` - non-numeric array index `non-int-index`"
+        ));
+        assert_eq!(
+            obj,
+            serde_json::json!({
+                "my_array": ["value1", true],
+            })
         );
     }
 

--- a/tensorzero-core/tests/e2e/tensorzero.toml
+++ b/tensorzero-core/tests/e2e/tensorzero.toml
@@ -1178,7 +1178,11 @@ type = "chat_completion"
 model = "gpt-4o-mini-2024-07-18"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
-extra_body = [{ pointer = "/temperature", value = 0.123 }]
+extra_body = [
+    { pointer = "/temperature", value = 0.123 },
+    { pointer = "/invalid-field-should-be-deleted", value = "Bad value" },
+    { pointer = "/invalid-field-should-be-deleted", delete = true },
+]
 
 [functions.basic_test.variants.openai-extra-body-provider-config]
 type = "chat_completion"


### PR DESCRIPTION
This allows deleting an key the body, rather than replacing or inserting a key.

The new type of `extra_body` entry looks like:
```
{ pointer = "/some/pointer, delete = true }
```

'delete' must be set to 'true' - setting `delete = false` produces an error during config loading.

If the specified pointer does not exist in the object (due to a parent being missing, an array index being out-of-bounds, or attempting to index an array with a string), we log a warning and continue on. This allows `delete = true` to be used to ensure that a particular key does not exist in the body, without breaking the model provider if it already does not exist

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `delete = true` option to `extra_body` config for key deletion, with logging for non-existent pointers.
> 
>   - **Behavior**:
>     - Adds `delete = true` option to `extra_body` config to delete keys instead of replacing or inserting them.
>     - Logs a warning if the pointer does not exist, allowing non-breaking deletions.
>   - **Implementation**:
>     - Introduces `ExtraBodyReplacementKind::Delete` in `extra_body.rs`.
>     - Implements `delete_json_pointer()` in `helpers.rs` to handle deletion logic.
>     - Updates `inject_extra_request_data()` in `helpers.rs` to support `Delete` kind.
>   - **Validation**:
>     - Adds tests in `config_parser.rs` and `helpers.rs` to verify `delete` functionality and error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for bc9123bcee450fbaf5dfef9117028270eeaf4f80. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->