### PR TITLE
Add `[gateway.base_path]` option to config

### DIFF
--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -271,7 +271,7 @@ async fn main() {
     let base_path = base_path.trim_end_matches("/");
 
     // The path was just `/` (or multiple slashes)
-    let router = if base_path == "" {
+    let router = if base_path.is_empty() {
         Router::new().merge(api_routes)
     } else {
         Router::new().nest(base_path, api_routes)

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -268,9 +268,10 @@ async fn main() {
         tracing::error!("[gateway.base_path] must start with a `/` : `{base_path}`");
         std::process::exit(1);
     }
+    let base_path = base_path.trim_end_matches("/");
 
-    // Axum panics if we use 'nest' with a path of "/"
-    let router = if base_path == "/" {
+    // The path was just `/` (or multiple slashes)
+    let router = if base_path == "" {
         Router::new().merge(api_routes)
     } else {
         Router::new().nest(base_path, api_routes)

--- a/gateway/tests/base_path.rs
+++ b/gateway/tests/base_path.rs
@@ -1,0 +1,82 @@
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::print_stdout)]
+use crate::common::{start_gateway_on_random_port, ChildData};
+
+mod common;
+
+#[tokio::test]
+async fn test_base_path_no_trailing_slash() {
+    let child_data = start_gateway_on_random_port(
+        r#"
+        base_path = "/my/prefix"
+    "#,
+        None,
+    )
+    .await;
+
+    test_base_path(child_data).await;
+}
+
+#[tokio::test]
+async fn test_base_path_with_trailing_slash() {
+    let child_data = start_gateway_on_random_port(
+        r#"
+        base_path = "/my/prefix/"
+    "#,
+        None,
+    )
+    .await;
+
+    test_base_path(child_data).await;
+}
+
+async fn test_base_path(child_data: ChildData) {
+    // The health endpoint should be available at the base path
+    let health_response = reqwest::Client::new()
+        .get(format!("http://{}/my/prefix/health", child_data.addr))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert_eq!(health_response, r#"{"gateway":"ok","clickhouse":"ok"}"#);
+
+    let inference_response = reqwest::Client::new()
+        .post(format!("http://{}/my/prefix/inference", child_data.addr))
+        .body("{}")
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    assert_eq!(inference_response, r#"{"error":"missing field `input`"}"#);
+
+    // The normal endpoints should not be available
+    let bad_health_response = reqwest::Client::new()
+        .get(format!("http://{}/health", child_data.addr))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert_eq!(
+        bad_health_response,
+        r#"{"error":"Route not found: GET /health"}"#
+    );
+
+    let bad_inference_response = reqwest::Client::new()
+        .post(format!("http://{}/inference", child_data.addr))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert_eq!(
+        bad_inference_response,
+        r#"{"error":"Route not found: POST /inference"}"#
+    );
+}

--- a/gateway/tests/common/mod.rs
+++ b/gateway/tests/common/mod.rs
@@ -1,0 +1,100 @@
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::print_stdout)]
+use std::{net::SocketAddr, process::Stdio};
+
+use tempfile::NamedTempFile;
+use tokio::{
+    io::{AsyncBufReadExt, BufReader, Lines},
+    process::{Child, ChildStdout, Command},
+};
+
+const GATEWAY_PATH: &str = env!("CARGO_BIN_EXE_gateway");
+
+pub async fn start_gateway_on_random_port(
+    config_suffix: &str,
+    rust_log: Option<&str>,
+) -> ChildData {
+    let config_str = format!(
+        r#"
+        [gateway]
+        observability.enabled = false
+        bind_address = "0.0.0.0:0"
+        {config_suffix}
+    "#
+    );
+
+    let tmpfile = NamedTempFile::new().unwrap();
+    std::fs::write(tmpfile.path(), config_str).unwrap();
+
+    let mut builder = Command::new(GATEWAY_PATH);
+    builder
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .args([
+            "--config-file",
+            tmpfile.path().to_str().unwrap(),
+            "--log-format",
+            "json",
+        ])
+        // Make sure we don't inherit `RUST_LOG` from the outer `cargo test/nextest` invocation
+        .env_remove("RUST_LOG")
+        .kill_on_drop(true);
+
+    if let Some(rust_log) = rust_log {
+        builder.env("RUST_LOG", rust_log);
+    }
+
+    let mut child = builder.spawn().unwrap();
+    let mut stdout = tokio::io::BufReader::new(child.stdout.take().unwrap()).lines();
+
+    let mut output = Vec::new();
+    let mut listening_line = None;
+    while let Some(line) = stdout.next_line().await.unwrap() {
+        println!("gateway output line: {line}");
+        output.push(line.clone());
+        if line.contains("listening on 0.0.0.0:") {
+            listening_line = Some(line);
+            break;
+        }
+    }
+
+    let port = listening_line
+        .expect("Gateway exited before listening")
+        .split_once("listening on 0.0.0.0:")
+        .expect("Gateway didn't log listening line")
+        .1
+        .split(" ")
+        .next()
+        .unwrap()
+        .parse::<u16>()
+        .unwrap();
+
+    ChildData {
+        addr: format!("0.0.0.0:{port}").parse::<SocketAddr>().unwrap(),
+        output,
+        stdout,
+        child,
+    }
+}
+
+#[expect(dead_code)] // Not all e2e tests use all fields
+pub struct ChildData {
+    pub addr: SocketAddr,
+    pub output: Vec<String>,
+    pub stdout: Lines<BufReader<ChildStdout>>,
+    // This kills the child on drop
+    pub child: Child,
+}
+
+impl ChildData {
+    #[allow(dead_code, clippy::allow_attributes)]
+    pub async fn call_health_endpoint(&self) -> String {
+        reqwest::Client::new()
+            .get(format!("http://{}/health", self.addr))
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap()
+    }
+}

--- a/gateway/tests/logging.rs
+++ b/gateway/tests/logging.rs
@@ -1,14 +1,9 @@
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::print_stdout)]
 
-use std::{net::SocketAddr, process::Stdio, time::Duration};
+mod common;
 
-use tempfile::NamedTempFile;
-use tokio::{
-    io::{AsyncBufReadExt, BufReader, Lines},
-    process::{Child, ChildStdout, Command},
-};
-
-const GATEWAY_PATH: &str = env!("CARGO_BIN_EXE_gateway");
+use common::start_gateway_on_random_port;
+use std::time::Duration;
 
 /// Test the gateway does not log '/health' requests when RUST_LOG and [gateway.debug] are not set
 #[tokio::test]
@@ -69,90 +64,4 @@ async fn test_logging_rust_log_debug_on() {
         tokio::time::timeout(Duration::from_secs(1), child_data.stdout.next_line())
             .await
             .expect_err("Gateway wrote to stdout after /health endpoint in non-debug mode");
-}
-
-struct ChildData {
-    addr: SocketAddr,
-    #[expect(dead_code)]
-    output: Vec<String>,
-    stdout: Lines<BufReader<ChildStdout>>,
-    #[expect(dead_code)] // This kills the child on drop
-    child: Child,
-}
-
-impl ChildData {
-    async fn call_health_endpoint(&self) -> String {
-        reqwest::Client::new()
-            .get(format!("http://{}/health", self.addr))
-            .send()
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap()
-    }
-}
-
-async fn start_gateway_on_random_port(config_suffix: &str, rust_log: Option<&str>) -> ChildData {
-    let config_str = format!(
-        r#"
-        [gateway]
-        observability.enabled = false
-        bind_address = "0.0.0.0:0"
-        {config_suffix}
-    "#
-    );
-
-    let tmpfile = NamedTempFile::new().unwrap();
-    std::fs::write(tmpfile.path(), config_str).unwrap();
-
-    let mut builder = Command::new(GATEWAY_PATH);
-    builder
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .args([
-            "--config-file",
-            tmpfile.path().to_str().unwrap(),
-            "--log-format",
-            "json",
-        ])
-        // Make sure we don't inherit `RUST_LOG` from the outer `cargo test/nextest` invocation
-        .env_remove("RUST_LOG")
-        .kill_on_drop(true);
-
-    if let Some(rust_log) = rust_log {
-        builder.env("RUST_LOG", rust_log);
-    }
-
-    let mut child = builder.spawn().unwrap();
-    let mut stdout = tokio::io::BufReader::new(child.stdout.take().unwrap()).lines();
-
-    let mut output = Vec::new();
-    let mut listening_line = None;
-    while let Some(line) = stdout.next_line().await.unwrap() {
-        println!("gateway output line: {line}");
-        output.push(line.clone());
-        if line.contains("listening on 0.0.0.0:") {
-            listening_line = Some(line);
-            break;
-        }
-    }
-
-    let port = listening_line
-        .expect("Gateway exited before listening")
-        .split_once("listening on 0.0.0.0:")
-        .expect("Gateway didn't log listening line")
-        .1
-        .split(" ")
-        .next()
-        .unwrap()
-        .parse::<u16>()
-        .unwrap();
-
-    ChildData {
-        addr: format!("0.0.0.0:{port}").parse::<SocketAddr>().unwrap(),
-        output,
-        stdout,
-        child,
-    }
 }

--- a/tensorzero-core/src/config_parser.rs
+++ b/tensorzero-core/src/config_parser.rs
@@ -98,6 +98,9 @@ pub struct GatewayConfig {
     pub enable_template_filesystem_access: bool,
     #[serde(default)]
     pub export: ExportConfig,
+    // If set, all of the HTTP endpoints will have this path prepended.
+    // E.g. a base path of `/custom/prefix` will cause the inference endpoint to become `/custom/prefix/inference`.
+    pub base_path: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/tensorzero-core/src/gateway_util.rs
+++ b/tensorzero-core/src/gateway_util.rs
@@ -244,6 +244,7 @@ mod tests {
             debug: false,
             enable_template_filesystem_access: false,
             export: Default::default(),
+            base_path: None,
         };
 
         let config = Box::leak(Box::new(Config {
@@ -295,6 +296,7 @@ mod tests {
             debug: false,
             enable_template_filesystem_access: false,
             export: Default::default(),
+            base_path: None,
         };
 
         let config = Box::leak(Box::new(Config {
@@ -317,6 +319,7 @@ mod tests {
             debug: false,
             enable_template_filesystem_access: false,
             export: Default::default(),
+            base_path: None,
         };
         let config = Box::leak(Box::new(Config {
             gateway: gateway_config,
@@ -341,6 +344,7 @@ mod tests {
             debug: false,
             enable_template_filesystem_access: false,
             export: Default::default(),
+            base_path: None,
         };
         let config = Config {
             gateway: gateway_config,


### PR DESCRIPTION
When set, we use `base_path` as a prefix for all of the routes that we register. For example, `gateway.base_path = "/my/prefix"` will cause us to register routes like `/my/prefix/health` and `/my/prefix/inference`

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `gateway.base_path` config option to prepend a base path to all HTTP endpoints, with validation and tests.
> 
>   - **Behavior**:
>     - Adds `gateway.base_path` option to prepend a base path to all HTTP endpoints in `main.rs`.
>     - Validates `base_path` starts with `/` and trims trailing slashes.
>     - Logs base path in startup message.
>   - **Tests**:
>     - Adds `test_base_path_no_trailing_slash` and `test_base_path_with_trailing_slash` in `base_path.rs` to verify endpoint availability with base path.
>     - Refactors `start_gateway_on_random_port` in `common/mod.rs` to support base path testing.
>   - **Config**:
>     - Updates `GatewayConfig` in `config_parser.rs` to include `base_path` field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for cfc48f9d1d05bfffb22a3519dba396a820dfba5f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->