### PR TITLE
allow configuration of database name for e2e tests

### DIFF
--- a/tensorzero-core/src/db/clickhouse/mod.rs
+++ b/tensorzero-core/src/db/clickhouse/mod.rs
@@ -129,7 +129,8 @@ impl ClickHouseConnectionInfo {
             .unwrap_or_else(|| "default".to_string());
 
         #[cfg(feature = "e2e_tests")]
-        let database = "tensorzero_e2e_tests".to_string();
+        let database = std::env::var("TENSORZERO_E2E_TESTS_DATABASE")
+            .unwrap_or_else(|_| "tensorzero_e2e_tests".to_string());
 
         // Although we take the database name from the URL path,
         // we need to set the query string for the database name for the ClickHouse TCP protocol


### PR DESCRIPTION
Will be useful for changes to ClickHouse cloud tests in #3141 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make e2e test database name configurable via `TENSORZERO_E2E_TESTS_DATABASE` environment variable in `ClickHouseConnectionInfo::new`.
> 
>   - **Behavior**:
>     - In `ClickHouseConnectionInfo::new`, the database name for e2e tests is now configurable via the `TENSORZERO_E2E_TESTS_DATABASE` environment variable.
>     - Defaults to `tensorzero_e2e_tests` if the environment variable is not set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 9b9525305b6b813c482b0c1dc19f16141f9c3c25. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->