### PR TITLE
Add default `max_tokens` for Claude Opus 4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,8 +1658,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf04c5ec15464ace8355a7b440a33aece288993475556d461154d7a62ad9947c"
 dependencies = [
  "bit-set",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2644,7 +2644,7 @@ dependencies = [
  "percent-encoding",
  "referencing",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "reqwest",
  "serde",
  "serde_json",
@@ -2817,11 +2817,11 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -3137,12 +3137,11 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3392,12 +3391,6 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -4049,17 +4042,8 @@ checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4070,7 +4054,7 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4078,12 +4062,6 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -5399,14 +5377,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -5447,7 +5425,7 @@ checksum = "6d7b8994f367f16e6fa14b5aebbcb350de5d7cbea82dc5b00ae997dd71680dd2"
 dependencies = [
  "cc",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "serde_json",
  "streaming-iterator",
  "tree-sitter-language",

--- a/tensorzero-core/src/providers/anthropic.rs
+++ b/tensorzero-core/src/providers/anthropic.rs
@@ -723,7 +723,11 @@ fn get_default_max_tokens(model_name: &str) -> Result<u32, Error> {
         || model_name == "claude-sonnet-4-0"
     {
         Ok(64_000)
-    } else if model_name.starts_with("claude-opus-4-202") || model_name == "claude-opus-4-0" {
+    } else if model_name.starts_with("claude-opus-4-202")
+        || model_name == "claude-opus-4-0"
+        || model_name.starts_with("claude-opus-4-1-202")
+        || model_name == "claude-opus-4-1"
+    {
         Ok(32_000)
     } else {
         Err(Error::new(ErrorDetails::InferenceClient {
@@ -1791,107 +1795,93 @@ mod tests {
             ..Default::default()
         };
 
+        let model = "claude-opus-4-1-20250805".to_string();
+        let body = AnthropicRequestBody::new(&model, &request);
+        assert_eq!(body.unwrap().max_tokens, 32_000);
+        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
+
         let model = "claude-opus-4-20250514".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 32_000);
-
-        let model = "claude-opus-4-20250514".to_string();
         let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-sonnet-4-20250514".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 64_000);
-
-        let model = "claude-sonnet-4-20250514".to_string();
         let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-7-sonnet-20250219".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 64_000);
-
-        let model = "claude-3-7-sonnet-20250219".to_string();
         let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-5-sonnet-20241022".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 8_192);
-
-        let model = "claude-3-5-sonnet-20241022".to_string();
         let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-5-haiku-20241022".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 8_192);
+        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
 
-        let model = "claude-3-5-haiku-20241022".to_string();
+        let model = "claude-opus-4-1".to_string();
+        let body = AnthropicRequestBody::new(&model, &request);
+        assert_eq!(body.unwrap().max_tokens, 32_000);
         let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-opus-4-0".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 32_000);
-
-        let model = "claude-opus-4-0".to_string();
         let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-sonnet-4-0".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 64_000);
-
-        let model = "claude-sonnet-4-0".to_string();
         let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-7-sonnet-latest".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 64_000);
-
-        let model = "claude-3-7-sonnet-latest".to_string();
         let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-5-sonnet-latest".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 8_192);
-
-        let model = "claude-3-5-sonnet-latest".to_string();
         let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-5-haiku-latest".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 8_192);
-
-        let model = "claude-3-5-haiku-latest".to_string();
         let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-haiku-20240307".to_string();
         let body = AnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 4_096);
-
-        let model = "claude-3-haiku-20240307".to_string();
         let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-5-ballad-latest".to_string(); // fake model
         let body = AnthropicRequestBody::new(&model, &request);
         assert!(body.is_err());
-
-        let model = "claude-3-5-ballad-latest".to_string(); // fake model
         let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-4-5-haiku-20260101".to_string(); // fake model
         let body = AnthropicRequestBody::new(&model, &request);
         assert!(body.is_err());
-
-        let model = "claude-4-5-haiku-20260101".to_string(); // fake model
         let body = AnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
     }

--- a/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
@@ -727,7 +727,7 @@ fn get_default_max_tokens(model_id: &str) -> Result<u32, Error> {
         Ok(64_000)
     } else if model_id.starts_with("claude-sonnet-4@") {
         Ok(64_000)
-    } else if model_id.starts_with("claude-opus-4@") {
+    } else if model_id.starts_with("claude-opus-4@") || model_id.starts_with("claude-opus-4-1@") {
         Ok(32_000)
     } else {
         Err(Error::new(ErrorDetails::InferenceClient {
@@ -1671,75 +1671,63 @@ mod tests {
             ..Default::default()
         };
 
+        let model = "claude-opus-4-1@20250805".to_string();
+        let body = GCPVertexAnthropicRequestBody::new(&model, &request);
+        assert_eq!(body.unwrap().max_tokens, 32_000);
+        let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
+        assert_eq!(body.unwrap().max_tokens, 100);
+
         let model = "claude-opus-4@20250514".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 32_000);
-
-        let model = "claude-opus-4@20250514".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-sonnet-4@20250514".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 64_000);
-
-        let model = "claude-sonnet-4@20250514".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-7-sonnet@20250219".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 64_000);
-
-        let model = "claude-3-7-sonnet@20250219".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-5-sonnet-v2@20240222".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 8_192);
-
-        let model = "claude-3-5-sonnet-v2@20240222".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-5-sonnet@20240229".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 8_192);
-
-        let model = "claude-3-5-sonnet@20240229".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-5-haiku@20240307".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 8_192);
-
-        let model = "claude-3-5-haiku@20240307".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-haiku@20240307".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert_eq!(body.unwrap().max_tokens, 4_096);
-
-        let model = "claude-3-haiku@20240307".to_string();
         let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-sonnet-4".to_string(); // fake model
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert!(body.is_err());
-
-        let model = "claude-sonnet-4".to_string(); // fake model
         let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-4-5-ballad@20260101".to_string(); // fake model
         let body = GCPVertexAnthropicRequestBody::new(&model, &request);
         assert!(body.is_err());
-
-        let model = "claude-4-5-ballad@20260101".to_string(); // fake model
         let body = GCPVertexAnthropicRequestBody::new(&model, &request_with_max_tokens);
         assert_eq!(body.unwrap().max_tokens, 100);
     }


### PR DESCRIPTION
Fix #3003. Also make tests simpler by grouping pairs of checks.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add default `max_tokens` for Claude Opus 4.1 models and simplify tests in `anthropic.rs` and `gcp_vertex_anthropic.rs`.
> 
>   - **Behavior**:
>     - Add default `max_tokens` of 32,000 for `claude-opus-4-1` models in `get_default_max_tokens()` in `anthropic.rs` and `gcp_vertex_anthropic.rs`.
>     - Update tests in `anthropic.rs` and `gcp_vertex_anthropic.rs` to include `claude-opus-4-1` model checks.
>   - **Tests**:
>     - Simplify tests by grouping pairs of checks in `anthropic.rs` and `gcp_vertex_anthropic.rs`.
>     - Ensure tests cover new model versions and default token behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for acf5ed6ae84e372481844da0e80f0ca6551598b1. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->