### PR TITLE
Use 'actions/setup-node' pnpm cache on Github runners

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -108,9 +108,8 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: latest
           run_install: false
-          
+
       - name: Setup Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -105,25 +105,17 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: latest
+          run_install: false
+          
       - name: Setup Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: "22.9.0"
           cache: "pnpm"
-
-      - name: Install pnpm
-        run: |
-          for attempt in 1 2 3; do
-            if npm install -g pnpm@latest; then
-              break
-            fi
-            if [ $attempt -eq 3 ]; then
-              echo "Failed to install pnpm after 3 attempts"
-              exit 1
-            fi
-            sleep $((10 * attempt))
-          done
-        shell: bash
 
       - name: Install dependencies
         working-directory: internal/tensorzero-node

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -109,6 +109,7 @@ jobs:
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: "22.9.0"
+          cache: "pnpm"
 
       - name: Install pnpm
         run: |

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -81,7 +81,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: latest
           run_install: false
 
       - name: Setup Node

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -81,6 +81,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "22.9.0"
+          cache: "pnpm"
 
       - name: Setup `pnpm`
         run: |

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -77,25 +77,18 @@ jobs:
       - name: Set DNS
         run: echo "127.0.0.1 howdy.tensorzero.com" | sudo tee -a /etc/hosts
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: latest
+          run_install: false
+
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "22.9.0"
           cache: "pnpm"
-
-      - name: Setup `pnpm`
-        run: |
-          for attempt in 1 2 3; do
-            if npm install -g pnpm@latest; then
-              break
-            fi
-            if [ $attempt -eq 3 ]; then
-              echo "Failed to install pnpm after 3 attempts"
-              exit 1
-            fi
-            sleep $((10 * attempt))
-          done
-        shell: bash
 
       - name: Install `pnpm` dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
This should help with the CI flakes we're seeing. I've left this off in places where we use actions/setup-node on Namespace runners, since we already have Namespace-level caching enabled there

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Use `actions/setup-node` with pnpm caching in GitHub Actions workflows to improve CI reliability on GitHub runners.
> 
>   - **CI Improvements**:
>     - Use `actions/setup-node` with `cache: "pnpm"` in `general.yml` and `ui-tests-e2e.yml` for GitHub runners.
>     - Replace manual `pnpm` installation with `pnpm/action-setup@v4` in `general.yml` and `ui-tests-e2e.yml`.
>   - **Namespace Runners**:
>     - No changes to workflows using Namespace runners due to existing caching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 27846eda9e821c45802f76ca92336f258d4816c7. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->