### PR TITLE
fixed hardcoded base url for rft tests

### DIFF
--- a/tensorzero-core/tests/optimization/common/openai_rft.rs
+++ b/tensorzero-core/tests/optimization/common/openai_rft.rs
@@ -8,6 +8,8 @@ use tensorzero_core::providers::openai::optimization::{
     OpenAIGrader, OpenAIModelGraderInput, OpenAIRFTRole, OpenAIStringCheckOp,
 };
 
+use super::mock_inference_provider_base;
+
 pub struct OpenAIRFTTestCase();
 
 impl OptimizationTestCase for OpenAIRFTTestCase {
@@ -70,7 +72,7 @@ impl OptimizationTestCase for OpenAIRFTTestCase {
                 reasoning_effort: Some("low".to_string()),
                 credentials: None,
                 api_base: if use_mock_inference_provider {
-                    Some("http://localhost:3030/openai/".parse().unwrap())
+                    Some(mock_inference_provider_base().join("openai/").unwrap())
                 } else {
                     None
                 },


### PR DESCRIPTION
Let's use a hardcoded base URL so that the dockerized tests pass (they're not yet required to pass to merge)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces hardcoded `api_base` URL with dynamic URL in `OpenAIRFTTestCase` for mock inference provider.
> 
>   - **Behavior**:
>     - Replaces hardcoded `api_base` URL with dynamic URL using `mock_inference_provider_base()` in `OpenAIRFTTestCase`.
>     - Affects `get_optimizer_info()` function when `use_mock_inference_provider` is true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for eacd6da3437f9f9bbfcf2fdba9d1c15aa489d69f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->