### PR TITLE
Disable Howdy in e2e test gateway

### DIFF
--- a/tensorzero-core/tests/e2e/docker-compose.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.yml
@@ -77,6 +77,8 @@ services:
       clickhouse:
         condition: service_healthy
     command: ["--default-config"]
+    extra_hosts:
+      - "howdy.tensorzero.com:127.0.0.1"
     healthcheck:
       test:
         [


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `extra_hosts` entry for `howdy.tensorzero.com` in `docker-compose.yml` to disable Howdy in e2e test gateway.
> 
>   - **Configuration**:
>     - Add `extra_hosts` entry for `howdy.tensorzero.com` in `docker-compose.yml` under `gateway` service to map to `127.0.0.1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 45e47ce172195e7939844bdbda3eb16b7fcf63b3. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->