### PR TITLE
Retry downloads of the provider-proxy cache

### DIFF
--- a/ci/download-provider-proxy-cache.sh
+++ b/ci/download-provider-proxy-cache.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
 set -euxo pipefail
 cd $(dirname $0)/provider-proxy-cache
-aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync s3://provider-proxy-cache .
+for i in {1..5}; do
+  if aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync s3://provider-proxy-cache .; then
+    break
+  else
+    echo "Attempt $i failed. Retrying..."
+    if [ $i -eq 5 ]; then
+      echo "All attempts failed."
+      exit 1
+    fi
+    sleep 5
+  fi
+done


### PR DESCRIPTION
This should work around the strange failures we're frequently seeing in CI:
https://github.com/tensorzero/tensorzero/actions/runs/16966643566/job/48092247115

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds retry mechanism to `ci/download-provider-proxy-cache.sh` to handle download failures by retrying up to 5 times.
> 
>   - **Behavior**:
>     - Adds retry mechanism to `ci/download-provider-proxy-cache.sh` for downloading provider-proxy cache.
>     - Retries `aws s3 sync` command up to 5 times with 5-second intervals.
>     - Logs attempt failures and exits with error after 5 failed attempts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 700f972b7adb5ce8ca04a82dbdbafb96b6d211d2. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->