### PR TITLE
replaced simple cases of FINAL with LIMIT 1

### DIFF
--- a/tensorzero-core/src/endpoints/batch_inference.rs
+++ b/tensorzero-core/src/endpoints/batch_inference.rs
@@ -1030,8 +1030,9 @@ pub async fn get_completed_batch_inference_response(
                 let query = format!(
                     "WITH inf_lookup AS (
                         SELECT episode_id
-                        FROM InferenceById FINAL
+                        FROM InferenceById
                         WHERE id_uint = toUInt128(toUUID('{}'))
+                        LIMIT 1
                     )
                     SELECT
                         ci.id as inference_id,
@@ -1129,8 +1130,9 @@ pub async fn get_completed_batch_inference_response(
                 let query = format!(
                     "WITH inf_lookup AS (
                         SELECT episode_id
-                        FROM InferenceById FINAL
+                        FROM InferenceById
                         WHERE id_uint = toUInt128(toUUID('{}'))
+                        LIMIT 1
                     )
                     SELECT
                         ji.id as inference_id,

--- a/tensorzero-core/tests/e2e/clickhouse.rs
+++ b/tensorzero-core/tests/e2e/clickhouse.rs
@@ -367,7 +367,7 @@ async fn run_migration_0020_with_data<R: Future<Output = bool>, F: FnOnce() -> R
 
     let matching_chat_by_id = clickhouse
         .run_query_synchronous_no_params(
-            format!("SELECT id_uint, toUInt128(episode_id) as episode_id_uint FROM InferenceById FINAL WHERE function_type = 'chat' AND id_uint = '{sample_chat_id}' LIMIT 1 FORMAT JSONEachRow"),
+            format!("SELECT id_uint, toUInt128(episode_id) as episode_id_uint FROM InferenceById WHERE function_type = 'chat' AND id_uint = '{sample_chat_id}' LIMIT 1 FORMAT JSONEachRow"),
         )
         .await
         .unwrap();
@@ -385,7 +385,7 @@ async fn run_migration_0020_with_data<R: Future<Output = bool>, F: FnOnce() -> R
 
     let matching_chat_by_episode_id = clickhouse
         .run_query_synchronous_no_params(
-            format!("SELECT * FROM InferenceByEpisodeId FINAL WHERE function_type = 'chat' AND episode_id_uint = '{sample_chat_episode_id}' LIMIT 1 FORMAT JSONEachRow"),
+            format!("SELECT * FROM InferenceByEpisodeId WHERE function_type = 'chat' AND episode_id_uint = '{sample_chat_episode_id}' LIMIT 1 FORMAT JSONEachRow"),
         )
         .await
         .unwrap();
@@ -413,7 +413,7 @@ async fn run_migration_0020_with_data<R: Future<Output = bool>, F: FnOnce() -> R
 
     let matching_json_by_id = clickhouse
         .run_query_synchronous_no_params(
-            format!("SELECT id_uint, toUInt128(episode_id) as episode_id_uint FROM InferenceById FINAL WHERE function_type = 'json' AND id_uint = '{sample_json_id}' LIMIT 1 FORMAT JSONEachRow"),
+            format!("SELECT id_uint, toUInt128(episode_id) as episode_id_uint FROM InferenceById WHERE function_type = 'json' AND id_uint = '{sample_json_id}' LIMIT 1 FORMAT JSONEachRow"),
         )
         .await
         .unwrap();
@@ -429,7 +429,7 @@ async fn run_migration_0020_with_data<R: Future<Output = bool>, F: FnOnce() -> R
 
     let matching_json_by_episode_id = clickhouse
         .run_query_synchronous_no_params(
-            format!("SELECT * FROM InferenceByEpisodeId FINAL WHERE function_type = 'json' AND episode_id_uint = '{sample_json_episode_id}' LIMIT 1 FORMAT JSONEachRow"),
+            format!("SELECT * FROM InferenceByEpisodeId WHERE function_type = 'json' AND episode_id_uint = '{sample_json_episode_id}' LIMIT 1 FORMAT JSONEachRow"),
         )
         .await
         .unwrap();

--- a/ui/app/utils/clickhouse/inference.server.ts
+++ b/ui/app/utils/clickhouse/inference.server.ts
@@ -556,7 +556,7 @@ export async function queryInferenceById(
             variant_name,
             episode_id,
             function_type
-        FROM InferenceById FINAL
+        FROM InferenceById
         WHERE id_uint = toUInt128({id:UUID})
         LIMIT 1
     )


### PR DESCRIPTION
Closes #2960 

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize SQL queries by replacing `FINAL` with `LIMIT 1` in `batch_inference.rs`, `clickhouse.rs`, and `inference.server.ts`.
> 
>   - **Behavior**:
>     - Replace `FINAL` with `LIMIT 1` in SQL queries to optimize performance by limiting result sets to one row.
>   - **Files Affected**:
>     - `batch_inference.rs`: Updated queries in `get_completed_batch_inference_response()`.
>     - `clickhouse.rs`: Modified queries in `run_migration_0020_with_data()`.
>     - `inference.server.ts`: Adjusted queries in `queryInferenceById()` and other functions.
>   - **Misc**:
>     - Ensures consistent query optimization across the codebase.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4b3e133c78e9243d1731f26cf5893332df47b4b8. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->