### PR TITLE
Wait for ClickHouse batch writer to finish in `run_evaluation`

### DIFF
--- a/evaluations/src/lib.rs
+++ b/evaluations/src/lib.rs
@@ -289,6 +289,21 @@ pub async fn run_evaluation(
         }
     }
 
+    // Since we construct our own `ClickHouseConnectionInfo` outside of our `TensorZeroClient`,
+    // we need to wait for the batch writer to finish.
+    // This happens automatically when `run_evaluation` is called from the standalone `evaluations` binary
+    // (since Tokio will wait for the `spawn_blocking` task to finish before shutting down the runtime).
+    // We explicitly wait here for the batch writer to finish, so that we can call `run_evaluation` can be called
+    // from other places in the codebase (e.g. e2e tests), and subsequently query ClickHouse for the evaluation results.
+    if let Some(handle) = clients.clickhouse_client.batcher_join_handle() {
+        drop(clients);
+        tracing::info!("Waiting for evaluations ClickHouse batch writer to finish");
+        handle
+            .await
+            .map_err(|e| anyhow!("Error waiting for ClickHouse batch writer: {e}"))?;
+        tracing::info!("Evaluations ClickHouse batch writer finished");
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
This should have no effect on the main evaluations binary (since there was already an implicit wait from the `spawn_blocking` task), but it might help with the flaky tests on CI

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->
