### PR TITLE
Add dynamic OTLP headers via `x-tensorzero-otlp-headers`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4874,6 +4874,7 @@ dependencies = [
  "mime 0.4.0-a.0",
  "mime_guess",
  "minijinja",
+ "moka",
  "object_store",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -4901,6 +4902,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml 0.9.5",
+ "tonic",
  "tower-http",
  "tower-layer",
  "tracing",
@@ -5146,6 +5148,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -399,11 +399,9 @@ async fn main() {
         .await
         .expect_pretty("Failed to start server");
 
-    if let Some(sdk_tracer_provider) = delayed_log_config.sdk_tracer_provider {
+    if let Some(tracer_wrapper) = delayed_log_config.otel_tracer {
         tracing::info!("Shutting down OpenTelemetry exporter");
-        observability::shutdown_otel(sdk_tracer_provider)
-            .await
-            .expect_pretty("Failed to shutdown OpenTelemetry");
+        tracer_wrapper.shutdown().await;
         tracing::info!("OpenTelemetry exporter shut down");
     }
 }

--- a/tensorzero-core/Cargo.toml
+++ b/tensorzero-core/Cargo.toml
@@ -127,9 +127,11 @@ base64 = "0.22.1"
 thiserror = "2.0.15"
 glob = "0.3.3"
 enum-map = "2.7.3"
-tokio-util = "0.7.15"
+tokio-util = { version = "0.7.15", features = ["rt"] }
 tempfile = "3.20.0"
 ts-rs = { workspace = true }
+moka = { version = "0.12.10", features = ["sync"] }
+tonic = { version = "0.13.1", default-features = false }
 
 
 [dev-dependencies]

--- a/tensorzero-core/tests/e2e/docker-compose.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.yml
@@ -52,17 +52,29 @@ services:
       timeout: 1s
 
   jaeger:
-    image: jaegertracing/jaeger:2.5.0
+    image: jaegertracing/jaeger:2.9.0
     volumes:
       - ./jaeger-config.yaml:/jaeger/config.yaml
     #command: --set=extensions.jaeger_storage.backends.some_store.memory.max_traces=1
     command: --config /jaeger/config.yaml
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:14269/health"]
+      interval: 1s
+      timeout: 3s
+      retries: 60    
     ports:
       - "16686:16686" # Browser UI
-      - "4317:4317"
-      - "4318:4318"
-      - "5778:5778"
-      - "9411:9411"
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
+    ports:
+      - 4317:4317 # OTLP gRPC receiver
+      - 4318:4318 # OTLP http receiver
+    depends_on:
+      jaeger:
+        condition: service_healthy
 
   # This is not a gateway to use but rather one that just sets up migrations for the ClickHouse db
   gateway:

--- a/tensorzero-core/tests/e2e/jaeger-config.yaml
+++ b/tensorzero-core/tests/e2e/jaeger-config.yaml
@@ -1,5 +1,5 @@
     service:
-      extensions: [jaeger_storage, jaeger_query]
+      extensions: [jaeger_storage, jaeger_query, healthcheckv2]
       pipelines:
         traces:
           receivers: [otlp]
@@ -13,13 +13,13 @@
           memstore:
             memory:
               max_traces: 10000
+      healthcheckv2:
+        endpoint: 0.0.0.0:14269            
     receivers:
       otlp:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
     exporters:
       jaeger_storage_exporter:
         trace_storage: memstore

--- a/tensorzero-core/tests/e2e/otel-collector-config.yaml
+++ b/tensorzero-core/tests/e2e/otel-collector-config.yaml
@@ -1,0 +1,26 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+        include_metadata: true
+
+processors:
+  attributes:
+    actions:
+      - key: tensorzero.custom_key # Attribute name to be created
+        from_context: x-dummy-tensorzero  # Source of the value from incoming HTTP header
+        action: upsert
+
+exporters:
+  otlp:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [attributes]
+      exporters: [otlp] # Or your desired exporter


### PR DESCRIPTION
The format is:
x-tensorzero-otlp-headers: [["header1", "value1"], ["header2", "value2"]]

The provided header key/value pairs will be added as HTTP headers to the outgoing OTLP export

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
