### PR TITLE
`ToolCallMessage` should make a distinction between parsed and raw name and arguments

### DIFF
--- a/ui/app/components/inference/InputSnippet.tsx
+++ b/ui/app/components/inference/InputSnippet.tsx
@@ -52,7 +52,9 @@ function renderContentBlock(block: DisplayInputMessageContent, index: number) {
         <ToolCallMessage
           key={index}
           toolName={block.name}
+          toolRawName={block.name} // tool calls in the input aren't parsed, so there's no "raw"
           toolArguments={block.arguments}
+          toolRawArguments={block.arguments} // tool calls in the input aren't parsed, so there's no "raw"
           toolCallId={block.id}
         />
       );

--- a/ui/app/components/inference/NewOutput.stories.tsx
+++ b/ui/app/components/inference/NewOutput.stories.tsx
@@ -89,21 +89,56 @@ export const ChatFunctionWithParallelToolCallsAndText: Story = {
 
 // TODO: we must fallback to raw_name if name is null (make it clear to user the name is problematic)
 // TODO: we must show the raw_arguments if arguments is null (make it clear to user the arguments are problematic)
-export const ChatFunctionWithBadToolCall: Story = {
+export const ChatFunctionWithBadToolCallName: Story = {
+  args: {
+    output: [
+      {
+        type: "tool_call",
+        id: "tc-1234567890",
+        raw_name: "get_temperatu",
+        raw_arguments: JSON.stringify(shortToolCallArgumentsFixture),
+        name: null,
+        arguments: shortToolCallArgumentsFixture,
+      },
+    ],
+  },
+};
+
+export const ChatFunctionWithBadToolCallArguments: Story = {
   args: {
     output: [
       {
         type: "tool_call",
         id: "tc-1234567890",
         raw_name: "get_temperature",
-        raw_arguments: JSON.stringify(shortToolCallArgumentsFixture),
-        name: null,
+        raw_arguments: JSON.stringify(shortToolCallArgumentsFixture).slice(
+          0,
+          -10,
+        ),
+        name: "get_temperature",
         arguments: null,
       },
     ],
   },
 };
 
+export const ChatFunctionWithBadToolCallBoth: Story = {
+  args: {
+    output: [
+      {
+        type: "tool_call",
+        id: "tc-1234567890",
+        raw_name: "get_temperatu",
+        raw_arguments: JSON.stringify(shortToolCallArgumentsFixture).slice(
+          0,
+          -10,
+        ),
+        name: null,
+        arguments: null,
+      },
+    ],
+  },
+};
 const massiveTextOutputFixture =
   "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent quis orci turpis. Phasellus tempor metus sed enim congue consectetur. Donec commodo sollicitudin libero, quis mollis sapien pulvinar sit amet. Suspendisse potenti. Morbi vestibulum, justo id iaculis imperdiet, sem ipsum dignissim metus, ac viverra massa ex sit amet velit. Maecenas lobortis velit diam, nec finibus lacus blandit in. Morbi sed ullamcorper lectus, id maximus magna. ".repeat(
     100,

--- a/ui/app/components/inference/NewOutput.tsx
+++ b/ui/app/components/inference/NewOutput.tsx
@@ -109,9 +109,13 @@ function renderChatInferenceOutput(output: ChatInferenceOutputRenderingData) {
                 return (
                   <ToolCallMessage
                     key={index}
-                    toolName={block.name ?? ""}
-                    toolArguments={JSON.stringify(block.arguments, null, 2)}
-                    // TODO: if arguments is null, display raw arguments without parsing
+                    toolName={block.name}
+                    toolRawName={block.raw_name}
+                    toolArguments={
+                      block.arguments &&
+                      JSON.stringify(block.arguments, null, 2)
+                    }
+                    toolRawArguments={block.raw_arguments}
                     toolCallId={block.id}
                   />
                 );

--- a/ui/app/components/layout/SnippetContent.tsx
+++ b/ui/app/components/layout/SnippetContent.tsx
@@ -134,11 +134,13 @@ export function ParameterizedMessage({ parameters }: { parameters?: unknown }) {
 
 function ToolDetails({
   name,
+  nameLabel,
   id,
   payload,
   payloadLabel,
 }: {
   name: string;
+  nameLabel: string;
   id: string;
   payload: string;
   payloadLabel: string;
@@ -147,7 +149,7 @@ function ToolDetails({
 
   return (
     <div className="border-border bg-bg-tertiary/50 grid grid-flow-row grid-cols-[min-content_1fr] grid-rows-[repeat(3,min-content)] place-content-center gap-x-4 gap-y-1 rounded-sm px-3 py-2 text-xs">
-      <p className="text-fg-secondary font-medium">Name</p>
+      <p className="text-fg-secondary font-medium">{nameLabel}</p>
       <p className="self-center truncate font-mono text-[0.6875rem]">{name}</p>
 
       <p className="text-fg-secondary font-medium">ID</p>
@@ -164,14 +166,18 @@ function ToolDetails({
 }
 
 interface ToolCallMessageProps {
-  toolName: string;
-  toolArguments: string;
+  toolName: string | null;
+  toolRawName: string;
+  toolArguments: string | null;
+  toolRawArguments: string;
   toolCallId: string;
 }
 
 export function ToolCallMessage({
   toolName,
+  toolRawName,
   toolArguments,
+  toolRawArguments,
   toolCallId,
 }: ToolCallMessageProps) {
   return (
@@ -181,10 +187,11 @@ export function ToolCallMessage({
         icon={<Terminal className="text-fg-muted h-3 w-3" />}
       />
       <ToolDetails
-        name={toolName}
+        name={toolName || toolRawName}
+        nameLabel={toolName ? "Name" : "Name (Invalid)"}
         id={toolCallId}
-        payload={toolArguments}
-        payloadLabel="Arguments"
+        payload={toolArguments || toolRawArguments}
+        payloadLabel={toolArguments ? "Arguments" : "Arguments (Invalid)"}
       />
     </div>
   );
@@ -209,6 +216,7 @@ export function ToolResultMessage({
       />
       <ToolDetails
         name={toolName}
+        nameLabel="Name"
         id={toolResultId}
         payload={toolResult}
         payloadLabel="Result"

--- a/ui/app/components/layout/ToolCallMessage.stories.tsx
+++ b/ui/app/components/layout/ToolCallMessage.stories.tsx
@@ -12,47 +12,55 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const simpletoolArguments = JSON.stringify(
+  {
+    location: "San Francisco, CA",
+    units: "celsius",
+  },
+  null,
+  2,
+);
+
 export const Simple: Story = {
   args: {
     toolName: "get_weather",
-    toolArguments: JSON.stringify(
-      {
-        location: "San Francisco, CA",
-        units: "celsius",
-      },
-      null,
-      2,
-    ),
+    toolRawName: "get_weather",
+    toolArguments: simpletoolArguments,
+    toolRawArguments: simpletoolArguments,
     toolCallId: "call_abc123def456",
   },
 };
 
+const complexToolArguments = JSON.stringify(
+  {
+    query: "SELECT * FROM users WHERE active = true",
+    filters: {
+      department: "engineering",
+      role: ["senior", "lead"],
+      join_date: {
+        after: "2020-01-01",
+        before: "2023-12-31",
+      },
+    },
+    pagination: {
+      limit: 50,
+      offset: 0,
+    },
+    sort: [
+      { field: "last_name", direction: "asc" },
+      { field: "join_date", direction: "desc" },
+    ],
+  },
+  null,
+  2,
+);
+
 export const ComplexArguments: Story = {
   args: {
     toolName: "search_database",
-    toolArguments: JSON.stringify(
-      {
-        query: "SELECT * FROM users WHERE active = true",
-        filters: {
-          department: "engineering",
-          role: ["senior", "lead"],
-          join_date: {
-            after: "2020-01-01",
-            before: "2023-12-31",
-          },
-        },
-        pagination: {
-          limit: 50,
-          offset: 0,
-        },
-        sort: [
-          { field: "last_name", direction: "asc" },
-          { field: "join_date", direction: "desc" },
-        ],
-      },
-      null,
-      2,
-    ),
+    toolRawName: "search_database",
+    toolArguments: complexToolArguments,
+    toolRawArguments: complexToolArguments,
     toolCallId: "call_xyz789abc123",
   },
 };
@@ -60,14 +68,9 @@ export const ComplexArguments: Story = {
 export const LongToolName: Story = {
   args: {
     toolName: "generate_quarterly_financial_report_with_charts_and_analysis",
-    toolArguments: JSON.stringify(
-      {
-        report_type: "quarterly_financial_summary",
-        include_charts: true,
-      },
-      null,
-      2,
-    ),
+    toolRawName: "generate_quarterly_financial_report_with_charts_and_analysis",
+    toolArguments: simpletoolArguments,
+    toolRawArguments: simpletoolArguments,
     toolCallId: "call_abc123",
   },
 };
@@ -75,13 +78,9 @@ export const LongToolName: Story = {
 export const LongToolId: Story = {
   args: {
     toolName: "simple_tool",
-    toolArguments: JSON.stringify(
-      {
-        param: "value",
-      },
-      null,
-      2,
-    ),
+    toolRawName: "simple_tool",
+    toolArguments: simpletoolArguments,
+    toolRawArguments: simpletoolArguments,
     toolCallId:
       "call_very_long_tool_call_id_that_should_be_truncated_properly_12345678901234567890",
   },
@@ -90,7 +89,9 @@ export const LongToolId: Story = {
 export const MinimalArguments: Story = {
   args: {
     toolName: "ping",
+    toolRawName: "ping",
     toolArguments: "{}",
+    toolRawArguments: "{}",
     toolCallId: "call_123",
   },
 };


### PR DESCRIPTION
Fix #2790