### PR TITLE
Convert more config methods to `async` and remove `block_on`

### DIFF
--- a/tensorzero-core/src/config_parser/mod.rs
+++ b/tensorzero-core/src/config_parser/mod.rs
@@ -475,25 +475,29 @@ impl Config {
             })
             .collect::<Result<HashMap<String, Arc<StaticToolConfig>>, Error>>()?;
 
-        let models = uninitialized_config
-            .models
-            .into_iter()
-            .map(|(name, config)| {
+        let models = try_join_all(uninitialized_config.models.into_iter().map(
+            |(name, config)| async {
                 config
                     .load(&name, &uninitialized_config.provider_types)
+                    .await
                     .map(|c| (name, c))
-            })
-            .collect::<Result<HashMap<_, _>, _>>()?;
+            },
+        ))
+        .await?
+        .into_iter()
+        .collect::<HashMap<_, _>>();
 
-        let embedding_models = uninitialized_config
-            .embedding_models
-            .into_iter()
-            .map(|(name, config)| {
+        let embedding_models = try_join_all(uninitialized_config.embedding_models.into_iter().map(
+            |(name, config)| async {
                 config
                     .load(&uninitialized_config.provider_types)
+                    .await
                     .map(|c| (name, c))
-            })
-            .collect::<Result<HashMap<_, _>, _>>()?;
+            },
+        ))
+        .await?
+        .into_iter()
+        .collect::<HashMap<_, _>>();
 
         let object_store_info = ObjectStoreInfo::new(uninitialized_config.object_storage)?;
         let optimizers = try_join_all(

--- a/tensorzero-core/src/model.rs
+++ b/tensorzero-core/src/model.rs
@@ -1,3 +1,4 @@
+use futures::future::try_join_all;
 use futures::StreamExt;
 use reqwest::Client;
 use secrecy::SecretString;
@@ -81,7 +82,7 @@ pub struct UninitializedModelConfig {
 }
 
 impl UninitializedModelConfig {
-    pub fn load(
+    pub async fn load(
         self,
         model_name: &str,
         provider_types: &ProviderTypesConfig,
@@ -89,15 +90,13 @@ impl UninitializedModelConfig {
         // We want `ModelProvider` to know its own name (from the 'providers' config section).
         // We first deserialize to `HashMap<Arc<str>, UninitializedModelProvider>`, and then
         // build `ModelProvider`s using the name keys from the map.
-        let providers = self
-            .providers
-            .into_iter()
-            .map(|(name, provider)| {
-                Ok((
+        let providers = try_join_all(self.providers.into_iter().map(
+            |(name, provider)| async move {
+                Ok::<_, Error>((
                     name.clone(),
                     ModelProvider {
                         name: name.clone(),
-                        config: provider.config.load(provider_types).map_err(|e| {
+                        config: provider.config.load(provider_types).await.map_err(|e| {
                             Error::new(ErrorDetails::Config {
                                 message: format!("models.{model_name}.providers.{name}: {e}"),
                             })
@@ -108,8 +107,11 @@ impl UninitializedModelConfig {
                         discard_unknown_chunks: provider.discard_unknown_chunks,
                     },
                 ))
-            })
-            .collect::<Result<HashMap<_, _>, Error>>()?;
+            },
+        ))
+        .await?
+        .into_iter()
+        .collect::<HashMap<_, _>>();
         Ok(ModelConfig {
             routing: self.routing,
             providers,
@@ -994,7 +996,7 @@ pub enum UninitializedProviderConfig {
 }
 
 impl UninitializedProviderConfig {
-    pub fn load(self, provider_types: &ProviderTypesConfig) -> Result<ProviderConfig, Error> {
+    pub async fn load(self, provider_types: &ProviderTypesConfig) -> Result<ProviderConfig, Error> {
         Ok(match self {
             UninitializedProviderConfig::Anthropic {
                 model_name,
@@ -1010,14 +1012,7 @@ impl UninitializedProviderConfig {
                     return Err(Error::new(ErrorDetails::Config { message: "AWS bedrock provider requires a region to be provided, or `allow_auto_detect_region = true`.".to_string() }));
                 }
 
-                // NB: We need to make an async call here to initialize the AWS Bedrock client.
-
-                let provider = tokio::task::block_in_place(move || {
-                    tokio::runtime::Handle::current()
-                        .block_on(async { AWSBedrockProvider::new(model_id, region).await })
-                })?;
-
-                ProviderConfig::AWSBedrock(provider)
+                ProviderConfig::AWSBedrock(AWSBedrockProvider::new(model_id, region).await?)
             }
             UninitializedProviderConfig::AWSSagemaker {
                 endpoint_name,
@@ -1045,15 +1040,10 @@ impl UninitializedProviderConfig {
                             Some(CredentialLocation::None),
                         )?),
                     };
-                // NB: We need to make an async call here to initialize the AWS Sagemaker client.
 
-                let provider = tokio::task::block_in_place(move || {
-                    tokio::runtime::Handle::current().block_on(async {
-                        AWSSagemakerProvider::new(endpoint_name, self_hosted, region).await
-                    })
-                })?;
-
-                ProviderConfig::AWSSagemaker(provider)
+                ProviderConfig::AWSSagemaker(
+                    AWSSagemakerProvider::new(endpoint_name, self_hosted, region).await?,
+                )
             }
             UninitializedProviderConfig::Azure {
                 deployment_id,
@@ -1078,36 +1068,27 @@ impl UninitializedProviderConfig {
                 location,
                 project_id,
                 credential_location: api_key_location,
-            } => ProviderConfig::GCPVertexAnthropic(tokio::task::block_in_place(move || {
-                tokio::runtime::Handle::current().block_on(async {
-                    GCPVertexAnthropicProvider::new(
-                        model_id,
-                        location,
-                        project_id,
-                        api_key_location,
-                    )
-                    .await
-                })
-            })?),
+            } => ProviderConfig::GCPVertexAnthropic(
+                GCPVertexAnthropicProvider::new(model_id, location, project_id, api_key_location)
+                    .await?,
+            ),
             UninitializedProviderConfig::GCPVertexGemini {
                 model_id,
                 endpoint_id,
                 location,
                 project_id,
                 credential_location: api_key_location,
-            } => ProviderConfig::GCPVertexGemini(tokio::task::block_in_place(move || {
-                tokio::runtime::Handle::current().block_on(async {
-                    GCPVertexGeminiProvider::new(
-                        model_id,
-                        endpoint_id,
-                        location,
-                        project_id,
-                        api_key_location,
-                        provider_types,
-                    )
-                    .await
-                })
-            })?),
+            } => ProviderConfig::GCPVertexGemini(
+                GCPVertexGeminiProvider::new(
+                    model_id,
+                    endpoint_id,
+                    location,
+                    project_id,
+                    api_key_location,
+                    provider_types,
+                )
+                .await?,
+            ),
             UninitializedProviderConfig::GoogleAIStudioGemini {
                 model_name,
                 api_key_location,

--- a/tensorzero-core/tests/e2e/dicl.rs
+++ b/tensorzero-core/tests/e2e/dicl.rs
@@ -362,6 +362,7 @@ async fn embed_insert_example(
         toml::from_str::<UninitializedEmbeddingProviderConfig>(provider_config_serialized)
             .expect("Failed to deserialize EmbeddingProviderConfig")
             .load(&ProviderTypesConfig::default())
+            .await
             .unwrap();
 
     let client = Client::new();

--- a/tensorzero-core/tests/e2e/providers/openai.rs
+++ b/tensorzero-core/tests/e2e/providers/openai.rs
@@ -1087,6 +1087,7 @@ async fn test_embedding_request() {
         toml::from_str::<UninitializedEmbeddingProviderConfig>(provider_config_serialized)
             .expect("Failed to deserialize EmbeddingProviderConfig")
             .load(&ProviderTypesConfig::default())
+            .await
             .unwrap();
     assert!(matches!(
         provider_config,
@@ -1203,6 +1204,7 @@ async fn test_embedding_sanity_check() {
         toml::from_str::<UninitializedEmbeddingProviderConfig>(provider_config_serialized)
             .expect("Failed to deserialize EmbeddingProviderConfig")
             .load(&ProviderTypesConfig::default())
+            .await
             .unwrap();
     let client = Client::new();
     let embedding_request_a = EmbeddingRequest {

--- a/tensorzero-core/tests/optimization/common/mod.rs
+++ b/tensorzero-core/tests/optimization/common/mod.rs
@@ -83,6 +83,7 @@ pub async fn run_test_case(test_case: &impl OptimizationTestCase) {
     };
     let model_config = model_config
         .load("test-fine-tuned-model", &ProviderTypesConfig::default())
+        .await
         .unwrap();
     let system = "You are a helpful assistant named Dr. M.M. Patel.".to_string();
     let messages = vec![RequestMessage {


### PR DESCRIPTION
This will allow us to use embedded gateways in tests without a multi-threaded runtime, which in turn allows `#[traced_test]` to capture logs from `tokio::spawn`

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Convert configuration loading methods to async and remove `block_on` for improved concurrency handling.
> 
>   - **Behavior**:
>     - Convert `load()` methods to `async` in `UninitializedModelConfig`, `UninitializedEmbeddingModelConfig`, and `UninitializedProviderConfig`.
>     - Remove `block_on` usage in `UninitializedProviderConfig::load()` for AWS providers.
>   - **Tests**:
>     - Update tests in `dicl.rs`, `openai.rs`, and `common/mod.rs` to await `load()` calls.
>   - **Misc**:
>     - Add `try_join_all` for concurrent loading in `config_parser/mod.rs`, `embeddings.rs`, and `model.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 91118166f492ecf8328a6f479705ef75bb28ab72. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->