### PR TITLE
added sleeps to evals tests

### DIFF
--- a/evaluations/tests/tests.rs
+++ b/evaluations/tests/tests.rs
@@ -80,7 +80,7 @@ async fn run_evaluations_json() {
         .await
         .unwrap();
     clickhouse_flush_async_insert(&clickhouse).await;
-    sleep(Duration::from_millis(200)).await;
+    sleep(Duration::from_secs(2)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
     let mut parsed_output = Vec::new();
@@ -277,7 +277,7 @@ async fn run_evaluations_json() {
         .await
         .unwrap();
     clickhouse_flush_async_insert(&clickhouse).await;
-    sleep(Duration::from_millis(200)).await;
+    sleep(Duration::from_secs(2)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
     let mut total_sports = 0;
@@ -351,7 +351,7 @@ async fn run_exact_match_evaluation_chat() {
         .await
         .unwrap();
     clickhouse_flush_async_insert(&clickhouse).await;
-    sleep(Duration::from_millis(1000)).await;
+    sleep(Duration::from_secs(2)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
     let mut parsed_output = Vec::new();
@@ -473,7 +473,7 @@ async fn run_llm_judge_evaluation_chat() {
         .await
         .unwrap();
     clickhouse_flush_async_insert(&clickhouse).await;
-    sleep(Duration::from_millis(200)).await;
+    sleep(Duration::from_secs(2)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
     let mut parsed_output = Vec::new();
@@ -618,7 +618,7 @@ async fn run_llm_judge_evaluation_chat() {
         .await
         .unwrap();
     clickhouse_flush_async_insert(&clickhouse).await;
-    sleep(Duration::from_millis(200)).await;
+    sleep(Duration::from_secs(2)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
     let mut total_topic_fs = 0;
@@ -691,7 +691,7 @@ async fn run_image_evaluation() {
         .await
         .unwrap();
     clickhouse_flush_async_insert(&clickhouse).await;
-    sleep(Duration::from_secs(1)).await;
+    sleep(Duration::from_secs(2)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
     let mut parsed_output = Vec::new();
@@ -904,7 +904,7 @@ async fn check_invalid_image_evaluation() {
         .await
         .unwrap();
     clickhouse_flush_async_insert(&clickhouse).await;
-    sleep(Duration::from_secs(1)).await;
+    sleep(Duration::from_secs(2)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
     for line in output_lines {
@@ -1003,6 +1003,7 @@ async fn run_llm_judge_evaluation_chat_pretty() {
     run_evaluation(args, evaluation_run_id, &mut output)
         .await
         .unwrap();
+    sleep(Duration::from_secs(2)).await;
     let output_str = String::from_utf8(output).unwrap();
     // Check for run info at the beginning
     assert!(output_str.contains("Run ID:"));
@@ -1044,6 +1045,7 @@ async fn run_llm_judge_evaluation_json_pretty() {
     let err = run_evaluation(args, evaluation_run_id, &mut output)
         .await
         .unwrap_err();
+    sleep(Duration::from_secs(2)).await;
     let output_str = String::from_utf8(output).unwrap();
     // Check for run info at the beginning
     assert!(output_str.contains("Run ID:"));
@@ -1198,7 +1200,7 @@ async fn run_evaluations_errors() {
         .await
         .unwrap();
     clickhouse_flush_async_insert(&clickhouse).await;
-    sleep(Duration::from_millis(200)).await;
+    sleep(Duration::from_secs(2)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
     for line in output_lines {
@@ -1598,7 +1600,7 @@ async fn run_evaluations_best_of_3() {
         .await
         .unwrap();
     clickhouse_flush_async_insert(&clickhouse).await;
-    sleep(Duration::from_millis(200)).await;
+    sleep(Duration::from_secs(2)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
     let mut parsed_output = Vec::new();
@@ -1784,7 +1786,7 @@ async fn run_evaluations_mixture_of_3() {
         .await
         .unwrap();
     clickhouse_flush_async_insert(&clickhouse).await;
-    sleep(Duration::from_millis(200)).await;
+    sleep(Duration::from_secs(2)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
     let mut parsed_output = Vec::new();
@@ -1973,7 +1975,7 @@ async fn run_evaluations_dicl() {
         .await
         .unwrap();
     clickhouse_flush_async_insert(&clickhouse).await;
-    sleep(Duration::from_millis(200)).await;
+    sleep(Duration::from_secs(2)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
     let mut parsed_output = Vec::new();


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase sleep durations in evaluation tests for better synchronization with ClickHouse.
> 
>   - **Tests**:
>     - Increase sleep duration from `200ms` to `2s` in `run_evaluations_json`, `run_evaluations_errors`, `run_evaluations_best_of_3`, `run_evaluations_mixture_of_3`, and `run_evaluations_dicl`.
>     - Increase sleep duration from `1s` to `2s` in `run_exact_match_evaluation_chat` and `run_image_evaluation`.
>     - Add `2s` sleep in `run_llm_judge_evaluation_chat_pretty` and `run_llm_judge_evaluation_json_pretty`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for cb0a87361690a03a58348868244736f4fc24102f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->