### PR TITLE
bumped version to 2025.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2025.6.2"
+version = "2025.6.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2025.6.2"
+version = "2025.6.3"
 dependencies = [
  "axum",
  "clap",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-bindings"
-version = "2025.6.2"
+version = "2025.6.3"
 dependencies = [
  "console_error_panic_hook",
  "minijinja",
@@ -4325,7 +4325,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2025.6.2"
+version = "2025.6.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4418,7 +4418,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2025.6.2"
+version = "2025.6.3"
 dependencies = [
  "napi",
  "napi-build",
@@ -4430,7 +4430,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.6.2"
+version = "2025.6.3"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2025.6.2"
+version = "2025.6.3"
 rust-version = "1.85.0"
 license = "Apache-2.0"
 

--- a/ui/app/utils/version.ts
+++ b/ui/app/utils/version.ts
@@ -5,4 +5,4 @@
  * It serves as the single source of truth for version information.
  */
 
-export const VERSION = "2025.6.2";
+export const VERSION = "2025.6.3";


### PR DESCRIPTION
Do not merge until #2640 merges
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump version to 2025.6.3 across multiple files including `Cargo.lock`, `Cargo.toml`, and `ui/app/utils/version.ts`.
> 
>   - **Version Bump**:
>     - Update version to `2025.6.3` in `Cargo.lock` for `evaluations`, `gateway`, `minijinja-bindings`, `tensorzero-core`, `tensorzero-node`, and `tensorzero-python`.
>     - Update version to `2025.6.3` in `Cargo.toml`.
>     - Update version to `2025.6.3` in `ui/app/utils/version.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 31d8eeabb0bf55f8ad4ab943f480876c268680fc. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->