### PR TITLE
Convert several `TryFrom` impls to standard methods

### DIFF
--- a/tensorzero-core/src/providers/anthropic.rs
+++ b/tensorzero-core/src/providers/anthropic.rs
@@ -501,10 +501,10 @@ pub enum AnthropicDocumentType {
     Base64,
 }
 
-impl<'a> TryFrom<&'a ContentBlock> for Option<FlattenUnknown<'a, AnthropicMessageContent<'a>>> {
-    type Error = Error;
-
-    fn try_from(block: &'a ContentBlock) -> Result<Self, Self::Error> {
+impl<'a> AnthropicMessageContent<'a> {
+    fn from_content_block(
+        block: &'a ContentBlock,
+    ) -> Result<Option<FlattenUnknown<'a, AnthropicMessageContent<'a>>>, Error> {
         match block {
             ContentBlock::Text(Text { text }) => Ok(Some(FlattenUnknown::Normal(
                 AnthropicMessageContent::Text { text },
@@ -600,22 +600,19 @@ struct AnthropicMessage<'a> {
     content: Vec<FlattenUnknown<'a, AnthropicMessageContent<'a>>>,
 }
 
-impl<'a> TryFrom<&'a RequestMessage> for AnthropicMessage<'a> {
-    type Error = Error;
-    fn try_from(
-        inference_message: &'a RequestMessage,
-    ) -> Result<AnthropicMessage<'a>, Self::Error> {
-        let content: Vec<FlattenUnknown<AnthropicMessageContent>> = inference_message
+impl<'a> AnthropicMessage<'a> {
+    fn from_request_message(message: &'a RequestMessage) -> Result<Self, Error> {
+        let content: Vec<FlattenUnknown<AnthropicMessageContent>> = message
             .content
             .iter()
-            .map(TryInto::try_into)
+            .map(AnthropicMessageContent::from_content_block)
             .collect::<Result<Vec<Option<FlattenUnknown<AnthropicMessageContent>>>, _>>()?
             .into_iter()
             .flatten()
             .collect();
 
         Ok(AnthropicMessage {
-            role: inference_message.role.into(),
+            role: message.role.into(),
             content,
         })
     }
@@ -658,7 +655,7 @@ impl<'a> AnthropicRequestBody<'a> {
         let request_messages: Vec<AnthropicMessage> = request
             .messages
             .iter()
-            .map(AnthropicMessage::try_from)
+            .map(AnthropicMessage::from_request_message)
             .collect::<Result<Vec<_>, _>>()?;
         let messages = prepare_messages(request_messages);
         let messages = if matches!(
@@ -1447,7 +1444,7 @@ mod tests {
     fn test_try_from_content_block() {
         let text_content_block: ContentBlock = "test".to_string().into();
         let anthropic_content_block =
-            Option::<FlattenUnknown<AnthropicMessageContent>>::try_from(&text_content_block)
+            AnthropicMessageContent::from_content_block(&text_content_block)
                 .unwrap()
                 .unwrap();
         assert_eq!(
@@ -1461,7 +1458,7 @@ mod tests {
             arguments: serde_json::to_string(&json!({"type": "string"})).unwrap(),
         });
         let anthropic_content_block =
-            Option::<FlattenUnknown<AnthropicMessageContent>>::try_from(&tool_call_content_block)
+            AnthropicMessageContent::from_content_block(&tool_call_content_block)
                 .unwrap()
                 .unwrap();
         assert_eq!(
@@ -1481,7 +1478,8 @@ mod tests {
             role: Role::User,
             content: vec!["test".to_string().into()],
         };
-        let anthropic_message = AnthropicMessage::try_from(&inference_request_message).unwrap();
+        let anthropic_message =
+            AnthropicMessage::from_request_message(&inference_request_message).unwrap();
         assert_eq!(
             anthropic_message,
             AnthropicMessage {
@@ -1497,7 +1495,8 @@ mod tests {
             role: Role::Assistant,
             content: vec!["test_assistant".to_string().into()],
         };
-        let anthropic_message = AnthropicMessage::try_from(&inference_request_message).unwrap();
+        let anthropic_message =
+            AnthropicMessage::from_request_message(&inference_request_message).unwrap();
         assert_eq!(
             anthropic_message,
             AnthropicMessage {
@@ -1517,7 +1516,8 @@ mod tests {
                 result: "test_tool_response".to_string(),
             })],
         };
-        let anthropic_message = AnthropicMessage::try_from(&inference_request_message).unwrap();
+        let anthropic_message =
+            AnthropicMessage::from_request_message(&inference_request_message).unwrap();
         assert_eq!(
             anthropic_message,
             AnthropicMessage {
@@ -1604,7 +1604,7 @@ mod tests {
                 model: &model,
                 messages: vec![
                     listening_message.clone(),
-                    AnthropicMessage::try_from(&inference_request.messages[0]).unwrap(),
+                    AnthropicMessage::from_request_message(&inference_request.messages[0]).unwrap(),
                     listening_message.clone(),
                 ],
                 max_tokens: 64_000,
@@ -1654,8 +1654,8 @@ mod tests {
             AnthropicRequestBody {
                 model: &model,
                 messages: vec![
-                    AnthropicMessage::try_from(&inference_request.messages[0]).unwrap(),
-                    AnthropicMessage::try_from(&inference_request.messages[1]).unwrap(),
+                    AnthropicMessage::from_request_message(&inference_request.messages[0]).unwrap(),
+                    AnthropicMessage::from_request_message(&inference_request.messages[1]).unwrap(),
                     listening_message.clone(),
                 ],
                 max_tokens: 100,
@@ -1711,7 +1711,7 @@ mod tests {
                 messages: inference_request
                     .messages
                     .iter()
-                    .map(|m| AnthropicMessage::try_from(m).unwrap())
+                    .map(|m| AnthropicMessage::from_request_message(m).unwrap())
                     .collect(),
                 max_tokens: 64_000,
                 stream: Some(false),
@@ -1763,11 +1763,11 @@ mod tests {
         assert_eq!(result.messages.len(), 4); // Original 2 messages + listening message + JSON prefill
         assert_eq!(
             result.messages[0],
-            AnthropicMessage::try_from(&inference_request.messages[0]).unwrap()
+            AnthropicMessage::from_request_message(&inference_request.messages[0]).unwrap()
         );
         assert_eq!(
             result.messages[1],
-            AnthropicMessage::try_from(&inference_request.messages[1]).unwrap()
+            AnthropicMessage::from_request_message(&inference_request.messages[1]).unwrap()
         );
         assert_eq!(result.messages[2], listening_message);
         assert_eq!(

--- a/tensorzero-core/src/providers/aws_bedrock.rs
+++ b/tensorzero-core/src/providers/aws_bedrock.rs
@@ -91,7 +91,7 @@ impl InferenceProvider for AWSBedrockProvider {
         let mut messages: Vec<Message> = request
             .messages
             .iter()
-            .map(Message::try_from)
+            .map(message_from_request_message)
             .filter_ok(|m| !m.content.is_empty())
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -239,7 +239,7 @@ impl InferenceProvider for AWSBedrockProvider {
         let mut messages: Vec<Message> = request
             .messages
             .iter()
-            .map(Message::try_from)
+            .map(message_from_request_message)
             .collect::<Result<Vec<_>, _>>()?;
 
         if self.model_id.contains("claude")
@@ -600,7 +600,7 @@ impl From<Role> for ConversationRole {
 /// Prefill messages for AWS Bedrock when conditions are met
 fn prefill_json_message(messages: &mut Vec<Message>) -> Result<(), Error> {
     // Add a JSON-prefill message for AWS Bedrock's JSON mode
-    messages.push(Message::try_from(&RequestMessage {
+    messages.push(message_from_request_message(&RequestMessage {
         role: Role::Assistant,
         content: vec![ContentBlock::Text(Text {
             text: "Here is the JSON requested:\n{".to_string(),
@@ -609,164 +609,162 @@ fn prefill_json_message(messages: &mut Vec<Message>) -> Result<(), Error> {
     Ok(())
 }
 
-impl TryFrom<&ContentBlock> for Option<BedrockContentBlock> {
-    type Error = Error;
+fn bedrock_content_block_from_content_block(
+    block: &ContentBlock,
+) -> Result<Option<BedrockContentBlock>, Error> {
+    match block {
+        ContentBlock::Text(Text { text }) => Ok(Some(BedrockContentBlock::Text(text.clone()))),
+        ContentBlock::ToolCall(tool_call) => {
+            // Convert the tool call arguments from String to JSON Value...
+            let input = serde_json::from_str(&tool_call.arguments).map_err(|e| {
+                Error::new(ErrorDetails::InferenceClient {
+                    raw_request: None,
+                    raw_response: Some(tool_call.arguments.clone()),
+                    status_code: Some(StatusCode::BAD_REQUEST),
+                    message: format!(
+                        "Error parsing tool call arguments as JSON Value: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
+                    provider_type: PROVIDER_TYPE.to_string(),
+                })
+            })?;
 
-    fn try_from(block: &ContentBlock) -> Result<Self, Self::Error> {
-        match block {
-            ContentBlock::Text(Text { text }) => Ok(Some(BedrockContentBlock::Text(text.clone()))),
-            ContentBlock::ToolCall(tool_call) => {
-                // Convert the tool call arguments from String to JSON Value...
-                let input = serde_json::from_str(&tool_call.arguments).map_err(|e| {
-                    Error::new(ErrorDetails::InferenceClient {
-                        raw_request: None,
-                        raw_response: Some(tool_call.arguments.clone()),
-                        status_code: Some(StatusCode::BAD_REQUEST),
-                        message: format!(
-                            "Error parsing tool call arguments as JSON Value: {}",
-                            DisplayOrDebugGateway::new(e)
-                        ),
-                        provider_type: PROVIDER_TYPE.to_string(),
-                    })
-                })?;
+            // ...then convert the JSON Value to an AWS SDK Document
+            let input = serde_json::from_value(input).map_err(|e| {
+                Error::new(ErrorDetails::InferenceServer {
+                    raw_request: None,
+                    raw_response: None,
+                    message: format!(
+                        "Error converting tool call arguments to AWS SDK Document: {e}"
+                    ),
+                    provider_type: PROVIDER_TYPE.to_string(),
+                })
+            })?;
 
-                // ...then convert the JSON Value to an AWS SDK Document
-                let input = serde_json::from_value(input).map_err(|e| {
-                    Error::new(ErrorDetails::InferenceServer {
-                        raw_request: None,
-                        raw_response: None,
-                        message: format!(
-                            "Error converting tool call arguments to AWS SDK Document: {e}"
-                        ),
-                        provider_type: PROVIDER_TYPE.to_string(),
-                    })
-                })?;
-
-                let tool_use_block = ToolUseBlock::builder()
-                    .name(tool_call.name.clone())
-                    .input(input)
-                    .tool_use_id(tool_call.id.clone())
-                    .build()
-                    .map_err(|_| {
-                        Error::new(ErrorDetails::InferenceClient {
-                            raw_request: None,
-                            raw_response: None,
-                            status_code: Some(StatusCode::BAD_REQUEST),
-                            message: "Error serializing tool call block".to_string(),
-                            provider_type: PROVIDER_TYPE.to_string(),
-                        })
-                    })?;
-
-                Ok(Some(BedrockContentBlock::ToolUse(tool_use_block)))
-            }
-            ContentBlock::ToolResult(tool_result) => {
-                let tool_result_block = ToolResultBlock::builder()
-                    .tool_use_id(tool_result.id.clone())
-                    .content(ToolResultContentBlock::Text(tool_result.result.clone()))
-                    // NOTE: The AWS Bedrock SDK doesn't include `name` in the ToolResultBlock
-                    .build()
-                    .map_err(|_| {
-                        Error::new(ErrorDetails::InferenceClient {
-                            raw_request: None,
-                            raw_response: None,
-                            status_code: Some(StatusCode::BAD_REQUEST),
-                            message: "Error serializing tool result block".to_string(),
-                            provider_type: PROVIDER_TYPE.to_string(),
-                        })
-                    })?;
-
-                Ok(Some(BedrockContentBlock::ToolResult(tool_result_block)))
-            }
-            ContentBlock::File(file) => {
-                let FileWithPath {
-                    file,
-                    storage_path: _,
-                } = &**file;
-                let file_bytes = aws_smithy_types::base64::decode(file.data()?).map_err(|e| {
+            let tool_use_block = ToolUseBlock::builder()
+                .name(tool_call.name.clone())
+                .input(input)
+                .tool_use_id(tool_call.id.clone())
+                .build()
+                .map_err(|_| {
                     Error::new(ErrorDetails::InferenceClient {
                         raw_request: None,
                         raw_response: None,
                         status_code: Some(StatusCode::BAD_REQUEST),
-                        message: format!("File was not valid base64: {e:?}"),
+                        message: "Error serializing tool call block".to_string(),
                         provider_type: PROVIDER_TYPE.to_string(),
                     })
                 })?;
-                if file.mime_type.type_() == mime::IMAGE {
-                    let image_block = ImageBlock::builder()
-                        .format(ImageFormat::from(file.mime_type.subtype()))
-                        .source(ImageSource::Bytes(file_bytes.into()))
-                        .build()
-                        .map_err(|e| {
-                            Error::new(ErrorDetails::InferenceClient {
-                                raw_request: None,
-                                raw_response: None,
-                                status_code: Some(StatusCode::BAD_REQUEST),
-                                message: format!("Error serializing image block: {e:?}"),
-                                provider_type: PROVIDER_TYPE.to_string(),
-                            })
-                        })?;
-                    Ok(Some(BedrockContentBlock::Image(image_block)))
-                } else {
-                    // Best-effort attempt to produce an AWS DocumentFormat, as their API doesn't support mime types
-                    let suffix = mime_type_to_ext(&file.mime_type)?.ok_or_else(|| {
-                        Error::new(ErrorDetails::InvalidMessage {
-                            message: format!("Mime type {} has no filetype suffix", file.mime_type),
-                        })
-                    })?;
-                    let document_format = DocumentFormat::from(suffix);
-                    let document = DocumentBlock::builder()
-                        .format(document_format)
-                        // TODO: Should we allow the user to specify the file name?
-                        .name("input")
-                        .source(DocumentSource::Bytes(file_bytes.into()))
-                        .build()
-                        .map_err(|e| {
-                            Error::new(ErrorDetails::InferenceClient {
-                                raw_request: None,
-                                raw_response: None,
-                                status_code: Some(StatusCode::BAD_REQUEST),
-                                message: format!("Error serializing document block: {e:?}"),
-                                provider_type: PROVIDER_TYPE.to_string(),
-                            })
-                        })?;
-                    Ok(Some(BedrockContentBlock::Document(document)))
-                }
-            }
-            ContentBlock::Thought(thought) => {
-                if let Some(text) = &thought.text {
-                    let mut builder = ReasoningTextBlock::builder().text(text);
-                    if let Some(signature) = &thought.signature {
-                        builder = builder.signature(signature);
-                    }
-                    let block = builder.build().map_err(|e| {
-                        Error::new(ErrorDetails::InferenceClient {
-                            raw_request: None,
-                            raw_response: None,
-                            status_code: Some(StatusCode::BAD_REQUEST),
-                            message: format!("Error serializing reasoning text block: {e:?}"),
-                            provider_type: PROVIDER_TYPE.to_string(),
-                        })
-                    })?;
-                    Ok(Some(BedrockContentBlock::ReasoningContent(
-                        ReasoningContentBlock::ReasoningText(block),
-                    )))
-                } else if thought.signature.is_some() {
-                    tracing::warn!("The TensorZero Gateway doesn't support redacted thinking for AWS Bedrock yet, as none of the models available at the time of implementation supported this content block correctly. If you're seeing this warning, this means that something must have changed, so please reach out to our team and we'll quickly collaborate on a solution. For now, the gateway will discard such content blocks.");
-                    Ok(None)
-                } else {
-                    // We have a thought block with no text or signature, so just ignore it
-                    tracing::warn!("The gateway received a reasoning content block with neither text nor signature. This is unsupported, so we'll drop it.");
-                    Ok(None)
-                }
-            }
-            ContentBlock::Unknown {
-                data: _,
-                model_provider_name: _,
-            } => Err(Error::new(ErrorDetails::UnsupportedContentBlockType {
-                content_block_type: "unknown".to_string(),
-                provider_type: PROVIDER_TYPE.to_string(),
-            })),
+
+            Ok(Some(BedrockContentBlock::ToolUse(tool_use_block)))
         }
+        ContentBlock::ToolResult(tool_result) => {
+            let tool_result_block = ToolResultBlock::builder()
+                .tool_use_id(tool_result.id.clone())
+                .content(ToolResultContentBlock::Text(tool_result.result.clone()))
+                // NOTE: The AWS Bedrock SDK doesn't include `name` in the ToolResultBlock
+                .build()
+                .map_err(|_| {
+                    Error::new(ErrorDetails::InferenceClient {
+                        raw_request: None,
+                        raw_response: None,
+                        status_code: Some(StatusCode::BAD_REQUEST),
+                        message: "Error serializing tool result block".to_string(),
+                        provider_type: PROVIDER_TYPE.to_string(),
+                    })
+                })?;
+
+            Ok(Some(BedrockContentBlock::ToolResult(tool_result_block)))
+        }
+        ContentBlock::File(file) => {
+            let FileWithPath {
+                file,
+                storage_path: _,
+            } = &**file;
+            let file_bytes = aws_smithy_types::base64::decode(file.data()?).map_err(|e| {
+                Error::new(ErrorDetails::InferenceClient {
+                    raw_request: None,
+                    raw_response: None,
+                    status_code: Some(StatusCode::BAD_REQUEST),
+                    message: format!("File was not valid base64: {e:?}"),
+                    provider_type: PROVIDER_TYPE.to_string(),
+                })
+            })?;
+            if file.mime_type.type_() == mime::IMAGE {
+                let image_block = ImageBlock::builder()
+                    .format(ImageFormat::from(file.mime_type.subtype()))
+                    .source(ImageSource::Bytes(file_bytes.into()))
+                    .build()
+                    .map_err(|e| {
+                        Error::new(ErrorDetails::InferenceClient {
+                            raw_request: None,
+                            raw_response: None,
+                            status_code: Some(StatusCode::BAD_REQUEST),
+                            message: format!("Error serializing image block: {e:?}"),
+                            provider_type: PROVIDER_TYPE.to_string(),
+                        })
+                    })?;
+                Ok(Some(BedrockContentBlock::Image(image_block)))
+            } else {
+                // Best-effort attempt to produce an AWS DocumentFormat, as their API doesn't support mime types
+                let suffix = mime_type_to_ext(&file.mime_type)?.ok_or_else(|| {
+                    Error::new(ErrorDetails::InvalidMessage {
+                        message: format!("Mime type {} has no filetype suffix", file.mime_type),
+                    })
+                })?;
+                let document_format = DocumentFormat::from(suffix);
+                let document = DocumentBlock::builder()
+                    .format(document_format)
+                    // TODO: Should we allow the user to specify the file name?
+                    .name("input")
+                    .source(DocumentSource::Bytes(file_bytes.into()))
+                    .build()
+                    .map_err(|e| {
+                        Error::new(ErrorDetails::InferenceClient {
+                            raw_request: None,
+                            raw_response: None,
+                            status_code: Some(StatusCode::BAD_REQUEST),
+                            message: format!("Error serializing document block: {e:?}"),
+                            provider_type: PROVIDER_TYPE.to_string(),
+                        })
+                    })?;
+                Ok(Some(BedrockContentBlock::Document(document)))
+            }
+        }
+        ContentBlock::Thought(thought) => {
+            if let Some(text) = &thought.text {
+                let mut builder = ReasoningTextBlock::builder().text(text);
+                if let Some(signature) = &thought.signature {
+                    builder = builder.signature(signature);
+                }
+                let block = builder.build().map_err(|e| {
+                    Error::new(ErrorDetails::InferenceClient {
+                        raw_request: None,
+                        raw_response: None,
+                        status_code: Some(StatusCode::BAD_REQUEST),
+                        message: format!("Error serializing reasoning text block: {e:?}"),
+                        provider_type: PROVIDER_TYPE.to_string(),
+                    })
+                })?;
+                Ok(Some(BedrockContentBlock::ReasoningContent(
+                    ReasoningContentBlock::ReasoningText(block),
+                )))
+            } else if thought.signature.is_some() {
+                tracing::warn!("The TensorZero Gateway doesn't support redacted thinking for AWS Bedrock yet, as none of the models available at the time of implementation supported this content block correctly. If you're seeing this warning, this means that something must have changed, so please reach out to our team and we'll quickly collaborate on a solution. For now, the gateway will discard such content blocks.");
+                Ok(None)
+            } else {
+                // We have a thought block with no text or signature, so just ignore it
+                tracing::warn!("The gateway received a reasoning content block with neither text nor signature. This is unsupported, so we'll drop it.");
+                Ok(None)
+            }
+        }
+        ContentBlock::Unknown {
+            data: _,
+            model_provider_name: _,
+        } => Err(Error::new(ErrorDetails::UnsupportedContentBlockType {
+            content_block_type: "unknown".to_string(),
+            provider_type: PROVIDER_TYPE.to_string(),
+        })),
     }
 }
 
@@ -823,31 +821,28 @@ fn bedrock_content_block_to_output(
     }
 }
 
-impl TryFrom<&RequestMessage> for Message {
-    type Error = Error;
-
-    fn try_from(inference_message: &RequestMessage) -> Result<Message, Error> {
-        let role: ConversationRole = inference_message.role.into();
-        let content: Vec<BedrockContentBlock> = inference_message
-            .content
-            .iter()
-            .map(TryInto::try_into)
-            .collect::<Result<Vec<Option<BedrockContentBlock>>, _>>()?
-            .into_iter()
-            .flatten()
-            .collect();
-        let mut message_builder = Message::builder().role(role).set_content(Some(vec![]));
-        for block in content {
-            message_builder = message_builder.content(block);
-        }
-        let message = message_builder.build().map_err(|e| {
-            Error::new(ErrorDetails::InvalidMessage {
-                message: e.to_string(),
-            })
-        })?;
-
-        Ok(message)
+// `Message` is a foreign type, so we cannot write an `impl` block on it
+fn message_from_request_message(message: &RequestMessage) -> Result<Message, Error> {
+    let role: ConversationRole = message.role.into();
+    let content: Vec<BedrockContentBlock> = message
+        .content
+        .iter()
+        .map(bedrock_content_block_from_content_block)
+        .collect::<Result<Vec<Option<BedrockContentBlock>>, _>>()?
+        .into_iter()
+        .flatten()
+        .collect();
+    let mut message_builder = Message::builder().role(role).set_content(Some(vec![]));
+    for block in content {
+        message_builder = message_builder.content(block);
     }
+    let message = message_builder.build().map_err(|e| {
+        Error::new(ErrorDetails::InvalidMessage {
+            message: e.to_string(),
+        })
+    })?;
+
+    Ok(message)
 }
 
 #[derive(Debug, PartialEq)]

--- a/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
@@ -510,12 +510,10 @@ enum GCPVertexAnthropicMessageContent<'a> {
     },
 }
 
-impl<'a> TryFrom<&'a ContentBlock>
-    for Option<FlattenUnknown<'a, GCPVertexAnthropicMessageContent<'a>>>
-{
-    type Error = Error;
-
-    fn try_from(block: &'a ContentBlock) -> Result<Self, Self::Error> {
+impl<'a> GCPVertexAnthropicMessageContent<'a> {
+    fn from_content_block(
+        block: &'a ContentBlock,
+    ) -> Result<Option<FlattenUnknown<'a, GCPVertexAnthropicMessageContent<'a>>>, Error> {
         match block {
             ContentBlock::Text(Text { text }) => Ok(Some(FlattenUnknown::Normal(
                 GCPVertexAnthropicMessageContent::Text { text },
@@ -601,23 +599,19 @@ struct GCPVertexAnthropicMessage<'a> {
     content: Vec<FlattenUnknown<'a, GCPVertexAnthropicMessageContent<'a>>>,
 }
 
-impl<'a> TryFrom<&'a RequestMessage> for GCPVertexAnthropicMessage<'a> {
-    type Error = Error;
-
-    fn try_from(
-        inference_message: &'a RequestMessage,
-    ) -> Result<GCPVertexAnthropicMessage<'a>, Self::Error> {
-        let content: Vec<FlattenUnknown<GCPVertexAnthropicMessageContent>> = inference_message
+impl<'a> GCPVertexAnthropicMessage<'a> {
+    fn from_request_message(message: &'a RequestMessage) -> Result<Self, Error> {
+        let content: Vec<FlattenUnknown<GCPVertexAnthropicMessageContent>> = message
             .content
             .iter()
-            .map(TryInto::try_into)
+            .map(GCPVertexAnthropicMessageContent::from_content_block)
             .collect::<Result<Vec<Option<FlattenUnknown<GCPVertexAnthropicMessageContent>>>, _>>()?
             .into_iter()
             .flatten()
             .collect();
 
         Ok(GCPVertexAnthropicMessage {
-            role: inference_message.role.into(),
+            role: message.role.into(),
             content,
         })
     }
@@ -660,7 +654,7 @@ impl<'a> GCPVertexAnthropicRequestBody<'a> {
         let request_messages: Vec<GCPVertexAnthropicMessage> = request
             .messages
             .iter()
-            .map(GCPVertexAnthropicMessage::try_from)
+            .map(GCPVertexAnthropicMessage::from_request_message)
             .filter_ok(|m| !m.content.is_empty())
             .collect::<Result<Vec<_>, _>>()?;
         let mut messages = prepare_messages(request_messages)?;
@@ -1331,11 +1325,9 @@ mod tests {
     fn test_try_from_content_block() {
         let text_content_block = "test".to_string().into();
         let anthropic_content_block =
-            Option::<FlattenUnknown<GCPVertexAnthropicMessageContent>>::try_from(
-                &text_content_block,
-            )
-            .unwrap()
-            .unwrap();
+            GCPVertexAnthropicMessageContent::from_content_block(&text_content_block)
+                .unwrap()
+                .unwrap();
         assert_eq!(
             anthropic_content_block,
             FlattenUnknown::Normal(GCPVertexAnthropicMessageContent::Text { text: "test" })
@@ -1347,11 +1339,9 @@ mod tests {
             arguments: serde_json::to_string(&json!({"type": "string"})).unwrap(),
         });
         let anthropic_content_block =
-            Option::<FlattenUnknown<GCPVertexAnthropicMessageContent>>::try_from(
-                &tool_call_content_block,
-            )
-            .unwrap()
-            .unwrap();
+            GCPVertexAnthropicMessageContent::from_content_block(&tool_call_content_block)
+                .unwrap()
+                .unwrap();
         assert_eq!(
             anthropic_content_block,
             FlattenUnknown::Normal(GCPVertexAnthropicMessageContent::ToolUse {
@@ -1370,7 +1360,7 @@ mod tests {
             content: vec!["test".to_string().into()],
         };
         let anthropic_message =
-            GCPVertexAnthropicMessage::try_from(&inference_request_message).unwrap();
+            GCPVertexAnthropicMessage::from_request_message(&inference_request_message).unwrap();
         assert_eq!(
             anthropic_message,
             GCPVertexAnthropicMessage {
@@ -1387,7 +1377,7 @@ mod tests {
             content: vec!["test_assistant".to_string().into()],
         };
         let anthropic_message =
-            GCPVertexAnthropicMessage::try_from(&inference_request_message).unwrap();
+            GCPVertexAnthropicMessage::from_request_message(&inference_request_message).unwrap();
         assert_eq!(
             anthropic_message,
             GCPVertexAnthropicMessage {
@@ -1410,7 +1400,7 @@ mod tests {
             })],
         };
         let anthropic_message =
-            GCPVertexAnthropicMessage::try_from(&inference_request_message).unwrap();
+            GCPVertexAnthropicMessage::from_request_message(&inference_request_message).unwrap();
         assert_eq!(
             anthropic_message,
             GCPVertexAnthropicMessage {
@@ -1504,8 +1494,8 @@ mod tests {
             GCPVertexAnthropicRequestBody {
                 anthropic_version: ANTHROPIC_API_VERSION,
                 messages: vec![
-                    GCPVertexAnthropicMessage::try_from(&messages[0]).unwrap(),
-                    GCPVertexAnthropicMessage::try_from(&messages[1]).unwrap(),
+                    GCPVertexAnthropicMessage::from_request_message(&messages[0]).unwrap(),
+                    GCPVertexAnthropicMessage::from_request_message(&messages[1]).unwrap(),
                     listening_message.clone(),
                 ],
                 max_tokens: 32_000,
@@ -1572,7 +1562,7 @@ mod tests {
                             })
                         ],
                     },
-                    GCPVertexAnthropicMessage::try_from(&messages[2]).unwrap(),
+                    GCPVertexAnthropicMessage::from_request_message(&messages[2]).unwrap(),
                     listening_message.clone(),
                 ],
                 max_tokens: 100,
@@ -1633,9 +1623,9 @@ mod tests {
             GCPVertexAnthropicRequestBody {
                 anthropic_version: ANTHROPIC_API_VERSION,
                 messages: vec![
-                    GCPVertexAnthropicMessage::try_from(&messages[0]).unwrap(),
-                    GCPVertexAnthropicMessage::try_from(&messages[1]).unwrap(),
-                    GCPVertexAnthropicMessage::try_from(&messages[2]).unwrap(),
+                    GCPVertexAnthropicMessage::from_request_message(&messages[0]).unwrap(),
+                    GCPVertexAnthropicMessage::from_request_message(&messages[1]).unwrap(),
+                    GCPVertexAnthropicMessage::from_request_message(&messages[2]).unwrap(),
                 ],
                 max_tokens: 100,
                 stream: Some(true),

--- a/tensorzero-core/src/providers/gcp_vertex_gemini/mod.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_gemini/mod.rs
@@ -1583,10 +1583,8 @@ pub struct GCPVertexGeminiContent<'a> {
     parts: Vec<FlattenUnknown<'a, GCPVertexGeminiContentPart<'a>>>,
 }
 
-impl<'a> TryFrom<&'a RequestMessage> for GCPVertexGeminiContent<'a> {
-    type Error = Error;
-
-    fn try_from(message: &'a RequestMessage) -> Result<Self, Error> {
+impl<'a> GCPVertexGeminiContent<'a> {
+    fn from_request_message(message: &'a RequestMessage) -> Result<Self, Error> {
         tensorzero_to_gcp_vertex_gemini_content(
             message.role.into(),
             Cow::Borrowed(&message.content),
@@ -1825,7 +1823,7 @@ impl<'a> GCPVertexGeminiRequest<'a> {
         let contents: Vec<GCPVertexGeminiContent> = request
             .messages
             .iter()
-            .map(GCPVertexGeminiContent::try_from)
+            .map(GCPVertexGeminiContent::from_request_message)
             .filter_ok(|m| !m.parts.is_empty())
             .collect::<Result<_, _>>()?;
         let (tools, tool_config) = prepare_tools(request, model_name);
@@ -1880,15 +1878,10 @@ impl<'a> GCPVertexGeminiRequest<'a> {
 
 pub fn prepare_gcp_vertex_gemini_messages<'a>(
     messages: &'a [RequestMessage],
-    provider_type: &str,
 ) -> Result<Vec<GCPVertexGeminiContent<'a>>, Error> {
     let mut gcp_vertex_gemini_messages = Vec::with_capacity(messages.len());
     for message in messages {
-        gcp_vertex_gemini_messages.push(tensorzero_to_gcp_vertex_gemini_content(
-            message.role.into(),
-            Cow::Borrowed(&message.content),
-            provider_type,
-        )?);
+        gcp_vertex_gemini_messages.push(GCPVertexGeminiContent::from_request_message(message)?);
     }
     Ok(gcp_vertex_gemini_messages)
 }
@@ -2592,7 +2585,7 @@ mod tests {
             role: Role::User,
             content: vec!["Hello, world!".to_string().into()],
         };
-        let content = GCPVertexGeminiContent::try_from(&message).unwrap();
+        let content = GCPVertexGeminiContent::from_request_message(&message).unwrap();
         assert_eq!(content.role, GCPVertexGeminiRole::User);
         assert_eq!(content.parts.len(), 1);
         assert_eq!(
@@ -2606,7 +2599,7 @@ mod tests {
             role: Role::Assistant,
             content: vec!["Hello, world!".to_string().into()],
         };
-        let content = GCPVertexGeminiContent::try_from(&message).unwrap();
+        let content = GCPVertexGeminiContent::from_request_message(&message).unwrap();
         assert_eq!(content.role, GCPVertexGeminiRole::Model);
         assert_eq!(content.parts.len(), 1);
         assert_eq!(
@@ -2626,7 +2619,8 @@ mod tests {
                 }),
             ],
         };
-        let content = GCPVertexGeminiContent::try_from(&message).unwrap();
+        let content = GCPVertexGeminiContent::from_request_message(&message).unwrap();
+
         assert_eq!(content.role, GCPVertexGeminiRole::Model);
         assert_eq!(content.parts.len(), 2);
         assert_eq!(
@@ -2653,7 +2647,7 @@ mod tests {
                 result: r#"{"temperature": 25, "conditions": "sunny"}"#.to_string(),
             })],
         };
-        let content = GCPVertexGeminiContent::try_from(&message).unwrap();
+        let content = GCPVertexGeminiContent::from_request_message(&message).unwrap();
         assert_eq!(content.role, GCPVertexGeminiRole::User);
         assert_eq!(content.parts.len(), 1);
         assert_eq!(

--- a/tensorzero-core/src/providers/gcp_vertex_gemini/optimization.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_gemini/optimization.rs
@@ -63,8 +63,7 @@ impl<'a> TryFrom<&'a RenderedSample> for GCPVertexGeminiSupervisedRow<'a> {
             Some(tool_params) => tool_params.tools_available.iter().map(Into::into).collect(),
             None => vec![],
         };
-        let mut contents =
-            prepare_gcp_vertex_gemini_messages(&inference.input.messages, PROVIDER_TYPE)?;
+        let mut contents = prepare_gcp_vertex_gemini_messages(&inference.input.messages)?;
         let system_instruction =
             inference
                 .input

--- a/tensorzero-core/src/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-core/src/providers/google_ai_studio_gemini.rs
@@ -440,10 +440,8 @@ struct GeminiContent<'a> {
     parts: Vec<GeminiContentPart<'a>>,
 }
 
-impl<'a> TryFrom<&'a RequestMessage> for GeminiContent<'a> {
-    type Error = Error;
-
-    fn try_from(message: &'a RequestMessage) -> Result<Self, Self::Error> {
+impl<'a> GeminiContent<'a> {
+    fn from_request_message(message: &'a RequestMessage) -> Result<Self, Error> {
         let role = GeminiRole::from(message.role);
         let mut output = Vec::with_capacity(message.content.len());
         let mut iter = message.content.iter();
@@ -764,7 +762,7 @@ impl<'a> GeminiRequest<'a> {
         let contents: Vec<GeminiContent> = request
             .messages
             .iter()
-            .map(GeminiContent::try_from)
+            .map(GeminiContent::from_request_message)
             .filter_ok(|m| !m.parts.is_empty())
             .collect::<Result<_, _>>()?;
         let (tools, tool_config) = prepare_tools(request);
@@ -1354,7 +1352,7 @@ mod tests {
             role: Role::User,
             content: vec!["Hello, world!".to_string().into()],
         };
-        let content = GeminiContent::try_from(&message).unwrap();
+        let content = GeminiContent::from_request_message(&message).unwrap();
         assert_eq!(content.role, GeminiRole::User);
         assert_eq!(content.parts.len(), 1);
         assert_eq!(
@@ -1372,7 +1370,7 @@ mod tests {
             role: Role::Assistant,
             content: vec!["Hello, world!".to_string().into()],
         };
-        let content = GeminiContent::try_from(&message).unwrap();
+        let content = GeminiContent::from_request_message(&message).unwrap();
         assert_eq!(content.role, GeminiRole::Model);
         assert_eq!(content.parts.len(), 1);
         assert_eq!(
@@ -1396,7 +1394,7 @@ mod tests {
                 }),
             ],
         };
-        let content = GeminiContent::try_from(&message).unwrap();
+        let content = GeminiContent::from_request_message(&message).unwrap();
         assert_eq!(content.role, GeminiRole::Model);
         assert_eq!(content.parts.len(), 2);
         assert_eq!(
@@ -1431,7 +1429,7 @@ mod tests {
                 result: r#"{"temperature": 25, "conditions": "sunny"}"#.to_string(),
             })],
         };
-        let content = GeminiContent::try_from(&message).unwrap();
+        let content = GeminiContent::from_request_message(&message).unwrap();
         assert_eq!(content.role, GeminiRole::User);
         assert_eq!(content.parts.len(), 1);
         assert_eq!(


### PR DESCRIPTION
We're going to need to make many of the `RequestMessage`-related functions `async` when we add lazy file resolution, which prevents us from using a `TryFrom` impl.