### PR TITLE
Test starting UI container without external network access

### DIFF
--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -42,21 +42,14 @@ jobs:
     - name: Start docker containers without external network access
       working-directory: ui
       run: |
-        # We set all of the environment variables for both the gateway and ui containers here
-        # The 'ui-tests-e2e' job tests that the UI container starts without some of these variables set,
-        echo "FIREWORKS_ACCOUNT_ID=fake_fireworks_account" >> fixtures/.env
-        echo "FIREWORKS_API_KEY=not_used" >> fixtures/.env
-        echo "FIREWORKS_BASE_URL=http://mock-inference-provider:3030/fireworks/" >> fixtures/.env
-        echo "OPENAI_API_KEY=not_used" >> fixtures/.env
-        echo "OPENAI_BASE_URL=http://mock-inference-provider:3030/openai/" >> fixtures/.env
-        echo "S3_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> fixtures/.env
-        echo "S3_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> fixtures/.env
+        # Environment variables shared by the gateway and ui containers
         echo "TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero_ui_fixtures" >> fixtures/.env
-        echo "TENSORZERO_GATEWAY_URL=http://gateway:3000/custom/prefix" >> fixtures/.env
-        echo "TENSORZERO_GATEWAY_CONFIG=/app/config/empty.toml" >> fixtures/.env
-        echo "TENSORZERO_UI_CONFIG_PATH=/app/config/empty.toml" >> fixtures/.env
+        echo "TENSORZERO_GATEWAY_URL=http://gateway:3000" >> fixtures/.env
         echo "TENSORZERO_GATEWAY_TAG=sha-${{ github.sha }}" >> fixtures/.env
         echo "TENSORZERO_UI_TAG=sha-${{ github.sha }}" >> fixtures/.env
+        echo "TENSORZERO_GATEWAY_CONFIG=/app/config/empty.toml" >> fixtures/.env
+        echo "TENSORZERO_UI_CONFIG_PATH=/app/config/empty.toml" >> fixtures/.env
+
         export TENSORZERO_SKIP_LARGE_FIXTURES=1
         docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml -f ../ci/internal-network.yml up --no-build -d
         docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml -f ../ci/internal-network.yml wait ui

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -60,6 +60,17 @@ jobs:
         export TENSORZERO_SKIP_LARGE_FIXTURES=1
         docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml -f ../ci/internal-network.yml up --no-build --wait
 
+    - name: Print Docker Compose logs
+      if: always()
+      working-directory: ui
+      run: docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml logs -t
+
+    - name: Print container health checks
+      if: always()
+      working-directory: ui
+      run: docker inspect --format "{{json .State.Health }}" $(docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml ps -q ui) | jq
+
+
   ui-tests-gateway-prefix:
     # We're only using namespace here so that we can download the container artifacts
     runs-on: namespace-profile-tensorzero-2x8

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -9,6 +9,57 @@ on:
         required: true
 
 jobs:
+
+  ui-tests-no-network:
+    # We're only using namespace here so that we can download the container artifacts
+    runs-on: namespace-profile-tensorzero-2x8
+    steps:
+    - name: Set DNS
+      run: echo "127.0.0.1 howdy.tensorzero.com" | sudo tee -a /etc/hosts
+    - uses: namespacelabs/nscloud-checkout-action@953fed31a6113cc2347ca69c9d823743c65bc84b
+    - name: Setup Node
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      with:
+        node-version: "22.9.0"
+
+    - name: Download container images
+      uses: namespace-actions/download-artifact@5c070f7d7ebdc47682b04aa736c76e46ff5f6e1e
+      with:
+        pattern: build-*-container
+        merge-multiple: true
+
+    - name: Load `gateway` and `ui` containers
+      run: |
+        docker load < gateway-container.tar
+        docker load < ui-container.tar
+
+    # This allows us to use 'no-build' on subsequent steps
+    - name: Build needed docker images
+      working-directory: ui
+      run: |
+        docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml build fixtures mock-inference-provider
+
+    - name: Start docker containers without external network access
+      working-directory: ui
+      run: |
+        # We set all of the environment variables for both the gateway and ui containers here
+        # The 'ui-tests-e2e' job tests that the UI container starts without some of these variables set,
+        echo "FIREWORKS_ACCOUNT_ID=fake_fireworks_account" >> fixtures/.env
+        echo "FIREWORKS_API_KEY=not_used" >> fixtures/.env
+        echo "FIREWORKS_BASE_URL=http://mock-inference-provider:3030/fireworks/" >> fixtures/.env
+        echo "OPENAI_API_KEY=not_used" >> fixtures/.env
+        echo "OPENAI_BASE_URL=http://mock-inference-provider:3030/openai/" >> fixtures/.env
+        echo "S3_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> fixtures/.env
+        echo "S3_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> fixtures/.env
+        echo "TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero_ui_fixtures" >> fixtures/.env
+        echo "TENSORZERO_GATEWAY_URL=http://gateway:3000/custom/prefix" >> fixtures/.env
+        echo "TENSORZERO_GATEWAY_CONFIG=/app/config/tensorzero.base-path.toml" >> fixtures/.env
+        echo "TENSORZERO_UI_CONFIG_PATH=/app/config/tensorzero.base-path.toml" >> fixtures/.env
+        echo "TENSORZERO_GATEWAY_TAG=sha-${{ github.sha }}" >> fixtures/.env
+        echo "TENSORZERO_UI_TAG=sha-${{ github.sha }}" >> fixtures/.env
+        export TENSORZERO_SKIP_LARGE_FIXTURES=1
+        docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml -f ../ci/internal-network.yml up --no-build --wait
+
   ui-tests-gateway-prefix:
     # We're only using namespace here so that we can download the container artifacts
     runs-on: namespace-profile-tensorzero-2x8

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -53,8 +53,8 @@ jobs:
         echo "S3_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> fixtures/.env
         echo "TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero_ui_fixtures" >> fixtures/.env
         echo "TENSORZERO_GATEWAY_URL=http://gateway:3000/custom/prefix" >> fixtures/.env
-        echo "TENSORZERO_GATEWAY_CONFIG=/app/config/tensorzero.base-path.toml" >> fixtures/.env
-        echo "TENSORZERO_UI_CONFIG_PATH=/app/config/tensorzero.base-path.toml" >> fixtures/.env
+        echo "TENSORZERO_GATEWAY_CONFIG=/app/config/empty.toml" >> fixtures/.env
+        echo "TENSORZERO_UI_CONFIG_PATH=/app/config/empty.toml" >> fixtures/.env
         echo "TENSORZERO_GATEWAY_TAG=sha-${{ github.sha }}" >> fixtures/.env
         echo "TENSORZERO_UI_TAG=sha-${{ github.sha }}" >> fixtures/.env
         export TENSORZERO_SKIP_LARGE_FIXTURES=1

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -52,7 +52,6 @@ jobs:
 
         export TENSORZERO_SKIP_LARGE_FIXTURES=1
         docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml -f ../ci/internal-network.yml up --no-build -d
-        docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml -f ../ci/internal-network.yml wait ui
 
     - name: Print Docker Compose logs
       if: always()

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -59,7 +59,7 @@ jobs:
         echo "TENSORZERO_UI_TAG=sha-${{ github.sha }}" >> fixtures/.env
         export TENSORZERO_SKIP_LARGE_FIXTURES=1
         docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml -f ../ci/internal-network.yml up --no-build -d
-        docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml -f ../ci/internal-network.yml up wait ui
+        docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml -f ../ci/internal-network.yml wait ui
 
     - name: Print Docker Compose logs
       if: always()

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -58,7 +58,8 @@ jobs:
         echo "TENSORZERO_GATEWAY_TAG=sha-${{ github.sha }}" >> fixtures/.env
         echo "TENSORZERO_UI_TAG=sha-${{ github.sha }}" >> fixtures/.env
         export TENSORZERO_SKIP_LARGE_FIXTURES=1
-        docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml -f ../ci/internal-network.yml up --no-build --wait
+        docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml -f ../ci/internal-network.yml up --no-build -d
+        docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml -f ../ci/internal-network.yml up wait ui
 
     - name: Print Docker Compose logs
       if: always()

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -150,4 +150,4 @@ ENV RUST_LOG=warn
 ENV TENSORZERO_UI_CONFIG_PATH=/app/config/tensorzero.toml
 
 ENTRYPOINT ["./entrypoint.sh"]
-HEALTHCHECK --start-period=1s --start-interval=1s --timeout=1s CMD wget --no-verbose --tries=1 --spider http://localhost:4000/api/tensorzero/status
+HEALTHCHECK CMD wget --no-verbose --tries=1 --spider http://localhost:4000/api/tensorzero/status

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -150,4 +150,4 @@ ENV RUST_LOG=warn
 ENV TENSORZERO_UI_CONFIG_PATH=/app/config/tensorzero.toml
 
 ENTRYPOINT ["./entrypoint.sh"]
-HEALTHCHECK --start-period=1s --start-interval=1s --timeout=1s CMD wget --no-verbose --tries=1 --spider http://localhost:4000/api/tensorzero/status
+HEALTHCHECK --start-period=10s --start-interval=1s --timeout=1s CMD wget --no-verbose --tries=1 --spider http://localhost:4000/api/tensorzero/status

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -150,4 +150,4 @@ ENV RUST_LOG=warn
 ENV TENSORZERO_UI_CONFIG_PATH=/app/config/tensorzero.toml
 
 ENTRYPOINT ["./entrypoint.sh"]
-HEALTHCHECK CMD wget --no-verbose --tries=1 --spider http://localhost:4000/api/tensorzero/status
+HEALTHCHECK --start-period=1s --start-interval=1s --timeout=1s CMD wget --no-verbose --tries=1 --spider http://localhost:4000/api/tensorzero/status


### PR DESCRIPTION
This just starts the UI docker container, and waits for the health check to pass (which will ping the gateway)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `ui-tests-no-network` job to GitHub Actions for testing UI container without network access and updates health check in `ui/Dockerfile`.
> 
>   - **GitHub Actions Workflow**:
>     - Adds `ui-tests-no-network` job in `.github/workflows/ui-tests-e2e.yml` to start UI container without external network access.
>     - Configures environment variables and Docker Compose setup for isolated testing.
>     - Includes steps to print logs and health checks for debugging.
>   - **Dockerfile**:
>     - Updates health check in `ui/Dockerfile` to `--start-period=10s` for UI container.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 9859271c1bd10c994b700203957909db181f8f70. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->