### PR TITLE
Set regen-fixtures commit author to github-actions[bot]@users.noreply…

### DIFF
--- a/.github/workflows/slash-command-regen-fixtures.yml
+++ b/.github/workflows/slash-command-regen-fixtures.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Push to PR
         run: |
           git config --global user.name "TensorZero Bot"
-          git config --global user.email "bot@tensorzero.com"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           git commit -m "Regenerate ModelInferenceCache fixtures"
           git push


### PR DESCRIPTION
….github.com

This should avoid the need to make a bot account

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
