### PR TITLE
Fix title for dashboard

### DIFF
--- a/ui/app/components/layout/ContentLayout.tsx
+++ b/ui/app/components/layout/ContentLayout.tsx
@@ -3,7 +3,10 @@ import { useBreadcrumbs } from "~/hooks/use-breadcrumbs";
 
 export function ContentLayout({ children }: React.PropsWithChildren) {
   const { segments, hideBreadcrumbs } = useBreadcrumbs();
-  const pageTitle = [...segments.map((b) => b.label), "TensorZero"].join(" • ");
+  const pageTitle =
+    segments.length > 0
+      ? [...segments.map((b) => b.label), "TensorZero"].join(" • ")
+      : "Dashboard • TensorZero";
 
   return (
     <>


### PR DESCRIPTION
Fix #2786 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes page title in `ContentLayout` to show "Dashboard • TensorZero" when no breadcrumbs exist.
> 
>   - **Behavior**:
>     - Fixes page title in `ContentLayout` in `ContentLayout.tsx` to display "Dashboard • TensorZero" when no breadcrumbs are present.
>     - Uses conditional logic to check `segments.length` to determine the title format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 39e9b47d7f79110ea02003bfee1699436c8edfcd. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->