### PR TITLE
Add 'delete = true' to extra_headers config

### DIFF
--- a/clients/openai-python/tests/test_openai_compatibility.py
+++ b/clients/openai-python/tests/test_openai_compatibility.py
@@ -1025,6 +1025,16 @@ async def test_async_extra_headers_param(async_client):
                     "name": "x-my-extra-header",
                     "value": "my-extra-header-value",
                 },
+                {
+                    "model_provider_name": "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
+                    "name": "x-my-delete-header",
+                    "value": "Should be deleted",
+                },
+                {
+                    "model_provider_name": "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
+                    "name": "x-my-delete-header",
+                    "delete": True,
+                },
             ]
         },
         messages=messages,

--- a/tensorzero-core/src/inference/types/extra_body.rs
+++ b/tensorzero-core/src/inference/types/extra_body.rs
@@ -1,5 +1,5 @@
-use serde::de::Error;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use super::{deserialize_delete, serialize_delete};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
@@ -25,26 +25,6 @@ pub enum ExtraBodyReplacementKind {
         deserialize_with = "deserialize_delete"
     )]
     Delete,
-}
-
-fn serialize_delete<S>(s: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    true.serialize(s)
-}
-
-fn deserialize_delete<'de, D>(d: D) -> Result<(), D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let val = bool::deserialize(d)?;
-    if !val {
-        return Err(D::Error::custom(
-            "Error deserializing extra body replacement: 'delete' must be 'true', or not set",
-        ));
-    }
-    Ok(())
 }
 
 /// The 'InferenceExtraBody' options provided directly in an inference request

--- a/tensorzero-core/src/inference/types/extra_headers.rs
+++ b/tensorzero-core/src/inference/types/extra_headers.rs
@@ -1,3 +1,4 @@
+use super::{deserialize_delete, serialize_delete};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
@@ -6,10 +7,23 @@ pub struct ExtraHeadersConfig {
     pub data: Vec<ExtraHeader>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ExtraHeader {
     pub name: String,
-    pub value: String,
+    #[serde(flatten)]
+    pub kind: ExtraHeaderKind,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtraHeaderKind {
+    Value(String),
+    // We only allow `"delete": true` to be set - deserializing `"delete": false` will error
+    #[serde(
+        serialize_with = "serialize_delete",
+        deserialize_with = "deserialize_delete"
+    )]
+    Delete,
 }
 
 /// The 'InferenceExtraHeaders' options provided directly in an inference request
@@ -58,12 +72,14 @@ pub enum InferenceExtraHeader {
     Provider {
         model_provider_name: String,
         name: String,
-        value: String,
+        #[serde(flatten)]
+        kind: ExtraHeaderKind,
     },
     Variant {
         variant_name: String,
         name: String,
-        value: String,
+        #[serde(flatten)]
+        kind: ExtraHeaderKind,
     },
 }
 

--- a/tensorzero-core/src/inference/types/mod.rs
+++ b/tensorzero-core/src/inference/types/mod.rs
@@ -17,7 +17,7 @@ use pyo3::types::{PyAny, PyList};
 use pyo3_helpers::{content_block_to_python, serialize_to_dict};
 use resolved_input::FileWithPath;
 pub use resolved_input::{ResolvedInput, ResolvedInputMessage, ResolvedInputMessageContent};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{Map, Value};
 use serde_untagged::UntaggedEnumVisitor;
 use std::borrow::Borrow;
@@ -44,6 +44,7 @@ use crate::{
     tool::{ToolCall, ToolCallChunk, ToolCallConfig, ToolCallOutput, ToolResult},
 };
 use crate::{jsonschema_util::DynamicJSONSchema, tool::ToolCallConfigDatabaseInsert};
+use serde::de::Error as _;
 
 pub mod batch;
 pub mod extra_body;
@@ -1888,6 +1889,26 @@ fn borrow_cow<'a, T: ToOwned + ?Sized>(cow: &'a Cow<'a, T>) -> Cow<'a, T> {
         Cow::Borrowed(x) => Cow::Borrowed(x),
         Cow::Owned(x) => Cow::Borrowed(x.borrow()),
     }
+}
+
+pub(super) fn serialize_delete<S>(s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    true.serialize(s)
+}
+
+pub(super) fn deserialize_delete<'de, D>(d: D) -> Result<(), D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let val = bool::deserialize(d)?;
+    if !val {
+        return Err(D::Error::custom(
+            "Error deserializing extra body replacement: 'delete' must be 'true', or not set",
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is very similar to 'delete = true' for extra_body:

```
{
    "model_provider_name": "tensorzero::model_name::dummy::echo_extra_info::provider_name::dummy",
    "name": "x-my-delete-header",
    "delete": true,
}
```

'delete = true' is supported in both config and inference-level extra_headers. When set, it removes the header with the matching 'name', if it exists

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
