### PR TITLE
Introduce helper functions for all 'test_poll_completed' batch functions

### DIFF
--- a/tensorzero-core/tests/e2e/providers/batch.rs
+++ b/tensorzero-core/tests/e2e/providers/batch.rs
@@ -578,7 +578,7 @@ async fn get_all_batch_inferences(
     rows
 }
 
-struct InsertedFakeDataIds {
+pub struct InsertedFakeDataIds {
     batch_id: Uuid,
     inference_id: Uuid,
 }
@@ -928,7 +928,15 @@ pub async fn test_poll_completed_simple_image_batch_inference_request_with_provi
         Some(batch_inference) => batch_inference,
     };
     sleep(Duration::from_millis(200)).await;
+    test_poll_completed_simple_image_batch_inference_request_with_provider_and_ids(provider, ids)
+        .await;
+}
 
+pub async fn test_poll_completed_simple_image_batch_inference_request_with_provider_and_ids(
+    provider: E2ETestProvider,
+    ids: InsertedFakeDataIds,
+) {
+    let clickhouse = get_clickhouse().await;
     // Poll by inference_id
     let url = get_poll_batch_inference_url(PollPathParams {
         batch_id: ids.batch_id,
@@ -1271,7 +1279,17 @@ pub async fn test_poll_completed_inference_params_batch_inference_request_with_p
         Some(batch_inference) => batch_inference,
     };
     sleep(Duration::from_millis(200)).await;
+    test_poll_completed_inference_params_batch_inference_request_with_provider_and_ids(
+        provider, ids,
+    )
+    .await;
+}
 
+pub async fn test_poll_completed_inference_params_batch_inference_request_with_provider_and_ids(
+    provider: E2ETestProvider,
+    ids: InsertedFakeDataIds,
+) {
+    let clickhouse = get_clickhouse().await;
     // Poll by inference_id
     let url = get_poll_batch_inference_url(PollPathParams {
         batch_id: ids.batch_id,
@@ -1929,12 +1947,19 @@ pub async fn test_poll_completed_tool_use_batch_inference_request_with_provider(
         None => return, // No completed batch inference found, so we can't test polling
         Some(batch_inference) => batch_inference,
     };
+    sleep(Duration::from_millis(200)).await;
+    test_poll_completed_tool_use_batch_inference_request_with_provider_and_ids(provider, ids).await;
+}
+
+pub async fn test_poll_completed_tool_use_batch_inference_request_with_provider_and_ids(
+    provider: E2ETestProvider,
+    ids: InsertedFakeDataIds,
+) {
+    let clickhouse = get_clickhouse().await;
     let batch_id = ids.batch_id;
     let inference_tags = get_tags_for_batch_inferences(&clickhouse, batch_id)
         .await
         .unwrap();
-    sleep(Duration::from_millis(200)).await;
-
     // Poll by `batch_id`
     let url = get_poll_batch_inference_url(PollPathParams {
         batch_id,
@@ -2316,7 +2341,15 @@ pub async fn test_poll_completed_allowed_tools_batch_inference_request_with_prov
         Some(batch_inference) => batch_inference,
     };
     sleep(Duration::from_millis(200)).await;
+    test_poll_completed_allowed_tools_batch_inference_request_with_provider_and_ids(provider, ids)
+        .await;
+}
 
+pub async fn test_poll_completed_allowed_tools_batch_inference_request_with_provider_and_ids(
+    provider: E2ETestProvider,
+    ids: InsertedFakeDataIds,
+) {
+    let clickhouse = get_clickhouse().await;
     // Poll by inference_id
     let url = get_poll_batch_inference_url(PollPathParams {
         batch_id: ids.batch_id,
@@ -3032,7 +3065,17 @@ pub async fn test_poll_completed_multi_turn_parallel_batch_inference_request_wit
         Some(batch_inference) => batch_inference,
     };
     sleep(Duration::from_millis(200)).await;
+    test_poll_completed_multi_turn_parallel_batch_inference_request_with_provider_and_ids(
+        provider, ids,
+    )
+    .await;
+}
 
+pub async fn test_poll_completed_multi_turn_parallel_batch_inference_request_with_provider_and_ids(
+    provider: E2ETestProvider,
+    ids: InsertedFakeDataIds,
+) {
+    let clickhouse = get_clickhouse().await;
     // Poll by inference_id
     let url = get_poll_batch_inference_url(PollPathParams {
         batch_id: ids.batch_id,
@@ -3126,7 +3169,15 @@ pub async fn test_poll_completed_multi_turn_batch_inference_request_with_provide
         Some(batch_inference) => batch_inference,
     };
     sleep(Duration::from_millis(200)).await;
+    test_poll_completed_multi_turn_batch_inference_request_with_provider_and_ids(provider, ids)
+        .await;
+}
 
+pub async fn test_poll_completed_multi_turn_batch_inference_request_with_provider_and_ids(
+    provider: E2ETestProvider,
+    ids: InsertedFakeDataIds,
+) {
+    let clickhouse = get_clickhouse().await;
     // Poll by inference_id
     let url = get_poll_batch_inference_url(PollPathParams {
         batch_id: ids.batch_id,
@@ -3484,7 +3535,17 @@ pub async fn test_poll_completed_dynamic_tool_use_batch_inference_request_with_p
         Some(batch_inference) => batch_inference,
     };
     sleep(Duration::from_millis(200)).await;
+    test_poll_completed_dynamic_tool_use_batch_inference_request_with_provider_and_ids(
+        provider, ids,
+    )
+    .await;
+}
 
+pub async fn test_poll_completed_dynamic_tool_use_batch_inference_request_with_provider_and_ids(
+    provider: E2ETestProvider,
+    ids: InsertedFakeDataIds,
+) {
+    let clickhouse = get_clickhouse().await;
     // Poll by inference_id
     let url = get_poll_batch_inference_url(PollPathParams {
         batch_id: ids.batch_id,
@@ -3847,7 +3908,17 @@ pub async fn test_poll_completed_parallel_tool_use_batch_inference_request_with_
         Some(batch_inference) => batch_inference,
     };
     sleep(Duration::from_millis(200)).await;
+    test_poll_completed_parallel_tool_use_batch_inference_request_with_provider_and_ids(
+        provider, ids,
+    )
+    .await;
+}
 
+pub async fn test_poll_completed_parallel_tool_use_batch_inference_request_with_provider_and_ids(
+    provider: E2ETestProvider,
+    ids: InsertedFakeDataIds,
+) {
+    let clickhouse = get_clickhouse().await;
     // Poll by inference_id
     let url = get_poll_batch_inference_url(PollPathParams {
         batch_id: ids.batch_id,
@@ -4188,7 +4259,15 @@ pub async fn test_poll_completed_json_mode_batch_inference_request_with_provider
         Some(batch_inference) => batch_inference,
     };
     sleep(Duration::from_millis(200)).await;
+    test_poll_completed_json_mode_batch_inference_request_with_provider_and_ids(provider, ids)
+        .await;
+}
 
+pub async fn test_poll_completed_json_mode_batch_inference_request_with_provider_and_ids(
+    provider: E2ETestProvider,
+    ids: InsertedFakeDataIds,
+) {
+    let clickhouse = get_clickhouse().await;
     // Poll by inference_id
     let url = get_poll_batch_inference_url(PollPathParams {
         batch_id: ids.batch_id,
@@ -4541,7 +4620,17 @@ pub async fn test_poll_completed_dynamic_json_mode_batch_inference_request_with_
         Some(batch_inference) => batch_inference,
     };
     sleep(Duration::from_millis(200)).await;
+    test_poll_completed_dynamic_json_mode_batch_inference_request_with_provider_and_ids(
+        provider, ids,
+    )
+    .await;
+}
 
+pub async fn test_poll_completed_dynamic_json_mode_batch_inference_request_with_provider_and_ids(
+    provider: E2ETestProvider,
+    ids: InsertedFakeDataIds,
+) {
+    let clickhouse = get_clickhouse().await;
     // Poll by inference_id
     let url = get_poll_batch_inference_url(PollPathParams {
         batch_id: ids.batch_id,


### PR DESCRIPTION
These functions will be used in a future 'trailing batch inference' job that checks that each batch job we kick off actually completes (after 1 day).

This PR itself has no function changes - it's just to avoid conflicts with other changes to batch tests.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduce helper functions in `batch.rs` for polling completed batch inferences to support future trailing batch inference jobs.
> 
>   - **Helper Functions**:
>     - Introduce helper functions for polling completed batch inferences in `batch.rs`.
>     - Functions include `test_poll_completed_simple_image_batch_inference_request_with_provider_and_ids`, `test_poll_completed_inference_params_batch_inference_request_with_provider_and_ids`, and `test_poll_completed_tool_use_batch_inference_request_with_provider_and_ids`.
>   - **Structs**:
>     - Make `InsertedFakeDataIds` struct public in `batch.rs`.
>   - **Purpose**:
>     - Prepare for a future trailing batch inference job to check batch job completion after 1 day.
>     - Avoid conflicts with other batch test changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b032080c1d5aa92a2d2041e958d3145418ff01e5. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->