### PR TITLE
Drain channel after close in ClickHouse batching implementation

### DIFF
--- a/tensorzero-core/src/db/clickhouse/batching.rs
+++ b/tensorzero-core/src/db/clickhouse/batching.rs
@@ -123,7 +123,10 @@ impl BatchWriter {
             let batch_timeout = Duration::from_millis(config.flush_interval_ms);
             join_set.spawn(async move {
                 let mut buffer = Vec::with_capacity(config.max_rows);
-                while !channel.is_closed() {
+                // The channel can be closed but still contain messages.
+                // We continue looping until the channel is closed and empty, at which point we're guaranteed
+                // to never see any new messages from `channel.recv/recv_many`.
+                while !channel.is_closed() && !channel.is_empty() {
                     let deadline = Instant::now() + batch_timeout;
                     // Repeatedly fetch entries from the channel until we have a full batch.
                     // We exit early from the loop if our deadline is reached, and submit

--- a/tensorzero-core/src/db/clickhouse/batching.rs
+++ b/tensorzero-core/src/db/clickhouse/batching.rs
@@ -126,7 +126,7 @@ impl BatchWriter {
                 // The channel can be closed but still contain messages.
                 // We continue looping until the channel is closed and empty, at which point we're guaranteed
                 // to never see any new messages from `channel.recv/recv_many`.
-                while !channel.is_closed() && !channel.is_empty() {
+                while !channel.is_closed() || !channel.is_empty() {
                     let deadline = Instant::now() + batch_timeout;
                     // Repeatedly fetch entries from the channel until we have a full batch.
                     // We exit early from the loop if our deadline is reached, and submit

--- a/tensorzero-core/tests/e2e/inference.rs
+++ b/tensorzero-core/tests/e2e/inference.rs
@@ -3941,6 +3941,19 @@ async fn test_clickhouse_bulk_insert() {
                 .unwrap()
         });
     }
+
+    // Directly wait on the batch shutdown, to simulate waiting for the last `Client` to be dropped.
+    let handle = client
+        .get_app_state_data()
+        .expect("Missing AppStateData")
+        .clickhouse_connection_info
+        .batcher_join_handle()
+        .expect("Missing batcher join handle");
+    drop(client);
+    handle
+        .await
+        .expect("Error waiting for ClickHouse batch writer");
+
     let mut expected_inference_ids = HashSet::new();
     while let Some(result) = join_set.join_next().await {
         let result = result.unwrap();

--- a/tensorzero-core/tests/e2e/inference.rs
+++ b/tensorzero-core/tests/e2e/inference.rs
@@ -1,4 +1,4 @@
-#![expect(clippy::print_stdout)]
+#![expect(clippy::print_stdout, clippy::print_stderr)]
 use std::collections::HashMap;
 use std::{collections::HashSet, sync::Arc};
 

--- a/tensorzero-core/tests/e2e/inference.rs
+++ b/tensorzero-core/tests/e2e/inference.rs
@@ -3953,9 +3953,12 @@ async fn test_clickhouse_bulk_insert() {
     assert_eq!(expected_inference_ids.len(), inference_count);
 
     assert_eq!(Arc::strong_count(&client), 1);
+    drop(batch_sender);
+    eprintln!("Dropping client");
     // Drop the last client, which will drop all of our `ClickhouseConnectionInfo`s
     // and allow the batch writer to shut down.
     drop(client);
+    eprintln!("Dropped client");
     // Wait for ClickHouse to finish processing batch writes.
     tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 


### PR DESCRIPTION
The channel can still have messages when it's closed (e.g. if the last ClickhouseConnectionInfo writes lots of messages and is then immediately dropped). We were assuming that the channel was empty when it was closed, which could cause us to drop messages during shutdown.

This showed as up flakes in our evaluations tests with batch writes enabled (since we check that all of the expected rows were written)

<!--
Thank you for contributing to TensorZero!

Before submitting your PR, make sure you've read **[Contributing to TensorZero](https://github.com/tensorzero/tensorzero/blob/main/CONTRIBUTING.md)**.

In particular, make sure you've run `pre-commit` and any tests relevant to your changes (including E2E tests for changes to the gateway).

By submitting this PR, unless otherwise specified, you agree to license your contributions under the **[Apache 2.0 license](https://github.com/tensorzero/tensorzero/blob/main/LICENSE)**.
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes message drop issue in ClickHouse batching by ensuring channels are fully drained after closure.
> 
>   - **Behavior**:
>     - Fixes issue in `BatchWriter` in `batching.rs` where messages could be dropped during shutdown by ensuring the channel is drained completely after closure.
>     - Updates `test_clickhouse_bulk_insert` in `inference.rs` to ensure all expected rows are written, reflecting the fix.
>   - **Tests**:
>     - Adds additional assertions in `test_clickhouse_bulk_insert` in `inference.rs` to verify that all messages are processed and written to ClickHouse.
>   - **Misc**:
>     - Updates clippy lint expectations in `inference.rs` to include `clippy::print_stderr`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4f53fb6481743102e6db8d2940c0a451b5742af5. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->