### PR TITLE
Use deploy key in checkout step in regen-fixtures command

### DIFF
--- a/.github/workflows/slash-command-regen-fixtures.yml
+++ b/.github/workflows/slash-command-regen-fixtures.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
+          ssh-key: "${{ secrets.REGEN_FIXTURES_DEPLOY_KEY }}"
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:


### PR DESCRIPTION
Pushing with a deploy key will trigger PR CI

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
