### PR TITLE
Increase sglang retries on CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -81,6 +81,8 @@ slow-timeout = { period = "60s", terminate-after = 2 }
 
 [[profile.default.overrides]]
 filter = 'binary(e2e) and test(providers::sglang::)'
+# The model we run on SGLang often fails to emit valid tool calls, so we need many retries
+retries = { backoff = "fixed", count = 8, delay = "10s", jitter = true }
 slow-timeout = { period = "60s", terminate-after = 2 }
 
 [[profile.default.overrides]]


### PR DESCRIPTION
This should help to ensure a pass on the tool-call tests when running without the provider-proxy cache

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase retry attempts for `providers::sglang::` tests in CI to improve pass rates without provider-proxy cache.
> 
>   - **Behavior**:
>     - Increase retry count to 8 for `providers::sglang::` tests in `.config/nextest.toml`.
>     - Set retry delay to 10 seconds with fixed backoff and jitter enabled.
>   - **Purpose**:
>     - Aims to improve test pass rates for tool-call tests without provider-proxy cache.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e4b2fe87cb8598b02067af45ae911a9c277cc303. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->