### PR TITLE
Do not sum usage counts in ModelInference rows

### DIFF
--- a/tensorzero-core/src/endpoints/batch_inference.rs
+++ b/tensorzero-core/src/endpoints/batch_inference.rs
@@ -874,7 +874,6 @@ pub async fn write_completed_batch_inference<'a>(
             .prepare_response(
                 inference_id,
                 output,
-                usage,
                 vec![model_inference_response],
                 &inference_config,
                 inference_params.into_owned(),

--- a/tensorzero-core/src/endpoints/inference.rs
+++ b/tensorzero-core/src/endpoints/inference.rs
@@ -879,13 +879,14 @@ pub struct JsonInferenceResponse {
 
 impl InferenceResponse {
     pub fn new(inference_result: InferenceResult, episode_id: Uuid, variant_name: String) -> Self {
+        let usage = inference_result.usage_considering_cached();
         match inference_result {
             InferenceResult::Chat(result) => InferenceResponse::Chat(ChatInferenceResponse {
                 inference_id: result.inference_id,
                 episode_id,
                 variant_name,
                 content: result.content,
-                usage: result.usage,
+                usage,
                 original_response: result.original_response,
                 finish_reason: result.finish_reason,
             }),
@@ -897,7 +898,7 @@ impl InferenceResponse {
                     episode_id,
                     variant_name,
                     output,
-                    usage: result.usage,
+                    usage,
                     original_response: result.original_response,
                     finish_reason: result.finish_reason,
                 })

--- a/tensorzero-core/src/function.rs
+++ b/tensorzero-core/src/function.rs
@@ -12,7 +12,7 @@ use crate::endpoints::inference::InferenceParams;
 use crate::error::{Error, ErrorDetails};
 use crate::inference::types::{
     ChatInferenceResult, ContentBlockOutput, InferenceResult, Input, InputMessageContent,
-    JsonInferenceResult, ModelInferenceResponseWithMetadata, Role, TextKind, Usage,
+    JsonInferenceResult, ModelInferenceResponseWithMetadata, Role, TextKind,
 };
 use crate::jsonschema_util::{JsonSchemaRef, StaticJSONSchema};
 use crate::minijinja_util::TemplateConfig;
@@ -178,12 +178,10 @@ impl FunctionConfig {
     }
 
     #[instrument(skip_all, fields(inference_id))]
-    #[expect(clippy::too_many_arguments)]
     pub async fn prepare_response<'request>(
         &self,
         inference_id: Uuid,
         content_blocks: Vec<ContentBlockOutput>,
-        usage: Usage,
         model_inference_results: Vec<ModelInferenceResponseWithMetadata>,
         inference_config: &'request InferenceConfig<'_, 'request>,
         inference_params: InferenceParams,
@@ -194,7 +192,6 @@ impl FunctionConfig {
                 ChatInferenceResult::new(
                     inference_id,
                     content_blocks,
-                    usage,
                     model_inference_results,
                     inference_config.tool_config,
                     inference_params,
@@ -242,7 +239,6 @@ impl FunctionConfig {
                     parsed_output,
                     json_block_index,
                     auxiliary_content,
-                    usage,
                     model_inference_results,
                     output_schema.value().clone(),
                     inference_params,
@@ -544,6 +540,7 @@ mod tests {
     use crate::inference::types::Latency;
     use crate::inference::types::Text;
     use crate::inference::types::Thought;
+    use crate::inference::types::Usage;
     use crate::jsonschema_util::DynamicJSONSchema;
     use crate::minijinja_util::TemplateConfig;
     use crate::tool::ToolCall;
@@ -1638,7 +1635,6 @@ mod tests {
             .prepare_response(
                 inference_id,
                 content_blocks,
-                usage.clone(),
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
@@ -1649,12 +1645,12 @@ mod tests {
         assert!(logs_contain(
             "Failed to parse output from JSON function response"
         ));
+        assert_eq!(response.usage_considering_cached(), usage);
         match response {
             InferenceResult::Json(result) => {
                 assert_eq!(result.inference_id, inference_id);
                 assert!(result.output.parsed.is_none());
                 assert_eq!(result.output.raw, Some("Hello, world!".to_string()));
-                assert_eq!(result.usage, usage);
                 assert_eq!(result.finish_reason, Some(FinishReason::Stop));
                 assert_eq!(result.model_inference_results, vec![model_response]);
             }
@@ -1690,7 +1686,6 @@ mod tests {
             .prepare_response(
                 inference_id,
                 content_blocks,
-                usage.clone(),
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
@@ -1698,6 +1693,7 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(response.usage_considering_cached(), usage);
         match response {
             InferenceResult::Json(result) => {
                 assert_eq!(result.inference_id, inference_id);
@@ -1709,7 +1705,6 @@ mod tests {
                     result.output.raw,
                     Some("{\"name\": \"Jerry\", \"age\": 30}".to_string())
                 );
-                assert_eq!(result.usage, usage);
                 assert_eq!(result.model_inference_results, vec![model_response]);
             }
             _ => panic!("Expected a JSON inference result"),
@@ -1744,7 +1739,6 @@ mod tests {
             .prepare_response(
                 inference_id,
                 content_blocks,
-                usage.clone(),
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
@@ -1752,6 +1746,7 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(response.usage_considering_cached(), usage);
         match response {
             InferenceResult::Json(result) => {
                 assert_eq!(result.inference_id, inference_id);
@@ -1760,7 +1755,6 @@ mod tests {
                     result.output.raw,
                     Some("{\"name\": \"Jerry\", \"age\": \"thirty\"}".to_string())
                 );
-                assert_eq!(result.usage, usage);
                 assert_eq!(result.model_inference_results, vec![model_response]);
                 assert_eq!(result.finish_reason, Some(FinishReason::ToolCall));
             }
@@ -1800,7 +1794,6 @@ mod tests {
             .prepare_response(
                 inference_id,
                 content_blocks,
-                usage.clone(),
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
@@ -1809,12 +1802,12 @@ mod tests {
             .await
             .unwrap();
         assert!(logs_contain("JSON Schema validation failed"));
+        assert_eq!(response.usage_considering_cached(), usage);
         match response {
             InferenceResult::Json(result) => {
                 assert_eq!(result.inference_id, inference_id);
                 assert!(result.output.parsed.is_none());
                 assert_eq!(result.output.raw, Some("tool_call_arguments".to_string()));
-                assert_eq!(result.usage, usage);
                 assert_eq!(result.model_inference_results, vec![model_response]);
                 assert_eq!(result.finish_reason, Some(FinishReason::ToolCall));
             }
@@ -1854,7 +1847,6 @@ mod tests {
             .prepare_response(
                 inference_id,
                 content_blocks,
-                usage.clone(),
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
@@ -1862,6 +1854,7 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(response.usage_considering_cached(), usage);
         match response {
             InferenceResult::Json(result) => {
                 assert_eq!(result.inference_id, inference_id);
@@ -1873,7 +1866,6 @@ mod tests {
                     result.output.raw,
                     Some(r#"{"name": "Jerry", "age": 30}"#.to_string())
                 );
-                assert_eq!(result.usage, usage);
                 assert_eq!(result.model_inference_results, vec![model_response]);
                 assert_eq!(result.finish_reason, Some(FinishReason::ContentFilter));
             }
@@ -1908,7 +1900,6 @@ mod tests {
             .prepare_response(
                 inference_id,
                 content_blocks,
-                usage.clone(),
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
@@ -1916,12 +1907,12 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(response.usage_considering_cached(), usage);
         match response {
             InferenceResult::Json(result) => {
                 assert_eq!(result.inference_id, inference_id);
                 assert!(result.output.parsed.is_none());
                 assert!(result.output.raw.is_none());
-                assert_eq!(result.usage, usage);
                 assert_eq!(result.finish_reason, model_response.finish_reason);
                 assert_eq!(result.model_inference_results, vec![model_response]);
             }
@@ -1980,7 +1971,6 @@ mod tests {
             .prepare_response(
                 inference_id,
                 content_blocks,
-                usage.clone(),
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
@@ -1988,12 +1978,12 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(response.usage_considering_cached(), usage);
         match response {
             InferenceResult::Json(result) => {
                 assert_eq!(result.inference_id, inference_id);
                 assert_eq!(result.output.parsed.unwrap(), json!({"answer": "42"}),);
                 assert_eq!(result.output.raw, Some(r#"{"answer": "42"}"#.to_string()));
-                assert_eq!(result.usage, usage);
                 assert_eq!(result.model_inference_results, vec![model_response]);
             }
             _ => panic!("Expected a JSON inference result"),
@@ -2028,7 +2018,6 @@ mod tests {
             .prepare_response(
                 inference_id,
                 content_blocks,
-                usage.clone(),
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
@@ -2036,6 +2025,7 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(response.usage_considering_cached(), usage);
         match response {
             InferenceResult::Json(result) => {
                 assert_eq!(result.inference_id, inference_id);
@@ -2044,7 +2034,6 @@ mod tests {
                     result.output.raw,
                     Some(r#"{"response": "forty-two"}"#.to_string())
                 );
-                assert_eq!(result.usage, usage);
                 assert_eq!(result.model_inference_results, vec![model_response]);
             }
             _ => panic!("Expected a JSON inference result"),
@@ -2083,7 +2072,6 @@ mod tests {
             .prepare_response(
                 inference_id,
                 content_blocks,
-                usage.clone(),
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
@@ -2092,12 +2080,12 @@ mod tests {
             .await
             .unwrap();
         assert!(logs_contain("JSON Schema validation failed"));
+        assert_eq!(response.usage_considering_cached(), usage);
         match response {
             InferenceResult::Json(result) => {
                 assert_eq!(result.inference_id, inference_id);
                 assert!(result.output.parsed.is_none());
                 assert_eq!(result.output.raw, Some("tool_call_arguments".to_string()));
-                assert_eq!(result.usage, usage);
                 assert_eq!(result.model_inference_results, vec![model_response]);
             }
             _ => panic!("Expected a JSON inference result"),
@@ -2136,7 +2124,6 @@ mod tests {
             .prepare_response(
                 inference_id,
                 content_blocks,
-                usage.clone(),
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
@@ -2144,12 +2131,12 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(response.usage_considering_cached(), usage);
         match response {
             InferenceResult::Json(result) => {
                 assert_eq!(result.inference_id, inference_id);
                 assert_eq!(result.output.parsed.unwrap(), json!({"answer": "42"}),);
                 assert_eq!(result.output.raw, Some(r#"{"answer": "42"}"#.to_string()));
-                assert_eq!(result.usage, usage);
                 assert_eq!(result.model_inference_results, vec![model_response]);
             }
             _ => panic!("Expected a JSON inference result"),
@@ -2196,7 +2183,6 @@ mod tests {
             .prepare_response(
                 inference_id,
                 content_blocks,
-                usage.clone(),
                 vec![model_response.clone()],
                 &inference_config,
                 InferenceParams::default(),
@@ -2204,12 +2190,12 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(response.usage_considering_cached(), usage);
         match response {
             InferenceResult::Json(result) => {
                 assert_eq!(result.inference_id, inference_id);
                 assert_eq!(result.output.parsed.unwrap(), json!({"answer": "42"}),);
                 assert_eq!(result.output.raw, Some(r#"{"answer": "42"}"#.to_string()));
-                assert_eq!(result.usage, usage);
                 assert_eq!(result.model_inference_results, vec![model_response]);
                 assert_eq!(result.finish_reason, Some(FinishReason::Stop));
             }

--- a/tensorzero-core/src/inference/types/mod.rs
+++ b/tensorzero-core/src/inference/types/mod.rs
@@ -626,7 +626,7 @@ impl ModelInferenceResponseWithMetadata {
     /// in the HTTP response.
     /// However, we store the number of tokens that would have been used in the database.
     /// So we need this function to compute the actual usage in order to send it in the HTTP response.
-    pub fn actual_usage(&self) -> Usage {
+    pub fn usage_considering_cached(&self) -> Usage {
         if self.cached {
             Usage {
                 input_tokens: 0,
@@ -657,7 +657,6 @@ pub struct ChatInferenceResult {
     pub inference_id: Uuid,
     pub created: u64,
     pub content: Vec<ContentBlockChatOutput>,
-    pub usage: Usage,
     pub model_inference_results: Vec<ModelInferenceResponseWithMetadata>,
     pub inference_params: InferenceParams,
     pub original_response: Option<String>,
@@ -669,7 +668,6 @@ pub struct JsonInferenceResult {
     pub inference_id: Uuid,
     pub created: u64,
     pub output: InternalJsonInferenceOutput,
-    pub usage: Usage,
     pub model_inference_results: Vec<ModelInferenceResponseWithMetadata>,
     pub output_schema: Value,
     pub inference_params: InferenceParams,
@@ -1102,18 +1100,11 @@ impl InferenceResult {
             .collect()
     }
 
-    pub fn usage(&self) -> &Usage {
-        match self {
-            InferenceResult::Chat(chat_result) => &chat_result.usage,
-            InferenceResult::Json(json_result) => &json_result.usage,
-        }
-    }
-
-    pub fn set_usage(&mut self, usage: Usage) {
-        match self {
-            InferenceResult::Chat(chat_result) => chat_result.usage = usage,
-            InferenceResult::Json(json_result) => json_result.usage = usage,
-        }
+    pub fn usage_considering_cached(&self) -> Usage {
+        self.model_inference_results()
+            .iter()
+            .map(|r| r.usage_considering_cached())
+            .sum()
     }
 
     pub fn set_original_response(&mut self, original_response: Option<String>) {
@@ -1146,7 +1137,6 @@ impl JsonInferenceResult {
         parsed: Option<Value>,
         json_block_index: Option<usize>,
         auxiliary_content: Vec<ContentBlockOutput>,
-        usage: Usage,
         model_inference_results: Vec<ModelInferenceResponseWithMetadata>,
         output_schema: Value,
         inference_params: InferenceParams,
@@ -1163,7 +1153,6 @@ impl JsonInferenceResult {
             inference_id,
             created: current_timestamp(),
             output,
-            usage,
             model_inference_results,
             output_schema,
             inference_params,
@@ -1177,7 +1166,6 @@ impl ChatInferenceResult {
     pub async fn new(
         inference_id: Uuid,
         raw_content: Vec<ContentBlockOutput>,
-        usage: Usage,
         model_inference_results: Vec<ModelInferenceResponseWithMetadata>,
         tool_config: Option<&ToolCallConfig>,
         inference_params: InferenceParams,
@@ -1190,7 +1178,6 @@ impl ChatInferenceResult {
             inference_id,
             created,
             content,
-            usage,
             model_inference_results,
             inference_params,
             original_response,
@@ -1769,7 +1756,6 @@ pub async fn collect_chunks(args: CollectChunksArgs<'_, '_>) -> Result<Inference
         .prepare_response(
             inference_id,
             content_blocks,
-            usage,
             vec![model_inference_result],
             &inference_config,
             inference_params,
@@ -1833,8 +1819,8 @@ impl From<JsonMode> for ModelInferenceRequestJsonMode {
     }
 }
 
-impl<'a> std::iter::Sum<&'a Usage> for Usage {
-    fn sum<I: Iterator<Item = &'a Usage>>(iter: I) -> Self {
+impl std::iter::Sum<Usage> for Usage {
+    fn sum<I: Iterator<Item = Usage>>(iter: I) -> Self {
         iter.fold(Usage::default(), |mut acc, u| {
             acc.input_tokens = acc.input_tokens.saturating_add(u.input_tokens);
             acc.output_tokens = acc.output_tokens.saturating_add(u.output_tokens);
@@ -1967,7 +1953,6 @@ mod tests {
         let chat_inference_response = ChatInferenceResult::new(
             inference_id,
             content.clone(),
-            usage.clone(),
             model_inference_responses,
             None,
             InferenceParams::default(),
@@ -1976,7 +1961,6 @@ mod tests {
         .await;
         let output_content = ["Hello, world!".to_string().into()];
         assert_eq!(chat_inference_response.content, output_content);
-        assert_eq!(chat_inference_response.usage, usage);
         assert_eq!(chat_inference_response.model_inference_results.len(), 1);
         assert_eq!(chat_inference_response.finish_reason, None);
         let model_inference_result = chat_inference_response
@@ -2019,7 +2003,6 @@ mod tests {
         let chat_inference_response = ChatInferenceResult::new(
             inference_id,
             content,
-            usage.clone(),
             model_inference_responses,
             Some(&weather_tool_config),
             InferenceParams::default(),
@@ -2070,7 +2053,6 @@ mod tests {
         let chat_inference_response = ChatInferenceResult::new(
             inference_id,
             content,
-            usage.clone(),
             model_inference_responses,
             Some(&weather_tool_config),
             InferenceParams::default(),
@@ -2118,7 +2100,6 @@ mod tests {
         let chat_inference_response = ChatInferenceResult::new(
             inference_id,
             content,
-            usage.clone(),
             model_inference_responses,
             Some(&weather_tool_config),
             InferenceParams::default(),
@@ -2186,7 +2167,6 @@ mod tests {
         let chat_inference_response = ChatInferenceResult::new(
             inference_id,
             content,
-            usage.clone(),
             model_inference_responses,
             Some(&weather_tool_config),
             InferenceParams::default(),
@@ -2272,7 +2252,6 @@ mod tests {
         let chat_inference_response = ChatInferenceResult::new(
             inference_id,
             content,
-            usage.clone(),
             model_inference_responses,
             Some(&weather_tool_config),
             InferenceParams::default(),
@@ -2365,7 +2344,6 @@ mod tests {
         let chat_inference_response = ChatInferenceResult::new(
             inference_id,
             content,
-            usage.clone(),
             model_inference_responses,
             Some(&additional_tool_config),
             InferenceParams::default(),
@@ -2416,7 +2394,6 @@ mod tests {
         let chat_inference_response = ChatInferenceResult::new(
             inference_id,
             content,
-            usage.clone(),
             model_inference_responses,
             Some(&additional_tool_config),
             InferenceParams::default(),
@@ -2489,7 +2466,6 @@ mod tests {
         let chat_inference_response = ChatInferenceResult::new(
             inference_id,
             content,
-            usage.clone(),
             model_inference_responses,
             Some(&restricted_tool_config),
             InferenceParams::default(),
@@ -2546,7 +2522,6 @@ mod tests {
         let chat_inference_response = ChatInferenceResult::new(
             inference_id,
             content,
-            usage.clone(),
             model_inference_responses,
             Some(&restricted_tool_config),
             InferenceParams::default(),
@@ -2676,13 +2651,6 @@ mod tests {
             chat_result.content,
             vec!["Hello, world!".to_string().into()]
         );
-        assert_eq!(
-            chat_result.usage,
-            Usage {
-                input_tokens: 2,
-                output_tokens: 4,
-            }
-        );
         assert_eq!(chat_result.model_inference_results.len(), 1);
         let model_inference_result = chat_result.model_inference_results.first().unwrap();
         assert_eq!(&*model_inference_result.model_name, model_name);
@@ -2762,6 +2730,13 @@ mod tests {
             extra_headers: Default::default(),
         };
         let response = collect_chunks(collect_chunks_args).await.unwrap();
+        assert_eq!(
+            response.usage_considering_cached(),
+            Usage {
+                input_tokens: 15,
+                output_tokens: 15,
+            }
+        );
         match response {
             InferenceResult::Json(json_result) => {
                 assert_eq!(json_result.inference_id, inference_id);
@@ -2772,13 +2747,6 @@ mod tests {
                 assert_eq!(
                     json_result.output.raw,
                     Some("{\"name\":\"John\",\"age\":30}".to_string())
-                );
-                assert_eq!(
-                    json_result.usage,
-                    Usage {
-                        input_tokens: 15,
-                        output_tokens: 15,
-                    }
                 );
                 assert_eq!(json_result.finish_reason, Some(FinishReason::Stop));
                 assert_eq!(json_result.model_inference_results.len(), 1);
@@ -2841,13 +2809,12 @@ mod tests {
             extra_body: Default::default(),
             extra_headers: Default::default(),
         };
-        let result = collect_chunks(collect_chunks_args).await;
-        assert!(result.is_ok());
+        let result = collect_chunks(collect_chunks_args).await.unwrap();
+        assert_eq!(result.usage_considering_cached(), usage);
         match result {
-            Ok(InferenceResult::Json(json_result)) => {
+            InferenceResult::Json(json_result) => {
                 assert_eq!(json_result.inference_id, inference_id);
                 assert_eq!(json_result.created, created);
-                assert_eq!(json_result.usage, usage);
                 assert_eq!(json_result.output.parsed, None);
                 assert_eq!(
                     json_result.output.raw,
@@ -2923,38 +2890,39 @@ mod tests {
             extra_body: Default::default(),
             extra_headers: Default::default(),
         };
-        let result = collect_chunks(collect_chunks_args).await;
-        if let Ok(InferenceResult::Chat(chat_response)) = result {
-            assert_eq!(chat_response.inference_id, inference_id);
-            assert_eq!(chat_response.created, created);
-            assert_eq!(
-                chat_response.content,
-                vec![
-                    ContentBlockChatOutput::Text(Text {
-                        text: "{\"name\":\"John\",\"age\":30}".to_string()
-                    }),
-                    ContentBlockChatOutput::Thought(Thought {
-                        text: "Thought 2".to_string(),
-                        signature: None,
-                    }),
-                ]
-            );
-            assert_eq!(chat_response.usage, usage);
-            assert_eq!(chat_response.model_inference_results.len(), 1);
-            let model_inference_result = chat_response.model_inference_results.first().unwrap();
-            assert_eq!(&*model_inference_result.model_name, model_name);
-            assert_eq!(chat_response.finish_reason, Some(FinishReason::Stop));
-            assert_eq!(
-                model_inference_result.finish_reason,
-                Some(FinishReason::Stop)
-            );
-            assert_eq!(
-                &*model_inference_result.model_provider_name,
-                model_provider_name
-            );
-            assert_eq!(model_inference_result.raw_request, raw_request);
-        } else {
-            panic!("Expected Ok(InferenceResult::Chat), got {result:?}");
+        let result = collect_chunks(collect_chunks_args).await.unwrap();
+        assert_eq!(result.usage_considering_cached(), usage);
+        match result {
+            InferenceResult::Chat(chat_response) => {
+                assert_eq!(chat_response.inference_id, inference_id);
+                assert_eq!(chat_response.created, created);
+                assert_eq!(
+                    chat_response.content,
+                    vec![
+                        ContentBlockChatOutput::Text(Text {
+                            text: "{\"name\":\"John\",\"age\":30}".to_string()
+                        }),
+                        ContentBlockChatOutput::Thought(Thought {
+                            text: "Thought 2".to_string(),
+                            signature: None,
+                        }),
+                    ]
+                );
+                assert_eq!(chat_response.model_inference_results.len(), 1);
+                let model_inference_result = chat_response.model_inference_results.first().unwrap();
+                assert_eq!(&*model_inference_result.model_name, model_name);
+                assert_eq!(chat_response.finish_reason, Some(FinishReason::Stop));
+                assert_eq!(
+                    model_inference_result.finish_reason,
+                    Some(FinishReason::Stop)
+                );
+                assert_eq!(
+                    &*model_inference_result.model_provider_name,
+                    model_provider_name
+                );
+                assert_eq!(model_inference_result.raw_request, raw_request);
+            }
+            _ => panic!("Expected Chat inference response"),
         }
 
         // Test Case 6: a JSON function with implicit tool call config
@@ -3029,6 +2997,13 @@ mod tests {
             extra_headers: Default::default(),
         };
         let response = collect_chunks(collect_chunks_args).await.unwrap();
+        assert_eq!(
+            response.usage_considering_cached(),
+            Usage {
+                input_tokens: 15,
+                output_tokens: 15,
+            }
+        );
         match response {
             InferenceResult::Json(json_result) => {
                 assert_eq!(json_result.inference_id, inference_id);
@@ -3039,13 +3014,6 @@ mod tests {
                 assert_eq!(
                     json_result.output.raw,
                     Some("{\"name\":\"John\",\"age\":30}".to_string())
-                );
-                assert_eq!(
-                    json_result.usage,
-                    Usage {
-                        input_tokens: 15,
-                        output_tokens: 15,
-                    }
                 );
                 assert_eq!(json_result.finish_reason, Some(FinishReason::Stop));
                 assert_eq!(json_result.model_inference_results.len(), 1);
@@ -3138,6 +3106,13 @@ mod tests {
             extra_headers: Default::default(),
         };
         let response = collect_chunks(collect_chunks_args).await.unwrap();
+        assert_eq!(
+            response.usage_considering_cached(),
+            Usage {
+                input_tokens: 15,
+                output_tokens: 15,
+            }
+        );
         match response {
             InferenceResult::Json(json_result) => {
                 assert_eq!(json_result.inference_id, inference_id);
@@ -3148,13 +3123,6 @@ mod tests {
                 assert_eq!(
                     json_result.output.raw,
                     Some("{\"name\":\"John\",\"age\":30}".to_string())
-                );
-                assert_eq!(
-                    json_result.usage,
-                    Usage {
-                        input_tokens: 15,
-                        output_tokens: 15,
-                    }
                 );
                 assert_eq!(json_result.model_inference_results.len(), 1);
                 let model_inference_result = json_result.model_inference_results.first().unwrap();
@@ -3271,6 +3239,13 @@ mod tests {
             extra_headers: Default::default(),
         };
         let result = collect_chunks(collect_chunks_args).await.unwrap();
+        assert_eq!(
+            result.usage_considering_cached(),
+            Usage {
+                input_tokens: 2,
+                output_tokens: 4,
+            }
+        );
         let chat_result = match result {
             InferenceResult::Chat(chat_result) => chat_result,
             _ => panic!("Expected Chat inference response"),
@@ -3278,13 +3253,6 @@ mod tests {
         assert_eq!(chat_result.inference_id, inference_id);
         assert_eq!(chat_result.created, created);
         assert_eq!(chat_result.finish_reason, Some(FinishReason::Stop));
-        assert_eq!(
-            chat_result.usage,
-            Usage {
-                input_tokens: 2,
-                output_tokens: 4,
-            }
-        );
 
         let expected_content = vec![
             ContentBlockChatOutput::Text(Text {

--- a/tensorzero-core/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-core/src/variant/best_of_n_sampling.rs
@@ -17,7 +17,7 @@ use crate::inference::types::extra_body::FullExtraBodyConfig;
 use crate::inference::types::extra_headers::FullExtraHeadersConfig;
 use crate::inference::types::{
     batch::StartBatchModelInferenceWithMetadata, FunctionType, ModelInferenceRequest,
-    ModelInferenceResponseWithMetadata, RequestMessage, Role, Usage,
+    ModelInferenceResponseWithMetadata, RequestMessage, Role,
 };
 use crate::inference::types::{ContentBlockOutput, ResolvedInput};
 use crate::jsonschema_util::StaticJSONSchema;
@@ -356,7 +356,6 @@ impl BestOfNSamplingConfig {
         };
 
         // Safely remove the selected candidate without panicking
-        let mut total_usage: Usage = candidates.iter().map(|c| c.usage()).sum();
         let mut candidates = candidates;
         let mut selected_candidate = if selection_idx < candidates.len() {
             candidates.swap_remove(selection_idx)
@@ -368,15 +367,12 @@ impl BestOfNSamplingConfig {
             .into());
         };
         if let Some(inference_result) = &inference_result {
-            total_usage.input_tokens += inference_result.usage.input_tokens;
-            total_usage.output_tokens += inference_result.usage.output_tokens;
             // Pass the evaluator response back to the user as 'original_response'
             selected_candidate.set_original_response(Some(inference_result.raw_response.clone()));
         } else {
             // If the evaluator failed, don't provide an 'original_response' to the uesr
             selected_candidate.set_original_response(None);
         }
-        selected_candidate.set_usage(total_usage);
         for candidate in candidates {
             selected_candidate
                 .mut_model_inference_results()
@@ -762,7 +758,9 @@ mod tests {
         clickhouse::ClickHouseConnectionInfo,
         endpoints::inference::{InferenceCredentials, InferenceIds},
         function::FunctionConfigChat,
-        inference::types::{ChatInferenceResult, FinishReason, JsonInferenceResult, Latency},
+        inference::types::{
+            ChatInferenceResult, FinishReason, JsonInferenceResult, Latency, Usage,
+        },
         minijinja_util::tests::get_test_template_config,
         model::{ModelConfig, ModelProvider, ProviderConfig},
         providers::dummy::DummyProvider,
@@ -973,10 +971,6 @@ mod tests {
             ChatInferenceResult::new(
                 Uuid::now_v7(),
                 vec!["Candidate answer 1".to_string().into()],
-                Usage {
-                    input_tokens: 10,
-                    output_tokens: 20,
-                },
                 vec![model_inference_response],
                 None,
                 InferenceParams::default(),
@@ -1013,10 +1007,6 @@ mod tests {
             ChatInferenceResult::new(
                 Uuid::now_v7(),
                 vec!["Candidate answer 2".to_string().into()],
-                Usage {
-                    input_tokens: 15,
-                    output_tokens: 25,
-                },
                 vec![model_inference_response2],
                 None,
                 InferenceParams::default(),
@@ -1083,10 +1073,6 @@ mod tests {
             Some(json!({"response": "Valid JSON response"})),
             Some(0),
             vec![],
-            Usage {
-                input_tokens: 10,
-                output_tokens: 20,
-            },
             vec![model_inference_response_valid],
             json!({"type": "object", "properties": {"response": {"type": "string"}}}),
             InferenceParams::default(),
@@ -1125,10 +1111,6 @@ mod tests {
             None, // malformed
             Some(0),
             vec![],
-            Usage {
-                input_tokens: 15,
-                output_tokens: 25,
-            },
             vec![model_inference_response_malformed],
             json!({"type": "object", "properties": {"response": {"type": "string"}}}),
             InferenceParams::default(),
@@ -1198,10 +1180,6 @@ mod tests {
             ChatInferenceResult::new(
                 inference_id0,
                 vec!["Candidate answer 0".to_string().into()],
-                Usage {
-                    input_tokens: 10,
-                    output_tokens: 20,
-                },
                 vec![model_inference_response0],
                 None,
                 InferenceParams::default(),
@@ -1238,10 +1216,6 @@ mod tests {
             ChatInferenceResult::new(
                 inference_id1,
                 vec!["Candidate answer 1".to_string().into()],
-                Usage {
-                    input_tokens: 15,
-                    output_tokens: 25,
-                },
                 vec![model_inference_response1],
                 None,
                 InferenceParams::default(),
@@ -1336,14 +1310,14 @@ mod tests {
         // based on "answer": 1 in best_of_n_1
         let expected_id = inference_id1;
         let expected_usage = Usage {
-            input_tokens: 35,
-            output_tokens: 55,
+            input_tokens: 75,
+            output_tokens: 135,
         };
         let expected_content = vec!["Candidate answer 1".to_string().into()];
+        assert_eq!(selected.usage_considering_cached(), expected_usage);
         match selected {
             InferenceResult::Chat(selected) => {
                 assert_eq!(selected.inference_id, expected_id);
-                assert_eq!(selected.usage, expected_usage);
                 assert_eq!(selected.content, expected_content);
                 assert_eq!(selected.model_inference_results.len(), 3);
                 assert_eq!(selected.finish_reason, Some(FinishReason::Stop));

--- a/tensorzero-core/src/variant/chain_of_thought.rs
+++ b/tensorzero-core/src/variant/chain_of_thought.rs
@@ -105,7 +105,6 @@ impl Variant for ChainOfThoughtConfig {
             inference_id: json_result.inference_id,
             created: json_result.created,
             output,
-            usage: json_result.usage,
             model_inference_results: json_result.model_inference_results,
             output_schema: original_output_schema.clone(),
             inference_params: json_result.inference_params,

--- a/tensorzero-core/src/variant/chat_completion.rs
+++ b/tensorzero-core/src/variant/chat_completion.rs
@@ -1369,18 +1369,18 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(result, InferenceResult::Chat(_)));
+        assert_eq!(
+            result.usage_considering_cached(),
+            Usage {
+                input_tokens: 10,
+                output_tokens: 10,
+            }
+        );
         match result {
             InferenceResult::Chat(chat_response) => {
                 assert_eq!(
                     chat_response.content,
                     vec![DUMMY_INFER_RESPONSE_CONTENT.to_string().into()]
-                );
-                assert_eq!(
-                    chat_response.usage,
-                    Usage {
-                        input_tokens: 10,
-                        output_tokens: 10,
-                    }
                 );
                 assert_eq!(chat_response.model_inference_results.len(), 1);
                 assert_eq!(
@@ -1448,6 +1448,13 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(result, InferenceResult::Chat(_)));
+        assert_eq!(
+            result.usage_considering_cached(),
+            Usage {
+                input_tokens: 10,
+                output_tokens: 10,
+            }
+        );
         match result {
             InferenceResult::Chat(chat_response) => {
                 assert_eq!(chat_response.content.len(), 1);
@@ -1467,13 +1474,6 @@ mod tests {
                     }
                     _ => panic!("Expected tool call"),
                 }
-                assert_eq!(
-                    chat_response.usage,
-                    Usage {
-                        input_tokens: 10,
-                        output_tokens: 10,
-                    }
-                );
                 assert_eq!(chat_response.model_inference_results.len(), 1);
                 assert_eq!(
                     &*chat_response.model_inference_results[0].model_provider_name,
@@ -1537,19 +1537,19 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(
+            result.usage_considering_cached(),
+            Usage {
+                input_tokens: 10,
+                output_tokens: 10,
+            }
+        );
         match result {
             InferenceResult::Json(json_result) => {
                 assert!(json_result.output.parsed.is_none());
                 assert_eq!(
                     json_result.output.raw,
                     Some(r#"{"location":"Brooklyn","units":"celsius"}"#.to_string())
-                );
-                assert_eq!(
-                    json_result.usage,
-                    Usage {
-                        input_tokens: 10,
-                        output_tokens: 10,
-                    }
                 );
                 assert_eq!(json_result.model_inference_results.len(), 1);
                 assert_eq!(json_result.inference_params, inference_params);
@@ -1612,19 +1612,19 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(
+            result.usage_considering_cached(),
+            Usage {
+                input_tokens: 10,
+                output_tokens: 10,
+            }
+        );
         match result {
             InferenceResult::Json(json_result) => {
                 assert_eq!(json_result.output.parsed, Some(json!({"answer": "Hello"})));
                 assert_eq!(
                     json_result.output.raw,
                     Some(DUMMY_JSON_RESPONSE_RAW.to_string())
-                );
-                assert_eq!(
-                    json_result.usage,
-                    Usage {
-                        input_tokens: 10,
-                        output_tokens: 10,
-                    }
                 );
                 assert_eq!(json_result.model_inference_results.len(), 1);
                 assert_eq!(
@@ -1724,19 +1724,19 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(
+            result.usage_considering_cached(),
+            Usage {
+                input_tokens: 10,
+                output_tokens: 10,
+            }
+        );
         match result {
             InferenceResult::Json(json_result) => {
                 assert_eq!(json_result.output.parsed, Some(json!({"answer": "Hello"})));
                 assert_eq!(
                     json_result.output.raw,
                     Some(DUMMY_JSON_RESPONSE_RAW.to_string())
-                );
-                assert_eq!(
-                    json_result.usage,
-                    Usage {
-                        input_tokens: 10,
-                        output_tokens: 10,
-                    }
                 );
                 assert_eq!(json_result.model_inference_results.len(), 1);
                 assert_eq!(
@@ -1831,19 +1831,19 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(
+            result.usage_considering_cached(),
+            Usage {
+                input_tokens: 10,
+                output_tokens: 10,
+            }
+        );
         match result {
             InferenceResult::Json(json_result) => {
                 assert_eq!(json_result.output.parsed, None);
                 assert_eq!(
                     json_result.output.raw,
                     Some(DUMMY_JSON_RESPONSE_RAW.to_string())
-                );
-                assert_eq!(
-                    json_result.usage,
-                    Usage {
-                        input_tokens: 10,
-                        output_tokens: 10,
-                    }
                 );
                 assert_eq!(json_result.model_inference_results.len(), 1);
                 assert_eq!(

--- a/tensorzero-core/src/variant/mixture_of_n.rs
+++ b/tensorzero-core/src/variant/mixture_of_n.rs
@@ -13,7 +13,7 @@ use crate::inference::types::extra_body::FullExtraBodyConfig;
 use crate::inference::types::extra_headers::FullExtraHeadersConfig;
 use crate::inference::types::ResolvedInput;
 use crate::inference::types::{
-    batch::StartBatchModelInferenceWithMetadata, ModelInferenceRequest, RequestMessage, Role, Usage,
+    batch::StartBatchModelInferenceWithMetadata, ModelInferenceRequest, RequestMessage, Role,
 };
 use crate::model::ModelTable;
 use crate::{
@@ -335,11 +335,6 @@ impl MixtureOfNConfig {
             }
         };
 
-        // Safely remove the selected candidate without panicking
-        let mut total_usage: Usage = candidates.iter().map(|c| c.usage()).sum();
-        total_usage.input_tokens += inference_result.usage().input_tokens;
-        total_usage.output_tokens += inference_result.usage().output_tokens;
-        inference_result.set_usage(total_usage);
         for candidate in candidates {
             inference_result
                 .mut_model_inference_results()
@@ -601,7 +596,7 @@ mod tests {
         function::{FunctionConfigChat, FunctionConfigJson},
         inference::types::{
             ChatInferenceResult, FinishReason, InternalJsonInferenceOutput, JsonInferenceResult,
-            Latency, ModelInferenceResponseWithMetadata,
+            Latency, ModelInferenceResponseWithMetadata, Usage,
         },
         jsonschema_util::StaticJSONSchema,
         minijinja_util::tests::get_test_template_config,
@@ -799,10 +794,6 @@ mod tests {
             ChatInferenceResult::new(
                 Uuid::now_v7(),
                 vec!["Candidate answer 1".to_string().into()],
-                Usage {
-                    input_tokens: 10,
-                    output_tokens: 20,
-                },
                 vec![model_inference_response],
                 None,
                 InferenceParams::default(),
@@ -836,10 +827,6 @@ mod tests {
             ChatInferenceResult::new(
                 Uuid::now_v7(),
                 vec!["Candidate answer 2".to_string().into()],
-                Usage {
-                    input_tokens: 15,
-                    output_tokens: 25,
-                },
                 vec![model_inference_response2],
                 None,
                 InferenceParams::default(),
@@ -885,8 +872,8 @@ mod tests {
             raw_request: "{\"prompt\": \"Example prompt\"}".to_string(),
             raw_response: "{\"response\": \"Valid JSON response\"}".to_string(),
             usage: Usage {
-                input_tokens: 50,
-                output_tokens: 100,
+                input_tokens: 10,
+                output_tokens: 20,
             },
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(500),
@@ -903,10 +890,6 @@ mod tests {
             Some(json!({"response": "Valid JSON response"})),
             Some(0),
             vec![],
-            Usage {
-                input_tokens: 10,
-                output_tokens: 20,
-            },
             vec![model_inference_response_valid],
             json!({"type": "object", "properties": {"response": {"type": "string"}}}),
             InferenceParams::default(),
@@ -942,10 +925,6 @@ mod tests {
             None, // malformed
             Some(0),
             vec![],
-            Usage {
-                input_tokens: 15,
-                output_tokens: 25,
-            },
             vec![model_inference_response_malformed],
             json!({"type": "object", "properties": {"response": {"type": "string"}}}),
             InferenceParams::default(),
@@ -1005,8 +984,8 @@ mod tests {
             raw_request: "{\"prompt\": \"Example prompt\"}".to_string(),
             raw_response: "{\"response\": \"Example response\"}".to_string(),
             usage: Usage {
-                input_tokens: 50,
-                output_tokens: 100,
+                input_tokens: 10,
+                output_tokens: 20,
             },
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(500),
@@ -1021,10 +1000,6 @@ mod tests {
             ChatInferenceResult::new(
                 inference_id0,
                 vec!["Candidate answer 0".to_string().into()],
-                Usage {
-                    input_tokens: 10,
-                    output_tokens: 20,
-                },
                 vec![model_inference_response0],
                 None,
                 InferenceParams::default(),
@@ -1058,10 +1033,6 @@ mod tests {
             ChatInferenceResult::new(
                 inference_id1,
                 vec!["Candidate answer 1".to_string().into()],
-                Usage {
-                    input_tokens: 15,
-                    output_tokens: 25,
-                },
                 vec![model_inference_response1],
                 None,
                 InferenceParams::default(),
@@ -1145,9 +1116,9 @@ mod tests {
             auxiliary_content: vec![],
             json_block_index: Some(0),
         };
+        assert_eq!(fused.usage_considering_cached(), expected_usage);
         match fused {
             InferenceResult::Json(fused) => {
-                assert_eq!(fused.usage, expected_usage);
                 assert_eq!(fused.output, expected_content);
                 assert_eq!(fused.model_inference_results.len(), 3);
             }

--- a/tensorzero-core/src/variant/mod.rs
+++ b/tensorzero-core/src/variant/mod.rs
@@ -638,14 +638,12 @@ async fn infer_model_request(
     let model_inference_result =
         ModelInferenceResponseWithMetadata::new(model_inference_response, args.model_name);
     let raw_content = model_inference_result.output.clone();
-    let usage = model_inference_result.actual_usage();
     let model_inference_results = vec![model_inference_result];
 
     args.function
         .prepare_response(
             args.inference_config.ids.inference_id,
             raw_content,
-            usage,
             model_inference_results,
             args.inference_config,
             args.inference_params,
@@ -1106,12 +1104,15 @@ mod tests {
         let result = infer_model_request(args).await;
 
         let inference_result = result.unwrap();
+        assert_eq!(
+            inference_result.usage_considering_cached(),
+            DUMMY_INFER_USAGE.clone()
+        );
         match inference_result {
             InferenceResult::Chat(chat_result) => {
                 // The DummyProvider returns DUMMY_INFER_RESPONSE_CONTENT by default
                 let expected_content = vec![DUMMY_INFER_RESPONSE_CONTENT.to_string().into()];
                 assert_eq!(chat_result.content, expected_content);
-                assert_eq!(chat_result.usage, DUMMY_INFER_USAGE.clone());
                 assert_eq!(chat_result.model_inference_results.len(), 1);
                 assert_eq!(
                     &*chat_result.model_inference_results[0].model_name,
@@ -1215,6 +1216,10 @@ mod tests {
         let result = infer_model_request(args).await;
 
         let inference_result = result.unwrap();
+        assert_eq!(
+            inference_result.usage_considering_cached(),
+            DUMMY_INFER_USAGE.clone()
+        );
         match inference_result {
             InferenceResult::Json(json_result) => {
                 assert_eq!(
@@ -1222,7 +1227,6 @@ mod tests {
                     Some(DUMMY_JSON_RESPONSE_RAW.to_string())
                 );
                 assert_eq!(json_result.output.parsed, Some(json!({"answer": "Hello"})));
-                assert_eq!(json_result.usage, DUMMY_INFER_USAGE.clone());
                 assert_eq!(json_result.model_inference_results.len(), 1);
                 assert_eq!(
                     &*json_result.model_inference_results[0].model_name,
@@ -1412,12 +1416,15 @@ mod tests {
         let result = infer_model_request(args).await;
 
         let inference_result = result.unwrap();
+        assert_eq!(
+            inference_result.usage_considering_cached(),
+            DUMMY_INFER_USAGE.clone()
+        );
         match inference_result {
             InferenceResult::Chat(chat_result) => {
                 // The DummyProvider returns DUMMY_INFER_RESPONSE_CONTENT by default
                 let expected_content = vec![DUMMY_INFER_RESPONSE_CONTENT.to_string().into()];
                 assert_eq!(chat_result.content, expected_content);
-                assert_eq!(chat_result.usage, DUMMY_INFER_USAGE.clone());
                 assert_eq!(chat_result.model_inference_results.len(), 1);
                 assert_eq!(
                     &*chat_result.model_inference_results[0].model_name,


### PR DESCRIPTION
The mixture_of_n/best_of_n variants now report the original provider usage for each `ModelInference` row they create. The `InferenceResult` type no longer tracks usage separately - instead, we sum up usage from all model inference results in a new method `InferenceResult::usage_considering_cached`

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
