### PR TITLE
Disable Dependabot for educational content

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,11 @@ updates:
       interval: "weekly"
     labels: []
     open-pull-requests-limit: 0 # only send security updates
+    # These paths contain educational content that is not directly meant for production use.
+    # Automatic upgrades are likely to break them over time as they're not actively tested.
+    exclude-paths:
+      - "examples/**"
+      - "recipes/**"
 
   - package-ecosystem: "cargo"
     directory: "/"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `exclude-paths` for educational content in Dependabot config to prevent automatic updates.
> 
>   - **Dependabot Configuration**:
>     - Added `exclude-paths` for `examples/**` and `recipes/**` in `.github/dependabot.yml` under the `uv` package-ecosystem.
>     - Prevents automatic updates for educational content not meant for production.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7f5a5bd4b84ce322998ed1a159e7c6e1bd792022. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->