### PR TITLE
Fix a few more deprecation warnings in rust/python e2e tests

### DIFF
--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -750,7 +750,10 @@ async def test_async_json_streaming(async_client: AsyncTensorZeroGateway):
         input={
             "system": {"assistant_name": "Alfred Pennyworth"},
             "messages": [
-                {"role": "user", "content": {"country": "Japan"}},
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "arguments": {"country": "Japan"}}],
+                },
                 {"role": "assistant", "content": "ok"},
                 # This function has a user schema but we can bypass with RawText
                 {"role": "user", "content": [RawText(value="Hello")]},

--- a/tensorzero-core/tests/e2e/providers/anthropic.rs
+++ b/tensorzero-core/tests/e2e/providers/anthropic.rs
@@ -865,7 +865,7 @@ async fn test_streaming_thinking() {
                             "type": "tool_call",
                             "name": "get_capital",
                             "id": tool_call_id,
-                            "arguments": serde_json::Value::String(content_blocks[tool_call_id].to_string()),
+                            "raw_arguments": content_blocks[tool_call_id].to_string(),
                         },
                     ]
                 },

--- a/tensorzero-core/tests/e2e/providers/batch.rs
+++ b/tensorzero-core/tests/e2e/providers/batch.rs
@@ -3928,7 +3928,7 @@ pub async fn test_json_mode_batch_inference_request_with_provider(provider: E2ET
                "messages": [
                 {
                     "role": "user",
-                    "content": {"country": "Japan"}
+                    "content": [{"type": "text", "arguments": {"country": "Japan"}}]
                 }
             ]}],
         "tags": [{"test_type": "json_mode"}]
@@ -4268,7 +4268,7 @@ pub async fn test_dynamic_json_mode_batch_inference_request_with_provider(
                "messages": [
                 {
                     "role": "user",
-                    "content": {"country": "Japan"}
+                    "content": [{"type": "text", "arguments": {"country": "Japan"}}]
                 }
             ]}],
         "output_schemas": [output_schema.clone()],


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix deprecation warnings in Rust and Python e2e tests by updating JSON content structure in test cases.
> 
>   - **Behavior**:
>     - Update JSON content structure in `test_async_json_streaming` in `test_client.py` to use a list with `type` and `arguments` keys.
>     - Modify JSON content in `test_json_mode_batch_inference_request_with_provider` and `test_dynamic_json_mode_batch_inference_request_with_provider` in `batch.rs` to use a list with `type` and `arguments` keys.
>     - Change `arguments` to `raw_arguments` in `test_streaming_thinking` in `anthropic.rs` for tool call content.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c66a7a535eaf9fde6df5294b8350748c74381176. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->