### PR TITLE
Switch back to dynamic ClickHouse Cloud instance choice on Buildkite

### DIFF
--- a/ci/buildkite/test-clickhouse-cloud.sh
+++ b/ci/buildkite/test-clickhouse-cloud.sh
@@ -13,7 +13,8 @@ export CLICKHOUSE_PASSWORD=$(buildkite-agent secret get clickhouse_password)
 # We concatenate our clickhouse instance prefix, along with our chosen clickhouse id (e.g. 'dev-tensorzero-e2e-tests-instance-' and '0'), to form the instance name
 # Then, we look up the instance url for this name, and add basic-auth credentials to the url to get our full TENSORZERO_CLICKHOUSE_URL
 export TENSORZERO_CLICKHOUSE_URL=$(curl --user "$CLICKHOUSE_API_KEY:$CLICKHOUSE_KEY_SECRET" https://api.clickhouse.cloud/v1/organizations/b55f1935-803f-4931-90b3-4d26089004d4/services | jq -r ".result[] | select(.name == \"${CLICKHOUSE_PREFIX}${CLICKHOUSE_ID}\") | .endpoints[] | select(.protocol == \"https\") | \"https://$CLICKHOUSE_USERNAME:$CLICKHOUSE_PASSWORD@\" + .host + \":\" + (.port | tostring)")
-echo $TENSORZERO_CLICKHOUSE_URL #| buildkite-agent redactor add
+echo $TENSORZERO_CLICKHOUSE_URL
+export CLICKHOUSE_HOST=$(echo $TENSORZERO_CLICKHOUSE_URL | sed 's|https://[^@]*@||' | sed 's|:[0-9]*||')
 
 # Generate unique database name with random suffix for isolation
 RANDOM_SUFFIX=$(openssl rand -hex 4)
@@ -74,7 +75,6 @@ cargo run-e2e > e2e_logs.txt 2>&1 &
     done
     export GATEWAY_PID=$!
 
-export CLICKHOUSE_HOST=$(echo $TENSORZERO_CLICKHOUSE_URL | sed 's|https://[^@]*@||' | sed 's|:[0-9]*||')
 export CLICKHOUSE_USER="$CLICKHOUSE_USERNAME"
 export CLICKHOUSE_PASSWORD="$CLICKHOUSE_PASSWORD"
 cd ui/fixtures

--- a/ui/fixtures/check-fixtures.sh
+++ b/ui/fixtures/check-fixtures.sh
@@ -3,21 +3,15 @@
 set -euo pipefail
 
 DATABASE_NAME="${1:-tensorzero_ui_fixtures}"
-
+CLICKHOUSE_HOST_VAR="${CLICKHOUSE_HOST}"
 # Determine credentials based on environment
 if command -v buildkite-agent >/dev/null 2>&1; then
   # Running on Buildkite - use secrets (fail if not available)
-  if [ "${TENSORZERO_CLICKHOUSE_FAST_CHANNEL:-}" = "1" ]; then
-    CLICKHOUSE_HOST_VAR=$(buildkite-agent secret get CLICKHOUSE_HOST_INSERT_FAST_CHANNEL)
-  else
-    CLICKHOUSE_HOST_VAR=$(buildkite-agent secret get CLICKHOUSE_HOST_INSERT)
-  fi
   CLICKHOUSE_USER_VAR=$(buildkite-agent secret get CLICKHOUSE_CLOUD_INSERT_USERNAME)
   CLICKHOUSE_PASSWORD_VAR=$(buildkite-agent secret get CLICKHOUSE_CLOUD_INSERT_PASSWORD)
   CLICKHOUSE_SECURE_FLAG="--secure"
 else
   # Not on Buildkite - use environment variables with defaults
-  CLICKHOUSE_HOST_VAR="${CLICKHOUSE_HOST}"
   CLICKHOUSE_USER_VAR="${CLICKHOUSE_USER:-chuser}"
   CLICKHOUSE_PASSWORD_VAR="${CLICKHOUSE_PASSWORD:-chpassword}"
   CLICKHOUSE_SECURE_FLAG=""

--- a/ui/fixtures/load_fixtures.sh
+++ b/ui/fixtures/load_fixtures.sh
@@ -6,20 +6,16 @@ if [ -f /load_complete.marker ]; then
   echo "Fixtures already loaded; this script will now exit with status 0"
   exit 0
 fi
+
+CLICKHOUSE_HOST_VAR="${CLICKHOUSE_HOST}"
 # Determine credentials based on environment
 if command -v buildkite-agent >/dev/null 2>&1; then
   # Running on Buildkite - use secrets (fail if not available)
-  if [ "${TENSORZERO_CLICKHOUSE_FAST_CHANNEL:-}" = "1" ]; then
-    CLICKHOUSE_HOST_VAR=$(buildkite-agent secret get CLICKHOUSE_HOST_INSERT_FAST_CHANNEL)
-  else
-    CLICKHOUSE_HOST_VAR=$(buildkite-agent secret get CLICKHOUSE_HOST_INSERT)
-  fi
   CLICKHOUSE_USER_VAR=$(buildkite-agent secret get CLICKHOUSE_CLOUD_INSERT_USERNAME)
   CLICKHOUSE_PASSWORD_VAR=$(buildkite-agent secret get CLICKHOUSE_CLOUD_INSERT_PASSWORD)
   CLICKHOUSE_SECURE_FLAG="--secure"
 else
   # Not on Buildkite - use environment variables with defaults
-  CLICKHOUSE_HOST_VAR="${CLICKHOUSE_HOST}"
   CLICKHOUSE_USER_VAR="${CLICKHOUSE_USER:-chuser}"
   CLICKHOUSE_PASSWORD_VAR="${CLICKHOUSE_PASSWORD:-chpassword}"
   CLICKHOUSE_SECURE_FLAG=""


### PR DESCRIPTION
This will let us raise our merge queue concurrency limit
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reverts to dynamic ClickHouse Cloud instance selection on Buildkite, removing static URL choice based on fast channel flag.
> 
>   - **Behavior**:
>     - Reverts to dynamic ClickHouse Cloud instance selection in `test-clickhouse-cloud.sh`, removing static URL choice based on `TENSORZERO_CLICKHOUSE_FAST_CHANNEL`.
>     - Removes conditional logic for `CLICKHOUSE_HOST_VAR` in `check-fixtures.sh` and `load_fixtures.sh`, using `CLICKHOUSE_HOST` directly.
>   - **Environment Variables**:
>     - `TENSORZERO_CLICKHOUSE_URL` is now dynamically constructed using API call in `test-clickhouse-cloud.sh`.
>     - `CLICKHOUSE_HOST` is derived from `TENSORZERO_CLICKHOUSE_URL` in `test-clickhouse-cloud.sh`.
>   - **Misc**:
>     - Removes redundant `CLICKHOUSE_HOST` export in `test-clickhouse-cloud.sh`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d290bac46bb2805d62d71613bc0b621e9244b6bb. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->