### PR TITLE
Don't write cache hits back to the cache

### DIFF
--- a/tensorzero-core/src/model.rs
+++ b/tensorzero-core/src/model.rs
@@ -422,7 +422,7 @@ impl ModelConfig {
                     Ok(response) => {
                         // Perform the cache write outside of the `non_streaming_total_timeout` timeout future,
                         // (in case we ever add a blocking cache write option)
-                        if clients.cache_options.enabled.write() {
+                        if !response.cached && clients.cache_options.enabled.write() {
                             let _ = start_cache_write(
                                 clients.clickhouse_connection_info,
                                 cache_key,

--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -10335,13 +10335,16 @@ pub async fn test_short_inference_request_with_provider(provider: E2ETestProvide
     let episode_id = Uuid::now_v7();
     let extra_headers = get_extra_headers();
 
+    // Include randomness in the prompt to force a cache miss for the first request
+    let randomness = Uuid::now_v7();
+
     let payload = json!({
         "function_name": "basic_test",
         "variant_name": provider.variant_name,
         "episode_id": episode_id,
         "input":
             {
-               "system": {"assistant_name": "Dr. Mehta"},
+               "system": {"assistant_name": format!("Dr. Mehta: {randomness}")},
                "messages": [
                 {
                     "role": "user",
@@ -10350,6 +10353,7 @@ pub async fn test_short_inference_request_with_provider(provider: E2ETestProvide
             ]},
         "stream": false,
         "tags": {"foo": "bar"},
+        "cache_options": {"enabled": "on", "lookback_s": 10},
         "params": {
             "chat_completion": {
                 "max_tokens": 1
@@ -10375,34 +10379,15 @@ pub async fn test_short_inference_request_with_provider(provider: E2ETestProvide
 
     println!("API response: {response_json:#?}");
 
-    check_short_inference_response(response_json, Some(episode_id), &provider, false).await;
+    check_short_inference_response(
+        randomness,
+        response_json,
+        Some(episode_id),
+        &provider,
+        false,
+    )
+    .await;
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-
-    let episode_id = Uuid::now_v7();
-
-    let payload = json!({
-        "function_name": "basic_test",
-        "variant_name": provider.variant_name,
-        "episode_id": episode_id,
-        "input":
-            {
-               "system": {"assistant_name": "Dr. Mehta"},
-               "messages": [
-                {
-                    "role": "user",
-                    "content": "What is the name of the capital city of Japan?"
-                }
-            ]},
-        "stream": false,
-        "tags": {"foo": "bar"},
-        "cache_options": {"enabled": "on", "lookback_s": 10},
-        "params": {
-            "chat_completion": {
-                "max_tokens": 1
-            }
-        },
-        "extra_headers": extra_headers.headers,
-    });
 
     let response = Client::new()
         .post(get_gateway_endpoint("/inference"))
@@ -10417,10 +10402,12 @@ pub async fn test_short_inference_request_with_provider(provider: E2ETestProvide
 
     println!("API response: {response_json:#?}");
 
-    check_short_inference_response(response_json, Some(episode_id), &provider, true).await;
+    check_short_inference_response(randomness, response_json, Some(episode_id), &provider, true)
+        .await;
 }
 
 async fn check_short_inference_response(
+    randomness: Uuid,
     response_json: Value,
     episode_id: Option<Uuid>,
     provider: &E2ETestProvider,
@@ -10494,7 +10481,7 @@ async fn check_short_inference_response(
     let input: Value =
         serde_json::from_str(result.get("input").unwrap().as_str().unwrap()).unwrap();
     let correct_input = json!({
-        "system": {"assistant_name": "Dr. Mehta"},
+        "system": {"assistant_name": format!("Dr. Mehta: {randomness}")},
         "messages": [
             {
                 "role": "user",
@@ -10577,7 +10564,7 @@ async fn check_short_inference_response(
     let system = result.get("system").unwrap().as_str().unwrap();
     assert_eq!(
         system,
-        "You are a helpful and friendly assistant named Dr. Mehta"
+        format!("You are a helpful and friendly assistant named Dr. Mehta: {randomness}")
     );
     let input_messages = result.get("input_messages").unwrap().as_str().unwrap();
     let input_messages: Vec<RequestMessage> = serde_json::from_str(input_messages).unwrap();
@@ -10617,21 +10604,16 @@ async fn check_short_inference_response(
         // Allow some time for an incorrect second cache write to happen
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        // Obtain the deduplicated and non-deduplicated counts
+        // Count the number of cache entries for this raw_request
         // Note that this can have false negatives (ClickHouse might decide to merge parts
         // immediately after a duplicate insert)
-        let first_count = clickhouse
-            .run_query_synchronous_no_params("SELECT COUNT(*) FROM ModelInferenceCache".to_string())
-            .await
-            .unwrap()
-            .response
-            .trim()
-            .parse::<u64>()
-            .unwrap();
-
-        let second_count = clickhouse
-            .run_query_synchronous_no_params(
-                "SELECT COUNT(*) FROM ModelInferenceCache FINAL".to_string(),
+        let count = clickhouse
+            .run_query_synchronous(
+                "SELECT COUNT(*) FROM ModelInferenceCache WHERE raw_request = {raw_request:String} "
+                    .to_string(),
+                &[("raw_request", result["raw_request"].as_str().unwrap())]
+                    .into_iter()
+                    .collect(),
             )
             .await
             .unwrap()
@@ -10640,8 +10622,7 @@ async fn check_short_inference_response(
             .parse::<u64>()
             .unwrap();
 
-        assert_ne!(first_count, 0);
-        assert_eq!(first_count, second_count);
+        assert_eq!(count, 1);
     }
 }
 


### PR DESCRIPTION
We already had the correct behavior for streaming cache hits

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Prevents cache hits from being written back to the cache and updates tests to verify correct cache behavior.
> 
>   - **Behavior**:
>     - Prevents cache hits from being written back to the cache in `model.rs` by checking `!response.cached` before writing.
>   - **Tests**:
>     - Updates `test_short_inference_request_with_provider` in `common.rs` to include randomness in prompts, ensuring cache misses on first request.
>     - Verifies cache entries are written only once by counting entries in `check_short_inference_response`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3bc64c9ea8fc1d5ed0c1df7b2de7854072e990c0. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->