### PR TITLE
Refactor GCP credential handling to support SDK creds everywhere

### DIFF
--- a/tensorzero-core/src/endpoints/optimization.rs
+++ b/tensorzero-core/src/endpoints/optimization.rs
@@ -115,7 +115,8 @@ pub async fn launch_optimization_workflow(
 
     // Launch the optimization job
     optimizer_config
-        .load()?
+        .load()
+        .await?
         .launch(
             http_client,
             train_examples,
@@ -149,7 +150,7 @@ pub async fn launch_optimization(
         val_samples: val_examples,
         optimization_config: optimizer_config,
     } = params;
-    let optimizer = optimizer_config.load()?;
+    let optimizer = optimizer_config.load().await?;
     optimizer
         .launch(
             http_client,

--- a/tensorzero-core/src/optimization/mod.rs
+++ b/tensorzero-core/src/optimization/mod.rs
@@ -38,9 +38,9 @@ pub struct OptimizerInfo {
 }
 
 impl OptimizerInfo {
-    pub fn new(uninitialized_info: UninitializedOptimizerInfo) -> Result<Self, Error> {
+    pub async fn new(uninitialized_info: UninitializedOptimizerInfo) -> Result<Self, Error> {
         Ok(Self {
-            inner: uninitialized_info.inner.load()?,
+            inner: uninitialized_info.inner.load().await?,
         })
     }
 }
@@ -294,9 +294,9 @@ pub struct UninitializedOptimizerInfo {
 }
 
 impl UninitializedOptimizerInfo {
-    pub fn load(self) -> Result<OptimizerInfo, Error> {
+    pub async fn load(self) -> Result<OptimizerInfo, Error> {
         Ok(OptimizerInfo {
-            inner: self.inner.load()?,
+            inner: self.inner.load().await?,
         })
     }
 }
@@ -318,7 +318,7 @@ pub enum UninitializedOptimizerConfig {
 
 impl UninitializedOptimizerConfig {
     // TODO: add a provider_types argument as needed
-    fn load(self) -> Result<OptimizerConfig, Error> {
+    async fn load(self) -> Result<OptimizerConfig, Error> {
         Ok(match self {
             UninitializedOptimizerConfig::OpenAISFT(config) => {
                 OptimizerConfig::OpenAISFT(config.load()?)
@@ -327,7 +327,7 @@ impl UninitializedOptimizerConfig {
                 OptimizerConfig::FireworksSFT(config.load()?)
             }
             UninitializedOptimizerConfig::GCPVertexGeminiSFT(config) => {
-                OptimizerConfig::GCPVertexGeminiSFT(Box::new(config.load()?))
+                OptimizerConfig::GCPVertexGeminiSFT(Box::new(config.load().await?))
             }
             UninitializedOptimizerConfig::TogetherSFT(config) => {
                 OptimizerConfig::TogetherSFT(config.load()?)

--- a/tensorzero-core/src/providers/gcp_vertex_gemini/mod.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_gemini/mod.rs
@@ -428,24 +428,24 @@ pub fn location_subdomain_prefix(location: &str) -> String {
 }
 
 impl GCPVertexGeminiProvider {
+    pub async fn build_credentials(
+        cred_location: Option<CredentialLocation>,
+    ) -> Result<GCPVertexCredentials, Error> {
+        GCPVertexCredentials::new(
+            cred_location,
+            &DEFAULT_CREDENTIALS,
+            default_api_key_location(),
+            PROVIDER_TYPE,
+        )
+        .await
+    }
     // Constructs a provider from a shorthand string of the form:
     // * 'projects/<project_id>/locations/<location>/publishers/google/models/XXX'
     // * 'projects/<project_id>/locations/<location>/endpoints/XXX'
     //
     // This is *not* a full url - we append ':generateContent' or ':streamGenerateContent' to the end of the path as needed.
     pub async fn new_shorthand(project_url_path: String) -> Result<Self, Error> {
-        let cred_location = default_api_key_location();
-        let credentials = if matches!(cred_location, CredentialLocation::Sdk) {
-            make_gcp_sdk_credentials(PROVIDER_TYPE).await?
-        } else {
-            build_creds_caching_default_with_fn(
-                None,
-                cred_location,
-                PROVIDER_TYPE,
-                &DEFAULT_CREDENTIALS,
-                |creds| GCPVertexCredentials::try_from((creds, PROVIDER_TYPE)),
-            )?
-        };
+        let credentials = Self::build_credentials(None).await?;
 
         let shorthand_url = parse_shorthand_url(&project_url_path, "google")?;
         let (location, model_id, endpoint_id, model_or_endpoint_id) = match shorthand_url {
@@ -505,18 +505,7 @@ impl GCPVertexGeminiProvider {
     ) -> Result<Self, Error> {
         let default_location = default_api_key_location();
         let cred_location = api_key_location.as_ref().unwrap_or(&default_location);
-
-        let credentials = if matches!(cred_location, CredentialLocation::Sdk) {
-            make_gcp_sdk_credentials(PROVIDER_TYPE).await?
-        } else {
-            build_creds_caching_default_with_fn(
-                api_key_location,
-                default_api_key_location(),
-                PROVIDER_TYPE,
-                &DEFAULT_CREDENTIALS,
-                |creds| GCPVertexCredentials::try_from((creds, PROVIDER_TYPE)),
-            )?
-        };
+        let credentials = Self::build_credentials(Some(cred_location.clone())).await?;
 
         let location_prefix = location_subdomain_prefix(&location);
 
@@ -649,26 +638,49 @@ pub enum GCPVertexCredentials {
     None,
 }
 
-impl TryFrom<(Credential, &str)> for GCPVertexCredentials {
-    type Error = Error;
+impl GCPVertexCredentials {
+    /// Helper method to build credentials for a GCP-based provider
+    /// You should call either `GCPVertexGeminiProvider::build_credentials` or
+    /// `GCPVertexAnthropicProvider::build_credentials` rather than calling this directly.
+    pub async fn new(
+        cred_location: Option<CredentialLocation>,
+        cache: &'static OnceLock<GCPVertexCredentials>,
+        default_location: CredentialLocation,
+        provider_type: &'static str,
+    ) -> Result<Self, Error> {
+        if matches!(cred_location, Some(CredentialLocation::Sdk)) {
+            make_gcp_sdk_credentials(provider_type).await
+        } else {
+            build_creds_caching_default_with_fn(
+                cred_location,
+                default_location,
+                PROVIDER_TYPE,
+                cache,
+                |creds| build_non_sdk_credentials(creds, provider_type),
+            )
+        }
+    }
+}
 
-    fn try_from((credentials, model): (Credential, &str)) -> Result<Self, Error> {
-        match credentials {
-            Credential::FileContents(file_content) => Ok(GCPVertexCredentials::Static {
-                parsed: GCPServiceAccountCredentials::from_json_str(file_content.expose_secret())
-                    .map_err(|e| {
+fn build_non_sdk_credentials(
+    credentials: Credential,
+    provider_type: &str,
+) -> Result<GCPVertexCredentials, Error> {
+    match credentials {
+        Credential::FileContents(file_content) => Ok(GCPVertexCredentials::Static {
+            parsed: GCPServiceAccountCredentials::from_json_str(file_content.expose_secret())
+                .map_err(|e| {
                     Error::new(ErrorDetails::GCPCredentials {
                         message: format!("Failed to load GCP credentials: {e}"),
                     })
                 })?,
-                raw: file_content,
-            }),
-            Credential::Dynamic(key_name) => Ok(GCPVertexCredentials::Dynamic(key_name)),
-            Credential::Missing => Ok(GCPVertexCredentials::None),
-            _ => Err(Error::new(ErrorDetails::GCPCredentials {
-                message: format!("Invalid credential_location for {model} provider"),
-            }))?,
-        }
+            raw: file_content,
+        }),
+        Credential::Dynamic(key_name) => Ok(GCPVertexCredentials::Dynamic(key_name)),
+        Credential::Missing => Ok(GCPVertexCredentials::None),
+        _ => Err(Error::new(ErrorDetails::GCPCredentials {
+            message: format!("Invalid credential_location for {provider_type} provider"),
+        }))?,
     }
 }
 
@@ -3739,23 +3751,23 @@ mod tests {
             "universe_domain": "googleapis.com"
         }"#;
         let generic = Credential::FileContents(SecretString::from(json_content));
-        let creds = GCPVertexCredentials::try_from((generic, "GCPVertexGemini")).unwrap();
+        let creds = build_non_sdk_credentials(generic, "GCPVertexGemini").unwrap();
         assert!(matches!(creds, GCPVertexCredentials::Static { .. }));
 
         // Test Dynamic credential
         let generic = Credential::Dynamic("key_name".to_string());
-        let creds = GCPVertexCredentials::try_from((generic, "GCPVertexGemini")).unwrap();
+        let creds = build_non_sdk_credentials(generic, "GCPVertexGemini").unwrap();
         assert!(matches!(creds, GCPVertexCredentials::Dynamic(_)));
 
         // Test Missing credential
         let generic = Credential::Missing;
-        let creds = GCPVertexCredentials::try_from((generic, "GCPVertexGemini")).unwrap();
+        let creds = build_non_sdk_credentials(generic, "GCPVertexGemini").unwrap();
         assert!(matches!(creds, GCPVertexCredentials::None));
 
         // Test invalid JSON content
         let invalid_json = "invalid json";
         let generic = Credential::FileContents(SecretString::from(invalid_json));
-        let result = GCPVertexCredentials::try_from((generic, "GCPVertexGemini"));
+        let result = build_non_sdk_credentials(generic, "GCPVertexGemini");
         assert!(result.is_err());
         let err = result.unwrap_err().get_owned_details();
         assert!(
@@ -3764,7 +3776,7 @@ mod tests {
 
         // Test invalid credential type (Static)
         let generic = Credential::Static(SecretString::from("test"));
-        let result = GCPVertexCredentials::try_from((generic, "GCPVertexGemini"));
+        let result = build_non_sdk_credentials(generic, "GCPVertexGemini");
         assert!(result.is_err());
         let err = result.unwrap_err().get_owned_details();
         assert!(

--- a/tensorzero-core/tests/optimization/common/mod.rs
+++ b/tensorzero-core/tests/optimization/common/mod.rs
@@ -47,6 +47,7 @@ pub async fn run_test_case(test_case: &impl OptimizationTestCase) {
     let optimizer_info = test_case
         .get_optimizer_info(use_mock_inference_provider())
         .load()
+        .await
         .unwrap();
     let client = reqwest::Client::new();
     let test_examples = get_examples(test_case, 10);


### PR DESCRIPTION
We now construct the credentials through two helper methods: `GCPVertexGeminiProvider::build_credentials` and
`GCPVertexAnthropicProvider::build_credentials`.
Previously, `build_creds_caching_default_with_fn` was being used directly within the SFT provider, which prevented it from supporting SDK credentials.

These helper methods are `aysnc`, which required adding `async` to a few functions above them in the call stack.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
