### PR TITLE
Increase MQ live-tests timeout / slow down R2 uploads

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -63,7 +63,7 @@ jobs:
       contents: read
       # Permission to fetch GitHub OIDC token authentication
       id-token: write
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       matrix:
         batch_writes: [true, false]

--- a/ci/upload-provider-proxy-cache.sh
+++ b/ci/upload-provider-proxy-cache.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 set -euxo pipefail
 cd $(dirname $0)/provider-proxy-cache
+
+export AWS_RETRY_MODE=standard
+export AWS_MAX_ATTEMPTS=10
+
+# Avoid: "Reduce your concurrent request rate for the same object"
+aws configure set default.s3.max_concurrent_requests 3
+aws configure set default.s3.multipart_threshold 64MB
+aws configure set default.s3.multipart_chunksize 64MB
+
 # Use --delete to remove stale cache files from the bucket.
 # This doesn't do anything for merge queue runs (since we start by downloading the entire bucket),
 # but it will help for cron job runs, where we intentionally start with an empty provider-proxy cache.
-aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync . s3://provider-proxy-cache --checksum-algorithm CRC32 --delete
+aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync . s3://provider-proxy-cache --checksum-algorithm CRC32 --delete --no-progress

--- a/ci/upload-provider-proxy-cache.sh
+++ b/ci/upload-provider-proxy-cache.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euxo pipefail
+
 cd $(dirname $0)/provider-proxy-cache
 
 export AWS_RETRY_MODE=standard
@@ -7,22 +8,24 @@ export AWS_MAX_ATTEMPTS=10
 
 # The following settings attempt to avoid the error:
 # "An error occurred (ServiceUnavailable) when calling the PutObject operation: Reduce your concurrent request rate for the same object."
-aws configure set default.s3.max_concurrent_requests 3
-aws configure set default.s3.multipart_threshold 64MB
-aws configure set default.s3.multipart_chunksize 64MB
+export AWS_S3_MAX_CONCURRENT_REQUESTS=3
+export AWS_S3_MULTIPART_THRESHOLD=67108864  # bytes (64MB)
+export AWS_S3_MULTIPART_CHUNKSIZE=67108864  # bytes (64MB)
 
-# Use --delete to remove stale cache files from the bucket.
-# This doesn't do anything for merge queue runs (since we start by downloading the entire bucket),
-# but it will help for cron job runs, where we intentionally start with an empty provider-proxy cache.
 for i in {1..5}; do
-  if aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync . s3://provider-proxy-cache --delete --no-progress; then
-    break
-  else
-    echo "Attempt $i failed. Retrying..."
-    if [ $i -eq 5 ]; then
-      echo "All attempts failed."
-      exit 1
+    # Use --delete to remove stale cache files from the bucket.
+    # This doesn't do anything for merge queue runs (since we start by downloading the entire bucket),
+    # but it will help for cron job runs, where we intentionally start with an empty provider-proxy cache.
+    if aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync . s3://provider-proxy-cache --delete --no-progress; then        sync . s3://provider-proxy-cache \
+        --delete \
+        --no-progress; then
+        break
+    else
+        echo "Attempt $i failed. Retrying..."
+        if [ $i -eq 5 ]; then
+            echo "All attempts failed."
+            exit 1
+        fi
+        sleep 5
     fi
-    sleep 5
-  fi
 done

--- a/ci/upload-provider-proxy-cache.sh
+++ b/ci/upload-provider-proxy-cache.sh
@@ -5,7 +5,8 @@ cd $(dirname $0)/provider-proxy-cache
 export AWS_RETRY_MODE=standard
 export AWS_MAX_ATTEMPTS=10
 
-# Avoid: "Reduce your concurrent request rate for the same object"
+# The following settings attempt to avoid the error:
+# "An error occurred (ServiceUnavailable) when calling the PutObject operation: Reduce your concurrent request rate for the same object."
 aws configure set default.s3.max_concurrent_requests 3
 aws configure set default.s3.multipart_threshold 64MB
 aws configure set default.s3.multipart_chunksize 64MB
@@ -13,4 +14,4 @@ aws configure set default.s3.multipart_chunksize 64MB
 # Use --delete to remove stale cache files from the bucket.
 # This doesn't do anything for merge queue runs (since we start by downloading the entire bucket),
 # but it will help for cron job runs, where we intentionally start with an empty provider-proxy cache.
-aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync . s3://provider-proxy-cache --checksum-algorithm CRC32 --delete --no-progress
+aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync . s3://provider-proxy-cache --delete --no-progress

--- a/ci/upload-provider-proxy-cache.sh
+++ b/ci/upload-provider-proxy-cache.sh
@@ -16,7 +16,7 @@ for i in {1..5}; do
     # Use --delete to remove stale cache files from the bucket.
     # This doesn't do anything for merge queue runs (since we start by downloading the entire bucket),
     # but it will help for cron job runs, where we intentionally start with an empty provider-proxy cache.
-    if aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync . s3://provider-proxy-cache --delete --no-progress; then        sync . s3://provider-proxy-cache \
+    if aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync . s3://provider-proxy-cache --delete --no-progress; then
         break
     else
         echo "Attempt $i failed. Retrying..."

--- a/ci/upload-provider-proxy-cache.sh
+++ b/ci/upload-provider-proxy-cache.sh
@@ -17,8 +17,6 @@ for i in {1..5}; do
     # This doesn't do anything for merge queue runs (since we start by downloading the entire bucket),
     # but it will help for cron job runs, where we intentionally start with an empty provider-proxy cache.
     if aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync . s3://provider-proxy-cache --delete --no-progress; then        sync . s3://provider-proxy-cache \
-        --delete \
-        --no-progress; then
         break
     else
         echo "Attempt $i failed. Retrying..."

--- a/ci/upload-provider-proxy-cache.sh
+++ b/ci/upload-provider-proxy-cache.sh
@@ -14,4 +14,15 @@ aws configure set default.s3.multipart_chunksize 64MB
 # Use --delete to remove stale cache files from the bucket.
 # This doesn't do anything for merge queue runs (since we start by downloading the entire bucket),
 # but it will help for cron job runs, where we intentionally start with an empty provider-proxy cache.
-aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync . s3://provider-proxy-cache --delete --no-progress
+for i in {1..5}; do
+  if aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync . s3://provider-proxy-cache --delete --no-progress; then
+    break
+  else
+    echo "Attempt $i failed. Retrying..."
+    if [ $i -eq 5 ]; then
+      echo "All attempts failed."
+      exit 1
+    fi
+    sleep 5
+  fi
+done


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Increase live-tests timeout and add retry logic for AWS S3 uploads to improve CI/CD reliability.
> 
>   - **GitHub Actions**:
>     - Increase `timeout-minutes` from 30 to 45 in `merge-queue.yml` for `live-tests` job.
>   - **AWS S3 Upload**:
>     - Add retry logic in `upload-provider-proxy-cache.sh` to handle `ServiceUnavailable` errors by retrying up to 5 times with a 5-second delay between attempts.
>     - Set `AWS_S3_MAX_CONCURRENT_REQUESTS` to 3 and `AWS_S3_MULTIPART_THRESHOLD` and `AWS_S3_MULTIPART_CHUNKSIZE` to 64MB to reduce concurrent request rate.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 89813aad12954769ed92eebea06632844f30f396. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->