### PR TITLE
removed flaky check in playground test

### DIFF
--- a/ui/e2e_tests/playground.spec.ts
+++ b/ui/e2e_tests/playground.spec.ts
@@ -203,17 +203,26 @@ test("playground should work for data with tools", async ({ page }) => {
   );
   await refreshButton.first().click();
 
-  // Instead of waiting for loading indicator, wait for the output to be refreshed
-  // by waiting for the output container to be detached and reattached
-  await page.getByTestId("datapoint-playground-output").waitFor({
-    state: "detached",
-    timeout: 5000,
-  });
+  // NOTE (bad tests coverage):
+  // we can't assert well that the refresh state was displayed since all the inferences are cached
+  // so the response could come super fast
+  // We would have to build in some delay in test mode to ensure the refresh state is displayed
+  // await page.waitForTimeout(1000);
+  // Since this test is flaky and blocking merges we'll remove the check for now
 
-  await page.getByTestId("datapoint-playground-output").waitFor({
-    state: "attached",
-    timeout: 15000,
-  });
+  // Wait for loading indicator to appear (indicates refresh started)
+  // await expect(
+  //   page.getByTestId("datapoint-playground-output-loading"),
+  // ).toBeVisible({
+  //   timeout: 5000,
+  // });
+
+  // Wait for loading indicator to disappear (indicates refresh completed)
+  // await expect(
+  //   page.getByTestId("datapoint-playground-output-loading"),
+  // ).not.toBeVisible({
+  //   timeout: 15000,
+  // });
 
   // Verify tool calls are still displayed after refresh
   await expect(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removed a flaky test check in `playground.spec.ts` related to waiting for a loading indicator during refresh, due to caching issues causing test flakiness.
> 
>   - **Tests**:
>     - Removed flaky check in `playground.spec.ts` for waiting on loading indicator during refresh.
>     - The check was unreliable due to caching, causing test flakiness and blocking merges.
>     - Commented out code suggests a need for delay in test mode to ensure refresh state visibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e96d9367b9c80771510eb6cf36ca54f357383e6a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->