### PR TITLE
dont run buildkite for external PRs

### DIFF
--- a/.github/workflows/buildkite-merge-queue.yml
+++ b/.github/workflows/buildkite-merge-queue.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   merge-queue-tests:
     runs-on: ubuntu-latest
-    if: github.repository == 'tensorzero/tensorzero' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.repository == 'tensorzero/tensorzero'
     steps:
       - name: Trigger a Buildkite Build on Push using v2.0.0
         uses: buildkite/trigger-pipeline-action@v2.0.0

--- a/.github/workflows/buildkite-merge-queue.yml
+++ b/.github/workflows/buildkite-merge-queue.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   merge-queue-tests:
     runs-on: ubuntu-latest
-    if: github.repository == 'tensorzero/tensorzero'
+    if: github.repository == 'tensorzero/tensorzero' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Trigger a Buildkite Build on Push using v2.0.0
         uses: buildkite/trigger-pipeline-action@v2.0.0

--- a/.github/workflows/buildkite-test-suite.yml
+++ b/.github/workflows/buildkite-test-suite.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   unit-tests:
-    if: github.repository == 'tensorzero/tensorzero'
+    if: github.repository == 'tensorzero/tensorzero' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - name: Trigger a Buildkite Build on Push using v2.0.0


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevent Buildkite builds for external pull requests in `buildkite-test-suite.yml`.
> 
>   - **Behavior**:
>     - Modify `unit-tests` job in `.github/workflows/buildkite-test-suite.yml` to prevent Buildkite builds for external pull requests.
>     - Adds condition to `if` statement: `github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 397c3c94efaead7cf53b5ff98e56f0e1c02dd139. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->