### PR TITLE
Filter attributes on derive variant fields as well as variant

### DIFF
--- a/internal/tensorzero-derive/src/lib.rs
+++ b/internal/tensorzero-derive/src/lib.rs
@@ -121,6 +121,9 @@ pub fn tensorzero_derive(input: TokenStream) -> TokenStream {
     let mut stripped_variants = data.variants.clone();
     for variant in stripped_variants.iter_mut() {
         variant.attrs.retain(|attr| attr.path().is_ident("serde"));
+        for field in variant.fields.iter_mut() {
+            field.attrs.retain(|attr| attr.path().is_ident("serde"));
+        }
     }
 
     // Build up match arms that looks like:


### PR DESCRIPTION
The `TensorZeroDerive` macro was stirpping non-`#[serde]` attributes from enum variants, but not from fields of the variants

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `tensorzero_derive` now retains only `#[serde]` attributes on both enum variants and their fields in `lib.rs`.
> 
>   - **Behavior**:
>     - `tensorzero_derive` in `lib.rs` now retains only `#[serde]` attributes on both enum variants and their fields.
>     - Strips non-`#[serde]` attributes from fields of enum variants, in addition to the variants themselves.
>   - **Misc**:
>     - No changes to the logic of `extract_tag` or other functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b67eb20fba32db5ab5bc221ccbe91af3dd4b4bb3. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->