### PR TITLE
Always upload Playwright artifacts for /regen-fixtures

### DIFF
--- a/.github/workflows/slash-command-regen-fixtures.yml
+++ b/.github/workflows/slash-command-regen-fixtures.yml
@@ -77,7 +77,7 @@ jobs:
         run: docker exec fixtures-clickhouse-1 cat /var/log/clickhouse-server/clickhouse-server.log
 
       - name: Upload Playwright artifacts
-        if: steps.e2e_tests.outcome == 'failure'
+        if: always()
         uses: namespace-actions/upload-artifact@9a78c62e083914789d908952f9773e42744b9f68
         with:
           name: playwright-report


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change Playwright artifact upload condition to always upload in `slash-command-regen-fixtures.yml`.
> 
>   - **Workflow Change**:
>     - In `.github/workflows/slash-command-regen-fixtures.yml`, the condition for uploading Playwright artifacts is changed from `steps.e2e_tests.outcome == 'failure'` to `always()`, ensuring artifacts are uploaded regardless of test results.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4c3028c654fa0db667d73b365c9f6f72b501c437. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->