### PR TITLE
Pin rust:1.88.0 in our Dockerfiles

### DIFF
--- a/evaluations/Dockerfile
+++ b/evaluations/Dockerfile
@@ -1,6 +1,6 @@
 # ========== builder ==========
 
-FROM rust:latest AS builder
+FROM rust:1.88.0 AS builder
 
 WORKDIR /src
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,6 +1,6 @@
 # ========== builder ==========
 
-FROM rust:latest AS builder
+FROM rust:1.88.0 AS builder
 
 WORKDIR /src
 

--- a/tensorzero-core/tests/mock-inference-provider/Dockerfile
+++ b/tensorzero-core/tests/mock-inference-provider/Dockerfile
@@ -1,6 +1,6 @@
 # ========== builder ==========
 
-FROM rust:latest AS builder
+FROM rust:1.88.0 AS builder
 
 WORKDIR /src
 COPY . .

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -51,7 +51,7 @@ RUN pnpm install --frozen-lockfile --prod
 
 # ========== tensorzero-node-build-env ==========
 
-FROM rust:latest AS tensorzero-node-build-env
+FROM rust:1.88.0 AS tensorzero-node-build-env
 
 RUN apt-get update && apt-get install -y nodejs npm && rm -rf /var/lib/apt/lists/*
 RUN npm install -g pnpm


### PR DESCRIPTION
The newest 'rust:latest' image is causing our builds to fail with strange glibc errors:
"/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by gateway)" https://github.com/tensorzero/tensorzero/actions/runs/17078362823/job/48425591669

Let's pin the previous version for now

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Pin Rust version to 1.88.0 in Dockerfiles to fix build failures due to glibc errors.
> 
>   - **Dockerfiles**:
>     - Pin Rust version to `1.88.0` in `evaluations/Dockerfile`, `gateway/Dockerfile`, and `tensorzero-core/tests/mock-inference-provider/Dockerfile` to avoid glibc errors.
>     - Update `ui/Dockerfile` to use `rust:1.88.0` for `tensorzero-node-build-env` stage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d820d0744598f4e94cf8a7dbaf70d0fcdeee6751. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->