### PR TITLE
Cleanup disk space in mock-optimization-tests job

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -481,6 +481,9 @@ jobs:
       - name: Download ClickHouse fixtures
         run: uv run ./ui/fixtures/download-fixtures.py
 
+      - name: Cleanup disk space
+        run: ./ci/free-disk-space.sh
+
       - name: Set up TENSORZERO_CLICKHOUSE_URL for E2E tests
         run: |
           echo "TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@localhost:8123/tensorzero_e2e_tests" >> $GITHUB_ENV


### PR DESCRIPTION
This started consistently running out of disk space today, so let's run our existing cleanup script to try to unbreak CI

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add disk cleanup step to `mock-optimization-tests` job in GitHub Actions workflow to address disk space issues.
> 
>   - **CI/CD**:
>     - Adds a disk cleanup step in `mock-optimization-tests` job in `.github/workflows/general.yml` using `./ci/free-disk-space.sh` to address disk space issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5fbf4088b7baf002fed11997749bb90cb61c8db5. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->