### PR TITLE
Reduce CI load for UI tests

### DIFF
--- a/.github/workflows/ui-tests-e2e-model-inference-cache.yml
+++ b/.github/workflows/ui-tests-e2e-model-inference-cache.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   ui-tests-e2e:
-    runs-on: ${{ inputs.regen_cache && 'namespace-profile-tensorzero-32x64' || 'namespace-profile-tensorzero-32x64' }}
+    runs-on: ${{ inputs.regen_cache && 'namespace-profile-tensorzero-32x64' || 'namespace-profile-tensorzero-16x32' }}
     # We currently only run this job when we have secrets available, since we need to use an S3 object_store
     # In the future, we might want to fix this so that it can run in PR CI for external (forked) PRs
     # For now, it just runs in the merge queue and on prs from the main repo

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   ui-tests-no-network:
-    runs-on: namespace-profile-tensorzero-32x64
+    runs-on: namespace-profile-tensorzero-16x32
     steps:
       - name: Set DNS
         run: echo "127.0.0.1 howdy.tensorzero.com" | sudo tee -a /etc/hosts
@@ -177,7 +177,7 @@ jobs:
           retention-days: 7
 
   ui-tests-e2e-credentials:
-    runs-on: namespace-profile-tensorzero-32x64
+    runs-on: namespace-profile-tensorzero-16x32
     # We currently only run this job when we have secrets available, since we need to use an S3 object_store
     # In the future, we might want to fix this so that it can run in PR CI for external (forked) PRs
     # For now, it just runs in the merge queue and on prs from the main repo

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   ui-tests:
-    runs-on: namespace-profile-tensorzero-32x64
+    runs-on: namespace-profile-tensorzero-16x32
 
     strategy:
       matrix:


### PR DESCRIPTION
Reduce instance size for the lighter tests.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reduce instance size for UI tests in GitHub workflows to decrease CI load.
> 
>   - **CI Load Reduction**:
>     - Change instance size from `namespace-profile-tensorzero-32x64` to `namespace-profile-tensorzero-16x32` in `ui-tests-e2e-model-inference-cache.yml`, `ui-tests-e2e.yml`, and `ui-tests.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d47a0d55cbe879cf31864c529975b95f2d36c95a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->