### PR TITLE
removed credential verification in tensorzero-node

### DIFF
--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -580,6 +580,7 @@ impl TensorZeroGateway {
             config_file: config_file.map(PathBuf::from),
             clickhouse_url,
             timeout,
+            verify_credentials: true,
         })
         .build();
         let client = tokio_block_on_without_gil(cls.py(), client_fut);
@@ -1138,6 +1139,7 @@ impl AsyncTensorZeroGateway {
             config_file: config_file.map(PathBuf::from),
             clickhouse_url,
             timeout,
+            verify_credentials: true,
         })
         .build();
 

--- a/clients/rust/examples/inference_demo/main.rs
+++ b/clients/rust/examples/inference_demo/main.rs
@@ -50,6 +50,7 @@ async fn main() {
             config_file: Some(config_file),
             clickhouse_url: std::env::var("TENSORZERO_CLICKHOUSE_URL").ok(),
             timeout: None,
+            verify_credentials: true,
         }),
         (Some(_), Some(_)) => {
             std::process::exit(1);

--- a/evaluations/src/lib.rs
+++ b/evaluations/src/lib.rs
@@ -121,6 +121,7 @@ pub async fn run_evaluation(
             config_file: Some(args.config_file),
             clickhouse_url: Some(clickhouse_url.clone()),
             timeout: None,
+            verify_credentials: true,
         }),
     }
     .build()

--- a/evaluations/tests/common/mod.rs
+++ b/evaluations/tests/common/mod.rs
@@ -69,6 +69,7 @@ pub async fn get_tensorzero_client() -> Client {
         ))),
         clickhouse_url: Some(CLICKHOUSE_URL.clone()),
         timeout: None,
+        verify_credentials: true,
     })
     .build()
     .await

--- a/evaluations/tests/tests.rs
+++ b/evaluations/tests/tests.rs
@@ -1220,6 +1220,7 @@ async fn test_run_llm_judge_evaluator_chat() {
         ))),
         clickhouse_url: None,
         timeout: None,
+        verify_credentials: true,
     })
     .build()
     .await

--- a/internal/tensorzero-node/__test__/integration.test.ts
+++ b/internal/tensorzero-node/__test__/integration.test.ts
@@ -14,9 +14,11 @@ describe("TensorZeroClient Integration Tests", () => {
     );
   });
 
-  it("should have required methods", async () => {
+  it("should have required methods and initialize without credentials", async () => {
+    // unset the OPENAI_API_KEY environment variable
+    process.env.OPENAI_API_KEY = undefined;
     const client = await TensorZeroClient.build(
-      "../../examples/quickstart/config/tensorzero.toml",
+      "../../ui/fixtures/config/tensorzero.toml",
     );
     expect(typeof client.experimentalLaunchOptimizationWorkflow).toBe(
       "function",

--- a/internal/tensorzero-node/package.json
+++ b/internal/tensorzero-node/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@eslint/js": "^9.23.0",
     "@napi-rs/cli": "^2.18.4",
-    "@types/node": "^20.0.0",
+    "@types/node": "^20.19.1",
     "eslint": "^9.23.0",
     "prettier": "^3.5.3",
     "typescript-eslint": "^8.29.0",

--- a/internal/tensorzero-node/src/lib.rs
+++ b/internal/tensorzero-node/src/lib.rs
@@ -23,6 +23,7 @@ impl TensorZeroClient {
             config_file: Some(Path::new(&config_path).to_path_buf()),
             clickhouse_url,
             timeout: timeout.map(Duration::from_secs_f64),
+            verify_credentials: false,
         })
         .build()
         .await

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,7 +93,7 @@ importers:
         specifier: ^2.18.4
         version: 2.18.4
       '@types/node':
-        specifier: ^20.0.0
+        specifier: ^20.19.1
         version: 20.19.1
       eslint:
         specifier: ^9.23.0

--- a/tensorzero-core/tests/e2e/human_feedback.rs
+++ b/tensorzero-core/tests/e2e/human_feedback.rs
@@ -25,6 +25,7 @@ async fn make_embedded_gateway() -> tensorzero::Client {
         config_file: Some(config_path),
         clickhouse_url: Some(CLICKHOUSE_URL.clone()),
         timeout: None,
+        verify_credentials: true,
     })
     .build()
     .await

--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -109,6 +109,7 @@ pub async fn make_embedded_gateway() -> tensorzero::Client {
         config_file: Some(config_path),
         clickhouse_url: Some(CLICKHOUSE_URL.clone()),
         timeout: None,
+        verify_credentials: true,
     })
     .build()
     .await
@@ -120,6 +121,7 @@ pub async fn make_embedded_gateway_no_config() -> tensorzero::Client {
         config_file: None,
         clickhouse_url: Some(CLICKHOUSE_URL.clone()),
         timeout: None,
+        verify_credentials: true,
     })
     .build()
     .await
@@ -133,6 +135,7 @@ pub async fn make_embedded_gateway_with_config(config: &str) -> tensorzero::Clie
         config_file: Some(tmp_config.path().to_owned()),
         clickhouse_url: Some(CLICKHOUSE_URL.clone()),
         timeout: None,
+        verify_credentials: true,
     })
     .build()
     .await


### PR DESCRIPTION
This is necessary before we cut a release because we don't want to require API keys in the UI