### PR TITLE
Set cache max capacity and idle time for dynamic otel

### DIFF
--- a/tensorzero-core/src/observability.rs
+++ b/tensorzero-core/src/observability.rs
@@ -47,6 +47,7 @@
 //!   and passed along to `TracerWrapper::build_with_context` when the span is closed and exported.
 use std::hash::Hash;
 use std::hash::Hasher;
+use std::time::Duration;
 
 use axum::extract::MatchedPath;
 use axum::middleware::Next;
@@ -257,6 +258,9 @@ fn internal_build_otel_layer<T: SpanExporter + 'static>(
         default_tracer: tracer,
         default_provider: provider,
         custom_tracers: Cache::builder()
+            .max_capacity(32)
+            // Expire entries that have been idle for 1 hour
+            .time_to_idle(Duration::from_secs(60 * 60))
             .eviction_listener(move |_key, val: CustomTracer, _reason| {
                 // When we evict a `CustomTracer` from the cache, shut it down, and add the shutdown task
                 // to `shutdown_tasks` so that we can wait for all of the custom tracers to shut down


### PR DESCRIPTION
We keep at most 32 traces, and evict idle entries after 60 minutes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set cache max capacity to 32 and idle time to 60 minutes for `custom_tracers` in `internal_build_otel_layer()` in `observability.rs`.
> 
>   - **Behavior**:
>     - Set `max_capacity` to 32 for `custom_tracers` cache in `internal_build_otel_layer()`.
>     - Set `time_to_idle` to 60 minutes for `custom_tracers` cache in `internal_build_otel_layer()`.
>   - **Misc**:
>     - Add `std::time::Duration` import in `observability.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5331891a4f01b91ab1944a3831005d625ddb8bc5. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->