### PR TITLE
ClickHouse queries in Rust all return ClickHouseResult now

### DIFF
--- a/evaluations/src/dataset.rs
+++ b/evaluations/src/dataset.rs
@@ -36,12 +36,15 @@ pub async fn query_dataset(
     let result = clickhouse_client
         .run_query_synchronous(query.to_string(), &params)
         .await?;
-    debug!(result_length = result.len(), "Query executed successfully");
+    debug!(
+        result_length = result.response.len(),
+        "Query executed successfully"
+    );
     debug!("Parsing datapoints from query result");
     let datapoints: Vec<Datapoint> = match function_config {
         FunctionConfig::Chat(_) => {
             debug!("Parsing as chat datapoints");
-            let chat_datapoints: serde_json::Value = serde_json::from_str(&result)?;
+            let chat_datapoints: serde_json::Value = serde_json::from_str(&result.response)?;
             let chat_datapoints: Vec<ChatInferenceDatapoint> =
                 serde_json::from_value(chat_datapoints["data"].clone())?;
             let datapoints: Vec<Datapoint> =
@@ -51,7 +54,7 @@ pub async fn query_dataset(
         }
         FunctionConfig::Json(_) => {
             debug!("Parsing as JSON datapoints");
-            let json_value: serde_json::Value = serde_json::from_str(&result)?;
+            let json_value: serde_json::Value = serde_json::from_str(&result.response)?;
             let json_datapoints: Vec<JsonInferenceDatapoint> =
                 serde_json::from_value(json_value["data"].clone())?;
             let datapoints: Vec<Datapoint> =

--- a/evaluations/src/helpers.rs
+++ b/evaluations/src/helpers.rs
@@ -116,11 +116,14 @@ pub async fn check_static_eval_human_feedback(
             ]),
         )
         .await?;
-    debug!(result_length = result.len(), "Query executed successfully");
-    if result.is_empty() {
+    debug!(
+        result_length = result.response.len(),
+        "Query executed successfully"
+    );
+    if result.response.is_empty() {
         return Ok(None);
     }
-    let human_feedback_result: HumanFeedbackResult = serde_json::from_str(&result)
+    let human_feedback_result: HumanFeedbackResult = serde_json::from_str(&result.response)
         .map_err(|e| anyhow!("Failed to parse human feedback result: {}", e))?;
     Ok(Some(human_feedback_result))
 }

--- a/examples/integrations/cursor/feedback/src/clickhouse.rs
+++ b/examples/integrations/cursor/feedback/src/clickhouse.rs
@@ -83,6 +83,7 @@ pub async fn get_inferences_in_time_range(
         .await?;
 
     let inferences: Vec<Arc<InferenceInfo>> = results
+        .response
         .lines()
         .filter(|line| !line.trim().is_empty())
         .map(|x| serde_json::from_str::<InferenceInfo>(x).map(Arc::new))

--- a/tensorzero-core/src/cache.rs
+++ b/tensorzero-core/src/cache.rs
@@ -442,10 +442,10 @@ pub async fn cache_lookup_inner<T: CacheOutput + DeserializeOwned>(
     let result = clickhouse_connection_info
         .run_query_synchronous(query.to_string(), &query_params)
         .await?;
-    if result.is_empty() {
+    if result.response.is_empty() {
         return Ok(None);
     }
-    let result: CacheData<T> = serde_json::from_str(&result).map_err(|e| {
+    let result: CacheData<T> = serde_json::from_str(&result.response).map_err(|e| {
         Error::new(ErrorDetails::Cache {
             message: format!("Failed to deserialize output: {e}"),
         })

--- a/tensorzero-core/src/clickhouse/migration_manager/migrations/migration_0003.rs
+++ b/tensorzero-core/src/clickhouse/migration_manager/migrations/migration_0003.rs
@@ -81,7 +81,7 @@ impl Migration for Migration0003<'_> {
                     .into());
                 }
                 Ok(response) => {
-                    if response.trim() != "1" {
+                    if response.response.trim() != "1" {
                         return Ok(true);
                     }
                 }

--- a/tensorzero-core/src/clickhouse/migration_manager/migrations/migration_0004.rs
+++ b/tensorzero-core/src/clickhouse/migration_manager/migrations/migration_0004.rs
@@ -50,7 +50,8 @@ impl Migration for Migration0004<'_> {
                     message: format!("Failed to fetch columns for ModelInference: {e}"),
                 })
             })?;
-        let present_columns: Vec<&str> = response.lines().map(|line| line.trim()).collect();
+        let present_columns: Vec<&str> =
+            response.response.lines().map(|line| line.trim()).collect();
         if present_columns.contains(&"system")
             && present_columns.contains(&"input_messages")
             && present_columns.contains(&"output")

--- a/tensorzero-core/src/clickhouse/migration_manager/migrations/migration_0005.rs
+++ b/tensorzero-core/src/clickhouse/migration_manager/migrations/migration_0005.rs
@@ -72,7 +72,7 @@ impl Migration for Migration0005<'_> {
                     .into());
                 }
                 Ok(response) => {
-                    if response.trim() != "1" {
+                    if response.response.trim() != "1" {
                         return Ok(true);
                     }
                 }

--- a/tensorzero-core/src/clickhouse/migration_manager/migrations/migration_0013.rs
+++ b/tensorzero-core/src/clickhouse/migration_manager/migrations/migration_0013.rs
@@ -82,7 +82,7 @@ impl Migration for Migration0013<'_> {
             .clickhouse
             .run_query_synchronous_no_params(query)
             .await?;
-        if !result.contains("UInt128") {
+        if !result.response.contains("UInt128") {
             return Err(ErrorDetails::ClickHouseMigration {
                 id: "0013".to_string(),
                 message:
@@ -96,7 +96,7 @@ impl Migration for Migration0013<'_> {
             .clickhouse
             .run_query_synchronous_no_params(query)
             .await?;
-        if !result.contains("UInt128") {
+        if !result.response.contains("UInt128") {
             return Err(ErrorDetails::ClickHouseMigration {
                 id: "0013".to_string(),
                 message:
@@ -110,7 +110,7 @@ impl Migration for Migration0013<'_> {
             .clickhouse
             .run_query_synchronous_no_params(query)
             .await?;
-        if !result.contains("1") {
+        if !result.response.contains("1") {
             return Ok(true);
         }
         Ok(false)
@@ -134,6 +134,7 @@ impl Migration for Migration0013<'_> {
             .clickhouse
             .run_query_synchronous_no_params(query)
             .await?
+            .response
             .trim()
             .parse()
             .map_err(|e| {
@@ -147,6 +148,7 @@ impl Migration for Migration0013<'_> {
             .clickhouse
             .run_query_synchronous_no_params(query)
             .await?
+            .response
             .trim()
             .parse()
             .map_err(|e| {

--- a/tensorzero-core/src/clickhouse/migration_manager/migrations/migration_0020.rs
+++ b/tensorzero-core/src/clickhouse/migration_manager/migrations/migration_0020.rs
@@ -105,7 +105,7 @@ impl Migration for Migration0020<'_> {
             .clickhouse
             .run_query_synchronous_no_params(query)
             .await?;
-        if !result.contains("UInt128") {
+        if !result.response.contains("UInt128") {
             // Table was created by an older migration. We should drop and recreate
             return Ok(true);
         }
@@ -114,7 +114,7 @@ impl Migration for Migration0020<'_> {
             .clickhouse
             .run_query_synchronous_no_params(query)
             .await?;
-        if !result.contains("UInt128") {
+        if !result.response.contains("UInt128") {
             // Table was created by an older migration. We should drop and recreate
             return Ok(true);
         }
@@ -123,7 +123,7 @@ impl Migration for Migration0020<'_> {
             .clickhouse
             .run_query_synchronous_no_params(query)
             .await?;
-        if !result.contains("1") {
+        if !result.response.contains("1") {
             return Ok(true);
         }
         Ok(false)

--- a/tensorzero-core/src/clickhouse/migration_manager/migrations/mod.rs
+++ b/tensorzero-core/src/clickhouse/migration_manager/migrations/mod.rs
@@ -52,7 +52,7 @@ async fn check_table_exists(
             .into())
         }
         Ok(response) => {
-            if response.trim() != "1" {
+            if response.response.trim() != "1" {
                 return Ok(false);
             }
         }
@@ -89,7 +89,7 @@ async fn check_column_exists(
             .into())
         }
         Ok(response) => {
-            if response.trim() != "1" {
+            if response.response.trim() != "1" {
                 return Ok(false);
             }
         }
@@ -115,7 +115,7 @@ async fn get_column_type(
             message: e.to_string(),
         }
         .into()),
-        Ok(response) => Ok(response.trim().to_string()),
+        Ok(response) => Ok(response.response.trim().to_string()),
     }
 }
 
@@ -137,7 +137,7 @@ async fn get_default_expression(
             message: e.to_string(),
         }
         .into()),
-        Ok(response) => Ok(response.trim().to_string()),
+        Ok(response) => Ok(response.response.trim().to_string()),
     }
 }
 
@@ -148,7 +148,7 @@ async fn table_is_nonempty(
 ) -> Result<bool, Error> {
     let query = format!("SELECT COUNT() FROM {table} FORMAT CSV");
     let result = clickhouse.run_query_synchronous_no_params(query).await?;
-    Ok(result.trim().parse::<i64>().map_err(|e| {
+    Ok(result.response.trim().parse::<i64>().map_err(|e| {
         Error::new(ErrorDetails::ClickHouseMigration {
             id: migration_id.to_string(),
             message: e.to_string(),
@@ -166,7 +166,7 @@ async fn get_table_engine(
         table
     );
     let result = clickhouse.run_query_synchronous_no_params(query).await?;
-    Ok(result.trim().to_string())
+    Ok(result.response.trim().to_string())
 }
 
 async fn check_index_exists(
@@ -176,5 +176,5 @@ async fn check_index_exists(
 ) -> Result<bool, Error> {
     let query = format!("SELECT 1 FROM system.data_skipping_indices WHERE database='{}' AND table='{}' AND name='{}'", clickhouse.database(), table, index);
     let result = clickhouse.run_query_synchronous_no_params(query).await?;
-    Ok(result.trim() == "1")
+    Ok(result.response.trim() == "1")
 }

--- a/tensorzero-core/src/clickhouse/mod.rs
+++ b/tensorzero-core/src/clickhouse/mod.rs
@@ -202,10 +202,22 @@ impl ClickHouseConnectionInfo {
         &self,
         query: String,
         parameters: &HashMap<&str, &str>,
-    ) -> Result<String, Error> {
+    ) -> Result<ClickHouseResponse, Error> {
         match self {
-            Self::Disabled => Ok("".to_string()),
-            Self::Mock { .. } => Ok("".to_string()),
+            Self::Disabled => Ok(ClickHouseResponse {
+                response: "".to_string(),
+                metadata: ClickHouseResponseMetadata {
+                    read_rows: 0,
+                    written_rows: 0,
+                },
+            }),
+            Self::Mock { .. } => Ok(ClickHouseResponse {
+                response: "".to_string(),
+                metadata: ClickHouseResponseMetadata {
+                    read_rows: 0,
+                    written_rows: 0,
+                },
+            }),
             Self::Production {
                 database_url,
                 client,
@@ -225,7 +237,7 @@ impl ClickHouseConnectionInfo {
                 database_url
                     .query_pairs_mut()
                     .append_pair("alter_sync", "2");
-                let response = client
+                let res = client
                     .post(database_url)
                     .body(query)
                     .send()
@@ -235,16 +247,42 @@ impl ClickHouseConnectionInfo {
                             message: DisplayOrDebugGateway::new(e).to_string(),
                         })
                     })?;
-                let status = response.status();
+                let status = res.status();
 
-                let response_body = response.text().await.map_err(|e| {
+                // Get the ClickHouse summary info from the headers
+                let metadata = if let Some(summary) = res.headers().get("x-clickhouse-summary") {
+                    let summary_str = summary.to_str().map_err(|e| {
+                        Error::new(ErrorDetails::ClickHouseQuery {
+                            message: format!("Failed to parse x-clickhouse-summary header: {e}"),
+                        })
+                    })?;
+
+                    serde_json::from_str::<ClickHouseResponseMetadata>(summary_str).map_err(
+                        |e| {
+                            Error::new(ErrorDetails::ClickHouseQuery {
+                                message: format!("Failed to deserialize x-clickhouse-summary: {e}"),
+                            })
+                        },
+                    )?
+                } else {
+                    tracing::warn!("No x-clickhouse-summary header found in ClickHouse response");
+                    ClickHouseResponseMetadata {
+                        read_rows: 0,
+                        written_rows: 0,
+                    }
+                };
+
+                let response_body = res.text().await.map_err(|e| {
                     Error::new(ErrorDetails::ClickHouseQuery {
                         message: DisplayOrDebugGateway::new(e).to_string(),
                     })
                 })?;
 
                 match status {
-                    reqwest::StatusCode::OK => Ok(response_body),
+                    reqwest::StatusCode::OK => Ok(ClickHouseResponse {
+                        response: response_body,
+                        metadata,
+                    }),
                     _ => Err(Error::new(ErrorDetails::ClickHouseQuery {
                         message: response_body,
                     })),
@@ -253,7 +291,10 @@ impl ClickHouseConnectionInfo {
         }
     }
 
-    pub async fn run_query_synchronous_no_params(&self, query: String) -> Result<String, Error> {
+    pub async fn run_query_synchronous_no_params(
+        &self,
+        query: String,
+    ) -> Result<ClickHouseResponse, Error> {
         self.run_query_synchronous(query, &HashMap::default()).await
     }
 
@@ -423,7 +464,8 @@ impl ClickHouseConnectionInfo {
             PRIMARY KEY (migration_id)"#
                 .to_string(),
         )
-        .await?;
+        .await
+        .map(|_| ())?;
         Ok(())
     }
 
@@ -439,6 +481,7 @@ impl ClickHouseConnectionInfo {
             .collect();
         let response = self.run_query_synchronous(sql, &params_map).await?;
         let inferences = response
+            .response
             .trim()
             .lines()
             .map(|line| {

--- a/tensorzero-core/src/clickhouse/mod.rs
+++ b/tensorzero-core/src/clickhouse/mod.rs
@@ -644,8 +644,10 @@ pub struct ClickHouseResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct ClickHouseResponseMetadata {
+    #[serde(default)]
     #[serde(deserialize_with = "deserialize_u64_from_str")]
     pub read_rows: u64,
+    #[serde(default)]
     #[serde(deserialize_with = "deserialize_u64_from_str")]
     pub written_rows: u64,
 }

--- a/tensorzero-core/src/clickhouse/mod.rs
+++ b/tensorzero-core/src/clickhouse/mod.rs
@@ -251,6 +251,8 @@ impl ClickHouseConnectionInfo {
 
                 // Get the ClickHouse summary info from the headers
                 let metadata = if let Some(summary) = res.headers().get("x-clickhouse-summary") {
+                    // NOTE: X-Clickhouse-Summary is a ClickHouse-specific header that contains information about the query execution.
+                    // It is not formally specified in the ClickHouse documentation so we only warn if it isn't working but won't error here.
                     let summary_str = summary.to_str().map_err(|e| {
                         Error::new(ErrorDetails::ClickHouseQuery {
                             message: format!("Failed to parse x-clickhouse-summary header: {e}"),

--- a/tensorzero-core/src/clickhouse/test_helpers.rs
+++ b/tensorzero-core/src/clickhouse/test_helpers.rs
@@ -53,7 +53,7 @@ pub async fn select_chat_datapoint_clickhouse(
         .run_query_synchronous_no_params(query)
         .await
         .unwrap();
-    let json: Value = serde_json::from_str(&text).ok()?;
+    let json: Value = serde_json::from_str(&text.response).ok()?;
     Some(json)
 }
 
@@ -72,7 +72,7 @@ pub async fn select_json_datapoint_clickhouse(
         .run_query_synchronous_no_params(query)
         .await
         .unwrap();
-    let json: Value = serde_json::from_str(&text).ok()?;
+    let json: Value = serde_json::from_str(&text.response).ok()?;
     Some(json)
 }
 
@@ -91,7 +91,7 @@ pub async fn select_chat_dataset_clickhouse(
         .run_query_synchronous_no_params(query)
         .await
         .unwrap();
-    let lines = text.lines();
+    let lines = text.response.lines();
     let mut chat_rows: Vec<ChatInferenceDatapoint> = Vec::new();
     for line in lines {
         let chat_row: ChatInferenceDatapoint = serde_json::from_str(line).unwrap();
@@ -115,7 +115,7 @@ pub async fn select_json_dataset_clickhouse(
         .run_query_synchronous_no_params(query)
         .await
         .unwrap();
-    let lines = text.lines();
+    let lines = text.response.lines();
     let mut json_rows: Vec<JsonInferenceDatapoint> = Vec::new();
     for line in lines {
         let json_row: JsonInferenceDatapoint = serde_json::from_str(line).unwrap();
@@ -140,7 +140,7 @@ pub async fn select_chat_inference_clickhouse(
         .run_query_synchronous_no_params(query)
         .await
         .unwrap();
-    let json: Value = serde_json::from_str(&text).ok()?;
+    let json: Value = serde_json::from_str(&text.response).ok()?;
     Some(json)
 }
 
@@ -160,7 +160,7 @@ pub async fn select_json_inference_clickhouse(
         .run_query_synchronous_no_params(query)
         .await
         .unwrap();
-    let json: Value = serde_json::from_str(&text).ok()?;
+    let json: Value = serde_json::from_str(&text.response).ok()?;
     Some(json)
 }
 
@@ -180,7 +180,7 @@ pub async fn select_model_inference_clickhouse(
         .run_query_synchronous_no_params(query)
         .await
         .unwrap();
-    let json: Value = serde_json::from_str(&text).ok()?;
+    let json: Value = serde_json::from_str(&text.response).ok()?;
     Some(json)
 }
 
@@ -201,6 +201,7 @@ pub async fn select_model_inferences_clickhouse(
         .await
         .unwrap();
     let json_rows: Vec<Value> = text
+        .response
         .lines()
         .filter_map(|line| serde_json::from_str(line).ok())
         .collect();
@@ -230,7 +231,7 @@ pub async fn select_inference_tags_clickhouse(
         .run_query_synchronous_no_params(query)
         .await
         .unwrap();
-    let json: Value = serde_json::from_str(&text).ok()?;
+    let json: Value = serde_json::from_str(&text.response).ok()?;
     Some(json)
 }
 
@@ -251,7 +252,7 @@ pub async fn select_batch_model_inference_clickhouse(
         .run_query_synchronous_no_params(query)
         .await
         .unwrap();
-    Some(serde_json::from_str(&text).unwrap())
+    Some(serde_json::from_str(&text.response).unwrap())
 }
 
 pub async fn select_batch_model_inferences_clickhouse(
@@ -271,6 +272,7 @@ pub async fn select_batch_model_inferences_clickhouse(
         .await
         .unwrap();
     let json_rows: Vec<Value> = text
+        .response
         .lines()
         .filter_map(|line| serde_json::from_str(line).ok())
         .collect();
@@ -290,7 +292,7 @@ pub async fn select_latest_batch_request_clickhouse(
         .run_query_synchronous_no_params(query)
         .await
         .unwrap();
-    let json: Value = serde_json::from_str(&text).ok()?;
+    let json: Value = serde_json::from_str(&text.response).ok()?;
     Some(json)
 }
 
@@ -308,7 +310,7 @@ pub async fn select_feedback_clickhouse(
         .run_query_synchronous_no_params(query)
         .await
         .unwrap();
-    let json: Value = serde_json::from_str(&text).ok()?;
+    let json: Value = serde_json::from_str(&text.response).ok()?;
     Some(json)
 }
 
@@ -334,7 +336,7 @@ pub async fn select_feedback_by_target_id_clickhouse(
         .run_query_synchronous_no_params(query)
         .await
         .unwrap();
-    let json: Value = serde_json::from_str(&text).ok()?;
+    let json: Value = serde_json::from_str(&text.response).ok()?;
     Some(json)
 }
 
@@ -446,7 +448,7 @@ pub async fn select_dynamic_evaluation_run_clickhouse(
         .await
         .unwrap();
 
-    Some(serde_json::from_str(&text).unwrap())
+    Some(serde_json::from_str(&text.response).unwrap())
 }
 
 pub async fn select_dynamic_evaluation_run_episode_clickhouse(
@@ -462,7 +464,7 @@ pub async fn select_dynamic_evaluation_run_episode_clickhouse(
         .run_query_synchronous_no_params(query)
         .await
         .unwrap();
-    Some(serde_json::from_str(&text).unwrap())
+    Some(serde_json::from_str(&text.response).unwrap())
 }
 
 #[cfg(feature = "e2e_tests")]
@@ -482,7 +484,7 @@ pub async fn select_feedback_tags_clickhouse(
         .run_query_synchronous_no_params(query)
         .await
         .unwrap();
-    let json: Value = serde_json::from_str(&text).ok()?;
+    let json: Value = serde_json::from_str(&text.response).ok()?;
     Some(json)
 }
 
@@ -522,12 +524,12 @@ pub async fn select_human_static_evaluation_feedback_clickhouse(
         .run_query_synchronous(query, &params)
         .await
         .unwrap();
-    if text.is_empty() {
+    if text.response.is_empty() {
         // Return None if the query returns no rows
         None
     } else {
         // Panic if the query fails to parse or multiple rows are returned
-        let json: StaticEvaluationHumanFeedback = serde_json::from_str(&text).unwrap();
+        let json: StaticEvaluationHumanFeedback = serde_json::from_str(&text.response).unwrap();
         Some(json)
     }
 }

--- a/tensorzero-core/src/endpoints/batch_inference.rs
+++ b/tensorzero-core/src/endpoints/batch_inference.rs
@@ -461,7 +461,7 @@ pub async fn get_batch_request(
                 "#
             );
             let response = clickhouse.run_query_synchronous_no_params(query).await?;
-            if response.is_empty() {
+            if response.response.is_empty() {
                 return Err(ErrorDetails::BatchNotFound { id: *batch_id }.into());
             }
             response
@@ -492,17 +492,18 @@ pub async fn get_batch_request(
                 "#,
             );
             let response = clickhouse.run_query_synchronous_no_params(query).await?;
-            if response.is_empty() {
+            if response.response.is_empty() {
                 return Err(ErrorDetails::BatchNotFound { id: *inference_id }.into());
             }
             response
         }
     };
-    let batch_request = serde_json::from_str::<BatchRequestRow>(&response).map_err(|e| {
-        Error::new(ErrorDetails::ClickHouseDeserialization {
-            message: e.to_string(),
-        })
-    })?;
+    let batch_request =
+        serde_json::from_str::<BatchRequestRow>(&response.response).map_err(|e| {
+            Error::new(ErrorDetails::ClickHouseDeserialization {
+                message: e.to_string(),
+            })
+        })?;
     Ok(batch_request)
 }
 
@@ -950,6 +951,7 @@ pub async fn get_batch_inferences(
         .run_query_synchronous_no_params(query)
         .await?;
     let rows = response
+        .response
         .lines()
         .filter(|line| !line.is_empty())
         .map(serde_json::from_str::<BatchModelInferenceRow>)
@@ -1005,7 +1007,7 @@ pub async fn get_completed_batch_inference_response(
                     .run_query_synchronous_no_params(query)
                     .await?;
                 let mut inference_responses = Vec::new();
-                for row in response.lines() {
+                for row in response.response.lines() {
                     let inference_response: ChatInferenceResponseDatabaseRead =
                         serde_json::from_str(row).map_err(|e| {
                             Error::new(ErrorDetails::Serialization {
@@ -1054,14 +1056,14 @@ pub async fn get_completed_batch_inference_response(
                 let response = clickhouse_connection_info
                     .run_query_synchronous_no_params(query)
                     .await?;
-                if response.is_empty() {
+                if response.response.is_empty() {
                     return Err(ErrorDetails::InferenceNotFound {
                         inference_id: *inference_id,
                     }
                     .into());
                 }
                 let inference_response: ChatInferenceResponseDatabaseRead =
-                    serde_json::from_str(&response).map_err(|e| {
+                    serde_json::from_str(&response.response).map_err(|e| {
                         Error::new(ErrorDetails::Serialization {
                             message: e.to_string(),
                         })
@@ -1104,7 +1106,7 @@ pub async fn get_completed_batch_inference_response(
                     .run_query_synchronous_no_params(query)
                     .await?;
                 let mut inference_responses = Vec::new();
-                for row in response.lines() {
+                for row in response.response.lines() {
                     let inference_response: JsonInferenceResponseDatabaseRead =
                         serde_json::from_str(row).map_err(|e| {
                             Error::new(ErrorDetails::Serialization {
@@ -1153,14 +1155,14 @@ pub async fn get_completed_batch_inference_response(
                 let response = clickhouse_connection_info
                     .run_query_synchronous_no_params(query)
                     .await?;
-                if response.is_empty() {
+                if response.response.is_empty() {
                     return Err(ErrorDetails::InferenceNotFound {
                         inference_id: *inference_id,
                     }
                     .into());
                 }
                 let inference_response: JsonInferenceResponseDatabaseRead =
-                    serde_json::from_str(&response).map_err(|e| {
+                    serde_json::from_str(&response.response).map_err(|e| {
                         Error::new(ErrorDetails::Serialization {
                             message: e.to_string(),
                         })

--- a/tensorzero-core/src/endpoints/dynamic_evaluation_run.rs
+++ b/tensorzero-core/src/endpoints/dynamic_evaluation_run.rs
@@ -338,15 +338,15 @@ async fn lookup_dynamic_evaluation_run(
     let result = clickhouse
         .run_query_synchronous(query.to_string(), &params)
         .await?;
-    if result.is_empty() {
+    if result.response.is_empty() {
         return Ok(None);
     }
-    let dynamic_evaluation_run: DynamicEvaluationRunInfo =
-        serde_json::from_str(&result).map_err(|_| {
-            Error::new(ErrorDetails::Serialization {
-                message: "Failed to deserialize dynamic evaluation run".to_string(),
-            })
-        })?;
+    let dynamic_evaluation_run: DynamicEvaluationRunInfo = serde_json::from_str(&result.response)
+        .map_err(|_| {
+        Error::new(ErrorDetails::Serialization {
+            message: "Failed to deserialize dynamic evaluation run".to_string(),
+        })
+    })?;
     Ok(Some(dynamic_evaluation_run))
 }
 

--- a/tensorzero-core/src/endpoints/feedback.rs
+++ b/tensorzero-core/src/endpoints/feedback.rs
@@ -461,6 +461,7 @@ async fn get_function_name(
     let function_name = connection_info
         .run_query_synchronous_no_params(query)
         .await?
+        .response
         .trim()
         .to_string();
     if function_name.is_empty() {
@@ -643,8 +644,8 @@ async fn get_dynamic_demonstration_info(
                 )
                 .await?;
 
-            let tool_params_result =
-                serde_json::from_str::<ToolParamsResult>(&result).map_err(|e| {
+            let tool_params_result = serde_json::from_str::<ToolParamsResult>(&result.response)
+                .map_err(|e| {
                     Error::new(ErrorDetails::ClickHouseQuery {
                         message: format!("Failed to parse demonstration result: {e}"),
                     })
@@ -670,7 +671,7 @@ async fn get_dynamic_demonstration_info(
                     ]),
                 )
                 .await?;
-            let result_value = serde_json::from_str::<Value>(&result).map_err(|e| {
+            let result_value = serde_json::from_str::<Value>(&result.response).map_err(|e| {
                 Error::new(ErrorDetails::ClickHouseQuery {
                     message: format!("Failed to parse demonstration result: {e}"),
                 })

--- a/tensorzero-core/src/variant/dicl.rs
+++ b/tensorzero-core/src/variant/dicl.rs
@@ -374,6 +374,7 @@ impl DiclConfig {
 
         // Parse each line into RawExample (since we will have some serialized JSON strings inside it)
         let raw_examples: Vec<RawExample> = result
+            .response
             .lines()
             .map(serde_json::from_str::<RawExample>)
             .collect::<Result<Vec<_>, _>>()

--- a/tensorzero-core/tests/e2e/clickhouse.rs
+++ b/tensorzero-core/tests/e2e/clickhouse.rs
@@ -162,6 +162,7 @@ async fn count_table_rows(clickhouse: &ClickHouseConnectionInfo, table: &str) ->
         .run_query_synchronous_no_params(format!("SELECT count(*) FROM {table}"))
         .await
         .unwrap()
+        .response
         .trim()
         .parse()
         .unwrap()
@@ -355,7 +356,8 @@ async fn run_migration_0020_with_data<R: Future<Output = bool>, F: FnOnce() -> R
         .await
         .unwrap();
 
-    let sample_chat_row_json = serde_json::from_str::<serde_json::Value>(&sample_chat_row).unwrap();
+    let sample_chat_row_json =
+        serde_json::from_str::<serde_json::Value>(&sample_chat_row.response).unwrap();
     let sample_chat_id = sample_chat_row_json["id_uint"].as_str().unwrap();
     let sample_chat_episode_id = sample_chat_row_json["episode_id_uint"].as_str().unwrap();
 
@@ -368,10 +370,10 @@ async fn run_migration_0020_with_data<R: Future<Output = bool>, F: FnOnce() -> R
         .await
         .unwrap();
 
-    println!("Matching chat by id: `{matching_chat_by_id}`");
+    println!("Matching chat by id: `{}`", matching_chat_by_id.response);
 
     let matching_chat_by_id_json =
-        serde_json::from_str::<serde_json::Value>(&matching_chat_by_id).unwrap();
+        serde_json::from_str::<serde_json::Value>(&matching_chat_by_id.response).unwrap();
     assert_eq!(
         matching_chat_by_id_json["episode_id_uint"]
             .as_str()
@@ -387,7 +389,7 @@ async fn run_migration_0020_with_data<R: Future<Output = bool>, F: FnOnce() -> R
         .unwrap();
 
     let matching_chat_by_episode_id_json =
-        serde_json::from_str::<serde_json::Value>(&matching_chat_by_episode_id).unwrap();
+        serde_json::from_str::<serde_json::Value>(&matching_chat_by_episode_id.response).unwrap();
     assert_eq!(
         matching_chat_by_episode_id_json["id_uint"]
             .as_str()
@@ -402,7 +404,8 @@ async fn run_migration_0020_with_data<R: Future<Output = bool>, F: FnOnce() -> R
         .await
         .unwrap();
 
-    let sample_json_row_json = serde_json::from_str::<serde_json::Value>(&sample_json_row).unwrap();
+    let sample_json_row_json =
+        serde_json::from_str::<serde_json::Value>(&sample_json_row.response).unwrap();
     let sample_json_id = sample_json_row_json["id_uint"].as_str().unwrap();
     let sample_json_episode_id = sample_json_row_json["episode_id_uint"].as_str().unwrap();
 
@@ -414,7 +417,7 @@ async fn run_migration_0020_with_data<R: Future<Output = bool>, F: FnOnce() -> R
         .unwrap();
 
     let matching_json_by_id_json =
-        serde_json::from_str::<serde_json::Value>(&matching_json_by_id).unwrap();
+        serde_json::from_str::<serde_json::Value>(&matching_json_by_id.response).unwrap();
     assert_eq!(
         matching_json_by_id_json["episode_id_uint"]
             .as_str()
@@ -430,7 +433,7 @@ async fn run_migration_0020_with_data<R: Future<Output = bool>, F: FnOnce() -> R
         .unwrap();
 
     let matching_json_by_episode_id_json =
-        serde_json::from_str::<serde_json::Value>(&matching_json_by_episode_id).unwrap();
+        serde_json::from_str::<serde_json::Value>(&matching_json_by_episode_id.response).unwrap();
     assert_eq!(
         matching_json_by_episode_id_json["id_uint"]
             .as_str()
@@ -720,6 +723,7 @@ async fn get_all_migration_records(
         )
         .await
         .unwrap()
+        .response
         .lines()
     {
         rows.push(serde_json::from_str::<MigrationRecordDatabaseInsert>(row).unwrap());

--- a/tensorzero-core/tests/e2e/common.rs
+++ b/tensorzero-core/tests/e2e/common.rs
@@ -35,11 +35,11 @@ pub async fn delete_datapoint(
             ("id", datapoint_id.to_string().as_str())
         ])).await.unwrap();
 
-    if datapoint.is_empty() {
+    if datapoint.response.is_empty() {
         panic!("Datapoint not found with params {datapoint_kind:?}, {function_name}, {dataset_name}, {datapoint_id}");
     }
 
-    let mut datapoint_json: serde_json::Value = serde_json::from_str(&datapoint).unwrap();
+    let mut datapoint_json: serde_json::Value = serde_json::from_str(&datapoint.response).unwrap();
 
     // We delete datapoints by writing a new row (which ClickHouse will merge)
     // with the 'is_deleted' and 'updated_at' fields modified.

--- a/tensorzero-core/tests/e2e/providers/batch.rs
+++ b/tensorzero-core/tests/e2e/providers/batch.rs
@@ -549,10 +549,10 @@ async fn get_latest_batch_inference(
         .run_query_synchronous_no_params(query)
         .await
         .unwrap();
-    if response.is_empty() {
+    if response.response.is_empty() {
         return None;
     }
-    let batch_request = serde_json::from_str::<BatchRequestRow>(&response).unwrap();
+    let batch_request = serde_json::from_str::<BatchRequestRow>(&response.response).unwrap();
     Some(batch_request)
 }
 
@@ -568,6 +568,7 @@ async fn get_all_batch_inferences(
         .await
         .unwrap();
     let rows = response
+        .response
         .lines()
         .filter(|line| !line.is_empty())
         .map(serde_json::from_str::<BatchModelInferenceRow>)


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor ClickHouse query handling in Rust to return `ClickHouseResult`, updating result access across the codebase.
> 
>   - **Behavior**:
>     - All ClickHouse queries in Rust now return a `ClickHouseResult` object, which includes a `response` field for the query result.
>     - Updated handling of query results to use `result.response` instead of `result` directly in `dataset.rs`, `helpers.rs`, and `clickhouse.rs`.
>   - **Refactor**:
>     - Introduced `ClickHouseResponse` and `ClickHouseResponseMetadata` structs in `clickhouse/mod.rs` to encapsulate query results and metadata.
>     - Updated `run_query_synchronous` and `run_query_synchronous_no_params` methods in `clickhouse/mod.rs` to return `ClickHouseResponse`.
>   - **Tests**:
>     - Adjusted test cases in `clickhouse.rs` and `batch.rs` to accommodate the new `ClickHouseResponse` structure.
>     - Ensured all test queries access `response` field for result validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8433cc39ec3fe3dbd51674043f7c931605d49690. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->