### PR TITLE
Bump sleep time for test_simple_streaming_inference_request

### DIFF
--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -3070,7 +3070,7 @@ pub async fn test_simple_streaming_inference_request_with_provider_cache(
     assert!(finish_reason.is_some());
 
     // Sleep to allow time for data to be inserted into ClickHouse (trailing writes from API)
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
     // Check ClickHouse - ChatInference Table
     let clickhouse = get_clickhouse().await;


### PR DESCRIPTION
This test is repeatedly flaking on CI with clickhouse batching

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase sleep duration in `test_simple_streaming_inference_request_with_provider_cache` to reduce CI flakiness.
> 
>   - **Test Stability**:
>     - Increase sleep duration from 100ms to 500ms in `test_simple_streaming_inference_request_with_provider_cache` in `common.rs` to reduce flakiness on CI with ClickHouse batching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for bae1561d15a45f1bc2736920640fb536916aa320. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->