### PR TITLE
Remove '|| true' from 'docker compose up' in ci

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -156,8 +156,7 @@ jobs:
 
       - name: Launch ClickHouse container for E2E tests
         run: |
-          # 'docker compose' will exit with status code 1 if any container exits, even if the container exits with status code 0
-          docker compose -f tensorzero-core/tests/e2e/docker-compose.yml up --build -d --wait || true
+          docker compose -f tensorzero-core/tests/e2e/docker-compose.yml up --build -d --wait
 
       - name: Print ClickHouse container logs
         if: always()


### PR DESCRIPTION
The 'fixtures' service no longer exits, so we don't have to ignore an unsuccessful exit code

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove '|| true' from 'docker compose' in `.github/workflows/merge-queue.yml` as 'fixtures' service no longer exits.
> 
>   - **CI Workflow**:
>     - Remove '|| true' from 'docker compose' command in `.github/workflows/merge-queue.yml`.
>     - The 'fixtures' service no longer exits, making the ignore of unsuccessful exit codes unnecessary.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ebc1d04a21483ae732697be1ae49b08e5e8b94cb. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->