### PR TITLE
Propagate error when acquiring semaphore in `ThrottledTensorZeroClient`

### DIFF
--- a/evaluations/src/lib.rs
+++ b/evaluations/src/lib.rs
@@ -465,7 +465,7 @@ impl ThrottledTensorZeroClient {
     }
 
     async fn inference(&self, params: ClientInferenceParams) -> Result<InferenceOutput> {
-        let _permit = self.semaphore.acquire().await;
+        let _permit = self.semaphore.acquire().await?;
         let inference_output = self.client.inference(params).await?;
         Ok(inference_output)
     }


### PR DESCRIPTION
Fixes https://github.com/tensorzero/tensorzero/issues/2917

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Propagate errors when acquiring semaphore in `ThrottledTensorZeroClient` to ensure proper error handling.
> 
>   - **Behavior**:
>     - Propagate errors when acquiring semaphore in `inference()` method of `ThrottledTensorZeroClient` in `lib.rs`.
>     - Ensures proper error handling during semaphore acquisition.
>   - **Misc**:
>     - Fixes issue #2917.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e53f679d7bfe10ff66fc828440cbf382b2478476. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->