### PR TITLE
Attempt to cancel stale merge queue runs

### DIFF
--- a/.github/workflows/cancel-stale-merge-queue.yml
+++ b/.github/workflows/cancel-stale-merge-queue.yml
@@ -22,14 +22,14 @@ jobs:
       - name: Cancel Workflow Runs by SHA
         run: |
           # Get all workflow runs for the specific SHA
-          workflow_runs=$(curl -s -H "Authorization: token ${{ github.token }}" \
+          workflow_runs=$(curl -s -H "Authorization: Bearer ${{ github.token }}" \
             "https://api.github.com/repos/${{ github.repository }}/actions/runs?head_sha=${{ github.sha }}")
           
           # Extract run IDs and cancel them
           echo "$workflow_runs" | jq -r '.workflow_runs[] | select(.status != "completed") | .id' | while read -r run_id; do
             if [ -n "$run_id" ]; then
               echo "Cancelling workflow run $run_id"
-              curl -X POST -H "Authorization: token ${{ github.token }}" \
+              curl -X POST -H "Authorization: Bearer ${{ github.token }}" \
                 "https://api.github.com/repos/${{ github.repository }}/actions/runs/$run_id/cancel"
             fi
           done


### PR DESCRIPTION
This listens for the 'merge_group.destroyed' event, and cancels all workflows with a matching head SHA
All running workflows for a merge queue commit should now be cancelled as soon as the PR is removed from the merge queue

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a GitHub Actions workflow to cancel stale workflows when a merge group is destroyed.
> 
>   - **Behavior**:
>     - New workflow `cancel-stale-merge-queue.yml` listens for `merge_group.destroyed` event.
>     - Cancels all running workflows with matching head SHA using GitHub API.
>   - **Implementation**:
>     - Uses `curl` and `jq` to fetch and process workflow runs.
>     - Cancels workflows by posting to GitHub API endpoint for each run ID.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2463306cd0abc5fece343669ccbfb80364e9de71. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->