### PR TITLE
Fix evaluation launch modal disabled for single variant

### DIFF
--- a/ui/app/routes/evaluations/LaunchEvaluationModal.tsx
+++ b/ui/app/routes/evaluations/LaunchEvaluationModal.tsx
@@ -93,7 +93,7 @@ function EvaluationForm({
       </div>
       <Select
         name="evaluation_name"
-        defaultValue={initialFormState?.evaluation_name ?? undefined}
+        value={selectedEvaluationName ?? undefined}
         onValueChange={(value) => {
           setSelectedEvaluationName(value);
           setSelectedVariantName(null); // Reset variant selection when evaluation changes
@@ -165,7 +165,7 @@ function EvaluationForm({
       </div>
       <Select
         name="variant_name"
-        defaultValue={initialFormState?.variant_name ?? undefined}
+        value={selectedVariantName ?? undefined}
         disabled={!selectedEvaluationName}
         onValueChange={(value) => setSelectedVariantName(value)}
       >


### PR DESCRIPTION
Fixes #3580?

I believe this was a caching issue if the form already has a `defaultValue` from a previous run.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes evaluation launch modal disabled for single variant selection and changes `Select` components to controlled in `LaunchEvaluationModal.tsx`.
> 
>   - **Behavior**:
>     - Fixes evaluation launch modal being disabled for single variant selection in `LaunchEvaluationModal.tsx`.
>     - Changes `Select` components to controlled (using `value` instead of `defaultValue`) to sync form field values with React state.
>   - **Test Plan**:
>     - Test evaluation launch with single variant functions.
>     - Verify form submits successfully after selecting a single variant.
>     - Test multi-variant functions for expected behavior.
>     - Verify form state persists when modal is reopened.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c0968066cc01d7ad6f80b430d162e670dc1eaf36. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->