### PR TITLE
Force 'gateway.observability.skip_completed_migrations` on

### DIFF
--- a/tensorzero-core/src/config/gateway.rs
+++ b/tensorzero-core/src/config/gateway.rs
@@ -1,7 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    config::{ExportConfig, ObservabilityConfig, TemplateFilesystemAccess},
+    config::{
+        ExportConfig, ObservabilityConfig, TemplateFilesystemAccess,
+        UninitializedObservabilityConfig,
+    },
     error::{Error, ErrorDetails},
 };
 
@@ -11,7 +14,7 @@ pub struct UninitializedGatewayConfig {
     #[serde(serialize_with = "serialize_optional_socket_addr")]
     pub bind_address: Option<std::net::SocketAddr>,
     #[serde(default)]
-    pub observability: ObservabilityConfig,
+    pub observability: UninitializedObservabilityConfig,
     #[serde(default)]
     pub debug: bool,
     /// If `true`, allow minijinja to read from the filesystem (within the tree of the config file) for '{% include %}'
@@ -62,7 +65,7 @@ impl UninitializedGatewayConfig {
         };
         Ok(GatewayConfig {
             bind_address: self.bind_address,
-            observability: self.observability,
+            observability: self.observability.load(),
             debug: self.debug,
             template_filesystem_access,
             export: self.export,

--- a/tensorzero-core/src/config/mod.rs
+++ b/tensorzero-core/src/config/mod.rs
@@ -311,10 +311,47 @@ pub struct ObservabilityConfig {
     pub async_writes: bool,
     #[serde(default)]
     pub batch_writes: BatchWritesConfig,
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(ts_rs::TS))]
+#[cfg_attr(test, ts(export))]
+pub struct UninitializedObservabilityConfig {
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub async_writes: bool,
+    #[serde(default)]
+    pub batch_writes: BatchWritesConfig,
     /// If `true`, then we skip checking/applying migrations if the `TensorZeroMigration` table
     /// contains exactly the migrations that we expect to have run.
     #[serde(default)]
-    pub skip_completed_migrations: bool,
+    pub skip_completed_migrations: Option<bool>,
+}
+
+impl UninitializedObservabilityConfig {
+    pub fn load(self) -> ObservabilityConfig {
+        let UninitializedObservabilityConfig {
+            enabled,
+            async_writes,
+            batch_writes,
+            skip_completed_migrations,
+        } = self;
+        match skip_completed_migrations {
+            None => {}
+            Some(true) => {
+                tracing::warn!("Deprecation Warning: `gateway.observability.skip_completed_migrations` is now always enabled, and does not need to be manually enabled");
+            }
+            Some(false) => {
+                tracing::warn!("Deprecation Warning: `gateway.observability.skip_completed_migrations` is now always enabled, and cannot be manually disabled");
+            }
+        }
+        ObservabilityConfig {
+            enabled,
+            async_writes,
+            batch_writes,
+        }
+    }
 }
 
 fn default_flush_interval_ms() -> u64 {

--- a/tensorzero-core/src/gateway_util.rs
+++ b/tensorzero-core/src/gateway_util.rs
@@ -198,7 +198,7 @@ pub async fn setup_clickhouse(
     if let ClickHouseConnectionInfo::Production { .. } = &clickhouse_connection_info {
         migration_manager::run(RunMigrationManagerArgs {
             clickhouse: &clickhouse_connection_info,
-            skip_completed_migrations: config.gateway.observability.skip_completed_migrations,
+            skip_completed_migrations: true,
             manual_run: false,
         })
         .await?;
@@ -366,7 +366,6 @@ mod tests {
                 enabled: Some(false),
                 async_writes: false,
                 batch_writes: Default::default(),
-                skip_completed_migrations: false,
             },
             bind_address: None,
             debug: false,
@@ -398,7 +397,6 @@ mod tests {
                 enabled: None,
                 async_writes: false,
                 batch_writes: Default::default(),
-                skip_completed_migrations: false,
             },
             unstable_error_json: false,
             ..Default::default()
@@ -426,7 +424,6 @@ mod tests {
                 enabled: Some(true),
                 async_writes: false,
                 batch_writes: Default::default(),
-                skip_completed_migrations: false,
             },
             bind_address: None,
             debug: false,
@@ -454,7 +451,6 @@ mod tests {
                 enabled: Some(true),
                 async_writes: false,
                 batch_writes: Default::default(),
-                skip_completed_migrations: false,
             },
             bind_address: None,
             debug: false,
@@ -484,7 +480,6 @@ mod tests {
                 enabled: Some(true),
                 async_writes: false,
                 batch_writes: Default::default(),
-                skip_completed_migrations: false,
             },
             bind_address: None,
             debug: false,

--- a/tensorzero-core/tests/e2e/tensorzero.toml
+++ b/tensorzero-core/tests/e2e/tensorzero.toml
@@ -13,7 +13,6 @@ template_filesystem_access.enabled = true
 template_filesystem_access.base_path = "."
 export.otlp.traces.enabled = true
 unstable_error_json = true
-observability.skip_completed_migrations = true
 
 [object_storage]
 type = "disabled"


### PR DESCRIPTION
We still allow it to be set in the config file for now, but it always produces a deprecation warning when set.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
