### PR TITLE
Stop producing deprecation warnings in openai-go and openai-node

### DIFF
--- a/clients/openai-go/tests/openai_compatibility_test.go
+++ b/clients/openai-go/tests/openai_compatibility_test.go
@@ -52,18 +52,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func OldFormatSystemMessageWithAssistant(t *testing.T, assistant_name string) *openai.ChatCompletionSystemMessageParam {
-	t.Helper()
-
-	sysMsg := param.OverrideObj[openai.ChatCompletionSystemMessageParam](map[string]interface{}{
-		"content": []map[string]interface{}{
-			{"assistant_name": assistant_name},
-		},
-		"role": "system",
-	})
-	return &sysMsg
-}
-
 func systemMessageWithAssistant(t *testing.T, assistant_name string) *openai.ChatCompletionSystemMessageParam {
 	t.Helper()
 
@@ -132,7 +120,7 @@ func TestBasicInference(t *testing.T) {
 		episodeID, _ := uuid.NewV7()
 
 		messages := []openai.ChatCompletionMessageParamUnion{
-			{OfSystem: OldFormatSystemMessageWithAssistant(t, "Alfred Pennyworth")},
+			{OfSystem: systemMessageWithAssistant(t, "Alfred Pennyworth")},
 			openai.UserMessage("Hello"),
 		}
 
@@ -175,7 +163,7 @@ func TestBasicInference(t *testing.T) {
 		episodeID, _ := uuid.NewV7()
 
 		messages := []openai.ChatCompletionMessageParamUnion{
-			{OfSystem: OldFormatSystemMessageWithAssistant(t, "Alfred Pennyworth")},
+			{OfSystem: systemMessageWithAssistant(t, "Alfred Pennyworth")},
 			openai.UserMessage("Hello"),
 		}
 
@@ -214,7 +202,7 @@ func TestBasicInference(t *testing.T) {
 
 	t.Run("it should handle basic json schema parsing and throw proper validation error", func(t *testing.T) {
 		messages := []openai.ChatCompletionMessageParamUnion{
-			{OfSystem: OldFormatSystemMessageWithAssistant(t, "Alfred Pennyworth")},
+			{OfSystem: systemMessageWithAssistant(t, "Alfred Pennyworth")},
 			openai.UserMessage("Hello"),
 		}
 
@@ -248,7 +236,7 @@ func TestBasicInference(t *testing.T) {
 
 	t.Run("it should handle inference with cache", func(t *testing.T) {
 		messages := []openai.ChatCompletionMessageParamUnion{
-			{OfSystem: OldFormatSystemMessageWithAssistant(t, "Alfred Pennyworth")},
+			{OfSystem: systemMessageWithAssistant(t, "Alfred Pennyworth")},
 			openai.UserMessage("Hello"),
 		}
 
@@ -510,12 +498,17 @@ func TestBasicInference(t *testing.T) {
 
 		userMsg := param.OverrideObj[openai.ChatCompletionUserMessageParam](map[string]interface{}{
 			"content": []map[string]interface{}{
-				{"country": "Japan"},
+				{
+					"type": "text",
+					"tensorzero::arguments": map[string]interface{}{
+						"country": "Japan",
+					},
+				},
 			},
 			"role": "user",
 		})
 		messages := []openai.ChatCompletionMessageParamUnion{
-			{OfSystem: OldFormatSystemMessageWithAssistant(t, "Alfred Pennyworth")},
+			{OfSystem: systemMessageWithAssistant(t, "Alfred Pennyworth")},
 			{OfUser: &userMsg},
 		}
 
@@ -568,7 +561,12 @@ func TestBasicInference(t *testing.T) {
 		})
 		userMsg := param.OverrideObj[openai.ChatCompletionUserMessageParam](map[string]interface{}{
 			"content": []map[string]interface{}{
-				{"country": "Japan"},
+				{
+					"type": "text",
+					"tensorzero::arguments": map[string]interface{}{
+						"country": "Japan",
+					},
+				},
 			},
 			"role": "user",
 		})
@@ -596,7 +594,7 @@ func TestBasicInference(t *testing.T) {
 		episodeID, _ := uuid.NewV7()
 
 		messages := []openai.ChatCompletionMessageParamUnion{
-			{OfSystem: OldFormatSystemMessageWithAssistant(t, "Alfred Pennyworth")},
+			{OfSystem: systemMessageWithAssistant(t, "Alfred Pennyworth")},
 			openai.UserMessage("Hello, world!"),
 		}
 
@@ -647,7 +645,7 @@ func TestStreamingInference(t *testing.T) {
 			" pizza.",
 		}
 		messages := []openai.ChatCompletionMessageParamUnion{
-			{OfSystem: OldFormatSystemMessageWithAssistant(t, "Alfred Pennyworth")},
+			{OfSystem: systemMessageWithAssistant(t, "Alfred Pennyworth")},
 			openai.UserMessage("Hello"),
 		}
 
@@ -740,7 +738,7 @@ func TestStreamingInference(t *testing.T) {
 	t.Run("it should handle streaming inference with cache", func(t *testing.T) {
 		episodeID, _ := uuid.NewV7()
 		messages := []openai.ChatCompletionMessageParamUnion{
-			{OfSystem: OldFormatSystemMessageWithAssistant(t, "Alfred Pennyworth")},
+			{OfSystem: systemMessageWithAssistant(t, "Alfred Pennyworth")},
 			openai.UserMessage("Hello"),
 		}
 
@@ -849,7 +847,7 @@ func TestStreamingInference(t *testing.T) {
 		episodeID, _ := uuid.NewV7()
 
 		messages := []openai.ChatCompletionMessageParamUnion{
-			{OfSystem: OldFormatSystemMessageWithAssistant(t, "Alfred Pennyworth")},
+			{OfSystem: systemMessageWithAssistant(t, "Alfred Pennyworth")},
 			openai.UserMessage("Hello"),
 		}
 
@@ -875,7 +873,7 @@ func TestStreamingInference(t *testing.T) {
 		episodeID, _ := uuid.NewV7()
 
 		messages := []openai.ChatCompletionMessageParamUnion{
-			{OfSystem: OldFormatSystemMessageWithAssistant(t, "Alfred Pennyworth")},
+			{OfSystem: systemMessageWithAssistant(t, "Alfred Pennyworth")},
 			openai.UserMessage("Hello"),
 		}
 
@@ -900,7 +898,7 @@ func TestStreamingInference(t *testing.T) {
 		episodeID, _ := uuid.NewV7()
 
 		messages := []openai.ChatCompletionMessageParamUnion{
-			{OfSystem: OldFormatSystemMessageWithAssistant(t, "Alfred Pennyworth")},
+			{OfSystem: systemMessageWithAssistant(t, "Alfred Pennyworth")},
 			openai.UserMessage("Hello"),
 		}
 
@@ -925,7 +923,7 @@ func TestStreamingInference(t *testing.T) {
 		episodeID, _ := uuid.NewV7()
 
 		messages := []openai.ChatCompletionMessageParamUnion{
-			{OfSystem: OldFormatSystemMessageWithAssistant(t, "Alfred Pennyworth")},
+			{OfSystem: systemMessageWithAssistant(t, "Alfred Pennyworth")},
 			openai.UserMessage("Hello"),
 		}
 
@@ -951,7 +949,12 @@ func TestStreamingInference(t *testing.T) {
 
 		sysMsg := param.OverrideObj[openai.ChatCompletionSystemMessageParam](map[string]interface{}{
 			"content": []map[string]interface{}{
-				{"name_of_assistant": "Alfred Pennyworth"},
+				{
+					"type": "text",
+					"tensorzero::arguments": map[string]interface{}{
+						"name_of_assistant": "Alfred Pennyworth",
+					},
+				},
 			},
 			"role": "system",
 		})
@@ -986,12 +989,17 @@ func TestStreamingInference(t *testing.T) {
 
 		userMsg := param.OverrideObj[openai.ChatCompletionUserMessageParam](map[string]interface{}{
 			"content": []map[string]interface{}{
-				{"country": "Japan"},
+				{
+					"type": "text",
+					"tensorzero::arguments": map[string]interface{}{
+						"country": "Japan",
+					},
+				},
 			},
 			"role": "user",
 		})
 		messages := []openai.ChatCompletionMessageParamUnion{
-			{OfSystem: OldFormatSystemMessageWithAssistant(t, "Alfred Pennyworth")},
+			{OfSystem: systemMessageWithAssistant(t, "Alfred Pennyworth")},
 			{OfUser: &userMsg},
 		}
 
@@ -1089,7 +1097,7 @@ func TestToolCallingInference(t *testing.T) {
 		episodeID, _ := uuid.NewV7()
 
 		messages := []openai.ChatCompletionMessageParamUnion{
-			{OfSystem: OldFormatSystemMessageWithAssistant(t, "Alfred Pennyworth")},
+			{OfSystem: systemMessageWithAssistant(t, "Alfred Pennyworth")},
 			openai.UserMessage("Hi I'm visiting Brooklyn from Brazil. What's the weather?"),
 		}
 
@@ -1135,7 +1143,7 @@ func TestToolCallingInference(t *testing.T) {
 		episodeID, _ := uuid.NewV7()
 
 		messages := []openai.ChatCompletionMessageParamUnion{
-			{OfSystem: OldFormatSystemMessageWithAssistant(t, "Alfred Pennyworth")},
+			{OfSystem: systemMessageWithAssistant(t, "Alfred Pennyworth")},
 			openai.UserMessage("Hi I'm visiting Brooklyn from Brazil. What's the weather?"),
 		}
 
@@ -1175,7 +1183,7 @@ func TestToolCallingInference(t *testing.T) {
 		episodeID, _ := uuid.NewV7()
 
 		messages := []openai.ChatCompletionMessageParamUnion{
-			{OfSystem: OldFormatSystemMessageWithAssistant(t, "Alfred Pennyworth")},
+			{OfSystem: systemMessageWithAssistant(t, "Alfred Pennyworth")},
 			openai.UserMessage("Hi I'm visiting Brooklyn from Brazil. What's the weather?"),
 		}
 
@@ -1268,7 +1276,7 @@ func TestToolCallingInference(t *testing.T) {
 		episodeID, _ := uuid.NewV7()
 
 		messages := []openai.ChatCompletionMessageParamUnion{
-			{OfSystem: OldFormatSystemMessageWithAssistant(t, "Dr. Mehta")},
+			{OfSystem: systemMessageWithAssistant(t, "Dr. Mehta")},
 			openai.UserMessage("What is the weather like in Tokyo (in Celsius)? Use the provided `get_temperature` tool. Do not say anything else, just call the function."),
 		}
 
@@ -1353,12 +1361,17 @@ func TestToolCallingInference(t *testing.T) {
 
 		usrMsg := param.OverrideObj[openai.ChatCompletionUserMessageParam](map[string]interface{}{
 			"content": []map[string]interface{}{
-				{"country": "Japan"},
+				{
+					"type": "text",
+					"tensorzero::arguments": map[string]interface{}{
+						"country": "Japan",
+					},
+				},
 			},
 			"role": "user",
 		})
 		messages := []openai.ChatCompletionMessageParamUnion{
-			{OfSystem: OldFormatSystemMessageWithAssistant(t, "Alfred Pennyworth")},
+			{OfSystem: systemMessageWithAssistant(t, "Alfred Pennyworth")},
 			openai.UserMessage("Hi how are you?"),
 			{OfUser: &usrMsg},
 		}

--- a/clients/openai-node/tests/openai-compatibility.test.ts
+++ b/clients/openai-node/tests/openai-compatibility.test.ts
@@ -33,8 +33,11 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            assistant_name: "Alfred Pennyworth",
+            "tensorzero::arguments": {
+              assistant_name: "Alfred Pennyworth",
+            },
           },
         ],
       },
@@ -70,8 +73,11 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            assistant_name: "Alfred Pennyworth",
+            "tensorzero::arguments": {
+              assistant_name: "Alfred Pennyworth",
+            },
           },
         ],
       },
@@ -110,8 +116,11 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            name_of_assistant: "Alfred Pennyworth",
+            "tensorzero::arguments": {
+              name_of_assistant: "Alfred Pennyworth",
+            },
           },
         ],
       },
@@ -142,8 +151,11 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            assistant_name: "Alfred Pennyworth",
+            "tensorzero::arguments": {
+              assistant_name: "Alfred Pennyworth",
+            },
           },
         ],
       },
@@ -235,8 +247,11 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            assistant_name: "Alfred Pennyworth",
+            "tensorzero::arguments": {
+              assistant_name: "Alfred Pennyworth",
+            },
           },
         ],
       },
@@ -261,8 +276,11 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            assistant_name: "Alfred Pennyworth",
+            "tensorzero::arguments": {
+              assistant_name: "Alfred Pennyworth",
+            },
           },
         ],
       },
@@ -287,8 +305,11 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            assistant_name: "Alfred Pennyworth",
+            "tensorzero::arguments": {
+              assistant_name: "Alfred Pennyworth",
+            },
           },
         ],
       },
@@ -313,8 +334,11 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            assistant_name: "Alfred Pennyworth",
+            "tensorzero::arguments": {
+              assistant_name: "Alfred Pennyworth",
+            },
           },
         ],
       },
@@ -335,8 +359,11 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            name_of_assistant: "Alfred Pennyworth",
+            "tensorzero::arguments": {
+              name_of_assistant: "Alfred Pennyworth",
+            },
           },
         ],
       },
@@ -362,8 +389,11 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            assistant_name: "Alfred Pennyworth",
+            "tensorzero::arguments": {
+              assistant_name: "Alfred Pennyworth",
+            },
           },
         ],
       },
@@ -410,8 +440,11 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            assistant_name: "Alfred Pennyworth",
+            "tensorzero::arguments": {
+              assistant_name: "Alfred Pennyworth",
+            },
           },
         ],
       },
@@ -458,8 +491,11 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            assistant_name: "Alfred Pennyworth",
+            "tensorzero::arguments": {
+              assistant_name: "Alfred Pennyworth",
+            },
           },
         ],
       },
@@ -543,8 +579,11 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            assistant_name: "Alfred Pennyworth",
+            "tensorzero::arguments": {
+              assistant_name: "Alfred Pennyworth",
+            },
           },
         ],
       },
@@ -552,8 +591,11 @@ describe("OpenAI Compatibility", () => {
         role: "user",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            country: "Japan",
+            "tensorzero::arguments": {
+              country: "Japan",
+            },
           },
         ],
       },
@@ -630,7 +672,9 @@ describe("OpenAI Compatibility", () => {
           {
             type: "text",
             // @ts-expect-error - custom TensorZero property
-            "tensorzero::arguments": { assistant_name: "Alfred Pennyworth" },
+            "tensorzero::arguments": {
+              assistant_name: "Alfred Pennyworth",
+            },
           },
         ],
       },
@@ -671,8 +715,11 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            assistant_name: "Alfred Pennyworth",
+            "tensorzero::arguments": {
+              assistant_name: "Alfred Pennyworth",
+            },
           },
         ],
       },
@@ -680,8 +727,11 @@ describe("OpenAI Compatibility", () => {
         role: "user",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            country: "Japan",
+            "tensorzero::arguments": {
+              country: "Japan",
+            },
           },
         ],
       },
@@ -721,8 +771,11 @@ describe("OpenAI Compatibility", () => {
         role: "user",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            country: "Japan",
+            "tensorzero::arguments": {
+              country: "Japan",
+            },
           },
         ],
       },
@@ -745,8 +798,11 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            assistant_name: "Alfred Pennyworth",
+            "tensorzero::arguments": {
+              assistant_name: "Alfred Pennyworth",
+            },
           },
         ],
       },
@@ -778,8 +834,11 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            assistant_name: "Alfred Pennyworth",
+            "tensorzero::arguments": {
+              assistant_name: "Alfred Pennyworth",
+            },
           },
         ],
       },
@@ -829,8 +888,11 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            assistant_name: "Alfred Pennyworth",
+            "tensorzero::arguments": {
+              assistant_name: "Alfred Pennyworth",
+            },
           },
         ],
       },
@@ -938,8 +1000,11 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            assistant_name: "Dr. Mehta",
+            "tensorzero::arguments": {
+              assistant_name: "Dr. Mehta",
+            },
           },
         ],
       },
@@ -1031,9 +1096,12 @@ describe("OpenAI Compatibility", () => {
         role: "system",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            assistant_name: "Dr. Mehta",
-            schema: serializedOutputSchema,
+            "tensorzero::arguments": {
+              assistant_name: "Dr. Mehta",
+              schema: serializedOutputSchema,
+            },
           },
         ],
       },
@@ -1041,8 +1109,11 @@ describe("OpenAI Compatibility", () => {
         role: "user",
         content: [
           {
+            type: "text",
             // @ts-expect-error - custom TensorZero property
-            country: "Japan",
+            "tensorzero::arguments": {
+              country: "Japan",
+            },
           },
         ],
       },
@@ -1188,8 +1259,11 @@ it("should reject string input for function with input schema", async () => {
       role: "system",
       content: [
         {
+          type: "text",
           // @ts-expect-error - custom TensorZero property
-          assistant_name: "Alfred Pennyworth",
+          "tensorzero::arguments": {
+            assistant_name: "Alfred Pennyworth",
+          },
         },
       ],
     },
@@ -1198,8 +1272,11 @@ it("should reject string input for function with input schema", async () => {
       role: "user",
       content: [
         {
+          type: "text",
           // @ts-expect-error - custom TensorZero property
-          country: "Japan",
+          "tensorzero::arguments": {
+            country: "Japan",
+          },
         },
       ],
     },


### PR DESCRIPTION
We no longer invoke the openai-endpoint with the deprecated syntax in these tests. This should be fine, as we already have test coverage for this in Python (with the embedded gateway + patched openai client) and in Rust

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR updates `openai-go` and `openai-node` tests to remove deprecated syntax, ensuring no deprecation warnings are produced.
> 
>   - **Behavior**:
>     - Replaces `OldFormatSystemMessageWithAssistant` with `systemMessageWithAssistant` in `openai_compatibility_test.go` and `openai-compatibility.test.ts` to remove deprecated syntax.
>     - Updates message format to include `type: text` and `tensorzero::arguments` in `openai_compatibility_test.go` and `openai-compatibility.test.ts`.
>   - **Tests**:
>     - Ensures no deprecation warnings in `openai-go` and `openai-node` tests by using updated syntax.
>     - Maintains test coverage for deprecated syntax in Python and Rust.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8587412ab2569f808d6623b19f5a716f91a9970b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->