### PR TITLE
Use 2x8 runner for UI tests job

### DIFF
--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -109,7 +109,8 @@ jobs:
         run: exit 1
 
   ui-tests-e2e:
-    runs-on: namespace-profile-tensorzero-8x16
+    # We're only using namespace here so that we can download the container artifacts
+    runs-on: namespace-profile-tensorzero-2x8
 
     # We currently only run this job when we have secrets available, since we need to use an S3 object_store
     # In the future, we might want to fix this so that it can run in PR CI for external (forked) PRs

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -5,7 +5,8 @@ on:
 
 jobs:
   ui-tests:
-    runs-on: namespace-profile-tensorzero-8x16
+    # We're only using namespace here so that we can download the container artifacts
+    runs-on: namespace-profile-tensorzero-2x8
 
     strategy:
       matrix:


### PR DESCRIPTION
We download prebuilt Docker image artifacts, so we don't need a large runner here.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Switch UI tests runner to `2x8` for efficiency due to prebuilt Docker images.
> 
>   - **Runner Configuration**:
>     - Change runner from `namespace-profile-tensorzero-8x16` to `namespace-profile-tensorzero-2x8` in `.github/workflows/ui-tests-e2e.yml` and `.github/workflows/ui-tests.yml`.
>     - Justification: Prebuilt Docker image artifacts are used, reducing the need for a larger runner.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a1eba414bebdd78ecbcf9b8595087478e1e78a9f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->