### PR TITLE
Only fail the build on skipped jobs for merge_group event

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -392,5 +392,7 @@ jobs:
       ]
     runs-on: ubuntu-latest
     steps:
-      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+      # When running in the merge queue, jobs should never be skipped.
+      # In a scheduled run, some jobs may be intentionally skipped, as we only care about regenerating the model inference cache.
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') || (github.event_name == 'merge_group' && contains(needs.*.result, 'skipped')) }}
         run: exit 1


### PR DESCRIPTION
We skip some jobs in the cron run of merge-queue.yml, which is now failing due to the unconditional check for skipped jobs

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `merge-queue.yml` to only fail build on skipped jobs for `merge_group` event, allowing skips in scheduled runs.
> 
>   - **Behavior**:
>     - Modify condition in `merge-queue.yml` to only fail build on skipped jobs for `merge_group` event.
>     - Allows skipped jobs in scheduled runs to regenerate model inference cache without failing the build.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7b0fa76a6d4117eec293a3db3fc0ce046b6b486d. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->