### PR TITLE
add config.gateway.unstable_disable_feedback_target_validation

### DIFF
--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -410,8 +410,7 @@ impl Client {
                         .await
                         .map_err(err_to_http)
                 })
-                .await?
-                .0)
+                .await?)
             }
         }
     }

--- a/internal/tensorzero-node/lib/bindings/GatewayConfig.ts
+++ b/internal/tensorzero-node/lib/bindings/GatewayConfig.ts
@@ -11,4 +11,5 @@ export type GatewayConfig = {
   export: ExportConfig;
   base_path: string | null;
   unstable_error_json: boolean;
+  unstable_disable_feedback_target_validation: boolean;
 };

--- a/tensorzero-core/src/config_parser/gateway.rs
+++ b/tensorzero-core/src/config_parser/gateway.rs
@@ -25,6 +25,9 @@ pub struct UninitializedGatewayConfig {
     // If set, all of the HTTP endpoints will have this path prepended.
     // E.g. a base path of `/custom/prefix` will cause the inference endpoint to become `/custom/prefix/inference`.
     pub base_path: Option<String>,
+    // If set to `true`, disables validation on feedback queries (read from ClickHouse to check that the target is valid)
+    #[serde(default)]
+    pub unstable_disable_feedback_target_validation: bool,
     /// If enabled, adds an 'error_json' field alongside the human-readable 'error' field
     /// in HTTP error responses. This contains a JSON-serialized version of the error.
     /// While 'error_json' will always be valid JSON when present, the exact contents is unstable,
@@ -63,6 +66,8 @@ impl UninitializedGatewayConfig {
             export: self.export,
             base_path: self.base_path,
             unstable_error_json: self.unstable_error_json,
+            unstable_disable_feedback_target_validation: self
+                .unstable_disable_feedback_target_validation,
         })
     }
 }
@@ -80,6 +85,7 @@ pub struct GatewayConfig {
     // E.g. a base path of `/custom/prefix` will cause the inference endpoint to become `/custom/prefix/inference`.
     pub base_path: Option<String>,
     pub unstable_error_json: bool,
+    pub unstable_disable_feedback_target_validation: bool,
 }
 
 fn serialize_optional_socket_addr<S>(

--- a/tensorzero-core/src/endpoints/feedback.rs
+++ b/tensorzero-core/src/endpoints/feedback.rs
@@ -32,7 +32,9 @@ use super::validate_tags;
 ///
 /// This is the amount of time we want to wait after the target was supposed to have been written
 /// before we decide that the target was actually not written because we can't find it in the database.
-const FEEDBACK_COOLDOWN_PERIOD: Duration = Duration::from_millis(5100);
+/// This should really be read at 5000ms but since there might be some jitter we want to make sure there's
+/// a read at ~5s
+const FEEDBACK_COOLDOWN_PERIOD: Duration = Duration::from_millis(6000);
 /// Since we can't be sure that an inference actually completed when the ID says it was
 /// (the ID is generated at the start of the inference), we wait a minimum amount of time
 /// before we decide that the target was actually not written because we can't find it in the database.

--- a/tensorzero-core/src/endpoints/feedback.rs
+++ b/tensorzero-core/src/endpoints/feedback.rs
@@ -32,11 +32,13 @@ use super::validate_tags;
 ///
 /// This is the amount of time we want to wait after the target was supposed to have been written
 /// before we decide that the target was actually not written because we can't find it in the database.
-const FEEDBACK_COOLDOWN_PERIOD: Duration = Duration::from_secs(5);
+const FEEDBACK_COOLDOWN_PERIOD: Duration = Duration::from_millis(5100);
 /// Since we can't be sure that an inference actually completed when the ID says it was
 /// (the ID is generated at the start of the inference), we wait a minimum amount of time
 /// before we decide that the target was actually not written because we can't find it in the database.
-const FEEDBACK_MINIMUM_WAIT_TIME: Duration = Duration::from_millis(1200);
+const FEEDBACK_MINIMUM_WAIT_TIME: Duration = Duration::from_millis(1000);
+/// We also poll in the intermediate time so that we can return as soon as we find a target entry.
+const FEEDBACK_TARGET_POLL_INTERVAL: Duration = Duration::from_millis(2000);
 
 /// The expected payload is a JSON object with the following fields:
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -434,7 +436,7 @@ async fn throttled_get_function_name(
                 }
             }
         }
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        tokio::time::sleep(FEEDBACK_TARGET_POLL_INTERVAL).await;
     }
 }
 

--- a/tensorzero-core/src/gateway_util.rs
+++ b/tensorzero-core/src/gateway_util.rs
@@ -278,6 +278,7 @@ mod tests {
             export: Default::default(),
             base_path: None,
             unstable_error_json: false,
+            unstable_disable_feedback_target_validation: false,
         };
 
         let config = Box::leak(Box::new(Config {
@@ -332,6 +333,7 @@ mod tests {
             export: Default::default(),
             base_path: None,
             unstable_error_json: false,
+            unstable_disable_feedback_target_validation: false,
         };
 
         let config = Box::leak(Box::new(Config {
@@ -356,6 +358,7 @@ mod tests {
             export: Default::default(),
             base_path: None,
             unstable_error_json: false,
+            unstable_disable_feedback_target_validation: false,
         };
         let config = Box::leak(Box::new(Config {
             gateway: gateway_config,
@@ -382,6 +385,7 @@ mod tests {
             export: Default::default(),
             base_path: None,
             unstable_error_json: false,
+            unstable_disable_feedback_target_validation: false,
         };
         let config = Config {
             gateway: gateway_config,

--- a/tensorzero-core/tests/e2e/feedback.rs
+++ b/tensorzero-core/tests/e2e/feedback.rs
@@ -2,6 +2,11 @@ use reqwest::{Client, StatusCode};
 use serde_json::{json, Value};
 use tensorzero_core::{
     clickhouse::test_helpers::{select_feedback_clickhouse, select_feedback_tags_clickhouse},
+    config_parser::{
+        Config, MetricConfig, MetricConfigLevel, MetricConfigOptimize, MetricConfigType,
+    },
+    endpoints::feedback::{feedback, Params},
+    gateway_util::AppStateData,
     inference::types::{ContentBlockChatOutput, JsonInferenceOutput, Role, Text, TextKind},
 };
 use tokio::time::{sleep, Duration};
@@ -168,6 +173,39 @@ async fn e2e_test_comment_feedback_with_payload(inference_payload: serde_json::V
     assert_eq!(retrieved_target_type, "inference");
     let retrieved_value = result.get("value").unwrap().as_str().unwrap();
     assert_eq!(retrieved_value, "bad job!");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn e2e_test_comment_feedback_validation_disabled() {
+    let mut config = Config::default();
+    let clickhouse = get_clickhouse().await;
+    config.gateway.unstable_disable_feedback_target_validation = true;
+    let state = AppStateData::new_with_clickhouse_and_http_client(
+        config.into(),
+        clickhouse.clone(),
+        reqwest::Client::new(),
+    );
+    let inference_id = Uuid::now_v7();
+    let params = Params {
+        inference_id: Some(inference_id),
+        metric_name: "comment".to_string(),
+        value: json!("foo bar"),
+        ..Default::default()
+    };
+    let val = feedback(state, params).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Check that this was correctly written to ClickHouse
+    let query = format!(
+        "SELECT * FROM CommentFeedback WHERE target_id='{inference_id}' FORMAT JsonEachRow"
+    );
+    let response = clickhouse
+        .run_query_synchronous_no_params(query)
+        .await
+        .unwrap();
+    let result: Value = serde_json::from_str(&response.response).unwrap();
+    let clickhouse_feedback_id = Uuid::parse_str(result["id"].as_str().unwrap()).unwrap();
+    assert_eq!(val.feedback_id, clickhouse_feedback_id);
 }
 
 #[tokio::test]
@@ -1160,6 +1198,47 @@ async fn e2e_test_float_feedback_with_payload(inference_payload: serde_json::Val
     assert_eq!(metric_name, "brevity_score");
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn e2e_test_float_feedback_validation_disabled() {
+    let mut config = Config::default();
+    let metric_config = MetricConfig {
+        r#type: MetricConfigType::Float,
+        optimize: MetricConfigOptimize::Max,
+        level: MetricConfigLevel::Inference,
+    };
+    config
+        .metrics
+        .insert("user_score".to_string(), metric_config);
+    let clickhouse = get_clickhouse().await;
+    config.gateway.unstable_disable_feedback_target_validation = true;
+    let state = AppStateData::new_with_clickhouse_and_http_client(
+        config.into(),
+        clickhouse.clone(),
+        reqwest::Client::new(),
+    );
+    let inference_id = Uuid::now_v7();
+    let params = Params {
+        inference_id: Some(inference_id),
+        metric_name: "user_score".to_string(),
+        value: json!(3.1),
+        ..Default::default()
+    };
+    let val = feedback(state, params).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Check that this was correctly written to ClickHouse
+    let query = format!(
+        "SELECT * FROM FloatMetricFeedback WHERE target_id='{inference_id}' FORMAT JsonEachRow"
+    );
+    let response = clickhouse
+        .run_query_synchronous_no_params(query)
+        .await
+        .unwrap();
+    let result: Value = serde_json::from_str(&response.response).unwrap();
+    let clickhouse_feedback_id = Uuid::parse_str(result["id"].as_str().unwrap()).unwrap();
+    assert_eq!(val.feedback_id, clickhouse_feedback_id);
+}
+
 #[tokio::test]
 async fn e2e_test_boolean_feedback_normal_function() {
     e2e_test_boolean_feedback_with_payload(serde_json::json!({
@@ -1351,6 +1430,47 @@ async fn e2e_test_boolean_feedback_with_payload(inference_payload: serde_json::V
     assert!(retrieved_value);
     let metric_name = result.get("metric_name").unwrap().as_str().unwrap();
     assert_eq!(metric_name, "goal_achieved");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn e2e_test_boolean_feedback_validation_disabled() {
+    let mut config = Config::default();
+    let metric_config = MetricConfig {
+        r#type: MetricConfigType::Boolean,
+        optimize: MetricConfigOptimize::Max,
+        level: MetricConfigLevel::Inference,
+    };
+    config
+        .metrics
+        .insert("task_success".to_string(), metric_config);
+    let clickhouse = get_clickhouse().await;
+    config.gateway.unstable_disable_feedback_target_validation = true;
+    let state = AppStateData::new_with_clickhouse_and_http_client(
+        config.into(),
+        clickhouse.clone(),
+        reqwest::Client::new(),
+    );
+    let inference_id = Uuid::now_v7();
+    let params = Params {
+        inference_id: Some(inference_id),
+        metric_name: "task_success".to_string(),
+        value: json!(true),
+        ..Default::default()
+    };
+    let val = feedback(state, params).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Check that this was correctly written to ClickHouse
+    let query = format!(
+        "SELECT * FROM BooleanMetricFeedback WHERE target_id='{inference_id}' FORMAT JsonEachRow"
+    );
+    let response = clickhouse
+        .run_query_synchronous_no_params(query)
+        .await
+        .unwrap();
+    let result: Value = serde_json::from_str(&response.response).unwrap();
+    let clickhouse_feedback_id = Uuid::parse_str(result["id"].as_str().unwrap()).unwrap();
+    assert_eq!(val.feedback_id, clickhouse_feedback_id);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/ui/app/components/feedback/FeedbackTable.stories.tsx
+++ b/ui/app/components/feedback/FeedbackTable.stories.tsx
@@ -31,6 +31,7 @@ const config: Config = {
     bind_address: "localhost:8080",
     base_path: "/",
     unstable_error_json: false,
+    unstable_disable_feedback_target_validation: false,
   },
   object_store_info: { kind: { type: "disabled" } },
   provider_types: {


### PR DESCRIPTION
If this flag is set: 
don't get the function name for comment / float / boolean feedback, just write

also decreases the frequency of the polling in `throttled_get_function_name`
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `unstable_disable_feedback_target_validation` flag to disable feedback target validation and adjust feedback polling intervals.
> 
>   - **Behavior**:
>     - Adds `unstable_disable_feedback_target_validation` flag to `GatewayConfig` in `GatewayConfig.ts` and `gateway.rs` to disable feedback target validation.
>     - Adjusts `FEEDBACK_COOLDOWN_PERIOD` to 6000ms and `FEEDBACK_MINIMUM_WAIT_TIME` to 1000ms in `feedback.rs`.
>     - Introduces `FEEDBACK_TARGET_POLL_INTERVAL` set to 2000ms in `feedback.rs`.
>   - **Feedback Handling**:
>     - Updates `feedback()`, `write_comment()`, `write_float()`, and `write_boolean()` in `feedback.rs` to respect the new flag.
>     - Modifies `throttled_get_function_name()` in `feedback.rs` to use `FEEDBACK_TARGET_POLL_INTERVAL`.
>   - **Tests**:
>     - Adds tests for disabled feedback validation in `feedback.rs` and `feedback.rs` e2e tests.
>     - Updates `GatewayConfig` instances in `gateway_util.rs` and `FeedbackTable.stories.tsx` to include the new flag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 23bfac44b36a03759788adee9c3518450a97f07a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->