### PR TITLE
Use `thiserror` for our `Error` struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4402,6 +4402,7 @@ dependencies = [
  "tempfile",
  "tensorzero",
  "tensorzero-derive",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "toml 0.8.23",

--- a/tensorzero-core/Cargo.toml
+++ b/tensorzero-core/Cargo.toml
@@ -124,6 +124,7 @@ mime = { workspace = true }
 mime_guess = "2.0.5"
 indexmap = "2.10.0"
 base64 = "0.22.1"
+thiserror = "2.0.12"
 
 
 [dev-dependencies]

--- a/tensorzero-core/src/clickhouse/query_builder/mod.rs
+++ b/tensorzero-core/src/clickhouse/query_builder/mod.rs
@@ -34,7 +34,7 @@ impl TryFrom<&str> for InferenceOutputSource {
             "inference" => Ok(InferenceOutputSource::Inference),
             "demonstration" => Ok(InferenceOutputSource::Demonstration),
             _ => Err(Error::new(ErrorDetails::InvalidInferenceOutputSource {
-                source: value.to_string(),
+                source_kind: value.to_string(),
             })),
         }
     }

--- a/tensorzero-core/src/error.rs
+++ b/tensorzero-core/src/error.rs
@@ -6,6 +6,7 @@ use axum::response::{IntoResponse, Json, Response};
 use serde::{Serialize, Serializer};
 use serde_json::{json, Value};
 use std::fmt::{Debug, Display};
+use thiserror::Error;
 use tokio::sync::OnceCell;
 use url::Url;
 use uuid::Uuid;
@@ -92,7 +93,8 @@ impl<T: Debug + Display> Display for DisplayOrDebugGateway<T> {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Debug, Error, PartialEq, Serialize)]
+#[error(transparent)]
 // As long as the struct member is private, we force people to use the `new` method and log the error.
 // We box `ErrorDetails` per the `clippy::result_large_err` lint
 pub struct Error(Box<ErrorDetails>);
@@ -145,19 +147,13 @@ where
     serializer.serialize_none()
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.0, f)
-    }
-}
-
 impl From<ErrorDetails> for Error {
     fn from(details: ErrorDetails) -> Self {
         Error::new(details)
     }
 }
 
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Debug, Error, PartialEq, Serialize)]
 pub enum ErrorDetails {
     AllVariantsFailed {
         errors: HashMap<String, Error>,
@@ -260,7 +256,7 @@ pub enum ErrorDetails {
         message: String,
     },
     InvalidInferenceOutputSource {
-        source: String,
+        source_kind: String,
     },
     ObjectStoreWrite {
         message: String,
@@ -967,8 +963,8 @@ impl std::fmt::Display for ErrorDetails {
             ErrorDetails::InvalidTensorzeroUuid { message, kind } => {
                 write!(f, "Invalid {kind} ID: {message}")
             }
-            ErrorDetails::InvalidInferenceOutputSource { source } => {
-                write!(f, "Invalid inference output source: {source}. Should be one of: \"inference\" or \"demonstration\".")
+            ErrorDetails::InvalidInferenceOutputSource { source_kind } => {
+                write!(f, "Invalid inference output source: {source_kind}. Should be one of: \"inference\" or \"demonstration\".")
             }
             ErrorDetails::InvalidMetricName { metric_name } => {
                 write!(f, "Invalid metric name: {metric_name}")
@@ -1177,8 +1173,6 @@ impl std::fmt::Display for ErrorDetails {
         }
     }
 }
-
-impl std::error::Error for Error {}
 
 impl IntoResponse for Error {
     /// Log the error and convert it into an Axum response


### PR DESCRIPTION
This will help us to produce nicer error messages with nested `source`s

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use `thiserror` for `Error` struct to improve error messages and rename `source` to `source_kind` in `ErrorDetails::InvalidInferenceOutputSource`.
> 
>   - **Error Handling**:
>     - Use `thiserror` for `Error` struct in `error.rs` to improve error messages with nested sources.
>     - Remove manual `Display` implementation for `Error` in `error.rs`.
>   - **Field Renaming**:
>     - Rename `source` to `source_kind` in `ErrorDetails::InvalidInferenceOutputSource` in `error.rs` and `query_builder/mod.rs`.
>   - **Dependencies**:
>     - Add `thiserror = "2.0.12"` to `Cargo.toml` and `Cargo.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 62321c1151c072cc1d10f3d9865bca88eda1d167. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->