### PR TITLE
Retry entire regenerate-model-inference-cache.sh script on failure

### DIFF
--- a/.github/workflows/ui-tests-e2e-model-inference-cache.yml
+++ b/.github/workflows/ui-tests-e2e-model-inference-cache.yml
@@ -112,7 +112,19 @@ jobs:
           echo "S3_SECRET_ACCESS_KEY=${{ secrets.S3_SECRET_ACCESS_KEY }}" >> fixtures/.env-gateway
           # Save the old cache file for comparison
           cp ./fixtures/model_inference_cache_e2e.jsonl ./fixtures/model_inference_cache_e2e.jsonl.old
-          ./fixtures/regenerate-model-inference-cache.sh
+          # Run up to 3 times if it fails. We need to retry *outside* of playwright, so that we wipe the
+          # model inference cache each time. Retrying an individual playwright test without wiping the database
+          # will pollute the cache with duplicate entries.
+          for i in {1..3}; do
+            if ./fixtures/regenerate-model-inference-cache.sh; then
+              break
+            elif [ $i -eq 3 ]; then
+              echo "Failed after 3 attempts"
+              exit 1
+            else
+              echo "Attempt $i failed, retrying..."
+            fi
+          done
           # Check that the old and new cache files have the same number of rows
           OLD_ROWS=$(wc -l < ./fixtures/model_inference_cache_e2e.jsonl.old)
           NEW_ROWS=$(wc -l < ./fixtures/model_inference_cache_e2e.jsonl)

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -277,7 +277,7 @@ jobs:
   ui-tests-e2e-existing-model-inference-cache:
     uses: ./.github/workflows/ui-tests-e2e-model-inference-cache.yml
     with:
-      regen_cache: true
+      regen_cache: false
     secrets:
       S3_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       S3_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -277,7 +277,7 @@ jobs:
   ui-tests-e2e-existing-model-inference-cache:
     uses: ./.github/workflows/ui-tests-e2e-model-inference-cache.yml
     with:
-      regen_cache: false
+      regen_cache: true
     secrets:
       S3_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       S3_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/ui/fixtures/regenerate-model-inference-cache.sh
+++ b/ui/fixtures/regenerate-model-inference-cache.sh
@@ -10,5 +10,6 @@ OPENAI_BASE_URL=http://mock-inference-provider:3030/openai/ FIREWORKS_BASE_URL=h
 docker compose -f ./fixtures/docker-compose.e2e.yml -f ./fixtures/docker-compose.ui.yml wait fixtures
 # Wipe the ModelInferenceCache table to ensure that we regenerate everything
 docker run --add-host=host.docker.internal:host-gateway clickhouse/clickhouse-server clickhouse-client --host host.docker.internal --user chuser --password chpassword --database tensorzero_ui_fixtures 'TRUNCATE TABLE ModelInferenceCache SYNC'
-TENSORZERO_PLAYWRIGHT_NO_WEBSERVER=1 TENSORZERO_GATEWAY_URL=http://localhost:3000 TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@localhost:8123/tensorzero_ui_fixtures pnpm test-e2e -j 1 --grep-invert "@credentials"
+# Don't use any retries, since this will pollute the model inference cache with duplicate entries.
+TENSORZERO_PLAYWRIGHT_RETRIES=0 TENSORZERO_PLAYWRIGHT_NO_WEBSERVER=1 TENSORZERO_GATEWAY_URL=http://localhost:3000 TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@localhost:8123/tensorzero_ui_fixtures pnpm test-e2e -j 1 --grep-invert "@credentials"
 docker run --add-host=host.docker.internal:host-gateway clickhouse/clickhouse-server clickhouse-client --host host.docker.internal --user chuser --password chpassword --database tensorzero_ui_fixtures 'SELECT * FROM ModelInferenceCache ORDER BY long_cache_key ASC FORMAT JSONEachRow' > ./fixtures/model_inference_cache_e2e.jsonl

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.TENSORZERO_CI,
   /* Retry on CI only */
-  retries: process.env.TENSORZERO_CI ? 2 : 0,
+  retries: process.env.TENSORZERO_PLAYWRIGHT_RETRIES ? parseInt(process.env.TENSORZERO_PLAYWRIGHT_RETRIES) : (process.env.TENSORZERO_CI ? 2 : 0),
   /* Opt out of parallel tests on CI. */
   workers: process.env.TENSORZERO_CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -15,7 +15,11 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.TENSORZERO_CI,
   /* Retry on CI only */
-  retries: process.env.TENSORZERO_PLAYWRIGHT_RETRIES ? parseInt(process.env.TENSORZERO_PLAYWRIGHT_RETRIES) : (process.env.TENSORZERO_CI ? 2 : 0),
+  retries: process.env.TENSORZERO_PLAYWRIGHT_RETRIES
+    ? parseInt(process.env.TENSORZERO_PLAYWRIGHT_RETRIES)
+    : process.env.TENSORZERO_CI
+      ? 2
+      : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.TENSORZERO_CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */


### PR DESCRIPTION
We can't retry individual playwright tests within Playwright, as this will pollute the database with duplicate model inference cache entries
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Retry `regenerate-model-inference-cache.sh` script up to 3 times on failure to prevent database pollution, with Playwright retries set to zero.
> 
>   - **Retry Mechanism**:
>     - In `.github/workflows/ui-tests-e2e-model-inference-cache.yml`, the `regenerate-model-inference-cache.sh` script is retried up to 3 times on failure to avoid database pollution.
>     - Logs attempts and exits after 3 failures.
>   - **Playwright Configuration**:
>     - In `playwright.config.ts`, `retries` is set via `TENSORZERO_PLAYWRIGHT_RETRIES` environment variable.
>     - `regenerate-model-inference-cache.sh` sets `TENSORZERO_PLAYWRIGHT_RETRIES=0` to prevent retries within Playwright.
>   - **Misc**:
>     - Minor changes in `regenerate-model-inference-cache.sh` to ensure no retries within Playwright tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2156f562c20adda1035feba59db809849ffd0805. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->