### PR TITLE
feat(helm): optionally enable config map and use all values

### DIFF
--- a/examples/production-deployment-k8s-helm/templates/configmap.yaml
+++ b/examples/production-deployment-k8s-helm/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.configMap.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,4 +8,5 @@ metadata:
 data:
   {{- range $key, $value := .Values.configMap.data }}
   {{ $key }}: {{ $value | quote }}
-  {{- end }} 
+  {{- end }}
+{{- end }}

--- a/examples/production-deployment-k8s-helm/templates/gateway.yaml
+++ b/examples/production-deployment-k8s-helm/templates/gateway.yaml
@@ -13,8 +13,10 @@ spec:
       app.kubernetes.io/component: gateway
   template:
     metadata:
+      {{- if .Values.configMap.enabled }}
       annotations:
-        checksum/config: {{ toYaml .Values.configMap | sha256sum }}
+        checksum/config: {{ toYaml .Values.configMap.data | sha256sum }}
+      {{- end }}
       labels:
         {{- include "tensorzero.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: gateway
@@ -45,24 +47,35 @@ spec:
                   key: {{ .key }}
             {{- end }}
             {{- end }}
+          envFrom:
+            {{- if and .Values.gateway.additionalEnv.secretName (not .Values.gateway.additionalEnv.keys) }}
+            - secretRef:
+                name: {{ .Values.gateway.additionalEnv.secretName }}
+            {{- end }}
           volumeMounts:
+            {{- if .Values.configMap.enabled }}
             - name: config-volume
               mountPath: /app/config
+            {{- end }}
             {{- if .Values.persistence.enabled }}
             - name: storage-volume
               mountPath: {{ .Values.persistence.mountPath }}
             {{- end }}
           resources:
             {{- toYaml .Values.gateway.resources | nindent 12 }}
+      {{- if or .Values.configMap.enabled .Values.persistence.enabled }}
       volumes:
+        {{- if .Values.configMap.enabled }}
         - name: config-volume
           configMap:
             name: {{ include "tensorzero.fullname" . }}
+        {{- end }}
         {{- if .Values.persistence.enabled }}
         - name: storage-volume
           persistentVolumeClaim:
             claimName: {{ include "tensorzero.fullname" . }}-storage
         {{- end }}
+      {{- end }}
       {{- with .Values.gateway.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/examples/production-deployment-k8s-helm/templates/ui.yaml
+++ b/examples/production-deployment-k8s-helm/templates/ui.yaml
@@ -14,8 +14,10 @@ spec:
       app.kubernetes.io/component: ui
   template:
     metadata:
+      {{- if .Values.configMap.enabled }}
       annotations:
-        checksum/config: {{ toYaml .Values.configMap | sha256sum }}
+        checksum/config: {{ toYaml .Values.configMap.data | sha256sum }}
+      {{- end }}
       labels:
         {{- include "tensorzero.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: ui
@@ -40,15 +42,24 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
+          envFrom:
+            {{- if and .Values.ui.additionalEnv.secretName (not .Values.ui.additionalEnv.keys) }}
+            - secretRef:
+                name: {{ .Values.ui.additionalEnv.secretName }}
+            {{- end }}
           volumeMounts:
+            {{- if .Values.configMap.enabled }}
             - name: config-volume
               mountPath: /app/config
+            {{- end }}
           resources:
             {{- toYaml .Values.ui.resources | nindent 12 }}
+      {{- if .Values.configMap.enabled }}
       volumes:
         - name: config-volume
           configMap:
             name: {{ include "tensorzero.fullname" . }}
+      {{- end }}
       {{- with .Values.ui.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -61,4 +72,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- end }} 
+{{- end }}

--- a/examples/production-deployment-k8s-helm/values.yaml
+++ b/examples/production-deployment-k8s-helm/values.yaml
@@ -19,7 +19,9 @@ gateway:
     port: 3000
 
   additionalEnv:
+    # Set secretName to "" to disable using additional environment variables
     secretName: "tensorzero-secret"
+    # Set keys to an empty list to use all environment variables from the secret
     keys:
       - name: TENSORZERO_CLICKHOUSE_URL
         key: TENSORZERO_CLICKHOUSE_URL
@@ -27,7 +29,6 @@ gateway:
         key: TENSORZERO_GATEWAY_URL
       - name: OPENAI_API_KEY
         key: OPENAI_API_KEY
-      # TODO: include other model provider credentials as needed
 
   resources:
     limits:
@@ -73,7 +74,9 @@ ui:
     port: 4000
 
   additionalEnv:
+    # Set secretName to "" to disable using additional environment variables
     secretName: "tensorzero-secret"
+    # Set keys to an empty list to use all environment variables from the secret
     keys:
       - name: TENSORZERO_CLICKHOUSE_URL
         key: TENSORZERO_CLICKHOUSE_URL
@@ -122,6 +125,7 @@ persistence:
 
 # TensorZero Configuration
 configMap:
+  enabled: true
   data:
     tensorzero.toml: |
       [functions.my_function_name]


### PR DESCRIPTION
- Make mounting the configmap optionally. Since our tensorzero image has already contained the tensorzero.toml etc, we don't need to mount configmap any more. I made the mounting optional.
- I prefer to set all the tensorzero runtime environment from a single secret as I don't need to update both the secret itself and the helm values options. So I added an option to export all the variables in a secret.

Originally part of https://github.com/tensorzero/tensorzero/pull/3042 . I think it is sensible to make config map improvements in a single PR.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Makes config map mounting optional and allows using all environment variables from a secret in Helm charts.
> 
>   - **ConfigMap**:
>     - Makes mounting the `configMap` optional in `configmap.yaml`, `gateway.yaml`, and `ui.yaml`.
>     - Controlled by `configMap.enabled` in `values.yaml`.
>   - **Environment Variables**:
>     - Adds option to use all environment variables from a secret in `gateway.yaml` and `ui.yaml`.
>     - Controlled by `additionalEnv.secretName` and `additionalEnv.keys` in `values.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for edc28e10ed59ad6c5fe5e06de5fa7ee870783403. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->