### PR TITLE
refactored InferenceConfig & sample_variant

### DIFF
--- a/tensorzero-core/src/endpoints/inference.rs
+++ b/tensorzero-core/src/endpoints/inference.rs
@@ -9,6 +9,7 @@ use object_store::{ObjectStore, PutMode, PutOptions};
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
@@ -238,11 +239,10 @@ pub async fn inference(
 
     let (function, function_name) = find_function(&params, &config)?;
     // Collect the function variant names as a Vec<&str>
-    let mut candidate_variant_names: Vec<&str> =
-        function.variants().keys().map(AsRef::as_ref).collect();
+    let mut candidate_variants = function.variants().clone();
 
     // If the function has no variants, return an error
-    if candidate_variant_names.is_empty() {
+    if candidate_variants.is_empty() {
         return Err(ErrorDetails::InvalidFunctionVariants {
             message: format!("Function `{function_name}` has no variants"),
         }
@@ -256,10 +256,10 @@ pub async fn inference(
 
     // If a variant is pinned, only that variant should be attempted
     if let Some(ref variant_name) = params.variant_name {
-        candidate_variant_names.retain(|k| k == variant_name);
+        candidate_variants.retain(|k, _| k == variant_name);
 
         // If the pinned variant doesn't exist, return an error
-        if candidate_variant_names.is_empty() {
+        if candidate_variants.is_empty() {
             return Err(ErrorDetails::UnknownVariant {
                 name: variant_name.to_string(),
             }
@@ -271,14 +271,9 @@ pub async fn inference(
         );
     } else {
         // Remove all zero-weight variants - these can only be used if explicitly pinned above
-        candidate_variant_names.retain(|name| {
-            if let Some(variant) = function.variants().get(*name) {
-                // Retain 'None' and positive-weight variants, discarding zero-weight variants
-                variant.inner.weight().is_none_or(|w| w > 0.0)
-            } else {
-                // Keep missing variants - later code will error if we try to use them
-                true
-            }
+        candidate_variants.retain(|_, variant| {
+            // Retain 'None' and positive-weight variants, discarding zero-weight variants
+            variant.inner.weight().is_none_or(|w| w > 0.0)
         });
     }
 
@@ -302,24 +297,11 @@ pub async fn inference(
     let stream = params.stream.unwrap_or(false);
 
     // Keep track of which variants failed
-    let mut variant_errors = std::collections::HashMap::new();
+    let mut variant_errors: HashMap<String, Error> = HashMap::new();
 
     // Set up inference config
     let output_schema = params.output_schema.map(DynamicJSONSchema::new);
-    let mut inference_config = InferenceConfig {
-        function_name: &function_name,
-        variant_name: None,
-        templates: &config.templates,
-        tool_config: tool_config.as_ref(),
-        dynamic_output_schema: output_schema.as_ref(),
-        ids: InferenceIds {
-            inference_id,
-            episode_id,
-        },
-        extra_cache_key: None,
-        extra_body: Default::default(),
-        extra_headers: Default::default(),
-    };
+
     let inference_clients = InferenceClients {
         http_client,
         clickhouse_connection_info: &clickhouse_connection_info,
@@ -339,19 +321,25 @@ pub async fn inference(
         })
         .await?;
     // Keep sampling variants until one succeeds
-    while !candidate_variant_names.is_empty() {
-        let (variant_name, variant) = sample_variant(
-            &mut candidate_variant_names,
-            function.variants(),
-            &function_name,
-            &episode_id,
-        )?;
+    while !candidate_variants.is_empty() {
+        let (variant_name, variant) =
+            sample_variant(&mut candidate_variants, &function_name, &episode_id)?;
         // Will be edited by the variant as part of making the request so we must clone here
         let variant_inference_params = params.params.clone();
-
-        inference_config.variant_name = Some(variant_name);
-        inference_config.extra_body = params.extra_body.clone();
-        inference_config.extra_headers = params.extra_headers.clone();
+        let inference_config = InferenceConfig {
+            function_name: &function_name,
+            variant_name: &variant_name,
+            templates: &config.templates,
+            tool_config: tool_config.as_ref(),
+            dynamic_output_schema: output_schema.as_ref(),
+            ids: InferenceIds {
+                inference_id,
+                episode_id,
+            },
+            extra_cache_key: None,
+            extra_body: Cow::Borrowed(&params.extra_body),
+            extra_headers: Cow::Borrowed(&params.extra_headers),
+        };
         if stream {
             let result = variant
                 .infer_stream(
@@ -372,20 +360,18 @@ pub async fn inference(
                     tracing::warn!(
                         "functions.{function_name:?}.variants.{variant_name:?} failed during inference: {e}",
                         function_name = params.function_name,
-                        variant_name = variant_name,
+                        variant_name = inference_config.variant_name,
                     );
-                    variant_errors.insert(variant_name.to_string(), e);
+                    variant_errors.insert(inference_config.variant_name.to_string(), e);
                     continue;
                 }
             };
-
-            let extra_body = inference_config.extra_body.clone();
-            let extra_headers = inference_config.extra_headers.clone();
-
+            let extra_body = inference_config.extra_body.into_owned();
+            let extra_headers = inference_config.extra_headers.into_owned();
             // Create InferenceMetadata for a streaming inference
             let inference_metadata = InferenceMetadata {
                 function_name: function_name.to_string(),
-                variant_name: variant_name.to_string(),
+                variant_name: inference_config.variant_name.to_string(),
                 inference_id,
                 episode_id,
                 input: resolved_input.clone(),
@@ -435,21 +421,21 @@ pub async fn inference(
                     tracing::warn!(
                         "functions.{function_name}.variants.{variant_name} failed during inference: {e}",
                         function_name = function_name,
-                        variant_name = variant_name,
+                        variant_name = inference_config.variant_name,
                     );
-                    variant_errors.insert(variant_name.to_string(), e);
+                    variant_errors.insert(inference_config.variant_name.to_string(), e);
                     continue;
                 }
             };
 
             if !dryrun {
                 // Spawn a thread for a trailing write to ClickHouse so that it doesn't block the response
-                let extra_body = inference_config.extra_body.clone();
-                let extra_headers = inference_config.extra_headers.clone();
                 let result_to_write = result.clone();
+                let extra_body = inference_config.extra_body.into_owned();
+                let extra_headers = inference_config.extra_headers.into_owned();
                 let write_metadata = InferenceDatabaseInsertMetadata {
                     function_name: function_name.to_string(),
-                    variant_name: variant_name.to_string(),
+                    variant_name: inference_config.variant_name.to_string(),
                     episode_id,
                     tool_config,
                     processing_time: Some(start_time.elapsed()),
@@ -487,7 +473,7 @@ pub async fn inference(
                 result.set_original_response(None);
             }
 
-            let response = InferenceResponse::new(result, episode_id, variant_name.to_string());
+            let response = InferenceResponse::new(result, episode_id, variant_name);
 
             return Ok(InferenceOutput::NonStreaming(response));
         }

--- a/tensorzero-core/src/error.rs
+++ b/tensorzero-core/src/error.rs
@@ -271,7 +271,7 @@ pub enum ErrorDetails {
         variant_name: String,
     },
     VariantTimeout {
-        variant_name: Option<String>,
+        variant_name: String,
         timeout: Duration,
         streaming: bool,
     },
@@ -752,11 +752,7 @@ impl std::fmt::Display for ErrorDetails {
                 timeout,
                 streaming,
             } => {
-                let variant_description = if let Some(variant_name) = variant_name {
-                    format!("Variant `{variant_name}`")
-                } else {
-                    "Unknown variant".to_string()
-                };
+                let variant_description = format!("Variant `{variant_name}`");
                 if *streaming {
                     write!(f, "{variant_description} timed out due to configured `streaming.ttft_ms` timeout ({timeout:?})")
                 } else {

--- a/tensorzero-core/src/function.rs
+++ b/tensorzero-core/src/function.rs
@@ -595,16 +595,20 @@ fn validate_single_message(
 }
 
 /// Sample a variant from the function based on variant weights (uniform random selection)
-pub fn sample_variant<'a>(
-    candidate_variant_names: &mut Vec<&'a str>,
-    variants: &'a HashMap<String, Arc<VariantInfo>>,
+/// This function pops the sampled variant from the candidate variants map.
+pub fn sample_variant(
+    candidate_variants: &mut HashMap<String, Arc<VariantInfo>>,
     function_name: &str,
     episode_id: &Uuid,
-) -> Result<(&'a str, &'a Arc<VariantInfo>), Error> {
+) -> Result<(String, Arc<VariantInfo>), Error> {
+    if candidate_variants.is_empty() {
+        return Err(Error::new(ErrorDetails::InvalidFunctionVariants {
+            message: format!("Function `{function_name}` has no variants"),
+        }));
+    }
     // Compute the total weight of variants present in variant_names
-    let total_weight = candidate_variant_names
-        .iter()
-        .filter_map(|name| variants.get(*name))
+    let total_weight = candidate_variants
+        .values()
         .map(|variant| variant.inner.weight().unwrap_or(0.0))
         .sum::<f64>();
 
@@ -613,71 +617,62 @@ pub fn sample_variant<'a>(
     //       but there's a chance we pin a weight-zero variant in the config.
     //       This check also ensures that we catch any regressions we might introduce in the future.
     if total_weight <= 0. {
-        if candidate_variant_names.is_empty() {
-            return Err(Error::new(ErrorDetails::InvalidFunctionVariants {
-                message: format!("Function `{function_name}` has no variants"),
-            }));
-        }
         // Perform uniform sampling if total weight is non-positive
         let random_index = (get_uniform_value(function_name, episode_id)
-            * candidate_variant_names.len() as f64)
+            * candidate_variants.len() as f64)
             .floor() as usize;
-        // Reorders this list (in place) by swapping the element at index with the last element.
-        // This should not matter and is more efficient than `remove`
-        let sampled_variant_name = if random_index < candidate_variant_names.len() {
-            // could panic if random_index is out of bounds
-            candidate_variant_names.swap_remove(random_index)
-        } else {
+        let Some(sampled_variant_name) = candidate_variants.keys().nth(random_index).cloned()
+        else {
             return Err(Error::new(ErrorDetails::InvalidFunctionVariants {
                 message: format!(
-                    "Invalid index {} for function `{}` with {} variants",
-                    random_index,
-                    function_name,
-                    candidate_variant_names.len()
+                    "Invalid index {random_index} for function `{function_name}` with {} variants. {IMPOSSIBLE_ERROR_MESSAGE}",
+                    candidate_variants.len()
                 ),
             }));
         };
-        let variant = variants.get(sampled_variant_name).ok_or_else(|| {
+        return candidate_variants.remove_entry(&sampled_variant_name).ok_or_else(|| {
             Error::new(ErrorDetails::InvalidFunctionVariants {
                 message: format!(
-                    "Function `{function_name}` has no variant `{sampled_variant_name}`"
-                ),
+                    "Function `{function_name}` has no variant for the sampled variant `{sampled_variant_name}`. {IMPOSSIBLE_ERROR_MESSAGE}"
+                )
             })
-        })?;
-        return Ok((sampled_variant_name, variant));
+        });
     }
 
     // Sample a random threshold between 0 and the total weight
     let random_threshold = get_uniform_value(function_name, episode_id) * total_weight;
 
     // Iterate over the variants to find the one that corresponds to the sampled threshold
-    let mut cumulative_weight = 0.;
-    let mut sampled_variant_name = "";
-    for (i, variant_name) in candidate_variant_names.iter().enumerate() {
-        let variant = variants.get(*variant_name).ok_or_else(|| {
-            Error::new(ErrorDetails::InvalidFunctionVariants {
-                message: format!("Function `{function_name}` has no variant `{variant_name}`"),
+    let variant_to_remove = {
+        let mut cumulative_weight = 0.0;
+        candidate_variants
+            .iter()
+            .find(|(_, variant)| {
+                cumulative_weight += variant.inner.weight().unwrap_or(0.0);
+                cumulative_weight > random_threshold
             })
-        })?;
-        cumulative_weight += variant.inner.weight().unwrap_or(0.0);
-        if cumulative_weight > random_threshold {
-            sampled_variant_name = candidate_variant_names.swap_remove(i);
-            break;
-        }
+            .map(|(name, _)| name.clone()) // Clone the key
+    };
+
+    if let Some(variant_name) = variant_to_remove {
+        return candidate_variants.remove_entry(&variant_name).ok_or_else(|| {
+            Error::new(ErrorDetails::InvalidFunctionVariants {
+                message: format!(
+                    "Function `{function_name}` has no variant for the sampled variant `{variant_name}`. {IMPOSSIBLE_ERROR_MESSAGE}"
+                )
+            })
+        });
     }
 
     // If we didn't find a variant (which should only happen due to rare numerical precision issues),
-    // use the last variant as a fallback
-    if sampled_variant_name.is_empty() {
-        sampled_variant_name = candidate_variant_names.swap_remove(variants.len() - 1);
-    }
-
-    let variant = variants.get(sampled_variant_name).ok_or_else(|| {
+    // pop an arbitrary variant as a fallback
+    return candidate_variants.drain().next().ok_or_else(|| {
         Error::new(ErrorDetails::InvalidFunctionVariants {
-            message: format!("Function `{function_name}` has no variant `{sampled_variant_name}`"),
+            message: format!(
+                "Function `{function_name}` has no variants. {IMPOSSIBLE_ERROR_MESSAGE}"
+            ),
         })
-    })?;
-    Ok((sampled_variant_name, variant))
+    });
 }
 
 /// Implements a uniform distribution over the interval [0, 1) using a hash function.
@@ -1577,14 +1572,9 @@ mod tests {
             let mut counts: HashMap<String, usize> = HashMap::new();
 
             for _ in 0..sample_size {
-                let mut variant_names = variants.keys().map(AsRef::as_ref).collect();
-                let (variant_name, _) = sample_variant(
-                    &mut variant_names,
-                    variants,
-                    "test_function",
-                    &Uuid::now_v7(),
-                )
-                .unwrap();
+                let mut variants = variants.clone();
+                let (variant_name, _) =
+                    sample_variant(&mut variants, "test_function", &Uuid::now_v7()).unwrap();
                 *counts.entry(variant_name.to_string()).or_insert(0) += 1;
             }
 
@@ -1623,14 +1613,9 @@ mod tests {
         let mut counts: HashMap<String, usize> = HashMap::new();
 
         for _ in 0..sample_size {
-            let mut variant_names = variants.keys().map(AsRef::as_ref).collect();
-            let (variant_name, _) = sample_variant(
-                &mut variant_names,
-                &variants,
-                "test_function",
-                &Uuid::now_v7(),
-            )
-            .unwrap();
+            let mut variants = variants.clone();
+            let (variant_name, _) =
+                sample_variant(&mut variants, "test_function", &Uuid::now_v7()).unwrap();
             *counts.entry(variant_name.to_string()).or_insert(0) += 1;
         }
 
@@ -1788,7 +1773,7 @@ mod tests {
             },
             tool_config: None,
             function_name: "",
-            variant_name: Some(""),
+            variant_name: "",
             templates: &templates,
             dynamic_output_schema: None,
             extra_body: Default::default(),
@@ -2099,7 +2084,7 @@ mod tests {
             },
             tool_config: None,
             function_name: "",
-            variant_name: Some(""),
+            variant_name: "",
             templates: &templates,
             dynamic_output_schema: Some(&dynamic_output_schema),
             extra_body: Default::default(),

--- a/tensorzero-core/src/inference/types/extra_body.rs
+++ b/tensorzero-core/src/inference/types/extra_body.rs
@@ -47,7 +47,7 @@ impl UnfilteredInferenceExtraBody {
     }
     /// Filter the 'InferenceExtraBody' options by variant name
     /// If the variant name is `None`, then all variant-specific extra body options are removed
-    pub fn filter(self, variant_name: Option<&str>) -> FilteredInferenceExtraBody {
+    pub fn filter(self, variant_name: &str) -> FilteredInferenceExtraBody {
         FilteredInferenceExtraBody {
             data: self
                 .extra_body
@@ -93,16 +93,12 @@ pub enum InferenceExtraBody {
 }
 
 impl InferenceExtraBody {
-    pub fn should_apply_variant(&self, variant_name: Option<&str>) -> bool {
-        match (self, variant_name) {
-            (InferenceExtraBody::Provider { .. }, _) => true,
-            (
-                InferenceExtraBody::Variant {
-                    variant_name: v, ..
-                },
-                Some(expected_name),
-            ) => v == expected_name,
-            (InferenceExtraBody::Variant { .. }, None) => false,
+    pub fn should_apply_variant(&self, variant_name: &str) -> bool {
+        match self {
+            InferenceExtraBody::Provider { .. } => true,
+            InferenceExtraBody::Variant {
+                variant_name: v, ..
+            } => v == variant_name,
         }
     }
 }

--- a/tensorzero-core/src/inference/types/extra_headers.rs
+++ b/tensorzero-core/src/inference/types/extra_headers.rs
@@ -47,7 +47,7 @@ impl UnfilteredInferenceExtraHeaders {
 
     /// Filter the 'InferenceExtraHeader' options by variant name
     /// If the variant name is `None`, then all variant-specific extra header options are removed
-    pub fn filter(self, variant_name: Option<&str>) -> FilteredInferenceExtraHeaders {
+    pub fn filter(self, variant_name: &str) -> FilteredInferenceExtraHeaders {
         FilteredInferenceExtraHeaders {
             data: self
                 .headers
@@ -90,16 +90,12 @@ pub enum InferenceExtraHeader {
 }
 
 impl InferenceExtraHeader {
-    pub fn should_apply_variant(&self, variant_name: Option<&str>) -> bool {
-        match (self, variant_name) {
-            (InferenceExtraHeader::Provider { .. }, _) => true,
-            (
-                InferenceExtraHeader::Variant {
-                    variant_name: v, ..
-                },
-                Some(expected_name),
-            ) => v == expected_name,
-            (InferenceExtraHeader::Variant { .. }, None) => false,
+    pub fn should_apply_variant(&self, variant_name: &str) -> bool {
+        match self {
+            InferenceExtraHeader::Provider { .. } => true,
+            InferenceExtraHeader::Variant {
+                variant_name: v, ..
+            } => v == variant_name,
         }
     }
 }

--- a/tensorzero-core/src/inference/types/mod.rs
+++ b/tensorzero-core/src/inference/types/mod.rs
@@ -1757,12 +1757,12 @@ pub async fn collect_chunks(args: CollectChunksArgs<'_, '_>) -> Result<Inference
             episode_id,
         },
         function_name,
-        variant_name: Some(variant_name),
+        variant_name,
         tool_config,
         templates,
         dynamic_output_schema: dynamic_output_schema.as_ref(),
-        extra_body,
-        extra_headers,
+        extra_body: Cow::Borrowed(&extra_body),
+        extra_headers: Cow::Borrowed(&extra_headers),
         extra_cache_key: None,
     };
     function

--- a/tensorzero-core/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-core/src/variant/best_of_n_sampling.rs
@@ -269,7 +269,7 @@ impl BestOfNSamplingConfig {
                 // However, the 'A, C' and 'C, D' evaluations will all have distinct cache keys:
                 // (A, 2), (C, 3), (C, 2), (D, 4)
                 let mut config = inference_config.clone();
-                config.variant_name = Some(candidate);
+                config.variant_name = candidate;
                 config.extra_cache_key = Some(format!("candidate_{i}"));
                 Ok((candidate.to_string(), variant, config))
             })
@@ -1303,7 +1303,7 @@ mod tests {
             tool_config: None,
             dynamic_output_schema: None,
             function_name: "",
-            variant_name: Some(""),
+            variant_name: "",
             extra_body: Default::default(),
             extra_headers: Default::default(),
             extra_cache_key: None,

--- a/tensorzero-core/src/variant/chat_completion.rs
+++ b/tensorzero-core/src/variant/chat_completion.rs
@@ -191,6 +191,7 @@ impl ChatCompletionConfig {
             inference_extra_body: inference_config
                 .extra_body
                 .clone()
+                .into_owned()
                 .filter(inference_config.variant_name),
         };
 
@@ -199,6 +200,7 @@ impl ChatCompletionConfig {
             inference_extra_headers: inference_config
                 .extra_headers
                 .clone()
+                .into_owned()
                 .filter(inference_config.variant_name),
         };
 
@@ -1161,7 +1163,7 @@ mod tests {
             templates: &templates,
             tool_config: None,
             function_name: "",
-            variant_name: Some(""),
+            variant_name: "",
             dynamic_output_schema: None,
             ids: InferenceIds {
                 inference_id: Uuid::now_v7(),
@@ -1216,7 +1218,7 @@ mod tests {
             templates: &templates,
             tool_config: None,
             function_name: "",
-            variant_name: Some(""),
+            variant_name: "",
             dynamic_output_schema: None,
             ids: InferenceIds {
                 inference_id: Uuid::now_v7(),
@@ -1268,7 +1270,7 @@ mod tests {
             templates: &templates,
             tool_config: None,
             function_name: "",
-            variant_name: Some(""),
+            variant_name: "",
             dynamic_output_schema: None,
             ids: InferenceIds {
                 inference_id: Uuid::now_v7(),
@@ -1352,7 +1354,7 @@ mod tests {
             templates: &templates,
             tool_config: None,
             function_name: "",
-            variant_name: Some(""),
+            variant_name: "",
             dynamic_output_schema: None,
             ids: InferenceIds {
                 inference_id: Uuid::now_v7(),
@@ -1431,7 +1433,7 @@ mod tests {
             templates: &templates,
             tool_config: Some(&weather_tool_config),
             function_name: "",
-            variant_name: Some(""),
+            variant_name: "",
             dynamic_output_schema: None,
             ids: InferenceIds {
                 inference_id: Uuid::now_v7(),
@@ -1520,7 +1522,7 @@ mod tests {
             templates: &templates,
             tool_config: None,
             function_name: "",
-            variant_name: Some(""),
+            variant_name: "",
             dynamic_output_schema: None,
             ids: InferenceIds {
                 inference_id: Uuid::now_v7(),
@@ -1586,7 +1588,7 @@ mod tests {
             templates: &templates,
             tool_config: None,
             function_name: "",
-            variant_name: Some(""),
+            variant_name: "",
             dynamic_output_schema: None,
             extra_body: Default::default(),
             extra_headers: Default::default(),
@@ -1699,7 +1701,7 @@ mod tests {
             templates: &templates,
             tool_config: None,
             function_name: "",
-            variant_name: Some(""),
+            variant_name: "",
             dynamic_output_schema: Some(&output_schema),
             extra_body: Default::default(),
             extra_headers: Default::default(),
@@ -1800,7 +1802,7 @@ mod tests {
             templates: &templates,
             tool_config: None,
             function_name: "",
-            variant_name: Some(""),
+            variant_name: "",
             dynamic_output_schema: Some(&output_schema),
             extra_body: Default::default(),
             extra_headers: Default::default(),
@@ -1986,7 +1988,7 @@ mod tests {
             tool_config: None,
             dynamic_output_schema: None,
             function_name: "",
-            variant_name: Some(""),
+            variant_name: "",
             extra_body: Default::default(),
             extra_headers: Default::default(),
             extra_cache_key: None,
@@ -2050,7 +2052,7 @@ mod tests {
             templates,
             tool_config: None,
             function_name: "",
-            variant_name: Some(""),
+            variant_name: "",
             dynamic_output_schema: None,
             extra_body: Default::default(),
             extra_headers: Default::default(),
@@ -2153,7 +2155,7 @@ mod tests {
             templates,
             tool_config: None,
             function_name: "",
-            variant_name: Some(""),
+            variant_name: "",
             dynamic_output_schema: None,
             extra_body: Default::default(),
             extra_headers: Default::default(),
@@ -2262,7 +2264,7 @@ mod tests {
             tool_config: None,
             dynamic_output_schema: None,
             function_name: "",
-            variant_name: Some(""),
+            variant_name: "",
             extra_body: Default::default(),
             extra_headers: Default::default(),
             extra_cache_key: None,
@@ -2338,7 +2340,7 @@ mod tests {
             tool_config: None,
             dynamic_output_schema: Some(&dynamic_output_schema),
             function_name: "",
-            variant_name: Some(""),
+            variant_name: "",
             ids: InferenceIds {
                 inference_id: Uuid::now_v7(),
                 episode_id: Uuid::now_v7(),

--- a/tensorzero-core/src/variant/dicl.rs
+++ b/tensorzero-core/src/variant/dicl.rs
@@ -107,11 +107,7 @@ impl Variant for DiclConfig {
                 models.embedding_models,
                 clients,
                 inference_config.function_name,
-                inference_config.variant_name.ok_or_else(|| {
-                    Error::new(ErrorDetails::InvalidDiclConfig {
-                        message: "missing variant_name".to_string(),
-                    })
-                })?,
+                inference_config.variant_name,
                 function,
             )
             .await?;
@@ -173,11 +169,7 @@ impl Variant for DiclConfig {
                 models.embedding_models,
                 clients,
                 inference_config.function_name,
-                inference_config.variant_name.ok_or_else(|| {
-                    Error::new(ErrorDetails::InvalidDiclConfig {
-                        message: "missing variant_name".to_string(),
-                    })
-                })?,
+                inference_config.variant_name,
                 function,
             )
             .await?;
@@ -533,6 +525,7 @@ impl DiclConfig {
             inference_extra_headers: inference_config
                 .extra_headers
                 .clone()
+                .into_owned()
                 .filter(inference_config.variant_name),
         };
         prepare_model_inference_request(

--- a/tensorzero-core/src/variant/mixture_of_n.rs
+++ b/tensorzero-core/src/variant/mixture_of_n.rs
@@ -400,7 +400,7 @@ impl MixtureOfNConfig {
                 // However, the 'A, C' and 'C, D' evaluations will all have distinct cache keys:
                 // (A, 2), (C, 3), (C, 2), (D, 4)
                 let mut config = inference_config.clone();
-                config.variant_name = Some(candidate);
+                config.variant_name = candidate;
                 config.extra_cache_key = Some(format!("candidate_{i}"));
                 Ok((candidate.to_string(), variant, config))
             })
@@ -818,6 +818,7 @@ impl FuserConfig {
             inference_extra_headers: inference_config
                 .extra_headers
                 .clone()
+                .into_owned()
                 .filter(inference_config.variant_name),
         };
         let model_inference_request = prepare_model_inference_request(
@@ -1342,7 +1343,7 @@ mod tests {
             tool_config: None,
             dynamic_output_schema: None,
             function_name: "",
-            variant_name: Some(""),
+            variant_name: "",
             extra_body: Default::default(),
             extra_headers: Default::default(),
             extra_cache_key: None,

--- a/tensorzero-core/src/variant/mod.rs
+++ b/tensorzero-core/src/variant/mod.rs
@@ -123,10 +123,10 @@ pub struct InferenceConfig<'a, 'request> {
     pub templates: &'request TemplateConfig<'a>,
     pub dynamic_output_schema: Option<&'request DynamicJSONSchema>,
     pub function_name: &'request str,
-    pub variant_name: Option<&'request str>,
+    pub variant_name: &'request str,
     pub ids: InferenceIds,
-    pub extra_body: UnfilteredInferenceExtraBody,
-    pub extra_headers: UnfilteredInferenceExtraHeaders,
+    pub extra_body: Cow<'request, UnfilteredInferenceExtraBody>,
+    pub extra_headers: Cow<'request, UnfilteredInferenceExtraHeaders>,
     /// Optional arbitrary data, only used when constructing the cache key.
     /// This is used by best_of_n/mixture_of_n to force different sub-variants
     /// to have different cache keys.
@@ -137,11 +137,11 @@ pub struct InferenceConfig<'a, 'request> {
 /// Maps to the subset of Config that applies to the current inference request.
 #[derive(Clone, Debug)]
 pub struct BatchInferenceConfig<'a> {
-    pub tool_configs: Vec<Option<ToolCallConfig>>,
+    pub tool_configs: &'a Vec<Option<ToolCallConfig>>,
     pub templates: &'a TemplateConfig<'a>,
-    pub dynamic_output_schemas: Vec<Option<DynamicJSONSchema>>,
+    pub dynamic_output_schemas: &'a Vec<Option<DynamicJSONSchema>>,
     pub function_name: &'a str,
-    pub variant_name: Option<&'a str>,
+    pub variant_name: &'a str,
 }
 impl<'a> BatchInferenceConfig<'a> {
     pub fn inference_configs(
@@ -248,7 +248,7 @@ impl VariantConfig {
 
 impl Variant for VariantInfo {
     #[instrument(
-        fields(function_name = %inference_config.function_name, variant_name = %inference_config.variant_name.unwrap_or(""), otel.name="variant_inference", stream=false),
+        fields(function_name = %inference_config.function_name, variant_name = %inference_config.variant_name, otel.name="variant_inference", stream=false),
         skip_all
     )]
     async fn infer<'a: 'request, 'request>(
@@ -333,7 +333,7 @@ impl Variant for VariantInfo {
                 // so that it can be handled by the `match response` block below
                 .unwrap_or_else(|_: Elapsed| {
                     Err(Error::new(ErrorDetails::VariantTimeout {
-                        variant_name: inference_config.variant_name.map(str::to_string),
+                        variant_name: inference_config.variant_name.to_string(),
                         timeout,
                         streaming: false,
                     }))
@@ -344,7 +344,7 @@ impl Variant for VariantInfo {
     }
 
     #[instrument(
-        fields(function_name = %inference_config.function_name, variant_name = %inference_config.variant_name.unwrap_or(""), otel.name="variant_inference", stream=true),
+        fields(function_name = %inference_config.function_name, variant_name = %inference_config.variant_name, otel.name="variant_inference", stream=true),
         skip_all
     )]
     async fn infer_stream<'request>(
@@ -429,7 +429,7 @@ impl Variant for VariantInfo {
                 .await
                 .unwrap_or_else(|_: Elapsed| {
                     Err(Error::new(ErrorDetails::VariantTimeout {
-                        variant_name: inference_config.variant_name.map(str::to_string),
+                        variant_name: inference_config.variant_name.to_string(),
                         timeout,
                         streaming: true,
                     }))
@@ -439,7 +439,7 @@ impl Variant for VariantInfo {
         }
     }
 
-    #[instrument(skip_all, fields(variant_name = %inference_configs.first().map(|x| x.variant_name.unwrap_or("")).unwrap_or("")))]
+    #[instrument(skip_all, fields(variant_name = %inference_configs.first().map(|x| x.variant_name).unwrap_or("")))]
     async fn start_batch_inference<'a>(
         &'a self,
         inputs: &[ResolvedInput],
@@ -762,10 +762,10 @@ impl RetryConfig {
 impl<'a> BatchInferenceConfig<'a> {
     pub fn new(
         templates: &'a TemplateConfig,
-        tool_configs: Vec<Option<ToolCallConfig>>,
-        dynamic_output_schemas: Vec<Option<DynamicJSONSchema>>,
+        tool_configs: &'a Vec<Option<ToolCallConfig>>,
+        dynamic_output_schemas: &'a Vec<Option<DynamicJSONSchema>>,
         function_name: &'a str,
-        variant_name: Option<&'a str>,
+        variant_name: &'a str,
     ) -> Self {
         Self {
             templates,
@@ -864,7 +864,7 @@ mod tests {
             templates: &templates,
             tool_config: Some(&tool_config),
             function_name: "test_function",
-            variant_name: Some("test_variant"),
+            variant_name: "test_variant",
             dynamic_output_schema: None,
             ids: InferenceIds {
                 inference_id: Uuid::now_v7(),
@@ -1006,7 +1006,7 @@ mod tests {
             templates: &templates,
             tool_config: Some(&tool_config),
             function_name: "test_function",
-            variant_name: Some("test_variant"),
+            variant_name: "test_variant",
             dynamic_output_schema: Some(&dynamic_output_schema),
             extra_body: Default::default(),
             extra_headers: Default::default(),
@@ -1097,7 +1097,7 @@ mod tests {
             templates: &templates,
             tool_config: None,
             function_name: "test_function",
-            variant_name: Some("test_variant"),
+            variant_name: "test_variant",
             dynamic_output_schema: None,
             ids: InferenceIds {
                 inference_id: Uuid::now_v7(),
@@ -1396,7 +1396,7 @@ mod tests {
             templates: &templates,
             tool_config: None,
             function_name: "test_function",
-            variant_name: Some("test_variant"),
+            variant_name: "test_variant",
             dynamic_output_schema: None,
             ids: InferenceIds {
                 inference_id: Uuid::now_v7(),


### PR DESCRIPTION
This is a pure refactor that makes an impossible state (no variant name in `InferenceConfig`) unrepresentable and simplifies the interface to our variant selection code (take just the variants dictionary rather than a list of names). 

No functionality or interface changes but this is in preparation for the dynamic variants feature.