### PR TITLE
dont construct the error unless needed in embeddings handler

### DIFF
--- a/tensorzero-core/src/endpoints/embeddings.rs
+++ b/tensorzero-core/src/endpoints/embeddings.rs
@@ -42,9 +42,11 @@ pub async fn embeddings(
         .embedding_models
         .get(&params.model_name)
         .await?
-        .ok_or(Error::new(ErrorDetails::ModelNotFound {
-            model_name: params.model_name.clone(),
-        }))?;
+        .ok_or_else(|| {
+            Error::new(ErrorDetails::ModelNotFound {
+                model_name: params.model_name.clone(),
+            })
+        })?;
     if let EmbeddingInput::Batch(array) = &params.input {
         if array.is_empty() {
             return Err(Error::new(ErrorDetails::InvalidRequest {


### PR DESCRIPTION
There were errors being logged even if they weren't being hit in the embeddings handler; we fix that here. One more reason to move towards errors being handled lazily rather than eagerly in tensorzero-core.