### PR TITLE
Launch ClickHouse server when running optimization-test cron

### DIFF
--- a/.github/workflows/optimization-test-cron.yml
+++ b/.github/workflows/optimization-test-cron.yml
@@ -52,8 +52,16 @@ jobs:
         with:
           tool: cargo-nextest
 
+      - name: Launch ClickHouse container for optimization tests
+        run: docker compose -f tensorzero-core/tests/optimization/docker-compose.yml up --wait
+
       - name: Run optimization tests
-        run: cargo test-optimization --nocapture --no-fail-fast
+        run: TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@localhost:8123/tensorzero_e2e_tests cargo test-optimization --nocapture --no-fail-fast
+
+      - name: Print ClickHouse container logs
+        if: always()
+        continue-on-error: true
+        run: docker compose -f tensorzero-core/tests/optimization/docker-compose.yml logs -t
 
       - name: Log test completion
         if: always()

--- a/tensorzero-core/tests/optimization/common/mod.rs
+++ b/tensorzero-core/tests/optimization/common/mod.rs
@@ -13,7 +13,7 @@ use tensorzero::{
 use tensorzero_core::{
     cache::CacheOptions,
     config::{Config, ConfigFileGlob, ProviderTypesConfig},
-    db::clickhouse::test_helpers::{get_clickhouse, CLICKHOUSE_URL},
+    db::clickhouse::test_helpers::CLICKHOUSE_URL,
     db::clickhouse::{ClickHouseConnectionInfo, ClickhouseFormat},
     endpoints::inference::InferenceClients,
     inference::types::{
@@ -66,9 +66,29 @@ pub async fn run_test_case(test_case: &impl OptimizationTestCase) {
     let test_examples = get_examples(test_case, 10);
     let val_examples = Some(get_examples(test_case, 10));
     let credentials: HashMap<String, secrecy::SecretBox<str>> = HashMap::new();
-    let clickhouse = get_clickhouse().await;
+
     let mut config_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     config_path.push("tests/e2e/tensorzero.toml");
+
+    // Create an embedded client so that we run migrations
+    let tensorzero_client =
+        tensorzero::ClientBuilder::new(tensorzero::ClientBuilderMode::EmbeddedGateway {
+            config_file: Some(config_path.clone()),
+            clickhouse_url: Some(CLICKHOUSE_URL.clone()),
+            timeout: None,
+            verify_credentials: true,
+            allow_batch_writes: true,
+        })
+        .build()
+        .await
+        .unwrap();
+
+    let clickhouse = tensorzero_client
+        .get_app_state_data()
+        .unwrap()
+        .clickhouse_connection_info
+        .clone();
+
     let config_glob = ConfigFileGlob::new_from_path(&config_path).unwrap();
     let config = Config::load_from_path_optional_verify_credentials(
         &config_glob,

--- a/tensorzero-core/tests/optimization/docker-compose.yml
+++ b/tensorzero-core/tests/optimization/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  clickhouse:
+    image: clickhouse/clickhouse-server:${TENSORZERO_CLICKHOUSE_VERSION:-24.12-alpine}
+    environment:
+      CLICKHOUSE_USER: chuser
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+      CLICKHOUSE_PASSWORD: chpassword
+    ports:
+      - "8123:8123" # HTTP port
+      - "9000:9000" # Native port
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    healthcheck:
+      test: wget --spider --tries 1 http://chuser:chpassword@clickhouse:8123/ping
+      start_period: 30s
+      start_interval: 1s
+      timeout: 1s


### PR DESCRIPTION
The dicl tests need a ClickHouse server available
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add ClickHouse server setup to optimization test workflow with Docker Compose configuration.
> 
>   - **Workflow Changes**:
>     - Add step to launch ClickHouse container in `optimization-test-cron.yml` using `docker-compose.yml`.
>     - Set `TENSORZERO_CLICKHOUSE_URL` environment variable for tests.
>     - Add step to print ClickHouse logs after tests.
>   - **Code Changes**:
>     - Remove `get_clickhouse()` call in `run_test_case()` in `common/mod.rs`.
>     - Use `tensorzero::ClientBuilder` to create ClickHouse client in `common/mod.rs`.
>   - **New Files**:
>     - Add `docker-compose.yml` for ClickHouse configuration in `tests/optimization`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8daa6a84fc83a91184b0a3d11bfeb8bedffa4bff. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->