### PR TITLE
Remove 'extra_handle' parameter from inference methods

### DIFF
--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -582,17 +582,12 @@ impl Client {
                 }
             }
             ClientMode::EmbeddedGateway { gateway, timeout } => {
-                let client = self.mode.clone();
                 Ok(with_embedded_timeout(*timeout, async {
                     let res = tensorzero_core::endpoints::inference::inference(
                         gateway.handle.app_state.config.clone(),
                         &gateway.handle.app_state.http_client,
                         gateway.handle.app_state.clickhouse_connection_info.clone(),
                         params.try_into().map_err(err_to_http)?,
-                        // Make the stream hold on to a reference to the client,
-                        // so that we client is only dropped after all streams have finished
-                        // See 'create_stream' and 'GatewayHandle' for more details
-                        client,
                     )
                     .await
                     .map_err(err_to_http)?;

--- a/tensorzero-core/src/endpoints/openai_compatible.rs
+++ b/tensorzero-core/src/endpoints/openai_compatible.rs
@@ -125,7 +125,7 @@ pub async fn inference_handler(
         .into()),
     }?;
 
-    let response = inference(config, &http_client, clickhouse_connection_info, params, ()).await?;
+    let response = inference(config, &http_client, clickhouse_connection_info, params).await?;
 
     match response {
         InferenceOutput::NonStreaming(response) => {


### PR DESCRIPTION
This only use of this method was to try to prevent deadlocks in Python. We now do this by explicitly holding on to gateway handles in our 'smart iterator' Python objects (StreamWrapper and AsyncStreamWrapper), so we no longer need this.

Additionally, we currently block external users from enabling batching with the python embedded client, so any batching-related changes cannot currently affect Python users.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `extra_handle` parameter from inference methods to simplify function signatures and eliminate unnecessary parameter passing.
> 
>   - **Behavior**:
>     - Remove `extra_handle` parameter from `inference` function in `tensorzero-core/src/endpoints/inference.rs` and `tensorzero-core/src/endpoints/openai_compatible.rs`.
>     - Update `create_stream` function to remove `extra_handle` parameter.
>   - **Rationale**:
>     - `extra_handle` was used to prevent deadlocks in Python, now managed by holding gateway handles in smart iterators.
>     - Batching is blocked for external users, so changes do not affect Python users.
>   - **Misc**:
>     - Remove related comments and parameter handling in `clients/rust/src/lib.rs` and `tensorzero-core/src/endpoints/inference.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 664e0de6bcb350ff9e38e351a87ea32c64e2aba5. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->