### PR TITLE
Switch back to Github runners for ui e2e tests

### DIFF
--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Set DNS
         run: echo "127.0.0.1 howdy.tensorzero.com" | sudo tee -a /etc/hosts
-      - uses: namespacelabs/nscloud-checkout-action@953fed31a6113cc2347ca69c9d823743c65bc84b
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
@@ -76,7 +76,7 @@ jobs:
     steps:
       - name: Set DNS
         run: echo "127.0.0.1 howdy.tensorzero.com" | sudo tee -a /etc/hosts
-      - uses: namespacelabs/nscloud-checkout-action@953fed31a6113cc2347ca69c9d823743c65bc84b
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -20,8 +20,7 @@ on:
 
 jobs:
   ui-tests-no-network:
-    # We're only using namespace here so that we can download the container artifacts
-    runs-on: namespace-profile-tensorzero-2x8
+    runs-on: ubuntu-latest
     steps:
       - name: Set DNS
         run: echo "127.0.0.1 howdy.tensorzero.com" | sudo tee -a /etc/hosts
@@ -32,7 +31,7 @@ jobs:
           node-version: "22.9.0"
 
       - name: Download container images
-        uses: namespace-actions/download-artifact@5c070f7d7ebdc47682b04aa736c76e46ff5f6e1e
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:
           pattern: build-*-container
           merge-multiple: true
@@ -73,8 +72,7 @@ jobs:
         run: docker inspect --format "{{json .State.Health }}" $(docker compose -f fixtures/docker-compose.e2e.yml -f fixtures/docker-compose.ui.yml ps -q ui) | jq
 
   ui-tests-gateway-prefix:
-    # We're only using namespace here so that we can download the container artifacts
-    runs-on: namespace-profile-tensorzero-2x8
+    runs-on: ubuntu-latest
     steps:
       - name: Set DNS
         run: echo "127.0.0.1 howdy.tensorzero.com" | sudo tee -a /etc/hosts
@@ -94,7 +92,7 @@ jobs:
         run: pnpm --filter=tensorzero-ui exec playwright install --with-deps chromium
 
       - name: Download container images
-        uses: namespace-actions/download-artifact@5c070f7d7ebdc47682b04aa736c76e46ff5f6e1e
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:
           pattern: build-*-container
           merge-multiple: true


### PR DESCRIPTION
We're now pushing the built gateway/ui container images to both Namespace and Github via upload-artifact actions, so we don't need a Namespace runner

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Switches UI E2E tests to use GitHub runners and updates actions for checkout and artifact download.
> 
>   - **Runner Change**:
>     - Switches `runs-on` from `namespace-profile-tensorzero-2x8` to `ubuntu-latest` in `ui-tests-no-network` and `ui-tests-gateway-prefix` jobs in `ui-tests-e2e.yml`.
>   - **Actions Update**:
>     - Replaces `namespacelabs/nscloud-checkout-action` with `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683`.
>     - Replaces `namespace-actions/download-artifact` with `actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f7d5322bc6baa71e1e579973f33f9fdffe7c80b8. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->