### PR TITLE
[3528] Fix <CodeEditor />'s copy button sizing to match other elements

### DIFF
--- a/ui/app/components/ui/code-editor.tsx
+++ b/ui/app/components/ui/code-editor.tsx
@@ -186,6 +186,9 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
     return exts;
   }, [language, wordWrap, readOnly]);
 
+  const buttonClassName =
+    "flex h-6 w-6 cursor-pointer items-center justify-center p-3 text-xs";
+
   return (
     // `min-width: 0` If within a grid parent, prevent editor from overflowing its grid cell and force horizontal scrolling
     <div className={cn("group relative isolate min-w-0 rounded-sm", className)}>
@@ -194,6 +197,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
           variant="secondary"
           size="iconSm"
           onClick={() => copy(value)}
+          className={buttonClassName}
           disabled={!mounted || !isCopyAvailable}
           title={didCopy ? "Copied!" : "Copy to clipboard"}
         >
@@ -204,11 +208,11 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
           )}
         </Button>
         <Button
-          variant={"secondary"}
+          variant="secondary"
           size="iconSm"
           onClick={() => setWordWrap((wrap) => !wrap)}
           aria-pressed={wordWrap}
-          className="flex h-6 w-6 cursor-pointer items-center justify-center p-3 text-xs"
+          className={buttonClassName}
           title="Toggle word wrap"
         >
           <span className="relative flex h-full w-full items-center justify-center">


### PR DESCRIPTION
### Related Issues

Resolves #3528 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Standardizes button size in `<CodeEditor />` by introducing `buttonClassName` for consistent styling.
> 
>   - **UI Consistency**:
>     - Introduces `buttonClassName` in `code-editor.tsx` to standardize button size and styling.
>     - Applies `buttonClassName` to the copy and word wrap toggle buttons.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2bb175384ec7abaeba69fc94404437ad4f0f1253. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->