### PR TITLE
loosened flaky test assertion in playgorund w tools

### DIFF
--- a/ui/e2e_tests/playground.spec.ts
+++ b/ui/e2e_tests/playground.spec.ts
@@ -166,11 +166,13 @@ test("playground should work for data with tools", async ({ page }) => {
   ).toHaveCount(1);
 
   // Verify that tool calls are displayed correctly
+  // Give the inference lots of time to run - assert at least one tool call since apparently sometimes the model outputs 2
   await expect(
-    page.getByTestId("datapoint-playground-output").getByText("Tool Call"),
-  )
-    // Give the inference lots of time to run
-    .toHaveCount(1, { timeout: 15_000 });
+    page
+      .getByTestId("datapoint-playground-output")
+      .getByText("Tool Call")
+      .first(),
+  ).toBeVisible({ timeout: 15_000 });
 
   // Verify that at least one tool call has the expected fields
   await expect(page.getByText("Name").first()).toBeVisible();


### PR DESCRIPTION
I saw a run with 2 output tool calls so we should not depend on exactly 1 here
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adjusted test assertion in `playground.spec.ts` to check for at least one tool call due to output variability.
> 
>   - **Test Adjustment**:
>     - In `playground.spec.ts`, modified the assertion for tool call visibility to check for at least one occurrence instead of exactly one.
>     - This change addresses variability where sometimes two tool calls are output instead of one.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1263626cdf349f177791f7ad06dcd08dc7830e95. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->