### PR TITLE
[3516] Support default function on variant detail page

### DIFF
--- a/ui/app/components/function/variant/VariantLink.tsx
+++ b/ui/app/components/function/variant/VariantLink.tsx
@@ -16,9 +16,10 @@ export function VariantLink({
 }: VariantLinkProps) {
   const functionConfig = useFunctionConfig(functionName);
   const variantConfig = functionConfig?.variants[variantName];
+  const encodedVariantName = encodeURIComponent(variantName);
   return variantConfig ? (
     <Link
-      to={`/observability/functions/${functionName}/variants/${variantName}`}
+      to={`/observability/functions/${functionName}/variants/${encodedVariantName}`}
     >
       {children}
     </Link>

--- a/ui/app/routes/observability/functions/$function_name/route.tsx
+++ b/ui/app/routes/observability/functions/$function_name/route.tsx
@@ -38,6 +38,7 @@ import {
 } from "~/components/layout/PageLayout";
 import { getFunctionTypeIcon } from "~/utils/icon";
 import { logger } from "~/utils/logger";
+import { DEFAULT_FUNCTION } from "~/utils/constants";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
   const { function_name } = params;
@@ -114,7 +115,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     variantThroughputPromise,
   ]);
   const variant_counts_with_metadata = variant_counts.map((variant_count) => {
-    const variant_config = function_config.variants[
+    let variant_config = function_config.variants[
       variant_count.variant_name
     ] || {
       inner: {
@@ -123,6 +124,32 @@ export async function loader({ request, params }: Route.LoaderArgs) {
         weight: 0,
       },
     };
+
+    if (function_name === DEFAULT_FUNCTION) {
+      variant_config = {
+        inner: {
+          type: "chat_completion",
+          model: DEFAULT_FUNCTION,
+          weight: null,
+          templates: {},
+          temperature: null,
+          top_p: null,
+          max_tokens: null,
+          presence_penalty: null,
+          frequency_penalty: null,
+          seed: null,
+          stop_sequences: null,
+          json_mode: null,
+          retries: { num_retries: 0, max_delay_s: 0 },
+        },
+        timeouts: {
+          non_streaming: { total_ms: null },
+          streaming: { ttft_ms: null },
+        },
+      };
+      function_config.variants[variant_count.variant_name] = variant_config;
+    }
+
     return {
       ...variant_count,
       type: variant_config.inner.type,

--- a/ui/app/utils/constants.ts
+++ b/ui/app/utils/constants.ts
@@ -1,0 +1,3 @@
+// TODO(bret): replace all instances
+// See: https://github.com/tensorzero/tensorzero/issues/3572
+export const DEFAULT_FUNCTION = "tensorzero::default";


### PR DESCRIPTION
### Testing

1. Navigate to [/observability/functions/tensorzero::default](http://localhost:5173/observability/functions/tensorzero::default)
2. Click on a variant name
3. Observe page loading

### Related Issues

Resolves #3516 