### PR TITLE
Gate ResolvedInput 'Serialized' impl behind 'pyo3' feature

### DIFF
--- a/tensorzero-core/src/inference/types/resolved_input.rs
+++ b/tensorzero-core/src/inference/types/resolved_input.rs
@@ -20,7 +20,7 @@ use pyo3::prelude::*;
 /// Currently, this is just used to fetch image URLs in the image input,
 /// so that we always pass a base64-encoded image to the model provider.
 #[derive(Clone, Debug, PartialEq)]
-// TODO - should we remove the Serialize impl entirely, rather than rely it on
+// TODO - should we remove the Serialize impl entirely, rather than rely on it
 // for the Pyo3 'str' impl?
 #[cfg_attr(feature = "pyo3", derive(Serialize))]
 #[cfg_attr(feature = "pyo3", serde(deny_unknown_fields))]
@@ -77,7 +77,7 @@ impl ResolvedInput {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-// TODO - should we remove the Serialize impl entirely, rather than rely it on
+// TODO - should we remove the Serialize impl entirely, rather than rely on it
 // for the Pyo3 'str' impl?
 #[cfg_attr(feature = "pyo3", derive(Serialize))]
 #[cfg_attr(feature = "pyo3", serde(deny_unknown_fields))]
@@ -135,7 +135,7 @@ impl ResolvedInputMessage {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-// TODO - should we remove the Serialize impl entirely, rather than rely it on
+// TODO - should we remove the Serialize impl entirely, rather than rely on it
 // for the Pyo3 'str' impl?
 #[cfg_attr(feature = "pyo3", derive(Serialize))]
 #[cfg_attr(feature = "pyo3", serde(tag = "type", rename_all = "snake_case"))]

--- a/tensorzero-core/src/inference/types/resolved_input.rs
+++ b/tensorzero-core/src/inference/types/resolved_input.rs
@@ -19,16 +19,19 @@ use pyo3::prelude::*;
 /// Like `Input`, but with all network resources resolved.
 /// Currently, this is just used to fetch image URLs in the image input,
 /// so that we always pass a base64-encoded image to the model provider.
-#[derive(Clone, Debug, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, PartialEq)]
+// TODO - should we remove the Serialize impl entirely, rather than rely it on
+// for the Pyo3 'str' impl?
+#[cfg_attr(feature = "pyo3", derive(Serialize))]
+#[cfg_attr(feature = "pyo3", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "pyo3", pyclass(str))]
 #[cfg_attr(test, derive(ts_rs::TS))]
 #[cfg_attr(test, ts(export))]
 pub struct ResolvedInput {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "pyo3", serde(skip_serializing_if = "Option::is_none"))]
     pub system: Option<Value>,
 
-    #[serde(default)]
+    #[cfg_attr(feature = "pyo3", serde(default))]
     pub messages: Vec<ResolvedInputMessage>,
 }
 
@@ -47,6 +50,7 @@ impl ResolvedInput {
     }
 }
 
+#[cfg(feature = "pyo3")]
 impl std::fmt::Display for ResolvedInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let json = serde_json::to_string_pretty(self).map_err(|_| std::fmt::Error)?;
@@ -72,8 +76,11 @@ impl ResolvedInput {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, PartialEq)]
+// TODO - should we remove the Serialize impl entirely, rather than rely it on
+// for the Pyo3 'str' impl?
+#[cfg_attr(feature = "pyo3", derive(Serialize))]
+#[cfg_attr(feature = "pyo3", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "pyo3", pyclass(str))]
 #[cfg_attr(test, derive(ts_rs::TS))]
 #[cfg_attr(test, ts(export))]
@@ -95,6 +102,7 @@ impl ResolvedInputMessage {
     }
 }
 
+#[cfg(feature = "pyo3")]
 impl std::fmt::Display for ResolvedInputMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let json = serde_json::to_string_pretty(self).map_err(|_| std::fmt::Error)?;
@@ -126,8 +134,11 @@ impl ResolvedInputMessage {
     }
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[derive(Clone, Debug, PartialEq)]
+// TODO - should we remove the Serialize impl entirely, rather than rely it on
+// for the Pyo3 'str' impl?
+#[cfg_attr(feature = "pyo3", derive(Serialize))]
+#[cfg_attr(feature = "pyo3", serde(tag = "type", rename_all = "snake_case"))]
 #[cfg_attr(test, derive(ts_rs::TS))]
 #[cfg_attr(test, ts(export))]
 pub enum ResolvedInputMessageContent {
@@ -140,7 +151,7 @@ pub enum ResolvedInputMessageContent {
         value: String,
     },
     Thought(Thought),
-    #[serde(alias = "image")]
+    #[cfg_attr(feature = "pyo3", serde(alias = "image"))]
     File(Box<FileWithPath>),
     Unknown {
         data: Value,

--- a/tensorzero-core/src/inference/types/resolved_input.rs
+++ b/tensorzero-core/src/inference/types/resolved_input.rs
@@ -22,16 +22,19 @@ use pyo3::prelude::*;
 #[derive(Clone, Debug, PartialEq)]
 // TODO - should we remove the Serialize impl entirely, rather than rely on it
 // for the Pyo3 'str' impl?
-#[cfg_attr(feature = "pyo3", derive(Serialize))]
-#[cfg_attr(feature = "pyo3", serde(deny_unknown_fields))]
+#[cfg_attr(any(feature = "pyo3", test), derive(Serialize))]
+#[cfg_attr(any(feature = "pyo3", test), serde(deny_unknown_fields))]
 #[cfg_attr(feature = "pyo3", pyclass(str))]
 #[cfg_attr(test, derive(ts_rs::TS))]
 #[cfg_attr(test, ts(export))]
 pub struct ResolvedInput {
-    #[cfg_attr(feature = "pyo3", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(
+        any(feature = "pyo3", test),
+        serde(skip_serializing_if = "Option::is_none")
+    )]
     pub system: Option<Value>,
 
-    #[cfg_attr(feature = "pyo3", serde(default))]
+    #[cfg_attr(any(feature = "pyo3", test), serde(default))]
     pub messages: Vec<ResolvedInputMessage>,
 }
 
@@ -79,8 +82,8 @@ impl ResolvedInput {
 #[derive(Clone, Debug, PartialEq)]
 // TODO - should we remove the Serialize impl entirely, rather than rely on it
 // for the Pyo3 'str' impl?
-#[cfg_attr(feature = "pyo3", derive(Serialize))]
-#[cfg_attr(feature = "pyo3", serde(deny_unknown_fields))]
+#[cfg_attr(any(feature = "pyo3", test), derive(Serialize))]
+#[cfg_attr(any(feature = "pyo3", test), serde(deny_unknown_fields))]
 #[cfg_attr(feature = "pyo3", pyclass(str))]
 #[cfg_attr(test, derive(ts_rs::TS))]
 #[cfg_attr(test, ts(export))]
@@ -137,8 +140,8 @@ impl ResolvedInputMessage {
 #[derive(Clone, Debug, PartialEq)]
 // TODO - should we remove the Serialize impl entirely, rather than rely on it
 // for the Pyo3 'str' impl?
-#[cfg_attr(feature = "pyo3", derive(Serialize))]
-#[cfg_attr(feature = "pyo3", serde(tag = "type", rename_all = "snake_case"))]
+#[cfg_attr(any(feature = "pyo3", test), derive(Serialize))]
+#[cfg_attr(any(feature = "pyo3", test), serde(tag = "type", rename_all = "snake_case"))]
 #[cfg_attr(test, derive(ts_rs::TS))]
 #[cfg_attr(test, ts(export))]
 pub enum ResolvedInputMessageContent {
@@ -151,7 +154,7 @@ pub enum ResolvedInputMessageContent {
         value: String,
     },
     Thought(Thought),
-    #[cfg_attr(feature = "pyo3", serde(alias = "image"))]
+    #[cfg_attr(any(feature = "pyo3", test), serde(alias = "image"))]
     File(Box<FileWithPath>),
     Unknown {
         data: Value,

--- a/tensorzero-core/src/inference/types/resolved_input.rs
+++ b/tensorzero-core/src/inference/types/resolved_input.rs
@@ -141,7 +141,10 @@ impl ResolvedInputMessage {
 // TODO - should we remove the Serialize impl entirely, rather than rely on it
 // for the Pyo3 'str' impl?
 #[cfg_attr(any(feature = "pyo3", test), derive(Serialize))]
-#[cfg_attr(any(feature = "pyo3", test), serde(tag = "type", rename_all = "snake_case"))]
+#[cfg_attr(
+    any(feature = "pyo3", test),
+    serde(tag = "type", rename_all = "snake_case")
+)]
 #[cfg_attr(test, derive(ts_rs::TS))]
 #[cfg_attr(test, ts(export))]
 pub enum ResolvedInputMessageContent {

--- a/tensorzero-core/src/variant/dicl.rs
+++ b/tensorzero-core/src/variant/dicl.rs
@@ -316,13 +316,14 @@ impl DiclConfig {
         function: &FunctionConfig,
     ) -> Result<(Vec<Example>, EmbeddingResponseWithMetadata), Error> {
         // Serialize the input so that it can be embedded
-        let serialized_input = serde_json::to_string(&input).map_err(|e| {
-            Error::new(ErrorDetails::Serialization {
-                message: format!(
-                    "Error in serializing Input in dynamic in-context learning variant: {e}"
-                ),
-            })
-        })?;
+        let serialized_input =
+            serde_json::to_string(&input.clone().into_stored_input()).map_err(|e| {
+                Error::new(ErrorDetails::Serialization {
+                    message: format!(
+                        "Error in serializing Input in dynamic in-context learning variant: {e}"
+                    ),
+                })
+            })?;
 
         let embedding_model = embedding_models
             .get(&self.embedding_model)
@@ -459,7 +460,7 @@ impl DiclConfig {
     }
 
     fn prepare_input_message(input: &ResolvedInput) -> Result<RequestMessage, Error> {
-        let content = vec![serde_json::to_string(&input)
+        let content = vec![serde_json::to_string(&input.clone().into_stored_input())
             .map_err(|e| {
                 Error::new(ErrorDetails::Serialization {
                     message: format!(

--- a/tensorzero-core/src/variant/dicl.rs
+++ b/tensorzero-core/src/variant/dicl.rs
@@ -809,7 +809,8 @@ mod tests {
         assert_eq!(request_message.role, Role::User);
 
         // The content should contain the serialized Input as a Text ContentBlock
-        let expected_serialized_input = serde_json::to_string(&input_data).unwrap();
+        let expected_serialized_input =
+            serde_json::to_string(&input_data.clone().into_stored_input()).unwrap();
         let expected_content = vec![ContentBlock::Text(Text {
             text: expected_serialized_input.clone(),
         })];

--- a/tensorzero-core/tests/e2e/dicl.rs
+++ b/tensorzero-core/tests/e2e/dicl.rs
@@ -374,7 +374,9 @@ async fn embed_insert_example(
 
     let client = Client::new();
     let request = EmbeddingRequest {
-        input: serde_json::to_string(&input).unwrap().into(),
+        input: serde_json::to_string(&input.clone().into_stored_input())
+            .unwrap()
+            .into(),
         dimensions: None,
         encoding_format: EmbeddingEncodingFormat::Float,
     };
@@ -387,7 +389,7 @@ async fn embed_insert_example(
     let id = Uuid::now_v7();
     let embedding = &response.embeddings[0];
 
-    let input_string = serde_json::to_string(&input).unwrap();
+    let input_string = serde_json::to_string(&input.clone().into_stored_input()).unwrap();
     let row = serde_json::json!({
         "id": id,
         "function_name": function_name,


### PR DESCRIPTION
This prevents us from using it in the rest of the codebase, while still allowing us to implement the python 'str' method
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Gate `Serialize` implementation of `ResolvedInput` and related structs behind `pyo3` feature, updating serialization logic in `dicl.rs`.
> 
>   - **Behavior**:
>     - Gate `Serialize` implementation of `ResolvedInput`, `ResolvedInputMessage`, and `ResolvedInputMessageContent` behind `pyo3` feature in `resolved_input.rs`.
>     - Use `into_stored_input()` for serialization in `dicl.rs` to ensure compatibility with the new gating.
>   - **Functions**:
>     - Modify `prepare_input_message()` and `retrieve_relevant_examples()` in `dicl.rs` to use `into_stored_input()` for serialization.
>   - **Tests**:
>     - Update tests in `dicl.rs` and `e2e/dicl.rs` to reflect changes in serialization behavior.
>     - Ensure tests handle serialization correctly with the `pyo3` feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0be4634fb4801f51f1a734ba6649eaa6466c3d38. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->