### PR TITLE
updated handling for metric names in CurationMetricSelector and tested

### DIFF
--- a/ui/app/components/metric/CurationMetricSelector.tsx
+++ b/ui/app/components/metric/CurationMetricSelector.tsx
@@ -152,7 +152,7 @@ export default function CurationMetricSelector<
                       {(() => {
                         const currentMetricName = field.value as string | null;
                         const selectedMetricDetails = currentMetricName
-                          ? config.metrics[currentMetricName]
+                          ? metrics[currentMetricName]
                           : undefined;
 
                         if (currentMetricName && selectedMetricDetails) {
@@ -306,7 +306,7 @@ export default function CurationMetricSelector<
                 </PopoverContent>
               </Popover>
 
-              {field.value && config.metrics[field.value]?.type === "float" && (
+              {field.value && metrics[field.value]?.type === "float" && (
                 <FormField
                   control={control}
                   name={"threshold" as Path<T>}

--- a/ui/e2e_tests/optimization.supervised-fine-tuning.spec.ts
+++ b/ui/e2e_tests/optimization.supervised-fine-tuning.spec.ts
@@ -235,6 +235,36 @@ model_name = "accounts/fake_fireworks_account/models/mock-fireworks-model"
 `),
     ).toBeVisible();
   });
+
+  test("should show demonstration metric option for write_haiku function", async ({
+    page,
+  }) => {
+    await page.goto("/optimization/supervised-fine-tuning");
+
+    // Select write_haiku function
+    await page
+      .getByRole("combobox")
+      .filter({ hasText: "Select a function" })
+      .click();
+    await page.getByRole("option", { name: "write_haiku" }).click();
+
+    // Open metric selector
+    await page
+      .getByRole("combobox")
+      .filter({ hasText: "Select a metric" })
+      .click();
+
+    // Verify demonstration option is visible and can be selected
+    await expect(
+      page.getByText("demonstration", { exact: true }),
+    ).toBeVisible();
+    await page.getByText("demonstration", { exact: true }).click();
+
+    // Verify the metric selection is shown in the form
+    await expect(
+      page.getByRole("combobox").filter({ hasText: "demonstration" }),
+    ).toBeVisible();
+  });
 });
 
 test.describe("Error handling", () => {


### PR DESCRIPTION
This fixed a UI bug where if "demonstration" was selected the selector would not render it
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix UI bug in `CurationMetricSelector` to correctly render 'demonstration' metric and add e2e test for verification.
> 
>   - **UI Bug Fix**:
>     - In `CurationMetricSelector.tsx`, change metric source from `config.metrics` to `metrics` to include 'demonstration' metric.
>     - Fixes issue where 'demonstration' metric was not rendered when selected.
>   - **Testing**:
>     - Add e2e test in `optimization.supervised-fine-tuning.spec.ts` to verify 'demonstration' metric is visible and selectable for 'write_haiku' function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0fe4b5a0bc3901de4e5e9c89b69a87ca57ae3680. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->