### PR TITLE
Fail workflow on container build failure

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -664,6 +664,8 @@ jobs:
         check-python-client-build,
         check-node-bindings,
         build-windows,
+        build-ui-container,
+        build-gateway-container,
         validate,
         clickhouse-tests,
         ui-tests,
@@ -672,5 +674,7 @@ jobs:
       ]
     runs-on: ubuntu-latest
     steps:
-      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      # When running in the merge queue, jobs should never be skipped.
+      # In PR CI, some jobs may be intentionally skipped (e.g. due to running from a fork, or to save money)
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled' || (github.event_name == 'merge_group' && contains(needs.*.result, 'skipped'))) }}
         run: exit 1

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -391,5 +391,5 @@ jobs:
       ]
     runs-on: ubuntu-latest
     steps:
-      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
         run: exit 1


### PR DESCRIPTION
To help prevent this kind of issue in the future, I've also adjusted the checks to treat a skip as a failure when running in the merge queue (since we never expect jobs to be skipped there)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
