### PR TITLE
Fix flaky check in playground tool call test

### DIFF
--- a/ui/app/routes/playground/DatapointPlaygroundOutput.tsx
+++ b/ui/app/routes/playground/DatapointPlaygroundOutput.tsx
@@ -24,7 +24,10 @@ const DatapointPlaygroundOutput = memo<ClientInferenceInputArgs>(
     });
 
     const loadingIndicator = (
-      <div className="flex min-h-[8rem] items-center justify-center">
+      <div
+        className="flex min-h-[8rem] items-center justify-center"
+        data-testid="datapoint-playground-output-loading"
+      >
         <Loader2 className="h-8 w-8 animate-spin" aria-hidden />
       </div>
     );

--- a/ui/app/routes/playground/DatapointPlaygroundOutput.tsx
+++ b/ui/app/routes/playground/DatapointPlaygroundOutput.tsx
@@ -38,6 +38,7 @@ const DatapointPlaygroundOutput = memo<ClientInferenceInputArgs>(
         variant="ghost"
         size="icon"
         className="absolute top-1 right-1 z-5 cursor-pointer opacity-25 transition-opacity hover:opacity-100"
+        data-testid="datapoint-playground-output-refresh-button"
         onClick={() => query.refetch()}
       >
         <Refresh />

--- a/ui/e2e_tests/playground.spec.ts
+++ b/ui/e2e_tests/playground.spec.ts
@@ -184,6 +184,8 @@ test("playground should work for data with tools", async ({ page }) => {
     page.getByRole("heading", { name: "Inference Error" }),
   ).toHaveCount(0);
 
+  await page.waitForTimeout(1000);
+
   // Click the refresh button to reload inference
   // Find the refresh button in the output area
   const refreshButton = page.getByTestId(

--- a/ui/e2e_tests/playground.spec.ts
+++ b/ui/e2e_tests/playground.spec.ts
@@ -184,6 +184,8 @@ test("playground should work for data with tools", async ({ page }) => {
     page.getByRole("heading", { name: "Inference Error" }),
   ).toHaveCount(0);
 
+  // TODO - clicking the refresh button immediately after the inference loads doesn't seem to work
+  // We should figure out what event to wait for, and remove this sleep
   await page.waitForTimeout(1000);
 
   // Click the refresh button to reload inference

--- a/ui/e2e_tests/playground.spec.ts
+++ b/ui/e2e_tests/playground.spec.ts
@@ -191,12 +191,24 @@ test("playground should work for data with tools", async ({ page }) => {
     .filter({ has: page.locator("svg") });
   await refreshButton.first().click();
 
-  // Verify tool calls are still displayed after refresh
+  // Wait for the refresh to start
   await expect(
-    page.getByTestId("datapoint-playground-output").getByText("Tool Call"),
-  )
-    // Give the inference lots of time to run
-    .toHaveCount(1, { timeout: 15_000 });
+    page.getByTestId("datapoint-playground-output-loading"),
+  ).toBeVisible();
+
+  // Verify tool calls are still displayed after refresh
+  // 'datapoint-playground-output' will show up after the refresh completes
+  await expect(
+    page
+      .getByTestId("datapoint-playground-output")
+      .getByText("Tool Call")
+      .first(),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // Verify that at least one tool call has the expected fields
+  await expect(page.getByText("Name").first()).toBeVisible();
+  await expect(page.getByText("ID").first()).toBeVisible();
+  await expect(page.getByText("Arguments").first()).toBeVisible();
 
   // Verify that there are no errors after refresh
   await expect(

--- a/ui/e2e_tests/playground.spec.ts
+++ b/ui/e2e_tests/playground.spec.ts
@@ -186,9 +186,9 @@ test("playground should work for data with tools", async ({ page }) => {
 
   // Click the refresh button to reload inference
   // Find the refresh button in the output area
-  const refreshButton = page
-    .getByRole("button")
-    .filter({ has: page.locator("svg") });
+  const refreshButton = page.getByTestId(
+    "datapoint-playground-output-refresh-button",
+  );
   await refreshButton.first().click();
 
   // Wait for the refresh to start


### PR DESCRIPTION
The post-refresh check was expecting exactly one tool call, rather than at least one. I've also adjusted the test to wait for the refresh to actually start, to ensure that we don't match on the tool calls from the initial request.

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix flaky test in `playground.spec.ts` by expecting at least one tool call and adding waits for refresh start.
> 
>   - **Tests**:
>     - Modify `playground.spec.ts` to expect at least one tool call instead of exactly one after refresh.
>     - Add wait for refresh to start by checking visibility of `datapoint-playground-output-loading` in `playground.spec.ts`.
>   - **UI**:
>     - Add `data-testid` attributes to `DatapointPlaygroundOutput.tsx` for refresh button and loading indicator.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5d718753ce02b1b09d2c85f0effd3a83ec70dd87. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->