### PR TITLE
Remove Deserialized impl from ResolvedInput types

### DIFF
--- a/examples/integrations/cursor/feedback/src/clickhouse.rs
+++ b/examples/integrations/cursor/feedback/src/clickhouse.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use tensorzero_core::serde_util::deserialize_json_string;
 use tensorzero_core::{
     db::clickhouse::ClickHouseConnectionInfo,
-    inference::types::{ContentBlockChatOutput, ResolvedInput},
+    inference::types::{ContentBlockChatOutput, StoredInput},
 };
 use uuid::Uuid;
 
@@ -18,7 +18,7 @@ use crate::util::{get_max_uuidv7, get_min_uuidv7};
 pub struct InferenceInfo {
     pub id: Uuid,
     #[serde(deserialize_with = "deserialize_json_string")]
-    pub input: ResolvedInput,
+    pub input: StoredInput,
     #[serde(deserialize_with = "deserialize_json_string")]
     pub output: Vec<ContentBlockChatOutput>,
 }

--- a/examples/integrations/cursor/feedback/src/cursor.rs
+++ b/examples/integrations/cursor/feedback/src/cursor.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 use serde_json::Value;
 use std::path::PathBuf;
 use tensorzero_core::inference::types::{
-    ContentBlockChatOutput, ResolvedInput, ResolvedInputMessage, ResolvedInputMessageContent,
+    ContentBlockChatOutput, StoredInput, StoredInputMessage, StoredInputMessageContent,
 };
 /*
 This file handles the outputs of inferences from Cursor. We handle two cases:
@@ -23,7 +23,7 @@ pub struct CursorCodeBlock {
 /// Instead, we use the content of the system message to determine which parser to use.
 /// This will be brittle to Cursor changing their system prompt.
 pub fn parse_cursor_output(
-    input: &ResolvedInput,
+    input: &StoredInput,
     output: &Vec<ContentBlockChatOutput>,
 ) -> Result<Vec<CursorCodeBlock>> {
     let Some(Value::String(system)) = &input.system else {
@@ -127,7 +127,7 @@ fn parse_cursor_ask_output(output_text: &str) -> Result<Vec<CursorCodeBlock>> {
 /// Therefore, we can simply extract the code block from the output and remove the comments.
 /// This is equivalent to taking the whole string except for the first two lines and the last 2 lines.
 fn parse_cursor_edit_output(
-    messages: &[ResolvedInputMessage],
+    messages: &[StoredInputMessage],
     output_text: &str,
 ) -> Result<Vec<CursorCodeBlock>> {
     // There should be 2 messages in the input:
@@ -139,7 +139,7 @@ fn parse_cursor_edit_output(
     }
     let second_message = &messages[1];
     let second_message_text = match second_message.content.as_slice() {
-        [ResolvedInputMessageContent::Text { value: text }] => {
+        [StoredInputMessageContent::Text { value: text }] => {
             let Value::String(text) = text else {
                 return Err(anyhow::anyhow!("Expected text in second user message"));
             };
@@ -200,7 +200,7 @@ fn parse_cursor_edit_output(
 /// and then the next line is ```path/to/file.ext
 /// We can grab this via a regex.
 fn parse_cursor_insert_output(
-    messages: &[ResolvedInputMessage],
+    messages: &[StoredInputMessage],
     output_text: &str,
 ) -> Result<Vec<CursorCodeBlock>> {
     if messages.is_empty() {
@@ -212,7 +212,7 @@ fn parse_cursor_insert_output(
     // Extract workspace path from the first message
     let first_message = &messages[0];
     let first_message_text = match first_message.content.as_slice() {
-        [ResolvedInputMessageContent::Text { value }] => {
+        [StoredInputMessageContent::Text { value }] => {
             let Value::String(s) = value else {
                 return Err(anyhow::anyhow!("Expected text in first user message"));
             };

--- a/examples/integrations/cursor/feedback/src/parsing.rs
+++ b/examples/integrations/cursor/feedback/src/parsing.rs
@@ -1650,6 +1650,8 @@ fn process_numbers() {
 
     // Tests for InferenceWithTrees struct
     mod inference_with_trees_tests {
+        use tensorzero_core::inference::types::StoredInput;
+
         use super::*;
         use std::path::PathBuf;
 
@@ -1666,7 +1668,10 @@ fn process_numbers() {
             // Rather than construct InferenceInfo manually, let's just test the struct operations
             let inference = Arc::new(InferenceInfo {
                 id: uuid::Uuid::nil(), // Use nil UUID for testing
-                input: serde_json::from_str(r#"{"messages": []}"#).unwrap(),
+                input: StoredInput {
+                    system: None,
+                    messages: vec![],
+                },
                 output: vec![],
             });
 
@@ -1682,7 +1687,10 @@ fn process_numbers() {
             let trees = vec![];
             let inference = Arc::new(InferenceInfo {
                 id: uuid::Uuid::nil(),
-                input: serde_json::from_str(r#"{"messages": []}"#).unwrap(),
+                input: StoredInput {
+                    system: None,
+                    messages: vec![],
+                },
                 output: vec![],
             });
 
@@ -1698,7 +1706,10 @@ fn process_numbers() {
             let trees = vec![];
             let inference = Arc::new(InferenceInfo {
                 id: uuid::Uuid::nil(),
-                input: serde_json::from_str(r#"{"messages": []}"#).unwrap(),
+                input: StoredInput {
+                    system: None,
+                    messages: vec![],
+                },
                 output: vec![],
             });
 

--- a/tensorzero-core/src/inference/types/resolved_input.rs
+++ b/tensorzero-core/src/inference/types/resolved_input.rs
@@ -19,7 +19,7 @@ use pyo3::prelude::*;
 /// Like `Input`, but with all network resources resolved.
 /// Currently, this is just used to fetch image URLs in the image input,
 /// so that we always pass a base64-encoded image to the model provider.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "pyo3", pyclass(str))]
 #[cfg_attr(test, derive(ts_rs::TS))]
@@ -72,7 +72,7 @@ impl ResolvedInput {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "pyo3", pyclass(str))]
 #[cfg_attr(test, derive(ts_rs::TS))]
@@ -126,7 +126,7 @@ impl ResolvedInputMessage {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[cfg_attr(test, derive(ts_rs::TS))]
 #[cfg_attr(test, ts(export))]

--- a/tensorzero-core/src/providers/gcp_vertex_gemini/optimization.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_gemini/optimization.rs
@@ -250,8 +250,8 @@ impl Display for GCPVertexGeminiFineTuningJobStatus {
 mod tests {
     use crate::{
         inference::types::{
-            ContentBlockChatOutput, ModelInput, RequestMessage, ResolvedInput,
-            ResolvedInputMessage, ResolvedInputMessageContent, Role, Text,
+            ContentBlockChatOutput, ModelInput, RequestMessage, Role, StoredInput,
+            StoredInputMessage, StoredInputMessageContent, Text,
         },
         model::CredentialLocation,
         providers::gcp_vertex_gemini::GCPVertexGeminiContentPart,
@@ -273,11 +273,11 @@ mod tests {
                     })],
                 }],
             },
-            stored_input: ResolvedInput {
+            stored_input: StoredInput {
                 system: Some(json!("You are a helpful assistant named Dr. M.M. Patel.")),
-                messages: vec![ResolvedInputMessage {
+                messages: vec![StoredInputMessage {
                     role: Role::User,
-                    content: vec![ResolvedInputMessageContent::Text {
+                    content: vec![StoredInputMessageContent::Text {
                         value: json!("What is the capital of France?"),
                     }],
                 }],

--- a/tensorzero-core/src/providers/openai/optimization.rs
+++ b/tensorzero-core/src/providers/openai/optimization.rs
@@ -299,8 +299,8 @@ pub enum OpenAIFineTuningJobStatus {
 mod tests {
     use crate::{
         inference::types::{
-            ContentBlockChatOutput, ModelInput, RequestMessage, ResolvedInput,
-            ResolvedInputMessage, ResolvedInputMessageContent, Role, Text,
+            ContentBlockChatOutput, ModelInput, RequestMessage, Role, StoredInput,
+            StoredInputMessage, StoredInputMessageContent, Text,
         },
         providers::openai::OpenAIContentBlock,
     };
@@ -321,12 +321,12 @@ mod tests {
                     })],
                 }],
             },
-            stored_input: ResolvedInput {
+            stored_input: StoredInput {
                 system: Some(json!("You are a helpful assistant named Dr. M.M. Patel.")),
-                messages: vec![ResolvedInputMessage {
+                messages: vec![StoredInputMessage {
                     role: Role::User,
-                    content: vec![ResolvedInputMessageContent::Text {
-                        value: json!("What is the capital of France?"),
+                    content: vec![StoredInputMessageContent::Text {
+                        value: "What is the capital of France?".into(),
                     }],
                 }],
             },

--- a/tensorzero-core/src/stored_inference.rs
+++ b/tensorzero-core/src/stored_inference.rs
@@ -425,7 +425,7 @@ fn json_output_to_content_block_chat_output(
 pub struct RenderedSample {
     pub function_name: String,
     pub input: ModelInput,
-    pub stored_input: ResolvedInput,
+    pub stored_input: StoredInput,
     pub output: Option<Vec<ContentBlockChatOutput>>,
     pub dispreferred_outputs: Vec<Vec<ContentBlockChatOutput>>,
     pub episode_id: Option<Uuid>,
@@ -511,7 +511,7 @@ impl RenderedSample {
     }
 
     #[getter]
-    pub fn get_stored_input(&self) -> ResolvedInput {
+    pub fn get_stored_input(&self) -> StoredInput {
         self.stored_input.clone()
     }
 }
@@ -590,7 +590,7 @@ pub fn render_stored_sample<T: StoredSample>(
         episode_id,
         inference_id,
         input: model_input,
-        stored_input: resolved_input,
+        stored_input: resolved_input.into_stored_input(),
         output,
         dispreferred_outputs,
         tool_params,

--- a/tensorzero-core/src/variant/dicl.rs
+++ b/tensorzero-core/src/variant/dicl.rs
@@ -14,6 +14,8 @@ use crate::inference::types::extra_headers::{ExtraHeadersConfig, FullExtraHeader
 use crate::inference::types::ContentBlock;
 use crate::inference::types::ResolvedInput;
 use crate::inference::types::ResolvedInputMessageContent;
+use crate::inference::types::StoredInput;
+use crate::inference::types::StoredInputMessageContent;
 use crate::inference::types::{
     batch::StartBatchModelInferenceWithMetadata, ModelInferenceRequest, RequestMessage, Role,
 };
@@ -280,13 +282,13 @@ impl Variant for DiclConfig {
 
 #[derive(Debug, Deserialize, PartialEq)]
 struct ChatExample {
-    input: ResolvedInput,
+    input: StoredInput,
     output: Vec<ContentBlockChatOutput>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 struct JsonExample {
-    input: ResolvedInput,
+    input: StoredInput,
     output: JsonInferenceOutput,
 }
 
@@ -570,8 +572,8 @@ fn parse_raw_examples(
 ) -> Result<Vec<Example>, Error> {
     let mut examples = Vec::new();
     for raw_example in raw_examples {
-        // Parse the `input` string into `Input`
-        let input: ResolvedInput = serde_json::from_str(&raw_example.input).map_err(|e| {
+        // Parse the `input` string into `StoredInput`
+        let input: StoredInput = serde_json::from_str(&raw_example.input).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
                 message: format!("Failed to parse `input`: {e}"),
             })
@@ -579,7 +581,7 @@ fn parse_raw_examples(
 
         for messages in &input.messages {
             for content in &messages.content {
-                if let ResolvedInputMessageContent::File(_) = content {
+                if let StoredInputMessageContent::File(_) = content {
                     return Err(Error::new(ErrorDetails::Serialization {
                         message: "Failed to deserialize raw_example - images are not supported in dynamic in-context learning".to_string(),
                     }));
@@ -654,12 +656,14 @@ impl LoadableConfig<DiclConfig> for UninitializedDiclConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::inference::types::stored_input::StoredFile;
+    use crate::inference::types::StoredInputMessage;
     use crate::{
         function::{FunctionConfigChat, FunctionConfigJson},
         inference::types::{
-            resolved_input::FileWithPath,
+            file::Base64FileMetadata,
             storage::{StorageKind, StoragePath},
-            Base64File, ResolvedInputMessage, ResolvedInputMessageContent, Role, Text,
+            ResolvedInputMessage, ResolvedInputMessageContent, Role, Text,
         },
         tool::{ToolCall, ToolCallOutput},
     };
@@ -670,18 +674,18 @@ mod tests {
         // ---------- Test with ChatExample ----------
 
         // Mock Input data
-        let input_data = ResolvedInput {
+        let input_data = StoredInput {
             system: Some(json!({"type": "system", "content": "System message"})),
             messages: vec![
-                ResolvedInputMessage {
+                StoredInputMessage {
                     role: Role::User,
-                    content: vec![ResolvedInputMessageContent::Text {
+                    content: vec![StoredInputMessageContent::Text {
                         value: json!("Hello, assistant!"),
                     }],
                 },
-                ResolvedInputMessage {
+                StoredInputMessage {
                     role: Role::Assistant,
-                    content: vec![ResolvedInputMessageContent::Text {
+                    content: vec![StoredInputMessageContent::Text {
                         value: json!("Hello, user!"),
                     }],
                 },
@@ -813,12 +817,12 @@ mod tests {
         // Define sample raw examples with serialized Input and Output
         let raw_examples = vec![
             RawExample {
-                input: serde_json::to_string(&ResolvedInput {
+                input: serde_json::to_string(&StoredInput {
                     system: Some(json!({"assistant_name": "Dr. Mehta"})),
-                    messages: vec![ResolvedInputMessage {
+                    messages: vec![StoredInputMessage {
                         role: Role::User,
-                        content: vec![ResolvedInputMessageContent::Text {
-                            value: json!("What is the boiling point of water?"),
+                        content: vec![StoredInputMessageContent::Text {
+                            value: "What is the boiling point of water?".into(),
                         }],
                     }],
                 })
@@ -829,19 +833,18 @@ mod tests {
                 .unwrap(),
             },
             RawExample {
-                input: serde_json::to_string(&ResolvedInput {
+                input: serde_json::to_string(&StoredInput {
                     system: Some(json!({"assistant_name": "Pinocchio"})),
-                    messages: vec![ResolvedInputMessage {
+                    messages: vec![StoredInputMessage {
                         role: Role::User,
                         content: vec![
-                            ResolvedInputMessageContent::Text {
+                            StoredInputMessageContent::Text {
                                 value: json!("What is the name of the capital city of Japan?"),
                             },
-                            ResolvedInputMessageContent::File(Box::new(FileWithPath {
-                                file: Base64File {
+                            StoredInputMessageContent::File(Box::new(StoredFile {
+                                file: Base64FileMetadata {
                                     url: None,
                                     mime_type: mime::IMAGE_PNG,
-                                    data: "ABC".to_string(),
                                 },
                                 storage_path: StoragePath {
                                     kind: StorageKind::Disabled,
@@ -877,12 +880,12 @@ mod tests {
         // Define sample raw examples with serialized Input and Output
         let raw_examples = vec![
             RawExample {
-                input: serde_json::to_string(&ResolvedInput {
+                input: serde_json::to_string(&StoredInput {
                     system: Some(json!({"assistant_name": "Dr. Mehta"})),
-                    messages: vec![ResolvedInputMessage {
+                    messages: vec![StoredInputMessage {
                         role: Role::User,
-                        content: vec![ResolvedInputMessageContent::Text {
-                            value: json!("What is the boiling point of water?"),
+                        content: vec![StoredInputMessageContent::Text {
+                            value: "What is the boiling point of water?".into(),
                         }],
                     }],
                 })
@@ -893,12 +896,12 @@ mod tests {
                 .unwrap(),
             },
             RawExample {
-                input: serde_json::to_string(&ResolvedInput {
+                input: serde_json::to_string(&StoredInput {
                     system: Some(json!({"assistant_name": "Pinocchio"})),
-                    messages: vec![ResolvedInputMessage {
+                    messages: vec![StoredInputMessage {
                         role: Role::User,
-                        content: vec![ResolvedInputMessageContent::Text {
-                            value: json!("What is the name of the capital city of Japan?"),
+                        content: vec![StoredInputMessageContent::Text {
+                            value: "What is the name of the capital city of Japan?".into(),
                         }],
                     }],
                 })
@@ -935,12 +938,12 @@ mod tests {
         // Test that we can parse a JSON example too
         let json_raw_examples = vec![
             RawExample {
-                input: serde_json::to_string(&ResolvedInput {
+                input: serde_json::to_string(&StoredInput {
                     system: Some(json!({"assistant_name": "JsonTester"})),
-                    messages: vec![ResolvedInputMessage {
+                    messages: vec![StoredInputMessage {
                         role: Role::User,
-                        content: vec![ResolvedInputMessageContent::Text {
-                            value: json!("Provide a sample JSON response."),
+                        content: vec![StoredInputMessageContent::Text {
+                            value: "Provide a sample JSON response.".into(),
                         }],
                     }],
                 })
@@ -957,12 +960,12 @@ mod tests {
                 .unwrap(),
             },
             RawExample {
-                input: serde_json::to_string(&ResolvedInput {
+                input: serde_json::to_string(&StoredInput {
                     system: Some(json!({"assistant_name": "JsonTester"})),
-                    messages: vec![ResolvedInputMessage {
+                    messages: vec![StoredInputMessage {
                         role: Role::User,
-                        content: vec![ResolvedInputMessageContent::Text {
-                            value: json!("Provide another JSON response."),
+                        content: vec![StoredInputMessageContent::Text {
+                            value: "Provide another JSON response.".into(),
                         }],
                     }],
                 })

--- a/tensorzero-core/tests/e2e/batch/mod.rs
+++ b/tensorzero-core/tests/e2e/batch/mod.rs
@@ -19,7 +19,7 @@ use tensorzero_core::inference::types::batch::{
     ProviderBatchInferenceOutput, ProviderBatchInferenceResponse, UnparsedBatchRequestRow,
 };
 use tensorzero_core::inference::types::{
-    ContentBlockChatOutput, FinishReason, JsonInferenceOutput, ResolvedInput, Usage,
+    ContentBlockChatOutput, FinishReason, JsonInferenceOutput, StoredInput, Usage,
 };
 use tensorzero_core::jsonschema_util::StaticJSONSchema;
 use tokio::time::{sleep, Duration};
@@ -79,7 +79,7 @@ async fn test_get_batch_request() {
     // Next, we'll insert a BatchModelInferenceRow
     let inference_id = Uuid::now_v7();
     let episode_id = Uuid::now_v7();
-    let input = ResolvedInput {
+    let input = StoredInput {
         system: None,
         messages: vec![],
     };
@@ -90,7 +90,7 @@ async fn test_get_batch_request() {
         function_name: function_name.into(),
         variant_name: variant_name.into(),
         episode_id,
-        input: input.clone().into_stored_input(),
+        input,
         input_messages: vec![],
         system: None,
         tool_params: None,
@@ -218,7 +218,7 @@ async fn write_2_batch_model_inference_rows(
     let function_name = "test_function";
     let variant_name = "test_variant";
     let episode_id = Uuid::now_v7();
-    let input = ResolvedInput {
+    let input = StoredInput {
         system: None,
         messages: vec![],
     };
@@ -230,7 +230,7 @@ async fn write_2_batch_model_inference_rows(
         function_name: function_name.into(),
         variant_name: variant_name.into(),
         episode_id,
-        input: input.clone().into_stored_input(),
+        input: input.clone(),
         input_messages: vec![],
         system: None,
         tool_params: None,
@@ -248,7 +248,7 @@ async fn write_2_batch_model_inference_rows(
         function_name: function_name.into(),
         variant_name: variant_name.into(),
         episode_id,
-        input: input.clone().into_stored_input(),
+        input,
         input_messages: vec![],
         system: None,
         tool_params: None,

--- a/tensorzero-core/tests/e2e/inference.rs
+++ b/tensorzero-core/tests/e2e/inference.rs
@@ -20,6 +20,7 @@ use tensorzero::{
     ClientBuilder, ClientBuilderMode, ClientInferenceParams, ClientInput, ClientInputMessage,
     ClientInputMessageContent, InferenceOutput, InferenceResponse,
 };
+use tensorzero_core::inference::types::StoredInput;
 use tensorzero_core::{
     db::clickhouse::test_helpers::get_clickhouse_replica,
     db::clickhouse::{
@@ -31,8 +32,8 @@ use tensorzero_core::{
     },
     endpoints::inference::ChatInferenceResponse,
     inference::types::{
-        ContentBlock, ContentBlockOutput, File, RequestMessage, ResolvedInput,
-        ResolvedInputMessageContent, Role, Text, TextKind,
+        ContentBlock, ContentBlockOutput, File, RequestMessage, Role, StoredInputMessageContent,
+        Text, TextKind,
     },
     providers::dummy::{
         DUMMY_BAD_TOOL_RESPONSE, DUMMY_INFER_RESPONSE_CONTENT, DUMMY_INFER_RESPONSE_RAW,
@@ -3852,16 +3853,16 @@ async fn test_multiple_text_blocks_in_message() {
 
     // Check that the inference has multiple content blocks
     let input = result.get("input").unwrap().as_str().unwrap();
-    let input: ResolvedInput = serde_json::from_str(input).unwrap();
+    let input: StoredInput = serde_json::from_str(input).unwrap();
     assert_eq!(input.messages.len(), 1);
     assert_eq!(input.messages[0].content.len(), 2);
     assert!(matches!(
         input.messages[0].content[0],
-        ResolvedInputMessageContent::Text { .. }
+        StoredInputMessageContent::Text { .. }
     ));
     assert!(matches!(
         input.messages[0].content[1],
-        ResolvedInputMessageContent::Text { .. }
+        StoredInputMessageContent::Text { .. }
     ));
 }
 

--- a/tensorzero-core/tests/e2e/optimization/dicl.rs
+++ b/tensorzero-core/tests/e2e/optimization/dicl.rs
@@ -2,8 +2,8 @@ use serde_json::json;
 use std::collections::HashMap;
 use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
 use tensorzero_core::inference::types::{
-    ContentBlock, ContentBlockChatOutput, ModelInput, RequestMessage, ResolvedInput,
-    ResolvedInputMessage, ResolvedInputMessageContent, Role, Text,
+    ContentBlock, ContentBlockChatOutput, ModelInput, RequestMessage, Role, StoredInput,
+    StoredInputMessage, StoredInputMessageContent, Text,
 };
 use tensorzero_core::optimization::dicl::insert_dicl_examples_with_batching;
 use tensorzero_core::stored_inference::RenderedSample;
@@ -21,11 +21,11 @@ fn create_test_rendered_sample(input: &str, output: &str) -> RenderedSample {
                 })],
             }],
         },
-        stored_input: ResolvedInput {
+        stored_input: StoredInput {
             system: None,
-            messages: vec![ResolvedInputMessage {
+            messages: vec![StoredInputMessage {
                 role: Role::User,
-                content: vec![ResolvedInputMessageContent::Text {
+                content: vec![StoredInputMessageContent::Text {
                     value: json!(input),
                 }],
             }],

--- a/tensorzero-core/tests/optimization/common/mod.rs
+++ b/tensorzero-core/tests/optimization/common/mod.rs
@@ -17,14 +17,17 @@ use tensorzero_core::{
     db::clickhouse::{ClickHouseConnectionInfo, ClickhouseFormat},
     endpoints::inference::InferenceClients,
     inference::types::{
+        file::Base64FileMetadata,
         resolved_input::FileWithPath,
         storage::{StorageKind, StoragePath},
+        stored_input::StoredFile,
         Base64File, ContentBlock, ContentBlockChatOutput, FunctionType, ModelInferenceRequest,
-        ModelInput, RequestMessage, ResolvedInput, ResolvedInputMessage,
-        ResolvedInputMessageContent, Text,
+        ModelInput, RequestMessage, StoredInput, StoredInputMessage, StoredInputMessageContent,
+        Text,
     },
-    optimization::JobHandle,
-    optimization::{OptimizationJobInfo, Optimizer, OptimizerOutput, UninitializedOptimizerInfo},
+    optimization::{
+        JobHandle, OptimizationJobInfo, Optimizer, OptimizerOutput, UninitializedOptimizerInfo,
+    },
     tool::{Tool, ToolCall, ToolCallConfigDatabaseInsert, ToolCallOutput, ToolChoice, ToolResult},
     variant::JsonMode,
 };
@@ -243,12 +246,12 @@ fn generate_text_example() -> RenderedSample {
                 })],
             }],
         },
-        stored_input: ResolvedInput {
+        stored_input: StoredInput {
             system: Some(json!(system_prompt)),
-            messages: vec![ResolvedInputMessage {
+            messages: vec![StoredInputMessage {
                 role: Role::User,
-                content: vec![ResolvedInputMessageContent::Text {
-                    value: json!("What is the capital of France?"),
+                content: vec![StoredInputMessageContent::Text {
+                    value: "What is the capital of France?".into(),
                 }],
             }],
         },
@@ -323,22 +326,22 @@ fn generate_tool_call_example() -> RenderedSample {
                 },
             ],
         },
-        stored_input: ResolvedInput {
+        stored_input: StoredInput {
             system: Some(json!(system_prompt)),
             messages: vec![
-                ResolvedInputMessage {
+                StoredInputMessage {
                     role: Role::User,
-                    content: vec![ResolvedInputMessageContent::Text {
+                    content: vec![StoredInputMessageContent::Text {
                         value: json!("What is the weather in Paris?"),
                     }],
                 },
-                ResolvedInputMessage {
+                StoredInputMessage {
                     role: Role::Assistant,
                     content: vec![
-                        ResolvedInputMessageContent::Text {
+                        StoredInputMessageContent::Text {
                             value: json!("Let me look that up for you."),
                         },
-                        ResolvedInputMessageContent::ToolCall(ToolCall {
+                        StoredInputMessageContent::ToolCall(ToolCall {
                             name: "get_weather".to_string(),
                             arguments: serde_json::json!({
                                 "location": "Paris"
@@ -348,9 +351,9 @@ fn generate_tool_call_example() -> RenderedSample {
                         }),
                     ],
                 },
-                ResolvedInputMessage {
+                StoredInputMessage {
                     role: Role::User,
-                    content: vec![ResolvedInputMessageContent::ToolResult(ToolResult {
+                    content: vec![StoredInputMessageContent::ToolResult(ToolResult {
                         name: "get_weather".to_string(),
                         result: serde_json::json!({
                             "weather": "sunny, 25 degrees Celsius",
@@ -359,15 +362,15 @@ fn generate_tool_call_example() -> RenderedSample {
                         id: "call_1".to_string(),
                     })],
                 },
-                ResolvedInputMessage {
+                StoredInputMessage {
                     role: Role::Assistant,
-                    content: vec![ResolvedInputMessageContent::Text {
+                    content: vec![StoredInputMessageContent::Text {
                         value: json!("The weather in Paris is sunny, 25 degrees Celsius."),
                     }],
                 },
-                ResolvedInputMessage {
+                StoredInputMessage {
                     role: Role::User,
-                    content: vec![ResolvedInputMessageContent::Text {
+                    content: vec![StoredInputMessageContent::Text {
                         value: json!("What is the weather in London?"),
                     }],
                 },
@@ -443,19 +446,18 @@ fn generate_image_example() -> RenderedSample {
                 ],
             }],
         },
-        stored_input: ResolvedInput {
+        stored_input: StoredInput {
             system: Some(json!(system_prompt)),
-            messages: vec![ResolvedInputMessage {
+            messages: vec![StoredInputMessage {
                 role: Role::User,
                 content: vec![
-                    ResolvedInputMessageContent::Text {
+                    StoredInputMessageContent::Text {
                         value: json!("What is the main color of this image?"),
                     },
-                    ResolvedInputMessageContent::File(Box::new(FileWithPath {
-                        file: Base64File {
+                    StoredInputMessageContent::File(Box::new(StoredFile {
+                        file: Base64FileMetadata {
                             url: None,
                             mime_type: mime::IMAGE_PNG,
-                            data: base64::prelude::BASE64_STANDARD.encode(FERRIS_PNG),
                         },
                         storage_path: StoragePath {
                             kind: StorageKind::Disabled,


### PR DESCRIPTION
This caught several places where we should have been used `StoredInput`. The only way to construct a `ResolvedInput` type is through calling `resolve` or `reresolve`