### PR TITLE
Fix Helm chart issues and improve consistency

### DIFF
--- a/examples/production-deployment-k8s-helm/templates/gateway-ingress-legacy.yaml
+++ b/examples/production-deployment-k8s-helm/templates/gateway-ingress-legacy.yaml
@@ -1,0 +1,49 @@
+{{- if and .Values.gateway.ingress.enabled .Values.gateway.ingress.createLegacyIngress -}}
+{{- $fullName := include "tensorzero.fullname" . -}}
+{{- $svcPort := .Values.gateway.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "tensorzero.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+  annotations:
+    # DEPRECATED: This ingress uses legacy naming and will be removed in a future release
+    # Switch DNS/load balancers to {{ $fullName }}-gateway, then set createLegacy: false
+    helm.sh/resource-policy: keep
+    {{- with .Values.gateway.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.gateway.ingress.className }}
+  ingressClassName: {{ .Values.gateway.ingress.className }}
+  {{- end }}
+  {{- if .Values.gateway.ingress.tls }}
+  tls:
+    {{- range .Values.gateway.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- if .secretName }}
+      secretName: {{ .secretName }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.gateway.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}-gateway
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/examples/production-deployment-k8s-helm/templates/gateway-ingress-legacy.yaml
+++ b/examples/production-deployment-k8s-helm/templates/gateway-ingress-legacy.yaml
@@ -1,6 +1,9 @@
 {{- if and .Values.gateway.ingress.enabled .Values.gateway.ingress.createLegacyIngress -}}
 {{- $fullName := include "tensorzero.fullname" . -}}
 {{- $svcPort := .Values.gateway.service.port -}}
+# ⚠️  DEPRECATION WARNING: Legacy gateway ingress is enabled and will be removed in a future version
+# Please migrate to the new ingress name: {{ $fullName }}-gateway
+# Then set gateway.ingress.createLegacyIngress=false
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/examples/production-deployment-k8s-helm/templates/gateway-ingress-legacy.yaml
+++ b/examples/production-deployment-k8s-helm/templates/gateway-ingress-legacy.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/component: gateway
   annotations:
     # DEPRECATED: This ingress uses legacy naming and will be removed in a future release
-    # Switch DNS/load balancers to {{ $fullName }}-gateway, then set createLegacy: false
+    # Switch DNS/load balancers to {{ $fullName }}-gateway, then set gateway.ingress.createLegacyIngress=false
     helm.sh/resource-policy: keep
     {{- with .Values.gateway.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/examples/production-deployment-k8s-helm/templates/gateway-ingress.yaml
+++ b/examples/production-deployment-k8s-helm/templates/gateway-ingress.yaml
@@ -4,9 +4,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ $fullName }}-gateway
   labels:
     {{- include "tensorzero.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
   {{- with .Values.gateway.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/examples/production-deployment-k8s-helm/templates/ui.yaml
+++ b/examples/production-deployment-k8s-helm/templates/ui.yaml
@@ -45,9 +45,9 @@ spec:
               mountPath: /app/config
           resources:
             {{- toYaml .Values.ui.resources | nindent 12 }}
-      {{- if .Values.gateway.image.pullSecret }}
+      {{- if .Values.ui.image.pullSecret }}
       imagePullSecrets:
-        - name: {{ .Values.gateway.image.pullSecret }}
+        - name: {{ .Values.ui.image.pullSecret }}
       {{- end }}
       volumes:
         - name: config-volume

--- a/examples/production-deployment-k8s-helm/values.yaml
+++ b/examples/production-deployment-k8s-helm/values.yaml
@@ -67,6 +67,7 @@ ui:
     repository: tensorzero/ui
     tag: "" # If empty, uses Chart.appVersion
     pullPolicy: IfNotPresent
+    pullSecret: "" # Optional pull secret for private registries
 
   service:
     type: ClusterIP

--- a/examples/production-deployment-k8s-helm/values.yaml
+++ b/examples/production-deployment-k8s-helm/values.yaml
@@ -59,6 +59,10 @@ gateway:
     #    hosts:
     #      - tensorzero-gateway.local
 
+    # Create legacy ingress with old naming pattern for zero-downtime upgrades
+    # Set to false after migrating DNS/load balancers to the new ingress name
+    createLegacyIngress: true
+
 # UI Configuration
 ui:
   deploy: true # TODO: change this to false if you don't want to deploy the UI


### PR DESCRIPTION
## Summary

This PR fixes several issues in the Helm chart and improves consistency while providing **zero-downtime upgrades** through a dual-ingress approach.

## Changes

### 🔧 **Bug Fixes**
- **Fix UI imagePullSecret reference**: UI template was incorrectly referencing `gateway.image.pullSecret` instead of `ui.image.pullSecret`
- **Add missing field**: Added `ui.image.pullSecret` to values.yaml for consistency with gateway configuration

### 🏗️ **Improvements** 
- **Rename for consistency**: `ingress.yaml` → `gateway-ingress.yaml` to match `ui-ingress.yaml` pattern
- **Add component labels**: Gateway ingress now includes `app.kubernetes.io/component: gateway` label

### ⚡ **Zero-Downtime Migration**
- **Dual ingress approach**: Creates both old and new ingress simultaneously during upgrades
- **User-controlled migration**: Switch traffic when ready, no forced downtime
- **Backward compatible**: Existing deployments continue working immediately

## 🚀 **Zero-Downtime Upgrade Process**

### **Step 1: Upgrade (Zero Downtime)**
```bash
helm upgrade my-release tensorzero/tensorzero -n <namespace>
```
**Result**: Both ingresses exist and serve traffic:
- `my-release-tensorzero` (legacy - your current traffic)  
- `my-release-tensorzero-gateway` (new - ready for migration)

### **Step 2: Migrate When Ready**
```bash
# Test the new ingress works
curl https://your-domain.com  # Should work via legacy ingress

# Update your DNS/load balancer to point to new ingress
# Wait for DNS propagation, verify traffic flows

# Disable legacy ingress (optional cleanup)
helm upgrade my-release tensorzero/tensorzero \
  --set gateway.ingress.createLegacyIngress=false \
  -n <namespace>
```

## 🎛️ **Configuration**

### **New Parameter:**
```yaml
gateway:
  ingress:
    # Creates legacy ingress for zero-downtime upgrades
    createLegacyIngress: true  # Default: true
```

- **`true`**: Creates both ingresses (recommended for upgrades)
- **`false`**: Only creates new ingress (for clean new installs)

## 🧪 **Testing**

- [x] `helm template . --dry-run` renders successfully  
- [x] Both gateway and UI ingresses have correct component labels
- [x] Legacy and new ingresses point to same service (zero downtime)
- [x] Can disable legacy ingress when `createLegacyIngress: false`
- [x] ImagePullSecret references are correct

## 📋 **Migration Timeline**

1. **This release**: Both ingresses created by default
2. **User action**: Migrate DNS/load balancers when convenient  
3. **Future release**: Change default to `createLegacyIngress: false`
4. **Later release**: Remove legacy ingress support entirely

🤖 Generated with [Claude Code](https://claude.ai/code)