### PR TITLE
Use 'performance' profile in gateway Dockerfile

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -13,7 +13,7 @@ ARG CARGO_BUILD_FLAGS=""
 RUN --mount=type=cache,id=tensorzero-gateway-release,sharing=shared,target=/usr/local/cargo/registry \
     --mount=type=cache,id=tensorzero-gateway-release,sharing=shared,target=/usr/local/cargo/git \
     cargo build --profile performance -p gateway $CARGO_BUILD_FLAGS && \
-    cp -r /src/target/release /release
+    cp -r /src/target/performance /release
 
 # ========== base ==========
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -12,7 +12,7 @@ ARG CARGO_BUILD_FLAGS=""
 
 RUN --mount=type=cache,id=tensorzero-gateway-release,sharing=shared,target=/usr/local/cargo/registry \
     --mount=type=cache,id=tensorzero-gateway-release,sharing=shared,target=/usr/local/cargo/git \
-    cargo build --release -p gateway $CARGO_BUILD_FLAGS && \
+    cargo build --profile performance -p gateway $CARGO_BUILD_FLAGS && \
     cp -r /src/target/release /release
 
 # ========== base ==========


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Switches build profile from 'release' to 'performance' in `gateway/Dockerfile`.
> 
>   - **Dockerfile Changes**:
>     - In `gateway/Dockerfile`, change build profile from `release` to `performance` in the `cargo build` command.
>     - Update copy command to use `/src/target/performance` instead of `/src/target/release`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 07f3d5d821f51e7a2e60752ad64cc597fefc65a2. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->