### PR TITLE
Use tensorzero-16x32 Namespace runner for clickhouse replicated tests

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -355,7 +355,7 @@ jobs:
     # We don't run many tests here, so use a normal runner with Github Actions caching
     # to avoid unnecessarily using Namespace credits (it should still always finish before
     # the main 'validate' job)
-    runs-on: ${{ matrix.replicated && 'tensorzero-16x32' || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.replicated && 'namespace-profile-tensorzero-16x32' || 'ubuntu-latest' }}
     continue-on-error: ${{ matrix.clickhouse_version.allow_failure }}
     strategy:
       matrix:


### PR DESCRIPTION
We were previously using a 32x64 runner - the smaller runner still has enough memory for the tests to pass.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Change ClickHouse test runner in GitHub Actions to `namespace-profile-tensorzero-16x32` for optimized resource usage.
> 
>   - **GitHub Actions Workflow**:
>     - In `.github/workflows/general.yml`, change runner for ClickHouse tests from `namespace-profile-tensorzero-large-cache-volume` to `namespace-profile-tensorzero-16x32`.
>     - This change optimizes resource usage while maintaining sufficient memory for tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c6678ada795fb4b1733c03a1c21ee766f873bd8e. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->