### PR TITLE
Don't set credentials in normal UI tests

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -60,6 +60,13 @@ jobs:
           echo "TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@localhost:8123/tensorzero_ui_fixtures" >> fixtures/.env
           echo "TENSORZERO_GATEWAY_TAG=sha-${{ github.sha }}" >> fixtures/.env
           echo "TENSORZERO_UI_TAG=sha-${{ github.sha }}" >> fixtures/.env
+
+          # Environment variables only used by the gateway container
+          # We deliberately leave these unset when starting the UI container, to ensure
+          # that it doesn't depend on them being set
+          echo "FIREWORKS_API_KEY=not_used" >> fixtures/.env-gateway
+          echo "OPENAI_API_KEY=not_used" >> fixtures/.env-gateway
+
           TENSORZERO_CLICKHOUSE_VERSION=${{ matrix.clickhouse_version }} docker compose -f fixtures/docker-compose.yml up -d
           docker compose -f fixtures/docker-compose.yml wait fixtures
 

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -56,8 +56,6 @@ jobs:
       - name: Start Docker containers and apply fixtures
         working-directory: ui
         run: |
-          echo "OPENAI_API_KEY=not_used" >> fixtures/.env
-          echo "FIREWORKS_API_KEY=not_used" >> fixtures/.env
           echo "FIREWORKS_ACCOUNT_ID=not_used" >> fixtures/.env
           echo "TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@localhost:8123/tensorzero_ui_fixtures" >> fixtures/.env
           echo "TENSORZERO_GATEWAY_TAG=sha-${{ github.sha }}" >> fixtures/.env

--- a/ui/fixtures/docker-compose.yml
+++ b/ui/fixtures/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero_ui_fixtures
     env_file:
       - .env
+      - .env-gateway
     ports:
       - "3000:3000"
     extra_hosts:


### PR DESCRIPTION
We already removed the credentials for the E2E tests - let's also remove there here, to ensure that the UI itself does not depend on having them available

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove `OPENAI_API_KEY` and `FIREWORKS_API_KEY` from UI test environment, setting them only for the gateway container.
> 
>   - **Environment Variables**:
>     - Removed `OPENAI_API_KEY` and `FIREWORKS_API_KEY` from `.env` in `ui-tests.yml`.
>     - Added `OPENAI_API_KEY` and `FIREWORKS_API_KEY` to `.env-gateway` in `ui-tests.yml` for gateway container only.
>   - **Docker Configuration**:
>     - Updated `docker-compose.yml` to include `.env-gateway` for the `gateway` service.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d0ebea5b627ac00d1d4b563b706d7cf973264ce1. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->