### PR TITLE
Make collect_chunks unit test deterministic

### DIFF
--- a/tensorzero-core/src/inference/types/mod.rs
+++ b/tensorzero-core/src/inference/types/mod.rs
@@ -2663,7 +2663,14 @@ mod tests {
             _ => panic!("Expected Chat inference response"),
         };
         assert_eq!(chat_result.inference_id, inference_id);
-        assert_eq!(chat_result.created, created);
+        // We make a new timestamp for `chat_result.created`, so just check that it's at least
+        // the timestamp of the first chunk.
+        assert!(
+            chat_result.created >= created,
+            "Chat result was created at {:?}, before the first chunk was created at {:?}",
+            chat_result.created,
+            created
+        );
         assert_eq!(chat_result.finish_reason, Some(FinishReason::Stop));
         assert_eq!(
             chat_result.content,
@@ -2830,7 +2837,14 @@ mod tests {
         match result {
             InferenceResult::Json(json_result) => {
                 assert_eq!(json_result.inference_id, inference_id);
-                assert_eq!(json_result.created, created);
+                // We make a new timestamp for `json_result.created`, so just check that it's at least
+                // the timestamp of the first chunk.
+                assert!(
+                    json_result.created >= created,
+                    "Json result was created at {:?}, before the first chunk was created at {:?}",
+                    json_result.created,
+                    created
+                );
                 assert_eq!(json_result.output.parsed, None);
                 assert_eq!(
                     json_result.output.raw,
@@ -2911,7 +2925,14 @@ mod tests {
         match result {
             InferenceResult::Chat(chat_response) => {
                 assert_eq!(chat_response.inference_id, inference_id);
-                assert_eq!(chat_response.created, created);
+                // We make a new timestamp for `chat_response.created`, so just check that it's at least
+                // the timestamp of the first chunk.
+                assert!(
+                    chat_response.created >= created,
+                    "Chat result was created at {:?}, before the first chunk was created at {:?}",
+                    chat_response.created,
+                    created
+                );
                 assert_eq!(
                     chat_response.content,
                     vec![
@@ -3267,7 +3288,14 @@ mod tests {
             _ => panic!("Expected Chat inference response"),
         };
         assert_eq!(chat_result.inference_id, inference_id);
-        assert_eq!(chat_result.created, created);
+        // We make a new timestamp for `chat_result.created`, so just check that it's at least
+        // the timestamp of the first chunk.
+        assert!(
+            chat_result.created >= created,
+            "Chat result was created at {:?}, before the first chunk was created at {:?}",
+            chat_result.created,
+            created
+        );
         assert_eq!(chat_result.finish_reason, Some(FinishReason::Stop));
 
         let expected_content = vec![


### PR DESCRIPTION
We no longer assert the exact value of the 'created' timestamp

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify unit tests in `mod.rs` to assert 'created' timestamp is at least the first chunk's timestamp, ensuring determinism.
> 
>   - **Tests**:
>     - Modify `test_collect_chunks` in `mod.rs` to assert `created` timestamp is at least the timestamp of the first chunk, instead of exact match.
>     - Similar changes in `test_collect_interleaved_chunks` and `test_collect_chunks_tool_name_accumulation` in `mod.rs`.
>   - **Misc**:
>     - Add comments explaining the new timestamp assertion logic in `mod.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8159cadfbbed39b5ef2211f417eb3f514a9ea6dc. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->