### PR TITLE
moved results above job details in SFT page

### DIFF
--- a/ui/app/routes/optimization/supervised-fine-tuning/FineTuningStatus.stories.tsx
+++ b/ui/app/routes/optimization/supervised-fine-tuning/FineTuningStatus.stories.tsx
@@ -83,6 +83,7 @@ const analysisData = {
 export const Idle: Story = {
   args: {
     status: { status: "idle" },
+    result: null,
   },
 };
 
@@ -96,6 +97,7 @@ export const Running: Story = {
       rawData: baseRawData,
       analysisData,
     } satisfies SFTJobStatus,
+    result: null,
   },
 };
 
@@ -110,6 +112,8 @@ export const RunningWithEstimatedCompletion: Story = {
       estimatedCompletionTime: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now
       analysisData,
     } satisfies SFTJobStatus,
+
+    result: null,
   },
 };
 
@@ -133,6 +137,7 @@ export const Completed: Story = {
       result: "ft:gpt-4o-mini-2024-07-18:my-org:custom-suffix:abc123",
       analysisData,
     } satisfies SFTJobStatus,
+    result: null,
   },
 };
 
@@ -150,6 +155,7 @@ export const Error: Story = {
       error: "Training data validation failed: Invalid format in line 42",
       analysisData,
     } satisfies SFTJobStatus,
+    result: null,
   },
 };
 
@@ -182,5 +188,6 @@ export const LongJobId: Story = {
       result: "ft:gpt-4o-mini-2024-07-18:my-org:custom-suffix:abc123",
       analysisData,
     } satisfies SFTJobStatus,
+    result: null,
   },
 };

--- a/ui/app/routes/optimization/supervised-fine-tuning/FineTuningStatus.tsx
+++ b/ui/app/routes/optimization/supervised-fine-tuning/FineTuningStatus.tsx
@@ -23,11 +23,14 @@ import {
   SectionLayout,
   SectionsGroup,
 } from "~/components/layout/PageLayout";
+import { SFTResult } from "./SFTResult";
 
 export default function LLMFineTuningStatus({
   status,
+  result,
 }: {
   status: SFTJobStatus;
+  result: string | null;
 }) {
   if (status.status === "idle") return null;
   const createdAt = extractTimestampFromUUIDv7(status.formData.jobId);
@@ -97,6 +100,7 @@ export default function LLMFineTuningStatus({
             </div>
           </SectionLayout>
         )}
+      <SFTResult finalResult={result} />
 
       <SectionLayout>
         <a

--- a/ui/app/routes/optimization/supervised-fine-tuning/route.tsx
+++ b/ui/app/routes/optimization/supervised-fine-tuning/route.tsx
@@ -13,7 +13,6 @@ import {
 } from "~/utils/config/models";
 import type { Route } from "./+types/route";
 import FineTuningStatus from "./FineTuningStatus";
-import { SFTResult } from "./SFTResult";
 import { SFTForm } from "./SFTForm";
 import {
   PageHeader,
@@ -161,9 +160,7 @@ function SupervisedFineTuningImpl(
         </div>
       </PageHeader>
 
-      <FineTuningStatus status={props} />
-
-      <SFTResult finalResult={finalResult} />
+      <FineTuningStatus status={props} result={finalResult} />
     </PageLayout>
   );
 }


### PR DESCRIPTION
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/b53879d7-0f33-4183-ab17-bdb1b1993d7a" />
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reorder UI components to display results above job details in the supervised fine-tuning page.
> 
>   - **UI Changes**:
>     - Move `SFTResult` component above job details in `LLMFineTuningStatus` in `FineTuningStatus.tsx`.
>     - Update `FineTuningStatus` component usage in `route.tsx` to pass `result` prop.
>   - **Storybook**:
>     - Add `result: null` to all stories in `FineTuningStatus.stories.tsx` to match new prop requirements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 51e7614f0656cf1ee9de778fa3c7fadeeb725a92. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->