### PR TITLE
Helm: Support ServiceMonitor creation

### DIFF
--- a/examples/production-deployment-k8s-helm/README.md
+++ b/examples/production-deployment-k8s-helm/README.md
@@ -109,11 +109,11 @@ The following table lists the configurable parameters of the chart and their def
 
 ### Monitoring Configuration
 
-| Parameter             | Description                                   | Default |
-|-----------------------|-----------------------------------------------|---------|
-| `monitoring.enabled`  | Enable ServiceMonitor creation                | `false` |
-| `monitoring.interval` | Scrape interval                               | `"30s"` |
-| `monitoring.labels`   | Additional labels to attach to ServiceMonitor | `{}`    |
+| Parameter                     | Description                                   | Default |
+|-------------------------------|-----------------------------------------------|---------|
+| `monitoring.metrics.enabled`  | Enable ServiceMonitor creation                | `false` |
+| `monitoring.metrics.interval` | Scrape interval                               | `"30s"` |
+| `monitoring.metrics.labels`   | Additional labels to attach to ServiceMonitor | `{}`    |
 
 ### ClickHouse Configuration
 

--- a/examples/production-deployment-k8s-helm/README.md
+++ b/examples/production-deployment-k8s-helm/README.md
@@ -106,6 +106,14 @@ The following table lists the configurable parameters of the chart and their def
 | `persistence.storageClass`   | Storage class name         | `""`                            |
 | `persistence.mountPath`      | Mount path in containers   | `/app/storage`                  |
 
+### Monitoring Configuration
+
+| Parameter             | Description                                   | Default |
+|-----------------------|-----------------------------------------------|---------|
+| `monitoring.enabled`  | Enable ServiceMonitor creation                | `false` |
+| `monitoring.interval` | Scrape interval                               | `"30s"` |
+| `monitoring.labels`   | Additional labels to attach to ServiceMonitor | `{}`    |
+
 ### ClickHouse Configuration
 
 This chart requires a ClickHouse instance for observability. We recommend using Altinity's ClickHouse Helm chart, which offers better cross-platform support (including ARM64 architecture).

--- a/examples/production-deployment-k8s-helm/README.md
+++ b/examples/production-deployment-k8s-helm/README.md
@@ -14,6 +14,7 @@ This example shows how to deploy the TensorZero (including the TensorZero Gatewa
 - Ingress controller installed in your cluster (e.g. `traefik-ingress-controller-v3`)
 - StorageClass configured for persistent volumes (e.g. `ebs-gp3-retain`)
 - Sufficient resources for running ClickHouse and TensorZero services (recommend at least 4GB memory for minikube)
+- If `monitoring.enabled` is set, [Prometheus Operator](https://prometheus-operator.dev/) needs to be installed in your cluster
 
 ## Installing the Chart
 

--- a/examples/production-deployment-k8s-helm/README.md
+++ b/examples/production-deployment-k8s-helm/README.md
@@ -14,7 +14,7 @@ This example shows how to deploy the TensorZero (including the TensorZero Gatewa
 - Ingress controller installed in your cluster (e.g. `traefik-ingress-controller-v3`)
 - StorageClass configured for persistent volumes (e.g. `ebs-gp3-retain`)
 - Sufficient resources for running ClickHouse and TensorZero services (recommend at least 4GB memory for minikube)
-- If `monitoring.enabled` is set, [Prometheus Operator](https://prometheus-operator.dev/) needs to be installed in your cluster
+- If `monitoring.metrics.enabled` is set, [Prometheus Operator](https://prometheus-operator.dev/) needs to be installed in your cluster
 
 ## Installing the Chart
 

--- a/examples/production-deployment-k8s-helm/templates/_helpers.tpl
+++ b/examples/production-deployment-k8s-helm/templates/_helpers.tpl
@@ -53,3 +53,12 @@ Selector labels
 app.kubernetes.io/name: {{ include "tensorzero.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Monitoring labels
+*/}}
+{{- define "tensorzero.monitorLabels" -}}
+{{- range $label, $value := .Values.monitoring.labels }}
+{{ $label }}: {{ $value }}
+{{- end }}
+{{- end }}

--- a/examples/production-deployment-k8s-helm/templates/_helpers.tpl
+++ b/examples/production-deployment-k8s-helm/templates/_helpers.tpl
@@ -58,7 +58,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Monitoring labels
 */}}
 {{- define "tensorzero.monitorLabels" -}}
-{{- range $label, $value := .Values.monitoring.labels }}
+{{- range $label, $value := .Values.monitoring.metrics.labels }}
 {{ $label }}: {{ $value }}
 {{- end }}
 {{- end }}

--- a/examples/production-deployment-k8s-helm/templates/_helpers.tpl
+++ b/examples/production-deployment-k8s-helm/templates/_helpers.tpl
@@ -59,6 +59,6 @@ Monitoring labels
 */}}
 {{- define "tensorzero.monitorLabels" -}}
 {{- range $label, $value := .Values.monitoring.metrics.labels }}
-{{ $label }}: {{ $value }}
+{{ $label }}: {{ $value | quote }}
 {{- end }}
 {{- end }}

--- a/examples/production-deployment-k8s-helm/templates/gateway-servicemonitor.yaml
+++ b/examples/production-deployment-k8s-helm/templates/gateway-servicemonitor.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.monitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "tensorzero.fullname" . }}-gateway-servicemonitor
+  labels:
+    {{- include "tensorzero.labels" . | nindent 4 }}
+    {{- include "tensorzero.monitorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  endpoints:
+    - interval: {{ .Values.monitoring.interval | default "30s" }}
+      targetPort: 3000
+      path: /metrics
+  selector:
+    matchLabels:
+      {{- include "tensorzero.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/examples/production-deployment-k8s-helm/templates/gateway-servicemonitor.yaml
+++ b/examples/production-deployment-k8s-helm/templates/gateway-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.monitoring.enabled }}
+{{- if .Values.monitoring.metrics.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: gateway
 spec:
   endpoints:
-    - interval: {{ .Values.monitoring.interval | default "30s" }}
+    - interval: {{ .Values.monitoring.metrics.interval | default "30s" }}
       targetPort: 3000
       path: /metrics
   selector:

--- a/examples/production-deployment-k8s-helm/templates/gateway-servicemonitor.yaml
+++ b/examples/production-deployment-k8s-helm/templates/gateway-servicemonitor.yaml
@@ -10,9 +10,10 @@ metadata:
 spec:
   endpoints:
     - interval: {{ .Values.monitoring.metrics.interval | default "30s" }}
-      targetPort: 3000
+      port: http
       path: /metrics
   selector:
     matchLabels:
       {{- include "tensorzero.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gateway
 {{- end }}

--- a/examples/production-deployment-k8s-helm/values.yaml
+++ b/examples/production-deployment-k8s-helm/values.yaml
@@ -2,6 +2,11 @@
 nameOverride: ""
 fullnameOverride: ""
 
+monitoring:
+  enabled: false
+  interval: "30s"
+  labels: {}
+
 # Gateway Configuration
 gateway:
   replicaCount: 1

--- a/examples/production-deployment-k8s-helm/values.yaml
+++ b/examples/production-deployment-k8s-helm/values.yaml
@@ -2,10 +2,17 @@
 nameOverride: ""
 fullnameOverride: ""
 
+# Monitoring configurations
 monitoring:
-  enabled: false
-  interval: "30s"
-  labels: {}
+  # Configurations for metrics scraping via Prometheus
+  metrics:
+    # Enable creation of ServiceMonitor for the TensorZero gateway. Requires
+    # Prometheus Operator to already exist on your clsuter.
+    enabled: false
+    # The desired scrape interval for the ServiceMonitor.
+    interval: "30s"
+    # Additional label key-values to attach to the created ServiceMonitor.
+    labels: {}
 
 # Gateway Configuration
 gateway:

--- a/examples/production-deployment-k8s-helm/values.yaml
+++ b/examples/production-deployment-k8s-helm/values.yaml
@@ -7,7 +7,7 @@ monitoring:
   # Configurations for metrics scraping via Prometheus
   metrics:
     # Enable creation of ServiceMonitor for the TensorZero gateway. Requires
-    # Prometheus Operator to already exist on your clsuter.
+    # Prometheus Operator to already exist on your cluster.
     enabled: false
     # The desired scrape interval for the ServiceMonitor.
     interval: "30s"


### PR DESCRIPTION
This PR enables users of the Helm chart to configure Prometheus scraping via the [`ServiceMonitor`](https://prometheus-operator.dev/docs/developer/getting-started/#using-servicemonitors) custom resource, defined and managed by [Prometheus Operator](https://prometheus-operator.dev).

Tested very informally by `helm template .`-ing the result, hand-applying it to my team's dev cluster, and confirming that metrics are exposed via Grafana.

<img width="1014" height="616" alt="image" src="https://github.com/user-attachments/assets/853c936d-548f-461a-9b64-398a1b56ac7b" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for `ServiceMonitor` creation in Helm chart for Prometheus scraping with new configuration options.
> 
>   - **Behavior**:
>     - Adds support for `ServiceMonitor` creation in Helm chart for Prometheus scraping.
>     - New parameters in `values.yaml`: `monitoring.enabled`, `monitoring.interval`, `monitoring.labels`.
>   - **Templates**:
>     - Adds `tensorzero.monitorLabels` in `_helpers.tpl` to handle custom monitoring labels.
>   - **Documentation**:
>     - Updates `README.md` with new monitoring configuration section and parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e8c1d636da37d8c194e8cb014b636cd8680388c1. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->