### PR TITLE
Disable gpt-oss VLLM tests for now

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -70,7 +70,8 @@ jobs:
         run: |
           curl -H "Modal-Key: $MODAL_KEY" -H "Modal-Secret: $MODAL_SECRET" https://tensorzero--vllm-inference-vllm-inference.modal.run/docs > vllm_modal_logs.txt &
           curl -H "Modal-Key: $MODAL_KEY" -H "Modal-Secret: $MODAL_SECRET" https://tensorzero--sglang-inference-sglang-inference.modal.run/ > sglang_modal_logs.txt &
-          curl -H "Modal-Key: $MODAL_KEY" -H "Modal-Secret: $MODAL_SECRET" https://tensorzero--vllm-gpt-oss-20b-serve.modal.run/ > vllm_gpt_oss_modal_logs.txt &
+          # TODO: Re-enable once we can switch to a T4 GPU
+          # curl -H "Modal-Key: $MODAL_KEY" -H "Modal-Secret: $MODAL_SECRET" https://tensorzero--vllm-gpt-oss-20b-serve.modal.run/ > vllm_gpt_oss_modal_logs.txt &
 
       - name: Install Namespace CLI
         uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -253,6 +253,7 @@ jobs:
 
       - name: Print vLLM GPT-OSS modal logs
         if: always()
+        continue-on-error: true
         run: cat vllm_gpt_oss_modal_logs.txt
 
       - name: Upload provider-proxy cache

--- a/tensorzero-core/tests/e2e/providers/vllm.rs
+++ b/tensorzero-core/tests/e2e/providers/vllm.rs
@@ -68,13 +68,15 @@ async fn get_providers() -> E2ETestProviders {
         credentials: HashMap::new(),
     }];
 
-    let reasoning_providers = vec![E2ETestProvider {
+    // TODO: Re-enable once we can switch to a T4 GPU
+    /*let reasoning_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "vllm-gpt-oss-20b".to_string(),
         model_name: "gpt-oss-20b-vllm".to_string(),
         model_provider_name: "vllm".to_string(),
         credentials: HashMap::new(),
-    }];
+    }];*/
+    let reasoning_providers = vec![];
 
     E2ETestProviders {
         simple_inference: providers.clone(),


### PR DESCRIPTION
The 'transformers' Python library now supports mxfp4 on a T4 GPU, but VLLM hasn't updated yet. For now, let's disable the test to avoid spending lots of money on an H100

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Disable VLLM GPT-OSS tests due to lack of T4 GPU support, with TODOs for future re-enablement.
> 
>   - **Tests**:
>     - Disable VLLM GPT-OSS tests in `.github/workflows/merge-queue.yml` and `vllm.rs` due to lack of T4 GPU support.
>     - Add TODO comments to re-enable tests once T4 GPU is available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ad1dcac60234d5d084c576817c59d3ab6ed82467. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->