### PR TITLE
Wait for all evals to finish in static evaluations e2e tests

### DIFF
--- a/ui/app/routes/evaluations/$evaluation_name/route.tsx
+++ b/ui/app/routes/evaluations/$evaluation_name/route.tsx
@@ -289,7 +289,7 @@ export default function EvaluationsPage({ loaderData }: Route.ComponentProps) {
           )}
           <div className="flex items-center">
             <SectionHeader heading="Results" />
-            <div className="ml-4">
+            <div className="ml-4" data-testid="auto-refresh-wrapper" data-running={any_evaluation_is_running}>
               <AutoRefreshIndicator isActive={any_evaluation_is_running} />
             </div>
           </div>

--- a/ui/e2e_tests/evaluations.spec.ts
+++ b/ui/e2e_tests/evaluations.spec.ts
@@ -11,6 +11,7 @@ test("should show the evaluation result page", async ({ page }) => {
 // This test depends on model inference cache hits (within ClickHouse)
 // If it starts failing, you may need to regenerate the model inference cache
 test("push the new run button, launch an evaluation", async ({ page }) => {
+  test.setTimeout(600_000);
   await page.goto("/evaluations");
   await page.waitForTimeout(500);
   await page.getByText("New Run").click();
@@ -27,11 +28,13 @@ test("push the new run button, launch an evaluation", async ({ page }) => {
   await page.waitForTimeout(500);
   await page.getByRole("option", { name: "gpt4o_mini_initial_prompt" }).click();
   await page.getByRole("button", { name: "Launch" }).click();
-  await page.waitForTimeout(10000);
 
   await expect(
     page.getByText("Select evaluation runs to compare..."),
   ).toBeVisible();
+  // Wait for evals to start, then wait for them to finish
+  await expect(page.getByTestId("auto-refresh-wrapper")).toHaveAttribute("data-running", "true");
+  await expect(page.getByTestId("auto-refresh-wrapper")).toHaveAttribute("data-running", "false", {timeout: 500_000});
   await expect(page.getByText("gpt4o_mini_initial_prompt")).toBeVisible();
   await expect(page.getByText("n=", { exact: false }).first()).toBeVisible();
 
@@ -44,6 +47,7 @@ test("push the new run button, launch an evaluation", async ({ page }) => {
 test("push the new run button, launch an image evaluation", async ({
   page,
 }) => {
+  test.setTimeout(600_000);
   await page.goto("/evaluations");
   await page.waitForTimeout(500);
   await page.getByText("New Run").click();
@@ -60,11 +64,15 @@ test("push the new run button, launch an image evaluation", async ({
   await page.waitForTimeout(500);
   await page.getByRole("option", { name: "honest_answer" }).click();
   await page.getByRole("button", { name: "Launch" }).click();
-  await page.waitForTimeout(5000);
 
   await expect(
     page.getByText("Select evaluation runs to compare..."),
   ).toBeVisible();
+
+  // Wait for evals to start, then wait for them to finish
+  await expect(page.getByTestId("auto-refresh-wrapper")).toHaveAttribute("data-running", "true");
+  await expect(page.getByTestId("auto-refresh-wrapper")).toHaveAttribute("data-running", "false", {timeout: 500_000});
+
   await expect(page.getByText("matches_reference")).toBeVisible();
   await expect(page.getByText("n=", { exact: false }).first()).toBeVisible();
 


### PR DESCRIPTION
This ensures that we see any errors produced during evaluation runs

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
