### PR TITLE
Improve feedback validation query

### DIFF
--- a/tensorzero-core/src/endpoints/feedback.rs
+++ b/tensorzero-core/src/endpoints/feedback.rs
@@ -476,7 +476,11 @@ async fn get_function_name(
         MetricConfigLevel::Episode => "episode_id_uint",
     };
     let query = format!(
-        "SELECT function_name FROM {table_name} FINAL WHERE {identifier_key} = toUInt128(toUUID('{target_id}'))"
+        "SELECT function_name
+         FROM {table_name}
+         WHERE {identifier_key} = toUInt128(toUUID('{target_id}'))
+         LIMIT 1
+         SETTINGS max_threads=1"
     );
     let function_name = connection_info
         .run_query_synchronous_no_params(query)


### PR DESCRIPTION
There is no need for `FINAL` since there is no versioning (i.e. duplicate replacement is non-deterministic). `LIMIT 1` is equivalent and generally much faster.

For a point lookup, more threads add unnecessary overhead.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize `get_function_name()` query in `feedback.rs` by removing `FINAL`, adding `LIMIT 1`, and setting `max_threads=1`.
> 
>   - **Query Optimization**:
>     - Removed `FINAL` from query in `get_function_name()` in `feedback.rs` as there is no versioning.
>     - Added `LIMIT 1` to the query for efficiency.
>     - Set `max_threads=1` to reduce overhead for point lookup queries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 20e2f3528a7cf1d79d5fc0d511906bf60254d5f1. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->