### PR TITLE
Stop running ClickHouse cloud tests on github actions

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -22,84 +22,6 @@ env:
   TENSORZERO_CLICKHOUSE_URL: "http://chuser:chpassword@localhost:8123/tensorzero"
 
 jobs:
-  clickhouse-tests-cloud:
-    if: github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        cloud_instance:
-          - release_channel: regular
-            url_secret: CLICKHOUSE_CLOUD_URL
-          - release_channel: fast
-            url_secret: CLICKHOUSE_CLOUD_FAST_CHANNEL_URL
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
-        with:
-          cache-provider: "buildjet"
-          shared-key: "build-gateway-cache"
-          save-if: false
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb
-        with:
-          tool: cargo-nextest
-
-      - name: Set up TENSORZERO_CLICKHOUSE_URL
-        run: |
-          echo "TENSORZERO_CLICKHOUSE_URL=${{ secrets[matrix.cloud_instance.url_secret] }}" >> $GITHUB_ENV
-
-      - name: Wake up ClickHouse cloud
-        run: |
-          curl "$TENSORZERO_CLICKHOUSE_URL" --retry 4 --retry-all-errors --data-binary 'SHOW DATABASES'
-
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh
-
-      - name: Download ClickHouse fixtures
-        run: uv run ./ui/fixtures/download-fixtures.py
-
-      - name: Delete old ClickHouse cloud dbs
-        run: ./ci/delete-clickhouse-dbs.sh
-
-      # We run this as a separate step so that we can see live build logs
-      # (and fail the job immediately if the build fails)
-      - name: Build the gateway for E2E tests
-        run: cargo build-e2e
-
-      - name: Launch the gateway for E2E tests
-        run: |
-          cargo run-e2e > e2e_logs.txt 2>&1 &
-            count=0
-            max_attempts=30
-            while ! curl -s -f http://localhost:3000/health >/dev/null 2>&1; do
-              echo "Waiting for gateway to be healthy..."
-              sleep 1
-              count=$((count + 1))
-              if [ $count -ge $max_attempts ]; then
-                echo "Gateway failed to become healthy after $max_attempts attempts"
-                exit 1
-              fi
-            done
-          echo "GATEWAY_PID=$!" >> $GITHUB_ENV
-
-      - name: Test (Rust)
-        # This test causes a huge slowdown on ClickHouse cloud, even though it uses a fresh database
-        # For now, let's skip it (we still run it in the local docker ClickHouse tests)
-        # See https://github.com/tensorzero/tensorzero/issues/2216
-        # Also, `test_clickhouse_migration_manager` is consistently taking a very long time (and timing out)
-        # on the fast release channel, so we temporarily skip it
-        run: |
-          if [ "${{ matrix.cloud_instance.release_channel }}" = "fast" ]; then
-            cargo test-e2e-no-creds -- --skip test_concurrent_clickhouse_migrations --skip test_clickhouse_migration_manager
-          else
-            cargo test-e2e-no-creds -- --skip test_concurrent_clickhouse_migrations
-          fi
-
-      - name: Print e2e logs
-        if: always()
-        run: cat e2e_logs.txt
-
   check-docker-compose:
     permissions:
       # Permission to checkout the repository
@@ -482,7 +404,6 @@ jobs:
     if: always()
     needs:
       [
-        clickhouse-tests-cloud,
         check-docker-compose,
         check-python-client-build,
         build-windows,


### PR DESCRIPTION
We now run this on Buildkite, so we don't need this job any more. The status check is reported as 'merge-checks-buildkite'

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `clickhouse-tests-cloud` job from GitHub Actions workflow as it is now run on Buildkite.
> 
>   - **Workflow Changes**:
>     - Remove `clickhouse-tests-cloud` job from `.github/workflows/general.yml`.
>     - Update `check-all-general-jobs-passed` dependencies to exclude `clickhouse-tests-cloud`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 38d1c5c4f295c0c701204f4534217587ab7201a7. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->