### PR TITLE
Only attach 'tensorzero::inference_id' label to GCP batch requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ node_modules/
 CLAUDE.md
 
 ui/fixtures/s3-fixtures
+ci/provider-proxy-cache

--- a/tensorzero-core/src/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_gemini.rs
@@ -914,6 +914,7 @@ impl InferenceProvider for GCPVertexGeminiProvider {
         let request_body = serde_json::to_value(GCPVertexGeminiRequest::new(
             provider_request.request,
             self.model_or_endpoint_id(),
+            false,
         )?)
         .map_err(|e| {
             Error::new(ErrorDetails::Serialization {
@@ -1018,6 +1019,7 @@ impl InferenceProvider for GCPVertexGeminiProvider {
         let request_body = serde_json::to_value(GCPVertexGeminiRequest::new(
             request,
             self.model_or_endpoint_id(),
+            false,
         )?)
         .map_err(|e| {
             Error::new(ErrorDetails::Serialization {
@@ -1079,7 +1081,7 @@ impl InferenceProvider for GCPVertexGeminiProvider {
         let mut raw_requests = Vec::with_capacity(requests.len());
         let mut jsonl_data = Vec::new();
         for request in requests {
-            let body = GCPVertexGeminiRequest::new(request, self.model_or_endpoint_id())?;
+            let body = GCPVertexGeminiRequest::new(request, self.model_or_endpoint_id(), true)?;
             let line =
                 serde_json::to_string(&GCPVertexBatchLine { request: body }).map_err(|e| {
                     Error::new(ErrorDetails::Serialization {
@@ -1740,7 +1742,11 @@ struct GCPVertexGeminiRequest<'a> {
 }
 
 impl<'a> GCPVertexGeminiRequest<'a> {
-    pub fn new(request: &'a ModelInferenceRequest<'a>, model_name: &'a str) -> Result<Self, Error> {
+    pub fn new(
+        request: &'a ModelInferenceRequest<'a>,
+        model_name: &'a str,
+        attach_label: bool,
+    ) -> Result<Self, Error> {
         if request.messages.is_empty() {
             return Err(ErrorDetails::InvalidRequest {
                 message: "GCP Vertex Gemini requires at least one message".to_string(),
@@ -1784,6 +1790,18 @@ impl<'a> GCPVertexGeminiRequest<'a> {
             response_mime_type,
             response_schema,
         });
+        // We attach our custom tag so that we can identify the original inference when
+        // retrieving batch results.
+        let labels = if attach_label {
+            [(
+                INFERENCE_ID_LABEL.to_string(),
+                request.inference_id.to_string(),
+            )]
+            .into_iter()
+            .collect()
+        } else {
+            HashMap::new()
+        };
         Ok(GCPVertexGeminiRequest {
             contents,
             tools,
@@ -1793,14 +1811,7 @@ impl<'a> GCPVertexGeminiRequest<'a> {
                 role: GCPVertexGeminiRole::Model,
                 parts: vec![FlattenUnknown::Normal(content)],
             }),
-            // We attach our custom tag so that we can identify the original inference when
-            // retrieving batch results.
-            labels: [(
-                INFERENCE_ID_LABEL.to_string(),
-                request.inference_id.to_string(),
-            )]
-            .into_iter()
-            .collect(),
+            labels,
         })
     }
 }
@@ -2494,7 +2505,7 @@ mod tests {
             extra_body: Default::default(),
             ..Default::default()
         };
-        let result = GCPVertexGeminiRequest::new(&inference_request, "gemini-pro");
+        let result = GCPVertexGeminiRequest::new(&inference_request, "gemini-pro", false);
         let details = result.unwrap_err().get_owned_details();
         assert_eq!(
             details,
@@ -2532,7 +2543,7 @@ mod tests {
             extra_body: Default::default(),
             ..Default::default()
         };
-        let result = GCPVertexGeminiRequest::new(&inference_request, "gemini-pro");
+        let result = GCPVertexGeminiRequest::new(&inference_request, "gemini-pro", false);
         let request = result.unwrap();
         assert_eq!(request.contents.len(), 2);
         assert_eq!(request.contents[0].role, GCPVertexGeminiRole::User);
@@ -2585,7 +2596,7 @@ mod tests {
         };
         // JSON schema should be supported for Gemini Pro models
         let result =
-            GCPVertexGeminiRequest::new(&inference_request, "gemini-2.5-pro-preview-06-05");
+            GCPVertexGeminiRequest::new(&inference_request, "gemini-2.5-pro-preview-06-05", false);
         let request = result.unwrap();
         assert_eq!(request.contents.len(), 3);
         assert_eq!(request.contents[0].role, GCPVertexGeminiRole::User);
@@ -2653,7 +2664,7 @@ mod tests {
             ..Default::default()
         };
         // JSON mode should be supported for Gemini Flash models but without a schema
-        let result = GCPVertexGeminiRequest::new(&inference_request, "gemini-flash");
+        let result = GCPVertexGeminiRequest::new(&inference_request, "gemini-flash", false);
         let request = result.unwrap();
         assert_eq!(request.contents.len(), 3);
         assert_eq!(request.contents[0].role, GCPVertexGeminiRole::User);

--- a/tensorzero-core/src/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_gemini.rs
@@ -1737,6 +1737,7 @@ struct GCPVertexGeminiRequest<'a> {
     tool_config: Option<GCPVertexGeminiToolConfig<'a>>,
     generation_config: Option<GCPVertexGeminiGenerationConfig<'a>>,
     system_instruction: Option<GCPVertexGeminiContent<'a>>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
     labels: HashMap<String, String>,
     // TODO (if needed): [Safety Settings](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/SafetySetting)
 }

--- a/tensorzero-core/tests/e2e/best_of_n.rs
+++ b/tensorzero-core/tests/e2e/best_of_n.rs
@@ -342,9 +342,6 @@ async fn e2e_test_best_of_n_dummy_candidates_real_judge() {
                     }
                   ]
                 },
-                "labels": {
-                    "tensorzero::inference_id": inference_id.to_string(),
-                }
             });
             assert_eq!(raw_request, expected_request);
             let system = result.get("system").unwrap().as_str().unwrap();
@@ -741,9 +738,6 @@ async fn e2e_test_best_of_n_json_real_judge() {
                   }
                 ]
               },
-              "labels": {
-                  "tensorzero::inference_id": inference_id.to_string(),
-              }
             });
             assert_eq!(raw_request, expected_request);
         }
@@ -1176,9 +1170,6 @@ async fn e2e_test_best_of_n_judge_extra_body() {
                     }
                   ]
                 },
-                "labels": {
-                    "tensorzero::inference_id": inference_id.to_string(),
-                }
             });
             assert_eq!(raw_request, expected_request);
         }


### PR DESCRIPTION
We were attaching this label to normal inferences, which was causing a randomly-generated UUID to get included in every request body. This prevented our provider-proxy cache from ever getting a cache hit for GCP

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Modify GCP Vertex Gemini provider to attach 'tensorzero::inference_id' label only to batch requests, improving cache efficiency.
> 
>   - **Behavior**:
>     - `GCPVertexGeminiRequest::new()` now takes an `attach_label` boolean to control label attachment.
>     - `tensorzero::inference_id` label is only attached to batch requests (`start_batch_inference()`), not normal inferences (`infer()` and `infer_stream()`).
>   - **Code Changes**:
>     - Updated `GCPVertexGeminiRequest::new()` calls in `gcp_vertex_gemini.rs` to include `attach_label` argument.
>     - Removed `tensorzero::inference_id` label from expected requests in `best_of_n.rs` tests.
>   - **Misc**:
>     - Added `#[serde(skip_serializing_if = "HashMap::is_empty")]` to `labels` in `GCPVertexGeminiRequest`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8cab8dc6a360871f90d2069a59b3fae8ae7c817d. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->