### PR TITLE
Enforce that `AppStateData` is only constructed through explicit methods

### DIFF
--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -298,11 +298,11 @@ impl ClientBuilder {
                 Ok(Client {
                     mode: ClientMode::EmbeddedGateway {
                         gateway: EmbeddedGateway {
-                            state: AppStateData {
+                            state: AppStateData::new_with_clickhouse_and_http_client(
                                 config,
-                                http_client,
                                 clickhouse_connection_info,
-                            },
+                                http_client,
+                            ),
                         },
                         timeout: *timeout,
                     },

--- a/tensorzero-core/src/endpoints/batch_inference.rs
+++ b/tensorzero-core/src/endpoints/batch_inference.rs
@@ -108,6 +108,7 @@ pub async fn start_batch_inference_handler(
         config,
         http_client,
         clickhouse_connection_info,
+        ..
     }): AppState,
     StructuredJson(params): StructuredJson<StartBatchInferenceParams>,
 ) -> Result<Response<Body>, Error> {
@@ -339,6 +340,7 @@ pub async fn poll_batch_inference_handler(
         config,
         http_client,
         clickhouse_connection_info,
+        ..
     }): AppState,
     Path(path_params): Path<PollPathParams>,
 ) -> Result<Response<Body>, Error> {

--- a/tensorzero-core/src/endpoints/inference.rs
+++ b/tensorzero-core/src/endpoints/inference.rs
@@ -143,6 +143,7 @@ pub async fn inference_handler(
         config,
         http_client,
         clickhouse_connection_info,
+        ..
     }): AppState,
     StructuredJson(params): StructuredJson<Params>,
 ) -> Result<Response<Body>, Error> {

--- a/tensorzero-core/src/endpoints/openai_compatible.rs
+++ b/tensorzero-core/src/endpoints/openai_compatible.rs
@@ -54,6 +54,7 @@ pub async fn inference_handler(
         config,
         http_client,
         clickhouse_connection_info,
+        ..
     }): AppState,
     headers: HeaderMap,
     StructuredJson(openai_compatible_params): StructuredJson<OpenAICompatibleParams>,

--- a/tensorzero-core/src/endpoints/optimization.rs
+++ b/tensorzero-core/src/endpoints/optimization.rs
@@ -51,6 +51,7 @@ pub async fn launch_optimization_workflow_handler(
         config,
         http_client,
         clickhouse_connection_info,
+        ..
     }): AppState,
     StructuredJson(params): StructuredJson<LaunchOptimizationWorkflowParams>,
 ) -> Result<Response<Body>, Error> {

--- a/tensorzero-core/src/gateway_util.rs
+++ b/tensorzero-core/src/gateway_util.rs
@@ -26,7 +26,7 @@ pub struct AppStateData {
     pub http_client: Client,
     pub clickhouse_connection_info: ClickHouseConnectionInfo,
     // Prevent `AppStateData` from being directly constructed outside of this module
-    // This ensures that `AppStateData`is only every constructed via explicit `new` methods,
+    // This ensures that `AppStateData` is only ever constructed via explicit `new` methods,
     // which can ensure that we update global state.
     _private: (),
 }

--- a/tensorzero-core/src/testing.rs
+++ b/tensorzero-core/src/testing.rs
@@ -2,17 +2,9 @@
 
 use std::sync::Arc;
 
-use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::config_parser::Config;
 use crate::gateway_util::AppStateData;
 
 pub fn get_unit_test_app_state_data(config: Arc<Config>, clickhouse_healthy: bool) -> AppStateData {
-    let http_client = reqwest::Client::new();
-    let clickhouse_connection_info = ClickHouseConnectionInfo::new_mock(clickhouse_healthy);
-
-    AppStateData {
-        config,
-        http_client,
-        clickhouse_connection_info,
-    }
+    AppStateData::new_unit_test_data(config, clickhouse_healthy)
 }


### PR DESCRIPTION
This allows us to enforce that global state is updated whenever an `AppStateData` is constructed. For now, the constructors don't do anything new - future PRs will start updating global error state.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enforces `AppStateData` construction through explicit methods, adding a private field to prevent direct construction and updating relevant files to use new methods.
> 
>   - **Behavior**:
>     - Enforces `AppStateData` construction through explicit methods in `gateway_util.rs`.
>     - Adds `_private` field to `AppStateData` to prevent direct construction.
>     - Introduces `new_with_clickhouse_and_http_client()` and `new_unit_test_data()` methods in `AppStateData`.
>   - **Refactoring**:
>     - Updates `lib.rs` to use `AppStateData::new_with_clickhouse_and_http_client()`.
>     - Modifies handlers in `batch_inference.rs`, `inference.rs`, `openai_compatible.rs`, and `optimization.rs` to destructure `AppState` with `..`.
>     - Refactors `get_unit_test_app_state_data()` in `testing.rs` to use `new_unit_test_data()`.
>   - **Misc**:
>     - Adds comments to clarify the purpose of `_private` field in `AppStateData`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7733a047a1aa78c0016c06314e6d7fa6a4fe1e29. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->