### PR TITLE
Don't cancel workflows on successful merge

### DIFF
--- a/.github/workflows/cancel-stale-merge-queue.yml
+++ b/.github/workflows/cancel-stale-merge-queue.yml
@@ -12,12 +12,14 @@ jobs:
   cancel-workflows:
     name: Cancel Workflow Runs
     runs-on: ubuntu-latest
+    if: github.merge_group.reason != 'merged'
     steps:
       - name: Get Merge Queue Commit SHA
         id: get-sha
         run: |
           echo "Repository: ${{ github.repository }}"
           echo "Head SHA: ${{ github.sha }}"
+          echo "Merge Group Reason: ${{ github.merge_group.reason }}"
 
       - name: Cancel Workflow Runs by SHA
         run: |


### PR DESCRIPTION
The 'destroyed' event fires on a successful merge, so we were cancelling the post-merge workflows that we run on push to 'main'

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
