### PR TITLE
Prevent any tests from running concurrently with a Jaeger test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -58,7 +58,7 @@ e2e_aws_sagemaker_openai = { max-threads = 2 }
 e2e_groq = { max-threads = 1 }
 
 # Require that nothing else runs at the same time as a Jaeger test,
-# so that so we can find our Jaeger traces (without other tests
+# so that we can find our Jaeger traces (without other tests
 # flushing our target spans out of the Jaeger buffer).
 [[profile.default.overrides]]
 filter = 'test(test_jaeger)'


### PR DESCRIPTION
This should fix the flakes we're seeing on CI (where other test runs insert spans into the buffer, causing us to miss the spans inserted by the jaeger tests)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevents concurrent execution of Jaeger tests by requiring all threads, ensuring accurate trace collection and fixing CI flakes.
> 
>   - **Behavior**:
>     - Prevents concurrent execution of Jaeger tests by requiring all threads in `.config/nextest.toml`.
>     - Ensures Jaeger traces are not flushed by other tests, fixing CI flakes.
>   - **Configuration**:
>     - Adds `threads-required = 'num-test-threads'` for `test(test_jaeger)` in `.config/nextest.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for cbff99b9418d2ae06c46b62b11c3b1cd096fe618. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->