### PR TITLE
Fix CSS for wrap icon

### DIFF
--- a/ui/app/components/ui/code-editor.tsx
+++ b/ui/app/components/ui/code-editor.tsx
@@ -21,6 +21,7 @@ import {
   WrapTextIcon,
   CheckCheckIcon,
   ClipboardIcon,
+  X,
 } from "lucide-react";
 import type { JsonValue } from "tensorzero-node";
 
@@ -185,14 +186,14 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
 
   return (
     // `min-width: 0` If within a grid parent, prevent editor from overflowing its grid cell and force horizontal scrolling
-    <div className={cn("group relative min-w-0 rounded-sm", className)}>
+    <div className={cn("group relative isolate min-w-0 rounded-sm", className)}>
       <div className="absolute top-1 right-1 z-10 flex gap-1.5 opacity-0 transition-opacity duration-200 group-hover:opacity-100 focus-within:opacity-100">
         {isCopyAvailable && (
           <Button
             variant="secondary"
             size="iconSm"
             onClick={() => copy(value)}
-            className="h-6 w-6 p-3 text-xs"
+            className="h-6 w-6 cursor-pointer p-3 text-xs"
             title={didCopy ? "Copied!" : "Copy to clipboard"}
           >
             {didCopy ? (
@@ -204,14 +205,23 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
         )}
 
         <Button
-          variant={wordWrap ? "default" : "secondary"}
+          variant={"secondary"}
           size="iconSm"
           onClick={() => setWordWrap((wrap) => !wrap)}
           aria-pressed={wordWrap}
-          className="h-6 w-6 p-3 text-xs"
+          className="flex h-6 w-6 cursor-pointer items-center justify-center p-3 text-xs"
           title="Toggle word wrap"
         >
-          <WrapTextIcon className="h-2 w-2" />
+          <span className="relative flex h-full w-full items-center justify-center">
+            <WrapTextIcon className="absolute top-1/2 left-1/2 z-10 h-3 w-3 -translate-x-1/2 -translate-y-1/2" />
+            {/* If disabled, show an X icon, larger and on top of the wrap icon */}
+            {wordWrap ? null : (
+              <X
+                className="absolute top-1/2 left-1/2 z-20 !h-7 !w-7 -translate-x-1/2 -translate-y-1/2"
+                strokeWidth={1}
+              />
+            )}
+          </span>
         </Button>
 
         {allowedLanguages.length > 1 && (


### PR DESCRIPTION
Overlay an [X] if disabled

<img width="682" height="232" alt="CleanShot 2025-07-23 at 17 10 01@2x" src="https://github.com/user-attachments/assets/4232fd7b-d95b-489e-9e92-2b82c5c484b0" />

<img width="412" height="148" alt="CleanShot 2025-07-23 at 17 10 04@2x" src="https://github.com/user-attachments/assets/266fd702-df3e-4025-8ca2-311578e52054" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Overlay an 'X' icon on the wrap icon in `code-editor.tsx` when word wrap is disabled.
> 
>   - **CSS Changes**:
>     - In `code-editor.tsx`, overlay an `X` icon on the `WrapTextIcon` when word wrap is disabled.
>     - Adjusts CSS classes for `Button` components to include `cursor-pointer` and flex properties.
>   - **Behavior**:
>     - The `X` icon is displayed larger and on top of the wrap icon when word wrap is disabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b0014e6532dee4132096993e2294919227fe8f8c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->