### PR TITLE
Use `CodeBlock` component for inference input snippets

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,9 @@ importers:
       tiktoken:
         specifier: ^1.0.20
         version: 1.0.21
+      type-fest:
+        specifier: ^4.41.0
+        version: 4.41.0
       typescript-eslint:
         specifier: ^8.35.0
         version: 8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
@@ -4201,6 +4204,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -8656,6 +8663,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@4.41.0: {}
 
   type-is@1.6.18:
     dependencies:

--- a/ui/app/components/inference/InputSnippet.stories.tsx
+++ b/ui/app/components/inference/InputSnippet.stories.tsx
@@ -20,333 +20,313 @@ type Story = StoryObj<typeof meta>;
 
 export const Empty: Story = {
   args: {
-    input: {
-      messages: [],
-    },
+    messages: [],
   },
 };
 
 export const SystemNoMessages: Story = {
   args: {
-    input: {
-      system: "You are a helpful assistant.",
-      messages: [],
-    },
+    system: "You are a helpful assistant.",
+    messages: [],
   },
 };
 
 export const MessagesNoSystem: Story = {
   args: {
-    input: {
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "What is the capital of Japan?",
-            },
-          ],
-        },
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "The capital of Japan is Tokyo.",
-            },
-          ],
-        },
-        {
-          role: "user",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "Arigatou!",
-            },
-          ],
-        },
-      ],
-    },
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "What is the capital of Japan?",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "The capital of Japan is Tokyo.",
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "Arigatou!",
+          },
+        ],
+      },
+    ],
   },
 };
 
 export const SingleUserMessageWithMultipleContentBlocks: Story = {
   args: {
-    input: {
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.",
-            },
-            {
-              type: "unstructured_text",
-              text: "Duis sodales facilisis mollis. Sed et molestie enim. Integer eget pharetra urna. In ullamcorper nisi vitae ullamcorper laoreet. Vestibulum at enim et mauris tristique pellentesque. Sed dignissim nunc porta arcu sodales viverra. Nunc vulputate neque quis arcu ultricies, eu convallis magna tincidunt. Integer bibendum nec mauris ut mattis. Suspendisse potenti. Quisque gravida dui turpis. Duis vestibulum odio in risus finibus placerat.",
-            },
-            {
-              type: "unstructured_text",
-              text: "Aliquam dapibus accumsan erat, eget volutpat mauris ultricies eu. Sed in tortor rutrum, scelerisque ipsum sit amet, volutpat ex. Ut sodales mauris ante, vitae condimentum elit euismod ac. Aliquam sed libero bibendum, venenatis lectus sed, pharetra diam. Ut eu viverra lacus. Fusce ornare vitae lectus ut ullamcorper. Mauris nec nisl convallis, tincidunt leo at, dignissim mi. Nam vehicula eleifend lectus eu scelerisque. Pellentesque feugiat eget risus sed posuere. Aliquam semper, enim eget consequat volutpat, felis sapien sagittis elit, condimentum gravida nisl ante sed eros. Vestibulum elementum efficitur mi, ac auctor lectus hendrerit vel. Quisque at enim libero. Cras in lectus vitae eros vestibulum mollis in et purus. Pellentesque tincidunt dui nec orci tincidunt, non fermentum felis molestie. Phasellus blandit, arcu quis interdum ultricies, turpis ligula tempor tellus, quis euismod est felis et tortor.",
-            },
-          ],
-        },
-      ],
-    },
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.",
+          },
+          {
+            type: "unstructured_text",
+            text: "Duis sodales facilisis mollis. Sed et molestie enim. Integer eget pharetra urna. In ullamcorper nisi vitae ullamcorper laoreet. Vestibulum at enim et mauris tristique pellentesque. Sed dignissim nunc porta arcu sodales viverra. Nunc vulputate neque quis arcu ultricies, eu convallis magna tincidunt. Integer bibendum nec mauris ut mattis. Suspendisse potenti. Quisque gravida dui turpis. Duis vestibulum odio in risus finibus placerat.",
+          },
+          {
+            type: "unstructured_text",
+            text: "Aliquam dapibus accumsan erat, eget volutpat mauris ultricies eu. Sed in tortor rutrum, scelerisque ipsum sit amet, volutpat ex. Ut sodales mauris ante, vitae condimentum elit euismod ac. Aliquam sed libero bibendum, venenatis lectus sed, pharetra diam. Ut eu viverra lacus. Fusce ornare vitae lectus ut ullamcorper. Mauris nec nisl convallis, tincidunt leo at, dignissim mi. Nam vehicula eleifend lectus eu scelerisque. Pellentesque feugiat eget risus sed posuere. Aliquam semper, enim eget consequat volutpat, felis sapien sagittis elit, condimentum gravida nisl ante sed eros. Vestibulum elementum efficitur mi, ac auctor lectus hendrerit vel. Quisque at enim libero. Cras in lectus vitae eros vestibulum mollis in et purus. Pellentesque tincidunt dui nec orci tincidunt, non fermentum felis molestie. Phasellus blandit, arcu quis interdum ultricies, turpis ligula tempor tellus, quis euismod est felis et tortor.",
+          },
+        ],
+      },
+    ],
   },
 };
 
 export const MultipleUserMessagesWithSingleContentBlock: Story = {
   args: {
-    input: {
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.",
-            },
-          ],
-        },
-        {
-          role: "user",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "Duis sodales facilisis mollis. Sed et molestie enim. Integer eget pharetra urna. In ullamcorper nisi vitae ullamcorper laoreet. Vestibulum at enim et mauris tristique pellentesque. Sed dignissim nunc porta arcu sodales viverra. Nunc vulputate neque quis arcu ultricies, eu convallis magna tincidunt. Integer bibendum nec mauris ut mattis. Suspendisse potenti. Quisque gravida dui turpis. Duis vestibulum odio in risus finibus placerat.",
-            },
-          ],
-        },
-        {
-          role: "user",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "Aliquam dapibus accumsan erat, eget volutpat mauris ultricies eu. Sed in tortor rutrum, scelerisque ipsum sit amet, volutpat ex. Ut sodales mauris ante, vitae condimentum elit euismod ac. Aliquam sed libero bibendum, venenatis lectus sed, pharetra diam. Ut eu viverra lacus. Fusce ornare vitae lectus ut ullamcorper. Mauris nec nisl convallis, tincidunt leo at, dignissim mi. Nam vehicula eleifend lectus eu scelerisque. Pellentesque feugiat eget risus sed posuere. Aliquam semper, enim eget consequat volutpat, felis sapien sagittis elit, condimentum gravida nisl ante sed eros. Vestibulum elementum efficitur mi, ac auctor lectus hendrerit vel. Quisque at enim libero. Cras in lectus vitae eros vestibulum mollis in et purus. Pellentesque tincidunt dui nec orci tincidunt, non fermentum felis molestie. Phasellus blandit, arcu quis interdum ultricies, turpis ligula tempor tellus, quis euismod est felis et tortor.",
-            },
-          ],
-        },
-      ],
-    },
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.",
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "Duis sodales facilisis mollis. Sed et molestie enim. Integer eget pharetra urna. In ullamcorper nisi vitae ullamcorper laoreet. Vestibulum at enim et mauris tristique pellentesque. Sed dignissim nunc porta arcu sodales viverra. Nunc vulputate neque quis arcu ultricies, eu convallis magna tincidunt. Integer bibendum nec mauris ut mattis. Suspendisse potenti. Quisque gravida dui turpis. Duis vestibulum odio in risus finibus placerat.",
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "Aliquam dapibus accumsan erat, eget volutpat mauris ultricies eu. Sed in tortor rutrum, scelerisque ipsum sit amet, volutpat ex. Ut sodales mauris ante, vitae condimentum elit euismod ac. Aliquam sed libero bibendum, venenatis lectus sed, pharetra diam. Ut eu viverra lacus. Fusce ornare vitae lectus ut ullamcorper. Mauris nec nisl convallis, tincidunt leo at, dignissim mi. Nam vehicula eleifend lectus eu scelerisque. Pellentesque feugiat eget risus sed posuere. Aliquam semper, enim eget consequat volutpat, felis sapien sagittis elit, condimentum gravida nisl ante sed eros. Vestibulum elementum efficitur mi, ac auctor lectus hendrerit vel. Quisque at enim libero. Cras in lectus vitae eros vestibulum mollis in et purus. Pellentesque tincidunt dui nec orci tincidunt, non fermentum felis molestie. Phasellus blandit, arcu quis interdum ultricies, turpis ligula tempor tellus, quis euismod est felis et tortor.",
+          },
+        ],
+      },
+    ],
   },
 };
 
 export const MultiTurnToolUse: Story = {
   args: {
-    input: {
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "What is the weather in Tokyo?",
-            },
-          ],
-        },
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "I can help you with that.",
-            },
-            {
-              type: "tool_call",
-              name: "weather_tool",
-              arguments: JSON.stringify({ city: "Tokyo" }),
-              id: "acd0806d-4ec6-4efd-864e-a29aa66ec3fc",
-            },
-          ],
-        },
-        {
-          role: "user",
-          content: [
-            {
-              type: "tool_result",
-              name: "weather_tool",
-              result: JSON.stringify({ temperature: 20, condition: "sunny" }),
-              id: "acd0806d-4ec6-4efd-864e-a29aa66ec3fc",
-            },
-          ],
-        },
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "The weather in Tokyo is sunny, with a temperature of 20 degrees Celsius.",
-            },
-          ],
-        },
-      ],
-    },
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "What is the weather in Tokyo?",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "I can help you with that.",
+          },
+          {
+            type: "tool_call",
+            name: "weather_tool",
+            arguments: JSON.stringify({ city: "Tokyo" }),
+            id: "acd0806d-4ec6-4efd-864e-a29aa66ec3fc",
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            name: "weather_tool",
+            result: JSON.stringify({ temperature: 20, condition: "sunny" }),
+            id: "acd0806d-4ec6-4efd-864e-a29aa66ec3fc",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "The weather in Tokyo is sunny, with a temperature of 20 degrees Celsius.",
+          },
+        ],
+      },
+    ],
   },
 };
 
 export const LongMultiTurnToolUse: Story = {
   args: {
-    input: {
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "What is the weather in Tokyo?",
-            },
-          ],
-        },
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "I can help you with that.",
-            },
-            {
-              type: "tool_call",
-              name: "summarize_tool",
-              arguments: JSON.stringify({
-                verbosity: "high",
-                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam et nunc augue. Pellentesque at facilisis ipsum. Donec facilisis lorem ligula, ultrices feugiat nibh consectetur id. Aenean pulvinar est ac ipsum vulputate, nec maximus ligula elementum. Cras a eros eget velit varius finibus ut sollicitudin enim. Nulla et augue ac massa consequat cursus. Curabitur eget dolor tristique, porttitor mi non, commodo augue. Integer tincidunt dui lectus, egestas dapibus mauris porta sit amet. Morbi tincidunt turpis id tortor ornare, vel viverra elit cursus. Cras a felis ultricies, interdum dui vel, facilisis risus.",
-              }),
-              id: "acd0806d-4ec6-4efd-864e-a29aa66ec3fc",
-            },
-          ],
-        },
-        {
-          role: "user",
-          content: [
-            {
-              type: "tool_result",
-              name: "summarize_tool",
-              result: JSON.stringify({
-                summary:
-                  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam et nunc augue. Pellentesque at facilisis ipsum. Donec facilisis lorem ligula, ultrices feugiat nibh consectetur id. Aenean pulvinar est ac ipsum vulputate, nec maximus ligula elementum. Cras a eros eget velit varius finibus ut sollicitudin enim. Nulla et augue ac massa consequat cursus. Curabitur eget dolor tristique, porttitor mi non, commodo augue. Integer tincidunt dui lectus, egestas dapibus mauris porta sit amet. Morbi tincidunt turpis id tortor ornare, vel viverra elit cursus. Cras a felis ultricies, interdum dui vel, facilisis risus.",
-              }),
-              id: "acd0806d-4ec6-4efd-864e-a29aa66ec3fc",
-            },
-          ],
-        },
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "unstructured_text",
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "What is the weather in Tokyo?",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "I can help you with that.",
+          },
+          {
+            type: "tool_call",
+            name: "summarize_tool",
+            arguments: JSON.stringify({
+              verbosity: "high",
               text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam et nunc augue. Pellentesque at facilisis ipsum. Donec facilisis lorem ligula, ultrices feugiat nibh consectetur id. Aenean pulvinar est ac ipsum vulputate, nec maximus ligula elementum. Cras a eros eget velit varius finibus ut sollicitudin enim. Nulla et augue ac massa consequat cursus. Curabitur eget dolor tristique, porttitor mi non, commodo augue. Integer tincidunt dui lectus, egestas dapibus mauris porta sit amet. Morbi tincidunt turpis id tortor ornare, vel viverra elit cursus. Cras a felis ultricies, interdum dui vel, facilisis risus.",
-            },
-          ],
-        },
-      ],
-    },
+            }),
+            id: "acd0806d-4ec6-4efd-864e-a29aa66ec3fc",
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            name: "summarize_tool",
+            result: JSON.stringify({
+              summary:
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam et nunc augue. Pellentesque at facilisis ipsum. Donec facilisis lorem ligula, ultrices feugiat nibh consectetur id. Aenean pulvinar est ac ipsum vulputate, nec maximus ligula elementum. Cras a eros eget velit varius finibus ut sollicitudin enim. Nulla et augue ac massa consequat cursus. Curabitur eget dolor tristique, porttitor mi non, commodo augue. Integer tincidunt dui lectus, egestas dapibus mauris porta sit amet. Morbi tincidunt turpis id tortor ornare, vel viverra elit cursus. Cras a felis ultricies, interdum dui vel, facilisis risus.",
+            }),
+            id: "acd0806d-4ec6-4efd-864e-a29aa66ec3fc",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam et nunc augue. Pellentesque at facilisis ipsum. Donec facilisis lorem ligula, ultrices feugiat nibh consectetur id. Aenean pulvinar est ac ipsum vulputate, nec maximus ligula elementum. Cras a eros eget velit varius finibus ut sollicitudin enim. Nulla et augue ac massa consequat cursus. Curabitur eget dolor tristique, porttitor mi non, commodo augue. Integer tincidunt dui lectus, egestas dapibus mauris porta sit amet. Morbi tincidunt turpis id tortor ornare, vel viverra elit cursus. Cras a felis ultricies, interdum dui vel, facilisis risus.",
+          },
+        ],
+      },
+    ],
   },
 };
 
 export const MultiTurnParallelToolUse: Story = {
   args: {
-    input: {
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "What is the weather in Tokyo?",
-            },
-          ],
-        },
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "I can help you with that.",
-            },
-            {
-              type: "tool_call",
-              name: "temperature_tool",
-              arguments: JSON.stringify({ city: "Tokyo" }),
-              id: "1",
-            },
-            {
-              type: "tool_call",
-              name: "humidity_tool",
-              arguments: JSON.stringify({ city: "Tokyo" }),
-              id: "2 ",
-            },
-          ],
-        },
-        {
-          role: "user",
-          content: [
-            {
-              type: "tool_result",
-              name: "temperature_tool",
-              result: JSON.stringify({ temperature: 20 }),
-              id: "1",
-            },
-            {
-              type: "tool_result",
-              name: "humidity_tool",
-              result: JSON.stringify({ humidity: 50 }),
-              id: "2",
-            },
-          ],
-        },
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "The weather in Tokyo is sunny, with a temperature of 20 degrees Celsius and a humidity of 50%.",
-            },
-          ],
-        },
-      ],
-    },
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "What is the weather in Tokyo?",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "I can help you with that.",
+          },
+          {
+            type: "tool_call",
+            name: "temperature_tool",
+            arguments: JSON.stringify({ city: "Tokyo" }),
+            id: "1",
+          },
+          {
+            type: "tool_call",
+            name: "humidity_tool",
+            arguments: JSON.stringify({ city: "Tokyo" }),
+            id: "2 ",
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            name: "temperature_tool",
+            result: JSON.stringify({ temperature: 20 }),
+            id: "1",
+          },
+          {
+            type: "tool_result",
+            name: "humidity_tool",
+            result: JSON.stringify({ humidity: 50 }),
+            id: "2",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "The weather in Tokyo is sunny, with a temperature of 20 degrees Celsius and a humidity of 50%.",
+          },
+        ],
+      },
+    ],
   },
 };
 
 export const TextWithArguments: Story = {
   args: {
-    input: {
-      system: "Write a haiku about the topic provided by the user.",
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "structured_text",
-              arguments: {
-                topic: "AI",
-              },
+    system: "Write a haiku about the topic provided by the user.",
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "structured_text",
+            arguments: {
+              topic: "AI",
             },
-          ],
-        },
-      ],
-    },
+          },
+        ],
+      },
+    ],
   },
 };
 
 export const RawTextInput: Story = {
   args: {
-    input: {
-      system: "Write a haiku about the topic provided by the user.",
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "raw_text",
-              value: "# Topic\n\nAI",
-            },
-          ],
-        },
-      ],
-    },
+    system: "Write a haiku about the topic provided by the user.",
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "raw_text",
+            value: "# Topic\n\nAI",
+          },
+        ],
+      },
+    ],
   },
 };
 
@@ -378,360 +358,348 @@ async function getBase64File(url: string): Promise<string> {
 
 export const ImageInput: Story = {
   args: {
-    input: {
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "Do the images share any common features?",
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "Do the images share any common features?",
+          },
+          {
+            type: "file",
+            file: {
+              dataUrl: await getBase64File(
+                "https://raw.githubusercontent.com/tensorzero/tensorzero/ff3e17bbd3e32f483b027cf81b54404788c90dc1/tensorzero-internal/tests/e2e/providers/ferris.png",
+              ),
+              mime_type: "image/png",
             },
-            {
-              type: "file",
-              file: {
-                dataUrl: await getBase64File(
-                  "https://raw.githubusercontent.com/tensorzero/tensorzero/ff3e17bbd3e32f483b027cf81b54404788c90dc1/tensorzero-internal/tests/e2e/providers/ferris.png",
-                ),
-                mime_type: "image/png",
+            storage_path: {
+              kind: {
+                type: "s3_compatible",
+                bucket_name: "tensorzero-e2e-test-images",
+                region: "us-east-1",
+                endpoint: null,
+                allow_http: null,
               },
-              storage_path: {
-                kind: {
-                  type: "s3_compatible",
-                  bucket_name: "tensorzero-e2e-test-images",
-                  region: "us-east-1",
-                  endpoint: null,
-                  allow_http: null,
-                },
-                path: "observability/files/e46e28c76498f7a7e935a502d3cd6f41052a76a6c6b0d8cda44e03fad8cc70f1.png",
-              },
+              path: "observability/files/e46e28c76498f7a7e935a502d3cd6f41052a76a6c6b0d8cda44e03fad8cc70f1.png",
             },
-            {
-              type: "file",
-              file: {
-                // This is a one pixel by one pixel orange image
-                dataUrl:
-                  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdj+O/P8B8ABe0CTsv8mHgAAAAASUVORK5CYII=",
-                mime_type: "image/png",
-              },
-              storage_path: {
-                kind: {
-                  type: "filesystem",
-                  path: "my_object_storage",
-                },
-                path: "observability/files/7f3a9b2e8d4c6f5a1e0b9d8c7a4b2e5f3d1c8b9a6e4f2d5c8b3a7e1f9d4c6b2.png",
-              },
+          },
+          {
+            type: "file",
+            file: {
+              // This is a one pixel by one pixel orange image
+              dataUrl:
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdj+O/P8B8ABe0CTsv8mHgAAAAASUVORK5CYII=",
+              mime_type: "image/png",
             },
-          ],
-        },
-      ],
-    },
+            storage_path: {
+              kind: {
+                type: "filesystem",
+                path: "my_object_storage",
+              },
+              path: "observability/files/7f3a9b2e8d4c6f5a1e0b9d8c7a4b2e5f3d1c8b9a6e4f2d5c8b3a7e1f9d4c6b2.png",
+            },
+          },
+        ],
+      },
+    ],
   },
 };
 
 export const ImageInputError: Story = {
   args: {
-    input: {
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "Do the images share any common features?",
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "Do the images share any common features?",
+          },
+          {
+            type: "file_error",
+            file: {
+              mime_type: "image/png",
+              url: "foo.png",
             },
-            {
-              type: "file_error",
-              file: {
-                mime_type: "image/png",
-                url: "foo.png",
+            storage_path: {
+              kind: {
+                type: "s3_compatible",
+                bucket_name: "tensorzero-e2e-test-images",
+                region: "us-east-1",
+                endpoint: null,
+                allow_http: null,
               },
-              storage_path: {
-                kind: {
-                  type: "s3_compatible",
-                  bucket_name: "tensorzero-e2e-test-images",
-                  region: "us-east-1",
-                  endpoint: null,
-                  allow_http: null,
-                },
-                path: "observability/files/e46e28c76498f7a7e935a502d3cd6f41052a76a6c6b0d8cda44e03fad8cc70f1.png",
-              },
-              error: "Failed to get object: Internal Server Error",
+              path: "observability/files/e46e28c76498f7a7e935a502d3cd6f41052a76a6c6b0d8cda44e03fad8cc70f1.png",
             },
-            {
-              type: "file_error",
-              file: {
-                mime_type: "image/png",
-                url: "foo.png",
-              },
-              storage_path: {
-                kind: {
-                  type: "s3_compatible",
-                  bucket_name: "tensorzero-e2e-test-images",
-                  region: "us-east-1",
-                  endpoint: null,
-                  allow_http: null,
-                },
-                path: "observability/files/e46e28c76498f7a7e935a502d3cd6f41052a76a6c6b0d8cda44e03fad8cc70f1.png",
-              },
-              error: "Failed to get object: Timeout",
+            error: "Failed to get object: Internal Server Error",
+          },
+          {
+            type: "file_error",
+            file: {
+              mime_type: "image/png",
+              url: "foo.png",
             },
-          ],
-        },
-      ],
-    },
+            storage_path: {
+              kind: {
+                type: "s3_compatible",
+                bucket_name: "tensorzero-e2e-test-images",
+                region: "us-east-1",
+                endpoint: null,
+                allow_http: null,
+              },
+              path: "observability/files/e46e28c76498f7a7e935a502d3cd6f41052a76a6c6b0d8cda44e03fad8cc70f1.png",
+            },
+            error: "Failed to get object: Timeout",
+          },
+        ],
+      },
+    ],
   },
 };
 
 export const PDFInput: Story = {
   args: {
-    input: {
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "Please analyze this research paper.",
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "Please analyze this research paper.",
+          },
+          {
+            type: "file",
+            file: {
+              dataUrl: await getBase64File(pdfUrl),
+              mime_type: "application/pdf",
             },
-            {
-              type: "file",
-              file: {
-                dataUrl: await getBase64File(pdfUrl),
-                mime_type: "application/pdf",
+            storage_path: {
+              kind: {
+                type: "s3_compatible",
+                bucket_name: "tensorzero-documents",
+                region: "us-east-1",
+                endpoint: null,
+                allow_http: null,
               },
-              storage_path: {
-                kind: {
-                  type: "s3_compatible",
-                  bucket_name: "tensorzero-documents",
-                  region: "us-east-1",
-                  endpoint: null,
-                  allow_http: null,
-                },
-                path: "observability/files/contract_fake_path_12345.pdf",
-              },
+              path: "observability/files/contract_fake_path_12345.pdf",
             },
-          ],
-        },
-      ],
-    },
+          },
+        ],
+      },
+    ],
   },
 };
 
 export const AudioInput: Story = {
   args: {
-    input: {
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "unstructured_text",
-              text: "Transcribe this audio recording.",
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "unstructured_text",
+            text: "Transcribe this audio recording.",
+          },
+          {
+            type: "file",
+            file: {
+              dataUrl: await getBase64File(mp3Url),
+              mime_type: "audio/mp3",
             },
-            {
-              type: "file",
-              file: {
-                dataUrl: await getBase64File(mp3Url),
-                mime_type: "audio/mp3",
+            storage_path: {
+              kind: {
+                type: "filesystem",
+                path: "my_audio_storage",
               },
-              storage_path: {
-                kind: {
-                  type: "filesystem",
-                  path: "my_audio_storage",
-                },
-                path: "observability/files/meeting_recording_fake_path_67890.mp3",
-              },
+              path: "observability/files/meeting_recording_fake_path_67890.mp3",
             },
-          ],
-        },
-      ],
-    },
+          },
+        ],
+      },
+    ],
   },
 };
 
 export const BadToolInput: Story = {
   args: {
-    input: {
-      system: {
-        question:
-          "Do adolescents associate with 'cliques' on a large or small scale?",
-      },
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "unstructured_text",
-              text: 'Do adolescents associate with "cliques" on a large or small scale?',
-            },
-          ],
-        },
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "unstructured_text",
-              text: 'Compact Research Summary: Do Adolescents Associate with "Cliques" on a Large or Small Scale?\n\nKey Findings:\n1. Scale of Clique Association:\n- Cliques typically consist of 5-6 people\n- Most adolescents fall into three categories:\n  a) Group members (less than half of school population)\n  b) Liaisons (connect across multiple groups)\n  c) Isolates (few or no close peer relationships)\n\n2. Prevalence:\n- Cliques are extremely common during adolescence\n- Form in early adolescence (girls around 11, boys around 13-14)\n- Present across different demographics, ethnicities, and socioeconomic backgrounds\n\n3. Characteristics:\n- Most cliques are homogeneous in:\n  - Age\n  - Gender\n  - Race\n  - Social status\n  - Socioeconomic background\n\n4. Duration and Stability:\n- Cliques are relatively stable, losing about one-third of members per year\n- Membership type (group member, liaison, isolate) is more consistent than specific clique membership\n- Typically dissolve by late adolescence, replaced by dating relationships\n\n5. Demographic Factors:\n- Strongly influenced by:\n  - School environment\n  - Shared interests\n  - Orientation toward school/teen culture\n  - Potential antisocial behaviors\n\nConclusion: Adolescents do associate with cliques on a moderate to large scale, with most students belonging to some form of social group during their teenage years.',
-            },
-          ],
-        },
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "tool_call",
-              name: "think",
-              arguments:
-                '{"thought":"I notice that my previous response was generated without using Wikipedia search tools, which goes against the established protocol. I should systematically search Wikipedia to provide a well-sourced answer about adolescent cliques."}',
-              id: "toolu_01B8b7WQWmT2XHE6AQo1Ms7E",
-            },
-          ],
-        },
-        {
-          role: "user",
-          content: [
-            {
-              type: "tool_result",
-              name: "think",
-              result: "",
-              id: "toolu_01B8b7WQWmT2XHE6AQo1Ms7E",
-            },
-          ],
-        },
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "tool_call",
-              name: "search_wikipedia",
-              arguments:
-                '{"query":"Adolescent cliques social groups peer relationships"}',
-              id: "toolu_011BJUPo2bXLyXMjzfDhZFVx",
-            },
-          ],
-        },
-        {
-          role: "user",
-          content: [
-            {
-              type: "tool_result",
-              name: "search_wikipedia",
-              result:
-                "Peer group\nClique\nAdolescent clique\nPeer pressure\nAdolescence\nElaboration principle\nSocial emotional development\nSocial software\nCrowds (adolescence)\nSocial network analysis",
-              id: "toolu_011BJUPo2bXLyXMjzfDhZFVx",
-            },
-          ],
-        },
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "tool_call",
-              name: "think",
-              arguments:
-                '{"thought":"The search results provide several promising pages to investigate. I\'ll start by loading the \\"Adolescent clique\\" page to get direct information about the scale and nature of cliques among adolescents."}',
-              id: "toolu_01UbpVHwqoY3QvUBmVE32HdA",
-            },
-          ],
-        },
-        {
-          role: "user",
-          content: [
-            {
-              type: "tool_result",
-              name: "think",
-              result: "",
-              id: "toolu_01UbpVHwqoY3QvUBmVE32HdA",
-            },
-          ],
-        },
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "tool_call",
-              name: "load_wikipedia_page",
-              arguments: '{"title":"Adolescent clique"}',
-              id: "toolu_019Wm8MrB7ECsV3ubbce9MJf",
-            },
-          ],
-        },
-        {
-          role: "user",
-          content: [
-            {
-              type: "tool_result",
-              name: "load_wikipedia_page",
-              result:
-                '# URL\n\nhttps://en.wikipedia.org/wiki/Adolescent_clique\n\n# CONTENT\n\n|  |  |\n| --- | --- |\n|  | This article needs to be **updated**. The reason given is: article is largely based on late 2000s and early 2010s conceptions of cliques (for example, the inclusion of virtually non-existent cliques that used to be prominent like skaters). Please help update this article to reflect recent events or newly available information. *(March 2023)* |\n\nCliques that develop among adolescents\n\n**Adolescent cliques** are [cliques](/wiki/Clique "Clique") that develop amongst [adolescents](/wiki/Adolescence "Adolescence"). In the social sciences, the word "**clique**" is used to describe a large group of 6 to 12 "who interact with each other more regularly and intensely than others in the same setting".[[1]](#cite_note-EEP-1) Cliques are distinguished from "[crowds](/wiki/Crowds_(adolescence) "Crowds (adolescence)")" in that their members socially interact with one another more than the typical crowd (e.g. hang out together, go shopping, play sports etc.). Crowds, on the other hand, are defined by reputation. Although the word \'clique\' or \'cliquey\' is often used in day-to-day conversation to describe [relational aggression](/wiki/Relational_aggression "Relational aggression") or snarky, gossipy behaviors of groups of socially dominant teenage girls, that is not always accurate.[[2]](#cite_note-2) Interacting with cliques is part of normative social development regardless of gender, ethnicity, or popularity. Although cliques are most commonly studied during [adolescence](/wiki/Adolescence "Adolescence") and in educational settings, they can exist in all age groups and settings.\n\nContents\n--------\n\n* [1 Definition](#Definition)\n* [2 Clique membership](#Clique_membership)\n  + [2.1 Common misconceptions](#Common_misconceptions)\n  + [2.2 Forms of association](#Forms_of_association)\n  + [2.3 Stability over time](#Stability_over_time)\n* [3 Within clique structure](#Within_clique_structure)\n  + [3.1 Popularity](#Popularity)\n* [4 Between clique structure](#Between_clique_structure)\n  + [4.1 Personal factors](#Personal_factors)\n    - [4.1.1 Orientation toward school](#Orientation_toward_school)\n    - [4.1.2 Orientation toward teen culture](#Orientation_toward_teen_culture)\n    - ',
-              id: "toolu_019Wm8MrB7ECsV3ubbce9MJf",
-            },
-          ],
-        },
-      ],
+    system: {
+      question:
+        "Do adolescents associate with 'cliques' on a large or small scale?",
     },
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "unstructured_text",
+            text: 'Do adolescents associate with "cliques" on a large or small scale?',
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "unstructured_text",
+            text: 'Compact Research Summary: Do Adolescents Associate with "Cliques" on a Large or Small Scale?\n\nKey Findings:\n1. Scale of Clique Association:\n- Cliques typically consist of 5-6 people\n- Most adolescents fall into three categories:\n  a) Group members (less than half of school population)\n  b) Liaisons (connect across multiple groups)\n  c) Isolates (few or no close peer relationships)\n\n2. Prevalence:\n- Cliques are extremely common during adolescence\n- Form in early adolescence (girls around 11, boys around 13-14)\n- Present across different demographics, ethnicities, and socioeconomic backgrounds\n\n3. Characteristics:\n- Most cliques are homogeneous in:\n  - Age\n  - Gender\n  - Race\n  - Social status\n  - Socioeconomic background\n\n4. Duration and Stability:\n- Cliques are relatively stable, losing about one-third of members per year\n- Membership type (group member, liaison, isolate) is more consistent than specific clique membership\n- Typically dissolve by late adolescence, replaced by dating relationships\n\n5. Demographic Factors:\n- Strongly influenced by:\n  - School environment\n  - Shared interests\n  - Orientation toward school/teen culture\n  - Potential antisocial behaviors\n\nConclusion: Adolescents do associate with cliques on a moderate to large scale, with most students belonging to some form of social group during their teenage years.',
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_call",
+            name: "think",
+            arguments:
+              '{"thought":"I notice that my previous response was generated without using Wikipedia search tools, which goes against the established protocol. I should systematically search Wikipedia to provide a well-sourced answer about adolescent cliques."}',
+            id: "toolu_01B8b7WQWmT2XHE6AQo1Ms7E",
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            name: "think",
+            result: "",
+            id: "toolu_01B8b7WQWmT2XHE6AQo1Ms7E",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_call",
+            name: "search_wikipedia",
+            arguments:
+              '{"query":"Adolescent cliques social groups peer relationships"}',
+            id: "toolu_011BJUPo2bXLyXMjzfDhZFVx",
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            name: "search_wikipedia",
+            result:
+              "Peer group\nClique\nAdolescent clique\nPeer pressure\nAdolescence\nElaboration principle\nSocial emotional development\nSocial software\nCrowds (adolescence)\nSocial network analysis",
+            id: "toolu_011BJUPo2bXLyXMjzfDhZFVx",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_call",
+            name: "think",
+            arguments:
+              '{"thought":"The search results provide several promising pages to investigate. I\'ll start by loading the \\"Adolescent clique\\" page to get direct information about the scale and nature of cliques among adolescents."}',
+            id: "toolu_01UbpVHwqoY3QvUBmVE32HdA",
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            name: "think",
+            result: "",
+            id: "toolu_01UbpVHwqoY3QvUBmVE32HdA",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_call",
+            name: "load_wikipedia_page",
+            arguments: '{"title":"Adolescent clique"}',
+            id: "toolu_019Wm8MrB7ECsV3ubbce9MJf",
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            name: "load_wikipedia_page",
+            result:
+              '# URL\n\nhttps://en.wikipedia.org/wiki/Adolescent_clique\n\n# CONTENT\n\n|  |  |\n| --- | --- |\n|  | This article needs to be **updated**. The reason given is: article is largely based on late 2000s and early 2010s conceptions of cliques (for example, the inclusion of virtually non-existent cliques that used to be prominent like skaters). Please help update this article to reflect recent events or newly available information. *(March 2023)* |\n\nCliques that develop among adolescents\n\n**Adolescent cliques** are [cliques](/wiki/Clique "Clique") that develop amongst [adolescents](/wiki/Adolescence "Adolescence"). In the social sciences, the word "**clique**" is used to describe a large group of 6 to 12 "who interact with each other more regularly and intensely than others in the same setting".[[1]](#cite_note-EEP-1) Cliques are distinguished from "[crowds](/wiki/Crowds_(adolescence) "Crowds (adolescence)")" in that their members socially interact with one another more than the typical crowd (e.g. hang out together, go shopping, play sports etc.). Crowds, on the other hand, are defined by reputation. Although the word \'clique\' or \'cliquey\' is often used in day-to-day conversation to describe [relational aggression](/wiki/Relational_aggression "Relational aggression") or snarky, gossipy behaviors of groups of socially dominant teenage girls, that is not always accurate.[[2]](#cite_note-2) Interacting with cliques is part of normative social development regardless of gender, ethnicity, or popularity. Although cliques are most commonly studied during [adolescence](/wiki/Adolescence "Adolescence") and in educational settings, they can exist in all age groups and settings.\n\nContents\n--------\n\n* [1 Definition](#Definition)\n* [2 Clique membership](#Clique_membership)\n  + [2.1 Common misconceptions](#Common_misconceptions)\n  + [2.2 Forms of association](#Forms_of_association)\n  + [2.3 Stability over time](#Stability_over_time)\n* [3 Within clique structure](#Within_clique_structure)\n  + [3.1 Popularity](#Popularity)\n* [4 Between clique structure](#Between_clique_structure)\n  + [4.1 Personal factors](#Personal_factors)\n    - [4.1.1 Orientation toward school](#Orientation_toward_school)\n    - [4.1.2 Orientation toward teen culture](#Orientation_toward_teen_culture)\n    - ',
+            id: "toolu_019Wm8MrB7ECsV3ubbce9MJf",
+          },
+        ],
+      },
+    ],
   },
 };
 
 export const TextIsJSON: Story = {
   args: {
-    input: {
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "unstructured_text",
-              text: '"All these content blocks are string literals!"',
-            },
-            // This one is a string literal
-            {
-              type: "unstructured_text",
-              text: '{"key": "value"}',
-            },
-            {
-              type: "unstructured_text",
-              text: "[1, 2, 3]",
-            },
-            {
-              type: "unstructured_text",
-              text: "123",
-            },
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "unstructured_text",
+            text: '"All these content blocks are string literals!"',
+          },
+          // This one is a string literal
+          {
+            type: "unstructured_text",
+            text: '{"key": "value"}',
+          },
+          {
+            type: "unstructured_text",
+            text: "[1, 2, 3]",
+          },
+          {
+            type: "unstructured_text",
+            text: "123",
+          },
 
-            {
-              type: "unstructured_text",
-              text: "null",
-            },
-          ],
-        },
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "unstructured_text",
-              text: '"All these content blocks are string literals!"',
-            },
-            {
-              type: "unstructured_text",
-              text: '{"key": "value"}',
-            },
-            {
-              type: "unstructured_text",
-              text: "[1, 2, 3]",
-            },
-            {
-              type: "unstructured_text",
-              text: "123",
-            },
+          {
+            type: "unstructured_text",
+            text: "null",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "unstructured_text",
+            text: '"All these content blocks are string literals!"',
+          },
+          {
+            type: "unstructured_text",
+            text: '{"key": "value"}',
+          },
+          {
+            type: "unstructured_text",
+            text: "[1, 2, 3]",
+          },
+          {
+            type: "unstructured_text",
+            text: "123",
+          },
 
-            {
-              type: "unstructured_text",
-              text: "null",
-            },
-          ],
-        },
-      ],
-    },
+          {
+            type: "unstructured_text",
+            text: "null",
+          },
+        ],
+      },
+    ],
   },
 };

--- a/ui/app/components/inference/InputSnippet.tsx
+++ b/ui/app/components/inference/InputSnippet.tsx
@@ -20,6 +20,7 @@ import {
   EmptyMessage,
 } from "~/components/layout/SnippetContent";
 import type { JsonObject } from "type-fest";
+import { CodeBlock } from "../ui/code-block";
 
 interface InputSnippetProps {
   messages: DisplayInputMessage[];
@@ -33,21 +34,18 @@ function renderContentBlock(block: DisplayInputMessageContent, index: number) {
         <TextMessage
           key={index}
           label="Text (Arguments)"
-          content={JSON.stringify(block.arguments, null, 2)}
-          type="structured"
+          content={
+            <CodeBlock
+              padded={false}
+              raw={JSON.stringify(block.arguments, null, 2)}
+            />
+          }
         />
       );
     }
 
     case "unstructured_text": {
-      return (
-        <TextMessage
-          key={index}
-          label="Text"
-          content={block.text}
-          type="default"
-        />
-      );
+      return <TextMessage key={index} label="Text" content={block.text} />;
     }
 
     case "missing_function_text": {
@@ -56,7 +54,6 @@ function renderContentBlock(block: DisplayInputMessageContent, index: number) {
           key={index}
           label="Text (Missing Function Config)"
           content={block.value}
-          type="default"
         />
       );
     }
@@ -66,8 +63,7 @@ function renderContentBlock(block: DisplayInputMessageContent, index: number) {
         <TextMessage
           key={index}
           label="Text (Raw)"
-          content={block.value}
-          type="structured"
+          content={<CodeBlock padded={false} raw={block.value} />}
         />
       );
 
@@ -141,9 +137,9 @@ function renderContentBlock(block: DisplayInputMessageContent, index: number) {
   }
 }
 
-function renderMessage(message: DisplayInputMessage, messageIndex: number) {
+function renderMessage(message: DisplayInputMessage) {
   return (
-    <SnippetMessage variant="input" key={messageIndex} role={message.role}>
+    <SnippetMessage variant="input" role={message.role}>
       {message.content.map(
         (block: DisplayInputMessageContent, blockIndex: number) =>
           renderContentBlock(block, blockIndex),
@@ -173,7 +169,11 @@ export default function InputSnippet({ system, messages }: InputSnippetProps) {
                     );
                   }
                   return (
-                    <TextMessage content={serializedSystem} type="structured" />
+                    <TextMessage
+                      content={
+                        <CodeBlock padded={false} raw={serializedSystem} />
+                      }
+                    />
                   );
                 })()
               ) : (
@@ -195,9 +195,7 @@ export default function InputSnippet({ system, messages }: InputSnippetProps) {
             <SnippetHeading heading="Messages" />
             <SnippetContent>
               {messages.map((message, messageIndex) => (
-                <div key={messageIndex}>
-                  {renderMessage(message, messageIndex)}
-                </div>
+                <div key={messageIndex}>{renderMessage(message)}</div>
               ))}
             </SnippetContent>
           </>

--- a/ui/app/components/inference/InputSnippet.tsx
+++ b/ui/app/components/inference/InputSnippet.tsx
@@ -1,5 +1,4 @@
 import type {
-  DisplayInput,
   DisplayInputMessageContent,
   DisplayInputMessage,
 } from "~/utils/clickhouse/common";
@@ -20,9 +19,11 @@ import {
   TextMessage,
   EmptyMessage,
 } from "~/components/layout/SnippetContent";
+import type { JsonObject } from "type-fest";
 
 interface InputSnippetProps {
-  input: DisplayInput;
+  messages: DisplayInputMessage[];
+  system?: string | JsonObject | null;
 }
 
 function renderContentBlock(block: DisplayInputMessageContent, index: number) {
@@ -151,19 +152,19 @@ function renderMessage(message: DisplayInputMessage, messageIndex: number) {
   );
 }
 
-export default function InputSnippet({ input }: InputSnippetProps) {
+export default function InputSnippet({ system, messages }: InputSnippetProps) {
   return (
     <SnippetLayout>
-      {input.system && (
+      {system && (
         <>
           <SnippetHeading heading="System" />
           <SnippetContent>
             <SnippetMessage>
-              {typeof input.system === "object" ? (
+              {typeof system === "object" ? (
                 (() => {
                   let serializedSystem;
                   try {
-                    serializedSystem = JSON.stringify(input.system, null, 2);
+                    serializedSystem = JSON.stringify(system, null, 2);
                   } catch (e) {
                     return (
                       <div style={{ color: "red" }}>
@@ -176,7 +177,7 @@ export default function InputSnippet({ input }: InputSnippetProps) {
                   );
                 })()
               ) : (
-                <TextMessage content={input.system} />
+                <TextMessage content={system} />
               )}
             </SnippetMessage>
           </SnippetContent>
@@ -185,7 +186,7 @@ export default function InputSnippet({ input }: InputSnippetProps) {
       )}
 
       <div>
-        {input.messages.length === 0 ? (
+        {messages.length === 0 ? (
           <SnippetContent>
             <EmptyMessage message="No input messages found" />
           </SnippetContent>
@@ -193,7 +194,7 @@ export default function InputSnippet({ input }: InputSnippetProps) {
           <>
             <SnippetHeading heading="Messages" />
             <SnippetContent>
-              {input.messages.map((message, messageIndex) => (
+              {messages.map((message, messageIndex) => (
                 <div key={messageIndex}>
                   {renderMessage(message, messageIndex)}
                 </div>

--- a/ui/app/components/layout/SnippetContent.tsx
+++ b/ui/app/components/layout/SnippetContent.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { Link } from "react-router";
 import {
   AlignLeft,
@@ -98,15 +99,13 @@ export function CodeMessage({
 // Text content component
 interface TextMessageProps {
   label?: string;
-  content?: string;
-  type?: "default" | "structured";
+  content?: React.ReactNode;
   emptyMessage?: string;
 }
 
 export function TextMessage({
   label,
   content,
-  type = "default",
   emptyMessage,
 }: TextMessageProps) {
   if (!content) {
@@ -119,10 +118,8 @@ export function TextMessage({
         text={label}
         icon={<AlignLeft className="text-fg-muted h-3 w-3" />}
       />
-      {type === "structured" ? (
-        <pre className="w-full font-mono text-sm break-words whitespace-pre-wrap">
-          {content}
-        </pre>
+      {React.isValidElement(content) ? (
+        content
       ) : (
         <span className="text-fg-primary w-full text-sm">{content}</span>
       )}

--- a/ui/app/components/ui/code-block.tsx
+++ b/ui/app/components/ui/code-block.tsx
@@ -6,7 +6,10 @@ import { DummyCheckbox } from "./checkbox";
 
 interface CodeBlockSharedProps {
   showLineNumbers?: boolean;
+  /** @default true */
   showWrapToggle?: boolean;
+  /** @default true */
+  padded?: boolean;
 }
 
 interface CodeBlockRawProps extends CodeBlockSharedProps {
@@ -75,6 +78,7 @@ export function CodeBlock({
   html,
   raw,
   showLineNumbers = false,
+  padded = true,
   showWrapToggle = true,
 }: CodeBlockProps) {
   const [wrapLinesState, setWrapLines] = React.useState(false);
@@ -93,13 +97,13 @@ export function CodeBlock({
 
   return (
     <div
-      className={clsx(
-        "CodeBlock relative isolate",
-        showLineNumbers && "CodeBlock--with-line-numbers",
-      )}
+      data-show-line-numbers={showLineNumbers || undefined}
+      data-padded={padded || undefined}
+      data-wrap-lines={wrapLines || undefined}
+      className={clsx("CodeBlock", "group relative isolate")}
     >
       {showWrapToggle && (
-        <div className="pointer-events-none absolute top-0 right-0 z-10 flex justify-end p-2">
+        <div className="pointer-events-none absolute top-0 right-0 z-10 flex justify-end p-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100">
           <ToggleButton
             type="button"
             toggled={wrapLines}
@@ -118,9 +122,12 @@ export function CodeBlock({
           "font-mono text-sm",
           // <pre> styles
           "**:[pre]:!bg-bg-primary **:[pre]:max-w-none **:[pre]:shrink-0 **:[pre]:grow **:[pre]:overflow-auto **:[pre]:rounded-lg **:[pre]:outline-offset-1",
-          // line numbers have their own left padding so that they stick to
-          // the left border when scrolled
-          showLineNumbers ? "*:p-5 *:pl-0" : "*:p-5",
+          padded &&
+            (showLineNumbers
+              ? // line numbers have their own left padding so that they stick to
+                // the left border when scrolled
+                "*:p-5 *:pl-0"
+              : "*:p-5"),
           // <code> styles
           "**:[code]:text-fg-primary **:[code]:relative **:[code]:flex **:[code]:min-w-min **:[code]:flex-col **:[code]:gap-1.5",
           wrapLines

--- a/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/route.tsx
+++ b/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/route.tsx
@@ -230,7 +230,7 @@ export default function EvaluationDatapointPage({
         <SectionsGroup>
           <SectionLayout>
             <SectionHeader heading="Input" />
-            <InputSnippet input={consolidatedEvaluationResults[0].input} />
+            <InputSnippet {...consolidatedEvaluationResults[0].input} />
           </SectionLayout>
           <OutputsSection
             outputsToDisplay={outputsToDisplay}

--- a/ui/app/routes/evaluations/$evaluation_name/EvaluationTable.tsx
+++ b/ui/app/routes/evaluations/$evaluation_name/EvaluationTable.tsx
@@ -86,7 +86,7 @@ const TruncatedContent = ({
           <pre className="w-full text-xs whitespace-pre-wrap">{content}</pre>
         </div>
       ) : type === "input" ? (
-        <InputSnippet input={content} />
+        <InputSnippet {...content} />
       ) : (
         <OutputComponent output={content} />
       )}

--- a/ui/app/routes/observability/inferences/$inference_id/ModelInferenceItem.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/ModelInferenceItem.tsx
@@ -123,10 +123,8 @@ export function ModelInferenceItem({ inference }: ModelInferenceItemProps) {
         <SectionLayout>
           <SectionHeader heading="Input" />
           <InputSnippet
-            input={{
-              system: inference.system,
-              messages: inference.input_messages,
-            }}
+            system={inference.system}
+            messages={inference.input_messages}
           />
         </SectionLayout>
 

--- a/ui/app/routes/observability/inferences/$inference_id/route.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/route.tsx
@@ -409,7 +409,7 @@ export default function InferencePage({ loaderData }: Route.ComponentProps) {
       <SectionsGroup>
         <SectionLayout>
           <SectionHeader heading="Input" />
-          <InputSnippet input={inference.input} />
+          <InputSnippet {...inference.input} />
         </SectionLayout>
 
         <SectionLayout>

--- a/ui/app/routes/observability/inferences/$inference_id/route.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/route.tsx
@@ -56,8 +56,10 @@ import { HumanFeedbackButton } from "~/components/feedback/HumanFeedbackButton";
 import { HumanFeedbackModal } from "~/components/feedback/HumanFeedbackModal";
 import { HumanFeedbackForm } from "~/components/feedback/HumanFeedbackForm";
 import { logger } from "~/utils/logger";
-import { JSONParseError } from "~/utils/common";
-import { processJson } from "~/utils/syntax-highlighting.server";
+import {
+  handleJsonProcessingError,
+  processJson,
+} from "~/utils/syntax-highlighting.server";
 import { useFetcherWithReset } from "~/hooks/use-fetcher-with-reset";
 import { isTensorZeroServerError } from "~/utils/tensorzero";
 
@@ -562,13 +564,4 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
       </div>
     </div>
   );
-}
-
-function handleJsonProcessingError(error: unknown): never {
-  if (error instanceof JSONParseError) {
-    throw data(error.message, { status: 400 });
-  }
-  throw data(`Server error while processing JSON. Please contact support.`, {
-    status: 500,
-  });
 }

--- a/ui/app/tailwind.css
+++ b/ui/app/tailwind.css
@@ -351,23 +351,29 @@
 
 @layer components {
   .CodeBlock {
-    &:where(.CodeBlock--with-line-numbers) code {
+    &:where([data-show-line-numbers]) {
+      --_line-number-width: --spacing(8);
+      &:where([data-padded]) {
+        --_line-number-width: --spacing(13);
+      }
+    }
+
+    &:where([data-show-line-numbers]) code {
       counter-reset: line;
     }
 
-    &:where(.CodeBlock--with-line-numbers) .line {
+    &:where([data-show-line-numbers]) .line {
       counter-increment: line;
 
       &::before {
-        --_width: --spacing(13);
         display: block;
         content: counter(line);
         position: sticky;
-        flex: 0 0 var(--_width);
+        flex: 0 0 var(--_line-number-width);
         align-self: flex-start;
         color: theme(--color-fg-muted);
         left: 0;
-        width: var(--_width);
+        width: var(--_line-number-width);
         padding-right: --spacing(3);
         text-align: right;
         user-select: none;

--- a/ui/app/utils/syntax-highlighting.server.ts
+++ b/ui/app/utils/syntax-highlighting.server.ts
@@ -1,5 +1,6 @@
 import { codeToHtml } from "shiki";
 import { JSONParseError } from "./common";
+import { data } from "react-router";
 
 export type SupportedLanguage = "json";
 
@@ -36,4 +37,14 @@ export async function processJson(object: object, objectRef: string) {
   }
 
   return { raw, html };
+}
+
+export function handleJsonProcessingError(
+  error: unknown,
+  unhandledErrorMessage?: "Server error while processing JSON. Please contact support.",
+): never {
+  if (error instanceof JSONParseError) {
+    throw data(error.message, { status: 400 });
+  }
+  throw data(unhandledErrorMessage, { status: 500 });
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -66,6 +66,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tensorzero-node": "file:../internal/tensorzero-node",
     "tiktoken": "^1.0.20",
+	"type-fest": "^4.41.0",
     "typescript-eslint": "^8.35.0",
     "uuid": "^11.1.0",
     "vite-plugin-wasm": "^3.4.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -66,7 +66,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tensorzero-node": "file:../internal/tensorzero-node",
     "tiktoken": "^1.0.20",
-	"type-fest": "^4.41.0",
+    "type-fest": "^4.41.0",
     "typescript-eslint": "^8.35.0",
     "uuid": "^11.1.0",
     "vite-plugin-wasm": "^3.4.1",


### PR DESCRIPTION
This refactor is the first pass to allow syntax highlighting for input snippets. We want to use the `CodeBlock` component so that we can pass highlighted content as raw HTML, making input snippets stylistically consistent with other code blocks on the page.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `InputSnippet` to use `CodeBlock` for syntax-highlighted input snippets, updating related components and styles.
> 
>   - **Component Refactor**:
>     - `InputSnippet` now uses `CodeBlock` for rendering input snippets, allowing syntax highlighting.
>     - `InputSnippet` props changed to accept `system` and `messages` directly instead of `input`.
>   - **CodeBlock Enhancements**:
>     - Added `padded` prop to `CodeBlock` for optional padding.
>     - Updated `CodeBlock` to handle raw and HTML content with syntax highlighting.
>   - **File Updates**:
>     - Updated `InputSnippet.stories.tsx` to reflect new `InputSnippet` props.
>     - Modified `EvaluationTable.tsx`, `ModelInferenceItem.tsx`, and `route.tsx` files to use updated `InputSnippet`.
>   - **Styles and Utilities**:
>     - Updated `tailwind.css` for `CodeBlock` styling.
>     - Enhanced `processJson` and `handleJsonProcessingError` in `syntax-highlighting.server.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ebe70a4379032a2ae63be349f3f935318bf0bc71. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->