### PR TITLE
Add extra_body support for embedding models

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -45,6 +45,7 @@ env:
   VLLM_API_KEY: ${{ secrets.VLLM_API_KEY }}
   VLLM_API_BASE: ${{ secrets.VLLM_API_BASE }}
   VLLM_MODEL_NAME: "microsoft/Phi-3.5-mini-instruct"
+  VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
   XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
 
 jobs:

--- a/examples/production-deployment/.env.example
+++ b/examples/production-deployment/.env.example
@@ -34,4 +34,5 @@ TENSORZERO_CLICKHOUSE_URL="http[s]://[username]:[password]@[hostname]:[port]/[da
 # TGI_API_KEY=example
 # TOGETHER_API_KEY=example
 # VLLM_API_KEY=example
+# VOYAGE_API_KEY=example
 # XAI_API_KEY=example

--- a/tensorzero-core/src/embeddings.rs
+++ b/tensorzero-core/src/embeddings.rs
@@ -8,7 +8,8 @@ use crate::cache::{
 };
 use crate::config_parser::{ProviderTypesConfig, TimeoutsConfig};
 use crate::endpoints::inference::InferenceClients;
-use crate::model::UninitializedProviderConfig;
+use crate::inference::types::extra_body::ExtraBodyConfig;
+use crate::model::{ModelProviderRequestInfo, UninitializedProviderConfig};
 use crate::model_table::BaseModelTable;
 use crate::model_table::ShorthandModelConfig;
 use crate::providers::azure::AzureProvider;
@@ -54,6 +55,7 @@ impl ShorthandModelConfig for EmbeddingModelConfig {
             inner: provider_config,
             timeouts: TimeoutsConfig::default(),
             provider_name: Arc::from(provider_type.to_string()),
+            extra_body: Default::default(),
         };
         Ok(EmbeddingModelConfig {
             routing: vec![provider_type.to_string().into()],
@@ -143,7 +145,12 @@ impl EmbeddingModelConfig {
                     }
                 }
                 let response = provider_config
-                    .embed(request, clients.http_client, clients.credentials)
+                    .embed(
+                        request,
+                        clients.http_client,
+                        clients.credentials,
+                        &provider_config.into(),
+                    )
                     .await;
 
                 match response {
@@ -392,6 +399,7 @@ pub trait EmbeddingProvider {
         request: &EmbeddingRequest,
         client: &Client,
         dynamic_api_keys: &InferenceCredentials,
+        model_provider_data: &EmbeddingProviderRequestInfo,
     ) -> impl Future<Output = Result<EmbeddingProviderResponse, Error>> + Send;
 }
 
@@ -412,6 +420,33 @@ pub struct EmbeddingProviderInfo {
     pub inner: EmbeddingProviderConfig,
     pub timeouts: TimeoutsConfig,
     pub provider_name: Arc<str>,
+    #[cfg_attr(test, ts(skip))]
+    pub extra_body: Option<ExtraBodyConfig>,
+}
+
+#[derive(Clone, Debug)]
+pub struct EmbeddingProviderRequestInfo {
+    pub provider_name: Arc<str>,
+    pub extra_body: Option<ExtraBodyConfig>,
+}
+
+impl From<&EmbeddingProviderInfo> for EmbeddingProviderRequestInfo {
+    fn from(val: &EmbeddingProviderInfo) -> Self {
+        EmbeddingProviderRequestInfo {
+            provider_name: val.provider_name.clone(),
+            extra_body: val.extra_body.clone(),
+        }
+    }
+}
+
+impl From<&EmbeddingProviderRequestInfo> for ModelProviderRequestInfo {
+    fn from(val: &EmbeddingProviderRequestInfo) -> Self {
+        crate::model::ModelProviderRequestInfo {
+            provider_name: val.provider_name.clone(),
+            extra_headers: None, // Embeddings don't use extra headers yet
+            extra_body: val.extra_body.clone(),
+        }
+    }
 }
 
 impl EmbeddingProvider for EmbeddingProviderInfo {
@@ -420,8 +455,11 @@ impl EmbeddingProvider for EmbeddingProviderInfo {
         request: &EmbeddingRequest,
         client: &Client,
         dynamic_api_keys: &InferenceCredentials,
+        model_provider_data: &EmbeddingProviderRequestInfo,
     ) -> Result<EmbeddingProviderResponse, Error> {
-        let response_fut = self.inner.embed(request, client, dynamic_api_keys);
+        let response_fut = self
+            .inner
+            .embed(request, client, dynamic_api_keys, model_provider_data);
         Ok(
             if let Some(timeout_ms) = self.timeouts.non_streaming.total_ms {
                 let timeout = Duration::from_millis(timeout_ms);
@@ -447,6 +485,8 @@ pub struct UninitializedEmbeddingProviderConfig {
     config: UninitializedProviderConfig,
     #[serde(default)]
     timeouts: TimeoutsConfig,
+    #[serde(default)]
+    pub extra_body: Option<ExtraBodyConfig>,
 }
 
 impl UninitializedEmbeddingProviderConfig {
@@ -457,22 +497,26 @@ impl UninitializedEmbeddingProviderConfig {
     ) -> Result<EmbeddingProviderInfo, Error> {
         let provider_config = self.config.load(provider_types).await?;
         let timeouts = self.timeouts;
+        let extra_body = self.extra_body;
         Ok(match provider_config {
             ProviderConfig::OpenAI(provider) => EmbeddingProviderInfo {
                 inner: EmbeddingProviderConfig::OpenAI(provider),
                 timeouts,
                 provider_name,
+                extra_body,
             },
             ProviderConfig::Azure(provider) => EmbeddingProviderInfo {
                 inner: EmbeddingProviderConfig::Azure(provider),
                 timeouts,
                 provider_name,
+                extra_body,
             },
             #[cfg(any(test, feature = "e2e_tests"))]
             ProviderConfig::Dummy(provider) => EmbeddingProviderInfo {
                 inner: EmbeddingProviderConfig::Dummy(provider),
                 timeouts,
                 provider_name,
+                extra_body,
             },
             _ => {
                 return Err(Error::new(ErrorDetails::Config {
@@ -491,17 +535,24 @@ impl EmbeddingProvider for EmbeddingProviderConfig {
         request: &EmbeddingRequest,
         client: &Client,
         dynamic_api_keys: &InferenceCredentials,
+        model_provider_data: &EmbeddingProviderRequestInfo,
     ) -> Result<EmbeddingProviderResponse, Error> {
         match self {
             EmbeddingProviderConfig::OpenAI(provider) => {
-                provider.embed(request, client, dynamic_api_keys).await
+                provider
+                    .embed(request, client, dynamic_api_keys, model_provider_data)
+                    .await
             }
             EmbeddingProviderConfig::Azure(provider) => {
-                provider.embed(request, client, dynamic_api_keys).await
+                provider
+                    .embed(request, client, dynamic_api_keys, model_provider_data)
+                    .await
             }
             #[cfg(any(test, feature = "e2e_tests"))]
             EmbeddingProviderConfig::Dummy(provider) => {
-                provider.embed(request, client, dynamic_api_keys).await
+                provider
+                    .embed(request, client, dynamic_api_keys, model_provider_data)
+                    .await
             }
         }
     }
@@ -574,6 +625,7 @@ mod tests {
             inner: bad_provider,
             timeouts: Default::default(),
             provider_name: Arc::from("error".to_string()),
+            extra_body: None,
         };
         let good_provider = EmbeddingProviderConfig::Dummy(DummyProvider {
             model_name: "good".into(),
@@ -583,6 +635,7 @@ mod tests {
             inner: good_provider,
             timeouts: Default::default(),
             provider_name: Arc::from("good".to_string()),
+            extra_body: None,
         };
         let fallback_embedding_model = EmbeddingModelConfig {
             routing: vec!["error".to_string().into(), "good".to_string().into()],
@@ -616,5 +669,42 @@ mod tests {
         assert!(logs_contain(
             "Error sending request to Dummy provider for model 'error'"
         ));
+    }
+
+    #[tokio::test]
+    async fn test_embedding_provider_config_with_extra_body() {
+        use crate::inference::types::extra_body::{
+            ExtraBodyConfig, ExtraBodyReplacement, ExtraBodyReplacementKind,
+        };
+        use serde_json::json;
+
+        let replacement = ExtraBodyReplacement {
+            pointer: "/task".to_string(),
+            kind: ExtraBodyReplacementKind::Value(json!("query")),
+        };
+        let extra_body_config = ExtraBodyConfig {
+            data: vec![replacement.clone()],
+        };
+
+        let uninitialized_config = UninitializedEmbeddingProviderConfig {
+            config: crate::model::UninitializedProviderConfig::OpenAI {
+                model_name: "text-embedding-ada-002".to_string(),
+                api_base: None,
+                api_key_location: Some(crate::model::CredentialLocation::None),
+            },
+            timeouts: TimeoutsConfig::default(),
+            extra_body: Some(extra_body_config.clone()),
+        };
+
+        let provider_info = uninitialized_config
+            .load(&ProviderTypesConfig::default(), Arc::from("test_provider"))
+            .await
+            .unwrap();
+
+        // Verify the extra_body is preserved
+        assert!(provider_info.extra_body.is_some());
+        let loaded_extra_body = provider_info.extra_body.unwrap();
+        assert_eq!(loaded_extra_body.data.len(), 1);
+        assert_eq!(loaded_extra_body.data[0], replacement);
     }
 }

--- a/tensorzero-core/src/endpoints/embeddings.rs
+++ b/tensorzero-core/src/endpoints/embeddings.rs
@@ -52,6 +52,7 @@ pub async fn embeddings(
             }));
         }
     }
+
     let request = EmbeddingRequest {
         input: params.input,
         dimensions: params.dimensions,

--- a/tensorzero-core/src/inference/types/extra_body.rs
+++ b/tensorzero-core/src/inference/types/extra_body.rs
@@ -27,7 +27,7 @@ pub enum ExtraBodyReplacementKind {
     Delete,
 }
 
-/// The 'InferenceExtraBody' options provided directly in an inference request
+/// The 'InferenceExtraBody' options provided directly in an inference request.
 /// These have not yet been filtered by variant name
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(transparent)]

--- a/tensorzero-core/src/providers/dummy.rs
+++ b/tensorzero-core/src/providers/dummy.rs
@@ -14,7 +14,8 @@ use crate::inference::InferenceProvider;
 
 use crate::cache::ModelProviderRequest;
 use crate::embeddings::{
-    Embedding, EmbeddingProvider, EmbeddingProviderResponse, EmbeddingRequest,
+    Embedding, EmbeddingProvider, EmbeddingProviderRequestInfo, EmbeddingProviderResponse,
+    EmbeddingRequest,
 };
 use crate::endpoints::inference::InferenceCredentials;
 use crate::error::{Error, ErrorDetails};
@@ -757,6 +758,7 @@ impl EmbeddingProvider for DummyProvider {
         request: &EmbeddingRequest,
         _http_client: &reqwest::Client,
         _dynamic_api_keys: &InferenceCredentials,
+        _model_provider_data: &EmbeddingProviderRequestInfo,
     ) -> Result<EmbeddingProviderResponse, Error> {
         if self.model_name.starts_with("error") {
             return Err(ErrorDetails::InferenceClient {

--- a/tensorzero-core/src/providers/openai/mod.rs
+++ b/tensorzero-core/src/providers/openai/mod.rs
@@ -20,7 +20,8 @@ use uuid::Uuid;
 use crate::cache::ModelProviderRequest;
 use crate::embeddings::EmbeddingEncodingFormat;
 use crate::embeddings::{
-    Embedding, EmbeddingInput, EmbeddingProvider, EmbeddingProviderResponse, EmbeddingRequest,
+    Embedding, EmbeddingInput, EmbeddingProvider, EmbeddingProviderRequestInfo,
+    EmbeddingProviderResponse, EmbeddingRequest,
 };
 use crate::endpoints::inference::InferenceCredentials;
 use crate::error::{warn_discarded_thought_block, DisplayOrDebugGateway, Error, ErrorDetails};
@@ -28,6 +29,7 @@ use crate::inference::types::batch::{BatchRequestRow, PollBatchInferenceResponse
 use crate::inference::types::batch::{
     ProviderBatchInferenceOutput, ProviderBatchInferenceResponse,
 };
+use crate::inference::types::extra_body::FullExtraBodyConfig;
 use crate::inference::types::file::{mime_type_to_ext, require_image};
 use crate::inference::types::resolved_input::FileWithPath;
 use crate::inference::types::{
@@ -586,6 +588,7 @@ impl EmbeddingProvider for OpenAIProvider {
         request: &EmbeddingRequest,
         client: &reqwest::Client,
         dynamic_api_keys: &InferenceCredentials,
+        model_provider_data: &EmbeddingProviderRequestInfo,
     ) -> Result<EmbeddingProviderResponse, Error> {
         let api_key = self.credentials.get_api_key(dynamic_api_keys)?;
         let request_body = OpenAIEmbeddingRequest::new(
@@ -601,22 +604,26 @@ impl EmbeddingProvider for OpenAIProvider {
         if let Some(api_key) = api_key {
             request_builder = request_builder.bearer_auth(api_key.expose_secret());
         }
-        let res = request_builder
-            .json(&request_body)
-            .send()
-            .await
-            .map_err(|e| {
-                Error::new(ErrorDetails::InferenceClient {
-                    status_code: e.status(),
-                    message: format!(
-                        "Error sending request to OpenAI: {}",
-                        DisplayOrDebugGateway::new(e)
-                    ),
-                    provider_type: PROVIDER_TYPE.to_string(),
-                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
-                    raw_response: None,
-                })
-            })?;
+
+        let request_body_value = serde_json::to_value(&request_body).map_err(|e| {
+            Error::new(ErrorDetails::Serialization {
+                message: format!(
+                    "Error serializing OpenAI embedding request: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
+            })
+        })?;
+
+        let (res, raw_request) = inject_extra_request_data_and_send(
+            PROVIDER_TYPE,
+            &FullExtraBodyConfig::default(), // No overrides supported
+            &Default::default(),             // No extra headers for embeddings yet
+            model_provider_data,
+            &self.model_name,
+            request_body_value,
+            request_builder,
+        )
+        .await?;
         if res.status().is_success() {
             let raw_response = res.text().await.map_err(|e| {
                 Error::new(ErrorDetails::InferenceServer {
@@ -624,7 +631,7 @@ impl EmbeddingProvider for OpenAIProvider {
                         "Error parsing text response: {}",
                         DisplayOrDebugGateway::new(e)
                     ),
-                    raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                    raw_request: Some(raw_request.clone()),
                     raw_response: None,
                     provider_type: PROVIDER_TYPE.to_string(),
                 })
@@ -637,7 +644,7 @@ impl EmbeddingProvider for OpenAIProvider {
                             "Error parsing JSON response: {}",
                             DisplayOrDebugGateway::new(e)
                         ),
-                        raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                        raw_request: Some(raw_request.clone()),
                         raw_response: Some(raw_response.clone()),
                         provider_type: PROVIDER_TYPE.to_string(),
                     })
@@ -655,7 +662,7 @@ impl EmbeddingProvider for OpenAIProvider {
             .try_into()?)
         } else {
             Err(handle_openai_error(
-                &serde_json::to_string(&request_body).unwrap_or_default(),
+                &raw_request,
                 res.status(),
                 &res.text().await.map_err(|e| {
                     Error::new(ErrorDetails::InferenceServer {
@@ -663,7 +670,7 @@ impl EmbeddingProvider for OpenAIProvider {
                             "Error parsing error response: {}",
                             DisplayOrDebugGateway::new(e)
                         ),
-                        raw_request: Some(serde_json::to_string(&request_body).unwrap_or_default()),
+                        raw_request: Some(raw_request.clone()),
                         raw_response: None,
                         provider_type: PROVIDER_TYPE.to_string(),
                     })
@@ -1775,6 +1782,7 @@ impl<'a> OpenAIBatchRequest<'a> {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub(super) struct OpenAIUsage {
+    #[serde(default)]
     pub prompt_tokens: u32,
     #[serde(default)]
     pub completion_tokens: u32,

--- a/tensorzero-core/tests/e2e/dicl.rs
+++ b/tensorzero-core/tests/e2e/dicl.rs
@@ -380,7 +380,7 @@ async fn embed_insert_example(
     };
     let api_keys = InferenceCredentials::default();
     let response = provider_config
-        .embed(&request, &client, &api_keys)
+        .embed(&request, &client, &api_keys, &(&provider_config).into())
         .await
         .unwrap();
 

--- a/tensorzero-core/tests/e2e/tensorzero.toml
+++ b/tensorzero-core/tests/e2e/tensorzero.toml
@@ -727,6 +727,20 @@ type = "azure"
 endpoint = "https://t0-azure-openai-east.openai.azure.com/"
 deployment_id = "text-embedding-3-small"
 
+[embedding_models.voyage_3_5_lite_256]
+routing = ["voyage"]
+
+[embedding_models.voyage_3_5_lite_256.providers.voyage]
+type = "openai"
+api_base = "https://api.voyageai.com/v1"
+model_name = "voyage-3.5-lite"
+api_key_location = "env::VOYAGE_API_KEY"
+extra_body = [
+  { pointer = "/dimensions", delete = true },
+  { pointer = "/encoding_format", delete = true },
+  { pointer = "/output_dimension", value = 256 },
+]
+
 [embedding_models.fallback]
 routing = ["slow", "openai"]
 


### PR DESCRIPTION
This PR adds support for extra_body field in the embedding model configs. Note that it does not add corresponding support to the OpenAI compatible embeddings endpoint.

Motivation: Many embedding providers use custom body fields that are necessary to properly use their APIs.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `extra_body` support to embedding model configurations for custom API request fields.
> 
>   - **Behavior**:
>     - Adds `extra_body` field to `EmbeddingProviderInfo` and `EmbeddingProviderRequestInfo` in `embeddings.rs`.
>     - Updates `embed()` method in `EmbeddingProvider` trait to accept `model_provider_data` with `extra_body`.
>     - Does not add support for `extra_body` to OpenAI compatible embeddings endpoint.
>   - **Tests**:
>     - Adds `test_embedding_provider_config_with_extra_body()` in `embeddings.rs` to verify `extra_body` handling.
>     - Adds `test_embedding_extra_body()` in `openai.rs` to ensure `extra_body` modifies output dimensions.
>   - **Misc**:
>     - Adds `VOYAGE_API_KEY` to `.env.example`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for eddda92a85ea541f4f7a85e4b786e8cb5cbd3826. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->