### PR TITLE
Relax batch test to only check 'arguments' if it's an object

### DIFF
--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -4876,8 +4876,6 @@ pub async fn check_tool_use_tool_choice_required_inference_response(
     }
 
     if let Some(arguments) = content_block["arguments"].as_object() {
-        let arguments = content_block.get("arguments").unwrap();
-        let arguments = arguments.as_object().unwrap();
         // OpenAI occasionally emits a tool call with an empty object for `arguments`
         assert!(arguments.len() <= 2);
         if let Some(location) = arguments.get("location") {

--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -4875,16 +4875,18 @@ pub async fn check_tool_use_tool_choice_required_inference_response(
         assert!(units == "celsius" || units == "fahrenheit");
     }
 
-    let arguments = content_block.get("arguments").unwrap();
-    let arguments = arguments.as_object().unwrap();
-    // OpenAI occasionally emits a tool call with an empty object for `arguments`
-    assert!(arguments.len() <= 2);
-    if let Some(location) = arguments.get("location") {
-        assert!(location.as_str().is_some())
-    }
-    if arguments.len() == 2 {
-        let units = arguments.get("units").unwrap().as_str().unwrap();
-        assert!(units == "celsius" || units == "fahrenheit");
+    if let Some(arguments) = content_block["arguments"].as_object() {
+        let arguments = content_block.get("arguments").unwrap();
+        let arguments = arguments.as_object().unwrap();
+        // OpenAI occasionally emits a tool call with an empty object for `arguments`
+        assert!(arguments.len() <= 2);
+        if let Some(location) = arguments.get("location") {
+            assert!(location.as_str().is_some())
+        }
+        if arguments.len() == 2 {
+            let units = arguments.get("units").unwrap().as_str().unwrap();
+            assert!(units == "celsius" || units == "fahrenheit");
+        }
     }
 
     let usage = response_json.get("usage").unwrap();


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update test in `common.rs` to check if `arguments` is an object before assertions.
> 
>   - **Test Update**:
>     - In `common.rs`, modify `check_tool_use_tool_choice_required_inference_response` to check if `arguments` is an object before asserting its properties.
>     - Handles cases where `arguments` is not an object, preventing potential panics.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3d05ac4650a2e6c8034907be4e7655946860b8d6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->