### PR TITLE
bumped version to 2025.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2025.8.5"
+version = "2025.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2025.8.5"
+version = "2025.9.0"
 dependencies = [
  "axum",
  "clap",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2025.8.5"
+version = "2025.9.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4912,7 +4912,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2025.8.5"
+version = "2025.9.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -4925,7 +4925,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.8.5"
+version = "2025.9.0"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2025.8.5"
+version = "2025.9.0"
 rust-version = "1.86.0"
 license = "Apache-2.0"
 

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.1
-appVersion: "2025.8.5"
+appVersion: "2025.9.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2025.8.5",
+  "version": "2025.9.0",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump version to 2025.9.0 across multiple components including Rust packages and UI package.
> 
>   - **Version Bump**:
>     - Update version to `2025.9.0` for `evaluations`, `gateway`, `tensorzero-core`, `tensorzero-node`, and `tensorzero-python` in `Cargo.lock`.
>     - Update workspace version to `2025.9.0` in `Cargo.toml`.
>     - Update `appVersion` to `2025.9.0` in `Chart.yaml`.
>     - Update UI package version to `2025.9.0` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7ac1581ab267b0328ced0e7cd163da5ce22776f3. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->