### PR TITLE
Add 'TENSORZERO_FORCE_CACHE_ON' env var and use it in ui server

### DIFF
--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -230,6 +230,7 @@ jobs:
           echo "FIREWORKS_BASE_URL=http://mock-inference-provider:3030/fireworks/" >> fixtures/.env
           echo "OPENAI_BASE_URL=http://mock-inference-provider:3030/openai/" >> fixtures/.env
           echo "FIREWORKS_ACCOUNT_ID=fake_fireworks_account" >> fixtures/.env
+          echo "TENSORZERO_FORCE_CACHE_ON=1" >> fixtures/.env
 
           # Environment variables only used by the gateway container
           # We deliberately leave these unset when starting the UI container, to ensure

--- a/ui/app/routes/api/tensorzero/inference.ts
+++ b/ui/app/routes/api/tensorzero/inference.ts
@@ -19,6 +19,7 @@ import {
 } from "~/utils/tensorzero";
 import { JSONParseError } from "~/utils/common";
 import type { Route } from "./+types/inference";
+import { getExtraInferenceOptions } from "~/utils/env.server";
 
 export async function action({ request }: Route.ActionArgs): Promise<Response> {
   const formData = await request.formData();
@@ -60,6 +61,7 @@ async function handleInferenceAction(
 
   return await getTensorZeroClient().inference({
     ...result.data,
+    ...getExtraInferenceOptions(),
     stream: false,
   });
 }

--- a/ui/app/routes/playground/route.tsx
+++ b/ui/app/routes/playground/route.tsx
@@ -36,6 +36,7 @@ import OutputRust from "~/components/inference/NewOutputRust";
 import { Label } from "~/components/ui/label";
 import DatapointPlaygroundOutput from "./DatapointPlaygroundOutput";
 import { safeParseInt } from "~/utils/common";
+import { getExtraInferenceOptions } from "~/utils/env.server";
 
 const DEFAULT_LIMIT = 5;
 
@@ -168,6 +169,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     }
     return await getTensorZeroClient().inference({
       ...result.data,
+      ...getExtraInferenceOptions(),
       stream: false,
     });
   };

--- a/ui/app/utils/env.server.ts
+++ b/ui/app/utils/env.server.ts
@@ -20,6 +20,12 @@ interface Env {
   OPENAI_BASE_URL: string | null;
   FIREWORKS_BASE_URL: string | null;
   FIREWORKS_ACCOUNT_ID: string | null;
+  /// When set, sets `cache_options.enabled = "on"` on all inference calls
+  /// Normally, we leave this unset, which uses the TensorZero default of 'write_only'
+  /// This is used by e2e tests to allow us to populate the model inference cache
+  /// from regen-fixtures without trampling existing entries, and then to use the cached
+  /// entries from the normal ui e2e tests
+  TENSORZERO_FORCE_CACHE_ON: boolean;
 }
 
 let _env: Env;
@@ -60,9 +66,23 @@ export function getEnv(): Env {
     TENSORZERO_EVALUATIONS_PATH:
       process.env.TENSORZERO_EVALUATIONS_PATH || "evaluations",
     FIREWORKS_ACCOUNT_ID: process.env.FIREWORKS_ACCOUNT_ID || null,
+    TENSORZERO_FORCE_CACHE_ON: process.env.TENSORZERO_FORCE_CACHE_ON === "1",
   };
 
   return _env;
+}
+
+/// Returns an object containing extra parameters that should be passed to
+/// inference calls on our TensorZero client
+export function getExtraInferenceOptions(): object {
+  if (getEnv().TENSORZERO_FORCE_CACHE_ON) {
+    return {
+      cache_options: {
+        enabled: "on",
+      },
+    };
+  }
+  return {};
 }
 
 function getClickhouseUrl() {

--- a/ui/fixtures/docker-compose.ui.yml
+++ b/ui/fixtures/docker-compose.ui.yml
@@ -11,6 +11,7 @@ services:
       - OPENAI_BASE_URL
       - FIREWORKS_BASE_URL
       - FIREWORKS_ACCOUNT_ID
+      - TENSORZERO_FORCE_CACHE_ON
     volumes:
       - ./config:/app/config:ro
     env_file:

--- a/ui/fixtures/regenerate-model-inference-cache.sh
+++ b/ui/fixtures/regenerate-model-inference-cache.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$0")"/../
 
 docker compose -f ./fixtures/docker-compose.e2e.yml -f ./fixtures/docker-compose.ui.yml down
 docker compose -f ./fixtures/docker-compose.e2e.yml -f ./fixtures/docker-compose.ui.yml rm -f
-OPENAI_BASE_URL=http://mock-inference-provider:3030/openai/ FIREWORKS_BASE_URL=http://mock-inference-provider:3030/fireworks/ FIREWORKS_ACCOUNT_ID=fake_fireworks_account TENSORZERO_SKIP_LARGE_FIXTURES=1 docker compose -f ./fixtures/docker-compose.e2e.yml -f ./fixtures/docker-compose.ui.yml up --build --force-recreate -d
+OPENAI_BASE_URL=http://mock-inference-provider:3030/openai/ FIREWORKS_BASE_URL=http://mock-inference-provider:3030/fireworks/ FIREWORKS_ACCOUNT_ID=fake_fireworks_account TENSORZERO_SKIP_LARGE_FIXTURES=1 TENSORZERO_FORCE_CACHE_ON=1 docker compose -f ./fixtures/docker-compose.e2e.yml -f ./fixtures/docker-compose.ui.yml up --build --force-recreate -d
 docker compose -f ./fixtures/docker-compose.e2e.yml -f ./fixtures/docker-compose.ui.yml wait fixtures
 # Wipe the ModelInferenceCache table to ensure that we regenerate everything
 docker run --add-host=host.docker.internal:host-gateway clickhouse/clickhouse-server clickhouse-client --host host.docker.internal --user chuser --password chpassword --database tensorzero_ui_fixtures 'TRUNCATE TABLE ModelInferenceCache SYNC'


### PR DESCRIPTION
We set this when running ui e2e tests (including when regenerating fixtures) to force 'cache_options.enabled = true` for all inference requests from the UI server (separate from 'evaluations' requests)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
