### PR TITLE
added http2 feature flag to axum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tokio-stream = "0.1.15"
 tokio = { version = "1.46.1", features = ["full"] }
 tracing = { version = "0.1.40", features = ["log"] }
 pyo3 = { version = "0.24.2", features = ["experimental-async", "abi3-py39"] }
-axum = { version = "0.8", features = ["macros"] }
+axum = { version = "0.8", features = ["macros", "http2"] }
 anyhow = "1.0.99"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt"] }
 clap = { version = "4.5.46", features = ["derive"] }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added `http2` feature to `axum` dependency in `Cargo.toml` to enable HTTP/2 support.
> 
>   - **Dependencies**:
>     - Added `http2` feature to `axum` dependency in `Cargo.toml` to enable HTTP/2 support.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1133ec30ec60586418c0ded5ce4ad05a7d0432bb. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->