### PR TITLE
Check for merge group event reason in 'github.event'

### DIFF
--- a/.github/workflows/cancel-stale-merge-queue.yml
+++ b/.github/workflows/cancel-stale-merge-queue.yml
@@ -12,14 +12,14 @@ jobs:
   cancel-workflows:
     name: Cancel Workflow Runs
     runs-on: ubuntu-latest
-    if: github.merge_group.reason != 'merged'
+    if: github.event.reason != 'merged'
     steps:
       - name: Get Merge Queue Commit SHA
         id: get-sha
         run: |
           echo "Repository: ${{ github.repository }}"
           echo "Head SHA: ${{ github.sha }}"
-          echo "Merge Group Reason: ${{ github.merge_group.reason }}"
+          echo "Merge Group Reason: ${{ github.event.reason }}"
 
       - name: Cancel Workflow Runs by SHA
         run: |


### PR DESCRIPTION
'github.event' gives us the webhook payload, which is documented as containing the 'reason' field for the 'merge_group' event

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change condition in GitHub Actions workflow to use `github.event.reason` instead of `github.merge_group.reason`.
> 
>   - **Behavior**:
>     - Change condition in `.github/workflows/cancel-stale-merge-queue.yml` from `github.merge_group.reason` to `github.event.reason` for canceling workflows.
>     - Specifically affects the condition checking if the reason is not 'merged'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3828415e6454eaa27bfa2ea99016cb6b631303cd. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->