### PR TITLE
Use stricter validation for OpenAI-compatible content blocks

### DIFF
--- a/clients/openai-python/tests/test_openai_compatibility.py
+++ b/clients/openai-python/tests/test_openai_compatibility.py
@@ -1013,6 +1013,96 @@ async def test_async_json_invalid_system(async_client):
 
 
 @pytest.mark.asyncio
+async def test_missing_text_fields(async_client):
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "tensorzero::arguments": {"assistant_name": "Alfred Pennyworth"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "text"}],
+        },
+    ]
+    with pytest.raises(BadRequestError) as exc_info:
+        await async_client.chat.completions.create(
+            messages=messages,
+            model="tensorzero::function_name::json_success",
+        )
+    assert (
+        'Invalid request to OpenAI-compatible endpoint: Invalid content block: Either `text` or `tensorzero::arguments` must be set when using `"type": "text"`'
+        in str(exc_info.value)
+    )
+
+
+@pytest.mark.asyncio
+async def test_bad_content_blocK_type(async_client):
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "tensorzero::arguments": {"assistant_name": "Alfred Pennyworth"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "my_fake_type", "my": "other_field"}],
+        },
+    ]
+    with pytest.raises(BadRequestError) as exc_info:
+        await async_client.chat.completions.create(
+            messages=messages,
+            model="tensorzero::function_name::json_success",
+        )
+    assert (
+        "Invalid request to OpenAI-compatible endpoint: Invalid content block: unknown variant `my_fake_type`, expected one of `text`, `image_url`, `file`"
+        in str(exc_info.value)
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_tensorzero_text_block(async_client):
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "tensorzero::arguments": {"assistant_name": "Alfred Pennyworth"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "My other text",
+                    "tensorzero::arguments": {"country": "Japan"},
+                }
+            ],
+        },
+    ]
+    with pytest.raises(BadRequestError) as exc_info:
+        await async_client.chat.completions.create(
+            messages=messages,
+            model="tensorzero::function_name::json_success",
+        )
+    assert (
+        'Invalid request to OpenAI-compatible endpoint: Invalid TensorZero content block: Only one of `text` or `tensorzero::arguments` can be set when using `"type": "text"`'
+        in str(exc_info.value)
+    )
+
+
+@pytest.mark.asyncio
 async def test_async_extra_headers_param(async_client):
     messages = [
         {"role": "user", "content": "Hello, world!"},


### PR DESCRIPTION
Whenver we encountered a parse error, we would wrap the entire content block in 'tensorzero::arguments', and produce a 'text' TensorZero content block. This could result in confusing behavior when the user wasn't trying to use a text block (e.g. if they used an unknown content block type, or left off fields).

We now look for a 'tensorzero::arguments' or 'type' field - if either of those are set we encounter a parse error, we assume that the user was *not* trying to use the deprecated behavior (passing a json object directly to the arguments of a TensorZero function).

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
