### PR TITLE
Remove Cargo registry cache mounts in gateway Dockerfile build

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -11,9 +11,7 @@ RUN git rev-parse HEAD
 
 ARG CARGO_BUILD_FLAGS=""
 
-RUN --mount=type=cache,id=tensorzero-gateway-release,sharing=locked,target=/usr/local/cargo/registry \
-    --mount=type=cache,id=tensorzero-gateway-release,sharing=locked,target=/usr/local/cargo/git \
-    cargo build --profile performance -p gateway $CARGO_BUILD_FLAGS && \
+RUN cargo build --profile performance -p gateway $CARGO_BUILD_FLAGS && \
     cp -r /src/target/performance /release
 
 # ========== base ==========


### PR DESCRIPTION
These might be responsible for the hangs we're seeing on CI

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove Cargo registry and git cache mounts in `gateway/Dockerfile` to potentially fix CI hangs.
> 
>   - **Dockerfile Changes**:
>     - Remove Cargo registry and git cache mounts in `gateway/Dockerfile`.
>     - Simplify `RUN` command for building the cargo project by removing cache mounts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3503d04f803c559a119f464d12e633ca350f335c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->