### PR TITLE
Remove timeout from 'check-docker-compose' job

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -74,7 +74,6 @@ jobs:
       # Permission to fetch GitHub OIDC token authentication
       id-token: write
     runs-on: ubuntu-latest
-    timeout-minutes: 25
     if: github.repository == 'tensorzero/tensorzero'
 
     steps:


### PR DESCRIPTION
This job sometimes takes a very long time (not hanging, just being slow). We should investigate this, but let's remove the timeout for now to stop spurious failures in the merge queue
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove timeout from `check-docker-compose` job in `general.yml` to prevent spurious failures.
> 
>   - **Workflow Changes**:
>     - Remove `timeout-minutes: 25` from `check-docker-compose` job in `general.yml` to prevent spurious failures due to long execution times.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8daee2cd4d2db99fcfe313e2b2c7568bb085b23a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->