### PR TITLE
Use 'aws s3 sync' to download from R2 when we have creds

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -9,6 +9,8 @@ on:
 env:
   FORCE_COLOR: 1
   TENSORZERO_CLICKHOUSE_URL: "http://chuser:chpassword@localhost:8123/tensorzero"
+  R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+  R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
 
 jobs:
   check-docker-compose:

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -417,6 +417,9 @@ jobs:
       FIREWORKS_ACCOUNT_ID: not_used
       TENSORZERO_USE_MOCK_INFERENCE_PROVIDER: 1
       TENSORZERO_SKIP_LARGE_FIXTURES: 1
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/ci/free-disk-space.sh
+++ b/ci/free-disk-space.sh
@@ -41,7 +41,6 @@ echo "Phase 3: Removing cloud tools and additional runtimes..."
 (sudo rm -rf /usr/share/miniconda &)     # ~698MB Miniconda
 (sudo rm -rf /opt/pipx &)                # ~528MB pipx
 (sudo rm -rf /opt/google &)              # ~366MB Google Cloud SDK
-(sudo rm -rf /usr/local/aws-cli &)       # AWS CLI
 (sudo rm -rf /usr/local/share/powershell &)  # PowerShell
 (sudo rm -rf /opt/microsoft &)           # ~772MB Microsoft tools
 wait

--- a/ui/fixtures/download-fixtures.py
+++ b/ui/fixtures/download-fixtures.py
@@ -101,7 +101,10 @@ def main():
     # Create s3-fixtures directory if it doesn't exist
     S3_FIXTURES_DIR.mkdir(exist_ok=True)
 
-    if os.environ.get("R2_ACCESS_KEY_ID") is not None:
+    if (
+        os.environ.get("R2_ACCESS_KEY_ID") is not None
+        and os.environ.get("R2_SECRET_ACCESS_KEY") != ""
+    ):
         print("R2_ACCESS_KEY_ID set, downloading fixtures using 'aws s3 sync'")
         subprocess.check_call(
             f"aws s3 --region auto --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync s3://tensorzero-fixtures/ {S3_FIXTURES_DIR}",

--- a/ui/fixtures/download-fixtures.py
+++ b/ui/fixtures/download-fixtures.py
@@ -2,7 +2,6 @@
 # dependencies = [
 #   "requests",
 #   "parquet-tools",
-#   "awscli",
 # ]
 # ///
 

--- a/ui/fixtures/download-fixtures.py
+++ b/ui/fixtures/download-fixtures.py
@@ -2,6 +2,7 @@
 # dependencies = [
 #   "requests",
 #   "parquet-tools",
+#   "awscli",
 # ]
 # ///
 

--- a/ui/fixtures/download-fixtures.py
+++ b/ui/fixtures/download-fixtures.py
@@ -101,6 +101,18 @@ def main():
     # Create s3-fixtures directory if it doesn't exist
     S3_FIXTURES_DIR.mkdir(exist_ok=True)
 
+    if os.environ.get("R2_ACCESS_KEY_ID") is not None:
+        print("R2_ACCESS_KEY_ID set, downloading fixtures using 'aws s3 sync'")
+        subprocess.check_call(
+            f"aws s3 --region auto --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync s3://tensorzero-fixtures/ {S3_FIXTURES_DIR}",
+            env={
+                "AWS_ACCESS_KEY_ID": os.environ["R2_ACCESS_KEY_ID"],
+                "AWS_SECRET_ACCESS_KEY": os.environ["R2_SECRET_ACCESS_KEY"],
+            },
+            shell=True,
+        )
+        return
+
     def process_fixture(fixture):
         local_file = S3_FIXTURES_DIR / fixture
         remote_etag = get_remote_etag(fixture)


### PR DESCRIPTION
This will avoid using the public dev endpoint for PRs made from the tensorzero repository, while still allowing external PRs to pass CI

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Use `aws s3 sync` in `download-fixtures.py` for fixture downloads when R2 credentials are available, and update GitHub Actions workflow with necessary environment variables.
> 
>   - **Behavior**:
>     - In `download-fixtures.py`, use `aws s3 sync` to download fixtures if `R2_ACCESS_KEY_ID` and `R2_SECRET_ACCESS_KEY` are set.
>     - Falls back to existing download method if credentials are not set.
>   - **Environment Variables**:
>     - Add `R2_ACCESS_KEY_ID` and `R2_SECRET_ACCESS_KEY` to `general.yml` and `mock-optimization-tests` job.
>   - **Misc**:
>     - Remove AWS CLI from `free-disk-space.sh` cleanup script.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8d03d4c409d974ccd5b2da3020108fa6568ed375. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->