### PR TITLE
Switch back to Github runners for ui tests

### DIFF
--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   ui-tests-no-network:
-    runs-on: namespace-profile-tensorzero-2x8
+    runs-on: ubuntu-latest
     if: github.repository == 'tensorzero/tensorzero'
     steps:
       - name: Set DNS
@@ -178,7 +178,7 @@ jobs:
           retention-days: 7
 
   ui-tests-e2e-credentials:
-    runs-on: namespace-profile-tensorzero-2x8
+    runs-on: ubuntu-latest
     # We currently only run this job when we have secrets available, since we need to use an S3 object_store
     # In the future, we might want to fix this so that it can run in PR CI for external (forked) PRs
     # For now, it just runs in the merge queue and on prs from the main repo


### PR DESCRIPTION
We were only using a Namespace runner to download artifacts, which we are now downloading from Github artifacts.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switches UI test runners from Namespace to GitHub's `ubuntu-latest` in `.github/workflows/ui-tests-e2e.yml`.
> 
>   - **CI/CD**:
>     - Change runner for `ui-tests-no-network`, `ui-tests-gateway-prefix`, and `ui-tests-e2e-credentials` jobs in `.github/workflows/ui-tests-e2e.yml` from `namespace-profile-tensorzero-2x8` to `ubuntu-latest`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for cfab23975cebaea196866b947a3a8bcce3e497fb. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->