### PR TITLE
Attach raw input/ouput to OpenInference spans for non-streaming requests

### DIFF
--- a/tensorzero-core/src/model.rs
+++ b/tensorzero-core/src/model.rs
@@ -1223,37 +1223,79 @@ impl ModelProvider {
         span: &Span,
         resp: &Result<ProviderInferenceResponse, Error>,
     ) {
-        if let Ok(resp) = resp {
-            if otlp_config.traces.enabled {
-                match otlp_config.traces.format {
-                    OtlpTracesFormat::OpenTelemetry => {
-                        span.set_attribute(
-                            "gen_ai.usage.input_tokens",
-                            resp.usage.input_tokens as i64,
-                        );
-                        span.set_attribute(
-                            "gen_ai.usage.output_tokens",
-                            resp.usage.output_tokens as i64,
-                        );
-                        span.set_attribute(
-                            "gen_ai.usage.total_tokens",
-                            (resp.usage.input_tokens + resp.usage.output_tokens) as i64,
-                        );
+        match resp {
+            Ok(resp) => {
+                if otlp_config.traces.enabled {
+                    match otlp_config.traces.format {
+                        OtlpTracesFormat::OpenTelemetry => {
+                            span.set_attribute(
+                                "gen_ai.usage.input_tokens",
+                                resp.usage.input_tokens as i64,
+                            );
+                            span.set_attribute(
+                                "gen_ai.usage.output_tokens",
+                                resp.usage.output_tokens as i64,
+                            );
+                            span.set_attribute(
+                                "gen_ai.usage.total_tokens",
+                                (resp.usage.input_tokens + resp.usage.output_tokens) as i64,
+                            );
+                        }
+                        OtlpTracesFormat::OpenInference => {
+                            span.set_attribute(
+                                "llm.token_count.prompt",
+                                resp.usage.input_tokens as i64,
+                            );
+                            span.set_attribute(
+                                "llm.token_count.completion",
+                                resp.usage.output_tokens as i64,
+                            );
+                            span.set_attribute(
+                                "llm.token_count.total",
+                                (resp.usage.input_tokens + resp.usage.output_tokens) as i64,
+                            );
+                            // If we ever add providers that don't use JSON, we'll need to update this.
+
+                            span.set_attribute("input.mime_type", "application/json");
+                            span.set_attribute("input.value", resp.raw_request.clone());
+
+                            span.set_attribute("output.mime_type", "application/json");
+                            span.set_attribute("output.value", resp.raw_response.clone());
+                        }
                     }
-                    OtlpTracesFormat::OpenInference => {
-                        span.set_attribute(
-                            "llm.token_count.prompt",
-                            resp.usage.input_tokens as i64,
-                        );
-                        span.set_attribute(
-                            "llm.token_count.completion",
-                            resp.usage.output_tokens as i64,
-                        );
-                        span.set_attribute(
-                            "llm.token_count.total",
-                            (resp.usage.input_tokens + resp.usage.output_tokens) as i64,
-                        );
+                }
+            }
+            // If an error occurs, try to extract the raw request/response to attach to the OpenTelemtry span
+            Err(e) => {
+                match e.get_details() {
+                    ErrorDetails::InferenceClient {
+                        raw_request,
+                        raw_response,
+                        ..
                     }
+                    | ErrorDetails::InferenceServer {
+                        raw_request,
+                        raw_response,
+                        ..
+                    } => {
+                        if otlp_config.traces.enabled {
+                            match otlp_config.traces.format {
+                                OtlpTracesFormat::OpenTelemetry => {}
+                                OtlpTracesFormat::OpenInference => {
+                                    // If we ever add providers that don't use JSON, we'll need to update this.
+                                    if let Some(raw_request) = raw_request {
+                                        span.set_attribute("input.mime_type", "application/json");
+                                        span.set_attribute("input.value", raw_request.clone());
+                                    }
+                                    if let Some(raw_response) = raw_response {
+                                        span.set_attribute("output.mime_type", "application/json");
+                                        span.set_attribute("output.value", raw_response.clone());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
                 }
             }
         }

--- a/tensorzero-core/src/model.rs
+++ b/tensorzero-core/src/model.rs
@@ -1265,7 +1265,7 @@ impl ModelProvider {
                     }
                 }
             }
-            // If an error occurs, try to extract the raw request/response to attach to the OpenTelemtry span
+            // If an error occurs, try to extract the raw request/response to attach to the OpenTelemetry span
             Err(e) => {
                 match e.get_details() {
                     ErrorDetails::InferenceClient {


### PR DESCRIPTION
We also attempt to attach the raw input/output when an error occurs. Only non-streaming requests are supported for now, as streaming support will require additional refactoring to `collect_chunks`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Attach raw input/output to OpenInference spans for non-streaming requests and handle errors in `model.rs`, with tests in `otel.rs`.
> 
>   - **Behavior**:
>     - Attach raw input/output to OpenInference spans for non-streaming requests in `apply_otlp_span_fields_output()` in `model.rs`.
>     - Attempt to attach raw input/output on errors in `apply_otlp_span_fields_output()`.
>     - Only non-streaming requests are supported; streaming requires refactoring.
>   - **Tests**:
>     - Update `test_capture_simple_inference_spans()` and `test_capture_model_error()` in `otel.rs` to verify raw input/output attachment.
>     - Add assertions for `input.mime_type`, `input.value`, `output.mime_type`, and `output.value` in OpenInference format tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 09cb9c2e580b63ac03bf623482d79526fba8cc08. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->