### PR TITLE
Remove explicit timeout from optimization-test-cron.yml

### DIFF
--- a/.github/workflows/optimization-test-cron.yml
+++ b/.github/workflows/optimization-test-cron.yml
@@ -14,7 +14,6 @@ jobs:
   optimization-tests:
     if: github.repository == 'tensorzero/tensorzero'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
We already have a timeout applied within 'cargo nextest'

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove redundant timeout setting from `optimization-test-cron.yml` in favor of `cargo nextest`'s internal timeout.
> 
>   - **GitHub Actions**:
>     - Remove `timeout-minutes: 30` from `optimization-test-cron.yml` as `cargo nextest` already applies a timeout.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ecb63b0e43ced272345263c13b5381a375d18b6b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->