### PR TITLE
allow dummy jobs to run for docs PRs

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -3,8 +3,6 @@ name: Dummy
 on:
   pull_request:
     branches: ["main"]
-    paths-ignore:
-      - "docs/**"
 
 jobs:
   # See 'ci/README.md' at the repository root for more details.


### PR DESCRIPTION
This was (incorrectly) excluded from the merge queue checks for PRs with all files in docs/*. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allows dummy jobs to run for documentation-only PRs by removing path exclusion in `.github/workflows/dummy.yml`.
> 
>   - **Behavior**:
>     - Removes `paths-ignore: - "docs/**"` from `.github/workflows/dummy.yml` to allow dummy jobs to run for PRs modifying only `docs/*` files.
>   - **Misc**:
>     - Ensures branch protection checks are satisfied for documentation-only PRs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 93aec408965e6ac6515c00d500b8b22051c46112. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->