### PR TITLE
Use debug log level for batch write start message

### DIFF
--- a/tensorzero-core/src/db/clickhouse/batching.rs
+++ b/tensorzero-core/src/db/clickhouse/batching.rs
@@ -78,7 +78,7 @@ impl BatchSender {
         // We use `spawn_blocking` to ensure that when the runtime shuts down, it waits for this task to complete.
         let writer_handle = tokio::task::spawn_blocking(move || {
             handle.block_on(async move {
-                tracing::info!("ClickHouse batch write handler started");
+                tracing::debug!("ClickHouse batch write handler started");
                 writer.process(clickhouse, config).await;
                 tracing::info!("ClickHouse batch write handler finished");
             });


### PR DESCRIPTION
The start message is less important than the shutdown messages (since the shutdown messages can be used to debug slow shutdowns / hangs), so let's lower the level.