### PR TITLE
Attach inference tags to otel under 'tags.'

### DIFF
--- a/tensorzero-core/src/endpoints/inference.rs
+++ b/tensorzero-core/src/endpoints/inference.rs
@@ -226,7 +226,7 @@ pub async fn inference<T: Send + 'static>(
         span.record("episode_id", episode_id.to_string());
     }
     for (tag_key, tag_value) in &params.tags {
-        span.set_attribute(format!("tag.{tag_key}"), tag_value.clone());
+        span.set_attribute(format!("tags.{tag_key}"), tag_value.clone());
     }
     // To be used for the Inference table processing_time measurements
     let start_time = Instant::now();

--- a/tensorzero-core/src/endpoints/inference.rs
+++ b/tensorzero-core/src/endpoints/inference.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use tokio::time::Instant;
 use tokio_stream::StreamExt;
 use tracing::instrument;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 use uuid::Uuid;
 
 use crate::cache::{CacheOptions, CacheParamsOptions};
@@ -223,6 +224,9 @@ pub async fn inference<T: Send + 'static>(
     }
     if let Some(episode_id) = &params.episode_id {
         span.record("episode_id", episode_id.to_string());
+    }
+    for (tag_key, tag_value) in &params.tags {
+        span.set_attribute(format!("tag.{tag_key}"), tag_value.clone());
     }
     // To be used for the Inference table processing_time measurements
     let start_time = Instant::now();

--- a/tensorzero-core/tests/e2e/otel.rs
+++ b/tensorzero-core/tests/e2e/otel.rs
@@ -120,6 +120,10 @@ pub async fn test_capture_simple_inference_spans() {
                     })],
                 }],
             },
+            tags: HashMap::from([
+                ("first_tag".to_string(), "first_value".to_string()),
+                ("second_tag".to_string(), "second_value".to_string()),
+            ]),
             ..Default::default()
         })
         .await
@@ -150,6 +154,14 @@ pub async fn test_capture_simple_inference_spans() {
     );
     assert_eq!(root_attr_map.get("function_name"), None);
     assert_eq!(root_attr_map.get("variant_name"), None);
+    assert_eq!(
+        root_attr_map.get("tag.first_tag").cloned(),
+        Some("first_value".to_string().into())
+    );
+    assert_eq!(
+        root_attr_map.get("tag.second_tag").cloned(),
+        Some("second_value".to_string().into())
+    );
 
     let root_children = &spans.span_children[&root_span.span_context.span_id()];
     let [variant_span] = root_children.as_slice() else {

--- a/tensorzero-core/tests/e2e/otel.rs
+++ b/tensorzero-core/tests/e2e/otel.rs
@@ -155,13 +155,19 @@ pub async fn test_capture_simple_inference_spans() {
     assert_eq!(root_attr_map.get("function_name"), None);
     assert_eq!(root_attr_map.get("variant_name"), None);
     assert_eq!(
-        root_attr_map.get("tag.first_tag").cloned(),
+        root_attr_map.get("tags.first_tag").cloned(),
         Some("first_value".to_string().into())
     );
     assert_eq!(
-        root_attr_map.get("tag.second_tag").cloned(),
+        root_attr_map.get("tags.second_tag").cloned(),
         Some("second_value".to_string().into())
     );
+    // Check that there are no other takes
+    let tag_count = root_attr_map
+        .iter()
+        .filter(|(k, _)| k.starts_with("tags."))
+        .count();
+    assert_eq!(tag_count, 2);
 
     let root_children = &spans.span_children[&root_span.span_context.span_id()];
     let [variant_span] = root_children.as_slice() else {


### PR DESCRIPTION
Providing a tag 'foo': 'bar' will result in an OTEL attribute 'tags.foo' = 'bar' on the `function_inference` span

Fixes https://github.com/tensorzero/tensorzero/issues/3165

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Attach inference tags to OpenTelemetry spans in `inference.rs` and verify with tests in `otel.rs`.
> 
>   - **Behavior**:
>     - Attach inference tags to OpenTelemetry spans in `inference()` in `inference.rs`.
>     - Tags are added as `tags.<key>` attributes on the `function_inference` span.
>   - **Tests**:
>     - Add test `test_capture_simple_inference_spans()` in `otel.rs` to verify tags are attached to spans.
>     - Ensure tags `first_tag` and `second_tag` are correctly set in the span attributes.
>     - Verify no additional tags are present beyond those specified.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 638065c9c93edfccd6e92b83abf4dc4438917b39. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->