### PR TITLE
Allow missing fs object store path with skip_credential_validation

### DIFF
--- a/tensorzero-core/src/config_parser/tests.rs
+++ b/tensorzero-core/src/config_parser/tests.rs
@@ -1632,6 +1632,28 @@ async fn test_config_missing_filesystem_object_store() {
         );
 }
 
+#[tokio::test]
+#[traced_test]
+#[cfg_attr(feature = "e2e_tests", ignore)]
+async fn test_config_no_verify_creds_missing_filesystem_object_store() {
+    let tempfile = NamedTempFile::new().unwrap();
+    write!(
+        &tempfile,
+        r#"
+            [object_storage]
+            type = "filesystem"
+            path = "/fake-tensorzero-path/other-path"
+
+            [functions]"#
+    )
+    .unwrap();
+    let config = Config::load_from_path_optional_verify_credentials(tempfile.path(), false)
+        .await
+        .unwrap();
+    assert!(config.object_store_info.is_none());
+    assert!(logs_contain("Filesystem object store path does not exist: /fake-tensorzero-path/other-path. Treating object store as unconfigured"));
+}
+
 #[traced_test]
 #[tokio::test]
 async fn test_config_load_invalid_s3_creds() {

--- a/tensorzero-core/src/config_parser/tests.rs
+++ b/tensorzero-core/src/config_parser/tests.rs
@@ -1610,6 +1610,7 @@ async fn test_config_load_no_config_file() {
 }
 
 #[tokio::test]
+#[cfg_attr(feature = "e2e_tests", ignore)]
 async fn test_config_missing_filesystem_object_store() {
     let tempfile = NamedTempFile::new().unwrap();
     write!(
@@ -1634,7 +1635,6 @@ async fn test_config_missing_filesystem_object_store() {
 
 #[tokio::test]
 #[traced_test]
-#[cfg_attr(feature = "e2e_tests", ignore)]
 async fn test_config_no_verify_creds_missing_filesystem_object_store() {
     let tempfile = NamedTempFile::new().unwrap();
     write!(


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Allow missing filesystem paths in `ObjectStoreInfo` when `skip_credential_validation` is enabled, updating logic and tests accordingly.
> 
>   - **Behavior**:
>     - In `mod.rs`, `ObjectStoreInfo::new()` now allows missing filesystem paths if `skip_credential_validation()` is true, logging a warning and treating the object store as unconfigured.
>   - **Tests**:
>     - Adds `test_config_no_verify_creds_missing_filesystem_object_store()` in `tests.rs` to verify behavior when filesystem path is missing and credential validation is skipped.
>     - Updates `test_config_missing_filesystem_object_store()` in `tests.rs` to ensure error is raised when path is missing and validation is not skipped.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 623f379010acdf474c0139daf817cadde9f753d0. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->