### PR TITLE
Make it clearer that ClickHouse is optional

### DIFF
--- a/docs/gateway/deployment.mdx
+++ b/docs/gateway/deployment.mdx
@@ -8,7 +8,7 @@ It's easy to get started with the TensorZero Gateway.
 
 To deploy the TensorZero Gateway, you need to:
 
-- Setup a ClickHouse database
+- Optional: Setup a ClickHouse database for observability
 - Optional: Create a [configuration file](/gateway/configuration-reference/)
 - Run the gateway
 
@@ -22,6 +22,8 @@ See the [TensorZero UI Deployment Guide](/ui/deployment/) for more details on ho
 
 The TensorZero Gateway stores inference and feedback data in a ClickHouse database.
 This data is later used for model observability, experimentation, and optimization.
+
+If you're not using observability features, you don't need to set up a ClickHouse database.
 
 ### Development
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Clarifies in `deployment.mdx` that ClickHouse setup is optional unless observability features are needed.
> 
>   - **Documentation**:
>     - In `deployment.mdx`, updated deployment steps to indicate that setting up a ClickHouse database is optional for observability.
>     - Added clarification in the ClickHouse section that the database is not needed if observability features are not used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1bae18b4c3d8191b1f940ddb67c19252b3ca4510. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->