### PR TITLE
Add connection pooling to TensorzeroHttpClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4598,6 +4598,7 @@ dependencies = [
  "minijinja",
  "moka",
  "object_store",
+ "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",

--- a/tensorzero-core/Cargo.toml
+++ b/tensorzero-core/Cargo.toml
@@ -133,6 +133,7 @@ ts-rs = { workspace = true }
 moka = { version = "0.12.10", features = ["sync"] }
 tonic = { version = "0.13.1", default-features = false }
 pin-project = "1.1.10"
+once_cell = "1.21.3"
 
 
 [dev-dependencies]

--- a/tensorzero-core/src/http.rs
+++ b/tensorzero-core/src/http.rs
@@ -1,6 +1,10 @@
+use once_cell::sync::OnceCell;
 use std::{
     pin::Pin,
-    sync::{atomic::AtomicU8, Arc},
+    sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc,
+    },
     task::{Context, Poll},
 };
 
@@ -17,9 +21,13 @@ use crate::{
     model_table::CowNoClone,
 };
 
+// A wrapper around `reqwest::Client` that tracks the number of outstanding concurrent requests.
+// We store an array of these in `TensorzeroHttpClient`, and pick the first one that has
+// a `concurrent_requests` count that's below `CONCURRENCY_LIMIT`.
 struct LimitedClient {
-    // Currently never incremented - we'll use this when we implement
-    // connection pooling
+    // This needs to be an `Arc` so that we can share the counter
+    // when we create a `TensorzeroEventSource` stream wrapper
+    // (we need to decrement it when the stream is dropped)
     concurrent_requests: Arc<AtomicU8>,
     client: Client,
 }
@@ -30,30 +38,132 @@ struct LimitedClientTicket<'a> {
 
 impl Drop for LimitedClientTicket<'_> {
     fn drop(&mut self) {
-        // We'll implement decrementing the counter here when we implement
-        // connection pooling
+        self.client
+            .concurrent_requests
+            .fetch_sub(1, Ordering::SeqCst);
     }
 }
+
+const MAX_NUM_CLIENTS: usize = 1024;
+// This is set to a common value for the HTTP `max_concurrent_streams` setting sent by the server
+// (OpenAI, Anthropic, and GCP Vertex all use this value).
+// This works around a limitation in reqwest/hyper - when a HTTP2 connection is negotiated,
+// request will only ever open at most one TCP connection to the remote (host, port) pair,.
+// If the total number of concurrency requests exceeds the HTTP2 `max_concurrent_streams` limit,
+// hyper will delay submitting new requests until a request completes.
+//
+// This is a significant limitation in our case, since what we actually care about is
+// the higher-level rate limit imposed by the model provider, which can be much higher.
+// To avoid artifically limiting our concurrency, we spread requests across multiple `reqwest::Client`
+// instances to allow opening multiple HTTP2 TCP connections to the remote server
+//
+// This unfortunately penalizes some other use cases:
+// * Multiple HTTP1 connections
+// * Many different requests (whether HTTP1 or HTTP2) to many different hosts
+//
+// If we have high concurrency in one of the above cases, we'll end up using more than one
+// `reqwest::Client` instance, even though we wouldn't have hit a `max_concurrent_streams` limit.
+// This will make the internal `reqwest` connection pool less effective, as we'll have more
+// duplicate connections than if we had used a single `reqwest::Client` instance.
+//
+// Users have reported hitting the `max_concurrent_streams`, so w're prioritizing the ability
+// to scale to high QPS. Ideally, `reqwest/hyper` would natively support opening multiple TCP
+// connections for HTTP2, allowing us to remove our manual connection pooling.
+const CONCURRENCY_LIMIT: u8 = 100;
 
 /// A wrapper for `reqwest::Client` that adds extra features:
 /// * Improved connection pooling support for HTTP/2
 #[derive(Clone)]
 pub struct TensorzeroHttpClient {
+    // A 'waterfall' of clients for connecting pooling.
+    // When we try to obtain a client with `take_ticket`, we iterate over
+    // the list until we find a client with an concurrent request count that's
+    // below `concurrency_limit`. This allows requests to share a `reqwest::Client`
+    // when possible (giving reqwest the chance to re-use TCP connections), while
+    // distributing requests across multiple clients to prevent hanging due to the
+    // HTTP2 concurrent stream limit.
+
+    // This implementation is deliberately simplistic:
+    // * We don't use the host/port as a key - all requests go through the same array
+    // * We don't attempt to detect if we're going to use HTTP2 (reqwest only exposes
+    //   this information after a request has completed)
+    // * The CONCURRENCY_LIMIT is static, as reqwest doesn't expose the HTTP2
+    //   `max_concurrent_streams` limit sent by the server.
+    //
+    // We're optimizing for the case where a large number of concurrent requests are made
+    // to the same model provider.
+    //
+    // Initialing 1024 `reqwest::Client`s can take several seconds. To avoid making
+    // embedding client construction very slow, we lazily construct them the first time
+    // our concurrent requests breaches a threshold (i.e. the first time we try
+    // to access a slot in the array). Once a `LimitedClient` is constructed,
+    // it stays alive for the lifetime of the `TensorzeroHttpClient` instance.
+    clients: Arc<[OnceCell<LimitedClient>]>,
     fallback_client: Arc<LimitedClient>,
 }
 
 impl TensorzeroHttpClient {
     pub fn new() -> Result<Self, Error> {
-        Ok(Self {
+        let clients = (0..MAX_NUM_CLIENTS)
+            .map(|_| OnceCell::new())
+            .collect::<Vec<_>>();
+        let client = Self {
+            clients: clients.into(),
             fallback_client: Arc::new(LimitedClient {
                 concurrent_requests: Arc::new(AtomicU8::new(0)),
                 client: build_client()?,
             }),
-        })
+        };
+        // Eagerly initialize the first `OnceCell`` in the array
+        client.take_ticket();
+        Ok(client)
     }
 
-    // This will eventually use a connection pool
     fn take_ticket(&self) -> LimitedClientTicket<'_> {
+        for client_cell in self.clients.iter() {
+            let client = match client_cell.get_or_try_init(|| {
+                Ok::<_, Error>(LimitedClient {
+                    concurrent_requests: Arc::new(AtomicU8::new(0)),
+                    client: build_client()?,
+                })
+            }) {
+                Ok(client) => client,
+                Err(_) => {
+                    // The error was already logged - continue on and try to access
+                    // the next `OnceCell` in the array. If all of them fail on this
+                    // pass through the loop, we'll end up using the fallback client.
+                    continue;
+                }
+            };
+
+            // Attempt to increment the value, failing if we're at `CONCURRENCY_LIMIT`
+            let val = client.concurrent_requests.fetch_update(
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+                |val| {
+                    if val < CONCURRENCY_LIMIT {
+                        Some(val + 1)
+                    } else {
+                        None
+                    }
+                },
+            );
+            // If we successfully incremented the value, then use this client.
+            if val.is_ok() {
+                return LimitedClientTicket {
+                    client: CowNoClone::Borrowed(client),
+                };
+            }
+            // Otherwise, continue looping through the array
+        }
+        // If we somehow have 'CONCURRENCY_LIMIT * NUM_CLIENTS' outstanding requests,
+        // then log an error, and use the fallback client.
+        // When this happens, we gracefully degrade to our behavior before `TensorzeroHttpClient`
+        // was introduced (sharing a single `reqwest::Client` instance, which will limit the
+        // concurrency for HTTP2 requests to the same host).
+        Error::new(ErrorDetails::InternalError {
+            message: "No available HTTP clients. {IMPOSSIBLE_ERROR_MESSAGE}".to_string(),
+        });
         LimitedClientTicket {
             client: CowNoClone::Borrowed(&self.fallback_client),
         }


### PR DESCRIPTION
This should avoid artificial conconcurrency limitations when making lots of concurrent HTTP2 requests to the same host

This still needs lots of tests