### PR TITLE
Set evaluations concurrency to 1 for ui e2e image test

### DIFF
--- a/ui/app/routes/evaluations/LaunchEvaluationModal.tsx
+++ b/ui/app/routes/evaluations/LaunchEvaluationModal.tsx
@@ -201,6 +201,7 @@ function EvaluationForm({
           type="number"
           id="concurrency_limit"
           name="concurrency_limit"
+          data-testid="concurrency-limit"
           min="1"
           value={concurrencyLimit}
           onChange={(e) => setConcurrencyLimit(e.target.value)}

--- a/ui/e2e_tests/evaluations.spec.ts
+++ b/ui/e2e_tests/evaluations.spec.ts
@@ -10,6 +10,9 @@ test("should show the evaluation result page", async ({ page }) => {
 
 // This test depends on model inference cache hits (within ClickHouse)
 // If it starts failing, you may need to regenerate the model inference cache
+// See the 'IMPORTANT' comment in the image evaluation test below for a note
+// about 'concurrency-limit' race conditions. If we ever add duplicate datapoints
+// to this test, we'll need to set concurrency to 1 here as well.
 test("push the new run button, launch an evaluation", async ({ page }) => {
   await page.goto("/evaluations");
   await page.waitForTimeout(500);
@@ -59,6 +62,10 @@ test("push the new run button, launch an image evaluation", async ({
   await page.getByText("Select a variant").click();
   await page.waitForTimeout(500);
   await page.getByRole("option", { name: "honest_answer" }).click();
+  // IMPORTANT - we need to set concurrency to 1 in order to prevent a race condition
+  // when regenerating fixtures, as we intentionally have multiple datapoints with
+  // identical inputs. See https://www.notion.so/tensorzerodotcom/Evaluations-cache-non-determinism-23a7520bbad3801f80fceaa7e859ce06
+  await page.getByTestId("concurrency-limit").fill("1");
   await page.getByRole("button", { name: "Launch" }).click();
   await page.waitForTimeout(5000);
 


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
