### PR TITLE
Bump pyo3 to 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3680,11 +3680,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
- "cfg-if",
  "indoc",
  "libc",
  "memoffset",
@@ -3698,9 +3697,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.24.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0b83dc42f9d41f50d38180dad65f0c99763b65a3ff2a81bf351dd35a1df8bf"
+checksum = "e6ee6d4cb3e8d5b925f5cdb38da183e0ff18122eb2048d4041c9e7034d026e23"
 dependencies = [
  "futures",
  "once_cell",
@@ -3711,19 +3710,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
 dependencies = [
- "once_cell",
  "target-lexicon 0.13.2",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3731,9 +3729,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3743,9 +3741,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ http = "1.3.1"
 tokio-stream = "0.1.15"
 tokio = { version = "1.46.1", features = ["full"] }
 tracing = { version = "0.1.40", features = ["log"] }
-pyo3 = { version = "0.24.2", features = ["experimental-async", "abi3-py39"] }
+pyo3 = { version = "0.26.0", features = ["experimental-async", "abi3-py39"] }
 axum = { version = "0.8", features = ["macros", "http2"] }
 anyhow = "1.0.99"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt"] }

--- a/clients/python/Cargo.toml
+++ b/clients/python/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 tensorzero-core = { path = "../../tensorzero-core" }
 futures = { workspace = true }
 pyo3 = { workspace = true }
-pyo3-async-runtimes = { version = "0.24.0", features = ["tokio-runtime"] }
+pyo3-async-runtimes = { version = "0.26", features = ["tokio-runtime"] }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/clients/python/src/gil_helpers.rs
+++ b/clients/python/src/gil_helpers.rs
@@ -5,8 +5,8 @@ use pyo3::Python;
 /// This is used when we need to drop a TensorZero client (or a type that holds it),
 /// so that we can block on the ClickHouse batcher shutting down, without holding the GIL.
 fn in_tokio_runtime_no_gil<F: FnOnce() + Send>(f: F) {
-    Python::with_gil(|py| {
-        py.allow_threads(|| {
+    Python::attach(|py| {
+        py.detach(|| {
             let _guard = pyo3_async_runtimes::tokio::get_runtime().enter();
             f();
         });

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -121,7 +121,7 @@ fn tensorzero(m: &Bound<'_, PyModule>) -> PyResult<()> {
     let json_loads = py_json.getattr("loads")?;
     let json_dumps = py_json.getattr("dumps")?;
 
-    // We don't care if the GILOnceCell was already set
+    // We don't care if the PyOnceLock was already set
     let _ = JSON_LOADS.set(m.py(), json_loads.unbind());
     let _ = JSON_DUMPS.set(m.py(), json_dumps.unbind());
 
@@ -177,7 +177,7 @@ fn _start_http_gateway(
     if async_setup {
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             gateway_fut.await.map_err(|e| {
-                Python::with_gil(|py| convert_error(py, TensorZeroError::Other { source: e }))
+                Python::attach(|py| convert_error(py, TensorZeroError::Other { source: e }))
             })
         })
     } else {
@@ -201,7 +201,7 @@ struct AsyncStreamWrapper {
     // after all `AsyncStreamWrapper` objects have been garbage collected.
     // This allows us to safely block from within the Drop impl of `AsyncTensorZeroGateway`.
     // knowing that there are no remaining Python objects holding on to a `ClickhouseConnectionInfo`
-    _gateway: PyObject,
+    _gateway: Py<PyAny>,
 }
 
 #[pymethods]
@@ -227,7 +227,7 @@ impl AsyncStreamWrapper {
             // the `py` parameter from `__anext__`.
             // We need to interact with Python objects here (to build up a Python `InferenceChunk`),
             // so we need the GIL
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let chunk = chunk.map_err(|e| convert_error(py, err_to_http(e)))?;
                 parse_inference_chunk(py, chunk)
             })
@@ -243,7 +243,7 @@ struct StreamWrapper {
     // after all `StreamWrapper` objects have been garbage collected.
     // This allows us to safely block from within the Drop impl of `TensorZeroGateway`.
     // knowing that there are no remaining Python objects holding on to a `ClickhouseConnectionInfo`
-    _gateway: PyObject,
+    _gateway: Py<PyAny>,
 }
 
 #[pymethods]
@@ -393,7 +393,7 @@ where
     // our crate (`python`) is the `pymodule` function, rather than
     // a `#[tokio::main]` function, so we need `pyo3_async_runtimes` to keep track of
     // a Tokio runtime for us.
-    py.allow_threads(|| pyo3_async_runtimes::tokio::get_runtime().block_on(fut))
+    py.detach(|| pyo3_async_runtimes::tokio::get_runtime().block_on(fut))
 }
 
 impl BaseTensorZeroGateway {
@@ -1215,7 +1215,7 @@ impl AsyncTensorZeroGateway {
             let client = client_fut.await;
             // We need to interact with Python objects here (to build up a Python `AsyncTensorZeroGateway`),
             // so we need the GIL
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let client = match client {
                     Ok(client) => client,
                     Err(e) => {
@@ -1316,7 +1316,7 @@ impl AsyncTensorZeroGateway {
             let client = client_fut.await;
             // We need to interact with Python objects here (to build up a Python `AsyncTensorZeroGateway`),
             // so we need the GIL
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let client = match client {
                     Ok(client) => client,
                     Err(e) => {
@@ -1434,7 +1434,7 @@ impl AsyncTensorZeroGateway {
             let res = client.inference(params).await;
             // We need to interact with Python objects here (to build up a Python inference response),
             // so we need the GIL
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let output = res.map_err(|e| convert_error(py, e))?;
                 match output {
                     InferenceOutput::NonStreaming(data) => parse_inference_response(py, data),
@@ -1491,7 +1491,7 @@ impl AsyncTensorZeroGateway {
             let res = client.feedback(params).await;
             // We need to interact with Python objects here (to build up a Python feedback response),
             // so we need the GIL
-            Python::with_gil(|py| match res {
+            Python::attach(|py| match res {
                 Ok(resp) => Ok(parse_feedback_response(py, resp)?.into_any()),
                 Err(e) => Err(convert_error(py, e)),
             })
@@ -1524,7 +1524,7 @@ impl AsyncTensorZeroGateway {
 
         pyo3_async_runtimes::tokio::future_into_py(this.py(), async move {
             let res = client.dynamic_evaluation_run(params).await;
-            Python::with_gil(|py| match res {
+            Python::attach(|py| match res {
                 Ok(resp) => parse_dynamic_evaluation_run_response(py, resp),
                 Err(e) => Err(convert_error(py, e)),
             })
@@ -1557,7 +1557,7 @@ impl AsyncTensorZeroGateway {
 
         pyo3_async_runtimes::tokio::future_into_py(this.py(), async move {
             let res = client.dynamic_evaluation_run_episode(run_id, params).await;
-            Python::with_gil(|py| match res {
+            Python::attach(|py| match res {
                 Ok(resp) => parse_dynamic_evaluation_run_episode_response(py, resp),
                 Err(e) => Err(convert_error(py, e)),
             })
@@ -1585,7 +1585,7 @@ impl AsyncTensorZeroGateway {
         let uuid = self_module.getattr("UUID")?.unbind();
         pyo3_async_runtimes::tokio::future_into_py(this.py(), async move {
             let res = client.bulk_insert_datapoints(dataset_name, params).await;
-            Python::with_gil(|py| match res {
+            Python::attach(|py| match res {
                 Ok(uuids) => Ok(PyList::new(
                     py,
                     uuids
@@ -1614,7 +1614,7 @@ impl AsyncTensorZeroGateway {
         let datapoint_id = python_uuid_to_uuid("datapoint_id", datapoint_id)?;
         pyo3_async_runtimes::tokio::future_into_py(this.py(), async move {
             let res = client.delete_datapoint(dataset_name, datapoint_id).await;
-            Python::with_gil(|py| match res {
+            Python::attach(|py| match res {
                 Ok(()) => Ok(()),
                 Err(e) => Err(convert_error(py, e)),
             })
@@ -1636,7 +1636,7 @@ impl AsyncTensorZeroGateway {
         let datapoint_id = python_uuid_to_uuid("datapoint_id", datapoint_id)?;
         pyo3_async_runtimes::tokio::future_into_py(this.py(), async move {
             let res = client.get_datapoint(dataset_name, datapoint_id).await;
-            Python::with_gil(|py| match res {
+            Python::attach(|py| match res {
                 Ok(resp) => Ok(resp.into_py_any(py)?),
                 Err(e) => Err(convert_error(py, e)),
             })
@@ -1660,7 +1660,7 @@ impl AsyncTensorZeroGateway {
             let res = client
                 .list_datapoints(dataset_name, function_name, limit, offset)
                 .await;
-            Python::with_gil(|py| match res {
+            Python::attach(|py| match res {
                 Ok(datapoints) => Ok(PyList::new(py, datapoints)?.unbind()),
                 Err(e) => Err(convert_error(py, e)),
             })
@@ -1732,7 +1732,7 @@ impl AsyncTensorZeroGateway {
                 format: ClickhouseFormat::JsonEachRow,
             };
             let res = client.experimental_list_inferences(params).await;
-            Python::with_gil(|py| match res {
+            Python::attach(|py| match res {
                 Ok(stored_inferences) => Ok(PyList::new(py, stored_inferences)?.unbind()),
                 Err(e) => Err(convert_error(py, e)),
             })
@@ -1780,7 +1780,7 @@ impl AsyncTensorZeroGateway {
             let res = client
                 .experimental_render_samples(stored_inferences, variants)
                 .await;
-            Python::with_gil(|py| match res {
+            Python::attach(|py| match res {
                 Ok(inferences) => Ok(PyList::new(py, inferences)?.unbind()),
                 Err(e) => Err(convert_error(py, e)),
             })
@@ -1816,7 +1816,7 @@ impl AsyncTensorZeroGateway {
             let res = client
                 .experimental_render_samples(stored_samples, variants)
                 .await;
-            Python::with_gil(|py| match res {
+            Python::attach(|py| match res {
                 Ok(samples) => Ok(PyList::new(py, samples)?.unbind()),
                 Err(e) => Err(convert_error(py, e)),
             })
@@ -1862,7 +1862,7 @@ impl AsyncTensorZeroGateway {
                 .await;
             match res {
                 Ok(job_handle) => Ok(job_handle),
-                Err(e) => Python::with_gil(|py| Err(convert_error(py, e))),
+                Err(e) => Python::attach(|py| Err(convert_error(py, e))),
             }
         })
     }
@@ -1881,7 +1881,7 @@ impl AsyncTensorZeroGateway {
             let res = client.experimental_poll_optimization(&job_handle).await;
             match res {
                 Ok(status) => Ok(OptimizationJobInfoPyClass::new(status)),
-                Err(e) => Python::with_gil(|py| Err(convert_error(py, e))),
+                Err(e) => Python::attach(|py| Err(convert_error(py, e))),
             }
         })
     }

--- a/clients/python/src/python_helpers.rs
+++ b/clients/python/src/python_helpers.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use pyo3::{exceptions::PyValueError, prelude::*, sync::GILOnceCell};
+use pyo3::{exceptions::PyValueError, prelude::*, sync::PyOnceLock};
 use tensorzero_core::endpoints::dynamic_evaluation_run::DynamicEvaluationRunEpisodeResponse;
 use tensorzero_core::inference::types::pyo3_helpers::{deserialize_from_pyobj, serialize_to_dict};
 use tensorzero_rust::{
@@ -14,8 +14,8 @@ use uuid::Uuid;
 // We lazily lookup the corresponding Python class/method for all of these helpers,
 // since they're not available during module initialization.
 pub fn parse_feedback_response(py: Python<'_>, data: FeedbackResponse) -> PyResult<Py<PyAny>> {
-    static PARSE_FEEDBACK_RESPONSE: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
-    static UUID: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
+    static PARSE_FEEDBACK_RESPONSE: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+    static UUID: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
     // This should never actually fail, since we're just importing code defined in our own Python
     // package. However, we still produce a Python error if it fails, rather than panicking
     // and bringing down the entire Python process.
@@ -36,7 +36,7 @@ pub fn parse_feedback_response(py: Python<'_>, data: FeedbackResponse) -> PyResu
 
 pub fn parse_inference_response(py: Python<'_>, data: InferenceResponse) -> PyResult<Py<PyAny>> {
     let json_data = serialize_to_dict(py, data)?;
-    static PARSE_INFERENCE_RESPONSE: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
+    static PARSE_INFERENCE_RESPONSE: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
     // This should never actually fail, since we're just importing code defined in our own Python
     // package. However, we still produce a Python error if it fails, rather than panicking
     // and bringing down the entire Python process.
@@ -50,7 +50,7 @@ pub fn parse_inference_response(py: Python<'_>, data: InferenceResponse) -> PyRe
 }
 
 pub fn parse_inference_chunk(py: Python<'_>, chunk: InferenceResponseChunk) -> PyResult<Py<PyAny>> {
-    static PARSE_INFERENCE_CHUNK: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
+    static PARSE_INFERENCE_CHUNK: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
     // This should never actually fail, since we're just importing code defined in our own Python
     // package. However, we still produce a Python error if it fails, rather than panicking
     // and bringing down the entire Python process.
@@ -68,7 +68,7 @@ pub fn parse_dynamic_evaluation_run_response(
     py: Python<'_>,
     data: DynamicEvaluationRunResponse,
 ) -> PyResult<Py<PyAny>> {
-    static PARSE_DYNAMIC_EVALUATION_RUN_RESPONSE: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
+    static PARSE_DYNAMIC_EVALUATION_RUN_RESPONSE: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
     // This should never actually fail, since we're just importing code defined in our own Python
     // package. However, we still produce a Python error if it fails, rather than panicking
     // and bringing down the entire Python process.
@@ -88,8 +88,7 @@ pub fn parse_dynamic_evaluation_run_episode_response(
     py: Python<'_>,
     data: DynamicEvaluationRunEpisodeResponse,
 ) -> PyResult<Py<PyAny>> {
-    static PARSE_DYNAMIC_EVALUATION_RUN_EPISODE_RESPONSE: GILOnceCell<Py<PyAny>> =
-        GILOnceCell::new();
+    static PARSE_DYNAMIC_EVALUATION_RUN_EPISODE_RESPONSE: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
     // This should never actually fail, since we're just importing code defined in our own Python
     // package. However, we still produce a Python error if it fails, rather than panicking
     // and bringing down the entire Python process.

--- a/tensorzero-core/src/inference/types/pyo3_helpers.rs
+++ b/tensorzero-core/src/inference/types/pyo3_helpers.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::types::{IntoPyDict, PyDict};
 use pyo3::{intern, prelude::*};
-use pyo3::{sync::GILOnceCell, types::PyModule, Bound, Py, PyAny, PyErr, PyResult, Python};
+use pyo3::{sync::PyOnceLock, types::PyModule, Bound, Py, PyAny, PyErr, PyResult, Python};
 use serde::Deserialize;
 use serde_json::Value;
 use uuid::Uuid;
@@ -26,11 +26,11 @@ use pyo3::types::PyNone;
 
 use super::ContentBlock;
 
-pub static JSON_LOADS: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
-pub static JSON_DUMPS: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
-pub static UUID_UUID: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
-static TENSORZERO_INTERNAL_ERROR: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
-static TENSORZERO_ERROR: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
+pub static JSON_LOADS: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+pub static JSON_DUMPS: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+pub static UUID_UUID: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+static TENSORZERO_INTERNAL_ERROR: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+static TENSORZERO_ERROR: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
 
 pub fn uuid_to_python(py: Python<'_>, uuid: Uuid) -> PyResult<Bound<'_, PyAny>> {
     let uuid_class = UUID_UUID.get_or_try_init::<_, PyErr>(py, || {
@@ -47,7 +47,7 @@ fn import_template_content_block(py: Python<'_>) -> PyResult<&Py<PyAny>> {
     // We may want to consider not doing this so that we don't have these tied together in our interface.
     // However, they are currently nearly identical so this would be duplicated code for now and
     // not intutitive for users
-    static TEMPLATE_CONTENT_BLOCK: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
+    static TEMPLATE_CONTENT_BLOCK: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
     TEMPLATE_CONTENT_BLOCK.get_or_try_init::<_, PyErr>(py, || {
         let self_module = PyModule::import(py, "tensorzero.types")?;
         Ok(self_module.getattr("Template")?.unbind())
@@ -59,7 +59,7 @@ fn import_text_content_block(py: Python<'_>) -> PyResult<&Py<PyAny>> {
     // We may want to consider not doing this so that we don't have these tied together in our interface.
     // However, they are currently nearly identical so this would be duplicated code for now and
     // not intutitive for users
-    static TEXT_CONTENT_BLOCK: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
+    static TEXT_CONTENT_BLOCK: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
     TEXT_CONTENT_BLOCK.get_or_try_init::<_, PyErr>(py, || {
         let self_module = PyModule::import(py, "tensorzero.types")?;
         Ok(self_module.getattr("Text")?.unbind())
@@ -67,7 +67,7 @@ fn import_text_content_block(py: Python<'_>) -> PyResult<&Py<PyAny>> {
 }
 
 fn import_raw_text_content_block(py: Python<'_>) -> PyResult<&Py<PyAny>> {
-    static RAW_TEXT_CONTENT_BLOCK: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
+    static RAW_TEXT_CONTENT_BLOCK: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
     RAW_TEXT_CONTENT_BLOCK.get_or_try_init::<_, PyErr>(py, || {
         let self_module = PyModule::import(py, "tensorzero.types")?;
         Ok(self_module.getattr("RawText")?.unbind())
@@ -75,7 +75,7 @@ fn import_raw_text_content_block(py: Python<'_>) -> PyResult<&Py<PyAny>> {
 }
 
 fn import_file_content_block(py: Python<'_>) -> PyResult<&Py<PyAny>> {
-    static FILE_CONTENT_BLOCK: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
+    static FILE_CONTENT_BLOCK: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
     FILE_CONTENT_BLOCK.get_or_try_init::<_, PyErr>(py, || {
         let self_module = PyModule::import(py, "tensorzero.types")?;
         Ok(self_module.getattr("FileBase64")?.unbind())
@@ -83,7 +83,7 @@ fn import_file_content_block(py: Python<'_>) -> PyResult<&Py<PyAny>> {
 }
 
 fn import_tool_call_content_block(py: Python<'_>) -> PyResult<&Py<PyAny>> {
-    static TOOL_CALL_CONTENT_BLOCK: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
+    static TOOL_CALL_CONTENT_BLOCK: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
     TOOL_CALL_CONTENT_BLOCK.get_or_try_init::<_, PyErr>(py, || {
         let self_module = PyModule::import(py, "tensorzero.types")?;
         Ok(self_module.getattr("ToolCall")?.unbind())
@@ -91,7 +91,7 @@ fn import_tool_call_content_block(py: Python<'_>) -> PyResult<&Py<PyAny>> {
 }
 
 fn import_thought_content_block(py: Python<'_>) -> PyResult<&Py<PyAny>> {
-    static THOUGHT_CONTENT_BLOCK: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
+    static THOUGHT_CONTENT_BLOCK: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
     THOUGHT_CONTENT_BLOCK.get_or_try_init::<_, PyErr>(py, || {
         let self_module = PyModule::import(py, "tensorzero.types")?;
         Ok(self_module.getattr("Thought")?.unbind())
@@ -99,7 +99,7 @@ fn import_thought_content_block(py: Python<'_>) -> PyResult<&Py<PyAny>> {
 }
 
 fn import_tool_result_content_block(py: Python<'_>) -> PyResult<&Py<PyAny>> {
-    static TOOL_RESULT_CONTENT_BLOCK: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
+    static TOOL_RESULT_CONTENT_BLOCK: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
     TOOL_RESULT_CONTENT_BLOCK.get_or_try_init::<_, PyErr>(py, || {
         let self_module = PyModule::import(py, "tensorzero.types")?;
         Ok(self_module.getattr("ToolResult")?.unbind())
@@ -107,7 +107,7 @@ fn import_tool_result_content_block(py: Python<'_>) -> PyResult<&Py<PyAny>> {
 }
 
 fn import_unknown_content_block(py: Python<'_>) -> PyResult<&Py<PyAny>> {
-    static UNKNOWN_CONTENT_BLOCK: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
+    static UNKNOWN_CONTENT_BLOCK: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
     UNKNOWN_CONTENT_BLOCK.get_or_try_init::<_, PyErr>(py, || {
         let self_module = PyModule::import(py, "tensorzero.types")?;
         Ok(self_module.getattr("UnknownContentBlock")?.unbind())


### PR DESCRIPTION
This prepares us to start generating (some) stubs directly from PyO3, rather than needing to hand-write all of then in tensorzero.pyi
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `pyo3` to `0.26.0` and update concurrency handling with `Python::attach` and `PyOnceLock`.
> 
>   - **Dependencies**:
>     - Bump `pyo3` to `0.26.0` in `Cargo.toml` and `clients/python/Cargo.toml`.
>     - Update `pyo3-async-runtimes`, `pyo3-build-config`, `pyo3-ffi`, `pyo3-macros`, and `pyo3-macros-backend` to `0.26.0` in `Cargo.lock`.
>   - **Concurrency**:
>     - Replace `Python::with_gil` with `Python::attach` in `gil_helpers.rs`, `lib.rs`, and `python_helpers.rs`.
>     - Replace `py.allow_threads` with `py.detach` in `gil_helpers.rs` and `lib.rs`.
>   - **Thread Safety**:
>     - Replace `GILOnceCell` with `PyOnceLock` in `python_helpers.rs` and `pyo3_helpers.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 875a04558aeba4ea5a05031d2376ec0be18ca17c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->