### PR TITLE
Remove Jaeger api response print in tests

### DIFF
--- a/tensorzero-core/tests/e2e/otel_jaeger.rs
+++ b/tensorzero-core/tests/e2e/otel_jaeger.rs
@@ -123,7 +123,6 @@ async fn test_jaeger_trace_export(
         .await
         .unwrap();
     let jaeger_traces = jaeger_result.json::<Value>().await.unwrap();
-    println!("Response: {jaeger_traces}");
     let mut target_span = None;
 
     let mut span_by_id = HashMap::new();


### PR DESCRIPTION
This isn't very useful for debugging, and causes the log output to become enormous in 'test_jaeger_trace_export_with_custom_header'
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unnecessary print statement in `test_jaeger_trace_export` in `otel_jaeger.rs` to reduce log output.
> 
>   - **Tests**:
>     - Remove `println!("Response: {jaeger_traces}")` from `test_jaeger_trace_export` in `otel_jaeger.rs` to reduce log output size.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 498e48c299348c6fa8179383c724377a229b5802. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->