### PR TITLE
[3107] Added thought signatures to `<Output />`

### DIFF
--- a/ui/app/components/inference/Output.stories.tsx
+++ b/ui/app/components/inference/Output.stories.tsx
@@ -248,6 +248,20 @@ export const ChatFunctionWithThinking: Story = {
   },
 };
 
+export const ChatFunctionWithThinkingAndSignature: Story = {
+  args: {
+    output: [
+      {
+        type: "thought",
+        text: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+        signature: "b1e302e1-c3d3-4ed5-950b-1060d005a82d",
+        _internal_provider_type: null,
+      },
+      { type: "text", text: "Hello, world!" },
+    ],
+  },
+};
+
 export const ChatFunctionWithUnknownContent: Story = {
   args: {
     output: [

--- a/ui/app/components/inference/Output.tsx
+++ b/ui/app/components/inference/Output.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import type {
   ContentBlockChatOutput,
   JsonInferenceOutput,
@@ -263,14 +263,26 @@ function ChatInferenceOutputComponent({
                     content={JSON.stringify(block.data)}
                   />
                 );
-              case "thought":
-                return (
-                  <TextMessage
-                    key={index}
-                    label="Thought"
-                    content={block.text || ""}
-                  />
+              case "thought": {
+                const footer = (
+                  <>
+                    Signature:{" "}
+                    <span className="text-fg-muted italic">
+                      {block.signature}
+                    </span>
+                  </>
                 );
+
+                return (
+                  <Fragment key={index}>
+                    <TextMessage
+                      label="Thought"
+                      content={block.text || ""}
+                      footer={footer}
+                    />
+                  </Fragment>
+                );
+              }
             }
           })}
         </SnippetMessage>

--- a/ui/app/components/inference/Output.tsx
+++ b/ui/app/components/inference/Output.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import type {
   ContentBlockChatOutput,
   JsonInferenceOutput,
@@ -274,13 +274,12 @@ function ChatInferenceOutputComponent({
                 );
 
                 return (
-                  <Fragment key={index}>
-                    <TextMessage
-                      label="Thought"
-                      content={block.text || ""}
-                      footer={footer}
-                    />
-                  </Fragment>
+                  <TextMessage
+                    key={index}
+                    label="Thought"
+                    content={block.text || ""}
+                    footer={footer}
+                  />
                 );
               }
             }

--- a/ui/app/components/inference/Output.tsx
+++ b/ui/app/components/inference/Output.tsx
@@ -264,14 +264,14 @@ function ChatInferenceOutputComponent({
                   />
                 );
               case "thought": {
-                const footer = (
+                const footer = block.signature ? (
                   <>
                     Signature:{" "}
                     <span className="text-fg-muted italic">
                       {block.signature}
                     </span>
                   </>
-                );
+                ) : null;
 
                 return (
                   <TextMessage

--- a/ui/app/components/layout/SnippetContent.tsx
+++ b/ui/app/components/layout/SnippetContent.tsx
@@ -43,6 +43,7 @@ export function Label({ text, icon }: LabelProps) {
 interface TextMessageProps {
   label?: string;
   content?: string;
+  footer?: string | React.ReactNode | null;
   emptyMessage?: string;
   isEditing?: boolean;
   onChange?: (value: string) => void;
@@ -51,6 +52,7 @@ interface TextMessageProps {
 export function TextMessage({
   label,
   content,
+  footer,
   emptyMessage,
   isEditing,
   onChange,
@@ -70,6 +72,9 @@ export function TextMessage({
         readOnly={!isEditing}
         onChange={onChange}
       />
+      {footer ? (
+        <div className="text-fg-tertiary text-xs font-medium">{footer}</div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
<img width="803" height="382" alt="Image" src="https://github.com/user-attachments/assets/2d1f4646-7059-4cb1-b93d-6229197e3039" />

### Testing

1. Run Storybook
2. Select [Output > Chat Function With Thinking And Signature](http://localhost:6006/?path=/story/output--chat-function-with-thinking-and-signature)
3. Observe signature being rendered

### Related Issues

Resolves #3107 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for rendering 'thought' type outputs with signatures in the `Output` component and updates Storybook with a new story.
> 
>   - **Behavior**:
>     - Adds `ChatFunctionWithThinkingAndSignature` story in `Output.stories.tsx` to demonstrate rendering of 'thought' type outputs with signatures.
>     - Updates `Output.tsx` to render signatures for 'thought' type outputs using `TextMessage` with a footer.
>   - **Components**:
>     - Modifies `TextMessage` in `SnippetContent.tsx` to accept and render a `footer` prop.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for bedd8e7ffc47ada033e7b6e4dd2c8374dd4bd4d6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->