### PR TITLE
Extract raw_response from AWS providers via TensorZeroInterceptor

### DIFF
--- a/tensorzero-core/src/providers/aws_common.rs
+++ b/tensorzero-core/src/providers/aws_common.rs
@@ -64,7 +64,7 @@ pub struct TensorZeroInterceptor {
     /// Captures the raw request from `modify_before_signing`.
     /// After the request is executed, we use this to retrieve the raw request.
     raw_request: Arc<Mutex<Option<String>>>,
-    /// Captures the raw response from `modify_after_signing`.
+    /// Captures the raw response from `read_after_deserialization`.
     /// After the request is executed, we use this to retrieve the raw response.
     raw_response: Arc<Mutex<Option<String>>>,
     extra_body: FullExtraBodyConfig,

--- a/tensorzero-core/src/providers/aws_common.rs
+++ b/tensorzero-core/src/providers/aws_common.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use aws_config::{meta::region::RegionProviderChain, Region};
+use aws_smithy_runtime_api::client::interceptors::context::AfterDeserializationInterceptorContextRef;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
 use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
@@ -63,15 +64,20 @@ pub struct TensorZeroInterceptor {
     /// Captures the raw request from `modify_before_signing`.
     /// After the request is executed, we use this to retrieve the raw request.
     raw_request: Arc<Mutex<Option<String>>>,
+    /// Captures the raw response from `modify_after_signing`.
+    /// After the request is executed, we use this to retrieve the raw response.
+    raw_response: Arc<Mutex<Option<String>>>,
     extra_body: FullExtraBodyConfig,
     extra_headers: FullExtraHeadersConfig,
     model_provider_info: ModelProviderRequestInfo,
     model_name: String,
 }
 
-pub struct InterceptorAndRawBody<F: Fn() -> Result<String, Error>> {
+pub struct InterceptorAndRawBody<P: Fn() -> Result<String, Error>, Q: Fn() -> Result<String, Error>>
+{
     pub interceptor: TensorZeroInterceptor,
-    pub get_raw_request: F,
+    pub get_raw_request: P,
+    pub get_raw_response: Q,
 }
 
 impl Intercept for TensorZeroInterceptor {
@@ -147,6 +153,25 @@ impl Intercept for TensorZeroInterceptor {
         }
         Ok(())
     }
+
+    fn read_after_deserialization(
+        &self,
+        context: &AfterDeserializationInterceptorContextRef<'_>,
+        _runtime_components: &RuntimeComponents,
+        _cfg: &mut ConfigBag,
+    ) -> Result<(), Box<dyn std::error::Error + Sync + Send>> {
+        let bytes = context.response().body().bytes();
+        if let Some(bytes) = bytes {
+            let raw_response = self.raw_response.lock();
+            // Ignore poisoned lock, since we're overwriting it.
+            let mut body = match raw_response {
+                Ok(body) => body,
+                Err(e) => e.into_inner(),
+            };
+            *body = Some(String::from_utf8_lossy(bytes).into_owned());
+        }
+        Ok(())
+    }
 }
 
 /// Builds our custom interceptor to the request builder, which injects our 'extra_body' parameters into
@@ -158,13 +183,15 @@ pub fn build_interceptor(
     request: &ModelInferenceRequest<'_>,
     model_provider: &ModelProvider,
     model_name: String,
-) -> InterceptorAndRawBody<impl Fn() -> Result<String, Error>> {
+) -> InterceptorAndRawBody<impl Fn() -> Result<String, Error>, impl Fn() -> Result<String, Error>> {
     let raw_request = Arc::new(Mutex::new(None));
+    let raw_response = Arc::new(Mutex::new(None));
     let extra_body = request.extra_body.clone();
     let extra_headers = request.extra_headers.clone();
 
     let interceptor = TensorZeroInterceptor {
         raw_request: raw_request.clone(),
+        raw_response: raw_response.clone(),
         extra_body,
         extra_headers,
         model_provider_info: model_provider.into(),
@@ -188,6 +215,22 @@ pub fn build_interceptor(
                     })
                 })?;
             Ok(raw_request)
+        },
+        get_raw_response: move || {
+            let raw_response = raw_response
+                .lock()
+                .map_err(|e| {
+                    Error::new(ErrorDetails::InternalError {
+                        message: format!("Poisoned raw_response mutex for AWS request: {e:?}"),
+                    })
+                })?
+                .clone()
+                .ok_or_else(|| {
+                    Error::new(ErrorDetails::Serialization {
+                        message: "Failed to get serialized AWS response".to_string(),
+                    })
+                })?;
+            Ok(raw_response)
         },
     }
 }

--- a/tensorzero-core/src/providers/aws_sagemaker.rs
+++ b/tensorzero-core/src/providers/aws_sagemaker.rs
@@ -70,6 +70,7 @@ impl InferenceProvider for AWSSagemakerProvider {
         let InterceptorAndRawBody {
             interceptor,
             get_raw_request,
+            get_raw_response,
         } = build_interceptor(
             request.request,
             model_provider,
@@ -102,7 +103,7 @@ impl InferenceProvider for AWSSagemakerProvider {
                         DisplayErrorContext(&e)
                     ),
                     raw_request: get_raw_request().ok(),
-                    raw_response: None,
+                    raw_response: get_raw_response().ok(),
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;
@@ -148,6 +149,7 @@ impl InferenceProvider for AWSSagemakerProvider {
         let InterceptorAndRawBody {
             interceptor,
             get_raw_request,
+            get_raw_response,
         } = build_interceptor(
             request.request,
             model_provider,
@@ -178,7 +180,7 @@ impl InferenceProvider for AWSSagemakerProvider {
                         DisplayErrorContext(&e)
                     ),
                     raw_request: get_raw_request().ok(),
-                    raw_response: None,
+                    raw_response: get_raw_response().ok(),
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
             })?;

--- a/tensorzero-core/tests/e2e/providers/aws_bedrock.rs
+++ b/tensorzero-core/tests/e2e/providers/aws_bedrock.rs
@@ -213,7 +213,13 @@ async fn test_inference_with_explicit_region() {
     assert!(result.get("ttft_ms").unwrap().is_null());
     let raw_response = result.get("raw_response").unwrap();
     let raw_response_json: Value = serde_json::from_str(raw_response.as_str().unwrap()).unwrap();
-    let _ = raw_response_json.get("debug").unwrap().as_str().unwrap();
+    assert!(
+        !raw_response_json["output"]["message"]["content"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "Unexpected raw response: {raw_response_json}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
We now use the correct 'raw_response' value, rather than going through the Debug impl

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Capture and utilize `raw_response` in AWS providers using `TensorZeroInterceptor`, updating inference methods and tests accordingly.
> 
>   - **Behavior**:
>     - Capture and utilize `raw_response` in `AWSBedrockProvider` and `AWSSagemakerProvider`.
>     - Update `infer` and `infer_stream` methods to use `get_raw_response()`.
>   - **Interceptor**:
>     - Add `raw_response` capture in `TensorZeroInterceptor` in `aws_common.rs`.
>     - Update `build_interceptor()` to return `get_raw_response` function.
>   - **Tests**:
>     - Update `test_inference_with_explicit_region()` in `aws_bedrock.rs` to check `raw_response` content.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 52580496055fd2f263031afe86926239ec7bdccd. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->