### PR TITLE
Use 'overrides' for cargo nextest optimization profile

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -31,10 +31,13 @@ default-filter = 'test(batch)'
 default-filter = 'test(test_dummy_only) | test(clickhouse)'
 
 [profile.optimization]
+default-filter = 'test(slow_optimization)'
+
+[[profile.optimization.overrides]]
 # Settings for running optimization tests
 # We may have to update this as we add faster optimization methods that shouldn't
 # take as long
-default-filter = 'test(slow_optimization)'
+filter = 'test(slow_optimization)'
 slow-timeout = { period = "21600s", terminate-after = 1 }
 retries = { count = 0, backoff = "fixed", delay = "0s" }
 


### PR DESCRIPTION
The 'profiles.default.overrides' was taking precedence over the standard 'profile.optimization' settings, so the optimization tests were getting a 10 second timeout applied

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix precedence issue in `.config/nextest.toml` to ensure `profile.optimization.overrides` apply correct timeout settings.
> 
>   - **Behavior**:
>     - Fixes precedence issue where `profiles.default.overrides` were overriding `profile.optimization` settings in `.config/nextest.toml`.
>     - Ensures `profile.optimization.overrides` apply correct timeout settings to optimization tests.
>   - **Configuration**:
>     - Moves `default-filter` from `profile.optimization` to `profile.optimization.overrides` in `.config/nextest.toml`.
>     - Adjusts `filter` in `profile.optimization.overrides` to ensure correct application of settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 9ec1d4e4febbf0212728e426205f357353071a9c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->