### PR TITLE
Fix Anthropic's default `max_tokens`

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -4,8 +4,6 @@ run-name: Merge Queue Checks for ${{ github.ref }}
 on:
   workflow_dispatch:
   merge_group:
-  pull_request:
-    branches: ["main"]
   schedule:
     - cron: "0 0 * * *" # Runs at 00:00 UTC every day
 

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -4,6 +4,8 @@ run-name: Merge Queue Checks for ${{ github.ref }}
 on:
   workflow_dispatch:
   merge_group:
+  pull_request:
+    branches: ["main"]
   schedule:
     - cron: "0 0 * * *" # Runs at 00:00 UTC every day
 

--- a/tensorzero-core/src/providers/anthropic.rs
+++ b/tensorzero-core/src/providers/anthropic.rs
@@ -1848,6 +1848,10 @@ mod tests {
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 4_096);
 
+        let model = "claude-3-5-ballad-latest".to_string(); // fake model
+        let body = AnthropicRequestBody::new(&model, &request);
+        assert!(body.is_err());
+
         let model = "claude-4-5-haiku-20260101".to_string(); // fake model
         let body = AnthropicRequestBody::new(&model, &request);
         assert!(body.is_err());

--- a/tensorzero-core/src/providers/anthropic.rs
+++ b/tensorzero-core/src/providers/anthropic.rs
@@ -1800,7 +1800,13 @@ mod tests {
         }];
 
         let request = ModelInferenceRequest {
+            messages: messages.clone(),
+            ..Default::default()
+        };
+
+        let request_with_max_tokens = ModelInferenceRequest {
             messages,
+            max_tokens: Some(100),
             ..Default::default()
         };
 
@@ -1808,53 +1814,105 @@ mod tests {
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 32_000);
 
+        let model = "claude-opus-4-20250514".to_string();
+        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
+
         let model = "claude-sonnet-4-20250514".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 64_000);
+
+        let model = "claude-sonnet-4-20250514".to_string();
+        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-7-sonnet-20250219".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 64_000);
 
+        let model = "claude-3-7-sonnet-20250219".to_string();
+        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
+
         let model = "claude-3-5-sonnet-20241022".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 8_192);
+
+        let model = "claude-3-5-sonnet-20241022".to_string();
+        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-5-haiku-20241022".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 8_192);
 
+        let model = "claude-3-5-haiku-20241022".to_string();
+        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
+
         let model = "claude-opus-4-0".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 32_000);
+
+        let model = "claude-opus-4-0".to_string();
+        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-sonnet-4-0".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 64_000);
 
+        let model = "claude-sonnet-4-0".to_string();
+        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
+
         let model = "claude-3-7-sonnet-latest".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 64_000);
+
+        let model = "claude-3-7-sonnet-latest".to_string();
+        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-5-sonnet-latest".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 8_192);
 
+        let model = "claude-3-5-sonnet-latest".to_string();
+        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
+
         let model = "claude-3-5-haiku-latest".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 8_192);
+
+        let model = "claude-3-5-haiku-latest".to_string();
+        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-haiku-20240307".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 4_096);
 
+        let model = "claude-3-haiku-20240307".to_string();
+        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
+
         let model = "claude-3-5-ballad-latest".to_string(); // fake model
         let body = AnthropicRequestBody::new(&model, &request);
         assert!(body.is_err());
 
+        let model = "claude-3-5-ballad-latest".to_string(); // fake model
+        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
+
         let model = "claude-4-5-haiku-20260101".to_string(); // fake model
         let body = AnthropicRequestBody::new(&model, &request);
         assert!(body.is_err());
+
+        let model = "claude-4-5-haiku-20260101".to_string(); // fake model
+        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
     }
 
     #[test]

--- a/tensorzero-core/src/providers/anthropic.rs
+++ b/tensorzero-core/src/providers/anthropic.rs
@@ -735,7 +735,7 @@ fn get_default_max_tokens(model_name: &str) -> Result<u32, Error> {
         Ok(32_000)
     } else {
         Err(Error::new(ErrorDetails::InferenceClient {
-            message: format!("The TensorZero Gateway doesn't know the output token limit for `{model_name}` and Anthropic requires you to provide a `max_token` value. Please set `max_tokens` in your configuration or inference request."),
+            message: format!("The TensorZero Gateway doesn't know the output token limit for `{model_name}` and Anthropic requires you to provide a `max_tokens` value. Please set `max_tokens` in your configuration or inference request."),
             status_code: None,
             provider_type: PROVIDER_TYPE.into(),
             raw_request: None,

--- a/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
@@ -1684,11 +1684,11 @@ mod tests {
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 8_000);
 
-        let model = "claude-3-5-ballad-latest".to_string(); // fake model
+        let model = "claude-sonnet-4@20300101".to_string(); // fake model
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert!(body.is_err());
 
-        let model = "claude-4-5-haiku-20260101".to_string(); // fake model
+        let model = "claude-4-5-ballad@20260101".to_string(); // fake model
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert!(body.is_err());
     }

--- a/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
@@ -1684,7 +1684,7 @@ mod tests {
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 8_000);
 
-        let model = "claude-sonnet-4@20300101".to_string(); // fake model
+        let model = "claude-sonnet-4".to_string(); // fake model
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert!(body.is_err());
 

--- a/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
@@ -709,19 +709,17 @@ impl<'a> GCPVertexAnthropicRequestBody<'a> {
 /// GCP Anthropic requires that the user provides `max_tokens`, but the value depends on the model.
 /// We maintain a library of known maximum values, and ask the user to hardcode it if it's unknown.
 fn get_default_max_tokens(model_id: &str) -> Result<u32, Error> {
-    if model_id.starts_with("claude-3-haiku@") || model_id.starts_with("claude-3-opus@") {
-        Ok(4_096)
-    } else if model_id.starts_with("claude-3-5-haiku@")
+    if model_id.starts_with("claude-3-haiku@")
+        || model_id.starts_with("claude-3-5-haiku@")
         || model_id.starts_with("claude-3-5-sonnet@")
         || model_id.starts_with("claude-3-5-sonnet-v2@")
     {
-        Ok(8_192)
-    } else if model_id.starts_with("claude-3-7-sonnet@")
-        || model_id.starts_with("claude-sonnet-4@")
-        || model_id == "claude-sonnet-4-0"
-    {
+        Ok(8_000)
+    } else if model_id.starts_with("claude-3-7-sonnet@") {
+        Ok(128_000)
+    } else if model_id.starts_with("claude-sonnet-4@") {
         Ok(64_000)
-    } else if model_id.starts_with("claude-opus-4@") || model_id == "claude-opus-4-0" {
+    } else if model_id.starts_with("claude-opus-4@") {
         Ok(32_000)
     } else {
         Err(Error::new(ErrorDetails::InferenceClient {
@@ -1668,23 +1666,23 @@ mod tests {
 
         let model = "claude-3-7-sonnet@20250219".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
-        assert_eq!(body.unwrap().max_tokens, 64_000);
+        assert_eq!(body.unwrap().max_tokens, 128_000);
 
         let model = "claude-3-5-sonnet-v2@20240222".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
-        assert_eq!(body.unwrap().max_tokens, 8_192);
+        assert_eq!(body.unwrap().max_tokens, 8_000);
 
         let model = "claude-3-5-sonnet@20240229".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
-        assert_eq!(body.unwrap().max_tokens, 8_192);
+        assert_eq!(body.unwrap().max_tokens, 8_000);
 
         let model = "claude-3-5-haiku@20240307".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
-        assert_eq!(body.unwrap().max_tokens, 8_192);
+        assert_eq!(body.unwrap().max_tokens, 8_000);
 
         let model = "claude-3-haiku@20240307".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
-        assert_eq!(body.unwrap().max_tokens, 4_096);
+        assert_eq!(body.unwrap().max_tokens, 8_000);
 
         let model = "claude-3-5-ballad-latest".to_string(); // fake model
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);

--- a/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
@@ -1661,7 +1661,13 @@ mod tests {
         }];
 
         let request = ModelInferenceRequest {
+            messages: messages.clone(),
+            ..Default::default()
+        };
+
+        let request_with_max_tokens = ModelInferenceRequest {
             messages,
+            max_tokens: Some(100),
             ..Default::default()
         };
 
@@ -1669,37 +1675,73 @@ mod tests {
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 32_000);
 
+        let model = "claude-opus-4@20250514".to_string();
+        let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
+
         let model = "claude-sonnet-4@20250514".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 64_000);
+
+        let model = "claude-sonnet-4@20250514".to_string();
+        let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-7-sonnet@20250219".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 64_000);
 
+        let model = "claude-3-7-sonnet@20250219".to_string();
+        let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
+
         let model = "claude-3-5-sonnet-v2@20240222".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 8_192);
+
+        let model = "claude-3-5-sonnet-v2@20240222".to_string();
+        let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-5-sonnet@20240229".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 8_192);
 
+        let model = "claude-3-5-sonnet@20240229".to_string();
+        let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
+
         let model = "claude-3-5-haiku@20240307".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 8_192);
+
+        let model = "claude-3-5-haiku@20240307".to_string();
+        let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-haiku@20240307".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 4_096);
 
+        let model = "claude-3-haiku@20240307".to_string();
+        let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
+
         let model = "claude-sonnet-4".to_string(); // fake model
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert!(body.is_err());
 
+        let model = "claude-sonnet-4".to_string(); // fake model
+        let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
+
         let model = "claude-4-5-ballad@20260101".to_string(); // fake model
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert!(body.is_err());
+
+        let model = "claude-4-5-ballad@20260101".to_string(); // fake model
+        let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
     }
 
     #[test]

--- a/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
@@ -716,7 +716,7 @@ impl<'a> GCPVertexAnthropicRequestBody<'a> {
 fn get_default_max_tokens(model_id: &str) -> Result<u32, Error> {
     if model_id.starts_with("claude-3-haiku@") {
         // GCP docs say 8k but that causes `max_tokens: XXX > 8192, which is the maximum allowed number of output tokens for claude-3-haiku-20250219`
-        Ok(4_192)
+        Ok(4_096)
     } else if model_id.starts_with("claude-3-5-haiku@")
         || model_id.starts_with("claude-3-5-sonnet@")
         || model_id.starts_with("claude-3-5-sonnet-v2@")
@@ -1675,7 +1675,7 @@ mod tests {
 
         let model = "claude-3-7-sonnet@20250219".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
-        assert_eq!(body.unwrap().max_tokens, 128_000);
+        assert_eq!(body.unwrap().max_tokens, 64_000);
 
         let model = "claude-3-5-sonnet-v2@20240222".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
@@ -1976,7 +1976,9 @@ mod tests {
                 status_code: Some(response_code),
                 provider_type: PROVIDER_TYPE.to_string(),
                 raw_request: None,
-                raw_response: Some("{\"type\":\"error\",\"message\":\"test_message\"}".to_string()),
+                raw_response: Some(
+                    "{\"type\":null,\"code\":null,\"message\":\"test_message\"}".to_string()
+                ),
             }
         );
         let response_code = StatusCode::UNAUTHORIZED;
@@ -1989,7 +1991,9 @@ mod tests {
                 status_code: Some(response_code),
                 provider_type: PROVIDER_TYPE.to_string(),
                 raw_request: None,
-                raw_response: Some("{\"type\":\"error\",\"message\":\"test_message\"}".to_string()),
+                raw_response: Some(
+                    "{\"type\":null,\"code\":null,\"message\":\"test_message\"}".to_string()
+                ),
             }
         );
         let response_code = StatusCode::TOO_MANY_REQUESTS;
@@ -2002,7 +2006,9 @@ mod tests {
                 status_code: Some(response_code),
                 provider_type: PROVIDER_TYPE.to_string(),
                 raw_request: None,
-                raw_response: Some("{\"type\":\"error\",\"message\":\"test_message\"}".to_string()),
+                raw_response: Some(
+                    "{\"type\":null,\"code\":null,\"message\":\"test_message\"}".to_string()
+                ),
             }
         );
         let response_code = StatusCode::NOT_FOUND;
@@ -2014,7 +2020,9 @@ mod tests {
             ErrorDetails::InferenceServer {
                 message: "test_message".to_string(),
                 raw_request: None,
-                raw_response: Some("{\"type\":\"error\",\"message\":\"test_message\"}".to_string()),
+                raw_response: Some(
+                    "{\"type\":null,\"code\":null,\"message\":\"test_message\"}".to_string()
+                ),
                 provider_type: PROVIDER_TYPE.to_string()
             }
         );
@@ -2026,7 +2034,9 @@ mod tests {
             ErrorDetails::InferenceServer {
                 message: "test_message".to_string(),
                 raw_request: None,
-                raw_response: Some("{\"type\":\"error\",\"message\":\"test_message\"}".to_string()),
+                raw_response: Some(
+                    "{\"type\":null,\"code\":null,\"message\":\"test_message\"}".to_string()
+                ),
                 provider_type: PROVIDER_TYPE.to_string()
             }
         );

--- a/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
@@ -723,7 +723,7 @@ fn get_default_max_tokens(model_id: &str) -> Result<u32, Error> {
         Ok(32_000)
     } else {
         Err(Error::new(ErrorDetails::InferenceClient {
-            message: format!("The TensorZero Gateway doesn't know the output token limit for `{model_id}` and GCP Vertex AI Anthropic requires you to provide a `max_token` value. Please set `max_tokens` in your configuration or inference request."),
+            message: format!("The TensorZero Gateway doesn't know the output token limit for `{model_id}` and GCP Vertex AI Anthropic requires you to provide a `max_tokens` value. Please set `max_tokens` in your configuration or inference request."),
             status_code: None,
             provider_type: PROVIDER_TYPE.into(),
             raw_request: None,


### PR DESCRIPTION
Also fix #2979 

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix default `max_tokens` for Anthropic models by introducing model-specific defaults in `anthropic.rs` and `gcp_vertex_anthropic.rs`.
> 
>   - **Behavior**:
>     - Update `AnthropicRequestBody` in `anthropic.rs` to use `get_default_max_tokens()` for default `max_tokens` based on model name.
>     - Update `GCPVertexAnthropicRequestBody` in `gcp_vertex_anthropic.rs` to use `get_default_max_tokens()` for default `max_tokens` based on model ID.
>   - **Functions**:
>     - Add `get_default_max_tokens()` in `anthropic.rs` to return default `max_tokens` for Anthropic models.
>     - Add `get_default_max_tokens()` in `gcp_vertex_anthropic.rs` to return default `max_tokens` for GCP Anthropic models.
>   - **Tests**:
>     - Add tests in `anthropic.rs` to verify default `max_tokens` behavior for various models.
>     - Add tests in `gcp_vertex_anthropic.rs` to verify default `max_tokens` behavior for various models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a6a8faae62311c1d2a091ec138969229f15191f1. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->