### PR TITLE
Remove 'continue-on-error' from ui e2e tests

### DIFF
--- a/.github/workflows/ui-tests-e2e-model-inference-cache.yml
+++ b/.github/workflows/ui-tests-e2e-model-inference-cache.yml
@@ -137,7 +137,6 @@ jobs:
         id: e2e_tests
         env:
           TENSORZERO_CI: 1
-        continue-on-error: true
         run: pnpm ui:test:e2e --grep-invert "@credentials"
 
       - name: Print Docker Compose logs
@@ -169,7 +168,7 @@ jobs:
         run: docker exec fixtures-clickhouse-1 cat /var/log/clickhouse-server/clickhouse-server.log
 
       - name: Upload Playwright artifacts
-        if: steps.e2e_tests.outcome == 'failure'
+        if: failure()
         uses: namespace-actions/upload-artifact@9a78c62e083914789d908952f9773e42744b9f68
         with:
           name: playwright-report
@@ -177,7 +176,3 @@ jobs:
             ui/playwright-report/
             ui/test-results/
           retention-days: 7
-
-      - name: Exit if tests failed
-        if: steps.e2e_tests.outcome == 'failure'
-        run: exit 1

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -132,15 +132,14 @@ jobs:
         id: e2e_tests
         env:
           TENSORZERO_CI: 1
-        continue-on-error: true
         run: pnpm ui:test:e2e-base-path
 
       - name: Run UI E2E tests that require credentials
         id: e2e_tests_credentials
         env:
           TENSORZERO_CI: 1
-        continue-on-error: true
-        run: pnpm ui:test:e2e --grep "@credentials"
+        # We currently have no tests that require credentials
+        run: pnpm ui:test:e2e --grep "@credentials" --pass-with-no-tests
 
       - name: Print Docker Compose logs
         if: always()
@@ -161,7 +160,7 @@ jobs:
         run: docker exec fixtures-clickhouse-1 cat /var/log/clickhouse-server/clickhouse-server.log
 
       - name: Upload Playwright artifacts
-        if: steps.e2e_tests.outcome == 'failure'
+        if: failure()
         uses: namespace-actions/upload-artifact@9a78c62e083914789d908952f9773e42744b9f68
         with:
           name: playwright-report-e2e-base-path
@@ -169,10 +168,6 @@ jobs:
             ui/playwright-report/
             ui/test-results/
           retention-days: 7
-
-      - name: Exit if tests failed
-        if: steps.e2e_tests.outcome == 'failure'
-        run: exit 1
 
   # Test that the ui e2e tests pass with model inference cache included in this commit
   ui-tests-e2e-existing-model-inference-cache:


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove 'continue-on-error' from UI E2E tests and update failure handling in GitHub workflows.
> 
>   - **Workflows**:
>     - Remove `continue-on-error: true` from `ui-tests-e2e-model-inference-cache.yml` and `ui-tests-e2e.yml` for E2E test steps.
>     - Change condition for uploading Playwright artifacts to `if: failure()` in both workflow files.
>     - Remove redundant exit step for failed tests in both workflow files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0cd6a2c6a1852271bccbf86167616094c664c630. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->