### PR TITLE
Map Anthropic 'redacted_thinking' to Thought with no text

### DIFF
--- a/tensorzero-core/tests/e2e/providers/anthropic.rs
+++ b/tensorzero-core/tests/e2e/providers/anthropic.rs
@@ -547,12 +547,9 @@ async fn test_redacted_thinking() {
     );
     let first_block = &content_blocks[0];
     let first_block_type = first_block.get("type").unwrap().as_str().unwrap();
-    assert_eq!(first_block_type, "unknown");
-    assert_eq!(
-        first_block["model_provider_name"],
-        "tensorzero::model_name::claude-3-7-sonnet-20250219-thinking::provider_name::anthropic-extra-body"
-    );
-    assert_eq!(first_block["data"]["type"], "redacted_thinking");
+    assert_eq!(first_block_type, "thought");
+    assert_eq!(first_block["_internal_provider_type"], "anthropic");
+    assert!(first_block["signature"].as_str().is_some());
 
     let second_block = &content_blocks[1];
     assert_eq!(second_block["type"], "text");
@@ -599,9 +596,9 @@ async fn test_redacted_thinking() {
     assert_eq!(content_blocks.len(), 2);
     let first_block = &content_blocks[0];
     // Check the type and content in the block
-    assert_eq!(first_block["type"], "unknown");
-    assert_eq!(first_block["data"]["type"], "redacted_thinking");
-    assert_eq!(first_block["model_provider_name"], "tensorzero::model_name::claude-3-7-sonnet-20250219-thinking::provider_name::anthropic-extra-body");
+    assert_eq!(first_block["type"], "thought");
+    assert_eq!(first_block["_internal_provider_type"], "anthropic");
+    assert!(first_block["signature"].as_str().is_some());
     let second_block = &content_blocks[1];
     assert_eq!(second_block["type"], "text");
     let clickhouse_content = second_block.get("text").unwrap().as_str().unwrap();


### PR DESCRIPTION
On the way out, we turn `ContentBlock::Thought` with a signature (but not text) into a 'redacted_thinking' content block. On the way in, we convert a 'redacted_thinking' block into `ContentBlock::Thought'. Previously, we were passing these through as 'ContentBlock::Unknown'.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Map 'redacted_thinking' blocks to `ContentBlock::Thought` with no text in Anthropic provider, updating tests accordingly.
> 
>   - **Behavior**:
>     - Map 'redacted_thinking' blocks to `ContentBlock::Thought` with no text in `anthropic.rs`.
>     - Previously, these were mapped to `ContentBlock::Unknown`.
>   - **Tests**:
>     - Update `test_redacted_thinking()` in `anthropic.rs` to check for `ContentBlock::Thought` instead of `ContentBlock::Unknown`.
>     - Ensure `signature` is present in the `Thought` block in tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c5e7efcf5e5aca26b118b4fc5f5d2f1ff35647d4. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->