### PR TITLE
Set a 5 minute timeout for pyo3 pytests on CI

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -192,6 +192,7 @@ jobs:
 
       - name: "Python: OpenAI Client: pytest"
         working-directory: clients/openai-python
+        timeout-minutes: 5
         run: |
           uv run pytest
 


### PR DESCRIPTION
Successful runs take under 2 minutes.
This will prevent CI from hanging if there are any remaining deadlocks in the Python code

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set a 5-minute timeout for `pytest` in CI to prevent hanging due to deadlocks.
> 
>   - **CI Configuration**:
>     - Set a 5-minute timeout for `pytest` in `merge-queue.yml` under the `Python: OpenAI Client` job to prevent hanging due to deadlocks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 502978922369f968fb6f91757460a38dd3841d69. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->