### PR TITLE
Disable parallel_tool_calls for multi_hop_rag_agent in tests

### DIFF
--- a/tensorzero-core/tests/e2e/tensorzero.toml
+++ b/tensorzero-core/tests/e2e/tensorzero.toml
@@ -3384,7 +3384,7 @@ json_mode = "strict"
 type = "chat"
 tools = ["think", "search_wikipedia", "load_wikipedia_page", "answer_question"]
 tool_choice = "required"
-parallel_tool_calls = true
+parallel_tool_calls = false
 
 [functions.multi_hop_rag_agent.variants.baseline]
 type = "chat_completion"

--- a/ui/fixtures/config/tensorzero.e2e.toml
+++ b/ui/fixtures/config/tensorzero.e2e.toml
@@ -211,7 +211,7 @@ retries = { num_retries = 4, max_delay_s = 10 }
 type = "chat"
 tools = ["think", "search_wikipedia", "load_wikipedia_page", "answer_question"]
 tool_choice = "required"
-parallel_tool_calls = true
+parallel_tool_calls = false
 
 [functions.multi_hop_rag_agent.variants.baseline]
 type = "chat_completion"

--- a/ui/fixtures/config/tensorzero.toml
+++ b/ui/fixtures/config/tensorzero.toml
@@ -197,7 +197,7 @@ model = "openai::gpt-4o-mini-2024-07-18"
 type = "chat"
 tools = ["think", "search_wikipedia", "load_wikipedia_page", "answer_question"]
 tool_choice = "required"
-parallel_tool_calls = true
+parallel_tool_calls = false
 
 [functions.multi_hop_rag_agent.variants.baseline]
 type = "chat_completion"


### PR DESCRIPTION
The model can nondeterministically output either one or two 'think' calls, which changes the number of judge calls that we make. This results in an inconsistent number of rows in the model inference cache, causing our regen tests to fail
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disables `parallel_tool_calls` for `multi_hop_rag_agent` in test configurations to prevent nondeterministic outputs affecting test consistency.
> 
>   - **Behavior**:
>     - Disables `parallel_tool_calls` for `multi_hop_rag_agent` in `tensorzero-core/tests/e2e/tensorzero.toml`, `tensorzero.e2e.toml`, and `tensorzero.toml` to prevent nondeterministic outputs affecting test consistency.
>   - **Reason**:
>     - The model could output one or two 'think' calls, leading to inconsistent judge calls and model inference cache rows, causing test failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3ac74a77dbdbfb3956b089ced6d0dfb761c0c228. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->