### PR TITLE
implemented HTTP endpoint for deletion and tested

### DIFF
--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -236,6 +236,10 @@ async fn main() {
             get(endpoints::datasets::list_datapoints_handler),
         )
         .route(
+            "/datasets/{dataset_name}",
+            delete(endpoints::datasets::stale_dataset_handler),
+        )
+        .route(
             "/datasets/{dataset_name}/datapoints/{datapoint_id}",
             get(endpoints::datasets::get_datapoint_handler),
         )

--- a/tensorzero-core/src/endpoints/datasets.rs
+++ b/tensorzero-core/src/endpoints/datasets.rs
@@ -1568,11 +1568,25 @@ async fn put_json_datapoints(
     Ok(result.metadata.written_rows)
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[cfg_attr(test, derive(ts_rs::TS))]
 #[cfg_attr(test, ts(export))]
 pub struct StaleDatasetResponse {
     pub num_staled_datapoints: u64,
+}
+
+#[axum::debug_handler(state = AppStateData)]
+pub async fn stale_dataset_handler(
+    State(app_state): AppState,
+    // These are the same as the path params for `list_datapoints_handler`
+    Path(path_params): Path<ListDatapointsPathParams>,
+) -> Result<Json<StaleDatasetResponse>, Error> {
+    let response = stale_dataset(
+        &app_state.clickhouse_connection_info,
+        &path_params.dataset_name,
+    )
+    .await?;
+    Ok(Json(response))
 }
 
 /// Stales all datapoints in a dataset that have not been staled yet.

--- a/tensorzero-core/tests/e2e/datasets.rs
+++ b/tensorzero-core/tests/e2e/datasets.rs
@@ -2793,9 +2793,16 @@ async fn test_stale_dataset_already_staled() {
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     println!("staling dataset again");
-    // Try to stale it again - should return 0 since datapoints are already staled
-    let stale_result2 = client.stale_dataset(dataset_name.clone()).await.unwrap();
-    assert_eq!(stale_result2.num_staled_datapoints, 0);
+    // Try to stale it again - should return 0 since datapoints are already staled (use HTTP for this)
+    let resp = http_client
+        .delete(get_gateway_endpoint(&format!("/datasets/{dataset_name}",)))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let resp_json: Value = resp.json().await.unwrap();
+    let num_staled_datapoints = resp_json["num_staled_datapoints"].as_u64().unwrap();
+    assert_eq!(num_staled_datapoints, 0);
 
     // Verify the datapoint is still staled
     let datapoint = select_chat_datapoint_clickhouse(&clickhouse, id)
@@ -2807,7 +2814,6 @@ async fn test_stale_dataset_already_staled() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_stale_dataset_mixed_staled_fresh() {
-    let client = make_embedded_gateway().await;
     let http_client = Client::new();
     let clickhouse = get_clickhouse().await;
     let dataset_name = format!("test-mixed-stale-{}", Uuid::now_v7());
@@ -2862,9 +2868,16 @@ async fn test_stale_dataset_mixed_staled_fresh() {
         .unwrap();
     assert!(resp.status().is_success());
 
-    // Now stale the entire dataset - should only stale the fresh datapoint
-    let stale_result = client.stale_dataset(dataset_name.clone()).await.unwrap();
-    assert_eq!(stale_result.num_staled_datapoints, 1);
+    // Now stale the entire dataset - should only stale the fresh datapoint (use HTTP for this)
+    let resp = http_client
+        .delete(get_gateway_endpoint(&format!("/datasets/{dataset_name}",)))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let resp_json: Value = resp.json().await.unwrap();
+    let num_staled_datapoints = resp_json["num_staled_datapoints"].as_u64().unwrap();
+    assert_eq!(num_staled_datapoints, 1);
 
     // Verify both datapoints are staled
     let datapoint2 = select_chat_datapoint_clickhouse(&clickhouse, datapoint_id2)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add HTTP endpoint for dataset deletion and update `stale_dataset()` to support HTTP and embedded modes, with tests for various scenarios.
> 
>   - **Behavior**:
>     - Adds HTTP endpoint for dataset deletion in `main.rs` using `delete` method.
>     - Updates `stale_dataset()` in `lib.rs` to support both `HTTPGateway` and `EmbeddedGateway` modes.
>   - **Handlers**:
>     - Adds `stale_dataset_handler()` in `datasets.rs` to handle HTTP requests for dataset deletion.
>   - **Tests**:
>     - Updates `test_stale_dataset_already_staled()` and `test_stale_dataset_mixed_staled_fresh()` in `datasets.rs` to test new HTTP endpoint for dataset deletion.
>     - Adds assertions to verify correct handling of already staled datasets and mixed staled/fresh datasets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 17ed791bdf80ed55cfce565f4eba5d413a11eab8. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->