### PR TITLE
Remove Github Actions concurrency groups

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -6,17 +6,6 @@ on:
   pull_request:
     branches: ["main"]
 
-# Hack to cancel existing merge-queue workflows when a new one is created.
-# This ensures that we don't have multiple ClickHouse cloud tests running at the same time.
-concurrency:
-  # This is how you do a ternary-if in Github Actions.defaults:
-  # In the merge queue, we use a fixed concurrency group name, which will cancel any
-  # leftover workflow runs when a PR was removed from the merge queue.
-  # Otherwise, we use the unique 'github.run_id' field, which will create a new concurrency group,
-  # and avoid cancelling any existing workflow runs.
-  group: ${{ (github.event_name == 'merge_group' && 'merge-group-general-checks') || github.run_id }}
-  cancel-in-progress: true
-
 env:
   FORCE_COLOR: 1
   TENSORZERO_CLICKHOUSE_URL: "http://chuser:chpassword@localhost:8123/tensorzero"

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -7,12 +7,6 @@ on:
   schedule:
     - cron: "0 0 * * *" # Runs at 00:00 UTC every day
 
-# See 'general.yml' for more details. Note that we use a difference concurrency group,
-# so that general.yml and merge-queue.yml can run in parallel.
-concurrency:
-  group: ${{ (github.event_name == 'merge_group' && 'merge-group-merge-checks') || github.run_id }}
-  cancel-in-progress: true
-
 env:
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Now that we're running clickhouse-cloud tests on buildkite, we no longer need to limit concurrency from the Github Actions side of things.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove concurrency settings from GitHub Actions workflows `general.yml` and `merge-queue.yml` due to migration to Buildkite.
> 
>   - **Workflows**:
>     - Remove `concurrency` settings from `.github/workflows/general.yml` and `.github/workflows/merge-queue.yml`.
>     - Previously used to limit concurrent ClickHouse cloud tests on GitHub Actions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 74259ac3d00941dc1cf0a74a4d850b5d73ad3765. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->