### PR TITLE
Automatically fix clippy::single_match_else

### DIFF
--- a/clients/rust/src/input_handling.rs
+++ b/clients/rust/src/input_handling.rs
@@ -79,12 +79,11 @@ async fn resolved_input_message_content_to_client_input_message_content(
         }
         ResolvedInputMessageContent::File(file) => {
             let mime_type = file.file.mime_type;
-            let data = match file.file.data {
-                Some(data) => data,
-                None => {
-                    let storage_path = file.storage_path;
-                    fetch_file_data(storage_path, client).await?
-                }
+            let data = if let Some(data) = file.file.data {
+                data
+            } else {
+                let storage_path = file.storage_path;
+                fetch_file_data(storage_path, client).await?
             };
 
             Ok(ClientInputMessageContent::File(File::Base64 {

--- a/evaluations/src/evaluators/exact_match.rs
+++ b/evaluations/src/evaluators/exact_match.rs
@@ -27,21 +27,18 @@ pub(super) fn run_exact_match_evaluator(
         }
         (InferenceResponse::Json(json_completion), Datapoint::Json(json_inference)) => {
             debug!("Running exact match evaluation for JSON response");
-            match &json_inference.output {
-                Some(output) => {
-                    // `output.parsed` is an Option<Value> but it should always be Some here
-                    if output.parsed.is_none() {
-                        warn!("Datapoint {} has no parsed output", json_inference.id);
-                        return Ok(None);
-                    }
-                    let matches = output.parsed == json_completion.output.parsed;
-                    debug!(matches = %matches, "JSON exact match comparison completed");
-                    Ok(Some(Value::Bool(matches)))
+            if let Some(output) = &json_inference.output {
+                // `output.parsed` is an Option<Value> but it should always be Some here
+                if output.parsed.is_none() {
+                    warn!("Datapoint {} has no parsed output", json_inference.id);
+                    return Ok(None);
                 }
-                None => {
-                    debug!("No reference output available for JSON comparison");
-                    Ok(None)
-                }
+                let matches = output.parsed == json_completion.output.parsed;
+                debug!(matches = %matches, "JSON exact match comparison completed");
+                Ok(Some(Value::Bool(matches)))
+            } else {
+                debug!("No reference output available for JSON comparison");
+                Ok(None)
             }
         }
         _ => {

--- a/evaluations/src/evaluators/llm_judge/mod.rs
+++ b/evaluations/src/evaluators/llm_judge/mod.rs
@@ -83,17 +83,15 @@ pub async fn run_llm_judge_evaluator(
         }));
     }
     debug!("Preparing LLM judge input");
-    let judge_input =
-        match prepare_llm_judge_input(llm_judge_config, input, inference_response, datapoint)? {
-            Some(input) => {
-                debug!("LLM judge input prepared successfully");
-                input
-            }
-            None => {
-                debug!("Cannot prepare LLM judge input, returning None");
-                return Ok(None);
-            }
-        };
+    let judge_input = if let Some(input) =
+        prepare_llm_judge_input(llm_judge_config, input, inference_response, datapoint)?
+    {
+        debug!("LLM judge input prepared successfully");
+        input
+    } else {
+        debug!("Cannot prepare LLM judge input, returning None");
+        return Ok(None);
+    };
 
     debug!("Making LLM judge inference request");
     let params = ClientInferenceParams {

--- a/evaluations/src/evaluators/mod.rs
+++ b/evaluations/src/evaluators/mod.rs
@@ -198,15 +198,14 @@ async fn run_evaluator(params: RunEvaluatorParams<'_>) -> Result<EvaluatorResult
         inference_cache,
     } = params;
     let EvaluationConfig::Static(static_evaluation_config) = evaluation_config;
-    let evaluator_config = match static_evaluation_config.evaluators.get(&evaluator_name) {
-        Some(evaluator_config) => {
-            debug!("Evaluator config found");
-            evaluator_config
-        }
-        None => {
-            error!("Evaluator config not found");
-            return Err(anyhow::anyhow!("Evaluator config not found for {}. This should never happen. Please file a bug report at https://github.com/tensorzero/tensorzero/discussions/categories/bug-reports.", evaluator_name));
-        }
+    let evaluator_config = if let Some(evaluator_config) =
+        static_evaluation_config.evaluators.get(&evaluator_name)
+    {
+        debug!("Evaluator config found");
+        evaluator_config
+    } else {
+        error!("Evaluator config not found");
+        return Err(anyhow::anyhow!("Evaluator config not found for {}. This should never happen. Please file a bug report at https://github.com/tensorzero/tensorzero/discussions/categories/bug-reports.", evaluator_name));
     };
     Ok(match evaluator_config {
         EvaluatorConfig::ExactMatch(_exact_match_config) => {

--- a/evaluations/src/lib.rs
+++ b/evaluations/src/lib.rs
@@ -359,15 +359,12 @@ async fn infer_datapoint(params: InferDatapointParams<'_>) -> Result<InferenceRe
     } = params;
 
     debug!("Processing tool parameters");
-    let dynamic_tool_params = match datapoint.tool_call_config() {
-        Some(tool_params) => {
-            debug!("Tool parameters found, processing");
-            get_tool_params_args(tool_params, function_config).await
-        }
-        None => {
-            debug!("No tool parameters found");
-            DynamicToolParams::default()
-        }
+    let dynamic_tool_params = if let Some(tool_params) = datapoint.tool_call_config() {
+        debug!("Tool parameters found, processing");
+        get_tool_params_args(tool_params, function_config).await
+    } else {
+        debug!("No tool parameters found");
+        DynamicToolParams::default()
     };
     debug!("Processing output schema");
     let output_schema = match (datapoint.output_schema(), function_config) {

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -472,12 +472,11 @@ impl<T, E: Display> ExpectPretty<T> for Result<T, E> {
 
 impl<T> ExpectPretty<T> for Option<T> {
     fn expect_pretty(self, msg: &str) -> T {
-        match self {
-            Some(value) => value,
-            None => {
-                tracing::error!("{msg}");
-                std::process::exit(1);
-            }
+        if let Some(value) = self {
+            value
+        } else {
+            tracing::error!("{msg}");
+            std::process::exit(1);
         }
     }
 }

--- a/tensorzero-core/src/endpoints/batch_inference.rs
+++ b/tensorzero-core/src/endpoints/batch_inference.rs
@@ -822,14 +822,13 @@ pub async fn write_completed_batch_inference<'a>(
             raw_response,
             usage,
             finish_reason,
-        } = match response.elements.remove(&inference_id) {
-            Some(inference_response) => inference_response,
-            None => {
-                Error::new(ErrorDetails::MissingBatchInferenceResponse {
-                    inference_id: Some(inference_id),
-                });
-                continue;
-            }
+        } = if let Some(inference_response) = response.elements.remove(&inference_id) {
+            inference_response
+        } else {
+            Error::new(ErrorDetails::MissingBatchInferenceResponse {
+                inference_id: Some(inference_id),
+            });
+            continue;
         };
         let model_inference_response = ModelInferenceResponseWithMetadata {
             id: Uuid::now_v7(),

--- a/tensorzero-core/src/endpoints/openai_compatible.rs
+++ b/tensorzero-core/src/endpoints/openai_compatible.rs
@@ -142,15 +142,14 @@ pub struct OpenAICompatibleEmbeddingParams {
 impl TryFrom<OpenAICompatibleEmbeddingParams> for EmbeddingParams {
     type Error = Error;
     fn try_from(params: OpenAICompatibleEmbeddingParams) -> Result<Self, Self::Error> {
-        let model_name = match params
+        let model_name = if let Some(model_name) = params
             .model
             .strip_prefix(TENSORZERO_EMBEDDING_MODEL_NAME_PREFIX)
         {
-            Some(model_name) => model_name.to_string(),
-            None => {
-                tracing::warn!("Deprecation Warning: Model names in the OpenAI-compatible embeddings endpoint should be prefixed with 'tensorzero::embedding_model_name::'");
-                params.model
-            }
+            model_name.to_string()
+        } else {
+            tracing::warn!("Deprecation Warning: Model names in the OpenAI-compatible embeddings endpoint should be prefixed with 'tensorzero::embedding_model_name::'");
+            params.model
         };
         Ok(EmbeddingParams {
             input: params.input,

--- a/tensorzero-core/src/inference/types/pyo3_helpers.rs
+++ b/tensorzero-core/src/inference/types/pyo3_helpers.rs
@@ -198,16 +198,13 @@ pub fn resolved_input_message_content_to_python(
     match content {
         ResolvedInputMessageContent::Text { value } => {
             let text_content_block = import_text_content_block(py)?;
-            match value {
-                Value::String(s) => {
-                    let kwargs = [(intern!(py, "text"), s)].into_py_dict(py)?;
-                    text_content_block.call(py, (), Some(&kwargs))
-                }
-                _ => {
-                    let value = serialize_to_dict(py, value)?;
-                    let kwargs = [(intern!(py, "arguments"), value)].into_py_dict(py)?;
-                    text_content_block.call(py, (), Some(&kwargs))
-                }
+            if let Value::String(s) = value {
+                let kwargs = [(intern!(py, "text"), s)].into_py_dict(py)?;
+                text_content_block.call(py, (), Some(&kwargs))
+            } else {
+                let value = serialize_to_dict(py, value)?;
+                let kwargs = [(intern!(py, "arguments"), value)].into_py_dict(py)?;
+                text_content_block.call(py, (), Some(&kwargs))
             }
         }
         ResolvedInputMessageContent::ToolCall(tool_call) => {

--- a/tensorzero-core/src/providers/helpers.rs
+++ b/tensorzero-core/src/providers/helpers.rs
@@ -430,23 +430,20 @@ fn delete_json_pointer(mut value: &mut serde_json::Value, pointer: &str) -> Resu
                     }
                 },
                 Value::Array(list) => {
-                    match parse_index(&token) {
-                        Some(index) => {
-                            if let Some(target) = list.get_mut(index) {
-                                value = target;
-                            } else {
-                                tracing::warn!("Skipping deletion of extra_body pointer `{pointer}` - index `{token}` out of bounds");
-                                // If a parent of our target pointer doesn't exist, then do nothing,
-                                // since `value`` is already an object where the target pointer doesn't exist
-                                return Ok(());
-                            }
-                        }
-                        None => {
-                            tracing::warn!("Skipping deletion of extra_body pointer `{pointer}` - non-numeric array index `{token}`");
+                    if let Some(index) = parse_index(&token) {
+                        if let Some(target) = list.get_mut(index) {
+                            value = target;
+                        } else {
+                            tracing::warn!("Skipping deletion of extra_body pointer `{pointer}` - index `{token}` out of bounds");
                             // If a parent of our target pointer doesn't exist, then do nothing,
                             // since `value`` is already an object where the target pointer doesn't exist
                             return Ok(());
                         }
+                    } else {
+                        tracing::warn!("Skipping deletion of extra_body pointer `{pointer}` - non-numeric array index `{token}`");
+                        // If a parent of our target pointer doesn't exist, then do nothing,
+                        // since `value`` is already an object where the target pointer doesn't exist
+                        return Ok(());
                     }
                 }
                 other => {

--- a/tensorzero-core/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-core/src/variant/best_of_n_sampling.rs
@@ -469,7 +469,7 @@ async fn inner_select_best_candidate<'a, 'request>(
         model_inference_response,
         evaluator.inner.model.clone(),
     );
-    let raw = match model_inference_result
+    let raw = if let Some(text) = model_inference_result
         .output
         .iter()
         .find_map(|block| match block {
@@ -477,13 +477,12 @@ async fn inner_select_best_candidate<'a, 'request>(
             ContentBlockOutput::ToolCall(tool_call) => Some(&tool_call.arguments),
             _ => None,
         }) {
-        Some(text) => text,
-        None => {
-            Error::new(ErrorDetails::Inference {
-                message: "The evaluator did not return a text response".to_string(),
-            });
-            return Ok((None, Some(model_inference_result)));
-        }
+        text
+    } else {
+        Error::new(ErrorDetails::Inference {
+            message: "The evaluator did not return a text response".to_string(),
+        });
+        return Ok((None, Some(model_inference_result)));
     };
     let parsed_output = match serde_json::from_str::<Value>(raw) {
         Ok(value) => value,
@@ -494,26 +493,24 @@ async fn inner_select_best_candidate<'a, 'request>(
             return Ok((None, Some(model_inference_result)));
         }
     };
-    let answer_choice = match parsed_output.get("answer_choice") {
-        Some(val) => match val.as_u64() {
-            Some(num) => num as usize,
-            None => {
-                Error::new(ErrorDetails::Inference {
-                    message: format!(
-                        "The evaluator did not return a valid integer answer choice: {val}"
-                    ),
-                });
-                return Ok((None, Some(model_inference_result)));
-            }
-        },
-        None => {
+    let answer_choice = if let Some(val) = parsed_output.get("answer_choice") {
+        if let Some(num) = val.as_u64() {
+            num as usize
+        } else {
             Error::new(ErrorDetails::Inference {
                 message: format!(
-                    "The evaluator returned a JSON response without an answer_choice field: {parsed_output}"
+                    "The evaluator did not return a valid integer answer choice: {val}"
                 ),
             });
             return Ok((None, Some(model_inference_result)));
         }
+    } else {
+        Error::new(ErrorDetails::Inference {
+            message: format!(
+                "The evaluator returned a JSON response without an answer_choice field: {parsed_output}"
+            ),
+        });
+        return Ok((None, Some(model_inference_result)));
     };
     // Map the evaluator's index to the actual index
     let answer_choice = map_evaluator_to_actual_index(answer_choice, &skipped_indices);

--- a/tensorzero-core/src/variant/mixture_of_n.rs
+++ b/tensorzero-core/src/variant/mixture_of_n.rs
@@ -521,20 +521,19 @@ impl MixtureOfNConfig {
             .map(InferenceOrStreamResult::NonStream)
         };
         // As long as the fuser returns an inference result, we want to include it in the observability
-        let mut inference_result = match inference_result {
-            Ok(inf_result) => inf_result,
-            Err(_) => {
-                let random_index = rand::rng().random_range(0..candidates.len());
-                if random_index >= candidates.len() {
-                    return Err(Error::new(ErrorDetails::Inference {
-                        message: "Failed to get random candidate (should never happen). Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new".to_string(),
-                    }));
-                }
-                // If the fuser fails, don't provide any 'original_response' to the user
-                let mut candidate = candidates.swap_remove(random_index);
-                candidate.set_original_response(None);
-                InferenceOrStreamResult::NonStream(candidate)
+        let mut inference_result = if let Ok(inf_result) = inference_result {
+            inf_result
+        } else {
+            let random_index = rand::rng().random_range(0..candidates.len());
+            if random_index >= candidates.len() {
+                return Err(Error::new(ErrorDetails::Inference {
+                    message: "Failed to get random candidate (should never happen). Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new".to_string(),
+                }));
             }
+            // If the fuser fails, don't provide any 'original_response' to the user
+            let mut candidate = candidates.swap_remove(random_index);
+            candidate.set_original_response(None);
+            InferenceOrStreamResult::NonStream(candidate)
         };
 
         match &mut inference_result {


### PR DESCRIPTION
This PR is the result of:

```
cargo clippy --fix -- -W clippy::single_match_else
cargo fmt
```

and adding `deny` for this lint in the future.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor code to replace `match` with `if let` for `clippy::single_match_else` lint across multiple files, improving code clarity.
> 
>   - **Refactor**:
>     - Replace `match` with `if let` for `clippy::single_match_else` lint in `input_handling.rs`, `exact_match.rs`, and `llm_judge/mod.rs`.
>     - Applied similar changes in `mod.rs`, `lib.rs`, `main.rs`, `clickhouse/mod.rs`, `batch_inference.rs`, `openai_compatible.rs`, `pyo3_helpers.rs`, `google_ai_studio_gemini.rs`, `helpers.rs`, `best_of_n_sampling.rs`, and `mixture_of_n.rs`.
>   - **Behavior**:
>     - No functional changes; purely refactoring for code clarity and adherence to linting standards.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f67d200f9bbe684901c164cf04fea0310ffdad4a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->