### PR TITLE
Refactor get_unit_test_gateway_handle to clarify mock database params

### DIFF
--- a/tensorzero-core/src/endpoints/feedback/mod.rs
+++ b/tensorzero-core/src/endpoints/feedback/mod.rs
@@ -1065,7 +1065,7 @@ mod tests {
         let config = Arc::new(Config {
             ..Default::default()
         });
-        let gateway_handle = get_unit_test_gateway_handle(config, true, true);
+        let gateway_handle = get_unit_test_gateway_handle(config);
         let timestamp = uuid::Timestamp::from_unix_time(1579751960, 0, 0, 0);
         let episode_id = Uuid::new_v7(timestamp);
         let value = json!("test comment");
@@ -1098,7 +1098,7 @@ mod tests {
         let config = Arc::new(Config {
             ..Default::default()
         });
-        let gateway_handle = get_unit_test_gateway_handle(config, true, true);
+        let gateway_handle = get_unit_test_gateway_handle(config);
         let timestamp = uuid::Timestamp::from_unix_time(1579751960, 0, 0, 0);
         let episode_id = Uuid::new_v7(timestamp);
         let value = json!("test demonstration");
@@ -1169,7 +1169,7 @@ mod tests {
             metrics,
             ..Default::default()
         });
-        let gateway_handle = get_unit_test_gateway_handle(config.clone(), true, true);
+        let gateway_handle = get_unit_test_gateway_handle(config);
         let value = json!(4.5);
         let timestamp = uuid::Timestamp::from_unix_time(1579751960, 0, 0, 0);
         let inference_id = Uuid::new_v7(timestamp);
@@ -1239,7 +1239,7 @@ mod tests {
             metrics,
             ..Default::default()
         });
-        let gateway_handle = get_unit_test_gateway_handle(config.clone(), true, true);
+        let gateway_handle = get_unit_test_gateway_handle(config.clone());
         let value = json!(true);
         let timestamp = uuid::Timestamp::from_unix_time(1579751960, 0, 0, 0);
         let inference_id = Uuid::new_v7(timestamp);

--- a/tensorzero-core/src/gateway_util.rs
+++ b/tensorzero-core/src/gateway_util.rs
@@ -127,14 +127,12 @@ impl GatewayHandle {
     /// # Panics
     /// Panics if a `TensorzeroHttpClient` cannot be constructed
     #[cfg(test)]
-    pub fn new_unit_test_data(
-        config: Arc<Config>,
-        clickhouse_healthy: bool,
-        postgres_healthy: bool,
-    ) -> Self {
+    pub fn new_unit_test_data(config: Arc<Config>, test_options: GatewayHandleTestOptions) -> Self {
         let http_client = TensorzeroHttpClient::new().unwrap();
-        let clickhouse_connection_info = ClickHouseConnectionInfo::new_mock(clickhouse_healthy);
-        let postgres_connection_info = PostgresConnectionInfo::new_mock(postgres_healthy);
+        let clickhouse_connection_info =
+            ClickHouseConnectionInfo::new_mock(test_options.clickhouse_healthy);
+        let postgres_connection_info =
+            PostgresConnectionInfo::new_mock(test_options.postgres_healthy);
         Self::new_with_database_and_http_client(
             config,
             clickhouse_connection_info,
@@ -360,6 +358,12 @@ pub async fn start_openai_compatible_gateway(
             gateway_handle,
         },
     ))
+}
+
+#[cfg(test)]
+pub struct GatewayHandleTestOptions {
+    pub clickhouse_healthy: bool,
+    pub postgres_healthy: bool,
 }
 
 #[cfg(test)]

--- a/tensorzero-core/src/testing.rs
+++ b/tensorzero-core/src/testing.rs
@@ -3,12 +3,21 @@
 use std::sync::Arc;
 
 use crate::config::Config;
-use crate::gateway_util::GatewayHandle;
+use crate::gateway_util::{GatewayHandle, GatewayHandleTestOptions};
 
-pub fn get_unit_test_gateway_handle(
+pub fn get_unit_test_gateway_handle(config: Arc<Config>) -> GatewayHandle {
+    get_unit_test_gateway_handle_with_options(
+        config,
+        GatewayHandleTestOptions {
+            clickhouse_healthy: true,
+            postgres_healthy: true,
+        },
+    )
+}
+
+pub fn get_unit_test_gateway_handle_with_options(
     config: Arc<Config>,
-    clickhouse_healthy: bool,
-    postgres_healthy: bool,
+    test_options: GatewayHandleTestOptions,
 ) -> GatewayHandle {
-    GatewayHandle::new_unit_test_data(config, clickhouse_healthy, postgres_healthy)
+    GatewayHandle::new_unit_test_data(config, test_options)
 }


### PR DESCRIPTION
A follow up to #3617, refactors get_unit_test_gateway_handle to take a new struct GatewayHandleTestOptions that allows passing "healthy" params by name.

Not sure whether there are any specific reasons for the current setup, but my gut reaction is that it's clearer to change GatewayHandle to use more dependency injection? So, callers construct the real connections or mocks, so GatewayHandle doesn't need to worry about connections.

This is also working towards #3603.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `get_unit_test_gateway_handle` to use `GatewayHandleTestOptions` for clearer mock database parameter handling.
> 
>   - **Refactor**:
>     - Replace `get_unit_test_gateway_handle` with `get_unit_test_gateway_handle_with_options` in `status.rs` and `feedback/mod.rs`.
>     - Introduce `GatewayHandleTestOptions` struct in `gateway_util.rs` to specify mock database health parameters.
>   - **Functions**:
>     - Modify `new_unit_test_data` in `gateway_util.rs` to accept `GatewayHandleTestOptions`.
>     - Update `get_unit_test_gateway_handle` and `get_unit_test_gateway_handle_with_options` in `testing.rs` to use `GatewayHandleTestOptions`.
>   - **Tests**:
>     - Update tests in `status.rs` and `feedback/mod.rs` to use `get_unit_test_gateway_handle_with_options` with `GatewayHandleTestOptions`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for acd0398a89619b22f49990e6c881f51a5c53f83d. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->