### PR TITLE
Avoid printing extra log lines in Python client

### DIFF
--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -316,6 +316,29 @@ impl ClientBuilder {
         }
     }
 
+    /// Builds a dummy client for use in pyo3. Should not otherwise be used
+    /// This avoids logging any messages
+    #[cfg(feature = "pyo3")]
+    pub fn build_dummy() -> Client {
+        use tensorzero_core::clickhouse::ClickHouseConnectionInfo;
+
+        Client {
+            mode: Arc::new(ClientMode::EmbeddedGateway {
+                gateway: EmbeddedGateway {
+                    handle: GatewayHandle::new_with_clickhouse_and_http_client(
+                        Arc::new(Config::default()),
+                        ClickHouseConnectionInfo::Disabled,
+                        reqwest::Client::new(),
+                    ),
+                },
+                timeout: None,
+            }),
+            verbose_errors: false,
+            #[cfg(feature = "e2e_tests")]
+            last_body: Default::default(),
+        }
+    }
+
     #[cfg(any(test, feature = "e2e_tests"))]
     pub async fn build_from_state(handle: GatewayHandle) -> Result<Client, ClientBuilderError> {
         Ok(Client {

--- a/tensorzero-core/src/gateway_util.rs
+++ b/tensorzero-core/src/gateway_util.rs
@@ -46,7 +46,6 @@ pub struct GatewayHandle {
 
 impl Drop for GatewayHandle {
     fn drop(&mut self) {
-        tracing::info!("Shutting down gateway");
         self.cancel_token.cancel();
         let handle = self
             .app_state


### PR DESCRIPTION
We now make the dummy client using a separate method, to avoid calling 'setup_clickhouse' and logging spurious messages for the dummy client

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor dummy client creation to avoid unnecessary logging and remove extra log lines during gateway shutdown.
> 
>   - **Behavior**:
>     - Refactor `make_dummy_client()` in `clients/python/src/lib.rs` to use `ClientBuilder::build_dummy()` to avoid logging during dummy client creation.
>     - Update `BaseTensorZeroGateway` and `TensorZeroGateway` constructors to use the new `make_dummy_client()`.
>     - Remove logging statement in `Drop` implementation of `GatewayHandle` in `tensorzero-core/src/gateway_util.rs` to prevent extra log lines during shutdown.
>   - **ClientBuilder**:
>     - Add `build_dummy()` method in `clients/rust/src/lib.rs` to create a dummy client without logging.
>   - **Misc**:
>     - Remove `setup_clickhouse` call from dummy client creation to prevent unnecessary logging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for caf9c50e1c37f6dbe3bf16085cd49fa250c6f688. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->