### PR TITLE
reduced minimum time for embeddings request test

### DIFF
--- a/tensorzero-core/tests/e2e/providers/openai.rs
+++ b/tensorzero-core/tests/e2e/providers/openai.rs
@@ -1184,7 +1184,11 @@ async fn test_embedding_request() {
     assert_eq!(response.usage.output_tokens, 0);
     match response.latency {
         Latency::NonStreaming { response_time } => {
-            assert!(response_time.as_millis() > 100);
+            assert!(
+                response_time.as_millis() > 10,
+                "Response time should be greater than 10ms: {}",
+                response_time.as_millis()
+            );
         }
         _ => panic!("Latency should be non-streaming"),
     }


### PR DESCRIPTION
We were seeing the assertion fail at <100ms so let's try 10ms
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reduced minimum response time assertion from 100ms to 10ms in `test_embedding_request()` in `openai.rs`.
> 
>   - **Tests**:
>     - In `test_embedding_request()` in `openai.rs`, reduced the minimum response time assertion from 100ms to 10ms for non-streaming latency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7266ce87e3c04fe1739197ff7a348349f39f6425. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->