### PR TITLE
Introduce `LazyResolvedInput` and use it during inference

### DIFF
--- a/tensorzero-core/src/endpoints/batch_inference.rs
+++ b/tensorzero-core/src/endpoints/batch_inference.rs
@@ -2,6 +2,7 @@ use axum::body::Body;
 use axum::extract::{Path, State};
 use axum::response::{IntoResponse, Response};
 use axum::{debug_handler, Json};
+use futures::future::join_all;
 use itertools::{izip, Itertools};
 use metrics::counter;
 use serde::{Deserialize, Serialize};
@@ -30,6 +31,8 @@ use crate::inference::types::batch::{
     BatchOutputSchemasWithSize, BatchRequestRow, BatchStatus, PollBatchInferenceResponse,
     ProviderBatchInferenceOutput, ProviderBatchInferenceResponse, UnparsedBatchRequestRow,
 };
+use crate::inference::types::resolved_input::LazyResolvedInput;
+use crate::inference::types::RequestMessage;
 use crate::inference::types::{batch::StartBatchModelInferenceWithMetadata, Input};
 use crate::inference::types::{
     current_timestamp, ChatInferenceDatabaseInsert, ContentBlockChatOutput, FetchContext,
@@ -37,7 +40,6 @@ use crate::inference::types::{
     JsonInferenceOutput, Latency, ModelInferenceResponseWithMetadata, RequestMessagesOrBatch,
     Usage,
 };
-use crate::inference::types::{RequestMessage, ResolvedInput};
 use crate::jsonschema_util::DynamicJSONSchema;
 use crate::model::ModelTable;
 use crate::tool::{
@@ -228,13 +230,11 @@ pub async fn start_batch_inference(
         object_store_info: &config.object_store_info,
     };
 
-    let resolved_inputs = futures::future::try_join_all(
-        params
-            .inputs
-            .into_iter()
-            .map(|input| input.resolve(&context)),
-    )
-    .await?;
+    let resolved_inputs = params
+        .inputs
+        .into_iter()
+        .map(|input| input.into_lazy_resolved_input(context))
+        .collect::<Result<Vec<LazyResolvedInput>, Error>>()?;
 
     // Keep sampling variants until one succeeds
     // We already guarantee there is at least one inference
@@ -552,7 +552,7 @@ async fn poll_batch_inference(
 // This is only used to help with iteration in the `write_batch_inference` function
 struct BatchInferenceRowHelper<'a> {
     inference_id: &'a Uuid,
-    input: ResolvedInput,
+    input: LazyResolvedInput,
     input_messages: Vec<RequestMessage>,
     system: Option<&'a str>,
     tool_config: Option<&'a ToolCallConfig>,
@@ -565,12 +565,14 @@ struct BatchInferenceRowHelper<'a> {
 async fn write_start_batch_inference<'a>(
     clickhouse_connection_info: &ClickHouseConnectionInfo,
     config: &Config,
-    inputs: Vec<ResolvedInput>,
+    inputs: Vec<LazyResolvedInput>,
     result: StartBatchModelInferenceWithMetadata<'a>,
     metadata: BatchInferenceDatabaseInsertMetadata<'a>,
     tool_configs: &[Option<ToolCallConfig>],
     inference_configs: &[InferenceConfig<'a>],
 ) -> Result<(Uuid, Vec<Uuid>), Error> {
+    let model_name = &result.model_name;
+    let model_provider_name = &result.model_provider_name;
     // Collect all the data into BatchInferenceRow structs
     let inference_rows = izip!(
         inference_configs.iter(),
@@ -612,23 +614,20 @@ async fn write_start_batch_inference<'a>(
             }
         },
     );
-    let mut rows: Vec<BatchModelInferenceRow<'_>> = vec![];
-    let mut file_futures = Vec::new();
-
-    // Process each row by serializing the stuff that needs to be serialized twice
-    for row in inference_rows {
+    let rows = join_all(inference_rows.enumerate().map(|(i, row)| async move {
         let tool_params: Option<ToolCallConfigDatabaseInsert> =
             row.tool_config.map(|tc| tc.clone().into());
 
-        file_futures.extend(row.input.clone().write_all_files(config));
+        let resolved_input = row.input.clone().resolve().await?;
+        join_all(resolved_input.clone().write_all_files(config)).await;
 
-        rows.push(BatchModelInferenceRow {
+        Ok::<_, Error>(BatchModelInferenceRow {
             inference_id: *row.inference_id,
             batch_id: result.batch_id,
             function_name: metadata.function_name.into(),
             variant_name: metadata.variant_name.into(),
-            episode_id: metadata.episode_ids[rows.len()],
-            input: row.input.into_stored_input(),
+            episode_id: metadata.episode_ids[i],
+            input: resolved_input.into_stored_input(),
             input_messages: row
                 .input_messages
                 .into_iter()
@@ -639,16 +638,26 @@ async fn write_start_batch_inference<'a>(
             inference_params: Cow::Borrowed(row.inference_params),
             output_schema: row.output_schema.map(Value::to_string),
             raw_request: Cow::Borrowed(row.raw_request),
-            model_name: Cow::Borrowed(result.model_name),
-            model_provider_name: Cow::Borrowed(&result.model_provider_name),
+            model_name: Cow::Borrowed(model_name),
+            model_provider_name: Cow::Borrowed(model_provider_name),
             tags: row.tags.unwrap_or_default(),
-        });
-    }
+        })
+    }))
+    .await;
 
-    futures::future::join_all(file_futures).await;
+    let success_rows = rows
+        .into_iter()
+        .flat_map(|res| match res {
+            Ok(row) => Some(row),
+            Err(e) => {
+                tracing::error!("Failed to resolve batch inference input: {e:?}");
+                None
+            }
+        })
+        .collect::<Vec<_>>();
 
     clickhouse_connection_info
-        .write_batched(rows.as_slice(), TableName::BatchModelInference)
+        .write_batched(success_rows.as_slice(), TableName::BatchModelInference)
         .await?;
 
     let batch_request_insert = BatchRequestRow::new(UnparsedBatchRequestRow {

--- a/tensorzero-core/src/endpoints/inference.rs
+++ b/tensorzero-core/src/endpoints/inference.rs
@@ -31,6 +31,7 @@ use crate::gateway_util::{AppState, AppStateData, StructuredJson};
 use crate::http::TensorzeroHttpClient;
 use crate::inference::types::extra_body::UnfilteredInferenceExtraBody;
 use crate::inference::types::extra_headers::UnfilteredInferenceExtraHeaders;
+use crate::inference::types::resolved_input::LazyResolvedInput;
 use crate::inference::types::{
     collect_chunks, ChatInferenceDatabaseInsert, ChatInferenceResultChunk, CollectChunksArgs,
     ContentBlockChatOutput, ContentBlockChunk, FetchContext, FinishReason, InferenceResult,
@@ -117,7 +118,7 @@ struct InferenceMetadata {
     pub variant_name: String,
     pub episode_id: Uuid,
     pub inference_id: Uuid,
-    pub input: ResolvedInput,
+    pub input: LazyResolvedInput,
     pub dryrun: bool,
     pub start_time: Instant,
     pub inference_params: InferenceParams,
@@ -318,13 +319,10 @@ pub async fn inference(
         models: &config.models,
         embedding_models: &config.embedding_models,
     };
-    let resolved_input = params
-        .input
-        .resolve(&FetchContext {
-            client: http_client,
-            object_store_info: &config.object_store_info,
-        })
-        .await?;
+    let resolved_input = params.input.into_lazy_resolved_input(FetchContext {
+        client: http_client,
+        object_store_info: &config.object_store_info,
+    })?;
     // Keep sampling variants until one succeeds
     while !candidate_variants.is_empty() {
         let (variant_name, variant) =
@@ -456,21 +454,22 @@ pub async fn inference(
                 // is cancelled. This reduces the chances that we only write to some tables and not others
                 // (but this is inherently best-effort due to ClickHouse's lack of transactions).
                 let write_future = tokio::spawn(async move {
-                    write_inference(
+                    let _: () = write_inference(
                         &clickhouse_connection_info,
                         &config,
-                        resolved_input,
+                        resolved_input.clone().resolve().await?,
                         result_to_write,
                         write_metadata,
                     )
                     .await;
+                    Ok::<_, Error>(())
                 });
                 if !async_writes {
                     write_future.await.map_err(|e| {
                         Error::new(ErrorDetails::InternalError {
                             message: format!("Failed to await ClickHouse inference write: {e:?}"),
                         })
-                    })?;
+                    })??;
                 }
             }
 
@@ -707,15 +706,25 @@ fn create_stream(
                         extra_headers,
                     };
                     let config = config.clone();
+                        // TODO - shuld we resolve this earlier in sync write mode, so that we can reject the request with
+                        // an error if it fails?
+                        match input.resolve().await {
+                            Ok(input) => {
+                                let clickhouse_connection_info = clickhouse_connection_info.clone();
+                                write_inference(
+                                    &clickhouse_connection_info,
+                                    &config,
+                                    input,
+                                    inference_response,
+                                    write_metadata,
+                                ).await;
+                            },
+                            Err(e) => {
+                                tracing::error!("Failed to resolve input: {e:?}");
 
-                        let clickhouse_connection_info = clickhouse_connection_info.clone();
-                        write_inference(
-                            &clickhouse_connection_info,
-                            &config,
-                            input,
-                            inference_response,
-                            write_metadata,
-                        ).await;
+                            }
+                        };
+
 
                 }
                 drop(clickhouse_connection_info);
@@ -1268,7 +1277,7 @@ mod tests {
             variant_name: "test_variant".to_string(),
             episode_id: Uuid::now_v7(),
             inference_id: Uuid::now_v7(),
-            input: ResolvedInput {
+            input: LazyResolvedInput {
                 messages: vec![],
                 system: None,
             },
@@ -1321,7 +1330,7 @@ mod tests {
             variant_name: "test_variant".to_string(),
             inference_id: Uuid::now_v7(),
             episode_id: Uuid::now_v7(),
-            input: ResolvedInput {
+            input: LazyResolvedInput {
                 messages: vec![],
                 system: None,
             },

--- a/tensorzero-core/src/endpoints/stored_inference.rs
+++ b/tensorzero-core/src/endpoints/stored_inference.rs
@@ -24,24 +24,31 @@ pub async fn render_samples<T: StoredSample>(
     // TODO: make it configurable whether to drop or error on failures.
     let results = join_all(resolution_futures).await;
 
-    let final_rendered_examples: Vec<RenderedSample> = stored_samples
-        .into_iter() // Consumes Vec<impl StoredSample>; elements are already mutated
-        .zip(results.into_iter()) // Creates an iterator of (StoredInference, Result<(), Error>)
-        .filter_map(|(example, resolution_result)| {
-            // Filter out examples where reresolve_input_for_fine_tuning failed.
-            // If resolution_result is Ok, map Some(()) to Some(example).
-            // If resolution_result is Err, .ok() yields None, so filter_map drops it.
-            resolution_result.ok().map(|resolved| (example, resolved))
-        })
-        .filter_map(|(sample, resolved_input)| {
-            // resolved_example is a StoredInference that was successfully processed by reresolve.
-            // Now, attempt to render it.
-            // render_stored_inference returns Result<RenderedStoredInference, Error>.
-            // .ok() converts this to Option<RenderedStoredInference>.
-            // filter_map will keep Some(RenderedStoredInference) and discard None (if rendering failed).
-            render_stored_sample(sample, resolved_input, &config, &variants).ok()
-        })
-        .collect();
+    let final_rendered_examples: Vec<RenderedSample> = join_all(
+        stored_samples
+            .into_iter() // Consumes Vec<impl StoredSample>; elements are already mutated
+            .zip(results.into_iter()) // Creates an iterator of (StoredInference, Result<(), Error>)
+            .filter_map(|(example, resolution_result)| {
+                // Filter out examples where reresolve_input_for_fine_tuning failed.
+                // If resolution_result is Ok, map Some(()) to Some(example).
+                // If resolution_result is Err, .ok() yields None, so filter_map drops it.
+                resolution_result.ok().map(|resolved| (example, resolved))
+            })
+            .map(|(sample, resolved_input)| async {
+                // resolved_example is a StoredInference that was successfully processed by reresolve.
+                // Now, attempt to render it.
+                // render_stored_inference returns Result<RenderedStoredInference, Error>.
+                // .ok() converts this to Option<RenderedStoredInference>.
+                // filter_map will keep Some(RenderedStoredInference) and discard None (if rendering failed).
+                render_stored_sample(sample, resolved_input, &config, &variants)
+                    .await
+                    .ok()
+            }),
+    )
+    .await
+    .into_iter()
+    .flatten()
+    .collect();
 
     Ok(final_rendered_examples)
 }

--- a/tensorzero-core/src/inference/types/mod.rs
+++ b/tensorzero-core/src/inference/types/mod.rs
@@ -1,4 +1,47 @@
+//! Main TensorZero types for inference requests and responses
+//!
+//! During inference processing, we transform between several different input types:
+//! * Input/InputMessage/InputMessageContent:
+//!     These types hold an input request deserialized directly from the client.
+//!     At this point, we have not fetched any network resources (e.g. file urls),
+//!     and we may have various legacy input types (e.g. `{"type": "text", "value": ...}`).
+//!     Templates have not yet been applied
+//! * `LazyResolvedInput`/`LazyResolvedInputMessage`/`LazyResolvedInputMessageContent`:
+//!     These types hold input with legacy input types normalized
+//!     (e.g. a `{"type": "text", "value": ...}` block is converted to a `{"type": "text", "template": <role>, "arguments": {}}` block
+//!     with the template name chosen based on the message role).
+//!     We also construct (but do not yet `.await`) and store futures to fetch any file urls in the input.
+//!     Templates have not yet been applied
+//! * `ResolvedInput/ResolvedInputMessage/ResolvedInputMessageContent`:
+//!    These types are almost the same as the `LazyResolvedInput`/`LazyResolvedInputMessage`/`LazyResolvedInputMessageContent` types,
+//!    but each file future is now resolved to an in-memory file. No network requests are needed to resolve any data
+//!    within these input types.
+//!    Templates have been applied.
+//! * `RequestMessage/ContentBlock`:
+//!    These types hold input specialized for a particular variant.
+//!    Templating has been applied, which prevents converting back to a `LazyResolvedInput`/`ResolvedInput` type.
+//!    All files are fully resolved to in-memory files.
+//! * `StoredInput/StoredInputMessage/StoredInputMessageContent`:
+//!    These types represent the actual data written to `ChatInference`/`JsonInference` in ClickHouse.
+//!    Files are stored as object store paths, without the actual file contents (since we only write paths to ClickHouse)
+//!    Templating has been applied.
+//! * `StoredRequestMessage/StoredContentBlock`:
+//!    These types represent the actual data written to `ModelInference` in ClickHouse.
+//!    Files are stored as object store paths, without the actual file contents (since we only write paths to ClickHouse)
+//!    Templating has been applied.
+//!
+//! During normal inference processing, the types are transformed as:
+//!
+//!                                                   -> `RequestMessage` -> `StoredRequestMessage`
+//! `Input` -> `LazyResolvedInput` -> `ResolvedInput`
+//!                                                   -> `StoredInput`
+//!
+//! The upper branch (constructing a `RequestMessage`) is used when invoking a chat completion variant.
+//! The lower branch (constructing a `StoredInput`) is used when we to write to `ChatInference`/`JsonInference` in ClickHouse.
 use crate::http::TensorzeroHttpClient;
+use crate::inference::types::resolved_input::{
+    LazyResolvedInput, LazyResolvedInputMessage, LazyResolvedInputMessageContent,
+};
 use crate::inference::types::stored_input::StoredFile;
 use crate::serde_util::{
     deserialize_defaulted_json_string, deserialize_json_string, deserialize_optional_json_string,
@@ -11,7 +54,7 @@ use extra_headers::{FullExtraHeadersConfig, UnfilteredInferenceExtraHeaders};
 use file::sanitize_raw_request;
 pub use file::{Base64File, File};
 use futures::stream::Peekable;
-use futures::Stream;
+use futures::{FutureExt, Stream};
 use indexmap::IndexMap;
 use itertools::Itertools;
 #[cfg(feature = "pyo3")]
@@ -81,19 +124,36 @@ pub struct Input {
     pub messages: Vec<InputMessage>,
 }
 
+#[derive(Copy, Clone)]
 pub struct FetchContext<'a> {
     pub client: &'a TensorzeroHttpClient,
     pub object_store_info: &'a Option<ObjectStoreInfo>,
 }
 
 impl Input {
+    pub fn into_lazy_resolved_input(
+        self,
+        context: FetchContext<'_>,
+    ) -> Result<LazyResolvedInput, Error> {
+        Ok(LazyResolvedInput {
+            system: self.system,
+            messages: self
+                .messages
+                .into_iter()
+                .map(|message| message.into_lazy_resolved_input_message(context))
+                .collect::<Result<Vec<LazyResolvedInputMessage>, Error>>()?,
+        })
+    }
+}
+
+impl LazyResolvedInput {
     /// Resolves any nested network resources in the input.
     /// Currently, this resolves input image urls into base64-encoded images.
-    pub async fn resolve(self, context: &FetchContext<'_>) -> Result<ResolvedInput, Error> {
+    pub async fn resolve(self) -> Result<ResolvedInput, Error> {
         let messages = futures::future::try_join_all(
             self.messages
                 .into_iter()
-                .map(|message| message.resolve(context)),
+                .map(resolved_input::LazyResolvedInputMessage::resolve),
         )
         .await?;
         Ok(ResolvedInput {
@@ -104,11 +164,27 @@ impl Input {
 }
 
 impl InputMessage {
-    pub async fn resolve(self, context: &FetchContext<'_>) -> Result<ResolvedInputMessage, Error> {
+    pub fn into_lazy_resolved_input_message(
+        self,
+        context: FetchContext<'_>,
+    ) -> Result<LazyResolvedInputMessage, Error> {
+        Ok(LazyResolvedInputMessage {
+            role: self.role,
+            content: self
+                .content
+                .into_iter()
+                .map(|content| content.into_lazy_resolved_input_message(self.role, context))
+                .collect::<Result<Vec<LazyResolvedInputMessageContent>, Error>>()?,
+        })
+    }
+}
+
+impl LazyResolvedInputMessage {
+    pub async fn resolve(self) -> Result<ResolvedInputMessage, Error> {
         let content = futures::future::try_join_all(
             self.content
                 .into_iter()
-                .map(|content| content.resolve(self.role, context)),
+                .map(resolved_input::LazyResolvedInputMessageContent::resolve),
         )
         .await?;
         Ok(ResolvedInputMessage {
@@ -122,45 +198,47 @@ impl InputMessageContent {
     /// The 'role' parameter is only used to handle legacy role-based templates (`{"type": "text", "value": ...}`).
     /// Once we removed support for these input blocks (and only support `{"type": "template", "name": "...", "arguments": ...}`),
     /// we can remove the 'role' parameter.
-    pub async fn resolve(
+    pub fn into_lazy_resolved_input_message(
         self,
         role: Role,
-        context: &FetchContext<'_>,
-    ) -> Result<ResolvedInputMessageContent, Error> {
+        context: FetchContext<'_>,
+    ) -> Result<LazyResolvedInputMessageContent, Error> {
         Ok(match self {
             InputMessageContent::Text(TextKind::Text { text }) => {
-                ResolvedInputMessageContent::Text { text }
+                LazyResolvedInputMessageContent::Text { text }
+            }
+            InputMessageContent::RawText { value } => {
+                LazyResolvedInputMessageContent::RawText { value }
+            }
+            InputMessageContent::Thought(thought) => {
+                LazyResolvedInputMessageContent::Thought(thought)
             }
             InputMessageContent::Template(template) => {
-                ResolvedInputMessageContent::Template(template)
+                LazyResolvedInputMessageContent::Template(template)
             }
             InputMessageContent::Text(TextKind::Arguments { arguments }) => {
                 // Map the legacy `{{"type": "text", "arguments": ...}}` format to an explicit
                 // `{{"type": "template", "name": "<role>", "arguments": ...}}` format, with the template
                 // name chosen based on the message role.
-                ResolvedInputMessageContent::Template(TemplateInput {
+                LazyResolvedInputMessageContent::Template(TemplateInput {
                     name: role.implicit_template_name().to_string(),
                     arguments,
                 })
             }
             InputMessageContent::ToolCall(tool_call) => {
-                ResolvedInputMessageContent::ToolCall(tool_call.try_into()?)
+                LazyResolvedInputMessageContent::ToolCall(tool_call.try_into()?)
             }
             InputMessageContent::ToolResult(tool_result) => {
-                ResolvedInputMessageContent::ToolResult(tool_result)
+                LazyResolvedInputMessageContent::ToolResult(tool_result)
             }
-            InputMessageContent::RawText { value } => {
-                ResolvedInputMessageContent::RawText { value }
-            }
-            InputMessageContent::Thought(thought) => ResolvedInputMessageContent::Thought(thought),
             InputMessageContent::Text(TextKind::LegacyValue { value }) => {
                 tracing::warn!(
                     r#"Deprecation Warning: `{{"type": "text", "value", ...}}` is deprecated. Please use `{{"type": "text", "text": "String input"}}` or `{{"type": "text", "arguments": {{..}}}} ` instead."#
                 );
                 match value {
-                    Value::String(text) => ResolvedInputMessageContent::Text { text },
+                    Value::String(text) => LazyResolvedInputMessageContent::Text { text },
                     Value::Object(arguments) => {
-                        ResolvedInputMessageContent::Template(TemplateInput {
+                        LazyResolvedInputMessageContent::Template(TemplateInput {
                             name: role.implicit_template_name().to_string(),
                             arguments,
                         })
@@ -183,14 +261,96 @@ impl InputMessageContent {
                     })?
                     .kind
                     .clone();
-                let file = file.take_or_fetch(context.client).await?;
-                let path = storage_kind.file_path(&file)?;
-                ResolvedInputMessageContent::File(Box::new(FileWithPath {
-                    file,
-                    storage_path: path,
-                }))
+                match &file {
+                    File::Url { .. } => {
+                        // Check that we have an object store *outside* of the future that we're going to store in
+                        // `LazyResolvedInputMessageContent::File`. We want to error immediately if the user tries
+                        // to use a file input without explicitly configuring an object store (either explicit enabled or disabled)
+                        let storage_kind = context
+                            .object_store_info
+                            .as_ref()
+                            .ok_or_else(|| {
+                                Error::new(ErrorDetails::ObjectStoreUnconfigured {
+                                    block_type: "file".to_string(),
+                                })
+                            })?
+                            .kind
+                            .clone();
+                        let client = context.client.clone();
+                        // Construct a future that will actually fetch the file URL from the network.
+                        // Important - we do *not* use `tokio::spawn` here. As a result, the future
+                        // will not actually begin executing (including opening the network connection)
+                        // until the first time the `Shared` wrapper is `.await`ed.
+                        // This ensures that if we never actually need to download the file
+                        // (due to model providers forwarding image urls, and object store observability being disabled),
+                        // we will skip downloading the file entirely.
+                        let delayed_file_future = async move {
+                            let file = file.take_or_fetch(&client).await?;
+                            let path = storage_kind.file_path(&file)?;
+                            Ok(FileWithPath {
+                                file,
+                                storage_path: path,
+                            })
+                        };
+                        LazyResolvedInputMessageContent::File(delayed_file_future.boxed().shared())
+                    }
+                    File::Base64 { mime_type, data } => {
+                        let file = Base64File {
+                            url: None,
+                            mime_type: mime_type.clone(),
+                            data: data.clone(),
+                        };
+
+                        let path = storage_kind.file_path(&file)?;
+
+                        // We have inline file data already, so construct
+                        LazyResolvedInputMessageContent::File(
+                            (futures::future::ready(Ok(FileWithPath {
+                                file,
+                                storage_path: path,
+                            })))
+                            .boxed()
+                            .shared(),
+                        )
+                    }
+                }
             }
             InputMessageContent::Unknown {
+                data,
+                model_provider_name,
+            } => LazyResolvedInputMessageContent::Unknown {
+                data,
+                model_provider_name,
+            },
+        })
+    }
+}
+
+impl LazyResolvedInputMessageContent {
+    pub async fn resolve(self) -> Result<ResolvedInputMessageContent, Error> {
+        Ok(match self {
+            LazyResolvedInputMessageContent::Text { text } => {
+                ResolvedInputMessageContent::Text { text }
+            }
+            LazyResolvedInputMessageContent::Template(template) => {
+                ResolvedInputMessageContent::Template(template)
+            }
+            LazyResolvedInputMessageContent::ToolCall(tool_call) => {
+                ResolvedInputMessageContent::ToolCall(tool_call)
+            }
+            LazyResolvedInputMessageContent::ToolResult(tool_result) => {
+                ResolvedInputMessageContent::ToolResult(tool_result)
+            }
+            LazyResolvedInputMessageContent::RawText { value } => {
+                ResolvedInputMessageContent::RawText { value }
+            }
+            LazyResolvedInputMessageContent::Thought(thought) => {
+                ResolvedInputMessageContent::Thought(thought)
+            }
+            LazyResolvedInputMessageContent::File(file) => {
+                ResolvedInputMessageContent::File(Box::new(file.await?))
+            }
+            LazyResolvedInputMessageContent::Unknown {
                 data,
                 model_provider_name,
             } => ResolvedInputMessageContent::Unknown {
@@ -1028,6 +1188,13 @@ impl From<String> for InputMessageContent {
 impl From<String> for ResolvedInputMessageContent {
     fn from(text: String) -> Self {
         ResolvedInputMessageContent::Text { text }
+    }
+}
+
+#[cfg(test)]
+impl From<String> for LazyResolvedInputMessageContent {
+    fn from(text: String) -> Self {
+        LazyResolvedInputMessageContent::Text { text }
     }
 }
 

--- a/tensorzero-core/src/inference/types/resolved_input.rs
+++ b/tensorzero-core/src/inference/types/resolved_input.rs
@@ -1,6 +1,7 @@
 use std::future::Future;
 use std::pin::Pin;
 
+use futures::future::Shared;
 use futures::FutureExt;
 use object_store::{PutMode, PutOptions};
 use serde::{Deserialize, Serialize};
@@ -23,6 +24,50 @@ use crate::inference::types::pyo3_helpers::{
 };
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
+
+#[derive(Clone, Debug)]
+pub struct LazyResolvedInput {
+    pub system: Option<Value>,
+    pub messages: Vec<LazyResolvedInputMessage>,
+}
+
+#[derive(Clone, Debug)]
+pub struct LazyResolvedInputMessage {
+    pub role: Role,
+    pub content: Vec<LazyResolvedInputMessageContent>,
+}
+
+/// Holds a lazily-resolved file from a `LazyResolvedInputMessageContent::File`.
+/// This is constructed as either:
+/// 1. An immediately-ready future, when we're converting a `ResolvedInputMessageContent` to a `LazyResolvedInputMessageContent`
+/// 2. A network fetch future, when we're resolving an image url in `InputMessageContent::File`.
+///
+/// This future is `Shared`, so that we can `.await` it from multiple different model providers
+/// (if we're not forwarding an image url to the model provider), as well as when writing the
+/// file to the object store (if enabled).
+pub type FileFuture = Shared<Pin<Box<dyn Future<Output = Result<FileWithPath, Error>> + Send>>>;
+
+#[derive(Clone, Debug)]
+pub enum LazyResolvedInputMessageContent {
+    Text {
+        text: String,
+    },
+    Template(TemplateInput),
+    ToolCall(ToolCall),
+    ToolResult(ToolResult),
+    RawText {
+        value: String,
+    },
+    Thought(Thought),
+    // When we add support for forwarding image urls to the model provider,
+    // we'll store additional information here
+    File(FileFuture),
+    Unknown {
+        data: Value,
+        model_provider_name: Option<String>,
+    },
+    // We may extend this in the future to include other types of content
+}
 
 /// Like `Input`, but with all network resources resolved.
 /// Currently, this is just used to fetch image URLs in the image input,
@@ -101,6 +146,17 @@ impl ResolvedInput {
                 .messages
                 .into_iter()
                 .map(ResolvedInputMessage::into_stored_input_message)
+                .collect(),
+        }
+    }
+
+    pub fn into_lazy_resolved_input(self) -> LazyResolvedInput {
+        LazyResolvedInput {
+            system: self.system,
+            messages: self
+                .messages
+                .into_iter()
+                .map(ResolvedInputMessage::into_lazy_resolved_input_message)
                 .collect(),
         }
     }
@@ -187,6 +243,17 @@ impl ResolvedInputMessage {
                 .content
                 .into_iter()
                 .map(ResolvedInputMessageContent::into_stored_input_message_content)
+                .collect(),
+        }
+    }
+
+    pub fn into_lazy_resolved_input_message(self) -> LazyResolvedInputMessage {
+        LazyResolvedInputMessage {
+            role: self.role,
+            content: self
+                .content
+                .into_iter()
+                .map(ResolvedInputMessageContent::into_lazy_resolved_input_message_content)
                 .collect(),
         }
     }
@@ -282,6 +349,41 @@ impl ResolvedInputMessageContent {
                 data,
                 model_provider_name,
             } => StoredInputMessageContent::Unknown {
+                data,
+                model_provider_name,
+            },
+        }
+    }
+
+    pub fn into_lazy_resolved_input_message_content(self) -> LazyResolvedInputMessageContent {
+        match self {
+            ResolvedInputMessageContent::Text { text } => {
+                LazyResolvedInputMessageContent::Text { text }
+            }
+            ResolvedInputMessageContent::Template(template) => {
+                LazyResolvedInputMessageContent::Template(template)
+            }
+            ResolvedInputMessageContent::ToolCall(tool_call) => {
+                LazyResolvedInputMessageContent::ToolCall(tool_call)
+            }
+            ResolvedInputMessageContent::ToolResult(tool_result) => {
+                LazyResolvedInputMessageContent::ToolResult(tool_result)
+            }
+
+            ResolvedInputMessageContent::RawText { value } => {
+                LazyResolvedInputMessageContent::RawText { value }
+            }
+            ResolvedInputMessageContent::Thought(thought) => {
+                LazyResolvedInputMessageContent::Thought(thought)
+            }
+            // We already have a resolved file, so construct an immediately-ready future
+            ResolvedInputMessageContent::File(file) => LazyResolvedInputMessageContent::File(
+                futures::future::ready(Ok(*file)).boxed().shared(),
+            ),
+            ResolvedInputMessageContent::Unknown {
+                data,
+                model_provider_name,
+            } => LazyResolvedInputMessageContent::Unknown {
                 data,
                 model_provider_name,
             },

--- a/tensorzero-core/src/optimization/dicl.rs
+++ b/tensorzero-core/src/optimization/dicl.rs
@@ -1216,6 +1216,7 @@ mod tests {
             tool_choice: ToolChoice::None,
             parallel_tool_calls: None,
             description: None,
+
             all_explicit_templates_names: HashSet::new(),
         })
     }

--- a/tensorzero-core/src/stored_inference.rs
+++ b/tensorzero-core/src/stored_inference.rs
@@ -558,7 +558,7 @@ impl std::fmt::Display for RenderedSample {
 /// `variants` should be a map from function name to variant name, i.e. what variant to use for a particular function
 /// as the stored inference is being rendered.
 /// This does not handle resolving network resources (e.g. images).
-fn render_model_input(
+async fn render_model_input(
     resolved_input: &ResolvedInput,
     function_name: &str,
     config: &Config,
@@ -590,6 +590,7 @@ fn render_model_input(
         &config.templates,
         &chat_completion_config.templates,
     )
+    .await
 }
 
 /// Render an impl StoredSample to a RenderedStoredInference.
@@ -597,7 +598,7 @@ fn render_model_input(
 /// as the inference example is being rendered.
 ///
 /// This does not handle resolving network resources (e.g. images).
-pub fn render_stored_sample<T: StoredSample>(
+pub async fn render_stored_sample<T: StoredSample>(
     stored_sample: T,
     resolved_input: ResolvedInput,
     config: &Config,
@@ -615,7 +616,7 @@ pub fn render_stored_sample<T: StoredSample>(
         inference_id,
         tags,
     } = stored_sample.owned_simple_info();
-    let model_input = render_model_input(&resolved_input, &function_name, config, variants)?;
+    let model_input = render_model_input(&resolved_input, &function_name, config, variants).await?;
     Ok(RenderedSample {
         function_name,
         episode_id,

--- a/tensorzero-core/src/variant/chain_of_thought.rs
+++ b/tensorzero-core/src/variant/chain_of_thought.rs
@@ -9,9 +9,10 @@ use crate::endpoints::inference::{InferenceClients, InferenceModels, InferencePa
 use crate::error::{Error, ErrorDetails, IMPOSSIBLE_ERROR_MESSAGE};
 use crate::function::FunctionConfig;
 use crate::inference::types::batch::StartBatchModelInferenceWithMetadata;
+use crate::inference::types::resolved_input::LazyResolvedInput;
 use crate::inference::types::{
     ContentBlockOutput, InferenceResult, InferenceResultStream, InternalJsonInferenceOutput,
-    JsonInferenceResult, ResolvedInput, Thought,
+    JsonInferenceResult, Thought,
 };
 use crate::jsonschema_util::DynamicJSONSchema;
 use crate::minijinja_util::TemplateConfig;
@@ -51,7 +52,7 @@ impl UninitializedChainOfThoughtConfig {
 impl Variant for ChainOfThoughtConfig {
     async fn infer<'a: 'request, 'request>(
         &self,
-        input: &ResolvedInput,
+        input: &LazyResolvedInput,
         models: &'request InferenceModels<'a>,
         function: &'a FunctionConfig,
         inference_config: &'request InferenceConfig<'request>,
@@ -117,7 +118,7 @@ impl Variant for ChainOfThoughtConfig {
 
     async fn infer_stream<'request>(
         &self,
-        _input: &ResolvedInput,
+        _input: &LazyResolvedInput,
         _models: &'request InferenceModels<'_>,
         _function: &FunctionConfig,
         _inference_config: &'request InferenceConfig<'request>,
@@ -171,7 +172,7 @@ impl Variant for ChainOfThoughtConfig {
 
     async fn start_batch_inference<'a>(
         &'a self,
-        _input: &[ResolvedInput],
+        _input: &[LazyResolvedInput],
         _models: &'a InferenceModels<'a>,
         _function: &'a FunctionConfig,
         _inference_configs: &'a [InferenceConfig<'a>],

--- a/tensorzero-core/src/variant/mod.rs
+++ b/tensorzero-core/src/variant/mod.rs
@@ -31,7 +31,7 @@ use crate::inference::types::extra_body::{FullExtraBodyConfig, UnfilteredInferen
 use crate::inference::types::extra_headers::{
     FullExtraHeadersConfig, UnfilteredInferenceExtraHeaders,
 };
-use crate::inference::types::ResolvedInput;
+use crate::inference::types::resolved_input::LazyResolvedInput;
 use crate::inference::types::{
     FunctionType, InferenceResultChunk, InferenceResultStream, ModelInferenceRequest,
     ModelInferenceResponseWithMetadata, RequestMessage,
@@ -201,7 +201,7 @@ pub struct ModelUsedInfo {
 pub trait Variant {
     async fn infer<'a: 'request, 'request>(
         &self,
-        input: &ResolvedInput,
+        input: &LazyResolvedInput,
         models: &'request InferenceModels<'a>,
         function: &'a FunctionConfig,
         inference_config: &'request InferenceConfig<'request>,
@@ -211,7 +211,7 @@ pub trait Variant {
 
     async fn infer_stream<'request>(
         &self,
-        input: &ResolvedInput,
+        input: &LazyResolvedInput,
         models: &'request InferenceModels<'_>,
         function: &FunctionConfig,
         inference_config: &'request InferenceConfig<'request>,
@@ -234,7 +234,7 @@ pub trait Variant {
 
     async fn start_batch_inference<'a>(
         &'a self,
-        input: &[ResolvedInput],
+        input: &[LazyResolvedInput],
         models: &'a InferenceModels<'a>,
         function: &'a FunctionConfig,
         inference_configs: &'a [InferenceConfig<'a>],
@@ -272,7 +272,7 @@ impl Variant for VariantInfo {
     )]
     async fn infer<'a: 'request, 'request>(
         &self,
-        input: &ResolvedInput,
+        input: &LazyResolvedInput,
         models: &'request InferenceModels<'a>,
         function: &'a FunctionConfig,
         inference_config: &'request InferenceConfig<'request>,
@@ -368,7 +368,7 @@ impl Variant for VariantInfo {
     )]
     async fn infer_stream<'request>(
         &self,
-        input: &ResolvedInput,
+        input: &LazyResolvedInput,
         models: &'request InferenceModels<'_>,
         function: &FunctionConfig,
         inference_config: &'request InferenceConfig<'request>,
@@ -461,7 +461,7 @@ impl Variant for VariantInfo {
     #[instrument(skip_all, fields(variant_name = %inference_configs.first().map(|x| x.variant_name).unwrap_or("")))]
     async fn start_batch_inference<'a>(
         &'a self,
-        inputs: &[ResolvedInput],
+        inputs: &[LazyResolvedInput],
         models: &'a InferenceModels<'a>,
         function: &'a FunctionConfig,
         inference_configs: &'a [InferenceConfig<'a>],


### PR DESCRIPTION
This type sits in between `Input` and `ResolvedInput` - it holds normalized legacy input data (e.g.
`{"type": "text", "value": {}}` has been converted to a template invocation), but file url inputs
have not yet been resolved to in-memory files.

This PR is a pure refactor, and is the first step
towards adding support for forwarding image urls
directly to model providers (without needing to
wait for the file to be downloaded by the gateway).

A follow-up PR will build on this to add a
similar `LazyRequestMessage/ResolvedRequestMessage` split, which which will be used to allow model providers to avoid taking in a fully-resolved image (which still being able to `.await` the file data if the backend does not have file url forwarding enabled).