### PR TITLE
Enable verbose errors in optimization test Tensorzero clients

### DIFF
--- a/tensorzero-core/tests/optimization/common/mod.rs
+++ b/tensorzero-core/tests/optimization/common/mod.rs
@@ -368,6 +368,7 @@ pub async fn make_embedded_gateway() -> Client {
         timeout: None,
         verify_credentials: true,
     })
+    .with_verbose_errors(true)
     .build()
     .await
     .unwrap()
@@ -378,6 +379,7 @@ pub async fn make_http_gateway() -> Client {
     tensorzero::ClientBuilder::new(tensorzero::ClientBuilderMode::HTTPGateway {
         url: "http://localhost:3000".parse().unwrap(),
     })
+    .with_verbose_errors(true)
     .build()
     .await
     .unwrap()


### PR DESCRIPTION
This will make things easier to debug

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
