### PR TITLE
Store original chunk usage in streaming cache entry

### DIFF
--- a/tensorzero-core/src/cache.rs
+++ b/tensorzero-core/src/cache.rs
@@ -284,6 +284,8 @@ pub fn start_cache_write<T: Serialize + CacheOutput + Send + Sync + 'static>(
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CachedProviderInferenceResponseChunk {
     pub content: Vec<ContentBlockChunk>,
+    #[serde(default)]
+    pub usage: Option<Usage>,
     pub raw_response: String,
 }
 
@@ -311,6 +313,7 @@ pub fn start_cache_write_streaming(
             .into_iter()
             .map(|c| CachedProviderInferenceResponseChunk {
                 content: c.content,
+                usage: c.usage,
                 raw_response: c.raw_response,
             })
             .collect(),

--- a/tensorzero-core/src/model.rs
+++ b/tensorzero-core/src/model.rs
@@ -140,15 +140,9 @@ impl StreamResponse {
                         // request:
                         // The new result was 'created' now
                         created: current_timestamp(),
-                        // Only include usage in the last chunk, None for all others
-                        usage: if index == chunks_len - 1 {
-                            Some(Usage {
-                                input_tokens: cache_lookup.input_tokens,
-                                output_tokens: cache_lookup.output_tokens,
-                            })
-                        } else {
-                            None
-                        },
+                        // Use the real usage (so that the `ModelInference` row we write is accurate)
+                        // The usage returned to over HTTP is adjusted in `InferenceResponseChunk::new`
+                        usage: c.usage,
                         // We didn't make any network calls to the model provider, so the latency is 0
                         latency: Duration::from_secs(0),
                         // For all chunks but the last one, the finish reason is None


### PR DESCRIPTION
This will become more important when we add streaming e2e support, as we'll want our 'extra_usage' behavior to be consistent between cached and non-cached responses

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Store original chunk usage in streaming cache entry for consistent behavior between cached and non-cached responses.
> 
>   - **Behavior**:
>     - Store original `usage` in `CachedProviderInferenceResponseChunk` in `cache.rs`.
>     - Update `StreamResponse::from_cache` in `model.rs` to use cached `usage`.
>   - **Tests**:
>     - Update `test_cache_stream_write_and_read()` in `cache.rs` to verify `usage` is stored and retrieved correctly.
>     - Add assertions for `usage` in `test_cache_stream_write_and_read()` to ensure consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e062335a6f2ea6215c10179bd8427721ec51e0c7. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->