### PR TITLE
Test that TensorZeroGateway.build_http does not emit warnings

### DIFF
--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -35,6 +35,7 @@ import pytest
 import tensorzero
 from clickhouse_connect import get_client  # type: ignore
 from openai import AsyncOpenAI, OpenAI
+from pytest import CaptureFixture
 from tensorzero import (
     AsyncTensorZeroGateway,
     ChatInferenceResponse,
@@ -3396,7 +3397,7 @@ async def test_async_cannot_enable_batch_writes():
         )
 
 
-def test_http_client_no_spurious_log(capfd):
+def test_http_client_no_spurious_log(capfd: CaptureFixture[str]):
     client = TensorZeroGateway.build_http(
         gateway_url="http://localhost:3000",
         verbose_errors=True,
@@ -3408,11 +3409,12 @@ def test_http_client_no_spurious_log(capfd):
 
 
 @pytest.mark.asyncio
-async def test_async_http_client_no_spurious_log(capfd):
+async def test_async_http_client_no_spurious_log(capfd: CaptureFixture[str]):
     client_fut = AsyncTensorZeroGateway.build_http(
         gateway_url="http://localhost:3000",
         verbose_errors=True,
     )
+    assert inspect.isawaitable(client_fut)
     client = await client_fut
     assert client is not None
     captured = capfd.readouterr()
@@ -3420,7 +3422,7 @@ async def test_async_http_client_no_spurious_log(capfd):
     assert captured.out == ""
 
 
-def test_embedded_client_no_spurious_log(capfd):
+def test_embedded_client_no_spurious_log(capfd: CaptureFixture[str]):
     client = TensorZeroGateway.build_embedded(
         config_file=TEST_CONFIG_FILE,
         clickhouse_url="http://chuser:chpassword@localhost:8123/tensorzero-python-e2e",
@@ -3432,11 +3434,12 @@ def test_embedded_client_no_spurious_log(capfd):
 
 
 @pytest.mark.asyncio
-async def test_async_embedded_client_no_spurious_log(capfd):
+async def test_async_embedded_client_no_spurious_log(capfd: CaptureFixture[str]):
     client_fut = AsyncTensorZeroGateway.build_embedded(
         config_file=TEST_CONFIG_FILE,
         clickhouse_url="http://chuser:chpassword@localhost:8123/tensorzero-python-e2e",
     )
+    assert inspect.isawaitable(client_fut)
     client = await client_fut
     assert client is not None
     captured = capfd.readouterr()
@@ -3444,7 +3447,7 @@ async def test_async_embedded_client_no_spurious_log(capfd):
     assert captured.out == ""
 
 
-def test_capfd_captured_warnings(capfd):
+def test_capfd_captured_warnings(capfd: CaptureFixture[str]):
     client = TensorZeroGateway.build_embedded()
     assert client is not None
     captured = capfd.readouterr()


### PR DESCRIPTION
Fixes #3383

We're using the pytest 'capfd' fixture, which captures at the file-descriptor level (which allows it to capture messages logged from Rust)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add tests to ensure `TensorZeroGateway` and `AsyncTensorZeroGateway` client builds do not emit spurious logs or warnings using `pytest` `capfd` fixture.
> 
>   - **Tests**:
>     - Add `test_http_client_no_spurious_log` to verify `TensorZeroGateway.build_http` does not emit warnings or logs.
>     - Add `test_async_http_client_no_spurious_log` for `AsyncTensorZeroGateway.build_http`.
>     - Add `test_embedded_client_no_spurious_log` for `TensorZeroGateway.build_embedded`.
>     - Add `test_async_embedded_client_no_spurious_log` for `AsyncTensorZeroGateway.build_embedded`.
>     - Add `test_capfd_captured_warnings` to check for specific warning messages.
>   - **Fixtures**:
>     - Use `pytest` `capfd` fixture to capture stdout and stderr in tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ae47ba3425159452cbf1e00961448292011af325. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->