### PR TITLE
bumped timeout in playground route to 30s

### DIFF
--- a/ui/app/routes/playground/route.tsx
+++ b/ui/app/routes/playground/route.tsx
@@ -39,6 +39,11 @@ import { getNativeTensorZeroClient } from "~/utils/tensorzero/native_client.serv
 import type { InferenceResponse } from "tensorzero-node";
 import { getExtraInferenceOptions } from "~/utils/feature_flags";
 
+/*
+ * By default, RR7 times out promises from the loader in 4950ms.
+ * Since inferences can easily take longer than that we bump to 30s here.
+ */
+export const streamTimeout = 30_000; // ms
 const DEFAULT_LIMIT = 5;
 
 export const handle: RouteHandle = {


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
