### PR TITLE
Skip 'ui-tests-e2e-credentials' job for PRs from external repositories

### DIFF
--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -167,6 +167,10 @@ jobs:
 
   ui-tests-e2e-credentials:
     runs-on: namespace-profile-tensorzero-8x16
+    # We currently only run this job when we have secrets available, since we need to use an S3 object_store
+    # In the future, we might want to fix this so that it can run in PR CI for external (forked) PRs
+    # For now, it just runs in the merge queue and on prs from the main repo
+    if: ${{ (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') || github.event_name == 'merge_group' }}    
     steps:
       # TODO - investigate why using the Namespace checkout action causes
       # 'tensorzero_core::built_info::GIT_COMMIT_HASH_SHORT' to be `None`


### PR DESCRIPTION
We still run it for PRs from the main repository, and for all PRs in the merge queue

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `ui-tests-e2e-credentials` job in `.github/workflows/ui-tests-e2e.yml` to skip for PRs from external repositories, running only for main repo PRs or in merge queue.
> 
>   - **Workflow Changes**:
>     - In `.github/workflows/ui-tests-e2e.yml`, modify `ui-tests-e2e-credentials` job to skip for PRs from external repositories.
>     - Add condition to `if` statement: runs only for PRs from main repo or in merge queue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ff071cdfe969c3aa9ea0b680215553dd69745d90. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->