### PR TITLE
Use Deepseek instead of Qwen for Fireworks tests

### DIFF
--- a/tensorzero-core/tests/e2e/providers/fireworks.rs
+++ b/tensorzero-core/tests/e2e/providers/fireworks.rs
@@ -22,7 +22,7 @@ async fn get_providers() -> E2ETestProviders {
     let extra_body_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks-extra-body".to_string(),
-        model_name: "qwen2p5-72b-instruct".into(),
+        model_name: "fireworks::accounts/fireworks/models/deepseek-r1-0528".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];
@@ -30,7 +30,7 @@ async fn get_providers() -> E2ETestProviders {
     let bad_auth_extra_headers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks-extra-headers".to_string(),
-        model_name: "qwen2p5-72b-instruct".into(),
+        model_name: "fireworks::accounts/fireworks/models/deepseek-r1-0528".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];

--- a/tensorzero-core/tests/e2e/tensorzero.toml
+++ b/tensorzero-core/tests/e2e/tensorzero.toml
@@ -981,14 +981,14 @@ max_tokens = 500
 
 [functions.basic_test.variants.fireworks-extra-body]
 type = "chat_completion"
-model = "qwen2p5-72b-instruct"
+model = "fireworks::accounts/fireworks/models/deepseek-r1-0528"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 extra_body = [{ pointer = "/temperature", value = 0.123 }]
 
 [functions.basic_test.variants.fireworks-extra-headers]
 type = "chat_completion"
-model = "qwen2p5-72b-instruct"
+model = "fireworks::accounts/fireworks/models/deepseek-r1-0528"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 extra_headers = [{ name = "Authorization", value = "invalid_fireworks_auth" }]


### PR DESCRIPTION
On Fireworks, 'accounts/fireworks/models/qwen2p5-72b-instruct' seems to be broken - it's returning
"Model not found, inaccessible, and/or not deployed" on the playground, locally, and on CI without the provider-proxy cache

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
