### PR TITLE
bumped docker compose timeout to 2h

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -74,7 +74,7 @@ jobs:
       # Permission to fetch GitHub OIDC token authentication
       id-token: write
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 120
     if: github.repository == 'tensorzero/tensorzero'
 
     steps:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increased `timeout-minutes` from 25 to 120 for `check-latest-docker-compose` job in `general.yml`.
> 
>   - **Workflow Timeout**:
>     - Increased `timeout-minutes` from 25 to 120 in `general.yml` for the `check-latest-docker-compose` job.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f254a320442408ca5235ad97dd161254bc28f49a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->