### PR TITLE
Skip performing a local gateway build just for fixtures

### DIFF
--- a/tensorzero-core/tests/e2e/docker-compose.replicated.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.replicated.yml
@@ -112,12 +112,10 @@ services:
       - "9411:9411"
 
   # This is not a gateway to use but rather one that just sets up migrations for the ClickHouse db
+  # If you need to add fixtures that reference newly-added database columns, you'll need to temporarily
+  # bump this to a locally-built image (or published 'sha' tag)
   gateway:
     image: tensorzero/gateway:${TENSORZERO_GATEWAY_TAG:-latest}
-    build:
-      context: ../../..
-      dockerfile: gateway/Dockerfile
-      target: gateway
     environment:
       TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse-01:8123/${TENSORZERO_E2E_TESTS_DATABASE:-tensorzero_e2e_tests}
       TENSORZERO_CLICKHOUSE_CLUSTER_NAME: tensorzero_e2e_tests_cluster

--- a/tensorzero-core/tests/e2e/docker-compose.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.yml
@@ -16,12 +16,10 @@ services:
       start_interval: 1s
       timeout: 1s
   # This is not a gateway to use but rather one that just sets up migrations for the ClickHouse db
+  # If you need to add fixtures that reference newly-added database columns, you'll need to temporarily
+  # bump this to a locally-built image (or published 'sha' tag)
   gateway:
     image: tensorzero/gateway:${TENSORZERO_GATEWAY_TAG:-latest}
-    build:
-      context: ../../..
-      dockerfile: gateway/Dockerfile
-      target: gateway
     environment:
       TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/${TENSORZERO_E2E_TESTS_DATABASE:-tensorzero_e2e_tests}
     depends_on:


### PR DESCRIPTION
We can just use a published image to initialize the database to a state where we can insert fixtures. The actual test run (e.g. live-tests) will start its own gateway, and run any new migrations that have been added since the last release.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove local build step for `gateway` service in Docker Compose files, using a published image for database migrations.
> 
>   - **Docker Compose Changes**:
>     - Remove local build step for `gateway` service in `docker-compose.replicated.yml` and `docker-compose.yml`.
>     - Use published image `tensorzero/gateway:${TENSORZERO_GATEWAY_TAG:-latest}` for database migrations.
>     - Comments added to guide temporary use of local builds if new database columns are added.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 789e96590dedc1ff445db49c4f53e6f6169b9d30. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->