### PR TITLE
Implement streaming support for best_of_n variant

### DIFF
--- a/tensorzero-core/src/variant/mixture_of_n.rs
+++ b/tensorzero-core/src/variant/mixture_of_n.rs
@@ -154,40 +154,7 @@ impl Variant for MixtureOfNConfig {
         {
             // We get a NonStream result if we don't have fuser result (either the fuser failed, or it wasn't run at all due to only one candidate existing)
             InferenceOrStreamResult::NonStream(inference_result) => {
-                // Use the first model inference result to construct our top-level result (since we don't have a fuser result)
-                let model_inference_result = inference_result
-                    .model_inference_results()
-                    .first()
-                    .ok_or_else(|| {
-                        Error::new(ErrorDetails::Inference {
-                            message: format!(
-                                "Expected one candidate but found none. {IMPOSSIBLE_ERROR_MESSAGE}"
-                            ),
-                        })
-                    })?;
-                // Copy the actual usage from the model inference result (without considering cached)
-                // We set the 'cached' flag on the 'ModelUsedInfo, which will adjust the usage as needed when producing
-                // the HTTP response stream.
-                let usage = model_inference_result.usage;
-                let model_used_info = ModelUsedInfo {
-                    model_name: model_inference_result.model_name.clone(),
-                    model_provider_name: model_inference_result.model_provider_name.clone(),
-                    raw_request: model_inference_result.raw_request.clone(),
-                    inference_params: inference_params.clone(),
-                    // Preserve the raw response from the candidate we chose (rather than attempting
-                    // to concatenate the raw_response from the chunks in our fake stream)
-                    raw_response: Some(model_inference_result.raw_response.clone()),
-                    // Preserve any other model inference results (we already processed the first one),
-                    // in case we're doing something like chained best-of-n/mixture-of-n variants.
-                    previous_model_inference_results: inference_result.model_inference_results()
-                        [1..]
-                        .to_vec(),
-                    system: model_inference_result.system.clone(),
-                    input_messages: model_inference_result.input_messages.clone(),
-                    cached: model_inference_result.cached,
-                };
-                let stream = make_stream_from_non_stream(inference_result, Some(usage))?;
-                Ok((stream, model_used_info))
+                stream_inference_from_non_stream(inference_result, inference_params)
             }
             InferenceOrStreamResult::Stream(stream, model_used_info) => {
                 Ok((stream, model_used_info))
@@ -275,6 +242,49 @@ enum InferenceOrStreamResult {
     /// We only produce `InferenceOrStreamResult::Stream` if the user requested a streaming inference,
     /// and the fuser successfully starts a stream.
     Stream(InferenceResultStream, ModelUsedInfo),
+}
+
+/// Constructs an `infer_stream` response `(InferenceResultStream, ModelUsedInfo)`,
+/// building bot from the information contained in the `InferenceResult`.
+/// Each content block in the `InferenceResult` is converted into a chunk in the `InferenceResultStream`.
+/// This is used by `best_of_n` and `mixture_of_n` when the user requests a stream response,
+/// but our candidate/judge has a non-streaming response.
+pub fn stream_inference_from_non_stream(
+    inference_result: InferenceResult,
+    inference_params: InferenceParams,
+) -> Result<(InferenceResultStream, ModelUsedInfo), Error> {
+    // Use the first model inference result to construct our top-level result (since we don't have a fuser/judge result)
+    let model_inference_result = inference_result
+        .model_inference_results()
+        .first()
+        .ok_or_else(|| {
+            Error::new(ErrorDetails::Inference {
+                message: format!(
+                    "Expected one candidate but found none. {IMPOSSIBLE_ERROR_MESSAGE}"
+                ),
+            })
+        })?;
+    // Copy the actual usage from the model inference result (without considering cached)
+    // We set the 'cached' flag on the 'ModelUsedInfo, which will adjust the usage as needed when producing
+    // the HTTP response stream.
+    let usage = model_inference_result.usage;
+    let model_used_info = ModelUsedInfo {
+        model_name: model_inference_result.model_name.clone(),
+        model_provider_name: model_inference_result.model_provider_name.clone(),
+        raw_request: model_inference_result.raw_request.clone(),
+        inference_params: inference_params.clone(),
+        // Preserve the raw response from the candidate we chose (rather than attempting
+        // to concatenate the raw_response from the chunks in our fake stream)
+        raw_response: Some(model_inference_result.raw_response.clone()),
+        // Preserve any other model inference results (we already processed the first one),
+        // in case we're doing something like chained best-of-n/mixture-of-n variants.
+        previous_model_inference_results: inference_result.model_inference_results()[1..].to_vec(),
+        system: model_inference_result.system.clone(),
+        input_messages: model_inference_result.input_messages.clone(),
+        cached: model_inference_result.cached,
+    };
+    let stream = make_stream_from_non_stream(inference_result, Some(usage))?;
+    Ok((stream, model_used_info))
 }
 
 fn make_stream_from_non_stream(

--- a/tensorzero-core/tests/e2e/best_of_n.rs
+++ b/tensorzero-core/tests/e2e/best_of_n.rs
@@ -1,4 +1,7 @@
+#![allow(clippy::print_stdout)]
+use futures::StreamExt;
 use reqwest::{Client, StatusCode};
+use reqwest_eventsource::{Event, RequestBuilderExt};
 use serde_json::{json, Value};
 use tensorzero_core::{
     inference::types::{ContentBlock, RequestMessage, Role},
@@ -13,16 +16,25 @@ use tensorzero_core::clickhouse::test_helpers::{
 };
 
 #[tokio::test]
-async fn e2e_test_best_of_n_dummy_candidates_dummy_judge() {
+async fn e2e_test_best_of_n_dummy_candidates_dummy_judge_non_stream() {
     // Include randomness in put to make sure that the first request is a cache miss
     let random_input = Uuid::now_v7();
-    e2e_test_best_of_n_dummy_candidates_dummy_judge_inner(random_input, false).await;
-    e2e_test_best_of_n_dummy_candidates_dummy_judge_inner(random_input, true).await;
+    e2e_test_best_of_n_dummy_candidates_dummy_judge_inner(random_input, false, false).await;
+    e2e_test_best_of_n_dummy_candidates_dummy_judge_inner(random_input, true, false).await;
+}
+
+#[tokio::test]
+async fn e2e_test_best_of_n_dummy_candidates_dummy_judge_streaming() {
+    // Include randomness in put to make sure that the first request is a cache miss
+    let random_input = Uuid::now_v7();
+    e2e_test_best_of_n_dummy_candidates_dummy_judge_inner(random_input, false, true).await;
+    e2e_test_best_of_n_dummy_candidates_dummy_judge_inner(random_input, true, true).await;
 }
 
 async fn e2e_test_best_of_n_dummy_candidates_dummy_judge_inner(
     random_input: Uuid,
     should_be_cached: bool,
+    stream: bool,
 ) {
     let episode_id = Uuid::now_v7();
 
@@ -40,22 +52,45 @@ async fn e2e_test_best_of_n_dummy_candidates_dummy_judge_inner(
                     ]
                 }
             ]},
-        "stream": false,
+        "stream": stream,
         "cache_options": {"enabled": "on", "lookback_s": 10}
     });
 
-    let response = Client::new()
+    let builder = Client::new()
         .post(get_gateway_endpoint("/inference"))
-        .json(&payload)
-        .send()
-        .await
-        .unwrap();
-    // Check Response is OK, then fields in order
-    assert_eq!(response.status(), StatusCode::OK);
-    let response_json = response.json::<Value>().await.unwrap();
-    // Check that inference_id is here
-    let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
-    let inference_id = Uuid::parse_str(inference_id).unwrap();
+        .json(&payload);
+
+    let inference_id = if stream {
+        let mut chunks = builder.eventsource().unwrap();
+        let mut first_inference_id = None;
+        while let Some(chunk) = chunks.next().await {
+            println!("chunk: {chunk:?}");
+            let chunk = chunk.unwrap();
+            let Event::Message(chunk) = chunk else {
+                continue;
+            };
+            if chunk.data == "[DONE]" {
+                break;
+            }
+            let chunk_json = chunk.data;
+            let chunk_json: Value = serde_json::from_str(&chunk_json).unwrap();
+            let inference_id = chunk_json.get("inference_id").unwrap().as_str().unwrap();
+            let inference_id = Uuid::parse_str(inference_id).unwrap();
+            if first_inference_id.is_none() {
+                first_inference_id = Some(inference_id);
+            }
+        }
+        // TODO - expand this test to build up 'content' from the chunks
+        first_inference_id.unwrap()
+    } else {
+        let response = builder.send().await.unwrap();
+        // Check Response is OK, then fields in order
+        assert_eq!(response.status(), StatusCode::OK);
+        let response_json = response.json::<Value>().await.unwrap();
+        // Check that inference_id is here
+        let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
+        Uuid::parse_str(inference_id).unwrap()
+    };
 
     // Sleep for 1 second to allow time for data to be inserted into ClickHouse (trailing writes from API)
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;


### PR DESCRIPTION
This just converts the chosen candidate into a stream, using the same logic that we use in `mixture_of_n`

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
