### PR TITLE
Set ANTHROPIC_API_KEY when regenerating fixtures

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -275,6 +275,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       FIREWORKS_ACCOUNT_ID: ${{ secrets.FIREWORKS_ACCOUNT_ID }}
       FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
   # See 'ci/README.md' at the repository root for more details.
   check-all-live-tests-passed:

--- a/.github/workflows/slash-command-regen-fixtures.yml
+++ b/.github/workflows/slash-command-regen-fixtures.yml
@@ -9,6 +9,7 @@ env:
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
 permissions:
   pull-requests: write # For doing the emoji reaction on a PR comment
@@ -42,6 +43,7 @@ jobs:
           echo "FIREWORKS_API_KEY=not_used" >> ui/fixtures/.env
           echo "FIREWORKS_BASE_URL=http://mock-inference-provider:3030/fireworks/" >> ui/fixtures/.env
           echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> ui/fixtures/.env
+          echo "ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}" >> ui/fixtures/.env
           echo "OPENAI_BASE_URL=http://mock-inference-provider:3030/openai/" >> ui/fixtures/.env
           echo "FIREWORKS_BASE_URL=http://mock-inference-provider:3030/fireworks/" >> ui/fixtures/.env
           echo "S3_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> ui/fixtures/.env

--- a/.github/workflows/ui-tests-e2e-model-inference-cache.yml
+++ b/.github/workflows/ui-tests-e2e-model-inference-cache.yml
@@ -13,6 +13,8 @@ on:
         required: false
       FIREWORKS_API_KEY:
         required: false
+      ANTHROPIC_API_KEY:
+        required: false
     inputs:
       regen_cache:
         required: true
@@ -95,6 +97,7 @@ jobs:
           echo "FIREWORKS_ACCOUNT_ID=${{ secrets.FIREWORKS_ACCOUNT_ID }}" >> fixtures/.env-gateway
           echo "FIREWORKS_API_KEY=${{ secrets.FIREWORKS_API_KEY }}" >> fixtures/.env-gateway
           echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> fixtures/.env-gateway
+          echo "ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}" >> fixtures/.env-gateway
           echo "S3_ACCESS_KEY_ID=${{ secrets.S3_ACCESS_KEY_ID }}" >> fixtures/.env-gateway
           echo "S3_SECRET_ACCESS_KEY=${{ secrets.S3_SECRET_ACCESS_KEY }}" >> fixtures/.env-gateway
           ./fixtures/regenerate-model-inference-cache.sh
@@ -124,6 +127,7 @@ jobs:
           echo "FIREWORKS_ACCOUNT_ID=${{ secrets.FIREWORKS_ACCOUNT_ID || 'not_used' }}" >> fixtures/.env-gateway
           echo "FIREWORKS_API_KEY=${{ secrets.FIREWORKS_API_KEY || 'not_used' }}" >> fixtures/.env-gateway
           echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY || 'not_used' }}" >> fixtures/.env-gateway
+          echo "ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY || 'not_used' }}" >> fixtures/.env-gateway
           echo "S3_ACCESS_KEY_ID=${{ secrets.S3_ACCESS_KEY_ID }}" >> fixtures/.env-gateway
           echo "S3_SECRET_ACCESS_KEY=${{ secrets.S3_SECRET_ACCESS_KEY }}" >> fixtures/.env-gateway
           docker compose -f fixtures/docker-compose.e2e.yml up --no-build -d

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -113,6 +113,7 @@ jobs:
           # The 'ui-tests-e2e' job tests that the UI container starts without some of these variables set,
           echo "FIREWORKS_ACCOUNT_ID=fake_fireworks_account" >> fixtures/.env
           echo "FIREWORKS_API_KEY=not_used" >> fixtures/.env
+          echo "ANTHROPIC_API_KEY=not_used" >> fixtures/.env
           echo "FIREWORKS_BASE_URL=http://mock-inference-provider:3030/fireworks/" >> fixtures/.env
           echo "OPENAI_API_KEY=not_used" >> fixtures/.env
           echo "OPENAI_BASE_URL=http://mock-inference-provider:3030/openai/" >> fixtures/.env


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `ANTHROPIC_API_KEY` to GitHub Actions workflows for fixture regeneration and E2E tests.
> 
>   - **Environment Variables**:
>     - Add `ANTHROPIC_API_KEY` to environment variables in `.github/workflows/merge-queue.yml`, `.github/workflows/slash-command-regen-fixtures.yml`, and `.github/workflows/ui-tests-e2e-model-inference-cache.yml`.
>     - Ensure `ANTHROPIC_API_KEY` is set in `.env` files for fixture regeneration and E2E tests in `slash-command-regen-fixtures.yml` and `ui-tests-e2e-model-inference-cache.yml`.
>   - **Secrets Management**:
>     - Add `ANTHROPIC_API_KEY` to secrets in `ui-tests-e2e-model-inference-cache.yml` and `ui-tests-e2e.yml` workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6370b8c84cbf8c182d8bebea0dcc8184f469b3ef. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->