### PR TITLE
Allow starting gateway when an empty database exists

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -66,6 +66,12 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      # Keep this in sync with the 'concurrency' section above
+      - name: Print concurrency group
+        run: |
+          echo "Concurrency group: ${{ github.event_name == 'merge_group' && format('{0}-{1}', github.workflow, github.ref) || github.run_id }}"
+
+      
       - name: Warm up modal instances
         run: |
           curl -H "Modal-Key: $MODAL_KEY" -H "Modal-Secret: $MODAL_SECRET" https://tensorzero--vllm-inference-vllm-inference.modal.run/docs > vllm_modal_logs.txt &


### PR DESCRIPTION
This allows us to start (and run migrations) if a user has manually done 'CREATE DATABASE'

Fixes https://github.com/tensorzero/tensorzero/issues/3125

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allows starting the gateway when an empty database exists by ensuring necessary tables are created, with tests added to verify this behavior.
> 
>   - **Behavior**:
>     - Allows starting the gateway when an empty database exists by ensuring the database and `TensorZeroMigration` table are created in `run()` in `mod.rs`.
>     - Handles cases where the database is manually created without the `TensorZeroMigration` table.
>   - **Tests**:
>     - Adds `test_run_migrations_existing_db()` in `clickhouse.rs` to verify migrations run on an existing empty database.
>   - **Misc**:
>     - Adds a step to print concurrency group in `merge-queue.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1b28f3b8bbe691d5174b0c47b6dd4d7cf52f8dc5. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->