### PR TITLE
Add '_internal_provider_type' field to Thought/ThoughtChunk

### DIFF
--- a/clients/python/tensorzero/types.py
+++ b/clients/python/tensorzero/types.py
@@ -123,6 +123,7 @@ class Thought(ContentBlock):
     text: str
     type: str = "thought"
     signature: Optional[str] = None
+    _internal_provider_type: Optional[str] = None
 
 
 @dataclass
@@ -282,6 +283,7 @@ class ThoughtChunk(ContentBlockChunk):
     text: str
     type: str = "thought"
     signature: Optional[str] = None
+    _internal_provider_type: Optional[str] = None
 
 
 @dataclass

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -312,7 +312,14 @@ async def test_async_thought_input(async_client: AsyncTensorZeroGateway):
                             "signature": "my_first_signature",
                         },
                         Thought(
-                            text="my_second_thought", signature="my_second_signature"
+                            text="my_second_thought",
+                            signature="my_second_signature",
+                            _internal_provider_type="dummy",
+                        ),
+                        Thought(
+                            text="my_discarded_thought",
+                            signature="my_discarded_signature",
+                            _internal_provider_type="wrong_provider_type",
                         ),
                     ],
                 }
@@ -323,9 +330,10 @@ async def test_async_thought_input(async_client: AsyncTensorZeroGateway):
     assert isinstance(result, ChatInferenceResponse)
     assert len(result.content) == 1
     assert isinstance(result.content[0], Text)
+    # The last thought should be discarded, since '_internal_provider_type' does not match
     assert (
         result.content[0].text
-        == '{"system":null,"messages":[{"role":"user","content":[{"type":"thought","text":"my_first_thought","signature":"my_first_signature"},{"type":"thought","text":"my_second_thought","signature":"my_second_signature"}]}]}'
+        == '{"system":null,"messages":[{"role":"user","content":[{"type":"thought","text":"my_first_thought","signature":"my_first_signature"},{"type":"thought","text":"my_second_thought","signature":"my_second_signature","_internal_provider_type":"dummy"}]}]}'
     )
 
 

--- a/evaluations/src/evaluators/llm_judge/mod.rs
+++ b/evaluations/src/evaluators/llm_judge/mod.rs
@@ -826,6 +826,7 @@ mod tests {
             ClientInputMessageContent::Thought(Thought {
                 text: "thought".to_string(),
                 signature: None,
+                provider_type: None,
             }),
         ];
         let serialized = serialize_content_for_messages_input(&content).unwrap();

--- a/tensorzero-core/src/function.rs
+++ b/tensorzero-core/src/function.rs
@@ -2391,10 +2391,12 @@ mod tests {
             ContentBlockOutput::Thought(Thought {
                 text: "thinking...".to_string(),
                 signature: None,
+                provider_type: None,
             }),
             ContentBlockOutput::Thought(Thought {
                 text: "still thinking".to_string(),
                 signature: Some("sig".to_string()),
+                provider_type: None,
             }),
         ];
         let (raw_output, auxiliary_content, json_block_index) =
@@ -2408,6 +2410,7 @@ mod tests {
             ContentBlockOutput::Thought(Thought {
                 text: "first thought".to_string(),
                 signature: None,
+                provider_type: None,
             }),
             ContentBlockOutput::Text(Text {
                 text: "Some text".to_string(),
@@ -2415,6 +2418,7 @@ mod tests {
             ContentBlockOutput::Thought(Thought {
                 text: "second thought".to_string(),
                 signature: Some("sig2".to_string()),
+                provider_type: None,
             }),
             ContentBlockOutput::ToolCall(ToolCall {
                 id: "id2".to_string(),
@@ -2466,6 +2470,7 @@ mod tests {
             ContentBlockOutput::Thought(Thought {
                 text: "final thought".to_string(),
                 signature: None,
+                provider_type: None,
             }),
         ];
         let (raw_output, auxiliary_content, json_block_index) =

--- a/tensorzero-core/src/inference/mod.rs
+++ b/tensorzero-core/src/inference/mod.rs
@@ -16,6 +16,7 @@ use futures::Future;
 use futures::Stream;
 use reqwest::Client;
 use reqwest_eventsource::Event;
+use std::borrow::Cow;
 use std::fmt::Debug;
 use std::pin::Pin;
 use tokio::time::Instant;
@@ -67,6 +68,8 @@ pub trait InferenceProvider {
 ///
 /// Currently, we only implement `WrappedProvider` for `OpenAI`
 pub trait WrappedProvider: Debug {
+    fn thought_block_provider_type_suffix(&self) -> Cow<'static, str>;
+
     fn make_body<'a>(
         &'a self,
         request: ModelProviderRequest<'a>,

--- a/tensorzero-core/src/model.rs
+++ b/tensorzero-core/src/model.rs
@@ -32,7 +32,8 @@ use crate::inference::types::extra_body::ExtraBodyConfig;
 use crate::inference::types::extra_headers::ExtraHeadersConfig;
 use crate::inference::types::{
     current_timestamp, ContentBlock, PeekableProviderInferenceResponseStream,
-    ProviderInferenceResponseChunk, ProviderInferenceResponseStreamInner, RequestMessage, Usage,
+    ProviderInferenceResponseChunk, ProviderInferenceResponseStreamInner, RequestMessage, Thought,
+    Usage,
 };
 use crate::inference::WrappedProvider;
 use crate::model_table::{BaseModelTable, ShorthandModelConfig};
@@ -182,20 +183,23 @@ impl ModelConfig {
         &self,
         request: &'a ModelInferenceRequest<'a>,
         model_name: &str,
-        provider_name: &str,
+        provider: &ModelProvider,
     ) -> Cow<'a, ModelInferenceRequest<'a>> {
-        let name = fully_qualified_name(model_name, provider_name);
+        let name = fully_qualified_name(model_name, provider.name.as_ref());
         let needs_filter = request.messages.iter().any(|m| {
-            m.content.iter().any(|c| {
-                if let ContentBlock::Unknown {
+            m.content.iter().any(|c| match c {
+                ContentBlock::Unknown {
                     model_provider_name,
                     data: _,
-                } = c
-                {
-                    model_provider_name.as_ref().is_some_and(|n| n != &name)
-                } else {
-                    false
-                }
+                } => model_provider_name.as_ref().is_some_and(|n| n != &name),
+                ContentBlock::Thought(Thought {
+                    text: _,
+                    signature: _,
+                    provider_type,
+                }) => provider_type
+                    .as_ref()
+                    .is_some_and(|t| t != &provider.config.thought_block_provider_type()),
+                _ => false,
             })
         });
         if needs_filter {
@@ -206,20 +210,31 @@ impl ModelConfig {
                     content: m
                         .content
                         .iter()
-                        .flat_map(|c| {
-                            if let ContentBlock::Unknown {
+                        .flat_map(|c| match c {
+                            ContentBlock::Unknown {
                                 model_provider_name,
                                 data: _,
-                            } = c
-                            {
+                            } => {
                                 if model_provider_name.as_ref().is_some_and(|n| n != &name) {
                                     None
                                 } else {
                                     Some(c.clone())
                                 }
-                            } else {
-                                Some(c.clone())
                             }
+                            ContentBlock::Thought(Thought {
+                                text: _,
+                                signature: _,
+                                provider_type,
+                            }) => {
+                                if provider_type.as_ref().is_some_and(|t| {
+                                    t != &provider.config.thought_block_provider_type()
+                                }) {
+                                    None
+                                } else {
+                                    Some(c.clone())
+                                }
+                            }
+                            _ => Some(c.clone()),
                         })
                         .collect(),
                     ..m.clone()
@@ -368,21 +383,18 @@ impl ModelConfig {
         let mut provider_errors: HashMap<String, Error> = HashMap::new();
         let run_all_models = async {
             for provider_name in &self.routing {
-                let request = self.filter_content_blocks(request, model_name, provider_name);
+                let provider = self.providers.get(provider_name).ok_or_else(|| {
+                    Error::new(ErrorDetails::ProviderNotFound {
+                        provider_name: provider_name.to_string(),
+                    })
+                })?;
+                let request = self.filter_content_blocks(request, model_name, provider);
                 let model_provider_request = ModelProviderRequest {
                     request: &request,
                     model_name,
                     provider_name,
                 };
                 let cache_key = model_provider_request.get_cache_key()?;
-                let provider = self
-                    .providers
-                    .get(model_provider_request.provider_name)
-                    .ok_or_else(|| {
-                        Error::new(ErrorDetails::ProviderNotFound {
-                            provider_name: model_provider_request.provider_name.to_string(),
-                        })
-                    })?;
 
                 let response_fut =
                     self.non_streaming_provider_request(model_provider_request, provider, clients);
@@ -463,17 +475,17 @@ impl ModelConfig {
         let mut provider_errors: HashMap<String, Error> = HashMap::new();
         let run_all_models = async {
             for provider_name in &self.routing {
-                let request = self.filter_content_blocks(request, model_name, provider_name);
-                let model_provider_request = ModelProviderRequest {
-                    request: &request,
-                    model_name,
-                    provider_name,
-                };
                 let provider = self.providers.get(provider_name).ok_or_else(|| {
                     Error::new(ErrorDetails::ProviderNotFound {
                         provider_name: provider_name.to_string(),
                     })
                 })?;
+                let request = self.filter_content_blocks(request, model_name, provider);
+                let model_provider_request = ModelProviderRequest {
+                    request: &request,
+                    model_name,
+                    provider_name,
+                };
 
                 // This future includes a call to `peek_first_chunk`, so applying
                 // `streaming_ttft_timeout` is correct.
@@ -770,6 +782,58 @@ pub enum ProviderConfig {
     XAI(XAIProvider),
     #[cfg(any(test, feature = "e2e_tests"))]
     Dummy(DummyProvider),
+}
+
+impl ProviderConfig {
+    fn thought_block_provider_type(&self) -> Cow<'static, str> {
+        match self {
+            ProviderConfig::Anthropic(_) => {
+                Cow::Borrowed(crate::providers::anthropic::PROVIDER_TYPE)
+            }
+            ProviderConfig::AWSBedrock(_) => {
+                Cow::Borrowed(crate::providers::aws_bedrock::PROVIDER_TYPE)
+            }
+            // Note - none of our current  wrapped provider types emit thought blocks
+            // If any of them ever start producing thoughts, we'll need to make sure that the `provider_type`
+            // field uses `thought_block_provider_type` on the parent SageMaker provider.
+            ProviderConfig::AWSSagemaker(sagemaker) => Cow::Owned(format!(
+                "aws_sagemaker::{}",
+                sagemaker
+                    .hosted_provider
+                    .thought_block_provider_type_suffix()
+            )),
+            ProviderConfig::Azure(_) => Cow::Borrowed(crate::providers::azure::PROVIDER_TYPE),
+            ProviderConfig::DeepSeek(_) => Cow::Borrowed(crate::providers::deepseek::PROVIDER_TYPE),
+            ProviderConfig::Fireworks(_) => {
+                Cow::Borrowed(crate::providers::fireworks::PROVIDER_TYPE)
+            }
+            ProviderConfig::GCPVertexAnthropic(_) => {
+                Cow::Borrowed(crate::providers::gcp_vertex_anthropic::PROVIDER_TYPE)
+            }
+            ProviderConfig::GCPVertexGemini(_) => {
+                Cow::Borrowed(crate::providers::gcp_vertex_gemini::PROVIDER_TYPE)
+            }
+            ProviderConfig::GoogleAIStudioGemini(_) => {
+                Cow::Borrowed(crate::providers::google_ai_studio_gemini::PROVIDER_TYPE)
+            }
+            ProviderConfig::Groq(_) => Cow::Borrowed(crate::providers::groq::PROVIDER_TYPE),
+            ProviderConfig::Hyperbolic(_) => {
+                Cow::Borrowed(crate::providers::hyperbolic::PROVIDER_TYPE)
+            }
+            ProviderConfig::Mistral(_) => Cow::Borrowed(crate::providers::mistral::PROVIDER_TYPE),
+            ProviderConfig::OpenAI(_) => Cow::Borrowed(crate::providers::openai::PROVIDER_TYPE),
+            ProviderConfig::OpenRouter(_) => {
+                Cow::Borrowed(crate::providers::openrouter::PROVIDER_TYPE)
+            }
+            ProviderConfig::SGLang(_) => Cow::Borrowed(crate::providers::sglang::PROVIDER_TYPE),
+            ProviderConfig::TGI(_) => Cow::Borrowed(crate::providers::tgi::PROVIDER_TYPE),
+            ProviderConfig::Together(_) => Cow::Borrowed(crate::providers::together::PROVIDER_TYPE),
+            ProviderConfig::VLLM(_) => Cow::Borrowed(crate::providers::vllm::PROVIDER_TYPE),
+            ProviderConfig::XAI(_) => Cow::Borrowed(crate::providers::xai::PROVIDER_TYPE),
+            #[cfg(any(test, feature = "e2e_tests"))]
+            ProviderConfig::Dummy(_) => Cow::Borrowed(crate::providers::dummy::PROVIDER_TYPE),
+        }
+    }
 }
 
 /// Contains all providers which implement `SelfHostedProvider` - these providers

--- a/tensorzero-core/src/providers/anthropic.rs
+++ b/tensorzero-core/src/providers/anthropic.rs
@@ -50,7 +50,7 @@ lazy_static! {
 }
 const ANTHROPIC_API_VERSION: &str = "2023-06-01";
 const PROVIDER_NAME: &str = "Anthropic";
-const PROVIDER_TYPE: &str = "anthropic";
+pub const PROVIDER_TYPE: &str = "anthropic";
 
 fn default_api_key_location() -> CredentialLocation {
     CredentialLocation::Env("ANTHROPIC_API_KEY".to_string())
@@ -856,6 +856,7 @@ fn convert_to_output(
         }) => Ok(ContentBlockOutput::Thought(Thought {
             text: thinking,
             signature: Some(signature),
+            provider_type: Some(PROVIDER_TYPE.to_string()),
         })),
         FlattenUnknown::Unknown(data) => Ok(ContentBlockOutput::Unknown {
             data: data.into_owned(),
@@ -1109,6 +1110,7 @@ fn anthropic_to_tensorzero_stream_message(
                         text: Some(thinking),
                         signature: None,
                         id: index.to_string(),
+                        provider_type: Some(PROVIDER_TYPE.to_string()),
                     })],
                     None,
                     raw_message,
@@ -1122,6 +1124,7 @@ fn anthropic_to_tensorzero_stream_message(
                         text: None,
                         signature: Some(signature),
                         id: index.to_string(),
+                        provider_type: Some(PROVIDER_TYPE.to_string()),
                     })],
                     None,
                     raw_message,
@@ -1172,6 +1175,7 @@ fn anthropic_to_tensorzero_stream_message(
                     text: Some(thinking),
                     signature: Some(signature),
                     id: index.to_string(),
+                    provider_type: Some(PROVIDER_TYPE.to_string()),
                 })],
                 None,
                 raw_message,

--- a/tensorzero-core/src/providers/aws_bedrock.rs
+++ b/tensorzero-core/src/providers/aws_bedrock.rs
@@ -42,7 +42,7 @@ use crate::tool::{ToolCall, ToolCallChunk, ToolChoice, ToolConfig};
 
 #[expect(unused)]
 const PROVIDER_NAME: &str = "AWS Bedrock";
-const PROVIDER_TYPE: &str = "aws_bedrock";
+pub const PROVIDER_TYPE: &str = "aws_bedrock";
 
 // NB: If you add `Clone` someday, you'll need to wrap client in Arc
 #[derive(Debug, Serialize)]

--- a/tensorzero-core/src/providers/aws_sagemaker.rs
+++ b/tensorzero-core/src/providers/aws_sagemaker.rs
@@ -35,7 +35,7 @@ pub struct AWSSagemakerProvider {
     #[serde(skip)]
     client: aws_sdk_sagemakerruntime::Client,
     #[serde(skip)] // TODO: add a way to Serialize the WrappedProvider
-    hosted_provider: Box<dyn WrappedProvider + Send + Sync>,
+    pub hosted_provider: Box<dyn WrappedProvider + Send + Sync>,
     #[serde(skip)]
     base_config: aws_sdk_sagemakerruntime::config::Builder,
 }

--- a/tensorzero-core/src/providers/azure.rs
+++ b/tensorzero-core/src/providers/azure.rs
@@ -32,7 +32,7 @@ use super::openai::{
 use crate::inference::{InferenceProvider, TensorZeroEventError};
 
 const PROVIDER_NAME: &str = "Azure";
-const PROVIDER_TYPE: &str = "azure";
+pub const PROVIDER_TYPE: &str = "azure";
 
 #[derive(Debug, Serialize)]
 #[cfg_attr(test, derive(ts_rs::TS))]

--- a/tensorzero-core/src/providers/deepseek.rs
+++ b/tensorzero-core/src/providers/deepseek.rs
@@ -51,7 +51,7 @@ fn default_api_key_location() -> CredentialLocation {
 }
 
 const PROVIDER_NAME: &str = "DeepSeek";
-const PROVIDER_TYPE: &str = "deepseek";
+pub const PROVIDER_TYPE: &str = "deepseek";
 
 #[derive(Debug)]
 pub enum DeepSeekCredentials {
@@ -516,6 +516,7 @@ fn deepseek_to_tensorzero_chunk(
                 text: Some(reasoning),
                 signature: None,
                 id: "0".to_string(),
+                provider_type: Some(PROVIDER_TYPE.to_string()),
             }));
         }
         if let Some(tool_calls) = choice.delta.tool_calls {
@@ -664,6 +665,7 @@ impl<'a> TryFrom<DeepSeekResponseWithMetadata<'a>> for ProviderInferenceResponse
             content.push(ContentBlockOutput::Thought(Thought {
                 text: reasoning,
                 signature: None,
+                provider_type: Some(PROVIDER_TYPE.to_string()),
             }));
         }
         if let Some(text) = message.content {
@@ -970,6 +972,7 @@ mod tests {
             ContentBlockOutput::Thought(Thought {
                 text: "I'm thinking about the weather".to_string(),
                 signature: None,
+                provider_type: Some(PROVIDER_TYPE.to_string()),
             })
         );
 

--- a/tensorzero-core/src/providers/dummy.rs
+++ b/tensorzero-core/src/providers/dummy.rs
@@ -30,7 +30,7 @@ use crate::providers::helpers::inject_extra_request_data;
 use crate::tool::{ToolCall, ToolCallChunk};
 
 const PROVIDER_NAME: &str = "Dummy";
-const PROVIDER_TYPE: &str = "dummy";
+pub const PROVIDER_TYPE: &str = "dummy";
 
 #[derive(Debug, Default, Serialize)]
 #[cfg_attr(test, derive(ts_rs::TS))]
@@ -97,6 +97,7 @@ impl DummyProvider {
                 text: Some(chunk.to_string()),
                 signature: None,
                 id: "0".to_string(),
+                provider_type: None,
             })
         });
         let response_chunks = response_chunks.into_iter().map(|chunk| {
@@ -336,6 +337,7 @@ impl InferenceProvider for DummyProvider {
                 ContentBlockOutput::Thought(Thought {
                     text: "hmmm".to_string(),
                     signature: None,
+                    provider_type: None,
                 }),
                 ContentBlockOutput::Text(Text {
                     text: DUMMY_INFER_RESPONSE_CONTENT.to_string(),
@@ -345,6 +347,7 @@ impl InferenceProvider for DummyProvider {
                 ContentBlockOutput::Thought(Thought {
                     text: "hmmm".to_string(),
                     signature: Some("my_signature".to_string()),
+                    provider_type: None,
                 }),
                 ContentBlockOutput::Text(Text {
                     text: DUMMY_INFER_RESPONSE_CONTENT.to_string(),
@@ -354,6 +357,7 @@ impl InferenceProvider for DummyProvider {
                 ContentBlockOutput::Thought(Thought {
                     text: "hmmm".to_string(),
                     signature: None,
+                    provider_type: None,
                 }),
                 ContentBlockOutput::Text(Text {
                     text: DUMMY_JSON_RESPONSE_RAW.to_string(),
@@ -418,13 +422,15 @@ impl InferenceProvider for DummyProvider {
                     .to_string(),
                 })]
             }
-            "echo_request_messages" => vec![ContentBlockOutput::Text(Text {
-                text: json!({
-                    "system": request.system,
-                    "messages": request.messages,
-                })
-                .to_string(),
-            })],
+            "echo_request_messages" => {
+                vec![ContentBlockOutput::Text(Text {
+                    text: json!({
+                        "system": request.system,
+                        "messages": request.messages,
+                    })
+                    .to_string(),
+                })]
+            }
             "extract_images" => {
                 let images: Vec<_> = request
                     .messages

--- a/tensorzero-core/src/providers/fireworks/mod.rs
+++ b/tensorzero-core/src/providers/fireworks/mod.rs
@@ -645,6 +645,7 @@ fn fireworks_to_tensorzero_chunk(
                                 text: Some(text.to_string()),
                                 signature: None,
                                 id: thinking_state.get_id(),
+                                provider_type: Some(PROVIDER_TYPE.to_string()),
                             }));
                         }
                     }
@@ -751,6 +752,7 @@ impl<'a> TryFrom<FireworksResponseWithMetadata<'a>> for ProviderInferenceRespons
                 content.push(ContentBlockOutput::Thought(Thought {
                     text: reasoning,
                     signature: None,
+                    provider_type: Some(PROVIDER_TYPE.to_string()),
                 }));
             }
             if !clean_text.is_empty() {

--- a/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
@@ -55,7 +55,7 @@ use super::openai::convert_stream_error;
 /// and [here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.publishers.models/streamGenerateContent) for streaming
 #[expect(unused)]
 const PROVIDER_NAME: &str = "GCP Vertex Anthropic";
-const PROVIDER_TYPE: &str = "gcp_vertex_anthropic";
+pub const PROVIDER_TYPE: &str = "gcp_vertex_anthropic";
 
 #[derive(Debug, Serialize)]
 #[cfg_attr(test, derive(ts_rs::TS))]

--- a/tensorzero-core/src/providers/gcp_vertex_gemini/mod.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_gemini/mod.rs
@@ -2149,6 +2149,7 @@ fn content_part_to_tensorzero_chunk(
                     id: "0".to_string(),
                     text: Some(text),
                     signature: part.thought_signature,
+                    provider_type: Some(PROVIDER_TYPE.to_string()),
                 })));
             }
             // Handle 'thought/thoughtSignature' with no other fields
@@ -2157,6 +2158,7 @@ fn content_part_to_tensorzero_chunk(
                     id: "0".to_string(),
                     text: None,
                     signature: part.thought_signature,
+                    provider_type: Some(PROVIDER_TYPE.to_string()),
                 })));
             }
             _ => {
@@ -2242,6 +2244,7 @@ fn convert_to_output(
                 return Ok(ContentBlockOutput::Thought(Thought {
                     signature: part.thought_signature,
                     text,
+                    provider_type: Some(PROVIDER_TYPE.to_string()),
                 }));
             }
             // Handle 'thought/thoughtSignature' with no other fields
@@ -2249,6 +2252,7 @@ fn convert_to_output(
                 return Ok(ContentBlockOutput::Thought(Thought {
                     signature: part.thought_signature,
                     text: "".to_string(),
+                    provider_type: Some(PROVIDER_TYPE.to_string()),
                 }));
             }
             _ => {

--- a/tensorzero-core/src/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-core/src/providers/google_ai_studio_gemini.rs
@@ -46,7 +46,7 @@ use super::helpers::inject_extra_request_data_and_send;
 use super::openai::convert_stream_error;
 
 const PROVIDER_NAME: &str = "Google AI Studio Gemini";
-const PROVIDER_TYPE: &str = "google_ai_studio_gemini";
+pub const PROVIDER_TYPE: &str = "google_ai_studio_gemini";
 
 /// Implements a subset of the Google AI Studio Gemini API as documented [here](https://ai.google.dev/gemini-api/docs/text-generation?lang=rest)
 /// See the `GCPVertexGeminiProvider` struct docs for information about our handling 'thought' and unknown blocks.
@@ -771,6 +771,7 @@ fn content_part_to_tensorzero_chunk(
                     id: "0".to_string(),
                     text: Some(text),
                     signature: part.thought_signature,
+                    provider_type: Some(PROVIDER_TYPE.to_string()),
                 })));
             }
             // Handle 'thought/thoughtSignature' with no other fields
@@ -779,6 +780,7 @@ fn content_part_to_tensorzero_chunk(
                     id: "0".to_string(),
                     text: None,
                     signature: part.thought_signature,
+                    provider_type: Some(PROVIDER_TYPE.to_string()),
                 })));
             }
             _ => {
@@ -852,6 +854,7 @@ fn convert_part_to_output(
                 return Ok(ContentBlockOutput::Thought(Thought {
                     signature: part.thought_signature,
                     text,
+                    provider_type: Some(PROVIDER_TYPE.to_string()),
                 }));
             }
             // Handle 'thought/thoughtSignature' with no other fields
@@ -859,6 +862,7 @@ fn convert_part_to_output(
                 return Ok(ContentBlockOutput::Thought(Thought {
                     signature: part.thought_signature,
                     text: "".to_string(),
+                    provider_type: Some(PROVIDER_TYPE.to_string()),
                 }));
             }
             _ => {

--- a/tensorzero-core/src/providers/groq.rs
+++ b/tensorzero-core/src/providers/groq.rs
@@ -37,7 +37,7 @@ fn default_api_key_location() -> CredentialLocation {
 }
 
 const PROVIDER_NAME: &str = "Groq";
-const PROVIDER_TYPE: &str = "groq";
+pub const PROVIDER_TYPE: &str = "groq";
 
 #[derive(Debug, Serialize)]
 #[cfg_attr(test, derive(ts_rs::TS))]

--- a/tensorzero-core/src/providers/hyperbolic.rs
+++ b/tensorzero-core/src/providers/hyperbolic.rs
@@ -40,7 +40,7 @@ pub fn default_api_key_location() -> CredentialLocation {
 }
 
 const PROVIDER_NAME: &str = "Hyperbolic";
-const PROVIDER_TYPE: &str = "hyperbolic";
+pub const PROVIDER_TYPE: &str = "hyperbolic";
 
 #[derive(Debug, Serialize)]
 #[cfg_attr(test, derive(ts_rs::TS))]

--- a/tensorzero-core/src/providers/mistral.rs
+++ b/tensorzero-core/src/providers/mistral.rs
@@ -50,7 +50,7 @@ fn default_api_key_location() -> CredentialLocation {
 }
 
 const PROVIDER_NAME: &str = "Mistral";
-const PROVIDER_TYPE: &str = "mistral";
+pub const PROVIDER_TYPE: &str = "mistral";
 
 #[derive(Debug, Serialize)]
 #[cfg_attr(test, derive(ts_rs::TS))]

--- a/tensorzero-core/src/providers/openai/mod.rs
+++ b/tensorzero-core/src/providers/openai/mod.rs
@@ -171,6 +171,10 @@ impl OpenAICredentials {
 }
 
 impl WrappedProvider for OpenAIProvider {
+    fn thought_block_provider_type_suffix(&self) -> Cow<'static, str> {
+        Cow::Borrowed("openai")
+    }
+
     fn make_body<'a>(
         &'a self,
         ModelProviderRequest {

--- a/tensorzero-core/src/providers/openrouter.rs
+++ b/tensorzero-core/src/providers/openrouter.rs
@@ -53,7 +53,7 @@ fn default_api_key_location() -> CredentialLocation {
 }
 
 const PROVIDER_NAME: &str = "OpenRouter";
-const PROVIDER_TYPE: &str = "openrouter";
+pub const PROVIDER_TYPE: &str = "openrouter";
 
 #[derive(Debug, Serialize)]
 #[cfg_attr(test, derive(ts_rs::TS))]

--- a/tensorzero-core/src/providers/sglang.rs
+++ b/tensorzero-core/src/providers/sglang.rs
@@ -42,7 +42,7 @@ fn default_api_key_location() -> CredentialLocation {
 }
 
 const PROVIDER_NAME: &str = "SGLang";
-const PROVIDER_TYPE: &str = "sglang";
+pub const PROVIDER_TYPE: &str = "sglang";
 
 #[derive(Debug, Serialize)]
 #[cfg_attr(test, derive(ts_rs::TS))]

--- a/tensorzero-core/src/providers/tgi.rs
+++ b/tensorzero-core/src/providers/tgi.rs
@@ -51,7 +51,7 @@ use crate::providers::openai::check_api_base_suffix;
 use crate::tool::ToolCall;
 
 const PROVIDER_NAME: &str = "TGI";
-const PROVIDER_TYPE: &str = "tgi";
+pub const PROVIDER_TYPE: &str = "tgi";
 
 fn default_api_key_location() -> CredentialLocation {
     CredentialLocation::Env("TGI_API_KEY".to_string())
@@ -132,6 +132,10 @@ impl TGICredentials {
 }
 
 impl WrappedProvider for TGIProvider {
+    fn thought_block_provider_type_suffix(&self) -> Cow<'static, str> {
+        Cow::Borrowed("tgi")
+    }
+
     fn make_body<'a>(
         &'a self,
         ModelProviderRequest {

--- a/tensorzero-core/src/providers/together.rs
+++ b/tensorzero-core/src/providers/together.rs
@@ -539,6 +539,7 @@ impl<'a> TryFrom<TogetherResponseWithMetadata<'a>> for ProviderInferenceResponse
                 content.push(ContentBlockOutput::Thought(Thought {
                     text: reasoning,
                     signature: None,
+                    provider_type: Some(PROVIDER_TYPE.to_string()),
                 }));
             }
             if !clean_text.is_empty() {
@@ -664,6 +665,7 @@ fn together_to_tensorzero_chunk(
                                 text: Some(text),
                                 signature: None,
                                 id: thinking_state.get_id(),
+                                provider_type: Some(PROVIDER_TYPE.to_string()),
                             }));
                         }
                     }
@@ -960,6 +962,7 @@ mod tests {
             ContentBlockOutput::Thought(Thought {
                 text: "hmmm".to_string(),
                 signature: None,
+                provider_type: Some("together".to_string()),
             })
         );
         assert_eq!(
@@ -1005,6 +1008,7 @@ mod tests {
             ContentBlockOutput::Thought(Thought {
                 text: "hmmm".to_string(),
                 signature: None,
+                provider_type: Some("together".to_string()),
             })
         );
         assert_eq!(
@@ -1468,6 +1472,7 @@ mod tests {
                 text: Some("some thinking content".to_string()),
                 signature: None,
                 id: "1".to_string(),
+                provider_type: Some("together".to_string()),
             })]
         );
         assert!(matches!(thinking_state, ThinkingState::Thinking));

--- a/tensorzero-core/src/providers/vllm.rs
+++ b/tensorzero-core/src/providers/vllm.rs
@@ -30,7 +30,7 @@ use crate::providers::helpers::{
 use crate::providers::openai::check_api_base_suffix;
 
 const PROVIDER_NAME: &str = "vLLM";
-const PROVIDER_TYPE: &str = "vllm";
+pub const PROVIDER_TYPE: &str = "vllm";
 
 #[derive(Debug, Serialize)]
 #[cfg_attr(test, derive(ts_rs::TS))]

--- a/tensorzero-core/src/providers/xai.rs
+++ b/tensorzero-core/src/providers/xai.rs
@@ -43,7 +43,7 @@ fn default_api_key_location() -> CredentialLocation {
 }
 
 const PROVIDER_NAME: &str = "xAI";
-const PROVIDER_TYPE: &str = "xai";
+pub const PROVIDER_TYPE: &str = "xai";
 
 #[derive(Debug, Serialize)]
 #[cfg_attr(test, derive(ts_rs::TS))]

--- a/tensorzero-core/src/variant/chain_of_thought.rs
+++ b/tensorzero-core/src/variant/chain_of_thought.rs
@@ -237,6 +237,7 @@ fn parse_thinking_output(
                     .push(ContentBlockOutput::Thought(Thought {
                         text: thinking,
                         signature: None,
+                        provider_type: None,
                     }));
                 return Ok(output);
             };
@@ -245,6 +246,7 @@ fn parse_thinking_output(
                 ContentBlockOutput::Thought(Thought {
                     text: thinking,
                     signature: None,
+                    provider_type: None,
                 }),
             );
             Ok(output)
@@ -337,6 +339,7 @@ mod tests {
             ContentBlockOutput::Thought(Thought {
                 text: "step by step".to_string(),
                 signature: None,
+                provider_type: None,
             })
         );
 
@@ -350,6 +353,7 @@ mod tests {
             auxiliary_content: vec![ContentBlockOutput::Thought(Thought {
                 text: "existing thinking".to_string(),
                 signature: None,
+                provider_type: None,
             })],
             json_block_index: Some(0),
         };
@@ -375,6 +379,7 @@ mod tests {
             ContentBlockOutput::Thought(Thought {
                 text: "new thinking process".to_string(),
                 signature: None,
+                provider_type: None,
             })
         );
         assert_eq!(
@@ -382,6 +387,7 @@ mod tests {
             ContentBlockOutput::Thought(Thought {
                 text: "existing thinking".to_string(),
                 signature: None,
+                provider_type: None,
             })
         );
     }

--- a/tensorzero-core/src/variant/mixture_of_n.rs
+++ b/tensorzero-core/src/variant/mixture_of_n.rs
@@ -319,6 +319,7 @@ fn make_stream_from_non_stream(
                         id: id.to_string(),
                         text: Some(thought.text),
                         signature: thought.signature,
+                        provider_type: thought.provider_type,
                     });
                     id += 1;
                     Ok(chunk)
@@ -1581,10 +1582,12 @@ mod tests {
                     ContentBlockChatOutput::Thought(Thought {
                         text: "My first thought".into(),
                         signature: Some("my_first_signature".into()),
+                        provider_type: Some("my_first_provider_type".into()),
                     }),
                     ContentBlockChatOutput::Thought(Thought {
                         text: "My second thought".into(),
                         signature: Some("my_second_signature".into()),
+                        provider_type: None,
                     }),
                     ContentBlockChatOutput::ToolCall(ToolCallOutput {
                         id: "456".into(),
@@ -1630,11 +1633,13 @@ mod tests {
                         id: "1".into(),
                         text: Some("My first thought".into()),
                         signature: Some("my_first_signature".into()),
+                        provider_type: Some("my_first_provider_type".into()),
                     }),
                     ContentBlockChunk::Thought(ThoughtChunk {
                         id: "2".into(),
                         text: Some("My second thought".into()),
                         signature: Some("my_second_signature".into()),
+                        provider_type: None,
                     }),
                     ContentBlockChunk::ToolCall(ToolCallChunk {
                         id: "456".into(),

--- a/tensorzero-core/tests/e2e/providers/anthropic.rs
+++ b/tensorzero-core/tests/e2e/providers/anthropic.rs
@@ -821,10 +821,14 @@ async fn test_streaming_thinking() {
     assert_eq!(clickhouse_content_blocks[1]["type"], "text");
     assert_eq!(clickhouse_content_blocks[2]["type"], "tool_call");
 
-    assert_eq!(clickhouse_content_blocks[0]["text"], content_blocks["0"]);
     assert_eq!(
-        clickhouse_content_blocks[0]["signature"],
-        content_block_signatures["0"]
+        clickhouse_content_blocks[0],
+        serde_json::json!({
+            "type": "thought",
+            "text": content_blocks["0"],
+            "signature": content_block_signatures["0"],
+            "_internal_provider_type": "anthropic",
+        })
     );
     assert_eq!(clickhouse_content_blocks[1]["text"], content_blocks["1"]);
 

--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -1730,6 +1730,7 @@ pub async fn test_warn_ignored_thought_block_with_provider(provider: E2ETestProv
                         content: vec![ClientInputMessageContent::Thought(Thought {
                             text: "My TensorZero thought".to_string(),
                             signature: Some("My TensorZero signature".to_string()),
+                            provider_type: None,
                         })],
                     },
                     ClientInputMessage {


### PR DESCRIPTION
This is set on all Thought/ThoughtChunks provided by TensorZero. When we see an '_internal_provider_type' field in an input 'Thought', we discard the thought if it doesn't match the target provider type (similar to how we handle 'unknown' content blocks)

This field is optional - when unset, we always pass the thought to the model provider. This will probably not be meaningful if the thought was produced by manually, or if it came from a different provider.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
