### PR TITLE
Clean up mock provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4604,9 +4604,9 @@ checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"

--- a/tensorzero-core/tests/mock-inference-provider/src/main.rs
+++ b/tensorzero-core/tests/mock-inference-provider/src/main.rs
@@ -347,7 +347,6 @@ async fn completions_handler(Json(params): Json<serde_json::Value>) -> Response<
             .keep_alive(axum::response::sse::KeepAlive::new())
             .into_response()
     } else {
-        // TODO (#82): map fixtures to functions in config
         let response = if function_call {
             include_str!("../fixtures/openai/chat_completions_function_example.json")
         } else if json_mode {
@@ -367,7 +366,6 @@ fn create_stream(
     function_call: bool,
 ) -> impl Stream<Item = Result<Event, axum::Error>> {
     try_stream! {
-        // TODO (#82): map fixtures to functions in config
         let lines = if function_call {
             include_str!("../fixtures/openai/chat_completions_streaming_function_example.jsonl")
         } else if json_mode {


### PR DESCRIPTION

- Implement new modules for Together and GCP Vertex Gemini integration
- Add corresponding routes to the mock server for both platforms
- Update mock tests to include new scenarios for Together and GCP Vertex Gemini

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for Together and GCP Vertex Gemini in mock inference provider with new modules, routes, and tests.
> 
>   - **Behavior**:
>     - Add support for Together and GCP Vertex Gemini in `mock-inference-provider`.
>     - Implement `create_fine_tune` and `get_fine_tune_job` in `gcp_vertex_gemini.rs`.
>     - Implement `create_fine_tune`, `get_fine_tune`, and `upload_file` in `together.rs`.
>   - **Routes**:
>     - Add routes for Together: `/together/v1/files/upload`, `/together/v1/fine-tunes`, `/together/v1/fine-tunes/{job_id}`.
>     - Add routes for GCP Vertex Gemini: `/gcp_vertex_gemini/v1/projects/{project_id}/locations/{region}/tuningJobs`, `/gcp_vertex_gemini/v1/{project_id}/locations/{region}/tuningJobs/{job_id}`.
>   - **Tests**:
>     - Add `together_sft` and `gcp_vertex_gemini_sft` test cases in `mock_tests.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0b79ddb2f4a0d8e2b961d88c1756f53278d253bc. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->