### PR TITLE
Add `vite-plugin-devtools-json` to remove noisy logs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,9 +299,6 @@ importers:
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
-      vite-plugin-wasm:
-        specifier: ^3.4.1
-        version: 3.4.1(vite@6.3.5(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3))
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -375,6 +372,12 @@ importers:
       vite:
         specifier: ^6.2.7
         version: 6.3.5(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)
+      vite-plugin-devtools-json:
+        specifier: ^0.3.0
+        version: 0.3.0(vite@6.3.5(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3))
+      vite-plugin-wasm:
+        specifier: ^3.4.1
+        version: 3.4.1(vite@6.3.5(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3))
@@ -6320,6 +6323,11 @@ packages:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
+
+  vite-plugin-devtools-json@0.3.0:
+    resolution: {integrity: sha512-y8QdN/uZNV0Jj96H9R3s7G9jtcSuyssk8EwSfWaY+NUAdy7976d7rjtXJzqmeCcgp4CZywcTyUc+k6zpPFHdeg==}
+    peerDependencies:
+      vite: ^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   vite-plugin-wasm@3.4.1:
     resolution: {integrity: sha512-ja3nSo2UCkVeitltJGkS3pfQHAanHv/DqGatdI39ja6McgABlpsZ5hVgl6wuR8Qx5etY3T5qgDQhOWzc5RReZA==}
@@ -13817,6 +13825,11 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vite-plugin-devtools-json@0.3.0(vite@6.3.5(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)):
+    dependencies:
+      uuid: 11.1.0
+      vite: 6.3.5(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)
 
   vite-plugin-wasm@3.4.1(vite@6.3.5(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)):
     dependencies:

--- a/ui/package.json
+++ b/ui/package.json
@@ -83,7 +83,6 @@
     "type-fest": "^4.41.0",
     "typescript-eslint": "^8.36.0",
     "uuid": "^11.1.0",
-    "vite-plugin-wasm": "^3.4.1",
     "zod": "^3.25.76"
   },
   "devDependencies": {
@@ -110,6 +109,8 @@
     "tailwindcss": "^4.1.11",
     "typescript": "^5.8.2",
     "vite": "^6.2.7",
+    "vite-plugin-devtools-json": "^0.3.0",
+    "vite-plugin-wasm": "^3.4.1",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.2.4"
   },

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -2,6 +2,7 @@ import { reactRouter } from "@react-router/dev/vite";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig, loadEnv } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
+import devtoolsJson from "vite-plugin-devtools-json";
 import wasm from "vite-plugin-wasm";
 import react from "@vitejs/plugin-react";
 
@@ -12,6 +13,7 @@ const shouldLoadReactRouter =
 
 export default defineConfig(({ mode }) => ({
   plugins: [
+    devtoolsJson(),
     wasm(),
     tailwindcss(),
     shouldLoadReactRouter ? reactRouter() : react(),


### PR DESCRIPTION
This cleans up some annoying useless logs from the UI dev server when Chrome dev tools are open, a la `Error: No route matches URL "/.well-known/appspecific/com.chrome.devtools.json"`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `vite-plugin-devtools-json` to suppress Chrome dev tools logs in Vite dev server.
> 
>   - **Dependencies**:
>     - Add `vite-plugin-devtools-json` to `devDependencies` in `package.json`.
>   - **Vite Configuration**:
>     - Import `devtoolsJson` from `vite-plugin-devtools-json` in `vite.config.ts`.
>     - Add `devtoolsJson()` to the `plugins` array in `vite.config.ts` to suppress logs related to Chrome dev tools.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 50a3a1037065a763de92706c19cb319d07e98bfa. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->