### PR TITLE
Only derive PartialEq for Error in test mode

### DIFF
--- a/tensorzero-core/src/error.rs
+++ b/tensorzero-core/src/error.rs
@@ -93,7 +93,8 @@ impl<T: Debug + Display> Display for DisplayOrDebugGateway<T> {
     }
 }
 
-#[derive(Debug, Error, PartialEq, Serialize)]
+#[derive(Debug, Error, Serialize)]
+#[cfg_attr(any(test, feature = "e2e_tests"), derive(PartialEq))]
 #[error(transparent)]
 // As long as the struct member is private, we force people to use the `new` method and log the error.
 // We box `ErrorDetails` per the `clippy::result_large_err` lint
@@ -153,7 +154,8 @@ impl From<ErrorDetails> for Error {
     }
 }
 
-#[derive(Debug, Error, PartialEq, Serialize)]
+#[derive(Debug, Error, Serialize)]
+#[cfg_attr(any(test, feature = "e2e_tests"), derive(PartialEq))]
 pub enum ErrorDetails {
     AllVariantsFailed {
         errors: HashMap<String, Error>,


### PR DESCRIPTION
When we start attaching additional 'source' fields, we'll need to adjust the `PartialEq` impl to skip some fields. Let's enforce that this impl is only used in tests, which is the only time we should be comparing errors.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Conditionally derive `PartialEq` for `Error` and `ErrorDetails` structs only in test and e2e test modes in `error.rs`.
> 
>   - **Behavior**:
>     - `PartialEq` is now conditionally derived for `Error` and `ErrorDetails` structs only in test and e2e test modes in `error.rs`.
>     - This change prepares for future additions of 'source' fields that should not be compared in non-test environments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c2d366e990b8d47014c3763c1b11dcef7bb773b7. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->