### PR TITLE
Remove extra parens in comparison

### DIFF
--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -6741,7 +6741,7 @@ pub async fn test_tool_use_tool_choice_specific_streaming_inference_request_with
     assert!(!output_clickhouse.is_empty()); // could be > 1 if the model returns text as well
     let content_block = output_clickhouse
         .iter()
-        .find(|block| (block.get("type").and_then(Value::as_str) == Some("tool_call")))
+        .find(|block| block.get("type").and_then(Value::as_str) == Some("tool_call"))
         .expect("No tool_call content block found in ClickHouse output");
     // The type check is implicitly handled by the find operation above.
     assert_eq!(content_block.get("id").unwrap().as_str().unwrap(), tool_id);


### PR DESCRIPTION
This fixes a warning on Rust 1.90
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unnecessary parentheses in a comparison in `common.rs` to fix a Rust 1.90 warning.
> 
>   - **Code Quality**:
>     - Remove unnecessary parentheses in comparison in `test_tool_use_tool_choice_specific_streaming_inference_request_with` in `common.rs` to fix a warning in Rust 1.90.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7828cc62d797aae3ded7b52b4509ab8f91afbaab. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->