### PR TITLE
Add 'signature' field to python Thought types

### DIFF
--- a/clients/python/tensorzero/types.py
+++ b/clients/python/tensorzero/types.py
@@ -122,6 +122,7 @@ class ToolCall(ContentBlock):
 class Thought(ContentBlock):
     text: str
     type: str = "thought"
+    signature: Optional[str] = None
 
 
 @dataclass
@@ -278,6 +279,7 @@ class ThoughtChunk(ContentBlockChunk):
     id: str
     text: str
     type: str = "thought"
+    signature: Optional[str] = None
 
 
 @dataclass

--- a/clients/python/tensorzero/types.py
+++ b/clients/python/tensorzero/types.py
@@ -238,7 +238,9 @@ def parse_content_block(block: Dict[str, Any]) -> ContentBlock:
             type=block_type,
         )
     elif block_type == "thought":
-        return Thought(text=block["text"], type=block_type)
+        return Thought(
+            text=block["text"], signature=block.get("signature"), type=block_type
+        )
     elif block_type == "unknown":
         return UnknownContentBlock(
             data=block["data"], model_provider_name=block.get("model_provider_name")

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -298,10 +298,41 @@ async def test_async_client_build_embedded_sync():
 
 
 @pytest.mark.asyncio
+async def test_async_thought_input(async_client: AsyncTensorZeroGateway):
+    result = await async_client.inference(
+        model_name="dummy::echo_request_messages",
+        input={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "thought",
+                            "text": "my_first_thought",
+                            "signature": "my_first_signature",
+                        },
+                        Thought(
+                            text="my_second_thought", signature="my_second_signature"
+                        ),
+                    ],
+                }
+            ],
+        },
+        tags={"key": "value"},
+    )
+    assert isinstance(result, ChatInferenceResponse)
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert (
+        result.content[0].text
+        == '{"system":null,"messages":[{"role":"user","content":[{"type":"thought","text":"my_first_thought","signature":"my_first_signature"},{"type":"thought","text":"my_second_thought","signature":"my_second_signature"}]}]}'
+    )
+
+
+@pytest.mark.asyncio
 async def test_async_reasoning_inference(async_client: AsyncTensorZeroGateway):
     result = await async_client.inference(
-        function_name="basic_test",
-        variant_name="reasoner",
+        model_name="dummy::reasoner_with_signature",
         input={
             "system": {"assistant_name": "Alfred Pennyworth"},
             "messages": [{"role": "user", "content": "Hello"}],
@@ -309,13 +340,14 @@ async def test_async_reasoning_inference(async_client: AsyncTensorZeroGateway):
         tags={"key": "value"},
     )
     assert isinstance(result, ChatInferenceResponse)
-    assert result.variant_name == "reasoner"
+    assert result.variant_name == "dummy::reasoner_with_signature"
     assert result.original_response is None
     content = result.content
     assert len(content) == 2
     assert isinstance(content[0], Thought)
     assert content[0].type == "thought"
     assert content[0].text == "hmmm"
+    assert content[0].signature == "my_signature"
     assert isinstance(content[1], Text)
     assert content[1].type == "text"
     assert (
@@ -524,6 +556,7 @@ async def test_async_reasoning_inference_streaming(
             assert chunk.content[0].type == "thought"
             assert isinstance(chunk.content[0], ThoughtChunk)
             assert chunk.content[0].text == expected_thinking[i]
+            assert chunk.content[0].signature is None
         elif i < len(expected_thinking) + len(expected_text):
             assert len(chunk.content) == 1
             assert chunk.content[0].type == "text"

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -322,7 +322,7 @@ async def test_async_thought_input(async_client: AsyncTensorZeroGateway):
     )
     assert isinstance(result, ChatInferenceResponse)
     assert len(result.content) == 1
-    assert result.content[0].type == "text"
+    assert isinstance(result.content[0], Text)
     assert (
         result.content[0].text
         == '{"system":null,"messages":[{"role":"user","content":[{"type":"thought","text":"my_first_thought","signature":"my_first_signature"},{"type":"thought","text":"my_second_thought","signature":"my_second_signature"}]}]}'

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -334,7 +334,6 @@ async def test_async_reasoning_inference(async_client: AsyncTensorZeroGateway):
     result = await async_client.inference(
         model_name="dummy::reasoner_with_signature",
         input={
-            "system": {"assistant_name": "Alfred Pennyworth"},
             "messages": [{"role": "user", "content": "Hello"}],
         },
         tags={"key": "value"},

--- a/tensorzero-core/src/providers/dummy.rs
+++ b/tensorzero-core/src/providers/dummy.rs
@@ -341,6 +341,15 @@ impl InferenceProvider for DummyProvider {
                     text: DUMMY_INFER_RESPONSE_CONTENT.to_string(),
                 }),
             ],
+            "reasoner_with_signature" => vec![
+                ContentBlockOutput::Thought(Thought {
+                    text: "hmmm".to_string(),
+                    signature: Some("my_signature".to_string()),
+                }),
+                ContentBlockOutput::Text(Text {
+                    text: DUMMY_INFER_RESPONSE_CONTENT.to_string(),
+                }),
+            ],
             "json_reasoner" => vec![
                 ContentBlockOutput::Thought(Thought {
                     text: "hmmm".to_string(),


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add optional 'signature' field to 'Thought' types in Python client and update dummy provider and tests.
> 
>   - **Python Client**:
>     - Add `signature: Optional[str]` to `Thought` and `ThoughtChunk` in `types.py`.
>     - Update `parse_content_block()` in `types.py` to handle `signature` field for `Thought`.
>   - **Rust Dummy Provider**:
>     - Add `signature` to `Thought` in `reasoner_with_signature` model in `dummy.rs`.
>   - **Tests**:
>     - Add `test_async_thought_input()` in `test_client.py` to verify `signature` handling.
>     - Update `test_async_reasoning_inference()` in `test_client.py` to check `signature` in `Thought`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3874742b6b4342a92355f716c130681cdc87bb50. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->