### PR TITLE
Use 'sharing=locked' for gateway Dockerfile cache mount

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -11,8 +11,8 @@ RUN git rev-parse HEAD
 
 ARG CARGO_BUILD_FLAGS=""
 
-RUN --mount=type=cache,id=tensorzero-gateway-release,sharing=shared,target=/usr/local/cargo/registry \
-    --mount=type=cache,id=tensorzero-gateway-release,sharing=shared,target=/usr/local/cargo/git \
+RUN --mount=type=cache,id=tensorzero-gateway-release,sharing=locked,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=tensorzero-gateway-release,sharing=locked,target=/usr/local/cargo/git \
     cargo build --profile performance -p gateway $CARGO_BUILD_FLAGS && \
     cp -r /src/target/performance /release
 


### PR DESCRIPTION
Using a shared cache volume is causing issues on Namespace with parallel builds:

```
3.749   failed to open `/usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/minimal-lexical-0.2.1/.cargo-ok`
 3.749 Caused by:
3.749   File exists (os error 17)
```

Let's only allow one Docker builder to have access to the registry cache mount

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change cache mount sharing to 'locked' in `gateway/Dockerfile` to prevent parallel build issues.
> 
>   - **Dockerfile Changes**:
>     - Change `sharing=shared` to `sharing=locked` for cache mounts in `gateway/Dockerfile` to prevent parallel build issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for dc48de8c4ae84ad2c358caa7d78570a0d2f18dc4. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->