### PR TITLE
added migration 33 for deployment id

### DIFF
--- a/tensorzero-core/src/clickhouse/migration_manager/migrations/migration_0033.rs
+++ b/tensorzero-core/src/clickhouse/migration_manager/migrations/migration_0033.rs
@@ -1,0 +1,97 @@
+use super::check_table_exists;
+use crate::clickhouse::migration_manager::migration_trait::Migration;
+use crate::clickhouse::migration_manager::migrations::table_is_nonempty;
+use crate::clickhouse::ClickHouseConnectionInfo;
+use crate::error::Error;
+use async_trait::async_trait;
+use uuid::Uuid;
+
+/// This migration adds a `DeploymentID` table with a single column `deployment_id`
+/// It should be initialized once on initial deployment of the gateway against a ClickHouse instance.
+/// We will use the oldest deployment ID in the table as the canonical deployment ID.
+/// The deployment ID in the ClickHouse will be the blake3 hash of a UUIDv7 generated at migration runtime.
+pub struct Migration0033<'a> {
+    pub clickhouse: &'a ClickHouseConnectionInfo,
+}
+
+const MIGRATION_ID: &str = "0033";
+
+#[async_trait]
+impl Migration for Migration0033<'_> {
+    async fn can_apply(&self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn should_apply(&self) -> Result<bool, Error> {
+        // If the table doesn't exist, we need to create it
+        if !check_table_exists(self.clickhouse, "DeploymentID", MIGRATION_ID).await? {
+            return Ok(true);
+        }
+        // If the table is empty, we need to insert the deployment ID
+        if !table_is_nonempty(self.clickhouse, "DeploymentID", MIGRATION_ID).await? {
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    async fn apply(&self, _clean_start: bool) -> Result<(), Error> {
+        self.clickhouse
+            .run_query_synchronous_no_params(
+                r#"CREATE TABLE IF NOT EXISTS DeploymentID (
+                        deployment_id String,
+                        dummy UInt32 DEFAULT 0, -- the dummy column is used to enforce a single row in the table
+                        created_at DateTime DEFAULT now(),
+                        version_number UInt32 DEFAULT 4294967295 - toUInt32(now()) -- So that the oldest version is highest version number
+                        -- we hardcode UINT32_MAX
+                    )
+                    ENGINE = ReplacingMergeTree(
+                        version_number
+                    )
+                    ORDER BY dummy;"#
+                    .to_string(),
+            )
+            .await?;
+        // Generate a UUIDv7 and compute the blake3 hash
+        let deployment_id = generate_deployment_id();
+        // Insert the deployment ID into the table
+        self.clickhouse
+            .write(
+                &[serde_json::json!({
+                    "deployment_id": deployment_id,
+                })],
+                "DeploymentID",
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    fn rollback_instructions(&self) -> String {
+        r#"DROP TABLE DeploymentID;"#.to_string()
+    }
+
+    async fn has_succeeded(&self) -> Result<bool, Error> {
+        let should_apply = self.should_apply().await?;
+        Ok(!should_apply)
+    }
+}
+
+fn generate_deployment_id() -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(Uuid::now_v7().as_bytes());
+    // Should generate a hex string of length 64
+    hasher.finalize().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deployment_id() {
+        let deployment_id = generate_deployment_id();
+        assert_eq!(deployment_id.len(), 64);
+        // Assert that the deployment ID contains only hex characters
+        assert!(deployment_id.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/tensorzero-core/src/clickhouse/migration_manager/migrations/mod.rs
+++ b/tensorzero-core/src/clickhouse/migration_manager/migrations/mod.rs
@@ -29,6 +29,7 @@ pub mod migration_0028;
 pub mod migration_0029;
 pub mod migration_0030;
 pub mod migration_0031;
+pub mod migration_0033;
 
 /// Returns true if the table exists, false if it does not
 /// Errors if the query fails

--- a/tensorzero-core/src/clickhouse/migration_manager/mod.rs
+++ b/tensorzero-core/src/clickhouse/migration_manager/mod.rs
@@ -1,7 +1,6 @@
 pub mod migration_trait;
 pub mod migrations;
 
-use crate::clickhouse::migration_manager::migrations::migration_0031::Migration0031;
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::error::{Error, ErrorDetails};
 use async_trait::async_trait;
@@ -30,10 +29,12 @@ use migrations::migration_0027::Migration0027;
 use migrations::migration_0028::Migration0028;
 use migrations::migration_0029::Migration0029;
 use migrations::migration_0030::Migration0030;
+use migrations::migration_0031::Migration0031;
+use migrations::migration_0033::Migration0033;
 
 /// This must match the number of migrations returned by `make_all_migrations` - the tests
 /// will panic if they don't match.
-pub const NUM_MIGRATIONS: usize = 25;
+pub const NUM_MIGRATIONS: usize = 26;
 
 /// Constructs (but does not run) a vector of all our database migrations.
 /// This is the single source of truth for all migration - it's used during startup to migrate
@@ -80,6 +81,7 @@ pub fn make_all_migrations<'a>(
         Box::new(Migration0029 { clickhouse }),
         Box::new(Migration0030 { clickhouse }),
         Box::new(Migration0031 { clickhouse }),
+        Box::new(Migration0033 { clickhouse }),
     ];
     assert_eq!(
         migrations.len(),

--- a/tensorzero-core/tests/e2e/clickhouse.rs
+++ b/tensorzero-core/tests/e2e/clickhouse.rs
@@ -489,7 +489,10 @@ async fn test_rollback_helper(migration_num: usize, logs_contain: fn(&str) -> bo
 invoke_all_separate_tests!(
     test_rollback_helper,
     test_rollback_up_to_migration_index_,
-    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
+    [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+        25
+    ]
 );
 
 #[tokio::test(flavor = "multi_thread")]
@@ -655,7 +658,7 @@ async fn test_clickhouse_migration_manager() {
         // for each element in the array.
         [
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
-            24
+            24, 25
         ]
     );
     run_all(&migrations).await;
@@ -682,6 +685,32 @@ async fn test_bad_clickhouse_write() {
 async fn test_clean_clickhouse_start() {
     let (clickhouse, _cleanup_db) = get_clean_clickhouse(false);
     migration_manager::run(&clickhouse).await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_deployment_id_oldest() {
+    let (clickhouse, _cleanup_db) = get_clean_clickhouse(false);
+    migration_manager::run(&clickhouse).await.unwrap();
+    // Add a row to the DeploymentID table and make sure that it isn't returned
+    let new_deployment_id = "foo";
+    clickhouse
+        .write(
+            &[serde_json::json!({
+                "deployment_id": new_deployment_id,
+            })],
+            "DeploymentID",
+        )
+        .await
+        .unwrap();
+    // Run a query that gets the newest deployment ID but since it's final it shouldn't be foo
+    let deployment_id = clickhouse
+        .run_query_synchronous_no_params(
+            "SELECT deployment_id FROM DeploymentID FINAL ORDER BY created_at DESC LIMIT 1"
+                .to_string(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(deployment_id, new_deployment_id);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Adds a table DeploymentID that is designed to keep a single (oldest value) that is a blake3 hex hash of a UUIDv7 we generate. Also added tests that ClickHouse keeps the oldest and that the blake3 thing generates the right thing.

```
CREATE TABLE IF NOT EXISTS DeploymentID (
                        deployment_id String,
                        dummy UInt32 DEFAULT 0, -- the dummy column is used to enforce a single row in the table
                        created_at DateTime DEFAULT now(),
                        version_number UInt32 DEFAULT 4294967295 - toUInt32(now()) -- So that the oldest version is highest version number
                        -- we hardcode UINT32_MAX
                    )
                    ENGINE = ReplacingMergeTree(
                        version_number
                    )
                    ORDER BY dummy;
```