### PR TITLE
Add missing 'json_mode' to 04-email-data-extraction example

### DIFF
--- a/examples/tutorial/04-email-data-extraction/config/tensorzero.toml
+++ b/examples/tutorial/04-email-data-extraction/config/tensorzero.toml
@@ -26,3 +26,4 @@ type = "chat_completion"
 weight = 1
 model = "my_gpt_4o_mini"
 system_template = "functions/extract_email/simple_variant/system.minijinja"
+json_mode = "strict"


### PR DESCRIPTION
We need to investigate why this wasn't caught by the 'check-latest-docker-compose' job
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add missing `json_mode` to `tensorzero.toml` in `04-email-data-extraction` example and note investigation for CI job oversight.
> 
>   - **Configuration**:
>     - Add `json_mode = "strict"` to `functions.extract_email.variants.simple_variant` in `tensorzero.toml` for `04-email-data-extraction` example.
>   - **Investigation**:
>     - Note to investigate why 'check-latest-docker-compose' job didn't catch the missing `json_mode`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a83703cd7595ccb55660daaa3c5b814003223ab5. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->