### PR TITLE
Disable external network access in check-docker-compose.sh

### DIFF
--- a/ci/check-docker-compose.sh
+++ b/ci/check-docker-compose.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -uxo pipefail
+script_path=$(dirname "$0")
 dir_path=$(dirname "$1")
 # Since the Cursor integration requires ngrok and ngrok will fail with fake credentials, we skip it
 if [[ "$dir_path" == */cursor ]]; then
@@ -9,12 +10,13 @@ fi
 # We already use this in CI, so no need to test it twice
 if [[ "$1" == *ui/fixtures/docker-compose.yml || \
       "$1" == *ui/fixtures/docker-compose.e2e.yml || \
-      "$1" == *tensorzero-core/tests/e2e/docker-compose.yml ]]; then
+      "$1" == *tensorzero-core/tests/e2e/docker-compose.yml || \
+      "$1" == *ci/internal-network.yml ]]; then
   exit 0
 fi
 
 cd "$dir_path"
-docker compose -f "$1" up --wait --wait-timeout 360
+docker compose -f "$1" -f $script_path/internal-network.yml up --wait --wait-timeout 360
 status=$?
 if [ $status -ne 0 ]; then
   echo "Docker Compose failed for $1 with status $status"

--- a/ci/check-docker-compose.sh
+++ b/ci/check-docker-compose.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -uxo pipefail
-script_path=$(dirname "$0")
+script_path=$(dirname $(realpath -s $0))
 dir_path=$(dirname "$1")
 # Since the Cursor integration requires ngrok and ngrok will fail with fake credentials, we skip it
 if [[ "$dir_path" == */cursor ]]; then

--- a/ci/internal-network.yml
+++ b/ci/internal-network.yml
@@ -1,0 +1,5 @@
+# We combine this with other files via 'docker compose up -of'
+# This blocks access to the outside internet (in particular, Howdy)
+networks:
+  default:
+    internal: true


### PR DESCRIPTION
This will prevent CI from pinging Howdy

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Disable external network access in CI by using `internal-network.yml` in `check-docker-compose.sh`.
> 
>   - **Behavior**:
>     - Modifies `check-docker-compose.sh` to include `internal-network.yml` to block external network access during CI.
>     - Prevents CI from pinging external services like Howdy.
>   - **Files**:
>     - Adds `internal-network.yml` to define internal network settings.
>     - Updates `check-docker-compose.sh` to use `internal-network.yml` with `docker compose` command.
>     - Excludes `internal-network.yml` from redundant CI tests in `check-docker-compose.sh`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 119d8c8d31de6a58d787a560d74fd16f8e312be7. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->