### PR TITLE
Store a Value directly in `StaticJSONSchema`

### DIFF
--- a/evaluations/src/lib.rs
+++ b/evaluations/src/lib.rs
@@ -369,7 +369,7 @@ async fn infer_datapoint(params: InferDatapointParams<'_>) -> Result<InferenceRe
     let output_schema = match (datapoint.output_schema(), function_config) {
         // If the datapoint has an output schema, use it only in the case where it is not the same as the output schema of the function
         (Some(output_schema), FunctionConfig::Json(json_function_config)) => {
-            if output_schema == json_function_config.output_schema.value {
+            if output_schema == &json_function_config.output_schema.value {
                 debug!("Output schema matches function schema, using function default");
                 None
             } else {

--- a/tensorzero-core/src/config_parser/tests.rs
+++ b/tensorzero-core/src/config_parser/tests.rs
@@ -566,7 +566,7 @@ async fn test_config_from_toml_table_json_function_no_output_schema() {
         _ => panic!("Expected a JSON function"),
     };
     assert_eq!(output_schema, &StaticJSONSchema::default());
-    assert_eq!(output_schema.value, &serde_json::json!({}));
+    assert_eq!(output_schema.value, serde_json::json!({}));
 }
 
 /// Ensure that the config parsing fails when there are extra variables for variants

--- a/tensorzero-core/src/endpoints/feedback.rs
+++ b/tensorzero-core/src/endpoints/feedback.rs
@@ -608,7 +608,7 @@ pub async fn validate_parse_demonstration(
         }
         (FunctionConfig::Json(_), DynamicDemonstrationInfo::Json(output_schema)) => {
             // For json functions, the value should be a valid json object.
-            StaticJSONSchema::from_value(&output_schema)?
+            StaticJSONSchema::from_value(output_schema)?
                 .validate(value)
                 .map_err(|e| {
                     Error::new(ErrorDetails::InvalidRequest {
@@ -1215,7 +1215,7 @@ mod tests {
         let weather_tool_config_static = StaticToolConfig {
             name: "get_temperature".to_string(),
             description: "Get the current temperature in a given location".to_string(),
-            parameters: StaticJSONSchema::from_value(&json!({
+            parameters: StaticJSONSchema::from_value(json!({
                 "type": "object",
                 "properties": {
                     "location": {"type": "string"},
@@ -1365,7 +1365,7 @@ mod tests {
             system_schema: None,
             user_schema: None,
             assistant_schema: None,
-            output_schema: StaticJSONSchema::from_value(&output_schema).unwrap(),
+            output_schema: StaticJSONSchema::from_value(output_schema.clone()).unwrap(),
             implicit_tool_call_config,
             description: None,
         })));

--- a/tensorzero-core/src/evaluations/mod.rs
+++ b/tensorzero-core/src/evaluations/mod.rs
@@ -384,7 +384,7 @@ impl UninitializedEvaluatorConfig {
                             message: format!("Failed to parse LLM judge output schema: {e}. This should never happen, please file a bug report at https://github.com/tensorzero/tensorzero/discussions/new?category=bug-reports."),
                         })
                     })?;
-                let output_schema = StaticJSONSchema::from_value(&output_schema_value)?;
+                let output_schema = StaticJSONSchema::from_value(output_schema_value)?;
                 let implicit_tool_call_config =
                     create_implicit_tool_call_config(output_schema.clone());
                 let variants = variants
@@ -395,7 +395,7 @@ impl UninitializedEvaluatorConfig {
                     variants,
                     system_schema: None,
                     user_schema: user_schema_value
-                        .map(|v| StaticJSONSchema::from_value(&v))
+                        .map(StaticJSONSchema::from_value)
                         .transpose()?,
                     assistant_schema: None,
                     output_schema,
@@ -1612,6 +1612,6 @@ mod tests {
             },
             "required": ["result"]
         });
-        StaticJSONSchema::from_value(&schema_value).unwrap()
+        StaticJSONSchema::from_value(schema_value).unwrap()
     }
 }

--- a/tensorzero-core/src/function.rs
+++ b/tensorzero-core/src/function.rs
@@ -98,7 +98,7 @@ impl FunctionConfigChatPyClass {
     fn get_system_schema(&self, py: Python) -> PyResult<Py<PyAny>> {
         self.inner
             .system_schema()
-            .map(|s| serialize_to_dict(py, s.value))
+            .map(|s| serialize_to_dict(py, &s.value))
             .transpose()?
             .into_py_any(py)
     }
@@ -106,7 +106,7 @@ impl FunctionConfigChatPyClass {
     fn get_user_schema(&self, py: Python) -> PyResult<Py<PyAny>> {
         self.inner
             .user_schema()
-            .map(|s| serialize_to_dict(py, s.value))
+            .map(|s| serialize_to_dict(py, &s.value))
             .transpose()?
             .into_py_any(py)
     }
@@ -115,7 +115,7 @@ impl FunctionConfigChatPyClass {
     fn get_assistant_schema(&self, py: Python) -> PyResult<Py<PyAny>> {
         self.inner
             .assistant_schema()
-            .map(|s| serialize_to_dict(py, s.value))
+            .map(|s| serialize_to_dict(py, &s.value))
             .transpose()?
             .into_py_any(py)
     }
@@ -140,7 +140,7 @@ impl FunctionConfigJsonPyClass {
     fn get_system_schema(&self, py: Python) -> PyResult<Py<PyAny>> {
         self.inner
             .system_schema()
-            .map(|s| serialize_to_dict(py, s.value))
+            .map(|s| serialize_to_dict(py, &s.value))
             .transpose()?
             .into_py_any(py)
     }
@@ -149,7 +149,7 @@ impl FunctionConfigJsonPyClass {
     fn get_user_schema(&self, py: Python) -> PyResult<Py<PyAny>> {
         self.inner
             .user_schema()
-            .map(|s| serialize_to_dict(py, s.value))
+            .map(|s| serialize_to_dict(py, &s.value))
             .transpose()?
             .into_py_any(py)
     }
@@ -158,7 +158,7 @@ impl FunctionConfigJsonPyClass {
     fn get_assistant_schema(&self, py: Python) -> PyResult<Py<PyAny>> {
         self.inner
             .assistant_schema()
-            .map(|s| serialize_to_dict(py, s.value))
+            .map(|s| serialize_to_dict(py, &s.value))
             .transpose()?
             .into_py_any(py)
     }
@@ -170,7 +170,7 @@ impl FunctionConfigJsonPyClass {
                 "FunctionConfig is not a JSON function: {IMPOSSIBLE_ERROR_MESSAGE}"
             )));
         };
-        serialize_to_dict(py, params.output_schema.value)
+        serialize_to_dict(py, &params.output_schema.value)
     }
 }
 
@@ -1207,7 +1207,7 @@ mod tests {
             system_schema: None,
             user_schema: None,
             assistant_schema: None,
-            output_schema: StaticJSONSchema::from_value(&json!({})).unwrap(),
+            output_schema: StaticJSONSchema::from_value(json!({})).unwrap(),
             implicit_tool_call_config,
             description: None,
         };
@@ -1280,7 +1280,7 @@ mod tests {
             system_schema: Some(system_schema),
             user_schema: None,
             assistant_schema: None,
-            output_schema: StaticJSONSchema::from_value(&output_schema).unwrap(),
+            output_schema: StaticJSONSchema::from_value(output_schema).unwrap(),
             implicit_tool_call_config,
             description: None,
         };
@@ -1343,7 +1343,7 @@ mod tests {
             system_schema: None,
             user_schema: Some(user_schema),
             assistant_schema: None,
-            output_schema: StaticJSONSchema::from_value(&output_schema).unwrap(),
+            output_schema: StaticJSONSchema::from_value(output_schema).unwrap(),
             implicit_tool_call_config,
             description: None,
         };
@@ -1407,7 +1407,7 @@ mod tests {
             system_schema: None,
             user_schema: None,
             assistant_schema: Some(assistant_schema),
-            output_schema: StaticJSONSchema::from_value(&output_schema).unwrap(),
+            output_schema: StaticJSONSchema::from_value(output_schema).unwrap(),
             implicit_tool_call_config,
             description: None,
         };
@@ -1475,7 +1475,7 @@ mod tests {
             system_schema: Some(system_schema),
             user_schema: Some(user_schema),
             assistant_schema: Some(assistant_schema),
-            output_schema: StaticJSONSchema::from_value(&output_schema).unwrap(),
+            output_schema: StaticJSONSchema::from_value(output_schema).unwrap(),
             implicit_tool_call_config,
             description: None,
         };
@@ -1676,7 +1676,7 @@ mod tests {
         );
 
         // Test for JSON function with description
-        let output_schema = StaticJSONSchema::from_value(&json!({})).unwrap();
+        let output_schema = StaticJSONSchema::from_value(json!({})).unwrap();
         let implicit_tool_call_config = ToolCallConfig::implicit_from_value(&json!({}));
         let json_config = FunctionConfigJson {
             variants: HashMap::new(),
@@ -1729,7 +1729,7 @@ mod tests {
           "additionalProperties": false
         });
         let implicit_tool_call_config = ToolCallConfig::implicit_from_value(&output_schema);
-        let output_schema = StaticJSONSchema::from_value(&output_schema).unwrap();
+        let output_schema = StaticJSONSchema::from_value(output_schema).unwrap();
         let function_config = FunctionConfig::Json(FunctionConfigJson {
             variants: HashMap::new(),
             system_schema: None,
@@ -2295,7 +2295,7 @@ mod tests {
         // Test with an empty output schema
         let output_schema = json!({});
         let implicit_tool_call_config = ToolCallConfig::implicit_from_value(&output_schema);
-        let output_schema = StaticJSONSchema::from_value(&output_schema).unwrap();
+        let output_schema = StaticJSONSchema::from_value(output_schema).unwrap();
         let function_config = FunctionConfig::Json(FunctionConfigJson {
             variants: HashMap::new(),
             system_schema: None,

--- a/tensorzero-core/src/inference/types/mod.rs
+++ b/tensorzero-core/src/inference/types/mod.rs
@@ -2687,7 +2687,7 @@ mod tests {
             "required": ["name", "age"]
         });
         let implicit_tool_call_config = ToolCallConfig::implicit_from_value(&output_schema);
-        let output_schema = StaticJSONSchema::from_value(&output_schema).unwrap();
+        let output_schema = StaticJSONSchema::from_value(output_schema).unwrap();
         let json_function_config = Arc::new(FunctionConfig::Json(FunctionConfigJson {
             variants: HashMap::new(),
             system_schema: None,
@@ -2955,7 +2955,7 @@ mod tests {
             "required": ["name", "age"]
         });
         let implicit_tool_call_config = ToolCallConfig::implicit_from_value(&output_schema);
-        let output_schema = StaticJSONSchema::from_value(&output_schema).unwrap();
+        let output_schema = StaticJSONSchema::from_value(output_schema).unwrap();
         let json_function_config = Arc::new(FunctionConfig::Json(FunctionConfigJson {
             variants: HashMap::new(),
             system_schema: None,
@@ -3055,7 +3055,7 @@ mod tests {
             "required": ["name"]
         });
         let implicit_tool_call_config = ToolCallConfig::implicit_from_value(&static_output_schema);
-        let output_schema = StaticJSONSchema::from_value(&static_output_schema).unwrap();
+        let output_schema = StaticJSONSchema::from_value(static_output_schema).unwrap();
         let json_function_config = Arc::new(FunctionConfig::Json(FunctionConfigJson {
             variants: HashMap::new(),
             system_schema: None,

--- a/tensorzero-core/src/jsonschema_util.rs
+++ b/tensorzero-core/src/jsonschema_util.rs
@@ -24,7 +24,7 @@ impl<'a> JsonSchemaRef<'a> {
 
     pub fn value(&'a self) -> &'a Value {
         match self {
-            JsonSchemaRef::Static(schema) => schema.value,
+            JsonSchemaRef::Static(schema) => &schema.value,
             JsonSchemaRef::Dynamic(schema) => &schema.value,
         }
     }
@@ -36,7 +36,7 @@ impl<'a> JsonSchemaRef<'a> {
 pub struct StaticJSONSchema {
     #[serde(skip)]
     pub compiled: Arc<Validator>,
-    pub value: &'static serde_json::Value,
+    pub value: serde_json::Value,
 }
 
 impl PartialEq for StaticJSONSchema {
@@ -50,17 +50,14 @@ impl Default for StaticJSONSchema {
         // Create an empty JSON object
         let empty_schema: serde_json::Value = serde_json::json!({});
 
-        // Leak the memory to create a 'static reference
-        let static_schema: &'static serde_json::Value = Box::leak(Box::new(empty_schema));
-
         // Compile the schema
         #[expect(clippy::expect_used)]
         let compiled_schema =
-            jsonschema::validator_for(static_schema).expect("Failed to compile empty schema");
+            jsonschema::validator_for(&empty_schema).expect("Failed to compile empty schema");
 
         Self {
             compiled: Arc::new(compiled_schema),
-            value: static_schema,
+            value: empty_schema,
         }
     }
 }
@@ -80,9 +77,7 @@ impl StaticJSONSchema {
                 ),
             })
         })?;
-        // We can 'leak' memory here because we want the schema to exist for the duration of the process
-        let schema_boxed: &'static serde_json::Value = Box::leak(Box::new(schema));
-        let compiled_schema = jsonschema::validator_for(schema_boxed).map_err(|e| {
+        let compiled_schema = jsonschema::validator_for(&schema).map_err(|e| {
             Error::new(ErrorDetails::JsonSchema {
                 message: format!(
                     "Failed to compile JSON Schema `{}`: {}",
@@ -92,20 +87,21 @@ impl StaticJSONSchema {
             })
         })?;
         let compiled = Arc::new(compiled_schema);
-        let value = schema_boxed;
-        Ok(Self { compiled, value })
+        Ok(Self {
+            compiled,
+            value: schema,
+        })
     }
 
-    pub fn from_value(value: &serde_json::Value) -> Result<Self, Error> {
-        let schema_boxed: &'static serde_json::Value = Box::leak(Box::new(value.clone()));
-        let compiled_schema = jsonschema::validator_for(schema_boxed).map_err(|e| {
+    pub fn from_value(value: serde_json::Value) -> Result<Self, Error> {
+        let compiled_schema = jsonschema::validator_for(&value).map_err(|e| {
             Error::new(ErrorDetails::JsonSchema {
                 message: format!("Failed to compile JSON Schema: {e}"),
             })
         })?;
         Ok(Self {
             compiled: Arc::new(compiled_schema),
-            value: schema_boxed,
+            value,
         })
     }
 

--- a/tensorzero-core/src/providers/test_helpers.rs
+++ b/tensorzero-core/src/providers/test_helpers.rs
@@ -10,7 +10,7 @@ lazy_static! {
     pub static ref WEATHER_TOOL_CONFIG_STATIC: Arc<StaticToolConfig> = Arc::new(StaticToolConfig {
         name: "get_temperature".to_string(),
         description: "Get the current temperature in a given location".to_string(),
-        parameters: StaticJSONSchema::from_value(&json!({
+        parameters: StaticJSONSchema::from_value(json!({
             "type": "object",
             "properties": {
                 "location": {"type": "string"},
@@ -30,7 +30,7 @@ lazy_static! {
     pub static ref QUERY_TOOL_CONFIG_STATIC: Arc<StaticToolConfig> = Arc::new(StaticToolConfig {
         name: "query_articles".to_string(),
         description: "Query articles from Wikipedia".to_string(),
-        parameters: StaticJSONSchema::from_value(&json!({
+        parameters: StaticJSONSchema::from_value(json!({
             "type": "object",
             "properties": {
                 "query": {"type": "string"},

--- a/tensorzero-core/src/tool.rs
+++ b/tensorzero-core/src/tool.rs
@@ -456,7 +456,7 @@ impl ToolCallOutput {
 impl ToolCallConfig {
     #[cfg(test)]
     pub fn implicit_from_value(value: &Value) -> Self {
-        let parameters = StaticJSONSchema::from_value(value).unwrap();
+        let parameters = StaticJSONSchema::from_value(value.clone()).unwrap();
         let implicit_tool_config = ToolConfig::Implicit(ImplicitToolConfig { parameters });
         Self {
             tools_available: vec![implicit_tool_config],
@@ -554,9 +554,9 @@ impl ToolConfig {
 
     pub fn parameters(&self) -> &Value {
         match self {
-            ToolConfig::Static(config) => config.parameters.value,
+            ToolConfig::Static(config) => &config.parameters.value,
             ToolConfig::Dynamic(config) => &config.parameters.value,
-            ToolConfig::Implicit(config) => config.parameters.value,
+            ToolConfig::Implicit(config) => &config.parameters.value,
             ToolConfig::DynamicImplicit(config) => &config.parameters.value,
         }
     }
@@ -767,7 +767,7 @@ mod tests {
                 Arc::new(StaticToolConfig {
                     name: "get_temperature".to_string(),
                     description: "Get the current temperature in a given location".to_string(),
-                    parameters: StaticJSONSchema::from_value(&json!({
+                    parameters: StaticJSONSchema::from_value(json!({
                     "type": "object",
                     "properties": {
                         "location": {"type": "string"},
@@ -785,7 +785,7 @@ mod tests {
                     name: "query_articles".to_string(),
                     description: "Query articles from a database based on given criteria"
                         .to_string(),
-                    parameters: StaticJSONSchema::from_value(&json!({
+                    parameters: StaticJSONSchema::from_value(json!({
                         "type": "object",
                         "properties": {
                             "keyword": {"type": "string"},

--- a/tensorzero-core/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-core/src/variant/best_of_n_sampling.rs
@@ -94,7 +94,7 @@ impl LoadableConfig<BestOfNSamplingConfig> for UninitializedBestOfNSamplingConfi
 lazy_static! {
     static ref EVALUATOR_OUTPUT_SCHEMA: StaticJSONSchema = {
         #[expect(clippy::expect_used)]
-        StaticJSONSchema::from_value(&json!({
+        StaticJSONSchema::from_value(json!({
             "type": "object",
             "properties": {
                 "thinking": { "type": "string" },
@@ -733,7 +733,7 @@ impl BestOfNEvaluatorConfig {
                 stream: false,
                 json_mode: json_mode.into(),
                 function_type: FunctionType::Json,
-                output_schema: Some(EVALUATOR_OUTPUT_SCHEMA.value),
+                output_schema: Some(&EVALUATOR_OUTPUT_SCHEMA.value),
                 extra_body,
                 extra_headers,
                 extra_cache_key: inference_config.extra_cache_key.clone(),

--- a/tensorzero-core/src/variant/chain_of_thought.rs
+++ b/tensorzero-core/src/variant/chain_of_thought.rs
@@ -66,7 +66,7 @@ impl Variant for ChainOfThoughtConfig {
         };
         let original_output_schema = match inference_config.dynamic_output_schema {
             Some(schema) => &schema.value,
-            None => json_config.output_schema.value,
+            None => &json_config.output_schema.value,
         };
         let augmented_output_schema = prepare_thinking_output_schema(original_output_schema);
         let augmented_inference_config = InferenceConfig {

--- a/tensorzero-core/src/variant/chat_completion.rs
+++ b/tensorzero-core/src/variant/chat_completion.rs
@@ -1065,7 +1065,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let schema_any = StaticJSONSchema::from_value(&json!({ "type": "object" })).unwrap();
+        let schema_any = StaticJSONSchema::from_value(json!({ "type": "object" })).unwrap();
         let function_config = FunctionConfig::Chat(FunctionConfigChat {
             variants: HashMap::new(),
             system_schema: Some(schema_any.clone()),
@@ -1510,8 +1510,8 @@ mod tests {
             "additionalProperties": false
         });
         let implicit_tool_call_config = ToolCallConfig::implicit_from_value(&output_schema);
-        let output_schema = StaticJSONSchema::from_value(&output_schema).unwrap();
-        let schema_any = StaticJSONSchema::from_value(&json!({ "type": "object" })).unwrap();
+        let output_schema = StaticJSONSchema::from_value(output_schema).unwrap();
+        let schema_any = StaticJSONSchema::from_value(json!({ "type": "object" })).unwrap();
         let json_function_config = FunctionConfig::Json(FunctionConfigJson {
             variants: HashMap::new(),
             assistant_schema: Some(schema_any.clone()),
@@ -1663,8 +1663,8 @@ mod tests {
         let implicit_tool_call_config =
             ToolCallConfig::implicit_from_value(&hardcoded_output_schema);
         let hardcoded_output_schema =
-            StaticJSONSchema::from_value(&hardcoded_output_schema).unwrap();
-        let schema_any = StaticJSONSchema::from_value(&json!({ "type": "object" })).unwrap();
+            StaticJSONSchema::from_value(hardcoded_output_schema).unwrap();
+        let schema_any = StaticJSONSchema::from_value(json!({ "type": "object" })).unwrap();
         let json_function_config = FunctionConfig::Json(FunctionConfigJson {
             variants: HashMap::new(),
             assistant_schema: Some(schema_any.clone()),
@@ -1775,8 +1775,8 @@ mod tests {
         let implicit_tool_call_config =
             ToolCallConfig::implicit_from_value(&hardcoded_output_schema);
         let hardcoded_output_schema =
-            StaticJSONSchema::from_value(&hardcoded_output_schema).unwrap();
-        let schema_any = StaticJSONSchema::from_value(&json!({ "type": "object" })).unwrap();
+            StaticJSONSchema::from_value(hardcoded_output_schema).unwrap();
+        let schema_any = StaticJSONSchema::from_value(json!({ "type": "object" })).unwrap();
         let json_function_config = FunctionConfig::Json(FunctionConfigJson {
             variants: HashMap::new(),
             assistant_schema: Some(schema_any.clone()),
@@ -1897,7 +1897,7 @@ mod tests {
             },
         };
         let templates = Box::leak(Box::new(get_test_template_config()));
-        let schema_any = StaticJSONSchema::from_value(&json!({ "type": "object" })).unwrap();
+        let schema_any = StaticJSONSchema::from_value(json!({ "type": "object" })).unwrap();
         let function_config = Box::leak(Box::new(FunctionConfig::Chat(FunctionConfigChat {
             variants: HashMap::new(),
             system_schema: Some(schema_any.clone()),
@@ -2250,7 +2250,7 @@ mod tests {
             system_schema: None,
             user_schema: None,
             assistant_schema: None,
-            output_schema: StaticJSONSchema::from_value(&output_schema_value).unwrap(),
+            output_schema: StaticJSONSchema::from_value(output_schema_value.clone()).unwrap(),
             implicit_tool_call_config: ToolCallConfig {
                 tools_available: vec![],
                 tool_choice: ToolChoice::Auto,

--- a/tensorzero-core/src/variant/mixture_of_n.rs
+++ b/tensorzero-core/src/variant/mixture_of_n.rs
@@ -1207,7 +1207,7 @@ mod tests {
             system_schema: None,
             user_schema: None,
             assistant_schema: None,
-            output_schema: StaticJSONSchema::from_value(&json!({})).unwrap(),
+            output_schema: StaticJSONSchema::from_value(json!({})).unwrap(),
             implicit_tool_call_config: ToolCallConfig::default(),
             description: None,
         });

--- a/tensorzero-core/src/variant/mod.rs
+++ b/tensorzero-core/src/variant/mod.rs
@@ -632,7 +632,7 @@ where
             };
             let output_schema = match inference_config.dynamic_output_schema {
                 Some(schema) => Some(&schema.value),
-                None => Some(json_config.output_schema.value),
+                None => Some(&json_config.output_schema.value),
             };
             ModelInferenceRequest {
                 messages,
@@ -967,7 +967,7 @@ mod tests {
             },
             "required": ["answer"],
         });
-        let output_schema = StaticJSONSchema::from_value(&output_schema_value).unwrap();
+        let output_schema = StaticJSONSchema::from_value(output_schema_value.clone()).unwrap();
         let implicit_tool_call_config = ToolCallConfig::implicit_from_value(&output_schema_value);
 
         let function_config_json = FunctionConfig::Json(FunctionConfigJson {
@@ -1237,7 +1237,7 @@ mod tests {
             system_schema: None,
             user_schema: None,
             assistant_schema: None,
-            output_schema: StaticJSONSchema::from_value(&json!({
+            output_schema: StaticJSONSchema::from_value(json!({
                 "type": "object",
                 "properties": {
                     "answer": { "type": "string" }

--- a/tensorzero-core/tests/e2e/batch/mod.rs
+++ b/tensorzero-core/tests/e2e/batch/mod.rs
@@ -515,7 +515,7 @@ async fn test_write_read_completed_batch_inference_json() {
         status,
         errors: vec![],
     });
-    let output_schema = StaticJSONSchema::from_value(&json!({
+    let output_schema = StaticJSONSchema::from_value(json!({
         "type": "object",
         "properties": {
             "answer": {


### PR DESCRIPTION
We weren't getting any benefit from storing a leaked static reference. This will allow us to deserialize a `StaticJSONSchema` without leaking memory.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `StaticJSONSchema` to store `serde_json::Value` directly, removing static references to prevent memory leaks.
> 
>   - **Behavior**:
>     - Change `StaticJSONSchema` to store `serde_json::Value` directly instead of a static reference.
>     - Update `StaticJSONSchema::from_value()` to accept `serde_json::Value` directly.
>   - **Code Adjustments**:
>     - Modify `JsonSchemaRef::value()` in `jsonschema_util.rs` to return a reference to `serde_json::Value`.
>     - Update `prepare_model_inference_request()` in `mod.rs` to handle new `StaticJSONSchema` structure.
>     - Adjust `infer()` and `infer_stream()` methods in `chain_of_thought.rs`, `chat_completion.rs`, and `mixture_of_n.rs` to use updated `StaticJSONSchema`.
>   - **Tests**:
>     - Update tests in `tests.rs` across various modules to use new `StaticJSONSchema` structure.
>     - Ensure tests in `batch/mod.rs` reflect changes in `StaticJSONSchema` handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 20943bda2772dd59974ce1473a7576d9af311146. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->