### PR TITLE
[DRAFT] fix: renamed types from Dicl* to DICL* in Python SDK (#3541)

### DIFF
--- a/clients/python/tensorzero/tensorzero.pyi
+++ b/clients/python/tensorzero/tensorzero.pyi
@@ -114,7 +114,7 @@ class RenderedSample:
 
 @final
 class OptimizationJobHandle:
-    Dicl: Type["OptimizationJobHandle"]
+    DICL: Type["OptimizationJobHandle"]
     OpenAISFT: Type["OptimizationJobHandle"]
     OpenAIRFT: Type["OptimizationJobHandle"]
     FireworksSFT: Type["OptimizationJobHandle"]
@@ -129,7 +129,7 @@ class OptimizationJobStatus:
 
 @final
 class OptimizationJobInfo:
-    Dicl: Type["OptimizationJobInfo"]
+    DICL: Type["OptimizationJobInfo"]
     OpenAISFT: Type["OptimizationJobInfo"]
     OpenAIRFT: Type["OptimizationJobInfo"]
     FireworksSFT: Type["OptimizationJobInfo"]


### PR DESCRIPTION
Hello!

Just started implementing the renaming for the type Dicl* to DICL*, was wondering if the test function names would also need to be renamed for maintaining consistency.

Thank you!