### PR TITLE
improve robustness of loading state check in tool playground test

### DIFF
--- a/ui/e2e_tests/playground.spec.ts
+++ b/ui/e2e_tests/playground.spec.ts
@@ -195,13 +195,19 @@ test("playground should work for data with tools", async ({ page }) => {
   );
   await refreshButton.first().click();
 
-  // Wait for the refresh to start
-  await expect(
-    page.getByTestId("datapoint-playground-output-loading"),
-  ).toBeVisible();
+  // Instead of waiting for loading indicator, wait for the output to be refreshed
+  // by waiting for the output container to be detached and reattached
+  await page.getByTestId("datapoint-playground-output").waitFor({
+    state: "detached",
+    timeout: 5000,
+  });
+
+  await page.getByTestId("datapoint-playground-output").waitFor({
+    state: "attached",
+    timeout: 15000,
+  });
 
   // Verify tool calls are still displayed after refresh
-  // 'datapoint-playground-output' will show up after the refresh completes
   await expect(
     page
       .getByTestId("datapoint-playground-output")


### PR DESCRIPTION
<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve loading state check in `playground.spec.ts` by waiting for output container detachment and reattachment.
> 
>   - **Behavior**:
>     - In `playground.spec.ts`, change loading state check by waiting for `datapoint-playground-output` to detach and reattach instead of checking visibility of `datapoint-playground-output-loading`.
>   - **Misc**:
>     - Remove outdated comment about waiting for loading indicator in `playground.spec.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 02ce981ee84f176540ce878c43d36778630d657b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->