### PR TITLE
Add pass-through for OpenAI cached_tokens usage value

### DIFF
--- a/evaluations/src/evaluators/exact_match.rs
+++ b/evaluations/src/evaluators/exact_match.rs
@@ -119,6 +119,7 @@ mod tests {
             usage: Usage {
                 input_tokens: 10,
                 output_tokens: 10,
+                provider_cached_input_tokens: None,
             },
             original_response: None,
             finish_reason: None,
@@ -137,6 +138,7 @@ mod tests {
             usage: Usage {
                 input_tokens: 10,
                 output_tokens: 10,
+                provider_cached_input_tokens: None,
             },
             original_response: None,
             finish_reason: None,
@@ -219,6 +221,7 @@ mod tests {
             usage: Usage {
                 input_tokens: 10,
                 output_tokens: 10,
+                provider_cached_input_tokens: None,
             },
             original_response: None,
             finish_reason: None,
@@ -238,6 +241,7 @@ mod tests {
             usage: Usage {
                 input_tokens: 10,
                 output_tokens: 10,
+                provider_cached_input_tokens: None,
             },
             original_response: None,
             finish_reason: None,

--- a/evaluations/tests/tests.rs
+++ b/evaluations/tests/tests.rs
@@ -1241,6 +1241,7 @@ async fn test_run_llm_judge_evaluator_chat() {
         usage: Usage {
             input_tokens: 0,
             output_tokens: 0,
+            provider_cached_input_tokens: None,
         },
         variant_name: "test_variant".to_string(),
     });
@@ -1409,6 +1410,7 @@ async fn test_run_llm_judge_evaluator_json() {
         usage: Usage {
             input_tokens: 0,
             output_tokens: 0,
+            provider_cached_input_tokens: None,
         },
         variant_name: "test_variant".to_string(),
     });

--- a/tensorzero-core/src/embeddings.rs
+++ b/tensorzero-core/src/embeddings.rs
@@ -210,6 +210,9 @@ impl EmbeddingResponse {
             usage: Usage {
                 input_tokens: cache_lookup.input_tokens,
                 output_tokens: cache_lookup.output_tokens,
+                // when cache hits, no tokens are consumed by the provider, so
+                // there is not provider cached input tokens either.
+                provider_cached_input_tokens: None,
             },
             latency: Latency::NonStreaming {
                 response_time: Duration::from_secs(0),

--- a/tensorzero-core/src/endpoints/batch_inference.rs
+++ b/tensorzero-core/src/endpoints/batch_inference.rs
@@ -1199,6 +1199,7 @@ impl TryFrom<ChatInferenceResponseDatabaseRead> for ChatInferenceResponse {
         let usage = Usage {
             input_tokens: value.input_tokens,
             output_tokens: value.output_tokens,
+            provider_cached_input_tokens: None,
         };
         let output: Vec<ContentBlockChatOutput> =
             serde_json::from_str(&value.output).map_err(|e| {
@@ -1237,6 +1238,7 @@ impl TryFrom<JsonInferenceResponseDatabaseRead> for JsonInferenceResponse {
         let usage = Usage {
             input_tokens: value.input_tokens,
             output_tokens: value.output_tokens,
+            provider_cached_input_tokens: None,
         };
         let output: JsonInferenceOutput = serde_json::from_str(&value.output).map_err(|e| {
             Error::new(ErrorDetails::Serialization {

--- a/tensorzero-core/src/endpoints/inference.rs
+++ b/tensorzero-core/src/endpoints/inference.rs
@@ -558,7 +558,7 @@ fn create_stream(
     async_stream::stream! {
         let mut buffer = vec![];
         let mut extra_usage = Some(metadata.previous_model_inference_results.iter().map(ModelInferenceResponseWithMetadata::usage_considering_cached).sum());
-        if extra_usage == Some(Usage { input_tokens: 0, output_tokens: 0 }) {
+        if extra_usage == Some(Usage { input_tokens: 0, output_tokens: 0, provider_cached_input_tokens: None }) {
             extra_usage = None;
         }
         let mut inference_ttft = None;
@@ -1018,6 +1018,7 @@ pub struct JsonInferenceResponseChunk {
 const ZERO_USAGE: Usage = Usage {
     input_tokens: 0,
     output_tokens: 0,
+    provider_cached_input_tokens: None,
 };
 
 impl InferenceResponseChunk {

--- a/tensorzero-core/src/function.rs
+++ b/tensorzero-core/src/function.rs
@@ -1747,6 +1747,7 @@ mod tests {
         let usage = Usage {
             input_tokens: 10,
             output_tokens: 10,
+            provider_cached_input_tokens: None,
         };
         let latency = Latency::NonStreaming {
             response_time: Duration::from_millis(100),
@@ -1813,6 +1814,7 @@ mod tests {
         let usage = Usage {
             input_tokens: 10,
             output_tokens: 10,
+            provider_cached_input_tokens: None,
         };
         let latency = Latency::NonStreaming {
             response_time: Duration::from_millis(100),
@@ -1866,6 +1868,7 @@ mod tests {
         let usage = Usage {
             input_tokens: 10,
             output_tokens: 10,
+            provider_cached_input_tokens: None,
         };
         let latency = Latency::NonStreaming {
             response_time: Duration::from_millis(100),
@@ -1922,6 +1925,7 @@ mod tests {
         let usage = Usage {
             input_tokens: 10,
             output_tokens: 10,
+            provider_cached_input_tokens: None,
         };
         let model_response = ModelInferenceResponseWithMetadata {
             id: Uuid::now_v7(),
@@ -1975,6 +1979,7 @@ mod tests {
         let usage = Usage {
             input_tokens: 10,
             output_tokens: 10,
+            provider_cached_input_tokens: None,
         };
         let model_response = ModelInferenceResponseWithMetadata {
             id: Uuid::now_v7(),
@@ -2028,6 +2033,7 @@ mod tests {
         let usage = Usage {
             input_tokens: 10,
             output_tokens: 0,
+            provider_cached_input_tokens: None,
         };
         let model_response = ModelInferenceResponseWithMetadata {
             id: Uuid::now_v7(),
@@ -2098,6 +2104,7 @@ mod tests {
         let usage = Usage {
             input_tokens: 10,
             output_tokens: 10,
+            provider_cached_input_tokens: None,
         };
         let latency = Latency::NonStreaming {
             response_time: Duration::from_millis(100),
@@ -2145,6 +2152,7 @@ mod tests {
         let usage = Usage {
             input_tokens: 10,
             output_tokens: 10,
+            provider_cached_input_tokens: None,
         };
         let latency = Latency::NonStreaming {
             response_time: Duration::from_millis(100),
@@ -2200,6 +2208,7 @@ mod tests {
         let usage = Usage {
             input_tokens: 10,
             output_tokens: 10,
+            provider_cached_input_tokens: None,
         };
         let model_response = ModelInferenceResponseWithMetadata {
             id: Uuid::now_v7(),
@@ -2252,6 +2261,7 @@ mod tests {
         let usage = Usage {
             input_tokens: 10,
             output_tokens: 10,
+            provider_cached_input_tokens: None,
         };
         let model_response = ModelInferenceResponseWithMetadata {
             id: Uuid::now_v7(),
@@ -2310,6 +2320,7 @@ mod tests {
         let usage = Usage {
             input_tokens: 10,
             output_tokens: 10,
+            provider_cached_input_tokens: None,
         };
         let latency = Latency::NonStreaming {
             response_time: Duration::from_millis(100),

--- a/tensorzero-core/src/providers/anthropic.rs
+++ b/tensorzero-core/src/providers/anthropic.rs
@@ -894,6 +894,7 @@ impl From<AnthropicUsage> for Usage {
         Usage {
             input_tokens: value.input_tokens,
             output_tokens: value.output_tokens,
+            provider_cached_input_tokens: None,
         }
     }
 }

--- a/tensorzero-core/src/providers/aws_bedrock.rs
+++ b/tensorzero-core/src/providers/aws_bedrock.rs
@@ -519,6 +519,9 @@ fn bedrock_to_tensorzero_stream_message(
                     let usage = Some(Usage {
                         input_tokens: usage.input_tokens as u32,
                         output_tokens: usage.output_tokens as u32,
+                        provider_cached_input_tokens: usage
+                            .cache_read_input_tokens
+                            .and_then(|i| i.try_into().ok()),
                     });
 
                     Ok(Some(ProviderInferenceResponseChunk::new(
@@ -848,6 +851,9 @@ impl TryFrom<ConverseOutputWithMetadata<'_>> for ProviderInferenceResponse {
             .map(|u| Usage {
                 input_tokens: u.input_tokens as u32,
                 output_tokens: u.output_tokens as u32,
+                provider_cached_input_tokens: u
+                    .cache_read_input_tokens
+                    .and_then(|i| i.try_into().ok()),
             })
             .ok_or_else(|| {
                 Error::new(ErrorDetails::InferenceServer {

--- a/tensorzero-core/src/providers/azure.rs
+++ b/tensorzero-core/src/providers/azure.rs
@@ -710,6 +710,8 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 20,
                 total_tokens: 30,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             },
         };
         let generic_request = ModelInferenceRequest {

--- a/tensorzero-core/src/providers/deepseek.rs
+++ b/tensorzero-core/src/providers/deepseek.rs
@@ -929,6 +929,8 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 20,
                 total_tokens: 30,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             },
         };
         let generic_request = ModelInferenceRequest {

--- a/tensorzero-core/src/providers/dummy.rs
+++ b/tensorzero-core/src/providers/dummy.rs
@@ -71,18 +71,22 @@ impl DummyProvider {
             "input_tokens_zero" => Usage {
                 input_tokens: 0,
                 output_tokens,
+                provider_cached_input_tokens: None,
             },
             "output_tokens_zero" => Usage {
                 input_tokens: 10,
                 output_tokens: 0,
+                provider_cached_input_tokens: None,
             },
             "input_tokens_output_tokens_zero" => Usage {
                 input_tokens: 0,
                 output_tokens: 0,
+                provider_cached_input_tokens: None,
             },
             _ => Usage {
                 input_tokens: 10,
                 output_tokens,
+                provider_cached_input_tokens: None,
             },
         }
     }
@@ -772,6 +776,7 @@ impl EmbeddingProvider for DummyProvider {
         let usage = Usage {
             input_tokens: 10,
             output_tokens: 1,
+            provider_cached_input_tokens: None,
         };
         let latency = Latency::NonStreaming {
             response_time: Duration::from_millis(100),

--- a/tensorzero-core/src/providers/fireworks/mod.rs
+++ b/tensorzero-core/src/providers/fireworks/mod.rs
@@ -834,6 +834,8 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 20,
                 total_tokens: 30,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             },
         };
 
@@ -1016,6 +1018,8 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 20,
                 total_tokens: 30,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             },
         };
         let generic_request = ModelInferenceRequest {
@@ -1149,6 +1153,8 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 20,
                 total_tokens: 30,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             }),
         };
         let message = fireworks_to_tensorzero_chunk(
@@ -1167,6 +1173,7 @@ mod tests {
             Some(Usage {
                 input_tokens: 10,
                 output_tokens: 20,
+                provider_cached_input_tokens: None,
             })
         );
     }

--- a/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
@@ -836,6 +836,7 @@ impl From<GCPVertexAnthropic> for Usage {
         Usage {
             input_tokens: value.input_tokens,
             output_tokens: value.output_tokens,
+            provider_cached_input_tokens: None,
         }
     }
 }

--- a/tensorzero-core/src/providers/gcp_vertex_gemini/mod.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_gemini/mod.rs
@@ -2385,6 +2385,7 @@ impl From<GCPVertexGeminiUsageMetadata> for Usage {
         Usage {
             input_tokens: usage_metadata.prompt_token_count.unwrap_or(0),
             output_tokens: usage_metadata.candidates_token_count.unwrap_or(0),
+            provider_cached_input_tokens: None,
         }
     }
 }
@@ -3068,6 +3069,7 @@ mod tests {
             Usage {
                 input_tokens: 0,
                 output_tokens: 0,
+                provider_cached_input_tokens: None,
             }
         );
         assert_eq!(model_inference_response.latency, latency);
@@ -3179,6 +3181,7 @@ mod tests {
             Usage {
                 input_tokens: 15,
                 output_tokens: 20,
+                provider_cached_input_tokens: None,
             }
         );
         assert_eq!(model_inference_response.latency, latency);
@@ -3302,6 +3305,7 @@ mod tests {
             Usage {
                 input_tokens: 25,
                 output_tokens: 40,
+                provider_cached_input_tokens: None,
             }
         );
         assert_eq!(model_inference_response.latency, latency);

--- a/tensorzero-core/src/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-core/src/providers/google_ai_studio_gemini.rs
@@ -1111,6 +1111,7 @@ impl From<GeminiUsageMetadata> for Usage {
         Usage {
             input_tokens: usage_metadata.prompt_token_count,
             output_tokens: usage_metadata.candidates_token_count.unwrap_or(0),
+            provider_cached_input_tokens: None,
         }
     }
 }
@@ -1794,6 +1795,7 @@ mod tests {
             Usage {
                 input_tokens: 10,
                 output_tokens: 10,
+                provider_cached_input_tokens: None,
             }
         );
         assert_eq!(model_inference_response.latency, latency);
@@ -1905,6 +1907,7 @@ mod tests {
             Usage {
                 input_tokens: 15,
                 output_tokens: 20,
+                provider_cached_input_tokens: None,
             }
         );
         assert_eq!(model_inference_response.latency, latency);
@@ -2027,6 +2030,7 @@ mod tests {
             Usage {
                 input_tokens: 25,
                 output_tokens: 40,
+                provider_cached_input_tokens: None,
             }
         );
         assert_eq!(model_inference_response.latency, latency);

--- a/tensorzero-core/src/providers/groq.rs
+++ b/tensorzero-core/src/providers/groq.rs
@@ -977,6 +977,7 @@ impl From<GroqUsage> for Usage {
         Usage {
             input_tokens: usage.prompt_tokens,
             output_tokens: usage.completion_tokens,
+            provider_cached_input_tokens: None,
         }
     }
 }
@@ -2153,6 +2154,7 @@ mod tests {
             Some(Usage {
                 input_tokens: 10,
                 output_tokens: 20,
+                provider_cached_input_tokens: None,
             })
         );
     }

--- a/tensorzero-core/src/providers/hyperbolic.rs
+++ b/tensorzero-core/src/providers/hyperbolic.rs
@@ -523,6 +523,8 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 20,
                 total_tokens: 30,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             },
         };
         let generic_request = ModelInferenceRequest {

--- a/tensorzero-core/src/providers/mistral.rs
+++ b/tensorzero-core/src/providers/mistral.rs
@@ -529,6 +529,7 @@ impl From<MistralUsage> for Usage {
         Usage {
             input_tokens: usage.prompt_tokens,
             output_tokens: usage.completion_tokens,
+            provider_cached_input_tokens: None,
         }
     }
 }

--- a/tensorzero-core/src/providers/openai/mod.rs
+++ b/tensorzero-core/src/providers/openai/mod.rs
@@ -1765,12 +1765,28 @@ impl<'a> OpenAIBatchRequest<'a> {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub(super) struct OpenAIUsagePromptTokensDetails {
+    pub cached_tokens: u32,
+    pub audio_tokens: u32,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub(super) struct OpenAIUsageCompletionTokensDetails {
+    pub reasoning_tokens: u32,
+    pub audio_tokens: u32,
+    pub accepted_prediction_tokens: u32,
+    pub rejected_prediction_tokens: u32,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub(super) struct OpenAIUsage {
     pub prompt_tokens: u32,
     #[serde(default)]
     pub completion_tokens: u32,
     pub total_tokens: u32,
+    pub prompt_tokens_details: Option<OpenAIUsagePromptTokensDetails>,
+    pub completion_tokens_details: Option<OpenAIUsageCompletionTokensDetails>,
 }
 
 impl From<OpenAIUsage> for Usage {
@@ -1778,6 +1794,9 @@ impl From<OpenAIUsage> for Usage {
         Usage {
             input_tokens: usage.prompt_tokens,
             output_tokens: usage.completion_tokens,
+            provider_cached_input_tokens: usage
+                .prompt_tokens_details
+                .map(|details| details.cached_tokens),
         }
     }
 }
@@ -2718,6 +2737,8 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 20,
                 total_tokens: 30,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             },
         };
         let generic_request = ModelInferenceRequest {
@@ -2816,6 +2837,8 @@ mod tests {
                 prompt_tokens: 15,
                 completion_tokens: 25,
                 total_tokens: 40,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             },
         };
         let generic_request = ModelInferenceRequest {
@@ -2906,6 +2929,8 @@ mod tests {
                 prompt_tokens: 5,
                 completion_tokens: 0,
                 total_tokens: 5,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             },
         };
         let request_body = OpenAIRequest {
@@ -2963,6 +2988,8 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 10,
                 total_tokens: 20,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             },
         };
 
@@ -3285,6 +3312,8 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 20,
                 total_tokens: 30,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             }),
         };
         let message = openai_to_tensorzero_chunk(
@@ -3300,6 +3329,7 @@ mod tests {
             Some(Usage {
                 input_tokens: 10,
                 output_tokens: 20,
+                provider_cached_input_tokens: None,
             })
         );
     }

--- a/tensorzero-core/src/providers/openrouter.rs
+++ b/tensorzero-core/src/providers/openrouter.rs
@@ -1057,6 +1057,7 @@ impl From<OpenRouterUsage> for Usage {
     fn from(usage: OpenRouterUsage) -> Self {
         Usage {
             input_tokens: usage.prompt_tokens,
+            provider_cached_input_tokens: None,
             output_tokens: usage.completion_tokens,
         }
     }
@@ -2347,6 +2348,7 @@ mod tests {
             Some(Usage {
                 input_tokens: 10,
                 output_tokens: 20,
+                provider_cached_input_tokens: None,
             })
         );
     }

--- a/tensorzero-core/src/providers/sglang.rs
+++ b/tensorzero-core/src/providers/sglang.rs
@@ -826,6 +826,8 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 20,
                 total_tokens: 30,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             },
         };
         let generic_request = ModelInferenceRequest {

--- a/tensorzero-core/src/providers/tgi.rs
+++ b/tensorzero-core/src/providers/tgi.rs
@@ -592,6 +592,7 @@ impl From<TGIUsage> for Usage {
     fn from(usage: TGIUsage) -> Self {
         Usage {
             input_tokens: usage.prompt_tokens,
+            provider_cached_input_tokens: None,
             output_tokens: usage.completion_tokens,
         }
     }

--- a/tensorzero-core/src/providers/together.rs
+++ b/tensorzero-core/src/providers/together.rs
@@ -871,6 +871,8 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 20,
                 total_tokens: 30,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             },
         };
         let generic_request = ModelInferenceRequest {
@@ -939,6 +941,8 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 20,
                 total_tokens: 30,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             },
         };
         let together_response_with_metadata = TogetherResponseWithMetadata {
@@ -985,6 +989,8 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 20,
                 total_tokens: 30,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             },
         };
         let together_response_with_metadata = TogetherResponseWithMetadata {
@@ -1037,6 +1043,8 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 20,
                 total_tokens: 30,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             },
         };
 
@@ -1406,6 +1414,8 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 20,
                 total_tokens: 30,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             }),
         };
         let message = together_to_tensorzero_chunk(
@@ -1423,6 +1433,7 @@ mod tests {
             Some(Usage {
                 input_tokens: 10,
                 output_tokens: 20,
+                provider_cached_input_tokens: None,
             })
         );
 

--- a/tensorzero-core/src/providers/vllm.rs
+++ b/tensorzero-core/src/providers/vllm.rs
@@ -605,6 +605,8 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 20,
                 total_tokens: 30,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             },
         };
         let generic_request = ModelInferenceRequest {

--- a/tensorzero-core/src/providers/xai.rs
+++ b/tensorzero-core/src/providers/xai.rs
@@ -651,6 +651,8 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 20,
                 total_tokens: 30,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
             },
         };
         let generic_request = ModelInferenceRequest {

--- a/tensorzero-core/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-core/src/variant/best_of_n_sampling.rs
@@ -972,6 +972,7 @@ mod tests {
             usage: Usage {
                 input_tokens: 50,
                 output_tokens: 100,
+                provider_cached_input_tokens: None,
             },
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(500),
@@ -1008,6 +1009,7 @@ mod tests {
             usage: Usage {
                 input_tokens: 15,
                 output_tokens: 25,
+                provider_cached_input_tokens: None,
             },
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(550),
@@ -1072,6 +1074,7 @@ mod tests {
             usage: Usage {
                 input_tokens: 50,
                 output_tokens: 100,
+                provider_cached_input_tokens: None,
             },
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(500),
@@ -1110,6 +1113,7 @@ mod tests {
             usage: Usage {
                 input_tokens: 15,
                 output_tokens: 25,
+                provider_cached_input_tokens: None,
             },
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(550),
@@ -1181,6 +1185,7 @@ mod tests {
             usage: Usage {
                 input_tokens: 50,
                 output_tokens: 100,
+                provider_cached_input_tokens: None,
             },
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(500),
@@ -1217,6 +1222,7 @@ mod tests {
             usage: Usage {
                 input_tokens: 15,
                 output_tokens: 25,
+                provider_cached_input_tokens: None,
             },
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(550),
@@ -1327,6 +1333,7 @@ mod tests {
         let expected_usage = Usage {
             input_tokens: 75,
             output_tokens: 126,
+            provider_cached_input_tokens: None,
         };
         let expected_content = vec!["Candidate answer 1".to_string().into()];
         assert_eq!(selected.usage_considering_cached(), expected_usage);

--- a/tensorzero-core/src/variant/chat_completion.rs
+++ b/tensorzero-core/src/variant/chat_completion.rs
@@ -1381,6 +1381,7 @@ mod tests {
             Usage {
                 input_tokens: 10,
                 output_tokens: 1,
+                provider_cached_input_tokens: None,
             }
         );
         match result {
@@ -1460,6 +1461,7 @@ mod tests {
             Usage {
                 input_tokens: 10,
                 output_tokens: 1,
+                provider_cached_input_tokens: None,
             }
         );
         match result {
@@ -1549,6 +1551,7 @@ mod tests {
             Usage {
                 input_tokens: 10,
                 output_tokens: 1,
+                provider_cached_input_tokens: None,
             }
         );
         match result {
@@ -1624,6 +1627,7 @@ mod tests {
             Usage {
                 input_tokens: 10,
                 output_tokens: 1,
+                provider_cached_input_tokens: None,
             }
         );
         match result {
@@ -1736,6 +1740,7 @@ mod tests {
             Usage {
                 input_tokens: 10,
                 output_tokens: 1,
+                provider_cached_input_tokens: None,
             }
         );
         match result {
@@ -1843,6 +1848,7 @@ mod tests {
             Usage {
                 input_tokens: 10,
                 output_tokens: 1,
+                provider_cached_input_tokens: None,
             }
         );
         match result {
@@ -2094,7 +2100,8 @@ mod tests {
                     chunk.usage(),
                     Some(&Usage {
                         input_tokens: 10,
-                        output_tokens: 16
+                        output_tokens: 16,
+                        provider_cached_input_tokens: None,
                     })
                 );
                 break;

--- a/tensorzero-core/src/variant/mixture_of_n.rs
+++ b/tensorzero-core/src/variant/mixture_of_n.rs
@@ -1035,6 +1035,7 @@ mod tests {
             usage: Usage {
                 input_tokens: 50,
                 output_tokens: 100,
+                provider_cached_input_tokens: None,
             },
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(500),
@@ -1068,6 +1069,7 @@ mod tests {
             usage: Usage {
                 input_tokens: 15,
                 output_tokens: 25,
+                provider_cached_input_tokens: None,
             },
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(550),
@@ -1129,6 +1131,7 @@ mod tests {
             usage: Usage {
                 input_tokens: 10,
                 output_tokens: 20,
+                provider_cached_input_tokens: None,
             },
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(500),
@@ -1164,6 +1167,7 @@ mod tests {
             usage: Usage {
                 input_tokens: 15,
                 output_tokens: 25,
+                provider_cached_input_tokens: None,
             },
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(550),
@@ -1241,6 +1245,7 @@ mod tests {
             usage: Usage {
                 input_tokens: 10,
                 output_tokens: 20,
+                provider_cached_input_tokens: None,
             },
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(500),
@@ -1274,6 +1279,7 @@ mod tests {
             usage: Usage {
                 input_tokens: 15,
                 output_tokens: 25,
+                provider_cached_input_tokens: None,
             },
             latency: Latency::NonStreaming {
                 response_time: Duration::from_millis(550),
@@ -1368,6 +1374,7 @@ mod tests {
         let expected_usage = Usage {
             input_tokens: 35,
             output_tokens: 46,
+            provider_cached_input_tokens: None,
         };
         let expected_content = InternalJsonInferenceOutput {
             raw: Some("{\"answer\":\"Hello\"}".to_string()),
@@ -1612,6 +1619,7 @@ mod tests {
             Some(Usage {
                 input_tokens: 10,
                 output_tokens: 20,
+                provider_cached_input_tokens: None,
             }),
         )
         .unwrap();
@@ -1656,6 +1664,7 @@ mod tests {
                 usage: Some(Usage {
                     input_tokens: 10,
                     output_tokens: 20,
+                    provider_cached_input_tokens: None,
                 }),
                 latency: Duration::from_secs(0),
                 raw_response: "My raw response".to_string(),

--- a/tensorzero-core/src/variant/mod.rs
+++ b/tensorzero-core/src/variant/mod.rs
@@ -1191,6 +1191,7 @@ mod tests {
             Usage {
                 input_tokens: 10,
                 output_tokens: 1,
+                provider_cached_input_tokens: None,
             }
         );
         match inference_result {
@@ -1306,6 +1307,7 @@ mod tests {
             Usage {
                 input_tokens: 10,
                 output_tokens: 1,
+                provider_cached_input_tokens: None,
             }
         );
         match inference_result {
@@ -1509,6 +1511,7 @@ mod tests {
             Usage {
                 input_tokens: 10,
                 output_tokens: 1,
+                provider_cached_input_tokens: None,
             }
         );
         match inference_result {

--- a/tensorzero-core/tests/e2e/batch/mod.rs
+++ b/tensorzero-core/tests/e2e/batch/mod.rs
@@ -342,6 +342,7 @@ async fn test_write_read_completed_batch_inference_chat() {
         usage: Usage {
             input_tokens: 10,
             output_tokens: 20,
+            provider_cached_input_tokens: None,
         },
         finish_reason: Some(FinishReason::Stop),
     };
@@ -353,6 +354,7 @@ async fn test_write_read_completed_batch_inference_chat() {
         usage: Usage {
             input_tokens: 20,
             output_tokens: 30,
+            provider_cached_input_tokens: None,
         },
         finish_reason: Some(FinishReason::ToolCall),
     };
@@ -544,6 +546,7 @@ async fn test_write_read_completed_batch_inference_json() {
         usage: Usage {
             input_tokens: 10,
             output_tokens: 20,
+            provider_cached_input_tokens: None,
         },
         finish_reason: Some(FinishReason::Stop),
     };
@@ -555,6 +558,7 @@ async fn test_write_read_completed_batch_inference_json() {
         usage: Usage {
             input_tokens: 20,
             output_tokens: 30,
+            provider_cached_input_tokens: None,
         },
         finish_reason: Some(FinishReason::ToolCall),
     };

--- a/tensorzero-core/tests/e2e/cache.rs
+++ b/tensorzero-core/tests/e2e/cache.rs
@@ -98,6 +98,7 @@ async fn test_cache_write_and_read() {
         &Usage {
             input_tokens: 10,
             output_tokens: 16,
+            provider_cached_input_tokens: None,
         },
         Some(&FinishReason::Stop),
     )
@@ -127,6 +128,7 @@ async fn test_cache_write_and_read() {
         Usage {
             input_tokens: 10,
             output_tokens: 16,
+            provider_cached_input_tokens: None
         }
     );
     assert_eq!(*result.model_provider_name, *"test_provider");
@@ -142,7 +144,8 @@ async fn test_cache_write_and_read() {
         result.usage,
         Usage {
             input_tokens: 10,
-            output_tokens: 16
+            output_tokens: 16,
+            provider_cached_input_tokens: None
         }
     );
     assert_eq!(
@@ -218,6 +221,7 @@ async fn test_cache_stream_write_and_read() {
             usage: Some(Usage {
                 input_tokens: 20,
                 output_tokens: 40,
+                provider_cached_input_tokens: None,
             }),
             raw_response: "raw response".to_string(),
             latency: Duration::from_secs(999),
@@ -232,6 +236,7 @@ async fn test_cache_stream_write_and_read() {
             usage: Some(Usage {
                 input_tokens: 100,
                 output_tokens: 200,
+                provider_cached_input_tokens: None,
             }),
             raw_response: "raw response 2".to_string(),
             latency: Duration::from_secs(999),
@@ -248,6 +253,7 @@ async fn test_cache_stream_write_and_read() {
         &Usage {
             input_tokens: 1,
             output_tokens: 2,
+            provider_cached_input_tokens: None,
         },
     )
     .unwrap();
@@ -283,6 +289,7 @@ async fn test_cache_stream_write_and_read() {
                 &Some(Usage {
                     input_tokens: 20,
                     output_tokens: 40,
+                    provider_cached_input_tokens: None,
                 })
             )
         } else {
@@ -291,6 +298,7 @@ async fn test_cache_stream_write_and_read() {
                 &Some(Usage {
                     input_tokens: 100,
                     output_tokens: 200,
+                    provider_cached_input_tokens: None,
                 })
             )
         };

--- a/tensorzero-core/tests/e2e/mixture_of_n.rs
+++ b/tensorzero-core/tests/e2e/mixture_of_n.rs
@@ -86,6 +86,7 @@ async fn e2e_test_mixture_of_n_dummy_candidates_dummy_judge_inner(
             Usage {
                 input_tokens,
                 output_tokens,
+                provider_cached_input_tokens: None,
             },
         )
     } else {
@@ -105,6 +106,7 @@ async fn e2e_test_mixture_of_n_dummy_candidates_dummy_judge_inner(
             Usage {
                 input_tokens,
                 output_tokens,
+                provider_cached_input_tokens: None,
             },
         )
     };
@@ -152,6 +154,7 @@ async fn e2e_test_mixture_of_n_dummy_candidates_dummy_judge_inner(
     let mut usage_sum = Usage {
         input_tokens: 0,
         output_tokens: 0,
+        provider_cached_input_tokens: None,
     };
 
     for result in results {
@@ -208,6 +211,7 @@ async fn e2e_test_mixture_of_n_dummy_candidates_dummy_judge_inner(
             Usage {
                 input_tokens: 40,
                 output_tokens: 8,
+                provider_cached_input_tokens: None,
             }
         );
     } else {
@@ -217,6 +221,7 @@ async fn e2e_test_mixture_of_n_dummy_candidates_dummy_judge_inner(
             Usage {
                 input_tokens: 40,
                 output_tokens: 4,
+                provider_cached_input_tokens: None,
             }
         );
     }
@@ -229,6 +234,7 @@ async fn e2e_test_mixture_of_n_dummy_candidates_dummy_judge_inner(
             Usage {
                 input_tokens: 0,
                 output_tokens: 0,
+                provider_cached_input_tokens: None,
             }
         );
     } else {


### PR DESCRIPTION
This PR adds an optional `provider_cached_input_tokens` field to the Usage struct to track tokens cached by the provider. Update all relevant code paths, including inference, endpoints, providers, and tests, to initialize and propagate this new field. This change ensures that usage accounting can include provider cached input tokens where applicable, while defaulting to None when not used. The new field is not stored in ClickHouse in this PR, to be decided if so in a later PR.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `provider_cached_input_tokens` to `Usage` struct for tracking provider cached tokens, updating relevant code paths and tests.
> 
>   - **Behavior**:
>     - Adds `provider_cached_input_tokens` to `Usage` struct to track provider cached tokens.
>     - Defaults to `None` when not used; not stored in ClickHouse.
>   - **Code Changes**:
>     - Updates `Usage` initialization in `exact_match.rs`, `embeddings.rs`, `batch_inference.rs`, `inference.rs`, `openai_compatible.rs`, `function.rs`, `mod.rs`, and `model.rs`.
>     - Modifies `OpenAICompatibleUsage` and `OpenAIUsage` to include `provider_cached_input_tokens`.
>     - Adjusts `consolidate_usage()` in `model.rs` to sum `provider_cached_input_tokens`.
>   - **Tests**:
>     - Updates tests in `tests.rs`, `batch/mod.rs`, `cache.rs`, and `mixture_of_n.rs` to include `provider_cached_input_tokens` in `Usage`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6d1619a6b7aeb1b1ba5f6791516aee350e9898c1. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->