### PR TITLE
Exclude more test-only docker compose files from check-docker-compose

### DIFF
--- a/ci/check-docker-compose.sh
+++ b/ci/check-docker-compose.sh
@@ -7,10 +7,15 @@ if [[ "$dir_path" == */cursor ]]; then
   exit 0
 fi
 
-# We already use this in CI, so no need to test it twice
+# We already use these in CI, so no need to test it twice
 if [[ "$1" == *ui/fixtures/docker-compose.yml || \
       "$1" == *ui/fixtures/docker-compose.e2e.yml || \
       "$1" == *tensorzero-core/tests/e2e/docker-compose.yml || \
+      "$1" == *tensorzero-core/tests/e2e/docker-compose.replicated.yml || \
+      "$1" == *tensorzero-core/tests/e2e/docker-compose.live.yml || \
+      "$1" == *tensorzero-core/tests/e2e/docker-compose.clickhouse.yml || \
+      "$1" == *tensorzero-core/tests/e2e/docker-compose-common.yml || \
+      "$1" == *tensorzero-core/tests/optimization/docker-compose.yml || \
       "$1" == *ui/docker-compose.yml || \
       "$1" == *ci/internal-network.yml ]]; then
   exit 0


### PR DESCRIPTION
We use these files as part of CI, so there's no need to run them again in a separate job
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Exclude additional test-only docker compose files from `ci/check-docker-compose.sh` to prevent redundant CI testing.
> 
>   - **Behavior**:
>     - Excludes additional test-only docker compose files from `ci/check-docker-compose.sh` to avoid redundant CI testing.
>     - Specifically excludes `docker-compose.replicated.yml`, `docker-compose.live.yml`, `docker-compose.clickhouse.yml`, `docker-compose-common.yml`, and `optimization/docker-compose.yml`.
>   - **Misc**:
>     - Updates comment in `ci/check-docker-compose.sh` to reflect the exclusion of multiple files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5d6ac77e2a47bef330474d794063b1e045848606. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->