### PR TITLE
Provide defaults for individual fields in 'retries' config

### DIFF
--- a/tensorzero-core/src/variant/mod.rs
+++ b/tensorzero-core/src/variant/mod.rs
@@ -754,17 +754,27 @@ async fn infer_model_request_stream<'request>(
 #[derive(Debug, Deserialize, Copy, Clone, Serialize, ts_rs::TS)]
 #[ts(export)]
 pub struct RetryConfig {
+    #[serde(default = "default_num_retries")]
     pub num_retries: usize,
+    #[serde(default = "default_max_delay_s")]
     pub max_delay_s: f32,
 }
 
 impl Default for RetryConfig {
     fn default() -> Self {
         RetryConfig {
-            num_retries: 0,
-            max_delay_s: 10.0,
+            num_retries: default_num_retries(),
+            max_delay_s: default_max_delay_s(),
         }
     }
+}
+
+fn default_num_retries() -> usize {
+    0
+}
+
+fn default_max_delay_s() -> f32 {
+    10.0
 }
 
 impl RetryConfig {

--- a/ui/fixtures/config/tensorzero.e2e.toml
+++ b/ui/fixtures/config/tensorzero.e2e.toml
@@ -58,7 +58,7 @@ type = "chat_completion"
 model = "gpt-4o-mini-2024-07-18"
 system_template = "functions/extract_entities/initial_prompt/system_template.minijinja"
 json_mode = "strict"
-retries = { num_retries = 4, max_delay_s = 10 }
+retries = { num_retries = 4 }
 temperature = 0
 
 [functions.extract_entities.variants.gpt4o_initial_prompt]


### PR DESCRIPTION
Fixes #3413
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Provide default values for `num_retries` and `max_delay_s` in `RetryConfig` and update `tensorzero.e2e.toml` to use these defaults.
> 
>   - **Behavior**:
>     - `RetryConfig` struct in `mod.rs` now uses `serde` to provide default values for `num_retries` and `max_delay_s` using `default_num_retries` and `default_max_delay_s` functions.
>     - Removed `max_delay_s` from `retries` in `tensorzero.e2e.toml` for `functions.extract_entities.variants.gpt4o_mini_initial_prompt`, relying on default.
>   - **Functions**:
>     - Added `default_num_retries()` returning `0`.
>     - Added `default_max_delay_s()` returning `10.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 34806c04ed89dfd944c54693969990e4329fe63d. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->