### PR TITLE
Use mixtral-8x22b-instruct for fireworks tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -48,7 +48,6 @@ retries = { count = 0, backoff = "fixed", delay = "0s" }
 # Run E2E provider tests sequentially to avoid rate limits
 [test-groups]
 e2e_aws_bedrock = { max-threads = 2 }
-e2e_fireworks = { max-threads = 1 }
 e2e_aws_sagemaker_tgi = { max-threads = 1 }
 # Our Sagemaker instance seems to be able to handle 2 concurrent requests
 e2e_aws_sagemaker_openai = { max-threads = 2 }
@@ -64,10 +63,6 @@ test-group = 'e2e_aws_sagemaker_openai'
 [[profile.default.overrides]]
 filter = 'binary(e2e) and test(providers::aws_sagemaker_tgi::)'
 test-group = 'e2e_aws_sagemaker_tgi'
-
-[[profile.default.overrides]]
-filter = 'binary(e2e) and test(providers::fireworks::)'
-test-group = 'e2e_fireworks'
 
 [[profile.default.overrides]]
 filter = 'binary(e2e) and test(providers::vllm::)'

--- a/tensorzero-core/fixtures/config/tensorzero.toml
+++ b/tensorzero-core/fixtures/config/tensorzero.toml
@@ -201,7 +201,7 @@ json_mode = "strict"
 
 [evaluations.evaluation1.evaluators.llm_judge_bool.variants.llama_promptA]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/llama4-maverick-instruct-basic"
+model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
 system_instructions = "fixtures/config/evaluations/evaluation1/llm_judge_bool/system_instructions.txt"
 json_mode = "strict"
 

--- a/tensorzero-core/tests/e2e/providers/fireworks.rs
+++ b/tensorzero-core/tests/e2e/providers/fireworks.rs
@@ -14,7 +14,7 @@ async fn get_providers() -> E2ETestProviders {
     let providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks".to_string(),
-        model_name: "qwen2p5-72b-instruct".into(),
+        model_name: "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];
@@ -38,7 +38,7 @@ async fn get_providers() -> E2ETestProviders {
     let inference_params_dynamic_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks-dynamic".to_string(),
-        model_name: "llama3.3-70b-instruct-fireworks-dynamic".into(),
+        model_name: "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct".into(),
         model_provider_name: "fireworks".into(),
         credentials,
     }];
@@ -46,7 +46,7 @@ async fn get_providers() -> E2ETestProviders {
     let tool_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks".to_string(),
-        model_name: "qwen2p5-72b-instruct".into(),
+        model_name: "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];
@@ -55,21 +55,21 @@ async fn get_providers() -> E2ETestProviders {
         E2ETestProvider {
             supports_batch_inference: false,
             variant_name: "fireworks".to_string(),
-            model_name: "llama3.3-70b-instruct-fireworks".into(),
+            model_name: "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct".into(),
             model_provider_name: "fireworks".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             supports_batch_inference: false,
             variant_name: "fireworks-implicit".to_string(),
-            model_name: "qwen2p5-72b-instruct".into(),
+            model_name: "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct".into(),
             model_provider_name: "fireworks".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             supports_batch_inference: false,
             variant_name: "fireworks-strict".to_string(),
-            model_name: "llama3.3-70b-instruct-fireworks".into(),
+            model_name: "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct".into(),
             model_provider_name: "fireworks".into(),
             credentials: HashMap::new(),
         },
@@ -78,7 +78,7 @@ async fn get_providers() -> E2ETestProviders {
     let json_mode_off_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks_json_mode_off".to_string(),
-        model_name: "llama3.3-70b-instruct-fireworks".into(),
+        model_name: "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];

--- a/tensorzero-core/tests/e2e/tensorzero.toml
+++ b/tensorzero-core/tests/e2e/tensorzero.toml
@@ -969,9 +969,9 @@ max_tokens = 100
 
 [functions.basic_test.variants.fireworks]
 type = "chat_completion"
-model = "qwen2p5-72b-instruct"
+model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
-max_tokens = 100
+max_tokens = 500
 
 [functions.basic_test.variants.fireworks-extra-body]
 type = "chat_completion"
@@ -989,7 +989,7 @@ extra_headers = [{ name = "Authorization", value = "invalid_fireworks_auth" }]
 
 [functions.basic_test.variants.fireworks-dynamic]
 type = "chat_completion"
-model = "llama3.3-70b-instruct-fireworks-dynamic"
+model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 
@@ -1686,7 +1686,7 @@ max_tokens = 100
 
 [functions.json_success.variants.fireworks]
 type = "chat_completion"
-model = "llama3.3-70b-instruct-fireworks"
+model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
 system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "on"
@@ -1694,7 +1694,7 @@ max_tokens = 100
 
 [functions.json_success.variants.fireworks-implicit]
 type = "chat_completion"
-model = "qwen2p5-72b-instruct"
+model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
 system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "implicit_tool"
@@ -1718,7 +1718,7 @@ max_tokens = 800
 
 [functions.json_success.variants.fireworks-strict]
 type = "chat_completion"
-model = "llama3.3-70b-instruct-fireworks"
+model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
 system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 max_tokens = 100
@@ -2122,7 +2122,7 @@ max_tokens = 100
 
 [functions.json_success.variants.fireworks_json_mode_off]
 type = "chat_completion"
-model = "llama3.3-70b-instruct-fireworks"
+model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "off"
@@ -2328,7 +2328,7 @@ max_tokens = 100
 
 [functions.dynamic_json.variants.fireworks]
 type = "chat_completion"
-model = "llama3.3-70b-instruct-fireworks"
+model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
 system_template = "../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 json_mode = "on"
@@ -2336,7 +2336,7 @@ max_tokens = 100
 
 [functions.dynamic_json.variants.fireworks-strict]
 type = "chat_completion"
-model = "llama3.3-70b-instruct-fireworks"
+model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
 system_template = "../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 max_tokens = 100
@@ -2344,7 +2344,7 @@ json_mode = "strict"
 
 [functions.dynamic_json.variants.fireworks-implicit]
 type = "chat_completion"
-model = "qwen2p5-72b-instruct"
+model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
 system_template = "../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 json_mode = "implicit_tool"
@@ -2846,7 +2846,7 @@ max_tokens = 100
 
 [functions.weather_helper.variants.fireworks]
 type = "chat_completion"
-model = "qwen2p5-72b-instruct"
+model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
 system_template = "../../fixtures/config/functions/weather_helper/prompt/system_template.minijinja"
 max_tokens = 100
 
@@ -3625,7 +3625,7 @@ json_mode = "strict"
 
 [evaluations.best_of_3.evaluators.llm_judge_bool.variants.llama_promptA]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/llama4-scout-instruct-basic"
+model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
 system_instructions = "../../fixtures/config/evaluations/best_of_3/llm_judge_bool/system_instructions.txt"
 json_mode = "strict"
 
@@ -3663,7 +3663,7 @@ json_mode = "strict"
 
 [evaluations.mixture_of_3.evaluators.llm_judge_bool.variants.llama_promptA]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/llama4-scout-instruct-basic"
+model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
 system_instructions = "../../fixtures/config/evaluations/best_of_3/llm_judge_bool/system_instructions.txt"
 json_mode = "strict"
 


### PR DESCRIPTION
This makes the tool call tests significantly less flaky - they almost always pass in two tries when running locally. I've also removed the test concurrency limitation for fireworks, as it doesn't seem to be needed

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
