### PR TITLE
Add uuid7_str helper and improve uuid7 fallback

### DIFF
--- a/clients/python/tensorzero/util.py
+++ b/clients/python/tensorzero/util.py
@@ -1,14 +1,67 @@
+"""Utility functions for working with UUIDs in the TensorZero Python client.
+
+This module provides helper functions for generating UUIDs in a way that
+maintains compatibility across Python versions and with the underlying
+TensorZero client implementation.  It wraps the `uuid_utils` library when
+available and falls back to the built‑in `uuid` module for older Python
+versions.
+"""
+
+from __future__ import annotations
+
 import uuid
 
-from uuid_utils import compat
+try:
+    # The optional uuid_utils package provides a forward‑compatible UUID v7
+    # implementation as described in
+    # https://github.com/fabihr/uuid_utils .  Importing compat allows us to
+    # generate v7 UUIDs on Python versions prior to 3.12.  If this import
+    # fails, we'll fall back to the standard library implementation below.
+    from uuid_utils import compat  # type: ignore[import-not-found]
+except Exception:
+    compat = None  # type: ignore[assignment]
 
 
 def uuid7() -> uuid.UUID:
     """
-    Generate a UUID v7 using uuid_utils compatibility layer.
-    This ensures type compatibility with the rest of the TensorZero client.
+    Generate a UUID version 7 object.
+
+    UUID v7 is a time‑based UUID that was recently added to the UUID
+    specification.  When the optional `uuid_utils` package is available,
+    this function delegates to its implementation to ensure forward
+    compatibility.  On Python ≥3.12, it falls back to the built‑in
+    ``uuid.uuid7``; otherwise it falls back to a random UUID (v4).
+
+    Returns:
+        uuid.UUID: A UUID v7 object (or a v4 UUID if v7 is unavailable).
     """
-    return compat.uuid7()
+    # Prefer the uuid_utils implementation when available.  See
+    # https://github.com/fabihr/uuid_utils for details.
+    if compat is not None and hasattr(compat, "uuid7"):
+        return compat.uuid7()
+    # Use Python 3.12's builtin uuid.uuid7 if present.  Not all versions of
+    # Python include this function, so guard with a try/except.
+    try:
+        return uuid.uuid7()  # type: ignore[attr-defined]
+    except Exception:
+        # Fall back to a random UUID (v4).  This preserves uniqueness but
+        # does not encode a timestamp.
+        return uuid.uuid4()
 
 
-__all__ = ["uuid7"]
+def uuid7_str() -> str:
+    """
+    Generate a UUID version 7 string.
+
+    This convenience wrapper returns the string representation of a UUID v7.
+    It is useful when a text UUID is required instead of a ``uuid.UUID``
+    object.  The implementation delegates to :func:`uuid7` and calls
+    ``str`` on the result.
+
+    Returns:
+        str: The canonical string representation of a UUID v7.
+    """
+    return str(uuid7())
+
+
+__all__ = ["uuid7", "uuid7_str"]


### PR DESCRIPTION
Adds uuid7_str helper returning string version of UUID v7. Updates uuid7() to use uuid_utils when available, fallback to Python's uuid.uuid7 or uuid.uuid4. Updates docs and __all__.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `uuid7_str` helper and improve `uuid7` fallback strategy in `util.py`.
> 
>   - **Functions**:
>     - Add `uuid7_str()` in `util.py` to return string representation of UUID v7.
>     - Update `uuid7()` in `util.py` to use `uuid_utils` if available, fallback to `uuid.uuid7` for Python ≥3.12, or `uuid.uuid4` otherwise.
>   - **Documentation**:
>     - Update module docstring in `util.py` to describe UUID generation strategy.
>   - **Exports**:
>     - Add `uuid7_str` to `__all__` in `util.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 906324dd9a270323b9df6dd69664533c01c8b6f8. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->