### PR TITLE
Make uv more reliable in CI

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -185,7 +185,7 @@ jobs:
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
 
       - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh
+        run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
 
       - name: Configure Namespace cache for Rust, Python (pip), and pnpm
         uses: namespacelabs/nscloud-cache-action@2f50e7d0f70475e6f59a55ba0f05eec9108e77cc
@@ -399,7 +399,7 @@ jobs:
         run: echo "TENSORZERO_CLICKHOUSE_CLUSTER_NAME=tensorzero_e2e_tests_cluster" >> $GITHUB_ENV
 
       - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh
+        run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
 
       - name: Download ClickHouse fixtures
         run: uv run ./ui/fixtures/download-fixtures.py
@@ -537,7 +537,7 @@ jobs:
           tool: cargo-nextest
 
       - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh
+        run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
 
       - name: Download ClickHouse fixtures
         run: uv run ./ui/fixtures/download-fixtures.py

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -102,7 +102,7 @@ jobs:
         run: rustc --version
 
       - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
+        run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
 
       - name: Download ClickHouse fixtures
         run: uv run ./ui/fixtures/download-fixtures.py

--- a/.github/workflows/python-client-build.yml
+++ b/.github/workflows/python-client-build.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
+        run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
       - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
         with:
@@ -64,7 +64,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
+        run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
       - name: Build wheels
         uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
         with:
@@ -100,7 +100,7 @@ jobs:
           python-version: 3.9
           architecture: ${{ matrix.platform.target }}
       - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
+        run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
         shell: bash
       - name: Build wheels
         uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
@@ -139,7 +139,7 @@ jobs:
           python-version: 3.9
 
       - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
+        run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
 
       - name: Build wheels
         uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
@@ -174,7 +174,7 @@ jobs:
           name: wheels-sdist
           path: ./clients/python/dist
       - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.6.4/install.sh | sh
+        run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
       - name: Check local sdist
         run: |
           ./ci/check-local-wheel.sh ./clients/python/dist/tensorzero-*.tar.gz

--- a/.github/workflows/upgrade-tensorzero-deps.yml
+++ b/.github/workflows/upgrade-tensorzero-deps.yml
@@ -27,10 +27,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install uv and jq
-        run: |
-          curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh
-          sudo apt-get update && sudo apt-get install -y jq
+      - name: Install uv
+        run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Wait for PyPI availability (auto-trigger only)
         if: github.event_name == 'workflow_run'


### PR DESCRIPTION
To mitigate: https://github.com/tensorzero/tensorzero/actions/runs/17208245457/job/48813543533

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance CI reliability by adding retry logic to `uv` installation and updating its version across multiple workflows.
> 
>   - **CI Reliability**:
>     - Add retry logic to `uv` installation command in `.github/workflows/general.yml`, `.github/workflows/merge-queue.yml`, and `.github/workflows/python-client-build.yml`.
>     - Update `uv` version to `0.6.17` in `.github/workflows/merge-queue.yml` and `.github/workflows/python-client-build.yml`.
>   - **Misc**:
>     - Split `uv` and `jq` installation into separate steps in `.github/workflows/upgrade-tensorzero-deps.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d2cdd79ff683b489ed5ba638977ca60676887100. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->