### PR TITLE
Use intermediate job to make 'check-all-general-jobs-passed' fail sooner

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -478,8 +478,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   # See 'ci/README.md' at the repository root for more details.
-  check-all-general-jobs-passed:
-    if: always()
+  check-all-general-jobs-passed-intermediate:
     needs:
       [
         clickhouse-tests-cloud,
@@ -493,5 +492,11 @@ jobs:
       ]
     runs-on: ubuntu-latest
     steps:
-      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      - run: exit 0
+
+  check-all-general-jobs-passed:
+    needs: [check-all-general-jobs-passed-intermediate]
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ needs.check-all-general-jobs-passed-intermediate.result != 'success' }}
         run: exit 1

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -496,6 +496,7 @@ jobs:
 
   check-all-general-jobs-passed:
     needs: [check-all-general-jobs-passed-intermediate]
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - if: ${{ needs.check-all-general-jobs-passed-intermediate.result != 'success' }}

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -149,6 +149,8 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      - run: exit 1
+
       # We allow the namespace builder setup to fail on Dependabot PRs and PRs from forks
       # (where the oidc token is not available)
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -149,7 +149,8 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - run: exit 1
+      - name: Fail the job
+        run: exit 1
 
       # We allow the namespace builder setup to fail on Dependabot PRs and PRs from forks
       # (where the oidc token is not available)


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces an intermediate job in the GitHub Actions workflow to make 'check-all-general-jobs-passed' fail sooner if dependencies fail.
> 
>   - **Workflow Changes**:
>     - Introduces `check-all-general-jobs-passed-intermediate` job in `general.yml`.
>     - `check-all-general-jobs-passed-intermediate` depends on multiple jobs including `clickhouse-tests-cloud`, `check-docker-compose`, and `validate`.
>     - `check-all-general-jobs-passed` now depends on `check-all-general-jobs-passed-intermediate` and fails if it does not succeed.
>   - **Behavior**:
>     - Allows `check-all-general-jobs-passed` to fail sooner if any dependent job fails.
>     - Adds a `run: exit 0` step in `check-all-general-jobs-passed-intermediate` to ensure it always succeeds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1fc6b4e11adabde678179202dd7e5501a7aa54d4. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->