### PR TITLE
Add missing steps to CONTRIBUTING.md 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,10 +82,6 @@ Did you have something else in mind? Reach out on Slack or Discord and let us kn
 
 ## Technical Guide
 
-### Requirements
-- Memory: 32 GB RAM
-- Storage: ~ 60 GB available space  
-
 ### Setup
 
 - Install Rust (1.80+) [→](https://www.rust-lang.org/tools/install)
@@ -200,7 +196,7 @@ Here are the steps in order to run or test the UI assuming you have the prerequi
 1. Install dependencies: `pnpm install`
 2. Build the WebAssembly module following instructions in `ui/app/utils/minijinja/README.md`.
 3. Build the internal N-API client for TensorZero using `pnpm -r build`. If you have changed your Rust code, you may also have to run `pnpm build-bindings` from `internal/tensorzero-node`.
-4. Create a `ui/fixtures/.env` following the `ui/fixtures/.env.example`. 
+4. Create a `ui/fixtures/.env` following the `ui/fixtures/.env.example`.
 5. Create a `ui/.env` file and set the following environment variables for the server:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,10 @@ Did you have something else in mind? Reach out on Slack or Discord and let us kn
 
 ## Technical Guide
 
+### Requirements
+- Memory: 32 GB RAM
+- Storage: ~ 60 GB available space  
+
 ### Setup
 
 - Install Rust (1.80+) [→](https://www.rust-lang.org/tools/install)
@@ -195,7 +199,9 @@ Here are the steps in order to run or test the UI assuming you have the prerequi
 
 1. Install dependencies: `pnpm install`
 2. Build the WebAssembly module following instructions in `ui/app/utils/minijinja/README.md`.
-3. Create a `ui/.env` file and set the following environment variables for the server:
+3. Build the internal N-API client for TensorZero using `pnpm -r build`. If you have changed your Rust code, you may also have to run `pnpm build-bindings` from `internal/tensorzero-node`.
+4. Create a `ui/fixtures/.env` following the `ui/fixtures/.env.example`. 
+5. Create a `ui/.env` file and set the following environment variables for the server:
 
 ```bash
 OPENAI_API_KEY=<your-key>
@@ -205,7 +211,7 @@ TENSORZERO_CLICKHOUSE_URL=<your-clickhouse-url> # For testing, set to http://chu
 TENSORZERO_UI_CONFIG_PATH=<path-to-config-file> # For testing, set to ./fixtures/config/tensorzero.toml
 ```
 
-4. Run the dependencies: `docker compose -f ui/fixtures/docker-compose.yml up --build --force-recreate`
+6. Run the dependencies: `docker compose -f ui/fixtures/docker-compose.yml up --build --force-recreate`
    (you can omit these last 2 flags to skip the build step, but they ensure you're using the latest gateway)
 
 With the dependencies running, you can run the tests with `pnpm ui:test` and the Playwright tests with `pnpm ui:test:e2e`.


### PR DESCRIPTION
### Summary

This PR updates the `CONTRIBUTING.md` file to improve the onboarding experience for new contributors. 

- Added system requirements like Storage and Memory requirements
- Included missing step for setting up the UI dashboard, like setting up the internal/tensorzero-node

### Motivation

Several contributors have experienced issues setting up the project due to missing or unclear steps in the guide. This update aims to make the process more consistent and user-friendly for beginners.

### Additional Context

I encountered these issues while setting up the repo from scratch on a Windows machine with VS Code. I closely followed the [CONTRIBUTING.md](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md), but it was missing a few steps, like building the N-API client for TensorZero. Without this step, the website would not boot when running `pnpm ui: dev`. 

Additionally, I noticed the TensorZero repo has big storage requirements on any of the local machines, and it is also quite RAM-intensive, which makes it hard for a lot of people to run on their local machines, so I think hardware requirements should be included in the `CONTRIBUTING.md`. 

PS. I know 16GB of RAM is not enough and 32 GB is the next upgrade. 

Shoutout @aaronlui415, @oiman23, @ImagineWagons8487, @HienXuanPham, @BretteFitzgibbon, @jerrynguyen04, @pgzcoa for helping me figure this out!

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates `CONTRIBUTING.md` with system requirements and additional UI setup steps for new contributors.
> 
>   - **Requirements**:
>     - Added memory requirement of 32 GB RAM and storage requirement of ~60 GB.
>   - **Setup**:
>     - Added step to build the internal N-API client for TensorZero using `pnpm -r build`.
>     - Added step to create `ui/fixtures/.env` from `ui/fixtures/.env.example`.
>     - Adjusted step numbers for setting up the UI dashboard.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4e1c8f9051c95b768c1417d7bc8e9154d79dc12a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->