### PR TITLE
Improve python GIL apis and store explicitly gateway reference

### DIFF
--- a/clients/python/src/gil_helpers.rs
+++ b/clients/python/src/gil_helpers.rs
@@ -1,31 +1,16 @@
 use std::{ops::Deref, sync::Arc};
 
 use pyo3::Python;
-use tensorzero_rust::InferenceStream;
-use tokio::sync::Mutex;
-
 /// Runs a function inside the Tokio runtime, with the GIL released.
 /// This is used when we need to drop a TensorZero client (or a type that holds it),
 /// so that we can block on the ClickHouse batcher shutting down, without holding the GIL.
-pub fn in_tokio_runtime_no_gil<F: FnOnce() + Send>(f: F) {
+fn in_tokio_runtime_no_gil<F: FnOnce() + Send>(f: F) {
     Python::with_gil(|py| {
         py.allow_threads(|| {
             let _guard = pyo3_async_runtimes::tokio::get_runtime().enter();
             f();
         });
     });
-}
-
-/// Helper method to drop an `InferenceStream` inside a Tokio runtime.
-/// An `InferenceStream` holds a reference to a `Client`, and thus may need to block
-/// inside Tokio when it gets dropped
-fn drop_stream_in_tokio(stream: &mut Arc<Mutex<InferenceStream>>) {
-    if let Some(mutex) = Arc::get_mut(stream) {
-        let real_stream = std::mem::replace(mutex, Mutex::new(Box::pin(futures::stream::empty())));
-        in_tokio_runtime_no_gil(|| {
-            drop(real_stream);
-        });
-    }
 }
 
 /// A wrapper type for an `InferenceStream`, which ensures that we enter the Tokio runtime
@@ -35,26 +20,55 @@ fn drop_stream_in_tokio(stream: &mut Arc<Mutex<InferenceStream>>) {
 /// We do not allow access to the underlying `Arc`, to prevent accidentally cloning
 /// the `Arc` and dropping it from somewhere else within pyo3 code.
 /// This is not an issue within `tensorzero-core`, since we're always in the Tokio runtime.
-#[derive(Clone)]
-pub struct TokioInferenceStream(Arc<Mutex<InferenceStream>>);
+pub struct DropInTokio<T: Send> {
+    value: Arc<T>,
+    make_dummy: fn() -> T,
+}
 
-impl TokioInferenceStream {
-    pub fn new(stream: InferenceStream) -> Self {
-        Self(Arc::new(Mutex::new(stream)))
+impl<T: Send> DropInTokio<T> {
+    /// Constructs a new `DropInTokio` wrapper, which will drop `value`
+    /// inside of the Tokio runtime with the python GIL released.
+    ///
+    /// The `make_dummy` function is called to produce a new value,
+    /// which is needed to satisfy the borrow checker. It will *not* be
+    /// dropped inside of Tokio, so it should shouldn't contain a `Client`
+    /// or similar TensorZero handle.
+    pub fn new(value: T, make_dummy: fn() -> T) -> Self {
+        Self {
+            value: Arc::new(value),
+            make_dummy,
+        }
     }
 }
 
-impl Deref for TokioInferenceStream {
+impl<T: Send> Clone for DropInTokio<T> {
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value.clone(),
+            make_dummy: self.make_dummy,
+        }
+    }
+}
+
+impl<T: Send> Deref for DropInTokio<T> {
     // This intentionally does not allow dereferencing the `Arc` itself,
     // since it could then be cloned and dropped from somewhere else within pyo3 code.
-    type Target = Mutex<InferenceStream>;
+    type Target = T;
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.value
     }
 }
 
-impl Drop for TokioInferenceStream {
+impl<T: Send> Drop for DropInTokio<T> {
     fn drop(&mut self) {
-        drop_stream_in_tokio(&mut self.0);
+        let dummy = (self.make_dummy)();
+        // 'self.value' may hold a reference `Client`, and thus may need to block
+        // inside Tokio when it gets dropped
+        if let Some(value_ref) = Arc::get_mut(&mut self.value) {
+            let inner_value = std::mem::replace(value_ref, dummy);
+            in_tokio_runtime_no_gil(|| {
+                drop(inner_value);
+            });
+        }
     }
 }

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -24,7 +24,6 @@ use python_helpers::{
     parse_feedback_response, parse_inference_chunk, parse_inference_response, parse_tool,
     python_uuid_to_uuid,
 };
-use tensorzero_core::error::IMPOSSIBLE_ERROR_MESSAGE;
 use tensorzero_core::{
     clickhouse::{query_builder::OrderBy, ClickhouseFormat},
     config_parser::{ConfigPyClass, FunctionsConfigPyClass},
@@ -62,15 +61,16 @@ use tensorzero_rust::{
     err_to_http, observability::LogFormat, CacheParamsOptions, Client, ClientBuilder,
     ClientBuilderMode, ClientInferenceParams, ClientInput, ClientSecretString, Datapoint,
     DynamicEvaluationRunParams, DynamicToolParams, FeedbackParams, InferenceOutput,
-    InferenceParams, LaunchOptimizationParams, ListInferencesParams, OptimizationJobHandle,
-    RenderedSample, StoredInference, TensorZeroError, Tool,
+    InferenceParams, InferenceStream, LaunchOptimizationParams, ListInferencesParams,
+    OptimizationJobHandle, RenderedSample, StoredInference, TensorZeroError, Tool,
 };
+use tokio::sync::Mutex;
 use url::Url;
-
-use crate::gil_helpers::{in_tokio_runtime_no_gil, TokioInferenceStream};
 
 mod gil_helpers;
 mod python_helpers;
+
+use crate::gil_helpers::DropInTokio;
 
 #[pymodule]
 fn tensorzero(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -130,7 +130,9 @@ fn tensorzero(m: &Bound<'_, PyModule>) -> PyResult<()> {
 struct LocalHttpGateway {
     #[pyo3(get)]
     base_url: String,
-    shutdown_handle: Option<ShutdownHandle>,
+    // We use a double `Option` so that we can implement `LocalHttpGateway.close`
+    // by setting it to `None`, without needing to complicate the api of `DropInTokio`
+    shutdown_handle: Option<DropInTokio<Option<ShutdownHandle>>>,
 }
 
 impl Drop for LocalHttpGateway {
@@ -142,10 +144,7 @@ impl Drop for LocalHttpGateway {
 #[pymethods]
 impl LocalHttpGateway {
     fn close(&mut self) {
-        // We need to be inside a Tokio content when the `Client` is dropped (if batch writes are enabled)
-        in_tokio_runtime_no_gil(|| {
-            self.shutdown_handle.take();
-        });
+        self.shutdown_handle = None;
     }
 }
 
@@ -166,7 +165,7 @@ fn _start_http_gateway(
         .await?;
         Ok(LocalHttpGateway {
             base_url: format!("http://{addr}/openai/v1"),
-            shutdown_handle: Some(handle),
+            shutdown_handle: Some(DropInTokio::new(Some(handle), || None)),
         })
     };
     if async_setup {
@@ -183,35 +182,20 @@ fn _start_http_gateway(
 }
 
 // TODO - this should extend the python `ABC` class once pyo3 supports it: https://github.com/PyO3/pyo3/issues/991
-#[pyclass(subclass)]
+#[pyclass(subclass, frozen)]
 struct BaseTensorZeroGateway {
-    client: Arc<Client>,
-    dummy_client: Option<Client>,
+    client: DropInTokio<Client>,
 }
 
-impl Drop for BaseTensorZeroGateway {
-    fn drop(&mut self) {
-        // We need to be inside a Tokio content when the `Client` is dropped.
-        // We might be the last holder of the `Arc`, so enter the Tokio runtime.
-        in_tokio_runtime_no_gil(|| {
-            if let Some(dummy_client) = self.dummy_client.take() {
-                // Use our dummy client to move out of `self.client` (we cannot clone the Arc,
-                // as the original instance would still exist in `self.client`, and be dropped
-                // outside of this `drop` method.
-                let real_client = std::mem::replace(&mut self.client, Arc::new(dummy_client));
-                drop(real_client);
-            } else {
-                tracing::error!(
-                "BaseTensorZeroGateway dropped without a dummy client. {IMPOSSIBLE_ERROR_MESSAGE}"
-            );
-            }
-        });
-    }
-}
-
-#[pyclass]
+#[pyclass(frozen)]
 struct AsyncStreamWrapper {
-    stream: TokioInferenceStream,
+    stream: Arc<Mutex<InferenceStream>>,
+    // A handle to the original `AsyncTensorZeroGateway` object.
+    // This ensures that Python will only garbage-collect the `AsyncTensorZeroGateway`
+    // after all `AsyncStreamWrapper` objects have been garbage collected.
+    // This allows us to safely block from within the Drop impl of `AsyncTensorZeroGateway`.
+    // knowing that there are no remaining Python objects holding on to a `ClickhouseConnectionInfo`
+    _gateway: PyObject,
 }
 
 #[pymethods]
@@ -245,9 +229,15 @@ impl AsyncStreamWrapper {
     }
 }
 
-#[pyclass]
+#[pyclass(frozen)]
 struct StreamWrapper {
-    stream: TokioInferenceStream,
+    stream: Arc<Mutex<InferenceStream>>,
+    // A handle to the original `TensorZeroGateway` object.
+    // This ensures that Python will only garbage-collect the `TensorZeroGateway`
+    // after all `StreamWrapper` objects have been garbage collected.
+    // This allows us to safely block from within the Drop impl of `TensorZeroGateway`.
+    // knowing that there are no remaining Python objects holding on to a `ClickhouseConnectionInfo`
+    _gateway: PyObject,
 }
 
 #[pymethods]
@@ -271,24 +261,8 @@ impl StreamWrapper {
 
 /// Constructs a dummy embedded client. We use this so that we can move out of the real 'client'
 /// field of `BaseTensorZeroGateway` when it is dropped.
-fn make_dummy_client(py: Python<'_>) -> PyResult<Client> {
-    let dummy_client = tokio_block_on_without_gil(py, async move {
-        ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
-            config_file: None,
-            clickhouse_url: None,
-            timeout: None,
-            verify_credentials: false,
-        })
-        .build()
-        .await
-    });
-    match dummy_client {
-        Ok(client) => Ok(client),
-        Err(e) => Err(tensorzero_core_error(
-            py,
-            &format!("Failed to construct dummy client: {e:?}"),
-        )?),
-    }
+fn make_dummy_client() -> Client {
+    ClientBuilder::build_dummy()
 }
 
 #[pymethods]
@@ -329,8 +303,7 @@ impl BaseTensorZeroGateway {
         };
 
         Ok(Self {
-            client: Arc::new(client),
-            dummy_client: Some(make_dummy_client(py)?),
+            client: DropInTokio::new(client, make_dummy_client),
         })
     }
 
@@ -614,8 +587,7 @@ impl TensorZeroGateway {
             }
         };
         let instance = PyClassInitializer::from(BaseTensorZeroGateway {
-            client: Arc::new(client),
-            dummy_client: Some(make_dummy_client(cls.py())?),
+            client: DropInTokio::new(client, make_dummy_client),
         })
         .add_subclass(TensorZeroGateway {});
         Py::new(cls.py(), instance)
@@ -693,8 +665,7 @@ impl TensorZeroGateway {
         };
         // Construct an instance of `TensorZeroGateway` (while providing the fields from the `BaseTensorZeroGateway` superclass).
         let instance = PyClassInitializer::from(BaseTensorZeroGateway {
-            client: Arc::new(client),
-            dummy_client: Some(make_dummy_client(cls.py())?),
+            client: DropInTokio::new(client, make_dummy_client),
         })
         .add_subclass(TensorZeroGateway {});
         Py::new(cls.py(), instance)
@@ -837,7 +808,8 @@ impl TensorZeroGateway {
         match resp {
             InferenceOutput::NonStreaming(data) => parse_inference_response(py, data),
             InferenceOutput::Streaming(stream) => Ok(StreamWrapper {
-                stream: TokioInferenceStream::new(stream),
+                stream: Arc::new(Mutex::new(stream)),
+                _gateway: this.into_pyobject(py)?.into_any().unbind(),
             }
             .into_pyobject(py)?
             .into_any()
@@ -1230,7 +1202,6 @@ impl AsyncTensorZeroGateway {
             client_builder = client_builder.with_http_client(http_client);
         }
         let client_fut = client_builder.build();
-        let dummy_client = make_dummy_client(cls.py())?;
         let build_gateway = async move {
             let client = client_fut.await;
             // We need to interact with Python objects here (to build up a Python `AsyncTensorZeroGateway`),
@@ -1248,8 +1219,7 @@ impl AsyncTensorZeroGateway {
 
                 // Construct an instance of `AsyncTensorZeroGateway` (while providing the fields from the `BaseTensorZeroGateway` superclass).
                 let instance = PyClassInitializer::from(BaseTensorZeroGateway {
-                    client: Arc::new(client),
-                    dummy_client: Some(dummy_client),
+                    client: DropInTokio::new(client, make_dummy_client),
                 })
                 .add_subclass(AsyncTensorZeroGateway {});
                 Py::new(py, instance)
@@ -1330,7 +1300,6 @@ impl AsyncTensorZeroGateway {
             verify_credentials: true,
         })
         .build();
-        let dummy_client = make_dummy_client(cls.py())?;
         let fut = async move {
             let client = client_fut.await;
             // We need to interact with Python objects here (to build up a Python `AsyncTensorZeroGateway`),
@@ -1348,8 +1317,7 @@ impl AsyncTensorZeroGateway {
 
                 // Construct an instance of `AsyncTensorZeroGateway` (while providing the fields from the `BaseTensorZeroGateway` superclass).
                 let instance = PyClassInitializer::from(BaseTensorZeroGateway {
-                    client: Arc::new(client),
-                    dummy_client: Some(dummy_client),
+                    client: DropInTokio::new(client, make_dummy_client),
                 })
                 .add_subclass(AsyncTensorZeroGateway {});
                 Py::new(py, instance)
@@ -1448,6 +1416,7 @@ impl AsyncTensorZeroGateway {
             include_original_response.unwrap_or(false),
         )?;
         let client = this.as_super().client.clone();
+        let gateway = this.into_pyobject(py)?.into_any().unbind();
         // See `AsyncStreamWrapper::__anext__` for more details about `future_into_py`
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let res = client.inference(params).await;
@@ -1458,7 +1427,8 @@ impl AsyncTensorZeroGateway {
                 match output {
                     InferenceOutput::NonStreaming(data) => parse_inference_response(py, data),
                     InferenceOutput::Streaming(stream) => Ok(AsyncStreamWrapper {
-                        stream: TokioInferenceStream::new(stream),
+                        stream: Arc::new(Mutex::new(stream)),
+                        _gateway: gateway,
                     }
                     .into_pyobject(py)?
                     .into_any()

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -329,6 +329,29 @@ impl ClientBuilder {
         }
     }
 
+    /// Builds a dummy client for use in pyo3. Should not otherwise be used
+    /// This avoids logging any messages
+    #[cfg(feature = "pyo3")]
+    pub fn build_dummy() -> Client {
+        use tensorzero_core::clickhouse::ClickHouseConnectionInfo;
+
+        Client {
+            mode: Arc::new(ClientMode::EmbeddedGateway {
+                gateway: EmbeddedGateway {
+                    handle: GatewayHandle::new_with_clickhouse_and_http_client(
+                        Arc::new(Config::default()),
+                        ClickHouseConnectionInfo::Disabled,
+                        reqwest::Client::new(),
+                    ),
+                },
+                timeout: None,
+            }),
+            verbose_errors: false,
+            #[cfg(feature = "e2e_tests")]
+            last_body: Default::default(),
+        }
+    }
+
     #[cfg(any(test, feature = "e2e_tests"))]
     pub async fn build_from_state(handle: GatewayHandle) -> Result<Client, ClientBuilderError> {
         Ok(Client {

--- a/tensorzero-core/src/gateway_util.rs
+++ b/tensorzero-core/src/gateway_util.rs
@@ -45,7 +45,6 @@ pub struct GatewayHandle {
 
 impl Drop for GatewayHandle {
     fn drop(&mut self) {
-        tracing::info!("Shutting down gateway");
         self.cancel_token.cancel();
         let handle = self
             .app_state


### PR DESCRIPTION
Our 'smart wrapper' stream types (StreamWrapper and AsyncStreamWrapper) now store an explicit `PyObject` reference to the original client object used to create them. This ensures that Python will only be able to garbage-collect the original `AsyncTensorZeroGateway/TensorZeroGateway` after all StreamWrapper/AsyncStreamWrapper objects have already been garbage-collected.

With the above invariant, it's safe for us to block from the `Drop` impl of the Python client. There can no longer be any `ClickhouseConnectionInfo` clones owned by Python code, so we'll only block until the remaining Rust background tasks (e.g. trailing stream writes) finish executing, and the Clickhouse batch writer exits.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
