### PR TITLE
Run merge-queue workflow in daily cron job

### DIFF
--- a/.github/workflows/batch-test.yml
+++ b/.github/workflows/batch-test.yml
@@ -31,8 +31,6 @@ env:
 on:
   workflow_dispatch:
   workflow_call:
-  schedule:
-    - cron: "0 0 * * *" # Runs at 00:00 UTC every day
 
 jobs:
   batch-tests:

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -4,6 +4,8 @@ run-name: Merge Queue Checks for ${{ github.ref }}
 on:
   workflow_dispatch:
   merge_group:
+  schedule:
+    - cron: "0 0 * * *" # Runs at 00:00 UTC every day
 
 # See 'general.yml' for more details. Note that we use a difference concurrency group,
 # so that general.yml and merge-queue.yml can run in parallel.
@@ -129,6 +131,9 @@ jobs:
           echo "TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@localhost:8123/tensorzero_e2e_tests" >> $GITHUB_ENV
 
       - name: Download provider-proxy cache
+        # When running as a cron job, don't use the provider-proxy cache.
+        # The cron job is used to gather information about provider flakiness.
+        if: github.event_name != 'schedule'
         run: |
           AWS_ACCESS_KEY_ID=$R2_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$R2_SECRET_ACCESS_KEY ./ci/download-provider-proxy-cache.sh
 

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -230,7 +230,10 @@ jobs:
           kill $GATEWAY_PID
 
       - name: Upload provider-proxy cache
-        if: github.event_name == 'merge_group'
+        # Only upload the cache when we're running from a 'good' run
+        # (a merge queue entry which passed this check, or a cron job)
+        # This prevents manual workflow runs from modifying the cache
+        if: github.event_name == 'merge_group' || github.event_name == 'schedule'
         run: |
           AWS_ACCESS_KEY_ID=$R2_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$R2_SECRET_ACCESS_KEY ./ci/upload-provider-proxy-cache.sh
 

--- a/ci/upload-provider-proxy-cache.sh
+++ b/ci/upload-provider-proxy-cache.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 cd $(dirname $0)/provider-proxy-cache
-aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync . s3://provider-proxy-cache --checksum-algorithm CRC32
+# Use --delete to remove stale cache files from the bucket.
+# This doesn't do anything for merge queue runs (since we start by downloading the entire bucket),
+# but it will help for cron job runs, where we intentionally start with an empty provider-proxy cache.
+aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync . s3://provider-proxy-cache --checksum-algorithm CRC32 --delete


### PR DESCRIPTION
I've disabled downloading the provider-proxy cache when running as a cron job. This will let us gather data about flaky providers without impacting the merge queue

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add daily cron job to `merge-queue.yml` and adjust provider-proxy cache handling for cron runs.
> 
>   - **Workflows**:
>     - Add daily cron schedule to `merge-queue.yml` to run at 00:00 UTC.
>     - Remove daily cron schedule from `batch-test.yml`.
>   - **Provider-Proxy Cache**:
>     - In `merge-queue.yml`, skip downloading provider-proxy cache when triggered by cron (`schedule` event).
>     - Allow cache upload for both `merge_group` and `schedule` events in `merge-queue.yml`.
>     - Modify `upload-provider-proxy-cache.sh` to use `--delete` option for cron runs to remove stale cache files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4ae644dfc772a19d0f07cc298e530f0060f33c06. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->