### PR TITLE
Stop using our fine-tuned NER model in e2e tests

### DIFF
--- a/tensorzero-core/tests/e2e/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-core/tests/e2e/providers/gcp_vertex_gemini.rs
@@ -16,6 +16,14 @@ crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
 async fn get_providers() -> E2ETestProviders {
+    // TODO - fine-tune a better model and add it back to our tests
+    let _tuned = E2ETestProvider {
+        supports_batch_inference: false,
+        variant_name: "gcp-vertex-gemini-flash-lite-tuned".to_string(),
+        model_name: "gemini-2.0-flash-lite-tuned".into(),
+        model_provider_name: "gcp_vertex_gemini".into(),
+        credentials: HashMap::new(),
+    };
     let standard_providers = vec![
         E2ETestProvider {
             supports_batch_inference: true,
@@ -28,13 +36,6 @@ async fn get_providers() -> E2ETestProviders {
             supports_batch_inference: false,
             variant_name: "gcp-vertex-gemini-pro".to_string(),
             model_name: "gcp-gemini-2.5-pro".into(),
-            model_provider_name: "gcp_vertex_gemini".into(),
-            credentials: HashMap::new(),
-        },
-        E2ETestProvider {
-            supports_batch_inference: false,
-            variant_name: "gcp-vertex-gemini-flash-lite-tuned".to_string(),
-            model_name: "gemini-2.0-flash-lite-tuned".into(),
             model_provider_name: "gcp_vertex_gemini".into(),
             credentials: HashMap::new(),
         },


### PR DESCRIPTION
This is causing tests to fail, since it doesn't work for normal question-answering.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
