### PR TITLE
Add 'feedback' OTEL span for feedback endpoint

### DIFF
--- a/tensorzero-core/tests/e2e/otel.rs
+++ b/tensorzero-core/tests/e2e/otel.rs
@@ -10,14 +10,14 @@ use opentelemetry_sdk::{
 };
 use tensorzero::{
     ClientInferenceParams, ClientInput, ClientInputMessage, ClientInputMessageContent,
-    InferenceOutput, Role,
+    FeedbackParams, InferenceOutput, Role,
 };
 use tensorzero_core::inference::types::TextKind;
 use tensorzero_core::observability::build_opentelemetry_layer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use uuid::Uuid;
 
-use crate::providers::common::make_embedded_gateway_no_config;
+use crate::providers::common::{make_embedded_gateway, make_embedded_gateway_no_config};
 
 type CapturedSpans = Arc<Mutex<Option<Vec<SpanData>>>>;
 
@@ -354,4 +354,83 @@ pub async fn test_capture_model_error() {
     );
 
     assert_eq!(num_spans, 4);
+}
+
+#[tokio::test]
+pub async fn test_capture_feedback_spans() {
+    let exporter = install_capturing_otel_exporter();
+
+    let client = make_embedded_gateway().await;
+    let res = client
+        .inference(ClientInferenceParams {
+            model_name: Some("dummy::good".to_string()),
+            input: ClientInput {
+                system: None,
+                messages: vec![ClientInputMessage {
+                    role: Role::User,
+                    content: vec![ClientInputMessageContent::Text(TextKind::Text {
+                        text: "What is your name?".to_string(),
+                    })],
+                }],
+            },
+            tags: HashMap::from([
+                ("first_tag".to_string(), "first_value".to_string()),
+                ("second_tag".to_string(), "second_value".to_string()),
+            ]),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let InferenceOutput::NonStreaming(output) = res else {
+        panic!("Expected non-streaming output, got: {res:#?}");
+    };
+
+    let _feedback_res = client
+        .feedback(FeedbackParams {
+            inference_id: Some(output.inference_id()),
+            metric_name: "task_success".to_string(),
+            value: true.into(),
+            tags: HashMap::from([
+                ("my_tag".to_string(), "my_value".to_string()),
+                ("my_tag2".to_string(), "my_value2".to_string()),
+            ]),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let all_spans = exporter.take_spans();
+    let mut spans = build_span_map(all_spans);
+    // We should have a feedback span and a function_inference span
+    assert_eq!(spans.root_spans.len(), 2);
+    spans.root_spans.sort_by_key(|span| span.name.clone());
+    assert_eq!(spans.root_spans[0].name, "feedback");
+    assert_eq!(spans.root_spans[1].name, "function_inference");
+
+    // We've already checked the function_inference span in the previous test,
+    // so just check the feedback span
+    let feedback_span = &spans.root_spans[0];
+    let feedback_attr_map = attrs_to_map(&feedback_span.attributes);
+    assert_eq!(
+        feedback_attr_map["inference_id"],
+        output.inference_id().to_string().into()
+    );
+    assert_eq!(
+        feedback_attr_map["tags.my_tag"],
+        "my_value".to_string().into()
+    );
+    assert_eq!(
+        feedback_attr_map["tags.my_tag2"],
+        "my_value2".to_string().into()
+    );
+    assert!(!feedback_attr_map.contains_key("episode_id"));
+    assert_eq!(feedback_attr_map["metric_name"], "task_success".into());
+
+    assert_eq!(
+        spans
+            .span_children
+            .get(&feedback_span.span_context.span_id()),
+        None,
+        "feedback span should have no children"
+    );
 }

--- a/tensorzero-core/tests/e2e/otel.rs
+++ b/tensorzero-core/tests/e2e/otel.rs
@@ -356,7 +356,7 @@ pub async fn test_capture_model_error() {
     assert_eq!(num_spans, 4);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 pub async fn test_capture_feedback_spans() {
     let exporter = install_capturing_otel_exporter();
 


### PR DESCRIPTION
Fixes https://github.com/tensorzero/tensorzero/issues/3177

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add OpenTelemetry span to feedback endpoint for improved observability and update tests accordingly.
> 
>   - **Behavior**:
>     - Adds OTEL span to `feedback` function in `mod.rs`, recording `inference_id`, `episode_id`, and tags.
>     - Updates `feedback_handler` to use the new span.
>   - **Tests**:
>     - Adds `test_capture_feedback_spans` in `otel.rs` to verify feedback spans.
>     - Updates existing tests to accommodate new span attributes.
>   - **Misc**:
>     - Imports `OpenTelemetrySpanExt` in `mod.rs` for span extension methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 281298a0cf7b1f557aad150a2cf339c78975e609. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->