### PR TITLE
Bump tool call test timeout to 20 seconds

### DIFF
--- a/ui/e2e_tests/playground.spec.ts
+++ b/ui/e2e_tests/playground.spec.ts
@@ -180,7 +180,7 @@ test("playground should work for data with tools", async ({ page }) => {
       .getByTestId("datapoint-playground-output")
       .getByText("Tool Call")
       .first(),
-  ).toBeVisible({ timeout: 15_000 });
+  ).toBeVisible({ timeout: 20_000 });
 
   // Verify that at least one tool call has the expected fields
   await expect(page.getByText("Name").first()).toBeVisible();
@@ -230,7 +230,7 @@ test("playground should work for data with tools", async ({ page }) => {
       .getByTestId("datapoint-playground-output")
       .getByText("Tool Call")
       .first(),
-  ).toBeVisible({ timeout: 15_000 });
+  ).toBeVisible({ timeout: 20_000 });
 
   // Verify that at least one tool call has the expected fields
   await expect(page.getByText("Name").first()).toBeVisible();


### PR DESCRIPTION
We saw a repeated timeout at 15 seconds in a flaky CI run, so let's give it even more time
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase timeout for tool call visibility test in `playground.spec.ts` to 20 seconds to address CI flakiness.
> 
>   - **Tests**:
>     - Increase timeout from 15 seconds to 20 seconds in `playground.spec.ts` for `toBeVisible` assertions related to tool calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 96b4068bc8a3f56951bfc8c2aabcfec84d833d5f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->