### PR TITLE
Lower together SFT batch size to 8

### DIFF
--- a/tensorzero-core/src/optimization/together_sft/mod.rs
+++ b/tensorzero-core/src/optimization/together_sft/mod.rs
@@ -333,7 +333,7 @@ impl Optimizer for TogetherSFTConfig {
                 n_checkpoints: Some(1),
                 n_evals: Some(n_evals),
                 learning_rate: 0.00001,
-                batch_size: 32,
+                batch_size: 8,
                 lr_scheduler: TogetherLRScheduler {
                     lr_scheduler_type: TogetherLRSchedulerType::Linear,
                     lr_scheduler_args: TogetherLRSchedulerArgs { min_lr_ratio: 0.0 },


### PR DESCRIPTION
Their API started rejecting 32 with
"Invalid param in Model request: batch size is higher than 8": https://github.com/tensorzero/tensorzero/actions/runs/17057954076/job/48359010125

We should make this parameter configurable at some point

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
