### PR TITLE
Print GDB backtrace if Python tests take more than 5 minutes

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -66,6 +66,9 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      - name: Install gdb
+        run: sudo apt-get update && sudo apt-get install -y gdb
+
       - name: Warm up modal instances
         run: |
           curl -H "Modal-Key: $MODAL_KEY" -H "Modal-Secret: $MODAL_SECRET" https://tensorzero--vllm-inference-vllm-inference.modal.run/docs > vllm_modal_logs.txt &
@@ -192,7 +195,45 @@ jobs:
         # the deadlocks.
         if: matrix.batch_writes == false
         run: |
-          bash ./test.sh --verbose
+          # Start the test in background and capture its PID
+          bash ./test.sh --verbose &
+          TEST_PID=$!
+          echo "Started test.sh with PID: $TEST_PID"
+          
+          # Wait for 5 minutes (300 seconds)
+          for i in {1..300}; do
+            if ! kill -0 $TEST_PID 2>/dev/null; then
+              echo "Test completed normally"
+              wait $TEST_PID
+              exit $?
+            fi
+            sleep 1
+          done
+          
+          echo "Test has been running for 5 minutes, capturing backtraces..."
+          
+          # Get all processes related to our test
+          echo "=== Process tree ==="
+          ps -ef | grep -E "(test\.sh|pytest|python)" | grep -v grep || true
+          
+          echo "=== Capturing backtraces with gdb ==="
+          # Find all python processes that might be related to our test
+          PYTHON_PIDS=$(pgrep -f "python.*pytest" || true)
+          if [ -n "$PYTHON_PIDS" ]; then
+            for pid in $PYTHON_PIDS; do
+              echo "--- Backtrace for Python process $pid ---"
+              gdb -p $pid --batch \
+                -ex "set pagination off" \
+                -ex "thread apply all bt" \
+                -ex "info threads" \
+                -ex "detach" \
+                -ex "quit" 2>&1 || true
+              echo ""
+            done
+          else
+            echo "No Python processes found"
+          fi
+          exit 1
 
       - name: "Python: OpenAI Client: Install dependencies"
         working-directory: clients/openai-python


### PR DESCRIPTION
This should help us debug the hangs we're seeing on CI

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Capture GDB backtraces if Python tests in `merge-queue.yml` exceed 5 minutes to aid debugging.
> 
>   - **Behavior**:
>     - Capture GDB backtraces if Python tests exceed 5 minutes in `merge-queue.yml`.
>     - Installs GDB in the workflow to enable backtrace capture.
>   - **Implementation**:
>     - Modifies test execution script to run tests in the background and monitor duration.
>     - If tests exceed 5 minutes, captures backtraces of Python processes using GDB.
>     - Logs process tree and backtraces for debugging purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 669764776b64be814d0b732c31a6ed6188902a72. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->