### PR TITLE
Support `raw_text` in the OpenAI-compatible inference endpoint #1322

### DIFF
--- a/tensorzero-core/src/endpoints/openai_compatible.rs
+++ b/tensorzero-core/src/endpoints/openai_compatible.rs
@@ -668,8 +668,16 @@ impl TryFrom<Vec<OpenAICompatibleMessage>> for Input {
 #[serde(tag = "type", deny_unknown_fields, rename_all = "snake_case")]
 enum OpenAICompatibleContentBlock {
     Text(TextContent),
-    ImageUrl { image_url: OpenAICompatibleImageUrl },
-    File { file: OpenAICompatibleFile },
+    ImageUrl {
+        image_url: OpenAICompatibleImageUrl,
+    },
+    File {
+        file: OpenAICompatibleFile,
+    },
+    #[serde(rename = "tensorzero::raw_text")]
+    RawText {
+        value: String,
+    },
 }
 
 #[derive(Deserialize, Debug)]
@@ -690,7 +698,7 @@ struct OpenAICompatibleFile {
 // Two mutually exclusive modes - the standard OpenAI text, and our special TensorZero mode
 pub enum TextContent {
     /// A normal openai text content block: `{"type": "text", "text": "Some content"}`. The `type` key comes from the parent `OpenAICompatibleContentBlock`
-    RawText { text: String },
+    Text { text: String },
     /// A special TensorZero mode: `{"type": "text", "tensorzero::arguments": {"custom_key": "custom_val"}}`.
     TensorZeroArguments {
         tensorzero_arguments: Map<String, Value>,
@@ -703,7 +711,7 @@ impl<'de> Deserialize<'de> for TextContent {
         let text = object.remove("text");
         let arguments = object.remove("tensorzero::arguments");
         match (text, arguments) {
-            (Some(text), None) => Ok(TextContent::RawText {
+            (Some(text), None) => Ok(TextContent::Text {
                 text: match text {
                     Value::String(text) => text,
                     _ => return Err(serde::de::Error::custom(
@@ -756,7 +764,8 @@ fn convert_openai_message_content(content: Value) -> Result<Vec<InputMessageCont
             for val in a {
                 let block = serde_json::from_value::<OpenAICompatibleContentBlock>(val.clone());
                 let output = match block {
-                    Ok(OpenAICompatibleContentBlock::Text(TextContent::RawText { text })) => InputMessageContent::Text(TextKind::Text {text }),
+                    Ok(OpenAICompatibleContentBlock::RawText{ value }) => InputMessageContent::RawText { value },
+                    Ok(OpenAICompatibleContentBlock::Text(TextContent::Text { text })) => InputMessageContent::Text(TextKind::Text {text }),
                     Ok(OpenAICompatibleContentBlock::Text(TextContent::TensorZeroArguments { tensorzero_arguments })) => InputMessageContent::Text(TextKind::Arguments { arguments: tensorzero_arguments }),
                     Ok(OpenAICompatibleContentBlock::ImageUrl { image_url }) => {
                         if image_url.url.scheme() == "data" {
@@ -1429,6 +1438,26 @@ mod tests {
 
     #[test]
     fn test_convert_openai_message_content() {
+        // text content
+        let content = "Hello, world!".to_string();
+        let value = convert_openai_message_content(Value::String(content.clone())).unwrap();
+        assert_eq!(
+            value,
+            vec![InputMessageContent::Text(TextKind::Text { text: content })]
+        );
+        // tensorzero::raw_text
+        let content = json!([{
+            "type": "tensorzero::raw_text",
+            "value": "This is raw text"
+        }]);
+        let value = convert_openai_message_content(content.clone()).unwrap();
+        assert_eq!(
+            value,
+            vec![InputMessageContent::RawText {
+                value: "This is raw text".to_string()
+            }]
+        );
+        // tensorzero::arguments
         let content = json!([{
             "country": "Japan",
             "city": "Tokyo",


### PR DESCRIPTION
Closes #1322

## Participants:
1) Aaron Pang (@pykm05) 
2) Hong An Tran (@hongantran3804)
3) Aryan Ahuja (@pycoder49)

## Overview
This PR adds support for the `tensorzero::raw_text` content type in the OpenAI-compatible inference endpoint as requested in issue #1322. This allows users to pass raw text that ignores template/schema processing.

## Changes to `openai_compatible.rs`
- Added `RawText` variant to the `OpenAICompatibleContentBlock` enum
```Rust
enum OpenAICompatibleContentBlock {
    Text(TextContent),
    ImageUrl { image_url: OpenAICompatibleImageUrl },
    File { file: OpenAICompatibleFile },
    #[serde(rename = "tensorzero::raw_text")]
    RawText { value: String },
}
```
- Updated the content processing logic in `convert_openai_message_content` to handle the new content type
Line 761 inside openai_compatible.rs
```Rust
Ok(OpenAICompatibleContentBlock::RawText{ value }) => InputMessageContent::RawText { value },
```
- Changed `RawText` to `Text` inside `enum TextContent` and ensured functionality inside `Deserialize` function right below it
```Rust
pub enum TextContent {
    /// A normal openai text content block: `{"type": "text", "text": "Some content"}`. The `type` key comes from the parent `OpenAICompatibleContentBlock`
    Text { text: String },
    /// A special TensorZero mode: `{"type": "text", "tensorzero::arguments": {"custom_key": "custom_val"}}`.
    TensorZeroArguments {
        tensorzero_arguments: Map<String, Value>,
    },
}
```

## Example Usage
System messages with type `text`
User messages with type `tensorzero::raw_text`
```python
with OpenAI(base_url="http://localhost:3000/openai/v1") as client:
    response = client.chat.completions.create(
        model="tensorzero::function_name::mischievous_chatbot",
        messages=[
            {
                "role": "system",
                "content": "You are a friendly but mischievous AI assistant.",
            },
            {
                "role": "user",
                "content": [
		    {
		        “type”: “tensorzero::raw_text”,
		        “content”: “What is the capital of Japan?”,
                    }
                ]
              },
          ],
      )
```

## Verification
We've verified the implementation works correctly by testing two key scenarios:

1) In the simple chatbot example ([examples/tutorial/01-simple-chatbot/run_openai.py](https://github.com/tensorzero/tensorzero/blob/main/examples/tutorial/01-simple-chatbot/run_openai.py)), we can see the raw text content being properly parsed and processed as shown in the debug logs and the example code.

(example code changed locally)
<img width="736" height="589" alt="Image" src="https://github.com/user-attachments/assets/ca553bda-a2fd-470b-a4da-7ac38a6a17cc" />

<img width="584" height="324" alt="Image" src="https://github.com/user-attachments/assets/c303ca76-98bb-4156-939b-39983801ff48" />

<img width="575" height="577" alt="Image" src="https://github.com/user-attachments/assets/babceffc-1af8-40e7-a714-10505a0274ba" />\


2) In the email copilot example ([02 email copilot](https://github.com/tensorzero/tensorzero/blob/main/examples/tutorial/02-email-copilot/run_openai.py)), which includes a schema, we've confirmed that when tensorzero::raw_text is specified, it correctly bypasses schema validation as intended (schema validation is skipped by default when `InputMessageContent` is not of type `Text`)
