### PR TITLE
Store an `Arc<ErrorDetails>` instead of `Box<ErrorDetails>`

### DIFF
--- a/tensorzero-core/src/endpoints/feedback/mod.rs
+++ b/tensorzero-core/src/endpoints/feedback/mod.rs
@@ -913,9 +913,9 @@ mod tests {
 
         // Case 1.2: ID not provided
         let metadata = get_feedback_metadata(&config, "test_metric", None, None).unwrap_err();
-        let details = metadata.get_owned_details();
+        let details = metadata.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: "Correct ID was not provided for feedback level \"inference\"."
                     .to_string(),
@@ -924,9 +924,9 @@ mod tests {
         // Case 1.3: ID provided but not for the correct level
         let metadata =
             get_feedback_metadata(&config, "test_metric", Some(Uuid::now_v7()), None).unwrap_err();
-        let details = metadata.get_owned_details();
+        let details = metadata.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: "Correct ID was not provided for feedback level \"inference\"."
                     .to_string(),
@@ -941,9 +941,9 @@ mod tests {
             Some(Uuid::now_v7()),
         )
         .unwrap_err();
-        let details = metadata.get_owned_details();
+        let details = metadata.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: "Both episode_id and inference_id cannot be provided".to_string(),
             }
@@ -966,9 +966,9 @@ mod tests {
         let metadata =
             get_feedback_metadata(&config, "comment", Some(episode_id), Some(inference_id))
                 .unwrap_err();
-        let details = metadata.get_owned_details();
+        let details = metadata.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: "Both episode_id and inference_id cannot be provided".to_string(),
             }
@@ -984,9 +984,9 @@ mod tests {
         // Case 3.2 Demonstration Feedback with only episode id
         let metadata =
             get_feedback_metadata(&config, "demonstration", Some(episode_id), None).unwrap_err();
-        let details = metadata.get_owned_details();
+        let details = metadata.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: "Correct ID was not provided for feedback level \"inference\"."
                     .to_string(),
@@ -1001,9 +1001,9 @@ mod tests {
             Some(inference_id),
         )
         .unwrap_err();
-        let details = metadata.get_owned_details();
+        let details = metadata.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: "Both episode_id and inference_id cannot be provided".to_string(),
             }
@@ -1032,9 +1032,9 @@ mod tests {
         let metadata =
             get_feedback_metadata(&config, "test_metric", Some(episode_id), Some(inference_id))
                 .unwrap_err();
-        let details = metadata.get_owned_details();
+        let details = metadata.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: "Both episode_id and inference_id cannot be provided".to_string(),
             }
@@ -1052,9 +1052,9 @@ mod tests {
         let metadata_err =
             get_feedback_metadata(&config, "missing_metric_name", None, Some(inference_id))
                 .unwrap_err();
-        let details = metadata_err.get_owned_details();
+        let details = metadata_err.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::UnknownMetric {
                 name: "missing_metric_name".to_string(),
             }
@@ -1083,9 +1083,10 @@ mod tests {
             StructuredJson(params),
         )
         .await;
-        let details = response.unwrap_err().get_owned_details();
+        let error = response.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: format!("Episode ID: {episode_id} does not exist"),
             }
@@ -1118,9 +1119,9 @@ mod tests {
         )
         .await
         .unwrap_err();
-        let details = response.get_owned_details();
+        let details = response.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: "Correct ID was not provided for feedback level \"inference\"."
                     .to_string(),
@@ -1143,9 +1144,10 @@ mod tests {
             StructuredJson(params),
         )
         .await;
-        let details = response.unwrap_err().get_owned_details();
+        let error = response.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: format!("Inference ID: {inference_id} does not exist"),
             }
@@ -1189,9 +1191,9 @@ mod tests {
         )
         .await
         .unwrap_err();
-        let details = response.get_owned_details();
+        let details = response.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: "Correct ID was not provided for feedback level \"episode\".".to_string(),
             }
@@ -1212,9 +1214,10 @@ mod tests {
             StructuredJson(params),
         )
         .await;
-        let details = response.unwrap_err().get_owned_details();
+        let error = response.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: format!("Episode ID: {episode_id} does not exist"),
             }
@@ -1254,9 +1257,10 @@ mod tests {
             StructuredJson(params),
         )
         .await;
-        let details = response.unwrap_err().get_owned_details();
+        let error = response.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: format!("Inference ID: {inference_id} does not exist"),
             }
@@ -1363,9 +1367,9 @@ mod tests {
         )
         .await
         .unwrap_err();
-        let details = err.get_owned_details();
+        let details = err.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: "Demonstration contains invalid tool name".to_string(),
             }
@@ -1386,9 +1390,9 @@ mod tests {
         )
         .await
         .unwrap_err();
-        let details = err.get_owned_details();
+        let details = err.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: "Demonstration contains invalid tool call arguments".to_string(),
             }
@@ -1457,9 +1461,9 @@ mod tests {
         )
         .await
         .unwrap_err();
-        let details = err.get_owned_details();
+        let details = err.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::Inference {
                 message: "The DynamicDemonstrationInfo does not match the function type. This should never happen. Please file a bug report at https://github.com/tensorzero/tensorzero/discussions/new?category=bug-reports.".to_string()
             }
@@ -1478,9 +1482,9 @@ mod tests {
         let err = validate_parse_demonstration(function_config, &value, dynamic_demonstration_info)
             .await
             .unwrap_err();
-        let details = err.get_owned_details();
+        let details = err.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::Inference {
                 message: "The DynamicDemonstrationInfo does not match the function type. This should never happen. Please file a bug report at https://github.com/tensorzero/tensorzero/discussions/new?category=bug-reports.".to_string()
             }
@@ -1509,9 +1513,9 @@ mod tests {
         tags.insert("tensorzero::human_feedback".to_string(), "true".to_string());
         assert!(validate_feedback_specific_tags(&tags).is_err());
         let err = validate_feedback_specific_tags(&tags).unwrap_err();
-        let details = err.get_owned_details();
+        let details = err.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: "tensorzero::evaluator_inference_id is required when tensorzero::datapoint_id and tensorzero::human_feedback are provided".to_string(),
             }

--- a/tensorzero-core/src/endpoints/openai_compatible.rs
+++ b/tensorzero-core/src/endpoints/openai_compatible.rs
@@ -1472,9 +1472,10 @@ mod tests {
             }),
         ];
         let input: Result<Input, Error> = messages.try_into();
-        let details = input.unwrap_err().get_owned_details();
+        let error = input.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidOpenAICompatibleRequest {
                 message: "message content must either be a string or an array of length 1 containing structured TensorZero inputs".to_string(),
             }
@@ -1627,9 +1628,9 @@ mod tests {
             "city": "Tokyo",
         });
         let error = convert_openai_message_content(content.clone()).unwrap_err();
-        let details = error.get_owned_details();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidOpenAICompatibleRequest {
                 message: "message content must either be a string or an array of length 1 containing structured TensorZero inputs".to_string(),
             }

--- a/tensorzero-core/src/error.rs
+++ b/tensorzero-core/src/error.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use axum::http::StatusCode;
@@ -100,28 +101,28 @@ impl<T: Debug + Display> Display for DisplayOrDebugGateway<T> {
     }
 }
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Clone, Debug, Error, Serialize)]
 #[cfg_attr(any(test, feature = "e2e_tests"), derive(PartialEq))]
 #[error(transparent)]
 // As long as the struct member is private, we force people to use the `new` method and log the error.
-// We box `ErrorDetails` per the `clippy::result_large_err` lint
-pub struct Error(Box<ErrorDetails>);
+// We arc `ErrorDetails` per the `clippy::result_large_err` lint, as well as to make it cloneable
+pub struct Error(Arc<ErrorDetails>);
 
 impl Error {
     pub fn new(details: ErrorDetails) -> Self {
         details.log();
-        Error(Box::new(details))
+        Error(Arc::new(details))
     }
 
     pub fn new_with_err_logging(details: ErrorDetails, err_logging: bool) -> Self {
         if err_logging {
             details.log();
         }
-        Error(Box::new(details))
+        Error(Arc::new(details))
     }
 
     pub fn new_without_logging(details: ErrorDetails) -> Self {
-        Error(Box::new(details))
+        Error(Arc::new(details))
     }
 
     pub fn status_code(&self) -> StatusCode {
@@ -130,10 +131,6 @@ impl Error {
 
     pub fn get_details(&self) -> &ErrorDetails {
         &self.0
-    }
-
-    pub fn get_owned_details(self) -> ErrorDetails {
-        *self.0
     }
 
     pub fn log(&self) {

--- a/tensorzero-core/src/providers/anthropic.rs
+++ b/tensorzero-core/src/providers/anthropic.rs
@@ -1564,9 +1564,10 @@ mod tests {
             ..Default::default()
         };
         let anthropic_request_body = AnthropicRequestBody::new(&model, &inference_request);
-        let details = anthropic_request_body.unwrap_err().get_owned_details();
+        let error = anthropic_request_body.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: "Anthropic requires at least one message".to_string(),
             }
@@ -2086,9 +2087,10 @@ mod tests {
             "raw request".to_string(),
             "raw response".to_string(),
         );
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InferenceClient {
                 message: "raw response".to_string(),
                 status_code: Some(response_code),
@@ -2103,9 +2105,10 @@ mod tests {
             "raw request".to_string(),
             "raw response".to_string(),
         );
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InferenceClient {
                 message: "raw response".to_string(),
                 status_code: Some(response_code),
@@ -2120,9 +2123,10 @@ mod tests {
             "raw request".to_string(),
             "raw response".to_string(),
         );
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InferenceClient {
                 message: "raw response".to_string(),
                 status_code: Some(response_code),
@@ -2137,9 +2141,10 @@ mod tests {
             "raw request".to_string(),
             "raw response".to_string(),
         );
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InferenceServer {
                 message: "raw response".to_string(),
                 raw_request: Some("raw request".to_string()),
@@ -2153,9 +2158,10 @@ mod tests {
             "raw request".to_string(),
             "raw response".to_string(),
         );
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InferenceServer {
                 message: "raw response".to_string(),
                 raw_request: Some("raw request".to_string()),
@@ -2464,9 +2470,10 @@ mod tests {
             &mut current_tool_name,
             false,
         );
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InferenceServer {
                 message: "Got InputJsonDelta chunk from Anthropic without current tool id being set by a ToolUse".to_string(),
                 raw_request: None,
@@ -2595,9 +2602,10 @@ mod tests {
             &mut current_tool_name,
             false,
         );
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InferenceServer {
                 message: r#"{"message":"Test error"}"#.to_string(),
                 raw_request: None,
@@ -2908,7 +2916,7 @@ mod tests {
         let result = AnthropicCredentials::try_from(generic);
         assert!(result.is_err());
         assert!(matches!(
-            result.unwrap_err().get_owned_details(),
+            result.unwrap_err().get_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
     }

--- a/tensorzero-core/src/providers/azure.rs
+++ b/tensorzero-core/src/providers/azure.rs
@@ -940,7 +940,7 @@ mod tests {
         let result = AzureCredentials::try_from(generic);
         assert!(result.is_err());
         assert!(matches!(
-            result.unwrap_err().get_owned_details(),
+            result.unwrap_err().get_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
     }

--- a/tensorzero-core/src/providers/deepseek.rs
+++ b/tensorzero-core/src/providers/deepseek.rs
@@ -912,7 +912,7 @@ mod tests {
         let result = DeepSeekCredentials::try_from(generic);
         assert!(result.is_err());
         assert!(matches!(
-            result.unwrap_err().get_owned_details(),
+            result.unwrap_err().get_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
     }

--- a/tensorzero-core/src/providers/fireworks/mod.rs
+++ b/tensorzero-core/src/providers/fireworks/mod.rs
@@ -1021,7 +1021,7 @@ mod tests {
         let result = FireworksCredentials::try_from(generic);
         assert!(result.is_err());
         assert!(matches!(
-            result.unwrap_err().get_owned_details(),
+            result.unwrap_err().get_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
     }

--- a/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
@@ -1458,9 +1458,10 @@ mod tests {
         };
         let anthropic_request_body =
             GCPVertexAnthropicRequestBody::new("claude-opus-4@20250514", &inference_request);
-        let details = anthropic_request_body.unwrap_err().get_owned_details();
+        let error = anthropic_request_body.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: "Anthropic requires at least one message".to_string(),
             }
@@ -1999,9 +2000,10 @@ mod tests {
         };
         let response_code = StatusCode::BAD_REQUEST;
         let result = handle_anthropic_error(response_code, error_body.clone());
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InferenceClient {
                 message: "test_message".to_string(),
                 status_code: Some(response_code),
@@ -2014,9 +2016,10 @@ mod tests {
         );
         let response_code = StatusCode::UNAUTHORIZED;
         let result = handle_anthropic_error(response_code, error_body.clone());
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InferenceClient {
                 message: "test_message".to_string(),
                 status_code: Some(response_code),
@@ -2029,9 +2032,10 @@ mod tests {
         );
         let response_code = StatusCode::TOO_MANY_REQUESTS;
         let result = handle_anthropic_error(response_code, error_body.clone());
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InferenceClient {
                 message: "test_message".to_string(),
                 status_code: Some(response_code),
@@ -2045,9 +2049,10 @@ mod tests {
         let response_code = StatusCode::NOT_FOUND;
         let result = handle_anthropic_error(response_code, error_body.clone());
         assert!(result.is_err());
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InferenceServer {
                 message: "test_message".to_string(),
                 raw_request: None,
@@ -2059,9 +2064,10 @@ mod tests {
         );
         let response_code = StatusCode::INTERNAL_SERVER_ERROR;
         let result = handle_anthropic_error(response_code, error_body.clone());
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InferenceServer {
                 message: "test_message".to_string(),
                 raw_request: None,
@@ -2421,9 +2427,10 @@ mod tests {
             &mut current_tool_id,
             false,
         );
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InferenceServer {
                 message: "Got InputJsonDelta chunk from Anthropic without current tool id being set by a ToolUse".to_string(),
                 raw_request: None,
@@ -2534,9 +2541,10 @@ mod tests {
             &mut current_tool_id,
             false,
         );
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InferenceServer {
                 message: "Unsupported content block type for ContentBlockStart".to_string(),
                 raw_request: None,
@@ -2570,9 +2578,10 @@ mod tests {
             &mut current_tool_id,
             false,
         );
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InferenceServer {
                 message: r#"{"message":"Test error"}"#.to_string(),
                 raw_request: None,

--- a/tensorzero-core/src/providers/gcp_vertex_gemini/mod.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_gemini/mod.rs
@@ -2771,9 +2771,10 @@ mod tests {
             ..Default::default()
         };
         let result = GCPVertexGeminiRequest::new(&inference_request, "gemini-pro", false);
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: "GCP Vertex Gemini requires at least one message".to_string()
             }
@@ -3558,7 +3559,7 @@ mod tests {
         );
         assert!(result.is_err());
         let err = result.unwrap_err();
-        let details = err.get_owned_details();
+        let details = err.get_details();
         match details {
             ErrorDetails::InferenceClient { message, .. } => {
                 assert!(message.contains("Error parsing tool call arguments as JSON Value"));
@@ -3580,7 +3581,7 @@ mod tests {
         );
         assert!(result.is_err());
         let err = result.unwrap_err();
-        let details = err.get_owned_details();
+        let details = err.get_details();
         match details {
             ErrorDetails::InferenceClient { message, .. } => {
                 assert_eq!(message, "Tool call arguments must be a JSON object");
@@ -3779,7 +3780,8 @@ mod tests {
         let generic = Credential::FileContents(SecretString::from(invalid_json));
         let result = build_non_sdk_credentials(generic, "GCPVertexGemini");
         assert!(result.is_err());
-        let err = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let err = error.get_details();
         assert!(
             matches!(err, ErrorDetails::GCPCredentials { message } if message.contains("Failed to load GCP credentials"))
         );
@@ -3788,7 +3790,8 @@ mod tests {
         let generic = Credential::Static(SecretString::from("test"));
         let result = build_non_sdk_credentials(generic, "GCPVertexGemini");
         assert!(result.is_err());
-        let err = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let err = error.get_details();
         assert!(
             matches!(err, ErrorDetails::GCPCredentials { message } if message.contains("Invalid credential_location"))
         );
@@ -3875,7 +3878,7 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(
-            err.get_owned_details(),
+            *err.get_details(),
             ErrorDetails::InferenceServer {
                 message: "Unknown content part in GCP Vertex Gemini response".to_string(),
                 provider_type: "gcp_vertex_gemini".to_string(),
@@ -4215,7 +4218,7 @@ mod tests {
 
         assert!(result.is_err());
         let error = result.unwrap_err();
-        let details = error.get_owned_details();
+        let details = error.get_details();
         match details {
             ErrorDetails::InferenceServer { message, .. } => {
                 assert_eq!(message, "GCP Vertex Gemini response has no candidates");
@@ -4463,7 +4466,7 @@ mod tests {
         );
         assert!(result.is_err());
         let error = result.unwrap_err();
-        let details = error.get_owned_details();
+        let details = error.get_details();
         match details {
             ErrorDetails::InferenceServer { message, .. } => {
                 assert!(message.contains("executableCode is not supported in streaming response"));
@@ -4494,7 +4497,7 @@ mod tests {
         );
         assert!(result.is_err());
         let error = result.unwrap_err();
-        let details = error.get_owned_details();
+        let details = error.get_details();
         match details {
             ErrorDetails::InferenceServer { message, .. } => {
                 assert_eq!(
@@ -4522,7 +4525,7 @@ mod tests {
         );
         assert!(result.is_err());
         let error = result.unwrap_err();
-        let details = error.get_owned_details();
+        let details = error.get_details();
         match details {
             ErrorDetails::InferenceServer { message, .. } => {
                 assert_eq!(

--- a/tensorzero-core/src/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-core/src/providers/google_ai_studio_gemini.rs
@@ -1552,9 +1552,10 @@ mod tests {
             ..Default::default()
         };
         let result = GeminiRequest::new(&inference_request);
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert_eq!(
-            details,
+            *details,
             ErrorDetails::InvalidRequest {
                 message: "Google AI Studio Gemini requires at least one message".to_string()
             }
@@ -2255,7 +2256,7 @@ mod tests {
         let result = GoogleAIStudioCredentials::try_from(generic);
         assert!(result.is_err());
         assert!(matches!(
-            result.unwrap_err().get_owned_details(),
+            result.unwrap_err().get_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
     }
@@ -2574,7 +2575,7 @@ mod tests {
         // Verify error is returned
         assert!(result.is_err());
         let error = result.unwrap_err();
-        let details = error.get_owned_details();
+        let details = error.get_details();
         if let ErrorDetails::InferenceServer { message, .. } = details {
             assert!(message.contains("no candidates"));
         } else {

--- a/tensorzero-core/src/providers/groq.rs
+++ b/tensorzero-core/src/providers/groq.rs
@@ -2399,7 +2399,7 @@ mod tests {
         let result = GroqCredentials::try_from(generic);
         assert!(result.is_err());
         assert!(matches!(
-            result.unwrap_err().get_owned_details(),
+            result.unwrap_err().get_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
     }

--- a/tensorzero-core/src/providers/helpers_thinking_block.rs
+++ b/tensorzero-core/src/providers/helpers_thinking_block.rs
@@ -156,7 +156,7 @@ mod tests {
         let result = process_think_blocks(text, true, provider_type);
         assert!(result.is_err());
         if let Err(err) = result {
-            if let ErrorDetails::InferenceServer { message, .. } = err.get_owned_details() {
+            if let ErrorDetails::InferenceServer { message, .. } = err.get_details() {
                 assert_eq!(message, "Multiple thinking blocks found");
             }
         }
@@ -176,7 +176,7 @@ mod tests {
         let result = process_think_blocks(text, true, provider_type);
         assert!(result.is_err());
         if let Err(err) = result {
-            if let ErrorDetails::InferenceServer { message, .. } = err.get_owned_details() {
+            if let ErrorDetails::InferenceServer { message, .. } = err.get_details() {
                 assert_eq!(message, "Mismatched thinking tags");
             }
         }
@@ -186,7 +186,7 @@ mod tests {
         let result = process_think_blocks(text, true, provider_type);
         assert!(result.is_err());
         if let Err(err) = result {
-            if let ErrorDetails::InferenceServer { message, .. } = err.get_owned_details() {
+            if let ErrorDetails::InferenceServer { message, .. } = err.get_details() {
                 assert_eq!(message, "Mismatched thinking tags");
             }
         }

--- a/tensorzero-core/src/providers/hyperbolic.rs
+++ b/tensorzero-core/src/providers/hyperbolic.rs
@@ -507,7 +507,7 @@ mod tests {
         let result = HyperbolicCredentials::try_from(generic);
         assert!(result.is_err());
         assert!(matches!(
-            result.unwrap_err().get_owned_details(),
+            result.unwrap_err().get_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
     }

--- a/tensorzero-core/src/providers/mistral.rs
+++ b/tensorzero-core/src/providers/mistral.rs
@@ -1045,7 +1045,8 @@ mod tests {
             generic_request: &generic_request,
             raw_response: raw_response.clone(),
         });
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert!(matches!(details, ErrorDetails::InferenceServer { .. }));
         // Test case 4: Invalid response with multiple choices
         let invalid_response_multiple_choices = MistralResponse {
@@ -1097,7 +1098,8 @@ mod tests {
             generic_request: &generic_request,
             raw_response: raw_response.clone(),
         });
-        let details = result.unwrap_err().get_owned_details();
+        let error = result.unwrap_err();
+        let details = error.get_details();
         assert!(matches!(details, ErrorDetails::InferenceServer { .. }));
     }
 
@@ -1107,7 +1109,8 @@ mod tests {
 
         // Test unauthorized error
         let unauthorized = handle_mistral_error(StatusCode::UNAUTHORIZED, "Unauthorized access");
-        let details = unauthorized.unwrap_err().get_owned_details();
+        let error = unauthorized.unwrap_err();
+        let details = error.get_details();
         assert!(matches!(details, ErrorDetails::InferenceClient { .. }));
         if let ErrorDetails::InferenceClient {
             message,
@@ -1117,16 +1120,17 @@ mod tests {
             raw_response,
         } = details
         {
-            assert_eq!(message, "Unauthorized access");
-            assert_eq!(status_code, Some(StatusCode::UNAUTHORIZED));
-            assert_eq!(provider, PROVIDER_TYPE.to_string());
-            assert_eq!(raw_request, None);
-            assert_eq!(raw_response, None);
+            assert_eq!(*message, "Unauthorized access");
+            assert_eq!(*status_code, Some(StatusCode::UNAUTHORIZED));
+            assert_eq!(*provider, PROVIDER_TYPE.to_string());
+            assert_eq!(*raw_request, None);
+            assert_eq!(*raw_response, None);
         }
 
         // Test forbidden error
         let forbidden = handle_mistral_error(StatusCode::FORBIDDEN, "Forbidden access");
-        let details = forbidden.unwrap_err().get_owned_details();
+        let error = forbidden.unwrap_err();
+        let details = error.get_details();
         assert!(matches!(details, ErrorDetails::InferenceClient { .. }));
         if let ErrorDetails::InferenceClient {
             message,
@@ -1136,16 +1140,17 @@ mod tests {
             raw_response,
         } = details
         {
-            assert_eq!(message, "Forbidden access");
-            assert_eq!(status_code, Some(StatusCode::FORBIDDEN));
-            assert_eq!(provider, PROVIDER_TYPE.to_string());
-            assert_eq!(raw_request, None);
-            assert_eq!(raw_response, None);
+            assert_eq!(*message, "Forbidden access");
+            assert_eq!(*status_code, Some(StatusCode::FORBIDDEN));
+            assert_eq!(*provider, PROVIDER_TYPE.to_string());
+            assert_eq!(*raw_request, None);
+            assert_eq!(*raw_response, None);
         }
 
         // Test rate limit error
         let rate_limit = handle_mistral_error(StatusCode::TOO_MANY_REQUESTS, "Rate limit exceeded");
-        let details = rate_limit.unwrap_err().get_owned_details();
+        let error = rate_limit.unwrap_err();
+        let details = error.get_details();
         assert!(matches!(details, ErrorDetails::InferenceClient { .. }));
         if let ErrorDetails::InferenceClient {
             message,
@@ -1155,16 +1160,17 @@ mod tests {
             raw_response,
         } = details
         {
-            assert_eq!(message, "Rate limit exceeded");
-            assert_eq!(status_code, Some(StatusCode::TOO_MANY_REQUESTS));
-            assert_eq!(provider, PROVIDER_TYPE.to_string());
-            assert_eq!(raw_request, None);
-            assert_eq!(raw_response, None);
+            assert_eq!(*message, "Rate limit exceeded");
+            assert_eq!(*status_code, Some(StatusCode::TOO_MANY_REQUESTS));
+            assert_eq!(*provider, PROVIDER_TYPE.to_string());
+            assert_eq!(*raw_request, None);
+            assert_eq!(*raw_response, None);
         }
 
         // Test server error
         let server_error = handle_mistral_error(StatusCode::INTERNAL_SERVER_ERROR, "Server error");
-        let details = server_error.unwrap_err().get_owned_details();
+        let error = server_error.unwrap_err();
+        let details = error.get_details();
         assert!(matches!(details, ErrorDetails::InferenceServer { .. }));
         if let ErrorDetails::InferenceServer {
             message,
@@ -1173,10 +1179,10 @@ mod tests {
             raw_response,
         } = details
         {
-            assert_eq!(message, "Server error");
-            assert_eq!(provider, PROVIDER_TYPE.to_string());
-            assert_eq!(raw_request, None);
-            assert_eq!(raw_response, None);
+            assert_eq!(*message, "Server error");
+            assert_eq!(*provider, PROVIDER_TYPE.to_string());
+            assert_eq!(*raw_request, None);
+            assert_eq!(*raw_response, None);
         }
     }
 
@@ -1207,7 +1213,7 @@ mod tests {
         let result = MistralCredentials::try_from(generic);
         assert!(result.is_err());
         assert!(matches!(
-            result.unwrap_err().get_owned_details(),
+            result.unwrap_err().get_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
     }

--- a/tensorzero-core/src/providers/openai/mod.rs
+++ b/tensorzero-core/src/providers/openai/mod.rs
@@ -3677,7 +3677,7 @@ mod tests {
         let result = OpenAICredentials::try_from(generic);
         assert!(result.is_err());
         assert!(matches!(
-            result.unwrap_err().get_owned_details(),
+            result.unwrap_err().get_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
     }

--- a/tensorzero-core/src/providers/openrouter.rs
+++ b/tensorzero-core/src/providers/openrouter.rs
@@ -2684,7 +2684,7 @@ mod tests {
         let result = OpenRouterCredentials::try_from(generic);
         assert!(result.is_err());
         assert!(matches!(
-            result.unwrap_err().get_owned_details(),
+            result.unwrap_err().get_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
     }

--- a/tensorzero-core/src/providers/together.rs
+++ b/tensorzero-core/src/providers/together.rs
@@ -859,7 +859,7 @@ mod tests {
         let result = TogetherCredentials::try_from(generic);
         assert!(result.is_err());
         assert!(matches!(
-            result.unwrap_err().get_owned_details(),
+            result.unwrap_err().get_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
     }

--- a/tensorzero-core/src/providers/vllm.rs
+++ b/tensorzero-core/src/providers/vllm.rs
@@ -595,7 +595,7 @@ mod tests {
         let result = VLLMCredentials::try_from(generic);
         assert!(result.is_err());
         assert!(matches!(
-            result.unwrap_err().get_owned_details(),
+            result.unwrap_err().get_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
     }

--- a/tensorzero-core/src/providers/xai.rs
+++ b/tensorzero-core/src/providers/xai.rs
@@ -635,7 +635,7 @@ mod tests {
         let result = XAICredentials::try_from(generic);
         assert!(result.is_err());
         assert!(matches!(
-            result.unwrap_err().get_owned_details(),
+            result.unwrap_err().get_details(),
             ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
         ));
     }


### PR DESCRIPTION
This allows us to make `Error` cloneable while still storing arbitrary source errors from other crates.

As a result, we need to remove `Error.get_owned_details` - fortunately, all of the uses were in tests, and could all use `get_details` instead.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `Error` to use `Arc<ErrorDetails>` for clonability and update tests to use `get_details`.
> 
>   - **Behavior**:
>     - Change `Error` to store `Arc<ErrorDetails>` instead of `Box<ErrorDetails>` to make it cloneable.
>     - Remove `Error.get_owned_details` method; replace with `get_details` in tests.
>   - **Tests**:
>     - Update tests in `feedback/mod.rs`, `openai_compatible.rs`, and `anthropic.rs` to use `get_details` instead of `get_owned_details`.
>     - Similar updates in 10 other files.
>   - **Misc**:
>     - Update `Error` struct in `error.rs` to reflect changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 9af9cbe840daddf6c515319996cce41fc78a1205. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->