### PR TITLE
Try CLICKHOUSE_SKIP_USER_SETUP in replicated clickhouse

### DIFF
--- a/tensorzero-core/tests/e2e/docker-compose.replicated.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.replicated.yml
@@ -12,6 +12,8 @@ services:
       nofile:
         soft: 262144
         hard: 262144
+    environment:
+      CLICKHOUSE_SKIP_USER_SETUP: 1
     healthcheck:
       test: wget --spider --tries 1 http://chuser:chpassword@clickhouse-01:8123/ping
       start_period: 30s
@@ -29,6 +31,8 @@ services:
     volumes:
       - ./replicated_clickhouse_config/ch2:/etc/clickhouse-server/config.d
       - ./replicated_clickhouse_config/common:/etc/clickhouse-server/users.d
+    environment:
+      CLICKHOUSE_SKIP_USER_SETUP: 1
     ulimits:
       nofile:
         soft: 262144
@@ -50,6 +54,8 @@ services:
     volumes:
       - ./replicated_clickhouse_config/ch3:/etc/clickhouse-server/config.d
       - ./replicated_clickhouse_config/common:/etc/clickhouse-server/users.d
+    environment:
+      CLICKHOUSE_SKIP_USER_SETUP: 1
     ulimits:
       nofile:
         soft: 262144


### PR DESCRIPTION
Hopefully, this fixes the startup flakes

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
