### PR TITLE
Assert that embeddings response is not cached in test

### DIFF
--- a/tensorzero-core/tests/e2e/providers/openai.rs
+++ b/tensorzero-core/tests/e2e/providers/openai.rs
@@ -1139,6 +1139,10 @@ async fn test_embedding_request() {
         )
         .await
         .unwrap();
+    assert!(
+        !response.cached,
+        "Response was incorrectly cached: {response:?}"
+    );
     let [first_embedding] = response.embeddings.as_slice() else {
         panic!("Expected exactly one embedding");
     };


### PR DESCRIPTION
This should help us to narrow down the cause of the abnormally fast response time we're seeing on CI
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add assertion in `test_embedding_request()` to ensure response is not cached, aiding in diagnosing CI performance issues.
> 
>   - **Tests**:
>     - Add assertion in `test_embedding_request()` in `openai.rs` to ensure `response.cached` is `false`, helping diagnose fast response times in CI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a6a417b084c06b621b20d68f0454797c754241af. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->