### PR TITLE
Bump rcgen to 0.14.1 in provider-proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytecount"
@@ -3542,9 +3542,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.13.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+checksum = "218a7fbb357f6da42c9fd3610b1a5128d087d460e5386eaa5040705c464611dc"
 dependencies = [
  "pem",
  "ring",

--- a/provider-proxy/Cargo.toml
+++ b/provider-proxy/Cargo.toml
@@ -21,7 +21,7 @@ hyper = { version = "1.6.0", features = ["client", "server", "http1", "http2"] }
 hyper-util = "0.1.12"
 moka = { version = "0.12.10", features = ["sync"] }
 pin-project = "1.1.10"
-rcgen = "0.13.2"
+rcgen = "0.14.1"
 reqwest.workspace = true
 rustls = "0.23.28"
 serde = { workspace = true }

--- a/provider-proxy/src/lib.rs
+++ b/provider-proxy/src/lib.rs
@@ -29,7 +29,7 @@ use tracing::level_filters::LevelFilter;
 
 const CACHE_HEADER_NAME: &str = "x-tensorzero-provider-proxy-cache";
 
-fn make_root_cert() -> rcgen::CertifiedKey {
+fn make_root_cert() -> rcgen::Issuer<'static, rcgen::KeyPair> {
     let mut param = rcgen::CertificateParams::default();
 
     param.distinguished_name = rcgen::DistinguishedName::new();
@@ -44,9 +44,7 @@ fn make_root_cert() -> rcgen::CertifiedKey {
     param.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
 
     let key_pair = rcgen::KeyPair::generate().unwrap();
-    let cert = param.self_signed(&key_pair).unwrap();
-
-    rcgen::CertifiedKey { cert, key_pair }
+    rcgen::Issuer::new(param, key_pair)
 }
 
 fn hash_value(request: &serde_json::Value) -> Result<String, anyhow::Error> {

--- a/provider-proxy/src/mitm_server.rs
+++ b/provider-proxy/src/mitm_server.rs
@@ -41,7 +41,7 @@ impl<C> MitmProxy<C> {
 
 impl<C> MitmProxy<C>
 where
-    C: Borrow<rcgen::CertifiedKey> + Send + Sync + 'static,
+    C: Borrow<rcgen::Issuer<'static, rcgen::KeyPair>> + Send + Sync + 'static,
 {
     /// Bind to a socket address and return a future that runs the proxy server.
     /// URL for requests that passed to service are full URL including scheme.

--- a/provider-proxy/src/tls.rs
+++ b/provider-proxy/src/tls.rs
@@ -7,7 +7,10 @@ pub struct CertifiedKeyDer {
     pub key_der: Vec<u8>,
 }
 
-pub fn generate_cert(host: String, root_cert: &rcgen::CertifiedKey) -> CertifiedKeyDer {
+pub fn generate_cert(
+    host: String,
+    root_cert: &rcgen::Issuer<'_, rcgen::KeyPair>,
+) -> CertifiedKeyDer {
     let mut cert_params = rcgen::CertificateParams::new(vec![host.clone()]).unwrap();
     cert_params
         .key_usages
@@ -26,9 +29,7 @@ pub fn generate_cert(host: String, root_cert: &rcgen::CertifiedKey) -> Certified
 
     let key_pair = rcgen::KeyPair::generate().unwrap();
 
-    let cert = cert_params
-        .signed_by(&key_pair, &root_cert.cert, &root_cert.key_pair)
-        .unwrap();
+    let cert = cert_params.signed_by(&key_pair, root_cert).unwrap();
 
     CertifiedKeyDer {
         cert_der: cert.der().to_vec(),


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `rcgen` to `0.14.1` in `provider-proxy` and update related code to accommodate API changes.
> 
>   - **Dependencies**:
>     - Bump `rcgen` from `0.13.2` to `0.14.1` in `Cargo.toml` and `Cargo.lock`.
>     - Update `bumpalo` from `3.18.1` to `3.19.0` in `Cargo.lock`.
>   - **Code Changes**:
>     - Change return type of `make_root_cert()` in `lib.rs` from `rcgen::CertifiedKey` to `rcgen::Issuer<'static, rcgen::KeyPair>`.
>     - Update `MitmProxy` in `mitm_server.rs` to use `rcgen::Issuer<'static, rcgen::KeyPair>` instead of `rcgen::CertifiedKey`.
>     - Modify `generate_cert()` in `tls.rs` to accept `rcgen::Issuer<'_, rcgen::KeyPair>` and return `CertifiedKeyDer`.
>   - **Misc**:
>     - Update checksums in `Cargo.lock` for updated dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 20ed60a4072cb0a0bf433711d9215f8734117896. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->