### PR TITLE
bumped version to 2025.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2025.8.1"
+version = "2025.8.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2025.8.1"
+version = "2025.8.2"
 dependencies = [
  "axum",
  "clap",
@@ -4810,7 +4810,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2025.8.1"
+version = "2025.8.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4905,7 +4905,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2025.8.1"
+version = "2025.8.2"
 dependencies = [
  "napi",
  "napi-build",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.8.1"
+version = "2025.8.2"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2025.8.1"
+version = "2025.8.2"
 rust-version = "1.86.0"
 license = "Apache-2.0"
 

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.1
-appVersion: "2025.8.1"
+appVersion: "2025.8.2"

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2025.8.1",
+  "version": "2025.8.2",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Bump version to 2025.8.2 across multiple files and add `sleep` import in `test_openai_compatibility.py`.
> 
>   - **Version Bump**:
>     - Update version to `2025.8.2` in `Cargo.lock`, `Cargo.toml`, `Chart.yaml`, and `package.json`.
>   - **Tests**:
>     - Import `sleep` from `time` in `test_openai_compatibility.py` to introduce a delay in `test_async_inference_cache()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 23345003210079660be99b57b80a8dd4192d3424. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->