### PR TITLE
Add extension trait for registering OpenAI-compatible routes

### DIFF
--- a/tensorzero-core/src/endpoints/openai_compatible.rs
+++ b/tensorzero-core/src/endpoints/openai_compatible.rs
@@ -51,6 +51,22 @@ use super::inference::{
     InferenceStream,
 };
 use crate::embeddings::EmbeddingEncodingFormat;
+use axum::routing::post;
+use axum::Router;
+
+pub trait RouterExt {
+    /// Applies our OpenAI-compatible endpoints to the router.
+    /// This is used by the the gateway for the patched OpenAI python client (`start_openai_compatible_gateway`),
+    /// as well as the normal standalone TensorZero gateway.
+    fn register_openai_compatible_routes(self) -> Self;
+}
+
+impl RouterExt for Router<AppStateData> {
+    fn register_openai_compatible_routes(self) -> Self {
+        self.route("/openai/v1/chat/completions", post(inference_handler))
+            .route("/openai/v1/embeddings", post(embeddings_handler))
+    }
+}
 
 /// A handler for the OpenAI-compatible inference endpoint
 #[debug_handler(state = AppStateData)]

--- a/tensorzero-core/src/gateway_util.rs
+++ b/tensorzero-core/src/gateway_util.rs
@@ -2,8 +2,8 @@ use std::future::IntoFuture;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use crate::endpoints::openai_compatible::RouterExt;
 use axum::extract::{rejection::JsonRejection, FromRequest, Json, Request};
-use axum::routing::post;
 use axum::Router;
 use reqwest::{Client, Proxy};
 use serde::de::DeserializeOwned;
@@ -316,18 +316,8 @@ pub async fn start_openai_compatible_gateway(
     };
     let gateway_handle = GatewayHandle::new_with_clickhouse(config, clickhouse_url).await?;
 
-    // TODO(# 3191): Implement a trait for openai compatible endpoints
-    // so this logic can be centralized to one place and not reimplemented in
-    // our gateway main.
     let router = Router::new()
-        .route(
-            "/openai/v1/chat/completions",
-            post(endpoints::openai_compatible::inference_handler),
-        )
-        .route(
-            "/openai/v1/embeddings",
-            post(endpoints::openai_compatible::embeddings_handler),
-        )
+        .register_openai_compatible_routes()
         .fallback(endpoints::fallback::handle_404)
         .with_state(gateway_handle.app_state.clone());
 


### PR DESCRIPTION
This deduplicates code between the patch OpenAI client and the normal TensorZero gateway

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces `RouterExt` trait to centralize OpenAI-compatible route registration, reducing code duplication in gateway setup.
> 
>   - **Behavior**:
>     - Introduces `RouterExt` trait in `openai_compatible.rs` to register OpenAI-compatible routes.
>     - Replaces explicit route definitions with `register_openai_compatible_routes()` in `main.rs` and `gateway_util.rs`.
>   - **Functions**:
>     - Adds `register_openai_compatible_routes()` to `RouterExt` trait for route registration.
>   - **Misc**:
>     - Removes redundant route definitions in `main.rs` and `gateway_util.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for cdb3fe45a611169fdcef39f5c25cb4abae51d5f2. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->