### PR TITLE
Remove option type from TimeoutsConfig in ModelProvider

### DIFF
--- a/internal/tensorzero-node/lib/bindings/ModelProvider.ts
+++ b/internal/tensorzero-node/lib/bindings/ModelProvider.ts
@@ -5,7 +5,7 @@ import type { TimeoutsConfig } from "./TimeoutsConfig";
 export type ModelProvider = {
   name: string;
   config: ProviderConfig;
-  timeouts: TimeoutsConfig | null;
+  timeouts: TimeoutsConfig;
   /**
    * See `UninitializedModelProvider.discard_unknown_chunks`.
    */

--- a/internal/tensorzero-node/lib/bindings/UninitializedModelProvider.ts
+++ b/internal/tensorzero-node/lib/bindings/UninitializedModelProvider.ts
@@ -3,7 +3,7 @@ import type { HostedProviderKind } from "./HostedProviderKind";
 import type { TimeoutsConfig } from "./TimeoutsConfig";
 
 export type UninitializedModelProvider = {
-  timeouts: TimeoutsConfig | null;
+  timeouts: TimeoutsConfig;
   /**
    * If `true`, we emit a warning and discard chunks that we don't recognize
    * (on a best-effort, per-provider basis).

--- a/tensorzero-core/src/model.rs
+++ b/tensorzero-core/src/model.rs
@@ -642,7 +642,8 @@ pub struct UninitializedModelProvider {
     pub extra_body: Option<ExtraBodyConfig>,
     #[cfg_attr(test, ts(skip))]
     pub extra_headers: Option<ExtraHeadersConfig>,
-    pub timeouts: Option<TimeoutsConfig>,
+    #[serde(default)]
+    pub timeouts: TimeoutsConfig,
     /// If `true`, we emit a warning and discard chunks that we don't recognize
     /// (on a best-effort, per-provider basis).
     /// By default, we produce an error in the stream
@@ -662,22 +663,18 @@ pub struct ModelProvider {
     pub extra_headers: Option<ExtraHeadersConfig>,
     #[cfg_attr(test, ts(skip))]
     pub extra_body: Option<ExtraBodyConfig>,
-    pub timeouts: Option<TimeoutsConfig>,
+    pub timeouts: TimeoutsConfig,
     /// See `UninitializedModelProvider.discard_unknown_chunks`.
     pub discard_unknown_chunks: bool,
 }
 
 impl ModelProvider {
     fn non_streaming_total_timeout(&self) -> Option<Duration> {
-        Some(Duration::from_millis(
-            self.timeouts.as_ref()?.non_streaming.total_ms?,
-        ))
+        Some(Duration::from_millis(self.timeouts.non_streaming.total_ms?))
     }
 
     fn streaming_ttft_timeout(&self) -> Option<Duration> {
-        Some(Duration::from_millis(
-            self.timeouts.as_ref()?.streaming.ttft_ms?,
-        ))
+        Some(Duration::from_millis(self.timeouts.streaming.ttft_ms?))
     }
 
     /// The name to report in the OTEL `gen_ai.system` attribute

--- a/tensorzero-core/src/optimization/fireworks_sft/mod.rs
+++ b/tensorzero-core/src/optimization/fireworks_sft/mod.rs
@@ -845,7 +845,7 @@ impl JobHandle for FireworksSFTJobHandle {
                         },
                         extra_headers: None,
                         extra_body: None,
-                        timeouts: None,
+                        timeouts: TimeoutsConfig::default(),
                         discard_unknown_chunks: false,
                     };
                     Ok(OptimizationJobInfo::Completed {

--- a/tensorzero-core/src/optimization/together_sft/mod.rs
+++ b/tensorzero-core/src/optimization/together_sft/mod.rs
@@ -431,7 +431,7 @@ impl JobHandle for TogetherSFTJobHandle {
                     },
                     extra_headers: None,
                     extra_body: None,
-                    timeouts: None,
+                    timeouts: TimeoutsConfig::default(),
                     discard_unknown_chunks: false,
                 };
                 Ok(OptimizationJobInfo::Completed {

--- a/tensorzero-core/src/providers/gcp_vertex_gemini/optimization.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_gemini/optimization.rs
@@ -208,7 +208,7 @@ pub fn convert_to_optimizer_status(
                 },
                 extra_headers: None,
                 extra_body: None,
-                timeouts: None,
+                timeouts: TimeoutsConfig::default(),
                 discard_unknown_chunks: false,
             };
             OptimizationJobInfo::Completed {

--- a/tensorzero-core/src/providers/openai/optimization.rs
+++ b/tensorzero-core/src/providers/openai/optimization.rs
@@ -262,7 +262,7 @@ pub fn convert_to_optimizer_status(job: OpenAIFineTuningJob) -> Result<Optimizat
                 },
                 extra_headers: None,
                 extra_body: None,
-                timeouts: None,
+                timeouts: TimeoutsConfig::default(),
                 discard_unknown_chunks: false,
             };
             OptimizationJobInfo::Completed {

--- a/ui/app/routes/optimization/supervised-fine-tuning/FineTuningStatus.stories.tsx
+++ b/ui/app/routes/optimization/supervised-fine-tuning/FineTuningStatus.stories.tsx
@@ -3,6 +3,7 @@ import FineTuningStatus from "./FineTuningStatus";
 import type {
   OptimizationJobInfo,
   OptimizationJobHandle,
+  TimeoutsConfig,
 } from "tensorzero-node";
 import { withRouter } from "storybook-addon-remix-react-router";
 
@@ -108,7 +109,7 @@ export const Completed: Story = {
             type: "openai",
             model_name: "ft:gpt-4o-mini-2024-07-18:my-org:custom-suffix:abc123",
             api_base: null,
-            timeouts: null,
+            timeouts: {} as TimeoutsConfig,
             discard_unknown_chunks: false,
             api_key_location: null,
           },
@@ -169,7 +170,7 @@ export const LongJobId: Story = {
             type: "openai",
             model_name: "ft:gpt-4o-mini-2024-07-18:my-org:custom-suffix:abc123",
             api_base: null,
-            timeouts: null,
+            timeouts: {} as TimeoutsConfig,
             discard_unknown_chunks: false,
             api_key_location: null,
           },

--- a/ui/app/routes/optimization/supervised-fine-tuning/FineTuningStatus.stories.tsx
+++ b/ui/app/routes/optimization/supervised-fine-tuning/FineTuningStatus.stories.tsx
@@ -3,7 +3,6 @@ import FineTuningStatus from "./FineTuningStatus";
 import type {
   OptimizationJobInfo,
   OptimizationJobHandle,
-  TimeoutsConfig,
 } from "tensorzero-node";
 import { withRouter } from "storybook-addon-remix-react-router";
 
@@ -109,7 +108,10 @@ export const Completed: Story = {
             type: "openai",
             model_name: "ft:gpt-4o-mini-2024-07-18:my-org:custom-suffix:abc123",
             api_base: null,
-            timeouts: {} as TimeoutsConfig,
+            timeouts: {
+              non_streaming: { total_ms: null },
+              streaming: { ttft_ms: null },
+            },
             discard_unknown_chunks: false,
             api_key_location: null,
           },
@@ -170,7 +172,10 @@ export const LongJobId: Story = {
             type: "openai",
             model_name: "ft:gpt-4o-mini-2024-07-18:my-org:custom-suffix:abc123",
             api_base: null,
-            timeouts: {} as TimeoutsConfig,
+            timeouts: {
+              non_streaming: { total_ms: null },
+              streaming: { ttft_ms: null },
+            },
             discard_unknown_chunks: false,
             api_key_location: null,
           },

--- a/ui/app/utils/config/models.test.ts
+++ b/ui/app/utils/config/models.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { dump_optimizer_output } from "./models";
-import type { OptimizerOutput } from "tensorzero-node";
+import type { OptimizerOutput, TimeoutsConfig } from "tensorzero-node";
 
 describe("dump_optimizer_output", () => {
   it("should create correct config for fireworks model", async () => {
@@ -14,7 +14,7 @@ describe("dump_optimizer_output", () => {
           parse_think_blocks: false,
           api_key_location: null,
           discard_unknown_chunks: false,
-          timeouts: null,
+          timeouts: {} as TimeoutsConfig,
         },
       },
       timeouts: {
@@ -43,7 +43,7 @@ describe("dump_optimizer_output", () => {
           api_base: null,
           api_key_location: null,
           discard_unknown_chunks: false,
-          timeouts: null,
+          timeouts: {} as TimeoutsConfig,
         },
       },
       timeouts: {

--- a/ui/app/utils/config/models.test.ts
+++ b/ui/app/utils/config/models.test.ts
@@ -14,7 +14,14 @@ describe("dump_optimizer_output", () => {
           parse_think_blocks: false,
           api_key_location: null,
           discard_unknown_chunks: false,
-          timeouts: {} as TimeoutsConfig,
+          timeouts: {
+            non_streaming: {
+              total_ms: null,
+            },
+            streaming: {
+              ttft_ms: null,
+            },
+          },
         },
       },
       timeouts: {

--- a/ui/app/utils/config/models.ts
+++ b/ui/app/utils/config/models.ts
@@ -12,12 +12,21 @@ export function dump_optimizer_output(optimizerOutput: OptimizerOutput) {
   }
   const modelName = rest.routing[0];
   const providerConfig = rest.providers[modelName];
+  // drop the timeout config
+  // allow it to be unused
+  if (!providerConfig) {
+    throw new Error(
+      `Provider config not found for model ${modelName} when dumping optimizer output.`,
+    );
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { timeouts, ...restProviderConfig } = providerConfig;
   const fullyQualifiedProviderConfig = {
     models: {
       [modelName]: {
         routing: [modelName],
         providers: {
-          [modelName]: providerConfig,
+          [modelName]: restProviderConfig,
         },
       },
     },


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

Fixes: #3023 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `Option` from `timeouts` in `ModelProvider`, making it mandatory with a default value, and update related structures and tests.
> 
>   - **Behavior**:
>     - Remove `Option` from `timeouts` in `ModelProvider` and `UninitializedModelProvider` in `model.rs`, making it mandatory with a default value.
>     - Update `non_streaming_total_timeout()` and `streaming_ttft_timeout()` in `ModelProvider` to remove `Option` handling.
>   - **Initialization**:
>     - Set `timeouts` to `TimeoutsConfig::default()` in `FireworksSFTJobHandle`, `TogetherSFTJobHandle`, and `GCPVertexGemini` in their respective files.
>   - **Misc**:
>     - Update `convert_to_optimizer_status()` in `optimization.rs` files to handle non-optional `timeouts`.
>     - Adjust tests in `model.rs` to reflect mandatory `timeouts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a6b3fce9a4b74b0f35de815222b72693931535f0. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->