### PR TITLE
Remove `max-h` from code editor component

### DIFF
--- a/ui/app/components/ui/code-editor.tsx
+++ b/ui/app/components/ui/code-editor.tsx
@@ -274,7 +274,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
             highlightActiveLine: !readOnly,
             highlightActiveLineGutter: !readOnly,
           }}
-          className="max-h-64 min-h-8 overflow-auto"
+          className="min-h-8 overflow-auto"
         />
       </div>
     </div>


### PR DESCRIPTION
The content blocks might be scrollable, but there's no visual cue right now. Later, we can reintroduce the max height if we add a "fade" or other cue.

![CleanShot 2025-07-11 at 18 19 39](https://github.com/user-attachments/assets/7c577899-29c1-4ccd-b51c-55e153785334)
