### PR TITLE
Skip running migrations when TensorZeroMigration is up to date

### DIFF
--- a/internal/tensorzero-node/lib/bindings/ObservabilityConfig.ts
+++ b/internal/tensorzero-node/lib/bindings/ObservabilityConfig.ts
@@ -3,4 +3,9 @@
 export type ObservabilityConfig = {
   enabled: boolean | null;
   async_writes: boolean;
+  /**
+   * If `true`, then we skip checking/applying migrations if the `TensorZeroMigration` table
+   * contains exactly the migrations that we expect to have run.
+   */
+  skip_completed_migrations: boolean;
 };

--- a/tensorzero-core/src/clickhouse/migration_manager/migrations/migration_0029.rs
+++ b/tensorzero-core/src/clickhouse/migration_manager/migrations/migration_0029.rs
@@ -24,6 +24,8 @@ impl Migration for Migration0029<'_> {
         // on a clean start, and write out the corresponding `TensorZeroMigration` record.
         // This ensures that running from a clean start runs every migration, which allows
         // us to skip running all migrations on subsequent runs.
+        // Applying this migration from a clean start doesn't do anything, since the views
+        // don't exist.
         Ok(true)
     }
 

--- a/tensorzero-core/src/clickhouse/migration_manager/migrations/migration_0029.rs
+++ b/tensorzero-core/src/clickhouse/migration_manager/migrations/migration_0029.rs
@@ -20,20 +20,11 @@ impl Migration for Migration0029<'_> {
     }
 
     async fn should_apply(&self) -> Result<bool, Error> {
-        let float_materialized_view_exists = check_table_exists(
-            self.clickhouse,
-            "StaticEvaluationHumanFeedbackFloatView",
-            MIGRATION_ID,
-        )
-        .await?;
-        let boolean_materialized_view_exists = check_table_exists(
-            self.clickhouse,
-            "StaticEvaluationHumanFeedbackBooleanView",
-            MIGRATION_ID,
-        )
-        .await?;
-        // We need to run this migration if either the float or boolean materialized views exist.
-        Ok(float_materialized_view_exists || boolean_materialized_view_exists)
+        // Note - we always return `true` here, so that we run this migration
+        // on a clean start, and write out the corresponding `TensorZeroMigration` record.
+        // This ensures that running from a clean start runs every migration, which allows
+        // us to skip running all migrations on subsequent runs.
+        Ok(true)
     }
 
     async fn apply(&self, _clean_start: bool) -> Result<(), Error> {
@@ -57,7 +48,18 @@ impl Migration for Migration0029<'_> {
     }
 
     async fn has_succeeded(&self) -> Result<bool, Error> {
-        let should_apply = self.should_apply().await?;
-        Ok(!should_apply)
+        let float_materialized_view_exists = check_table_exists(
+            self.clickhouse,
+            "StaticEvaluationHumanFeedbackFloatView",
+            MIGRATION_ID,
+        )
+        .await?;
+        let boolean_materialized_view_exists = check_table_exists(
+            self.clickhouse,
+            "StaticEvaluationHumanFeedbackBooleanView",
+            MIGRATION_ID,
+        )
+        .await?;
+        Ok(!float_materialized_view_exists && !boolean_materialized_view_exists)
     }
 }

--- a/tensorzero-core/src/config_parser/mod.rs
+++ b/tensorzero-core/src/config_parser/mod.rs
@@ -310,6 +310,10 @@ pub struct ObservabilityConfig {
     pub enabled: Option<bool>,
     #[serde(default)]
     pub async_writes: bool,
+    /// If `true`, then we skip checking/applying migrations if the `TensorZeroMigration` table
+    /// contains exactly the migrations that we expect to have run.
+    #[serde(default)]
+    pub skip_completed_migrations: bool,
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq, Serialize)]

--- a/tensorzero-core/src/error.rs
+++ b/tensorzero-core/src/error.rs
@@ -114,6 +114,13 @@ impl Error {
         Error(Box::new(details))
     }
 
+    pub fn new_with_err_logging(details: ErrorDetails, err_logging: bool) -> Self {
+        if err_logging {
+            details.log();
+        }
+        Error(Box::new(details))
+    }
+
     pub fn new_without_logging(details: ErrorDetails) -> Self {
         Error(Box::new(details))
     }

--- a/tensorzero-core/src/gateway_util.rs
+++ b/tensorzero-core/src/gateway_util.rs
@@ -155,7 +155,11 @@ pub async fn setup_clickhouse(
 
     // Run ClickHouse migrations (if any) if we have a production ClickHouse connection
     if let ClickHouseConnectionInfo::Production { .. } = &clickhouse_connection_info {
-        migration_manager::run(&clickhouse_connection_info).await?;
+        migration_manager::run(
+            &clickhouse_connection_info,
+            config.gateway.observability.skip_completed_migrations,
+        )
+        .await?;
     }
     Ok(clickhouse_connection_info)
 }
@@ -312,6 +316,7 @@ mod tests {
             observability: ObservabilityConfig {
                 enabled: Some(false),
                 async_writes: false,
+                skip_completed_migrations: false,
             },
             bind_address: None,
             debug: false,
@@ -341,6 +346,7 @@ mod tests {
             observability: ObservabilityConfig {
                 enabled: None,
                 async_writes: false,
+                skip_completed_migrations: false,
             },
             unstable_error_json: false,
             ..Default::default()
@@ -367,6 +373,7 @@ mod tests {
             observability: ObservabilityConfig {
                 enabled: Some(true),
                 async_writes: false,
+                skip_completed_migrations: false,
             },
             bind_address: None,
             debug: false,
@@ -392,6 +399,7 @@ mod tests {
             observability: ObservabilityConfig {
                 enabled: Some(true),
                 async_writes: false,
+                skip_completed_migrations: false,
             },
             bind_address: None,
             debug: false,
@@ -419,6 +427,7 @@ mod tests {
             observability: ObservabilityConfig {
                 enabled: Some(true),
                 async_writes: false,
+                skip_completed_migrations: false,
             },
             bind_address: None,
             debug: false,

--- a/tensorzero-core/tests/e2e/clickhouse.rs
+++ b/tensorzero-core/tests/e2e/clickhouse.rs
@@ -681,7 +681,7 @@ async fn test_clickhouse_migration_manager() {
     );
     let rows = get_all_migration_records(&clickhouse).await.unwrap();
     println!("Rows: {rows:#?}");
-    let expected_migrations = migrations.clone();
+    let expected_migrations = &migrations;
 
     // Check that we wrote out migration records for all migrations
     assert_eq!(rows.len(), expected_migrations.len());

--- a/tensorzero-core/tests/e2e/clickhouse.rs
+++ b/tensorzero-core/tests/e2e/clickhouse.rs
@@ -571,14 +571,17 @@ async fn test_clickhouse_migration_manager() {
                     assert!(!clean_start);
                 }
                 let name = migrations[i].name();
-                assert!(
-                    !logs_contain(&format!("Applying migration: {name}")),
-                    "Migration {name} should not have been applied"
-                );
-                assert!(
-                    !logs_contain(&format!("Migration succeeded: {name}")),
-                    "Migration {name} should not have succeeded (because it wasn't applied)"
-                );
+                // Migration0029 always runs (since we want it to write a migration row on a clean start)
+                if migration.name() == "Migration0029" {
+                    assert!(
+                        !logs_contain(&format!("Applying migration: {name}")),
+                        "Migration {name} should not have been applied"
+                    );
+                    assert!(
+                        !logs_contain(&format!("Migration succeeded: {name}")),
+                        "Migration {name} should not have succeeded (because it wasn't applied)"
+                    );
+                }
             }
             assert!(!logs_contain("Materialized view `CumulativeUsageView` was not written because it was recently created"),
                 "CumulativeUsage backfilling failed.");

--- a/tensorzero-core/tests/e2e/clickhouse.rs
+++ b/tensorzero-core/tests/e2e/clickhouse.rs
@@ -714,7 +714,7 @@ async fn test_clickhouse_migration_manager() {
         assert!(applied_at.is_some());
     }
     run_all(&clickhouse, &migrations).await;
-    let new_rows = get_all_migration_records(&clickhouse).await.unwrap();
+    let mut new_rows = get_all_migration_records(&clickhouse).await.unwrap();
 
     let response = clickhouse
         .run_query_synchronous_no_params(
@@ -734,6 +734,8 @@ async fn test_clickhouse_migration_manager() {
     assert_eq!(output_token_total, 200000000);
     // Since we've already ran all of the migrations, we shouldn't have written any new records
     // except for Migration0029 (which runs every time)
+
+    let mut rows = rows;
     let _new_migration0029 = new_rows
         .iter()
         .find(|row| row.migration_name == "Migration0029")

--- a/tensorzero-core/tests/e2e/clickhouse.rs
+++ b/tensorzero-core/tests/e2e/clickhouse.rs
@@ -572,7 +572,7 @@ async fn test_clickhouse_migration_manager() {
                 }
                 let name = migrations[i].name();
                 // Migration0029 always runs (since we want it to write a migration row on a clean start)
-                if migration.name() == "Migration0029" {
+                if migration.name() != "Migration0029" {
                     assert!(
                         !logs_contain(&format!("Applying migration: {name}")),
                         "Migration {name} should not have been applied"

--- a/tensorzero-core/tests/e2e/clickhouse.rs
+++ b/tensorzero-core/tests/e2e/clickhouse.rs
@@ -681,12 +681,7 @@ async fn test_clickhouse_migration_manager() {
     );
     let rows = get_all_migration_records(&clickhouse).await.unwrap();
     println!("Rows: {rows:#?}");
-    // Migration0029 is currently skipped, because 'StaticEvaluationHumanFeedbackFloatView' is created
-    // by a banned migration
-    let expected_migrations = migrations
-        .iter()
-        .filter(|m| m.name() != "Migration0029")
-        .collect::<Vec<_>>();
+    let expected_migrations = migrations.clone();
 
     // Check that we wrote out migration records for all migrations
     assert_eq!(rows.len(), expected_migrations.len());

--- a/tensorzero-core/tests/e2e/clickhouse.rs
+++ b/tensorzero-core/tests/e2e/clickhouse.rs
@@ -976,12 +976,12 @@ async fn test_migration_0013_data_no_table() {
 #[traced_test]
 async fn test_run_migrations_clean() {
     let (clickhouse, _cleanup_db) = get_clean_clickhouse(false);
-    migration_manager::run(&clickhouse, false).await.unwrap();
+    migration_manager::run(&clickhouse, true).await.unwrap();
     assert!(logs_contain("Database not found, assuming clean start"));
     assert!(!logs_contain("All migrations have already been applied"));
 
     // Run again, and we should skip all migrations
-    migration_manager::run(&clickhouse, false).await.unwrap();
+    migration_manager::run(&clickhouse, true).await.unwrap();
     assert!(logs_contain("All migrations have already been applied"));
 }
 

--- a/tensorzero-core/tests/e2e/clickhouse.rs
+++ b/tensorzero-core/tests/e2e/clickhouse.rs
@@ -657,8 +657,17 @@ async fn test_clickhouse_migration_manager() {
                 assert!(!clean_start);
             }
             let name = migrations[i].name();
-            assert!(!logs_contain(&format!("Applying migration: {name}")));
-            assert!(!logs_contain(&format!("Migration succeeded: {name}")));
+            // Migration0029 always runs
+            if name != "Migration0029" {
+                assert!(
+                    !logs_contain(&format!("Applying migration: {name}")),
+                    "Missing log for {name}"
+                );
+                assert!(
+                    !logs_contain(&format!("Migration succeeded: {name}")),
+                    "Missing success for {name}"
+                );
+            }
         }
 
         assert!(!logs_contain("Failed to apply migration"));

--- a/tensorzero-core/tests/e2e/clickhouse.rs
+++ b/tensorzero-core/tests/e2e/clickhouse.rs
@@ -733,6 +733,18 @@ async fn test_clickhouse_migration_manager() {
     let output_token_total: u64 = response.response.trim().parse().unwrap();
     assert_eq!(output_token_total, 200000000);
     // Since we've already ran all of the migrations, we shouldn't have written any new records
+    // except for Migration0029 (which runs every time)
+    let _new_migration0029 = new_rows
+        .iter()
+        .find(|row| row.migration_name == "Migration0029")
+        .unwrap();
+    new_rows.retain(|row| row.migration_name != "Migration0029");
+
+    let _old_migration0029 = rows
+        .iter()
+        .find(|row| row.migration_name == "Migration0029")
+        .unwrap();
+    rows.retain(|row| row.migration_name != "Migration0029");
 
     assert_eq!(new_rows, rows);
 }

--- a/tensorzero-core/tests/e2e/clickhouse.rs
+++ b/tensorzero-core/tests/e2e/clickhouse.rs
@@ -813,7 +813,7 @@ async fn test_concurrent_clickhouse_migrations() {
         .unwrap();
     assert!(
         total_runs as usize > all_migrations.len(),
-        "Expected more than {} migration runs, but only only found {total_runs}",
+        "Expected more than {} migration runs, but only found {total_runs}",
         all_migrations.len()
     );
 

--- a/tensorzero-core/tests/e2e/howdy.rs
+++ b/tensorzero-core/tests/e2e/howdy.rs
@@ -36,7 +36,7 @@ async fn get_embedded_client(clickhouse: ClickHouseConnectionInfo) -> tensorzero
             .await
             .unwrap(),
     );
-    migration_manager::run(&clickhouse).await.unwrap();
+    migration_manager::run(&clickhouse, false).await.unwrap();
     let handle =
         GatewayHandle::new_with_clickhouse_and_http_client(config, clickhouse, Client::new());
     ClientBuilder::build_from_state(handle).await.unwrap()

--- a/tensorzero-core/tests/e2e/tensorzero.toml
+++ b/tensorzero-core/tests/e2e/tensorzero.toml
@@ -12,6 +12,7 @@ debug = true
 template_filesystem_access.enabled = true
 export.otlp.traces.enabled = true
 unstable_error_json = true
+observability.skip_completed_migrations = true
 
 [object_storage]
 type = "disabled"

--- a/ui/app/components/feedback/FeedbackTable.stories.tsx
+++ b/ui/app/components/feedback/FeedbackTable.stories.tsx
@@ -15,6 +15,7 @@ const config: Config = {
     observability: {
       enabled: true,
       async_writes: false,
+      skip_completed_migrations: false,
     },
     export: {
       otlp: {


### PR DESCRIPTION
We only skip running migrations when the table has exactly the migration ids that we expect to see.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add logic to skip running migrations if the `TensorZeroMigration` table is up to date, with configuration and tests updated accordingly.
> 
>   - **Behavior**:
>     - Introduces `skip_completed_migrations` in `ObservabilityConfig` to skip migrations if `TensorZeroMigration` table is up to date.
>     - Updates `should_apply()` in `migration_0029.rs` to always return `true` for initial run.
>     - Adds `should_skip_migrations()` in `mod.rs` to check if migrations can be skipped.
>   - **Configuration**:
>     - Adds `skip_completed_migrations` to `ObservabilityConfig` in `config_parser/mod.rs`.
>     - Updates `tensorzero.toml` to include `observability.skip_completed_migrations = true`.
>   - **Tests**:
>     - Updates tests in `clickhouse.rs` and `howdy.rs` to verify migration skipping logic.
>     - Adds test cases for `should_skip_migrations()` and scenarios with fake migration rows.
>   - **Misc**:
>     - Adds `skip_completed_migrations` to `ObservabilityConfig` in `FeedbackTable.stories.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 94de59ab0b6eb33e1ceb0aeece9e847435882c26. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->