### PR TITLE
Use 'SYNC' modifier when dropping database in tests

### DIFF
--- a/tensorzero-core/tests/e2e/clickhouse.rs
+++ b/tensorzero-core/tests/e2e/clickhouse.rs
@@ -46,13 +46,13 @@ impl Drop for DeleteDbOnDrop {
                 if allow_db_missing {
                     client
                         .run_query_synchronous_no_params(format!(
-                            "DROP DATABASE IF EXISTS {database}"
+                            "DROP DATABASE IF EXISTS {database} SYNC"
                         ))
                         .await
                         .unwrap();
                 } else {
                     client
-                        .run_query_synchronous_no_params(format!("DROP DATABASE {database}"))
+                        .run_query_synchronous_no_params(format!("DROP DATABASE {database} SYNC"))
                         .await
                         .unwrap();
                 }


### PR DESCRIPTION
This should free up disk space for subsequent retries of the test

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add 'SYNC' modifier to `DROP DATABASE` command in `clickhouse.rs` tests to ensure complete database removal.
> 
>   - **Behavior**:
>     - Add 'SYNC' modifier to `DROP DATABASE` command in `DeleteDbOnDrop::drop()` in `clickhouse.rs` to ensure complete database removal before proceeding.
>   - **Tests**:
>     - Affects database cleanup in tests, potentially reducing disk usage for retries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 02a8a6701d111ee2d982b9b0f7130f47fdfce123. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->