### PR TITLE
Fix ClickHouse cluster message

### DIFF
--- a/tensorzero-core/src/clickhouse/mod.rs
+++ b/tensorzero-core/src/clickhouse/mod.rs
@@ -134,11 +134,11 @@ impl ClickHouseConnectionInfo {
         // Get the cluster name from the `TENSORZERO_CLICKHOUSE_CLUSTER_NAME` environment variable
         let cluster_name = match std::env::var("TENSORZERO_CLICKHOUSE_CLUSTER_NAME") {
             Ok(cluster_name) => {
-                tracing::info!("Using ClickHouse cluster name: {cluster_name}");
+                tracing::info!("The gateway is expecting a self-hosted replicated ClickHouse deployment with cluster name `{cluster_name}`. Note: The environment variable `TENSORZERO_CLICKHOUSE_CLUSTER_NAME` doesn't apply to ClickHouse Cloud or self-managed single-node deployments.");
                 Some(cluster_name)
             }
             Err(_) => {
-                tracing::info!("No ClickHouse cluster name provided");
+                tracing::debug!("The environment variable `TENSORZERO_CLICKHOUSE_CLUSTER_NAME` wasn't provided, so the gateway will assume that ClickHouse is not running a self-hosted replicated cluster. Note: This variable doesn't apply to ClickHouse Cloud or self-managed single-node deployments.");
                 None
             }
         };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves logging for ClickHouse cluster configuration in `ClickHouseConnectionInfo` by clarifying the use of `TENSORZERO_CLICKHOUSE_CLUSTER_NAME`.
> 
>   - **Logging**:
>     - Updated log message in `ClickHouseConnectionInfo` to clarify the use of `TENSORZERO_CLICKHOUSE_CLUSTER_NAME` for self-hosted replicated deployments.
>     - Changed log level from `info` to `debug` when `TENSORZERO_CLICKHOUSE_CLUSTER_NAME` is not provided, indicating assumption of non-replicated cluster.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 541f72ee28e95d0b9af4c61d879271134b5ad708. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->