### PR TITLE
Allow specifying clickhouse url without user credentials

### DIFF
--- a/ui/entrypoint.sh
+++ b/ui/entrypoint.sh
@@ -13,7 +13,7 @@ BASE_URL=$(echo "$TENSORZERO_CLICKHOUSE_URL" | sed -E 's#(https?://[^/]+).*#\1#'
 # This is used for display purposes only
 DISPLAY_BASE_URL=$(
   echo "$TENSORZERO_CLICKHOUSE_URL" |
-  sed -E 's#(https?://)[^@/]*@?([^/?]+).*#\1\2#'
+  sed -E 's#(https?://)([^@/]*@)?([^/?]+).*#\1\3#'
 )
 
 


### PR DESCRIPTION
I ran a local clickhouse instance which is connectable with the default credentials (i.e. the address http://127.0.0.1:8123/tensorzero works).

Current script does not handle url without @ well. I have changed the sed expression to handle that.


```
sed -E 's#(https?://)[^@/]*@?([^/?]+).*#\1\2#' <<< 'http://127.0.0.1:8123/tensorzero'
```
http://3

```
sed -E 's#(https?://)([^@/]*@)?([^/?]+).*#\1\3#' <<< 'http://127.0.0.1:8123/tensorzero'
```
http://127.0.0.1:8123

```
sed -E 's#(https?://)[^@/]*@?([^/?]+).*#\1\2#' <<< 'http://default:abc@127.0.0.1:8123/tensorzero'
```
http://127.0.0.1:8123

```
sed -E 's#(https?://)([^@/]*@)?([^/?]+).*#\1\3#' <<< 'http://default:abc@127.0.0.1:8123/tensorzero'
```
http://127.0.0.1:8123
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `sed` command in `ui/entrypoint.sh` to handle ClickHouse URLs without user credentials.
> 
>   - **Behavior**:
>     - Modify `sed` command in `ui/entrypoint.sh` to handle ClickHouse URLs without user credentials.
>     - Ensures URLs like `http://127.0.0.1:8123/tensorzero` are correctly processed.
>   - **Misc**:
>     - No changes to logic or additional features added.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 234cf67077229af209365b1cd84bf7091f261553. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->