### PR TITLE
Double sleep time for test_clickhouse_bulk_insert

### DIFF
--- a/tensorzero-core/tests/e2e/inference.rs
+++ b/tensorzero-core/tests/e2e/inference.rs
@@ -3952,7 +3952,7 @@ async fn test_clickhouse_bulk_insert() {
     assert_eq!(expected_inference_ids.len(), inference_count);
 
     assert_eq!(Arc::strong_count(&client), 1);
-    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
     let clickhouse_client = get_clickhouse().await;
     let inferences = select_chat_inferences_clickhouse(&clickhouse_client, episode_id)


### PR DESCRIPTION
This flaked several times on Clickhouse Cloud, so let's give it more time.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Double sleep duration in `test_clickhouse_bulk_insert()` to address flakiness on Clickhouse Cloud.
> 
>   - **Tests**:
>     - Double sleep duration from 5 to 10 seconds in `test_clickhouse_bulk_insert()` in `inference.rs` to address flakiness on Clickhouse Cloud.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7a8868fcbea5d5a34166ccf9a7a057cffa83470c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->