### PR TITLE
Relax required tool choice batch inference test

### DIFF
--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -5263,16 +5263,20 @@ pub async fn check_tool_use_tool_choice_required_inference_response(
         .filter(|block| matches!(block, ContentBlock::ToolCall(_)))
         .collect();
 
-    // Assert exactly one tool call
-    assert_eq!(tool_call_blocks.len(), 1, "Expected exactly one tool call");
+    // Assert at least one tool call
+    assert!(
+        !tool_call_blocks.is_empty(),
+        "Expected at least one tool call"
+    );
 
-    let tool_call_block = tool_call_blocks[0];
-    match tool_call_block {
-        ContentBlock::ToolCall(tool_call) => {
-            assert_eq!(tool_call.name, "get_temperature");
-            serde_json::from_str::<Value>(&tool_call.arguments.to_lowercase()).unwrap();
+    for tool_call_block in tool_call_blocks {
+        match tool_call_block {
+            ContentBlock::ToolCall(tool_call) => {
+                assert_eq!(tool_call.name, "get_temperature");
+                serde_json::from_str::<Value>(&tool_call.arguments.to_lowercase()).unwrap();
+            }
+            _ => panic!("Unreachable"),
         }
-        _ => panic!("Unreachable"),
     }
 }
 


### PR DESCRIPTION
We ask an unrelated question ("What is your name?") without turning off parallel tool calling, so let's just assert that we have at least one tool call. OpenAI is sometimes giving us multiple `get_temperature` tool calls in this batch test.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Relax test in `common.rs` to assert at least one tool call instead of exactly one.
> 
>   - **Test Adjustment**:
>     - In `common.rs`, `check_tool_use_tool_choice_required_inference_response` now asserts at least one tool call instead of exactly one.
>     - Iterates over `tool_call_blocks` to check each `tool_call.name` is `get_temperature` and validates `tool_call.arguments`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 9f442eb0792871e231de4d60d10512e0f3e9df42. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->