### PR TITLE
fixed chat datapoint editing and added more tests

### DIFF
--- a/ui/app/routes/datasets/$dataset_name/datapoint/$id/route.tsx
+++ b/ui/app/routes/datasets/$dataset_name/datapoint/$id/route.tsx
@@ -51,7 +51,6 @@ import type {
 
 export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
-  console.log(formData);
 
   try {
     const rawData = {
@@ -77,15 +76,12 @@ export async function action({ request }: ActionFunctionArgs) {
       source_inference_id: formData.get("source_inference_id"),
       is_custom: true,
     };
-    console.log(rawData);
 
     const cleanedData = Object.fromEntries(
       Object.entries(rawData).filter(([, value]) => value !== undefined),
     );
-    console.log(cleanedData);
     const parsedFormData: ParsedDatasetRow =
       ParsedDatasetRowSchema.parse(cleanedData);
-    console.log(parsedFormData);
     const config = await getConfig();
     const functionConfig = await getFunctionConfig(
       parsedFormData.function_name,
@@ -98,7 +94,6 @@ export async function action({ request }: ActionFunctionArgs) {
       );
     }
     const functionType = functionConfig.type;
-    console.log(functionType);
 
     const action = formData.get("action");
     if (action === "delete") {
@@ -126,8 +121,6 @@ export async function action({ request }: ActionFunctionArgs) {
       const transformedOutput = transformOutputForTensorZero(
         parsedFormData.output,
       );
-      console.log(transformedInput);
-      console.log(transformedOutput);
 
       try {
         // For future reference:

--- a/ui/app/routes/datasets/$dataset_name/datapoint/$id/route.tsx
+++ b/ui/app/routes/datasets/$dataset_name/datapoint/$id/route.tsx
@@ -51,6 +51,7 @@ import type {
 
 export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
+  console.log(formData);
 
   try {
     const rawData = {
@@ -76,12 +77,15 @@ export async function action({ request }: ActionFunctionArgs) {
       source_inference_id: formData.get("source_inference_id"),
       is_custom: true,
     };
+    console.log(rawData);
 
     const cleanedData = Object.fromEntries(
       Object.entries(rawData).filter(([, value]) => value !== undefined),
     );
+    console.log(cleanedData);
     const parsedFormData: ParsedDatasetRow =
       ParsedDatasetRowSchema.parse(cleanedData);
+    console.log(parsedFormData);
     const config = await getConfig();
     const functionConfig = await getFunctionConfig(
       parsedFormData.function_name,
@@ -94,6 +98,7 @@ export async function action({ request }: ActionFunctionArgs) {
       );
     }
     const functionType = functionConfig.type;
+    console.log(functionType);
 
     const action = formData.get("action");
     if (action === "delete") {
@@ -121,6 +126,8 @@ export async function action({ request }: ActionFunctionArgs) {
       const transformedOutput = transformOutputForTensorZero(
         parsedFormData.output,
       );
+      console.log(transformedInput);
+      console.log(transformedOutput);
 
       try {
         // For future reference:
@@ -143,10 +150,13 @@ export async function action({ request }: ActionFunctionArgs) {
             ...baseDatapoint,
             output_schema: parsedFormData.output_schema,
           };
-        } else if (functionType === "chat" && "tool_params" in parsedFormData) {
+        } else if (functionType === "chat") {
           datapoint = {
             ...baseDatapoint,
-            tool_params: parsedFormData.tool_params,
+            tool_params:
+              "tool_params" in parsedFormData
+                ? parsedFormData.tool_params
+                : undefined,
           };
         } else {
           throw new Error(

--- a/ui/e2e_tests/datasets.$dataset_name.datapoint.$datapoint_id.spec.ts
+++ b/ui/e2e_tests/datasets.$dataset_name.datapoint.$datapoint_id.spec.ts
@@ -70,20 +70,39 @@ test("should be able to add, edit and save a json datapoint", async ({
   // Edit the input
   const topic = v7();
   const input = `{"topic":"${topic}"}`;
-
   await page.locator("div[contenteditable='true']").first().fill(input);
+
+  // Edit the output
+  const output = `{
+    "person": [
+      "Ian Thorpe",
+      "Garry Kasparov"
+    ],
+    "organization": [],
+    "location": [
+      "Australia",
+      "Russia"
+    ],
+    "miscellaneous": [
+    ]
+  }`;
+  await page.locator("div[contenteditable='true']").last().fill(output);
 
   // Save the datapoint
   await page.getByRole("button", { name: "Save" }).click();
 
+  // Wait for save to complete
+  await page.waitForLoadState("networkidle");
+
   // Assert that "error" is not in the page
   await expect(page.getByText("error", { exact: false })).not.toBeVisible();
 
-  // Assert that the input is updated
-  await expect(page.getByText(input)).toBeVisible();
+  // Assert that both input and output are updated
+  await expect(page.getByText(input, { exact: true })).toBeVisible();
+  await expect(page.getByText("Garry Kasparov")).toBeVisible();
 
   // Should show "Custom" badge and link original inference
-  await expect(page.getByText("Custom")).toBeVisible();
+  await expect(page.getByText("Custom", { exact: true })).toBeVisible();
   await expect(page.getByText("Inference", { exact: true })).toBeVisible();
 });
 
@@ -125,22 +144,30 @@ test("should be able to add, edit and save a chat datapoint", async ({
   // Click the edit button
   await page.getByRole("button", { name: "Edit" }).click();
 
-  // Edit the output
-  const topic = v7();
-  const output = `fdfasdfdsfafs ${topic}`;
+  // Edit the input (first contenteditable element)
+  const inputTopic = v7();
+  const inputMessage = `Tell me about ${inputTopic}`;
+  await page.locator("div[contenteditable='true']").first().fill(inputMessage);
 
+  // Edit the output (last contenteditable element)
+  const outputTopic = v7();
+  const output = `Here's information about ${outputTopic}`;
   await page.locator("div[contenteditable='true']").last().fill(output);
 
   // Save the datapoint
   await page.getByRole("button", { name: "Save" }).click();
 
+  // Wait for save to complete
+  await page.waitForLoadState("networkidle");
+
   // Assert that "error" is not in the page
   await expect(page.getByText("error", { exact: false })).not.toBeVisible();
 
-  // Assert that the output is updated
-  await expect(page.getByText(output)).toBeVisible();
+  // Assert that both input and output are updated
+  await expect(page.getByText(inputMessage, { exact: true })).toBeVisible();
+  await expect(page.getByText(output, { exact: true })).toBeVisible();
 
   // Should show "Custom" badge and link original inference
-  await expect(page.getByText("Custom")).toBeVisible();
+  await expect(page.getByText("Custom", { exact: true })).toBeVisible();
   await expect(page.getByText("Inference", { exact: true })).toBeVisible();
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes chat datapoint editing by adjusting `tool_params` handling and adds tests for JSON and chat datapoint operations.
> 
>   - **Behavior**:
>     - Fixes handling of `tool_params` for chat datapoints in `action()` in `route.tsx`.
>     - Ensures `tool_params` is set to `undefined` if not present in `parsedFormData`.
>   - **Tests**:
>     - Adds test for adding, editing, and saving a JSON datapoint in `datasets.$dataset_name.datapoint.$datapoint_id.spec.ts`.
>     - Adds test for adding, editing, and saving a chat datapoint in `datasets.$dataset_name.datapoint.$datapoint_id.spec.ts`.
>     - Adds test for adding, editing, and saving a chat datapoint with tool call in `datasets.$dataset_name.datapoint.$datapoint_id.spec.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 468d302b0d93ceba19e1ae3332437f69e4e196ff. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->