### PR TITLE
Add human_feedback.rs to module

### DIFF
--- a/tensorzero-core/tests/e2e/human_feedback.rs
+++ b/tensorzero-core/tests/e2e/human_feedback.rs
@@ -110,25 +110,6 @@ async fn e2e_test_comment_human_feedback() {
     let id = result.get("feedback_id").unwrap().as_str().unwrap();
     let id_uuid = Uuid::parse_str(id).unwrap();
     assert_eq!(id_uuid, feedback_id);
-    // Check ClickHouse StaticEvaluationHumanFeedback
-    // Currently this fails because the output is being escaped as it is passed into the query to compare against the values
-    // in the table.
-    // We need to figure out how do effectively compare strings in ClickHouse without manually escaping them.
-    let result = select_human_static_evaluation_feedback_clickhouse(
-        &clickhouse,
-        "comment",
-        datapoint_id,
-        &serialized_inference_output,
-    )
-    .await
-    .unwrap();
-    assert_eq!(result.metric_name, "comment");
-    assert_eq!(result.datapoint_id, datapoint_id);
-    assert_eq!(result.output, serialized_inference_output);
-    assert_eq!(
-        result.value,
-        serde_json::to_string(&json!("good job!")).unwrap() // All feedback values are JSON encoded in the StaticEvaluationHumanFeedback table
-    );
 
     // Running without datapoint_id.
     // We generate a new datapoint_id so these don't trample. We'll only use it to check that there is no StaticEvaluationHumanFeedback

--- a/tensorzero-core/tests/e2e/human_feedback.rs
+++ b/tensorzero-core/tests/e2e/human_feedback.rs
@@ -62,9 +62,11 @@ async fn e2e_test_comment_human_feedback() {
     let serialized_inference_output =
         serde_json::to_string(&inference_response_json.get("output").unwrap()).unwrap();
 
+    let evaluator_id = Uuid::now_v7();
+
     let datapoint_id = Uuid::now_v7();
     // Test comment human evaluation feedback on episode
-    let payload = json!({"episode_id": episode_id, "metric_name": "comment", "value": "good job!", "internal": true, "tags": {"tensorzero::datapoint_id": datapoint_id.to_string(), "tensorzero::human_feedback": "true"}});
+    let payload = json!({"episode_id": episode_id, "metric_name": "comment", "value": "good job!", "internal": true, "tags": {"tensorzero::evaluator_inference_id": evaluator_id.to_string(), "tensorzero::datapoint_id": datapoint_id.to_string(), "tensorzero::human_feedback": "true"}});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
         .json(&payload)
@@ -367,7 +369,7 @@ async fn e2e_test_demonstration_feedback_json() {
     let retrieved_value = serde_json::from_str::<JsonInferenceOutput>(retrieved_value).unwrap();
     let expected_value = JsonInferenceOutput {
         parsed: Some(json!({"answer": "Tokyo"})),
-        raw: "{\"answer\":\"Tokyo\"}".to_string(),
+        raw: Some("{\"answer\":\"Tokyo\"}".to_string()),
     };
     assert_eq!(retrieved_value, expected_value);
 
@@ -493,7 +495,7 @@ async fn e2e_test_demonstration_feedback_dynamic_json() {
     let retrieved_value = serde_json::from_str::<JsonInferenceOutput>(retrieved_value).unwrap();
     let expected_value = JsonInferenceOutput {
         parsed: Some(json!({"answer": "Tokyo", "comment": "This is a comment"})),
-        raw: "{\"answer\":\"Tokyo\",\"comment\":\"This is a comment\"}".to_string(),
+        raw: Some("{\"answer\":\"Tokyo\",\"comment\":\"This is a comment\"}".to_string()),
     };
     assert_eq!(retrieved_value, expected_value);
 
@@ -966,8 +968,7 @@ async fn e2e_test_float_feedback() {
     let error_message = response_json.get("error").unwrap().as_str().unwrap();
     assert!(
         error_message.contains("Correct ID was not provided for feedback level"),
-        "Unexpected error message: {}",
-        error_message
+        "Unexpected error message: {error_message}"
     );
 
     // Running without valid inference_id. Should fail.
@@ -1138,8 +1139,7 @@ async fn e2e_test_boolean_feedback() {
     let error_message = response_json.get("error").unwrap().as_str().unwrap();
     assert!(
         error_message.contains("Correct ID was not provided for feedback level"),
-        "Unexpected error message: {}",
-        error_message
+        "Unexpected error message: {error_message}"
     );
 
     // Try string feedback (should fail)

--- a/tensorzero-core/tests/e2e/tests.rs
+++ b/tensorzero-core/tests/e2e/tests.rs
@@ -10,6 +10,7 @@ mod dynamic_evaluations;
 mod fallback;
 mod feedback;
 mod health;
+mod human_feedback;
 mod human_static_evaluation_feedback;
 mod inference;
 mod list_inferences;


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `human_feedback` module and update tests in `human_feedback.rs` for evaluator ID and error message consistency.
> 
>   - **Modules**:
>     - Add `human_feedback` module to `tests.rs`.
>   - **Tests**:
>     - In `human_feedback.rs`, add `evaluator_id` to feedback payload.
>     - Remove ClickHouse `StaticEvaluationHumanFeedback` checks in `human_feedback.rs`.
>     - Update error message assertions in `e2e_test_float_feedback` and `e2e_test_boolean_feedback` for consistency.
>     - Modify `JsonInferenceOutput` struct usage in `e2e_test_demonstration_feedback_json` and `e2e_test_demonstration_feedback_dynamic_json` to use `Some` for `raw` field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3817b293008cd698f3fa8154f35b8e022c53496b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->