### PR TITLE
fixed error handling so UI grabs right field to display

### DIFF
--- a/tensorzero-core/tests/mock-inference-provider/src/main.rs
+++ b/tensorzero-core/tests/mock-inference-provider/src/main.rs
@@ -181,9 +181,9 @@ async fn get_openai_fine_tuning_job(
         }
         if let Some(finish_at) = job.finish_at {
             if job.val["model"].as_str().unwrap().contains("error") {
-                job.val["status"] = "failed because the model is an error model".into();
+                job.val["status"] = "failed".into();
                 job.val["error"] = json!({
-                    "unexpected_error": "error model"
+                    "unexpected_error": "failed because the model is an error model"
                 });
             }
             if chrono::Utc::now() >= finish_at {

--- a/ui/app/utils/supervised_fine_tuning/client.ts
+++ b/ui/app/utils/supervised_fine_tuning/client.ts
@@ -69,7 +69,8 @@ class NativeSFTJob extends SFTJob {
             info: this.jobStatus,
           },
         };
-      case "failed":
+      case "failed": {
+        const stringifiedError = JSON.stringify(this.jobStatus.error, null, 2);
         return {
           status: "error",
           modelProvider: this.provider,
@@ -77,10 +78,11 @@ class NativeSFTJob extends SFTJob {
           jobUrl: this.jobHandle.job_url,
           rawData: {
             status: "error",
-            message: this.jobStatus.message,
+            message: stringifiedError,
           },
-          error: this.jobStatus.message,
+          error: stringifiedError,
         };
+      }
       case "completed": {
         // NOTE: the native SFT backend actually returns a model provider that is all we need
         // and guaranteed to match the Rust type.


### PR DESCRIPTION
under the current `main` prior to this PR I got an error that logged this: 

<img width="2546" height="418" alt="image" src="https://github.com/user-attachments/assets/30ce92fd-001e-4d54-a412-8a3b0b2095c1" />

but then saw "Failed" as the message on the screen. I have now fixed this.

here is what you get now:

<img width="1369" height="293" alt="image" src="https://github.com/user-attachments/assets/2da5ca21-dc2f-4638-afc0-0bd25e23429e" />

not pretty, but much more useful
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix error handling to display detailed error messages in UI by updating `main.rs` and `client.ts`.
> 
>   - **Error Handling**:
>     - In `main.rs`, change `job.val["status"]` to "failed" and `job.val["error"]` to include detailed error message.
>     - In `client.ts`, update `NativeSFTJob` to stringify `jobStatus.error` for "failed" status, ensuring detailed error message is displayed in UI.
>   - **Misc**:
>     - Add block for "failed" case in `client.ts` to handle error message formatting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for cb2e30b3446aa31d33702ff7d3fb0d07e02a19c4. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->