### PR TITLE
added sleeps so openai node cache tests will not be flaky

### DIFF
--- a/clients/openai-node/tests/openai-compatibility.test.ts
+++ b/clients/openai-node/tests/openai-compatibility.test.ts
@@ -860,6 +860,8 @@ describe("OpenAI Compatibility", () => {
     expect(usage?.prompt_tokens).toBe(10);
     expect(usage?.completion_tokens).toBe(1);
     expect(usage?.total_tokens).toBe(11);
+    // Sleep so we're sure the cache is updated
+    await new Promise((resolve) => setTimeout(resolve, 2000));
 
     // Test caching
     const cachedResult = await client.chat.completions.create({
@@ -952,6 +954,9 @@ describe("OpenAI Compatibility", () => {
     expect(finalChunk.usage?.prompt_tokens).toBe(10);
     expect(finalChunk.usage?.completion_tokens).toBe(16);
     expect(finalChunk.choices).toStrictEqual([]);
+
+    // Sleep so we're sure the cache is warmed up
+    await new Promise((resolve) => setTimeout(resolve, 2000));
 
     // Second streaming request with cache
     // @ts-expect-error - custom TensorZero property


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added sleeps in `openai-compatibility.test.ts` to ensure cache updates, preventing test flakiness.
> 
>   - **Tests**:
>     - Added `setTimeout` sleeps in `openai-compatibility.test.ts` to ensure cache updates before testing cached results.
>     - Specifically added sleeps before testing cache in `should handle caching` and `should handle streaming caching` tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 51da273a734034a298107f501db84badc4e47bd4. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->