### PR TITLE
Bump our MSRV to Rust 1.86.0

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -150,10 +150,10 @@ jobs:
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       # We deliberately install our MSRV here (rather than 'stable') to ensure that everything compiles with that version
-      - name: Install Rust 1.85.0
+      - name: Install Rust 1.86.0
         run: |
-          rustup install 1.85.0 --component clippy,rustfmt
-          rustup default 1.85.0
+          rustup install 1.86.0 --component clippy,rustfmt
+          rustup default 1.86.0
 
       - name: Print Rust version
         run: rustc --version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "2"
 
 [workspace.package]
 version = "2025.7.4"
-rust-version = "1.85.0"
+rust-version = "1.86.0"
 license = "Apache-2.0"
 
 [workspace.dependencies]


### PR DESCRIPTION
This will allow us to upgrade the latest AWS SDK, which has an MSRV of 1.86.0

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump MSRV to Rust 1.86.0 in `Cargo.toml` and GitHub Actions to support the latest AWS SDK.
> 
>   - **Rust Version Update**:
>     - Bump MSRV to 1.86.0 in `Cargo.toml` and `.github/workflows/general.yml`.
>     - Ensures compatibility with the latest AWS SDK.
>   - **Workflow Changes**:
>     - Update Rust installation step in `general.yml` to use version 1.86.0.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 9b82eef55e309ce9787a78a361b46b40a000f0ac. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->