### PR TITLE
Test using the ui with a custom gateway base_path

### DIFF
--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -9,6 +9,105 @@ on:
         required: true
 
 jobs:
+  ui-tests-gateway-prefix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "22.9.0"
+
+      - name: Setup `pnpm`
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+
+      - name: Install `pnpm` dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Playwright
+        run: pnpm --filter=tensorzero-ui exec playwright install --with-deps chromium
+
+      - name: Download `gateway` container
+        uses: namespace-actions/download-artifact@5c070f7d7ebdc47682b04aa736c76e46ff5f6e1e
+        with:
+          name: build-gateway-container
+
+      - name: Download `ui` container
+        uses: namespace-actions/download-artifact@5c070f7d7ebdc47682b04aa736c76e46ff5f6e1e
+        with:
+          name: build-ui-container
+
+      - name: Load `gateway` and `ui` containers
+        run: |
+          docker load < gateway-container.tar
+          docker load < ui-container.tar
+
+      # This allows us to use 'no-build' on subsequent steps
+      - name: Build needed docker images
+        working-directory: ui
+        run: |
+          docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml build fixtures mock-inference-provider
+
+      - name: Start Docker containers and apply fixtures
+        working-directory: ui
+        run: |
+          echo "FIREWORKS_ACCOUNT_ID=fake_fireworks_account" >> fixtures/.env
+          echo "FIREWORKS_API_KEY=not_used" >> fixtures/.env
+          echo "FIREWORKS_BASE_URL=http://mock-inference-provider:3030/fireworks/" >> fixtures/.env
+          echo "OPENAI_API_KEY=not_used" >> fixtures/.env
+          echo "OPENAI_BASE_URL=http://mock-inference-provider:3030/openai/" >> fixtures/.env
+          echo "S3_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> fixtures/.env
+          echo "S3_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> fixtures/.env
+          echo "TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero_ui_fixtures" >> fixtures/.env
+          echo "TENSORZERO_GATEWAY_URL=http://gateway:3000/custom/prefix" >> fixtures/.env
+          echo "TENSORZERO_GATEWAY_CONFIG=./config/tensorzero.base-path.toml"
+          echo "TENSORZERO_UI_CONFIG_PATH=./config/tensorzero.base-path.toml"
+          echo "TENSORZERO_GATEWAY_TAG=sha-${{ github.sha }}" >> fixtures/.env
+          echo "TENSORZERO_UI_TAG=sha-${{ github.sha }}" >> fixtures/.env
+          export TENSORZERO_SKIP_LARGE_FIXTURES=1
+          docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml up --no-build -d
+          docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml wait fixtures
+
+      - name: Run UI base-path E2E tests
+        id: e2e_tests
+        env:
+          TENSORZERO_CI: 1
+        continue-on-error: true
+        run: pnpm ui:test:e2e-base-path
+
+      - name: Print Docker Compose logs
+        if: always()
+        working-directory: ui
+        run: docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml logs -t
+
+      - name: Check for correct base-path in logs
+        working-directory: ui
+        run: |
+          docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml logs -t | grep "/custom/prefix"
+
+      - name: Print ClickHouse error logs
+        if: always()
+        run: docker exec fixtures-clickhouse-1 cat /var/log/clickhouse-server/clickhouse-server.err.log
+
+      - name: Print ClickHouse trace logs
+        if: always()
+        run: docker exec fixtures-clickhouse-1 cat /var/log/clickhouse-server/clickhouse-server.log
+
+      - name: Upload Playwright artifacts
+        if: steps.e2e_tests.outcome == 'failure'
+        uses: namespace-actions/upload-artifact@9a78c62e083914789d908952f9773e42744b9f68
+        with:
+          name: playwright-report-e2e-base-path
+          path: |
+            ui/playwright-report/
+            ui/test-results/
+          retention-days: 7
+
+      - name: Exit if tests failed
+        if: steps.e2e_tests.outcome == 'failure'
+        run: exit 1
+
+
   ui-tests-e2e:
     runs-on: namespace-profile-tensorzero-8x16
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "ui:storybook": "pnpm --filter=tensorzero-ui storybook",
     "ui:test": "pnpm --filter=tensorzero-ui test",
     "ui:test:e2e": "pnpm --filter=tensorzero-ui test-e2e",
+    "ui:test:e2e-base-path": "pnpm --filter=tensorzero-ui test-e2e-base-path",
     "clean:node": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +"
   },
   "devDependencies": {

--- a/tensorzero-core/tests/e2e/tensorzero.toml
+++ b/tensorzero-core/tests/e2e/tensorzero.toml
@@ -11,6 +11,7 @@ bind_address = "0.0.0.0:3000"
 debug = true
 enable_template_filesystem_access = true
 export.otlp.traces.enabled = true
+base_path = "/my/prefix"
 
 [object_storage]
 type = "disabled"

--- a/ui/e2e_tests/homePage.spec.ts
+++ b/ui/e2e_tests/homePage.spec.ts
@@ -7,3 +7,10 @@ test("should show the home page", async ({ page }) => {
   // Assert that "error" is not in the page
   await expect(page.getByText("error", { exact: false })).not.toBeVisible();
 });
+
+test("@base-path should check the health endpoint with the correct base path", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.getByText("TensorZero Gateway")).toBeVisible();
+});

--- a/ui/fixtures/docker-compose.e2e.yml
+++ b/ui/fixtures/docker-compose.e2e.yml
@@ -44,7 +44,7 @@ services:
       target: gateway
     volumes:
       - ./config:/app/config:ro
-    command: --config-file /app/config/tensorzero.e2e.toml
+    command: --config-file /app/config/${TENSORZERO_GATEWAY_CONFIG:-tensorzero.e2e.toml}
     environment:
       TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero_ui_fixtures
     env_file:

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,6 +14,7 @@
     "test": "vitest",
     "test-e2e-fast": "playwright test --grep-invert @slow",
     "test-e2e": "playwright test",
+    "test-e2e-base-path": "playwright test --grep @base-path",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },


### PR DESCRIPTION
This adds a CI job that starts the gateway with a separate config file, and runs a single test (whih verifies that the health check succeeds)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
