### PR TITLE
Add maxHeight prop to InputSnippet component

### DIFF
--- a/ui/app/components/inference/InputSnippet.tsx
+++ b/ui/app/components/inference/InputSnippet.tsx
@@ -26,6 +26,7 @@ interface InputSnippetProps {
   isEditing?: boolean;
   onSystemChange?: (system: string | object) => void;
   onMessagesChange?: (messages: DisplayInputMessage[]) => void;
+  maxHeight?: number | "Content";
 }
 
 function renderContentBlock(
@@ -196,6 +197,7 @@ export default function InputSnippet({
   isEditing,
   onSystemChange,
   onMessagesChange,
+  maxHeight,
 }: InputSnippetProps) {
   const onContentBlockChange = (
     messageIndex: number,
@@ -214,13 +216,13 @@ export default function InputSnippet({
   return (
     <SnippetLayout>
       {!system && messages.length === 0 && (
-        <SnippetContent>
+        <SnippetContent maxHeight={maxHeight}>
           <EmptyMessage message="Empty input" />
         </SnippetContent>
       )}
 
       {system && (
-        <SnippetContent>
+        <SnippetContent maxHeight={maxHeight}>
           <SnippetMessage role="system">
             {typeof system === "object" ? (
               <ParameterizedMessage
@@ -240,7 +242,7 @@ export default function InputSnippet({
       )}
 
       {messages.length > 0 && (
-        <SnippetContent>
+        <SnippetContent maxHeight={maxHeight}>
           {messages.map((message, messageIndex) => (
             <SnippetMessage role={message.role} key={messageIndex}>
               {message.content.map((block, contentBlockIndex) =>

--- a/ui/app/routes/playground/route.tsx
+++ b/ui/app/routes/playground/route.tsx
@@ -443,6 +443,7 @@ export default function PlaygroundPage({ loaderData }: Route.ComponentProps) {
                             <InputSnippet
                               messages={inputs[index].messages}
                               system={inputs[index].system}
+                              maxHeight={150}
                             />
                           </div>
                           <div>


### PR DESCRIPTION
Close #3240
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `maxHeight` prop to `InputSnippet` component for height control, used in `PlaygroundPage`.
> 
>   - **Behavior**:
>     - Add `maxHeight` prop to `InputSnippet` component in `InputSnippet.tsx` to control maximum height.
>     - `maxHeight` can be a number or "Content".
>   - **Usage**:
>     - Set `maxHeight={150}` in `PlaygroundPage` in `route.tsx` for `InputSnippet` instances.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d888d6db35b9c45aa74b910f82b72d0acb9bc2e1. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->