### PR TITLE
Remove 'RUN --mount=type=cache' from all Dockerfiles

### DIFF
--- a/evaluations/Dockerfile
+++ b/evaluations/Dockerfile
@@ -10,9 +10,7 @@ COPY . .
 
 ARG CARGO_BUILD_FLAGS=""
 
-RUN --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/registry \
-    --mount=type=cache,id=tensorzero-evaluations-release,sharing=shared,target=/usr/local/cargo/git \
-    cargo build --release -p evaluations $CARGO_BUILD_FLAGS && \
+RUN cargo build --release -p evaluations $CARGO_BUILD_FLAGS && \
     cp -r /src/target/release /release
 
 # ========== base ==========

--- a/tensorzero-core/tests/mock-inference-provider/Dockerfile
+++ b/tensorzero-core/tests/mock-inference-provider/Dockerfile
@@ -7,9 +7,7 @@ COPY . .
 
 ARG CARGO_BUILD_FLAGS=""
 
-RUN --mount=type=cache,id=tensorzero-mock-inference-provider-release,sharing=shared,target=/usr/local/cargo/registry \
-    --mount=type=cache,id=tensorzero-mock-inference-provider-release,sharing=shared,target=/usr/local/cargo/git \
-    cargo build --release -p mock-inference-provider $CARGO_BUILD_FLAGS && \
+RUN cargo build --release -p mock-inference-provider $CARGO_BUILD_FLAGS && \
     cp -r /src/target/release /release
 
 # ========== mock-inference-provider ==========


### PR DESCRIPTION
This has been repeatedly causing issues on Namespaces runners, (.cargo-ok "File exists" errors), so let's get rid of it

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `RUN --mount=type=cache` from Dockerfiles to fix `.cargo-ok "File exists"` errors on Namespaces runners.
> 
>   - **Dockerfiles**:
>     - Remove `RUN --mount=type=cache` from `evaluations/Dockerfile` and `mock-inference-provider/Dockerfile`.
>     - Affects `cargo build` commands, removing cache mounts for `/usr/local/cargo/registry` and `/usr/local/cargo/git`.
>   - **Reason**:
>     - Fixes `.cargo-ok "File exists"` errors on Namespaces runners.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 05c02acf017a2e7c7a493b76239e2e4cff36d4ff. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->