### PR TITLE
Make 'text' field in Thought optional

### DIFF
--- a/clients/python/tensorzero/types.py
+++ b/clients/python/tensorzero/types.py
@@ -120,7 +120,7 @@ class ToolCall(ContentBlock):
 
 @dataclass
 class Thought(ContentBlock):
-    text: str
+    text: Optional[str] = None
     type: str = "thought"
     signature: Optional[str] = None
 

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -330,6 +330,53 @@ async def test_async_thought_input(async_client: AsyncTensorZeroGateway):
 
 
 @pytest.mark.asyncio
+async def test_async_thought_signature_only_input(async_client: AsyncTensorZeroGateway):
+    result = await async_client.inference(
+        model_name="dummy::echo_request_messages",
+        input={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "thought",
+                            "signature": "my_first_signature",
+                        },
+                        Thought(signature="my_second_signature"),
+                    ],
+                }
+            ],
+        },
+        tags={"key": "value"},
+    )
+    assert isinstance(result, ChatInferenceResponse)
+    assert len(result.content) == 1
+    assert isinstance(result.content[0], Text)
+    assert (
+        result.content[0].text
+        == '{"system":null,"messages":[{"role":"user","content":[{"type":"thought","text":null,"signature":"my_first_signature"},{"type":"thought","text":null,"signature":"my_second_signature"}]}]}'
+    )
+
+
+def test_display_thought():
+    t1 = Thought(signature="my_signature")
+    assert str(t1) == "Thought(text=None, type='thought', signature='my_signature')"
+    assert repr(t1) == "Thought(text=None, type='thought', signature='my_signature')"
+
+    t2 = Thought(text="my_text", signature="my_signature")
+    assert (
+        str(t2) == "Thought(text='my_text', type='thought', signature='my_signature')"
+    )
+    assert (
+        repr(t2) == "Thought(text='my_text', type='thought', signature='my_signature')"
+    )
+
+    t3 = Thought(text="my_text")
+    assert str(t3) == "Thought(text='my_text', type='thought', signature=None)"
+    assert repr(t3) == "Thought(text='my_text', type='thought', signature=None)"
+
+
+@pytest.mark.asyncio
 async def test_async_reasoning_inference(async_client: AsyncTensorZeroGateway):
     result = await async_client.inference(
         model_name="dummy::reasoner_with_signature",

--- a/evaluations/src/evaluators/llm_judge/mod.rs
+++ b/evaluations/src/evaluators/llm_judge/mod.rs
@@ -824,7 +824,7 @@ mod tests {
                 value: "raw text".to_string(),
             },
             ClientInputMessageContent::Thought(Thought {
-                text: "thought".to_string(),
+                text: Some("thought".to_string()),
                 signature: None,
             }),
         ];

--- a/tensorzero-core/src/error.rs
+++ b/tensorzero-core/src/error.rs
@@ -42,7 +42,7 @@ pub fn set_debug(debug: bool) -> Result<(), Error> {
 
 pub fn warn_discarded_thought_block(provider_type: &str, thought: &Thought) {
     if *DEBUG.get().unwrap_or(&false) {
-        tracing::warn!("Provider type `{provider_type}` does not support input thought blocks, discarding: {thought}");
+        tracing::warn!("Provider type `{provider_type}` does not support input thought blocks, discarding: {thought:?}");
     } else {
         tracing::warn!(
             "Provider type `{provider_type}` does not support input thought blocks, discarding"

--- a/tensorzero-core/src/function.rs
+++ b/tensorzero-core/src/function.rs
@@ -2389,11 +2389,11 @@ mod tests {
         // Case 2: Only Thought blocks
         let content_blocks = vec![
             ContentBlockOutput::Thought(Thought {
-                text: "thinking...".to_string(),
+                text: Some("thinking...".to_string()),
                 signature: None,
             }),
             ContentBlockOutput::Thought(Thought {
-                text: "still thinking".to_string(),
+                text: Some("still thinking".to_string()),
                 signature: Some("sig".to_string()),
             }),
         ];
@@ -2406,14 +2406,14 @@ mod tests {
         // Case 3: Mixed Text, Thought, ToolCall
         let content_blocks = vec![
             ContentBlockOutput::Thought(Thought {
-                text: "first thought".to_string(),
+                text: Some("first thought".to_string()),
                 signature: None,
             }),
             ContentBlockOutput::Text(Text {
                 text: "Some text".to_string(),
             }),
             ContentBlockOutput::Thought(Thought {
-                text: "second thought".to_string(),
+                text: Some("second thought".to_string()),
                 signature: Some("sig2".to_string()),
             }),
             ContentBlockOutput::ToolCall(ToolCall {
@@ -2464,7 +2464,7 @@ mod tests {
                 text: "A".to_string(),
             }),
             ContentBlockOutput::Thought(Thought {
-                text: "final thought".to_string(),
+                text: Some("final thought".to_string()),
                 signature: None,
             }),
         ];
@@ -2474,7 +2474,9 @@ mod tests {
         assert_eq!(auxiliary_content.len(), 1);
         assert_eq!(json_block_index, Some(0));
         match &auxiliary_content[0] {
-            ContentBlockOutput::Thought(t) => assert_eq!(t.text, "final thought"),
+            ContentBlockOutput::Thought(t) => {
+                assert_eq!(t.text, Some("final thought".to_string()))
+            }
             _ => panic!("Expected Thought block"),
         }
     }

--- a/tensorzero-core/src/inference/types/mod.rs
+++ b/tensorzero-core/src/inference/types/mod.rs
@@ -311,27 +311,13 @@ impl Text {
 #[cfg_attr(test, derive(ts_rs::TS))]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[cfg_attr(test, ts(export))]
-#[cfg_attr(feature = "pyo3", pyclass(get_all, str))]
+#[cfg_attr(feature = "pyo3", pyclass(get_all))]
 pub struct Thought {
-    pub text: String,
+    pub text: Option<String>,
     /// An optional signature - currently, this is only used with Anthropic,
     /// and is ignored by other providers.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<String>,
-}
-
-impl std::fmt::Display for Thought {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.text)
-    }
-}
-
-#[cfg(feature = "pyo3")]
-#[pymethods]
-impl Thought {
-    pub fn __repr__(&self) -> String {
-        self.to_string()
-    }
 }
 
 /// Core representation of the types of content that could go into a model provider
@@ -1602,13 +1588,13 @@ pub async fn collect_chunks(args: CollectChunksArgs<'_, '_>) -> Result<Inference
                                     chunk.latency,
                                     |text| {
                                         ContentBlockOutput::Thought(Thought {
-                                            text,
+                                            text: Some(text),
                                             signature: None,
                                         })
                                     },
                                     |block, text| {
                                         if let ContentBlockOutput::Thought(thought) = block {
-                                            thought.text.push_str(text);
+                                            thought.text.get_or_insert_default().push_str(text);
                                         }
                                     },
                                 );
@@ -1622,7 +1608,7 @@ pub async fn collect_chunks(args: CollectChunksArgs<'_, '_>) -> Result<Inference
                                     chunk.latency,
                                     |signature| {
                                         ContentBlockOutput::Thought(Thought {
-                                            text: String::new(),
+                                            text: None,
                                             signature: Some(signature),
                                         })
                                     },
@@ -1701,14 +1687,17 @@ pub async fn collect_chunks(args: CollectChunksArgs<'_, '_>) -> Result<Inference
                     match blocks.get_mut(&(ContentBlockOutputType::Thought, "".to_string())) {
                         // If there is already a thought block, append to it
                         Some(ContentBlockOutput::Thought(existing_thought)) => {
-                            existing_thought.text.push_str(&thought);
+                            existing_thought
+                                .text
+                                .get_or_insert_default()
+                                .push_str(&thought);
                         }
                         // If there is no thought block, create one
                         _ => {
                             blocks.insert(
                                 (ContentBlockOutputType::Thought, "".to_string()),
                                 ContentBlockOutput::Thought(Thought {
-                                    text: thought,
+                                    text: Some(thought),
                                     signature: None,
                                 }),
                             );
@@ -2913,7 +2902,7 @@ mod tests {
                             text: "{\"name\":\"John\",\"age\":30}".to_string()
                         }),
                         ContentBlockChatOutput::Thought(Thought {
-                            text: "Thought 2".to_string(),
+                            text: Some("Thought 2".to_string()),
                             signature: None,
                         }),
                     ]
@@ -3276,11 +3265,11 @@ mod tests {
                 id: "0".to_string(),
             }),
             ContentBlockChatOutput::Thought(Thought {
-                text: "Some thought".to_string(),
+                text: Some("Some thought".to_string()),
                 signature: None,
             }),
             ContentBlockChatOutput::Thought(Thought {
-                text: "My other interleaved thought".to_string(),
+                text: Some("My other interleaved thought".to_string()),
                 signature: None,
             }),
         ];
@@ -4152,13 +4141,13 @@ mod tests {
             chunk_latency,
             |text| {
                 ContentBlockOutput::Thought(Thought {
-                    text,
+                    text: Some(text),
                     signature: None,
                 })
             },
             |block, text| {
                 if let ContentBlockOutput::Thought(thought) = block {
-                    thought.text.push_str(text);
+                    thought.text.get_or_insert_default().push_str(text);
                 }
             },
         );
@@ -4169,7 +4158,7 @@ mod tests {
             .unwrap()
         {
             ContentBlockOutput::Thought(Thought { text, signature: _ }) => {
-                assert_eq!(text, "Thinking...")
+                assert_eq!(text, &Some("Thinking...".to_string()))
             }
             _ => panic!("Expected thought block"),
         }

--- a/tensorzero-core/src/providers/anthropic.rs
+++ b/tensorzero-core/src/providers/anthropic.rs
@@ -476,7 +476,7 @@ enum AnthropicMessageContent<'a> {
         content: Vec<AnthropicMessageContent<'a>>,
     },
     Thinking {
-        thinking: &'a str,
+        thinking: Option<&'a str>,
         signature: Option<&'a str>,
     },
     ToolUse {
@@ -573,7 +573,7 @@ impl<'a> TryFrom<&'a ContentBlock> for Option<FlattenUnknown<'a, AnthropicMessag
             }
             ContentBlock::Thought(thought) => Ok(Some(FlattenUnknown::Normal(
                 AnthropicMessageContent::Thinking {
-                    thinking: &thought.text,
+                    thinking: thought.text.as_deref(),
                     signature: thought.signature.as_deref(),
                 },
             ))),
@@ -854,7 +854,7 @@ fn convert_to_output(
             thinking,
             signature,
         }) => Ok(ContentBlockOutput::Thought(Thought {
-            text: thinking,
+            text: Some(thinking),
             signature: Some(signature),
         })),
         FlattenUnknown::Unknown(data) => Ok(ContentBlockOutput::Unknown {

--- a/tensorzero-core/src/providers/deepseek.rs
+++ b/tensorzero-core/src/providers/deepseek.rs
@@ -662,7 +662,7 @@ impl<'a> TryFrom<DeepSeekResponseWithMetadata<'a>> for ProviderInferenceResponse
         let mut content: Vec<ContentBlockOutput> = Vec::new();
         if let Some(reasoning) = message.reasoning_content {
             content.push(ContentBlockOutput::Thought(Thought {
-                text: reasoning,
+                text: Some(reasoning),
                 signature: None,
             }));
         }
@@ -968,7 +968,7 @@ mod tests {
         assert_eq!(
             inference_response.output[0],
             ContentBlockOutput::Thought(Thought {
-                text: "I'm thinking about the weather".to_string(),
+                text: Some("I'm thinking about the weather".to_string()),
                 signature: None,
             })
         );

--- a/tensorzero-core/src/providers/dummy.rs
+++ b/tensorzero-core/src/providers/dummy.rs
@@ -334,7 +334,7 @@ impl InferenceProvider for DummyProvider {
             })],
             "reasoner" => vec![
                 ContentBlockOutput::Thought(Thought {
-                    text: "hmmm".to_string(),
+                    text: Some("hmmm".to_string()),
                     signature: None,
                 }),
                 ContentBlockOutput::Text(Text {
@@ -343,7 +343,7 @@ impl InferenceProvider for DummyProvider {
             ],
             "reasoner_with_signature" => vec![
                 ContentBlockOutput::Thought(Thought {
-                    text: "hmmm".to_string(),
+                    text: Some("hmmm".to_string()),
                     signature: Some("my_signature".to_string()),
                 }),
                 ContentBlockOutput::Text(Text {
@@ -352,7 +352,7 @@ impl InferenceProvider for DummyProvider {
             ],
             "json_reasoner" => vec![
                 ContentBlockOutput::Thought(Thought {
-                    text: "hmmm".to_string(),
+                    text: Some("hmmm".to_string()),
                     signature: None,
                 }),
                 ContentBlockOutput::Text(Text {

--- a/tensorzero-core/src/providers/fireworks/mod.rs
+++ b/tensorzero-core/src/providers/fireworks/mod.rs
@@ -749,7 +749,7 @@ impl<'a> TryFrom<FireworksResponseWithMetadata<'a>> for ProviderInferenceRespons
                 process_think_blocks(&raw_text, parse_think_blocks, PROVIDER_TYPE)?;
             if let Some(reasoning) = extracted_reasoning {
                 content.push(ContentBlockOutput::Thought(Thought {
-                    text: reasoning,
+                    text: Some(reasoning),
                     signature: None,
                 }));
             }
@@ -859,7 +859,7 @@ mod tests {
         // First block should be a thought
         match &inference_response.output[0] {
             ContentBlockOutput::Thought(thought) => {
-                assert_eq!(thought.text, "This is reasoning");
+                assert_eq!(thought.text, Some("This is reasoning".to_string()));
                 assert_eq!(thought.signature, None);
             }
             _ => panic!("Expected a thought block"),
@@ -868,7 +868,7 @@ mod tests {
         // Second block should be text
         match &inference_response.output[1] {
             ContentBlockOutput::Text(text) => {
-                assert_eq!(text.text, "Hello  world");
+                assert_eq!(text.text, "Hello  world".to_string());
             }
             _ => panic!("Expected a text block"),
         }

--- a/tensorzero-core/src/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_gemini.rs
@@ -2028,14 +2028,14 @@ fn convert_to_output(
             FlattenUnknown::Normal(GCPVertexGeminiResponseContentPartData::Text(text)) => {
                 return Ok(ContentBlockOutput::Thought(Thought {
                     signature: part.thought_signature,
-                    text,
+                    text: Some(text),
                 }));
             }
             // Handle 'thought/thoughtSignature' with no other fields
             FlattenUnknown::Unknown(obj) if obj.as_object().is_some_and(|m| m.is_empty()) => {
                 return Ok(ContentBlockOutput::Thought(Thought {
                     signature: part.thought_signature,
-                    text: "".to_string(),
+                    text: None,
                 }));
             }
             _ => {

--- a/tensorzero-core/src/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-core/src/providers/google_ai_studio_gemini.rs
@@ -851,14 +851,14 @@ fn convert_part_to_output(
             FlattenUnknown::Normal(GeminiResponseContentPartData::Text(text)) => {
                 return Ok(ContentBlockOutput::Thought(Thought {
                     signature: part.thought_signature,
-                    text,
+                    text: Some(text),
                 }));
             }
             // Handle 'thought/thoughtSignature' with no other fields
             FlattenUnknown::Unknown(obj) if obj.as_object().is_some_and(|m| m.is_empty()) => {
                 return Ok(ContentBlockOutput::Thought(Thought {
                     signature: part.thought_signature,
-                    text: "".to_string(),
+                    text: None,
                 }));
             }
             _ => {

--- a/tensorzero-core/src/providers/together.rs
+++ b/tensorzero-core/src/providers/together.rs
@@ -537,7 +537,7 @@ impl<'a> TryFrom<TogetherResponseWithMetadata<'a>> for ProviderInferenceResponse
                 process_think_blocks(&raw_text, parse_think_blocks, PROVIDER_TYPE)?;
             if let Some(reasoning) = extracted_reasoning {
                 content.push(ContentBlockOutput::Thought(Thought {
-                    text: reasoning,
+                    text: Some(reasoning),
                     signature: None,
                 }));
             }
@@ -958,7 +958,7 @@ mod tests {
         assert_eq!(
             inference_response.output[0],
             ContentBlockOutput::Thought(Thought {
-                text: "hmmm".to_string(),
+                text: Some("hmmm".to_string()),
                 signature: None,
             })
         );
@@ -1003,7 +1003,7 @@ mod tests {
         assert_eq!(
             inference_response.output[0],
             ContentBlockOutput::Thought(Thought {
-                text: "hmmm".to_string(),
+                text: Some("hmmm".to_string()),
                 signature: None,
             })
         );
@@ -1081,7 +1081,10 @@ mod tests {
             ContentBlockOutput::Thought(_)
         ));
         if let ContentBlockOutput::Thought(thought) = &inference_response.output[0] {
-            assert_eq!(thought.text, "This is the reasoning process");
+            assert_eq!(
+                thought.text,
+                Some("This is the reasoning process".to_string())
+            );
             assert_eq!(thought.signature, None);
         }
 
@@ -1091,7 +1094,7 @@ mod tests {
             ContentBlockOutput::Text(_)
         ));
         if let ContentBlockOutput::Text(text) = &inference_response.output[1] {
-            assert_eq!(text.text, "This is the answer");
+            assert_eq!(text.text, "This is the answer".to_string());
         }
 
         // With parsing disabled

--- a/tensorzero-core/src/variant/chain_of_thought.rs
+++ b/tensorzero-core/src/variant/chain_of_thought.rs
@@ -235,7 +235,7 @@ fn parse_thinking_output(
                 output
                     .auxiliary_content
                     .push(ContentBlockOutput::Thought(Thought {
-                        text: thinking,
+                        text: Some(thinking),
                         signature: None,
                     }));
                 return Ok(output);
@@ -243,7 +243,7 @@ fn parse_thinking_output(
             output.auxiliary_content.insert(
                 json_block_index,
                 ContentBlockOutput::Thought(Thought {
-                    text: thinking,
+                    text: Some(thinking),
                     signature: None,
                 }),
             );
@@ -335,7 +335,7 @@ mod tests {
         assert_eq!(
             out.auxiliary_content[0],
             ContentBlockOutput::Thought(Thought {
-                text: "step by step".to_string(),
+                text: Some("step by step".to_string()),
                 signature: None,
             })
         );
@@ -348,7 +348,7 @@ mod tests {
                 "response": {"answer": "the ultimate answer is 42"}
             })),
             auxiliary_content: vec![ContentBlockOutput::Thought(Thought {
-                text: "existing thinking".to_string(),
+                text: Some("existing thinking".to_string()),
                 signature: None,
             })],
             json_block_index: Some(0),
@@ -373,14 +373,14 @@ mod tests {
         assert_eq!(
             out.auxiliary_content[0],
             ContentBlockOutput::Thought(Thought {
-                text: "new thinking process".to_string(),
+                text: Some("new thinking process".to_string()),
                 signature: None,
             })
         );
         assert_eq!(
             out.auxiliary_content[1],
             ContentBlockOutput::Thought(Thought {
-                text: "existing thinking".to_string(),
+                text: Some("existing thinking".to_string()),
                 signature: None,
             })
         );

--- a/tensorzero-core/src/variant/mixture_of_n.rs
+++ b/tensorzero-core/src/variant/mixture_of_n.rs
@@ -317,7 +317,7 @@ fn make_stream_from_non_stream(
                 ContentBlockChatOutput::Thought(thought) => {
                     let chunk = ContentBlockChunk::Thought(ThoughtChunk {
                         id: id.to_string(),
-                        text: Some(thought.text),
+                        text: thought.text,
                         signature: thought.signature,
                     });
                     id += 1;
@@ -1579,11 +1579,11 @@ mod tests {
                         raw_arguments: r#"{"my"  :  "first_arg"}"#.to_string(),
                     }),
                     ContentBlockChatOutput::Thought(Thought {
-                        text: "My first thought".into(),
+                        text: Some("My first thought".into()),
                         signature: Some("my_first_signature".into()),
                     }),
                     ContentBlockChatOutput::Thought(Thought {
-                        text: "My second thought".into(),
+                        text: Some("My second thought".into()),
                         signature: Some("my_second_signature".into()),
                     }),
                     ContentBlockChatOutput::ToolCall(ToolCallOutput {

--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -1728,7 +1728,7 @@ pub async fn test_warn_ignored_thought_block_with_provider(provider: E2ETestProv
                     ClientInputMessage {
                         role: Role::Assistant,
                         content: vec![ClientInputMessageContent::Thought(Thought {
-                            text: "My TensorZero thought".to_string(),
+                            text: Some("My TensorZero thought".to_string()),
                             signature: Some("My TensorZero signature".to_string()),
                         })],
                     },

--- a/tensorzero-core/tests/e2e/providers/reasoning.rs
+++ b/tensorzero-core/tests/e2e/providers/reasoning.rs
@@ -993,5 +993,10 @@ pub async fn test_streaming_reasoning_inference_request_with_provider_json_mode(
         ContentBlock::Thought(thought) => thought,
         _ => panic!("Expected a thought block"),
     };
-    assert!(thought.text.to_lowercase().contains("tokyo"));
+    assert!(thought
+        .text
+        .as_ref()
+        .unwrap()
+        .to_lowercase()
+        .contains("tokyo"));
 }


### PR DESCRIPTION
This will allow us to support Google AI Studio thought signatures, which never have thought text

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
