### PR TITLE
Pin ClickHouse 25.7 in CI

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -411,7 +411,7 @@ jobs:
       matrix:
         # Only include replicated: true when running in merge queue
         replicated: ${{ github.event_name == 'merge_group' && fromJSON('[true, false]') || fromJSON('[false]') }}
-        clickhouse_version: ${{ github.event_name == 'merge_group' && fromJSON('[{"tag":"24.12-alpine","prefix":"24.12","allow_failure":false},{"tag":"25.7.4-alpine","prefix":"25.7","allow_failure":false}]') || fromJSON('[{"tag":"25.7.4-alpine","prefix":"25.7","allow_failure":false}]') }}
+        clickhouse_version: ${{ github.event_name == 'merge_group' && fromJSON('[{"tag":"24.12-alpine","prefix":"24.12","allow_failure":false},{"tag":"25.7-alpine","prefix":"25.7","allow_failure":false}]') || fromJSON('[{"tag":"25.7-alpine","prefix":"25.7","allow_failure":false}]') }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        clickhouse_version: ${{ github.event_name == 'merge_group' && fromJSON('["24.12-alpine", "25.7.4-alpine"]') || fromJSON('["25.7.4-alpine"]') }}
+        clickhouse_version: ${{ github.event_name == 'merge_group' && fromJSON('["24.12-alpine", "25.7-alpine"]') || fromJSON('["25.7-alpine"]') }}
 
     steps:
       - name: Set DNS

--- a/tensorzero-core/tests/e2e/docker-compose.replicated.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.replicated.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse-01:
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:${TENSORZERO_CLICKHOUSE_VERSION:-25.7-alpine}
     hostname: clickhouse-01
     ports:
       - "8123:8123"
@@ -23,7 +23,7 @@ services:
       retries: 3
 
   clickhouse-02:
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:${TENSORZERO_CLICKHOUSE_VERSION:-25.7-alpine}
     hostname: clickhouse-02
     ports:
       - "8124:8123" # Host port 8124 -> Container port 8123
@@ -46,7 +46,7 @@ services:
       retries: 3
 
   clickhouse-03:
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:${TENSORZERO_CLICKHOUSE_VERSION:-25.7-alpine}
     hostname: clickhouse-03
     ports:
       - "8125:8123"


### PR DESCRIPTION
The ClickHouse 25.8 has a bug in 'SELECT EXISTS', which prevents our migrations from working. Until it's fixed, let's stop testing against it.

See https://github.com/ClickHouse/ClickHouse/issues/86415

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Pin ClickHouse version to 25.7 in CI workflows due to a bug in 25.8 affecting migrations.
> 
>   - **CI Configuration**:
>     - Pin ClickHouse version to `25.7-alpine` in `.github/workflows/general.yml` and `.github/workflows/ui-tests.yml`.
>     - Update `docker-compose.replicated.yml` to use `clickhouse/clickhouse-server:25.7-alpine` for `clickhouse-01`, `clickhouse-02`, and `clickhouse-03` services.
>   - **Reason**:
>     - ClickHouse 25.8 has a bug in `SELECT EXISTS` that affects migrations, necessitating the version pinning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b32dfb2556f1e048929588011d128dc80d97f5fd. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->