### PR TITLE
Don't take down containers at the end of fixture regeneration

### DIFF
--- a/ui/fixtures/regenerate-model-inference-cache.sh
+++ b/ui/fixtures/regenerate-model-inference-cache.sh
@@ -12,5 +12,3 @@ docker compose -f ./fixtures/docker-compose.e2e.yml -f ./fixtures/docker-compose
 docker run --add-host=host.docker.internal:host-gateway clickhouse/clickhouse-server clickhouse-client --host host.docker.internal --user chuser --password chpassword --database tensorzero_ui_fixtures 'TRUNCATE TABLE ModelInferenceCache SYNC'
 TENSORZERO_PLAYWRIGHT_NO_WEBSERVER=1 TENSORZERO_GATEWAY_URL=http://localhost:3000 TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@localhost:8123/tensorzero_ui_fixtures pnpm test-e2e -j 1
 docker run --add-host=host.docker.internal:host-gateway clickhouse/clickhouse-server clickhouse-client --host host.docker.internal --user chuser --password chpassword --database tensorzero_ui_fixtures 'SELECT * FROM ModelInferenceCache ORDER BY long_cache_key ASC FORMAT JSONEachRow' > ./fixtures/model_inference_cache_e2e.jsonl
-docker compose -f ./fixtures/docker-compose.e2e.yml -f ./fixtures/docker-compose.ui.yml down
-docker compose -f ./fixtures/docker-compose.e2e.yml -f ./fixtures/docker-compose.ui.yml rm


### PR DESCRIPTION
This will let us print Docker logs in ci

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove Docker container shutdown in `regenerate-model-inference-cache.sh` to enable log printing in CI.
> 
>   - **Behavior**:
>     - Removed commands in `regenerate-model-inference-cache.sh` that take down and remove Docker containers at the end of the script.
>     - Allows Docker logs to be printed in CI for debugging purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 94a8c9148fd350a207d657ac249d2143c4b9a745. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->