### PR TITLE
Introduce a new `GatewayHandle` wrapper type

### DIFF
--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -26,7 +26,7 @@ use tensorzero_core::{
         validate_tags,
     },
     error::{Error, ErrorDetails},
-    gateway_util::{setup_clickhouse, setup_http_client, AppStateData, GatewayHandle},
+    gateway_util::{setup_clickhouse, setup_http_client, GatewayHandle},
 };
 use thiserror::Error;
 use tokio::{sync::Mutex, time::error::Elapsed};
@@ -1163,7 +1163,7 @@ impl Client {
     }
 
     #[cfg(any(feature = "e2e_tests", feature = "pyo3"))]
-    pub fn get_app_state_data(&self) -> Option<&AppStateData> {
+    pub fn get_app_state_data(&self) -> Option<&tensorzero_core::gateway_util::AppStateData> {
         match &self.mode {
             ClientMode::EmbeddedGateway { gateway, .. } => Some(&gateway.handle.app_state),
             _ => None,

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -26,7 +26,7 @@ use tensorzero_core::{
         validate_tags,
     },
     error::{Error, ErrorDetails},
-    gateway_util::{setup_clickhouse, setup_http_client, AppStateData},
+    gateway_util::{setup_clickhouse, setup_http_client, AppStateData, GatewayHandle},
 };
 use thiserror::Error;
 use tokio::{sync::Mutex, time::error::Elapsed};
@@ -122,7 +122,7 @@ impl HTTPGateway {
 }
 
 struct EmbeddedGateway {
-    state: AppStateData,
+    handle: GatewayHandle,
 }
 
 /// Used to construct a `Client`
@@ -301,7 +301,7 @@ impl ClientBuilder {
                 Ok(Client {
                     mode: ClientMode::EmbeddedGateway {
                         gateway: EmbeddedGateway {
-                            state: AppStateData::new_with_clickhouse_and_http_client(
+                            handle: GatewayHandle::new_with_clickhouse_and_http_client(
                                 config,
                                 clickhouse_connection_info,
                                 http_client,
@@ -318,10 +318,10 @@ impl ClientBuilder {
     }
 
     #[cfg(any(test, feature = "e2e_tests"))]
-    pub async fn build_from_state(state: AppStateData) -> Result<Client, ClientBuilderError> {
+    pub async fn build_from_state(handle: GatewayHandle) -> Result<Client, ClientBuilderError> {
         Ok(Client {
             mode: ClientMode::EmbeddedGateway {
-                gateway: EmbeddedGateway { state },
+                gateway: EmbeddedGateway { handle },
                 timeout: None,
             },
             verbose_errors: false,
@@ -374,7 +374,8 @@ impl Client {
                 gateway,
                 timeout: _,
             } => gateway
-                .state
+                .handle
+                .app_state
                 .clickhouse_connection_info
                 .health()
                 .await
@@ -406,9 +407,12 @@ impl Client {
             }
             ClientMode::EmbeddedGateway { gateway, timeout } => {
                 Ok(with_embedded_timeout(*timeout, async {
-                    tensorzero_core::endpoints::feedback::feedback(gateway.state.clone(), params)
-                        .await
-                        .map_err(err_to_http)
+                    tensorzero_core::endpoints::feedback::feedback(
+                        gateway.handle.app_state.clone(),
+                        params,
+                    )
+                    .await
+                    .map_err(err_to_http)
                 })
                 .await?)
             }
@@ -482,9 +486,9 @@ impl Client {
             ClientMode::EmbeddedGateway { gateway, timeout } => {
                 Ok(with_embedded_timeout(*timeout, async {
                     tensorzero_core::endpoints::inference::inference(
-                        gateway.state.config.clone(),
-                        &gateway.state.http_client,
-                        gateway.state.clickhouse_connection_info.clone(),
+                        gateway.handle.app_state.config.clone(),
+                        &gateway.handle.app_state.http_client,
+                        gateway.handle.app_state.clickhouse_connection_info.clone(),
                         params.try_into().map_err(err_to_http)?,
                     )
                     .await
@@ -530,7 +534,7 @@ impl Client {
             ClientMode::EmbeddedGateway { gateway, timeout } => {
                 Ok(with_embedded_timeout(*timeout, async {
                     tensorzero_core::endpoints::object_storage::get_object(
-                        &gateway.state.config,
+                        &gateway.handle.app_state.config,
                         storage_path,
                     )
                     .await
@@ -568,7 +572,7 @@ impl Client {
             ClientMode::EmbeddedGateway { gateway, timeout } => {
                 Ok(with_embedded_timeout(*timeout, async {
                     tensorzero_core::endpoints::dynamic_evaluation_run::dynamic_evaluation_run(
-                        gateway.state.clone(),
+                        gateway.handle.app_state.clone(),
                         params,
                     )
                     .await
@@ -598,7 +602,7 @@ impl Client {
             ClientMode::EmbeddedGateway { gateway, timeout } => {
                 Ok(with_embedded_timeout(*timeout, async {
                     tensorzero_core::endpoints::dynamic_evaluation_run::dynamic_evaluation_run_episode(
-                        gateway.state.clone(),
+                        gateway.handle.app_state.clone(),
                         run_id,
                         params,
                     )
@@ -631,9 +635,9 @@ impl Client {
                     tensorzero_core::endpoints::datasets::insert_datapoint(
                         dataset_name,
                         params,
-                        &gateway.state.config,
-                        &gateway.state.http_client,
-                        &gateway.state.clickhouse_connection_info,
+                        &gateway.handle.app_state.config,
+                        &gateway.handle.app_state.http_client,
+                        &gateway.handle.app_state.clickhouse_connection_info,
                     )
                     .await
                     .map_err(err_to_http)
@@ -682,7 +686,7 @@ impl Client {
                     tensorzero_core::endpoints::datasets::delete_datapoint(
                         dataset_name,
                         datapoint_id,
-                        &gateway.state.clickhouse_connection_info,
+                        &gateway.handle.app_state.clickhouse_connection_info,
                     )
                     .await
                     .map_err(err_to_http)
@@ -720,7 +724,7 @@ impl Client {
                 Ok(with_embedded_timeout(*timeout, async {
                     tensorzero_core::endpoints::datasets::list_datapoints(
                         dataset_name,
-                        &gateway.state.clickhouse_connection_info,
+                        &gateway.handle.app_state.clickhouse_connection_info,
                         function_name,
                         limit,
                         offset,
@@ -754,7 +758,7 @@ impl Client {
                     tensorzero_core::endpoints::datasets::get_datapoint(
                         dataset_name,
                         datapoint_id,
-                        &gateway.state.clickhouse_connection_info,
+                        &gateway.handle.app_state.clickhouse_connection_info,
                     )
                     .await
                     .map_err(err_to_http)
@@ -775,7 +779,7 @@ impl Client {
             ClientMode::EmbeddedGateway { gateway, timeout } => {
                 with_embedded_timeout(*timeout, async {
                     tensorzero_core::endpoints::datasets::stale_dataset(
-                        &gateway.state.clickhouse_connection_info,
+                        &gateway.handle.app_state.clickhouse_connection_info,
                         &dataset_name,
                     )
                     .await
@@ -824,9 +828,10 @@ impl Client {
             });
         };
         let inferences = gateway
-            .state
+            .handle
+            .app_state
             .clickhouse_connection_info
-            .list_inferences(&gateway.state.config, &params)
+            .list_inferences(&gateway.handle.app_state.config, &params)
             .await
             .map_err(err_to_http)?;
         Ok(inferences)
@@ -854,9 +859,13 @@ impl Client {
                 .into(),
             });
         };
-        render_samples(gateway.state.config.clone(), stored_samples, variants)
-            .await
-            .map_err(err_to_http)
+        render_samples(
+            gateway.handle.app_state.config.clone(),
+            stored_samples,
+            variants,
+        )
+        .await
+        .map_err(err_to_http)
     }
 
     /// Launch an optimization job.
@@ -868,7 +877,7 @@ impl Client {
             ClientMode::EmbeddedGateway { gateway, timeout } => {
                 // TODO: do we want this?
                 Ok(with_embedded_timeout(*timeout, async {
-                    launch_optimization(&gateway.state.http_client, params)
+                    launch_optimization(&gateway.handle.app_state.http_client, params)
                         .await
                         .map_err(err_to_http)
                 })
@@ -894,9 +903,9 @@ impl Client {
             ClientMode::EmbeddedGateway { gateway, timeout } => {
                 with_embedded_timeout(*timeout, async {
                     launch_optimization_workflow(
-                        &gateway.state.http_client,
-                        gateway.state.config.clone(),
-                        &gateway.state.clickhouse_connection_info,
+                        &gateway.handle.app_state.http_client,
+                        gateway.handle.app_state.config.clone(),
+                        &gateway.handle.app_state.clickhouse_connection_info,
                         params,
                     )
                     .await
@@ -946,7 +955,7 @@ impl Client {
             ClientMode::EmbeddedGateway { gateway, timeout } => {
                 Ok(with_embedded_timeout(*timeout, async {
                     tensorzero_core::endpoints::optimization::poll_optimization(
-                        &gateway.state.http_client,
+                        &gateway.handle.app_state.http_client,
                         job_handle,
                     )
                     .await
@@ -977,7 +986,9 @@ impl Client {
 
     pub fn get_config(&self) -> Result<Arc<Config>, TensorZeroError> {
         match &self.mode {
-            ClientMode::EmbeddedGateway { gateway, .. } => Ok(gateway.state.config.clone()),
+            ClientMode::EmbeddedGateway { gateway, .. } => {
+                Ok(gateway.handle.app_state.config.clone())
+            }
             ClientMode::HTTPGateway(_) => Err(TensorZeroError::Other {
                 source: tensorzero_core::error::Error::new(ErrorDetails::InvalidClientMode {
                     mode: "Http".to_string(),
@@ -1154,7 +1165,7 @@ impl Client {
     #[cfg(any(feature = "e2e_tests", feature = "pyo3"))]
     pub fn get_app_state_data(&self) -> Option<&AppStateData> {
         match &self.mode {
-            ClientMode::EmbeddedGateway { gateway, .. } => Some(&gateway.state),
+            ClientMode::EmbeddedGateway { gateway, .. } => Some(&gateway.handle.app_state),
             _ => None,
         }
     }

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -178,13 +178,13 @@ async fn main() {
     }
 
     // Initialize AppState
-    let app_state = gateway_util::AppStateData::new(config.clone())
+    let gateway_handle = gateway_util::GatewayHandle::new(config.clone())
         .await
         .expect_pretty("Failed to initialize AppState");
-    setup_howdy(app_state.clickhouse_connection_info.clone());
+    setup_howdy(gateway_handle.app_state.clickhouse_connection_info.clone());
 
     // Create a new observability_enabled_pretty string for the log message below
-    let observability_enabled_pretty = match &app_state.clickhouse_connection_info {
+    let observability_enabled_pretty = match &gateway_handle.app_state.clickhouse_connection_info {
         ClickHouseConnectionInfo::Disabled => "disabled".to_string(),
         ClickHouseConnectionInfo::Mock { healthy, .. } => {
             format!("mocked (healthy={healthy})")
@@ -301,7 +301,7 @@ async fn main() {
         // OTEL exporting is done by the `OtelAxumLayer` above, which is only enabled for certain routes (and includes much more information)
         // We log failed requests messages at 'DEBUG', since we already have our own error-logging code,
         .layer(TraceLayer::new_for_http().on_failure(DefaultOnFailure::new().level(Level::DEBUG)))
-        .with_state(app_state);
+        .with_state(gateway_handle.app_state.clone());
 
     // Bind to the socket address specified in the config, or default to 0.0.0.0:3000
     let bind_address = config

--- a/tensorzero-core/src/endpoints/feedback.rs
+++ b/tensorzero-core/src/endpoints/feedback.rs
@@ -828,7 +828,7 @@ mod tests {
     use crate::config_parser::{Config, MetricConfig, MetricConfigOptimize};
     use crate::function::{FunctionConfigChat, FunctionConfigJson};
     use crate::jsonschema_util::StaticJSONSchema;
-    use crate::testing::get_unit_test_app_state_data;
+    use crate::testing::get_unit_test_gateway_handle;
     use crate::tool::{StaticToolConfig, ToolCallOutput, ToolChoice, ToolConfig};
 
     #[tokio::test]
@@ -1008,7 +1008,7 @@ mod tests {
         let config = Arc::new(Config {
             ..Default::default()
         });
-        let app_state_data = get_unit_test_app_state_data(config, true);
+        let gateway_handle = get_unit_test_gateway_handle(config, true);
         let timestamp = uuid::Timestamp::from_unix_time(1579751960, 0, 0, 0);
         let episode_id = Uuid::new_v7(timestamp);
         let value = json!("test comment");
@@ -1021,8 +1021,11 @@ mod tests {
             internal: false,
             dryrun: Some(false),
         };
-        let response =
-            feedback_handler(State(app_state_data.clone()), StructuredJson(params)).await;
+        let response = feedback_handler(
+            State(gateway_handle.app_state.clone()),
+            StructuredJson(params),
+        )
+        .await;
         let details = response.unwrap_err().get_owned_details();
         assert_eq!(
             details,
@@ -1037,7 +1040,7 @@ mod tests {
         let config = Arc::new(Config {
             ..Default::default()
         });
-        let app_state_data = get_unit_test_app_state_data(config, true);
+        let gateway_handle = get_unit_test_gateway_handle(config, true);
         let timestamp = uuid::Timestamp::from_unix_time(1579751960, 0, 0, 0);
         let episode_id = Uuid::new_v7(timestamp);
         let value = json!("test demonstration");
@@ -1052,9 +1055,12 @@ mod tests {
             dryrun: Some(false),
             internal: false,
         };
-        let response = feedback_handler(State(app_state_data.clone()), StructuredJson(params))
-            .await
-            .unwrap_err();
+        let response = feedback_handler(
+            State(gateway_handle.app_state.clone()),
+            StructuredJson(params),
+        )
+        .await
+        .unwrap_err();
         let details = response.get_owned_details();
         assert_eq!(
             details,
@@ -1075,8 +1081,11 @@ mod tests {
             dryrun: Some(false),
             internal: false,
         };
-        let response =
-            feedback_handler(State(app_state_data.clone()), StructuredJson(params)).await;
+        let response = feedback_handler(
+            State(gateway_handle.app_state.clone()),
+            StructuredJson(params),
+        )
+        .await;
         let details = response.unwrap_err().get_owned_details();
         assert_eq!(
             details,
@@ -1101,7 +1110,7 @@ mod tests {
             metrics,
             ..Default::default()
         });
-        let app_state_data = get_unit_test_app_state_data(config.clone(), true);
+        let gateway_handle = get_unit_test_gateway_handle(config.clone(), true);
         let value = json!(4.5);
         let timestamp = uuid::Timestamp::from_unix_time(1579751960, 0, 0, 0);
         let inference_id = Uuid::new_v7(timestamp);
@@ -1117,9 +1126,12 @@ mod tests {
             dryrun: Some(false),
             internal: false,
         };
-        let response = feedback_handler(State(app_state_data.clone()), StructuredJson(params))
-            .await
-            .unwrap_err();
+        let response = feedback_handler(
+            State(gateway_handle.app_state.clone()),
+            StructuredJson(params),
+        )
+        .await
+        .unwrap_err();
         let details = response.get_owned_details();
         assert_eq!(
             details,
@@ -1138,8 +1150,11 @@ mod tests {
             dryrun: Some(false),
             internal: false,
         };
-        let response =
-            feedback_handler(State(app_state_data.clone()), StructuredJson(params)).await;
+        let response = feedback_handler(
+            State(gateway_handle.app_state.clone()),
+            StructuredJson(params),
+        )
+        .await;
         let details = response.unwrap_err().get_owned_details();
         assert_eq!(
             details,
@@ -1164,7 +1179,7 @@ mod tests {
             metrics,
             ..Default::default()
         });
-        let app_state_data = get_unit_test_app_state_data(config.clone(), true);
+        let gateway_handle = get_unit_test_gateway_handle(config.clone(), true);
         let value = json!(true);
         let timestamp = uuid::Timestamp::from_unix_time(1579751960, 0, 0, 0);
         let inference_id = Uuid::new_v7(timestamp);
@@ -1177,8 +1192,11 @@ mod tests {
             dryrun: None,
             internal: false,
         };
-        let response =
-            feedback_handler(State(app_state_data.clone()), StructuredJson(params)).await;
+        let response = feedback_handler(
+            State(gateway_handle.app_state.clone()),
+            StructuredJson(params),
+        )
+        .await;
         let details = response.unwrap_err().get_owned_details();
         assert_eq!(
             details,

--- a/tensorzero-core/src/endpoints/status.rs
+++ b/tensorzero-core/src/endpoints/status.rs
@@ -48,22 +48,22 @@ mod tests {
     use std::sync::Arc;
 
     use crate::config_parser::Config;
-    use crate::testing::get_unit_test_app_state_data;
+    use crate::testing::get_unit_test_gateway_handle;
 
     use super::*;
 
     #[tokio::test]
     async fn test_health_handler() {
         let config = Arc::new(Config::default());
-        let app_state_data = get_unit_test_app_state_data(config.clone(), true);
-        let response = health_handler(State(app_state_data)).await;
+        let gateway_handle = get_unit_test_gateway_handle(config.clone(), true);
+        let response = health_handler(State(gateway_handle.app_state.clone())).await;
         assert!(response.is_ok());
         let response_value = response.unwrap();
         assert_eq!(response_value.get("gateway").unwrap(), "ok");
         assert_eq!(response_value.get("clickhouse").unwrap(), "ok");
 
-        let app_state_data = get_unit_test_app_state_data(config, false);
-        let response = health_handler(State(app_state_data)).await;
+        let gateway_handle = get_unit_test_gateway_handle(config, false);
+        let response = health_handler(State(gateway_handle.app_state.clone())).await;
         assert!(response.is_err());
         let (status_code, error_json) = response.unwrap_err();
         assert_eq!(status_code, StatusCode::SERVICE_UNAVAILABLE);

--- a/tensorzero-core/src/gateway_util.rs
+++ b/tensorzero-core/src/gateway_util.rs
@@ -17,6 +17,29 @@ use crate::config_parser::Config;
 use crate::endpoints;
 use crate::error::{Error, ErrorDetails};
 
+/// Represents an active gateway (either standalone or embedded)
+/// The contained `app_state` can be freely cloned and dropped.
+/// However, dropping the `GatewayHandle` itself will wait for any
+/// needed background tasks to exit (in the future, this will
+/// include the ClickHouse batch insert task).
+///
+/// It's insufficient to put this kind of drop logic in `AppStateData` - since
+/// it can be freely cloned, any contained `Arc`s might only be dropped when
+/// the Tokio runtime is shutting down (e.g. if a background `tokio::spawn`
+/// task looped forever without using a `CancellationToken` to exit).
+/// During runtime shutdown, it's too late to call things like `tokio::spawn_blocking`,
+/// so we may be unable to safely wait for our batch insert task to finish writing.
+///
+/// `GatewayHandle` should *not* be wrapped in an `Arc` (or given a `Clone` impl),
+/// so that it's easy for us to tell where it gets dropped.
+///
+// Using `#[non_exhaustive]` has no effect within the crate
+#[expect(clippy::manual_non_exhaustive)]
+pub struct GatewayHandle {
+    pub app_state: AppStateData,
+    _private: (),
+}
+
 /// State for the API
 #[derive(Clone)]
 // `#[non_exhaustive]` only affects downstream crates, so we can't use it here
@@ -32,7 +55,7 @@ pub struct AppStateData {
 }
 pub type AppState = axum::extract::State<AppStateData>;
 
-impl AppStateData {
+impl GatewayHandle {
     pub async fn new(config: Arc<Config>) -> Result<Self, Error> {
         let clickhouse_url = std::env::var("TENSORZERO_CLICKHOUSE_URL")
             .ok()
@@ -52,9 +75,12 @@ impl AppStateData {
         let http_client = setup_http_client()?;
 
         Ok(Self {
-            config,
-            http_client,
-            clickhouse_connection_info,
+            app_state: AppStateData {
+                config,
+                http_client,
+                clickhouse_connection_info,
+                _private: (),
+            },
             _private: (),
         })
     }
@@ -65,9 +91,12 @@ impl AppStateData {
         http_client: Client,
     ) -> Self {
         Self {
-            config,
-            http_client,
-            clickhouse_connection_info,
+            app_state: AppStateData {
+                config,
+                http_client,
+                clickhouse_connection_info,
+                _private: (),
+            },
             _private: (),
         }
     }
@@ -76,10 +105,13 @@ impl AppStateData {
     pub fn new_unit_test_data(config: Arc<Config>, clickhouse_healthy: bool) -> Self {
         let http_client = reqwest::Client::new();
         let clickhouse_connection_info = ClickHouseConnectionInfo::new_mock(clickhouse_healthy);
-        AppStateData {
-            config,
-            http_client,
-            clickhouse_connection_info,
+        Self {
+            app_state: AppStateData {
+                config,
+                http_client,
+                clickhouse_connection_info,
+                _private: (),
+            },
             _private: (),
         }
     }
@@ -200,9 +232,12 @@ pub fn setup_http_client() -> Result<Client, Error> {
     })
 }
 
+// We hold on to these fields so that their Drop impls run when `ShutdownHandle` is dropped
 pub struct ShutdownHandle {
     #[expect(dead_code)]
     sender: Sender<()>,
+    #[expect(dead_code)]
+    gateway_handle: GatewayHandle,
 }
 
 /// Starts a new HTTP TensorZero gateway on an unused port, with only the openai-compatible endpoint enabled.
@@ -233,7 +268,7 @@ pub async fn start_openai_compatible_gateway(
     } else {
         Arc::new(Config::default())
     };
-    let app_state = AppStateData::new_with_clickhouse(config, clickhouse_url).await?;
+    let gateway_handle = GatewayHandle::new_with_clickhouse(config, clickhouse_url).await?;
 
     let router = Router::new()
         .route(
@@ -241,7 +276,7 @@ pub async fn start_openai_compatible_gateway(
             post(endpoints::openai_compatible::inference_handler),
         )
         .fallback(endpoints::fallback::handle_404)
-        .with_state(app_state);
+        .with_state(gateway_handle.app_state.clone());
 
     let (sender, recv) = tokio::sync::oneshot::channel::<()>();
     let shutdown_fut = async move {
@@ -253,7 +288,13 @@ pub async fn start_openai_compatible_gateway(
             .with_graceful_shutdown(shutdown_fut)
             .into_future(),
     );
-    Ok((bind_addr, ShutdownHandle { sender }))
+    Ok((
+        bind_addr,
+        ShutdownHandle {
+            sender,
+            gateway_handle,
+        },
+    ))
 }
 
 #[cfg(test)]

--- a/tensorzero-core/src/testing.rs
+++ b/tensorzero-core/src/testing.rs
@@ -3,8 +3,11 @@
 use std::sync::Arc;
 
 use crate::config_parser::Config;
-use crate::gateway_util::AppStateData;
+use crate::gateway_util::GatewayHandle;
 
-pub fn get_unit_test_app_state_data(config: Arc<Config>, clickhouse_healthy: bool) -> AppStateData {
-    AppStateData::new_unit_test_data(config, clickhouse_healthy)
+pub fn get_unit_test_gateway_handle(
+    config: Arc<Config>,
+    clickhouse_healthy: bool,
+) -> GatewayHandle {
+    GatewayHandle::new_unit_test_data(config, clickhouse_healthy)
 }

--- a/tensorzero-core/tests/e2e/feedback.rs
+++ b/tensorzero-core/tests/e2e/feedback.rs
@@ -6,7 +6,7 @@ use tensorzero_core::{
         Config, MetricConfig, MetricConfigLevel, MetricConfigOptimize, MetricConfigType,
     },
     endpoints::feedback::{feedback, Params},
-    gateway_util::AppStateData,
+    gateway_util::GatewayHandle,
     inference::types::{ContentBlockChatOutput, JsonInferenceOutput, Role, Text, TextKind},
 };
 use tokio::time::{sleep, Duration};
@@ -180,7 +180,7 @@ async fn e2e_test_comment_feedback_validation_disabled() {
     let mut config = Config::default();
     let clickhouse = get_clickhouse().await;
     config.gateway.unstable_disable_feedback_target_validation = true;
-    let state = AppStateData::new_with_clickhouse_and_http_client(
+    let handle = GatewayHandle::new_with_clickhouse_and_http_client(
         config.into(),
         clickhouse.clone(),
         reqwest::Client::new(),
@@ -192,7 +192,7 @@ async fn e2e_test_comment_feedback_validation_disabled() {
         value: json!("foo bar"),
         ..Default::default()
     };
-    let val = feedback(state, params).await.unwrap();
+    let val = feedback(handle.app_state, params).await.unwrap();
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Check that this was correctly written to ClickHouse
@@ -1211,7 +1211,7 @@ async fn e2e_test_float_feedback_validation_disabled() {
         .insert("user_score".to_string(), metric_config);
     let clickhouse = get_clickhouse().await;
     config.gateway.unstable_disable_feedback_target_validation = true;
-    let state = AppStateData::new_with_clickhouse_and_http_client(
+    let handle = GatewayHandle::new_with_clickhouse_and_http_client(
         config.into(),
         clickhouse.clone(),
         reqwest::Client::new(),
@@ -1223,7 +1223,7 @@ async fn e2e_test_float_feedback_validation_disabled() {
         value: json!(3.1),
         ..Default::default()
     };
-    let val = feedback(state, params).await.unwrap();
+    let val = feedback(handle.app_state, params).await.unwrap();
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Check that this was correctly written to ClickHouse
@@ -1445,7 +1445,7 @@ async fn e2e_test_boolean_feedback_validation_disabled() {
         .insert("task_success".to_string(), metric_config);
     let clickhouse = get_clickhouse().await;
     config.gateway.unstable_disable_feedback_target_validation = true;
-    let state = AppStateData::new_with_clickhouse_and_http_client(
+    let handle = GatewayHandle::new_with_clickhouse_and_http_client(
         config.into(),
         clickhouse.clone(),
         reqwest::Client::new(),
@@ -1457,7 +1457,7 @@ async fn e2e_test_boolean_feedback_validation_disabled() {
         value: json!(true),
         ..Default::default()
     };
-    let val = feedback(state, params).await.unwrap();
+    let val = feedback(handle.app_state, params).await.unwrap();
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Check that this was correctly written to ClickHouse

--- a/tensorzero-core/tests/e2e/howdy.rs
+++ b/tensorzero-core/tests/e2e/howdy.rs
@@ -15,7 +15,7 @@ use tensorzero_core::clickhouse::migration_manager;
 use tensorzero_core::clickhouse::test_helpers::get_clickhouse;
 use tensorzero_core::clickhouse::ClickHouseConnectionInfo;
 use tensorzero_core::config_parser::Config;
-use tensorzero_core::gateway_util::AppStateData;
+use tensorzero_core::gateway_util::GatewayHandle;
 use tensorzero_core::howdy::{get_deployment_id, get_howdy_report};
 use tensorzero_core::inference::types::TextKind;
 use tokio::time::Duration;
@@ -37,9 +37,9 @@ async fn get_embedded_client(clickhouse: ClickHouseConnectionInfo) -> tensorzero
             .unwrap(),
     );
     migration_manager::run(&clickhouse).await.unwrap();
-    let state =
-        AppStateData::new_with_clickhouse_and_http_client(config, clickhouse, Client::new());
-    ClientBuilder::build_from_state(state).await.unwrap()
+    let handle =
+        GatewayHandle::new_with_clickhouse_and_http_client(config, clickhouse, Client::new());
+    ClientBuilder::build_from_state(handle).await.unwrap()
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
This type is not cloneable, and wraps `AppStateData` (which remains cloneable). When we add support for ClickHouse write batching, the Drop impl for `GatewayHandle` will block and wait for the batcher to exit, to ensure that we don't lose writes during a graceful shutdown.

See the comments on `GatewayHandle` for more details

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduce `GatewayHandle` to manage gateway resources, ensuring proper cleanup during shutdown, and update related code and tests.
> 
>   - **Behavior**:
>     - Introduces `GatewayHandle` to manage gateway resources, ensuring proper cleanup during shutdown.
>     - `GatewayHandle` wraps `AppStateData`, which remains cloneable.
>     - `GatewayHandle` is not cloneable to ensure proper resource management.
>   - **Code Changes**:
>     - Replaces `AppStateData` with `GatewayHandle` in `EmbeddedGateway` in `lib.rs`.
>     - Updates `feedback_handler` in `feedback.rs` to use `GatewayHandle`.
>     - Modifies `health_handler` in `status.rs` to use `GatewayHandle`.
>   - **Testing**:
>     - Updates unit tests in `feedback.rs` and `status.rs` to use `GatewayHandle`.
>     - Adjusts e2e tests in `feedback.rs` and `howdy.rs` to accommodate `GatewayHandle`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0852dc27f1a4b2ae32195fe7c2dd4dfcfdf3cbbb. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->