### PR TITLE
Set 'TENSORZERO_CI=1' when regenerating fixtures to enable retries

### DIFF
--- a/.github/workflows/ui-tests-e2e-model-inference-cache.yml
+++ b/.github/workflows/ui-tests-e2e-model-inference-cache.yml
@@ -93,6 +93,8 @@ jobs:
       - name: Regenerate model inference cache
         working-directory: ui
         if: inputs.regen_cache == true
+        env:
+          TENSORZERO_CI: 1
         run: |
           echo "FIREWORKS_ACCOUNT_ID=${{ secrets.FIREWORKS_ACCOUNT_ID }}" >> fixtures/.env-gateway
           echo "FIREWORKS_API_KEY=${{ secrets.FIREWORKS_API_KEY }}" >> fixtures/.env-gateway

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -18,8 +18,6 @@ export default defineConfig({
   retries: process.env.TENSORZERO_CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.TENSORZERO_CI ? 1 : undefined,
-  /* Fail immediately while we're debugging the CI issue */
-  maxFailures: process.env.TENSORZERO_CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.TENSORZERO_CI ? [["list"], ["github"]] : [["dot"]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `TENSORZERO_CI=1` for retries during fixture regeneration and remove `maxFailures` in Playwright config.
> 
>   - **Environment Variable**:
>     - Set `TENSORZERO_CI=1` in `.github/workflows/ui-tests-e2e-model-inference-cache.yml` to enable retries during fixture regeneration.
>   - **Configuration Changes**:
>     - Remove `maxFailures` setting in `playwright.config.ts` to prevent immediate test failure in CI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b53ba3515df4ca48180eceab79b9d594275403b2. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->