### PR TITLE
Map tool choice 'required' to 'auto' for Together

### DIFF
--- a/tensorzero-core/src/providers/together.rs
+++ b/tensorzero-core/src/providers/together.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, sync::OnceLock, time::Duration};
 
 use crate::inference::types::RequestMessage;
+use crate::providers::openai::OpenAIToolChoiceString;
 use futures::StreamExt;
 use lazy_static::lazy_static;
 use reqwest_eventsource::{Event, EventSource};
@@ -365,10 +366,14 @@ impl<'a> TogetherRequest<'a> {
             .as_ref()
             .map(|config| &config.tool_choice);
 
-        let (tools, tool_choice, parallel_tool_calls) = match tool_choice {
+        let (tools, mut tool_choice, parallel_tool_calls) = match tool_choice {
             Some(&ToolChoice::None) => (None, None, None),
             _ => prepare_openai_tools(request),
         };
+        // Together AI doesn't seem to support `tool_choice="required"`, so we convert it to `tool_choice="auto"`
+        if let Some(OpenAIToolChoice::String(OpenAIToolChoiceString::Required)) = tool_choice {
+            tool_choice = Some(OpenAIToolChoice::String(OpenAIToolChoiceString::Auto));
+        }
 
         Ok(TogetherRequest {
             messages,


### PR DESCRIPTION
Together doesn't mention supporting 'required' in its docs, and attempting to pass it in gives a generic 'Invalid request' error. This fixes a Together tool-calling test when running without the provider-proxy cache

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
