### PR TITLE
Make ChatCompletion, BestOfN, MixtureOfN, ChainOfThought config fields private with getters

### DIFF
--- a/tensorzero-core/src/config/mod.rs
+++ b/tensorzero-core/src/config/mod.rs
@@ -1305,7 +1305,7 @@ impl UninitializedFunctionConfig {
                 for (name, variant) in &variants {
                     all_template_names.extend(variant.get_all_explicit_template_names());
                     if let VariantConfig::ChatCompletion(chat_config) = &variant.inner {
-                        if chat_config.json_mode.is_some() {
+                        if chat_config.json_mode().is_some() {
                             return Err(ErrorDetails::Config {
                                 message: format!(
                                     "JSON mode is not supported for variant `{name}` (parent function is a chat function)",
@@ -1371,17 +1371,17 @@ impl UninitializedFunctionConfig {
                     all_template_names.extend(variant.get_all_explicit_template_names());
                     match &variant.inner {
                         VariantConfig::ChatCompletion(chat_config) => {
-                            if chat_config.json_mode.is_none() {
+                            if chat_config.json_mode().is_none() {
                                 variant_missing_mode = Some(name.clone());
                             }
                         }
                         VariantConfig::BestOfNSampling(best_of_n_config) => {
-                            if best_of_n_config.evaluator.inner.json_mode.is_none() {
+                            if best_of_n_config.evaluator().inner.json_mode().is_none() {
                                 variant_missing_mode = Some(format!("{name}.evaluator"));
                             }
                         }
                         VariantConfig::MixtureOfN(mixture_of_n_config) => {
-                            if mixture_of_n_config.fuser.inner.json_mode.is_none() {
+                            if mixture_of_n_config.fuser().inner.json_mode().is_none() {
                                 variant_missing_mode = Some(format!("{name}.fuser"));
                             }
                         }
@@ -1391,7 +1391,7 @@ impl UninitializedFunctionConfig {
                             }
                         }
                         VariantConfig::ChainOfThought(chain_of_thought_config) => {
-                            if chain_of_thought_config.inner.json_mode.is_none() {
+                            if chain_of_thought_config.inner.json_mode().is_none() {
                                 variant_missing_mode = Some(name.clone());
                             }
                         }

--- a/tensorzero-core/src/config/tests.rs
+++ b/tensorzero-core/src/config/tests.rs
@@ -37,7 +37,7 @@ async fn test_config_from_toml_table_valid() {
         .unwrap()
         .inner
     {
-        VariantConfig::ChatCompletion(chat_config) => &chat_config.json_mode.unwrap(),
+        VariantConfig::ChatCompletion(chat_config) => chat_config.json_mode().unwrap(),
         _ => panic!("Expected a chat completion variant"),
     };
     assert_eq!(prompt_a_json_mode, &JsonMode::ImplicitTool);
@@ -51,10 +51,10 @@ async fn test_config_from_toml_table_valid() {
         .unwrap()
         .inner
     {
-        VariantConfig::ChatCompletion(chat_config) => chat_config.json_mode,
+        VariantConfig::ChatCompletion(chat_config) => chat_config.json_mode(),
         _ => panic!("Expected a chat completion variant"),
     };
-    assert_eq!(prompt_b_json_mode, Some(JsonMode::Strict));
+    assert_eq!(prompt_b_json_mode, Some(&JsonMode::Strict));
     // Check that the tool choice for get_weather is set to "specific" and the correct tool
     let function = config.functions.get("weather_helper").unwrap();
     match &**function {
@@ -77,7 +77,7 @@ async fn test_config_from_toml_table_valid() {
                 match &variant.inner {
                     VariantConfig::BestOfNSampling(best_of_n_config) => {
                         assert!(
-                            best_of_n_config.candidates.len() > 1,
+                            best_of_n_config.candidates().len() > 1,
                             "Best of n variant should have multiple candidates"
                         );
                     }
@@ -104,7 +104,7 @@ async fn test_config_from_toml_table_valid() {
             let variant = json_config.variants.get("variant_with_variables").unwrap();
             match &variant.inner {
                 VariantConfig::ChatCompletion(chat_config) => {
-                    assert_eq!(chat_config.weight, None); // Default weight should be None
+                    assert_eq!(chat_config.weight(), None); // Default weight should be None
                 }
                 _ => panic!("Expected a chat completion variant"),
             }
@@ -135,10 +135,10 @@ async fn test_config_from_toml_table_valid() {
             assert_eq!(json_config.variants.len(), 7);
             match &json_config.variants["anthropic_promptA"].inner {
                 VariantConfig::ChatCompletion(chat_config) => {
-                    assert_eq!(chat_config.model, "anthropic::claude-3.5-sonnet".into());
-                    assert_eq!(chat_config.weight, Some(1.0));
+                    assert_eq!(chat_config.model(), &"anthropic::claude-3.5-sonnet".into());
+                    assert_eq!(chat_config.weight(), Some(1.0));
                     assert_eq!(
-                            chat_config.templates.get_implicit_system_template().unwrap().template,
+                            chat_config.templates().get_implicit_system_template().unwrap().template,
                             PathWithContents {
                                 // We don't use a real path for programmatically generated templates
                                 // Instead we use this handle and then the same in minijinja
@@ -153,37 +153,37 @@ async fn test_config_from_toml_table_valid() {
                                         .to_string(),
                             }
                         );
-                    assert_eq!(chat_config.json_mode, Some(JsonMode::ImplicitTool));
+                    assert_eq!(chat_config.json_mode(), Some(&JsonMode::ImplicitTool));
                 }
                 _ => panic!("Expected a chat completion variant"),
             }
             match &json_config.variants["best_of_3"].inner {
                 VariantConfig::BestOfNSampling(best_of_n_config) => {
-                    assert_eq!(best_of_n_config.candidates.len(), 3);
+                    assert_eq!(best_of_n_config.candidates().len(), 3);
                     assert_eq!(
-                        best_of_n_config.evaluator.inner.model,
-                        "openai::gpt-4o-mini".into()
+                        best_of_n_config.evaluator().inner.model().as_ref(),
+                        "openai::gpt-4o-mini"
                     );
                     assert_eq!(
-                        best_of_n_config.evaluator.inner.json_mode,
-                        Some(JsonMode::Strict)
+                        best_of_n_config.evaluator().inner.json_mode(),
+                        Some(&JsonMode::Strict)
                     );
-                    assert_eq!(best_of_n_config.evaluator.inner.temperature, Some(0.3));
+                    assert_eq!(best_of_n_config.evaluator().inner.temperature(), Some(0.3));
                 }
                 _ => panic!("Expected a best of n sampling variant"),
             }
             match &json_config.variants["mixture_of_3"].inner {
                 VariantConfig::MixtureOfN(mixture_of_n_config) => {
-                    assert_eq!(mixture_of_n_config.candidates.len(), 3);
+                    assert_eq!(mixture_of_n_config.candidates().len(), 3);
                     assert_eq!(
-                        mixture_of_n_config.fuser.inner.model,
-                        "openai::gpt-4o-mini".into()
+                        mixture_of_n_config.fuser().inner.model().as_ref(),
+                        "openai::gpt-4o-mini"
                     );
                     assert_eq!(
-                        mixture_of_n_config.fuser.inner.json_mode,
-                        Some(JsonMode::Strict)
+                        mixture_of_n_config.fuser().inner.json_mode(),
+                        Some(&JsonMode::Strict)
                     );
-                    assert_eq!(mixture_of_n_config.fuser.inner.temperature, Some(0.3));
+                    assert_eq!(mixture_of_n_config.fuser().inner.temperature(), Some(0.3));
                 }
                 _ => panic!("Expected a mixture of n sampling variant"),
             }
@@ -2576,7 +2576,7 @@ async fn test_glob_relative_path() {
     };
     assert_eq!(
         variant
-            .templates
+            .templates()
             .get_implicit_template(Role::User)
             .unwrap()
             .template
@@ -2589,7 +2589,7 @@ async fn test_glob_relative_path() {
     );
     assert_eq!(
         variant
-            .templates
+            .templates()
             .get_implicit_system_template()
             .unwrap()
             .template
@@ -2599,7 +2599,7 @@ async fn test_glob_relative_path() {
 
     assert_eq!(
         variant
-            .templates
+            .templates()
             .get_implicit_system_template()
             .unwrap()
             .template
@@ -2613,7 +2613,7 @@ async fn test_glob_relative_path() {
 
     assert_eq!(
         variant
-            .templates
+            .templates()
             .get_implicit_template(Role::User)
             .unwrap()
             .template

--- a/tensorzero-core/src/evaluations/mod.rs
+++ b/tensorzero-core/src/evaluations/mod.rs
@@ -19,12 +19,12 @@ use crate::{
     tool::create_implicit_tool_call_config,
     variant::{
         best_of_n_sampling::{
-            BestOfNEvaluatorConfig as OnlineEvaluatorConfig, BestOfNSamplingConfig,
+            UninitializedBestOfNEvaluatorConfig, UninitializedBestOfNSamplingConfig,
         },
         chain_of_thought::ChainOfThoughtConfig,
         chat_completion::ChatCompletionConfig,
         dicl::UninitializedDiclConfig,
-        mixture_of_n::{FuserConfig, MixtureOfNConfig},
+        mixture_of_n::{UninitializedFuserConfig, UninitializedMixtureOfNConfig},
         JsonMode, RetryConfig, VariantConfig, VariantInfo,
     },
 };
@@ -385,19 +385,19 @@ impl UninitializedEvaluatorConfig {
                     }
                     match &mut variant.inner {
                         VariantConfig::ChatCompletion(variant) => {
-                            variant.weight = Some(1.0);
+                            variant.set_weight(Some(1.0));
                         }
                         VariantConfig::BestOfNSampling(variant) => {
-                            variant.weight = Some(1.0);
+                            variant.set_weight(Some(1.0));
                         }
                         VariantConfig::MixtureOfN(variant) => {
-                            variant.weight = Some(1.0);
+                            variant.set_weight(Some(1.0));
                         }
                         VariantConfig::Dicl(variant) => {
                             variant.set_weight(Some(1.0));
                         }
                         VariantConfig::ChainOfThought(variant) => {
-                            variant.inner.weight = Some(1.0);
+                            variant.inner.set_weight(Some(1.0));
                         }
                     };
                 }
@@ -683,46 +683,48 @@ impl UninitializedLLMJudgeVariantInfo {
                     }
                     LLMJudgeInputFormat::Messages => None,
                 };
-                VariantConfig::BestOfNSampling(BestOfNSamplingConfig {
-                    weight: get_weight(params.active),
-                    timeout_s: params.timeout_s,
-                    candidates: params.candidates,
-                    evaluator: OnlineEvaluatorConfig {
-                        inner: UninitializedChatCompletionConfig {
-                            weight: None,
-                            model: params.evaluator.model,
-                            user_template: evaluator_user_template.map(|t| t.path),
-                            system_template: Some(evaluator_system_template.path),
-                            templates: Default::default(),
-                            input_wrappers: None,
-                            assistant_template: None,
-                            temperature: params.evaluator.temperature,
-                            top_p: params.evaluator.top_p,
-                            max_tokens: params.evaluator.max_tokens,
-                            presence_penalty: params.evaluator.presence_penalty,
-                            frequency_penalty: params.evaluator.frequency_penalty,
-                            seed: params.evaluator.seed,
-                            json_mode: Some(params.evaluator.json_mode),
-                            stop_sequences: params.evaluator.stop_sequences,
-                            retries: params.evaluator.retries,
-                            extra_body: params.evaluator.extra_body,
-                            extra_headers: params.evaluator.extra_headers,
-                        }
-                        .load(
-                            &SchemaData::load(
-                                user_schema,
-                                None,
-                                None,
-                                UninitializedSchemas::default(),
-                                &format!("tensorzero::evaluator::{evaluator_name}"),
-                            )?,
-                            &ErrorContext {
-                                function_name: "tensorzero::evaluator".to_string(),
-                                variant_name: evaluator_name.to_string(),
+                VariantConfig::BestOfNSampling(
+                    UninitializedBestOfNSamplingConfig {
+                        weight: get_weight(params.active),
+                        timeout_s: params.timeout_s,
+                        candidates: params.candidates,
+                        evaluator: UninitializedBestOfNEvaluatorConfig {
+                            inner: UninitializedChatCompletionConfig {
+                                weight: None,
+                                model: params.evaluator.model,
+                                user_template: evaluator_user_template.map(|t| t.path),
+                                system_template: Some(evaluator_system_template.path),
+                                templates: Default::default(),
+                                input_wrappers: None,
+                                assistant_template: None,
+                                temperature: params.evaluator.temperature,
+                                top_p: params.evaluator.top_p,
+                                max_tokens: params.evaluator.max_tokens,
+                                presence_penalty: params.evaluator.presence_penalty,
+                                frequency_penalty: params.evaluator.frequency_penalty,
+                                seed: params.evaluator.seed,
+                                json_mode: Some(params.evaluator.json_mode),
+                                stop_sequences: params.evaluator.stop_sequences,
+                                retries: params.evaluator.retries,
+                                extra_body: params.evaluator.extra_body,
+                                extra_headers: params.evaluator.extra_headers,
                             },
+                        },
+                    }
+                    .load(
+                        &SchemaData::load(
+                            user_schema,
+                            None,
+                            None,
+                            UninitializedSchemas::default(),
+                            &format!("tensorzero::evaluator::{evaluator_name}"),
                         )?,
-                    },
-                })
+                        &ErrorContext {
+                            function_name: "tensorzero::evaluator".to_string(),
+                            variant_name: evaluator_name.to_string(),
+                        },
+                    )?,
+                )
             }
             UninitializedLLMJudgeVariantConfig::MixtureOfNSampling(params) => {
                 let fuser_system_instructions = &params.fuser.system_instructions.read()?;
@@ -749,46 +751,48 @@ impl UninitializedLLMJudgeVariantInfo {
                     }
                     LLMJudgeInputFormat::Messages => None,
                 };
-                VariantConfig::MixtureOfN(MixtureOfNConfig {
-                    weight: get_weight(params.active),
-                    timeout_s: params.timeout_s,
-                    candidates: params.candidates,
-                    fuser: FuserConfig {
-                        inner: UninitializedChatCompletionConfig {
-                            weight: None,
-                            model: params.fuser.model,
-                            user_template: fuser_user_template.map(|t| t.path),
-                            system_template: Some(fuser_system_template.path),
-                            templates: Default::default(),
-                            assistant_template: None,
-                            input_wrappers: None,
-                            temperature: params.fuser.temperature,
-                            top_p: params.fuser.top_p,
-                            max_tokens: params.fuser.max_tokens,
-                            presence_penalty: params.fuser.presence_penalty,
-                            frequency_penalty: params.fuser.frequency_penalty,
-                            seed: params.fuser.seed,
-                            json_mode: Some(params.fuser.json_mode),
-                            retries: params.fuser.retries,
-                            stop_sequences: params.fuser.stop_sequences,
-                            extra_body: params.fuser.extra_body,
-                            extra_headers: params.fuser.extra_headers,
-                        }
-                        .load(
-                            &SchemaData::load(
-                                user_schema,
-                                None,
-                                None,
-                                UninitializedSchemas::default(),
-                                &format!("tensorzero::evaluator::{evaluator_name}"),
-                            )?,
-                            &ErrorContext {
-                                function_name: "tensorzero::evaluator".to_string(),
-                                variant_name: evaluator_name.to_string(),
+                VariantConfig::MixtureOfN(
+                    UninitializedMixtureOfNConfig {
+                        weight: get_weight(params.active),
+                        timeout_s: params.timeout_s,
+                        candidates: params.candidates,
+                        fuser: UninitializedFuserConfig {
+                            inner: UninitializedChatCompletionConfig {
+                                weight: None,
+                                model: params.fuser.model,
+                                user_template: fuser_user_template.map(|t| t.path),
+                                system_template: Some(fuser_system_template.path),
+                                templates: Default::default(),
+                                assistant_template: None,
+                                input_wrappers: None,
+                                temperature: params.fuser.temperature,
+                                top_p: params.fuser.top_p,
+                                max_tokens: params.fuser.max_tokens,
+                                presence_penalty: params.fuser.presence_penalty,
+                                frequency_penalty: params.fuser.frequency_penalty,
+                                seed: params.fuser.seed,
+                                json_mode: Some(params.fuser.json_mode),
+                                retries: params.fuser.retries,
+                                stop_sequences: params.fuser.stop_sequences,
+                                extra_body: params.fuser.extra_body,
+                                extra_headers: params.fuser.extra_headers,
                             },
+                        },
+                    }
+                    .load(
+                        &SchemaData::load(
+                            user_schema,
+                            None,
+                            None,
+                            UninitializedSchemas::default(),
+                            &format!("tensorzero::evaluator::{evaluator_name}"),
                         )?,
-                    },
-                })
+                        &ErrorContext {
+                            function_name: "tensorzero::evaluator".to_string(),
+                            variant_name: evaluator_name.to_string(),
+                        },
+                    )?,
+                )
             }
             UninitializedLLMJudgeVariantConfig::Dicl(params) => {
                 let dicl_system_instructions = params
@@ -858,22 +862,22 @@ fn check_convert_variant_to_llm_judge_variant(
             Ok(UninitializedLLMJudgeVariantConfig::ChatCompletion(
                 UninitializedLLMJudgeChatCompletionVariantConfig {
                     active: Some(false),
-                    model: variant.model,
+                    model: variant.model().clone(),
                     system_instructions: ResolvedTomlPath::new_fake_path(
                         String::new(),
                         String::new(),
                     ),
-                    temperature: variant.temperature,
-                    top_p: variant.top_p,
-                    max_tokens: variant.max_tokens,
-                    presence_penalty: variant.presence_penalty,
-                    frequency_penalty: variant.frequency_penalty,
-                    seed: variant.seed,
+                    temperature: variant.temperature(),
+                    top_p: variant.top_p(),
+                    max_tokens: variant.max_tokens(),
+                    presence_penalty: variant.presence_penalty(),
+                    frequency_penalty: variant.frequency_penalty(),
+                    seed: variant.seed(),
                     json_mode: JsonMode::Off,
-                    retries: variant.retries,
-                    stop_sequences: variant.stop_sequences,
-                    extra_body: variant.extra_body,
-                    extra_headers: variant.extra_headers,
+                    retries: *variant.retries(),
+                    stop_sequences: variant.stop_sequences().cloned(),
+                    extra_body: variant.extra_body().cloned(),
+                    extra_headers: variant.extra_headers().cloned(),
                 },
             ))
         }
@@ -881,26 +885,26 @@ fn check_convert_variant_to_llm_judge_variant(
             Ok(UninitializedLLMJudgeVariantConfig::BestOfNSampling(
                 UninitializedLLMJudgeBestOfNVariantConfig {
                     active: Some(false),
-                    timeout_s: variant.timeout_s,
-                    candidates: variant.candidates,
+                    timeout_s: variant.timeout_s(),
+                    candidates: variant.candidates().clone(),
                     evaluator: UninitializedLLMJudgeChatCompletionVariantConfig {
                         active: Some(false),
-                        model: variant.evaluator.inner.model,
+                        model: variant.evaluator().inner.model().clone(),
                         system_instructions: ResolvedTomlPath::new_fake_path(
                             String::new(),
                             String::new(),
                         ),
-                        temperature: variant.evaluator.inner.temperature,
-                        top_p: variant.evaluator.inner.top_p,
-                        max_tokens: variant.evaluator.inner.max_tokens,
-                        presence_penalty: variant.evaluator.inner.presence_penalty,
-                        frequency_penalty: variant.evaluator.inner.frequency_penalty,
-                        seed: variant.evaluator.inner.seed,
+                        temperature: variant.evaluator().inner.temperature(),
+                        top_p: variant.evaluator().inner.top_p(),
+                        max_tokens: variant.evaluator().inner.max_tokens(),
+                        presence_penalty: variant.evaluator().inner.presence_penalty(),
+                        frequency_penalty: variant.evaluator().inner.frequency_penalty(),
+                        seed: variant.evaluator().inner.seed(),
                         json_mode: JsonMode::Off,
-                        retries: variant.evaluator.inner.retries,
-                        stop_sequences: variant.evaluator.inner.stop_sequences,
-                        extra_body: variant.evaluator.inner.extra_body,
-                        extra_headers: variant.evaluator.inner.extra_headers,
+                        retries: *variant.evaluator().inner.retries(),
+                        stop_sequences: variant.evaluator().inner.stop_sequences().cloned(),
+                        extra_body: variant.evaluator().inner.extra_body().cloned(),
+                        extra_headers: variant.evaluator().inner.extra_headers().cloned(),
                     },
                 },
             ))
@@ -909,26 +913,26 @@ fn check_convert_variant_to_llm_judge_variant(
             Ok(UninitializedLLMJudgeVariantConfig::MixtureOfNSampling(
                 UninitializedLLMJudgeMixtureOfNVariantConfig {
                     active: Some(false),
-                    timeout_s: variant.timeout_s,
-                    candidates: variant.candidates,
+                    timeout_s: variant.timeout_s(),
+                    candidates: variant.candidates().clone(),
                     fuser: UninitializedLLMJudgeChatCompletionVariantConfig {
                         active: Some(false),
-                        model: variant.fuser.inner.model,
+                        model: variant.fuser().inner.model().clone(),
                         system_instructions: ResolvedTomlPath::new_fake_path(
                             String::new(),
                             String::new(),
                         ),
-                        temperature: variant.fuser.inner.temperature,
-                        top_p: variant.fuser.inner.top_p,
-                        max_tokens: variant.fuser.inner.max_tokens,
-                        presence_penalty: variant.fuser.inner.presence_penalty,
-                        frequency_penalty: variant.fuser.inner.frequency_penalty,
-                        seed: variant.fuser.inner.seed,
+                        temperature: variant.fuser().inner.temperature(),
+                        top_p: variant.fuser().inner.top_p(),
+                        max_tokens: variant.fuser().inner.max_tokens(),
+                        presence_penalty: variant.fuser().inner.presence_penalty(),
+                        frequency_penalty: variant.fuser().inner.frequency_penalty(),
+                        seed: variant.fuser().inner.seed(),
                         json_mode: JsonMode::Off,
-                        retries: variant.fuser.inner.retries,
-                        stop_sequences: variant.fuser.inner.stop_sequences,
-                        extra_body: variant.fuser.inner.extra_body,
-                        extra_headers: variant.fuser.inner.extra_headers,
+                        retries: *variant.fuser().inner.retries(),
+                        stop_sequences: variant.fuser().inner.stop_sequences().cloned(),
+                        extra_body: variant.fuser().inner.extra_body().cloned(),
+                        extra_headers: variant.fuser().inner.extra_headers().cloned(),
                     },
                 },
             ))
@@ -958,22 +962,22 @@ fn check_convert_variant_to_llm_judge_variant(
                 UninitializedLLMJudgeChainOfThoughtVariantConfig {
                     inner: UninitializedLLMJudgeChatCompletionVariantConfig {
                         active: Some(false),
-                        model: variant.inner.model,
+                        model: variant.inner.model().to_string().into(),
                         system_instructions: ResolvedTomlPath::new_fake_path(
                             String::new(),
                             String::new(),
                         ),
-                        temperature: variant.inner.temperature,
-                        top_p: variant.inner.top_p,
-                        max_tokens: variant.inner.max_tokens,
-                        presence_penalty: variant.inner.presence_penalty,
-                        frequency_penalty: variant.inner.frequency_penalty,
-                        seed: variant.inner.seed,
+                        temperature: variant.inner.temperature(),
+                        top_p: variant.inner.top_p(),
+                        max_tokens: variant.inner.max_tokens(),
+                        presence_penalty: variant.inner.presence_penalty(),
+                        frequency_penalty: variant.inner.frequency_penalty(),
+                        seed: variant.inner.seed(),
                         json_mode: JsonMode::Off,
-                        retries: variant.inner.retries,
-                        stop_sequences: variant.inner.stop_sequences,
-                        extra_body: variant.inner.extra_body,
-                        extra_headers: variant.inner.extra_headers,
+                        retries: *variant.inner.retries(),
+                        stop_sequences: variant.inner.stop_sequences().cloned(),
+                        extra_body: variant.inner.extra_body().cloned(),
+                        extra_headers: variant.inner.extra_headers().cloned(),
                     },
                 },
             ))
@@ -1602,7 +1606,7 @@ mod tests {
                     // Check that the weight is Some(1.0) which indicates it defaulted to active
                     match &variant.inner {
                         VariantConfig::ChatCompletion(cc_config) => {
-                            assert_eq!(cc_config.weight, Some(1.0));
+                            assert_eq!(cc_config.weight(), Some(1.0));
                         }
                         _ => panic!("Expected ChatCompletion variant config"),
                     }

--- a/tensorzero-core/src/stored_inference.rs
+++ b/tensorzero-core/src/stored_inference.rs
@@ -630,7 +630,7 @@ async fn render_model_input(
         resolved_input.system.as_ref(),
         &resolved_input.messages,
         &config.templates,
-        &chat_completion_config.templates,
+        chat_completion_config.templates(),
     )
     .await
 }

--- a/tensorzero-core/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-core/src/variant/best_of_n_sampling.rs
@@ -41,10 +41,32 @@ use super::{InferenceConfig, JsonMode, ModelUsedInfo, Variant};
 #[cfg_attr(test, derive(ts_rs::TS))]
 #[cfg_attr(test, ts(export))]
 pub struct BestOfNSamplingConfig {
-    pub weight: Option<f64>,
-    pub timeout_s: f64,
-    pub candidates: Vec<String>,
-    pub evaluator: BestOfNEvaluatorConfig,
+    weight: Option<f64>,
+    timeout_s: f64,
+    candidates: Vec<String>,
+    evaluator: BestOfNEvaluatorConfig,
+}
+
+impl BestOfNSamplingConfig {
+    pub fn weight(&self) -> Option<f64> {
+        self.weight
+    }
+
+    pub fn set_weight(&mut self, weight: Option<f64>) {
+        self.weight = weight;
+    }
+
+    pub fn timeout_s(&self) -> f64 {
+        self.timeout_s
+    }
+
+    pub fn candidates(&self) -> &Vec<String> {
+        &self.candidates
+    }
+
+    pub fn evaluator(&self) -> &BestOfNEvaluatorConfig {
+        &self.evaluator
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, ts_rs::TS)]
@@ -462,21 +484,21 @@ async fn inner_select_best_candidate<'a, 'request>(
         // Return the selected index and None for the model inference result
         return Ok((Some(selected_index), None));
     }
-    let model_config = models.get(&evaluator.inner.model).await?.ok_or_else(|| {
+    let model_config = models.get(evaluator.inner.model()).await?.ok_or_else(|| {
         Error::new(ErrorDetails::UnknownModel {
-            name: evaluator.inner.model.to_string(),
+            name: evaluator.inner.model().to_string(),
         })
     })?;
     let model_inference_response = (|| async {
         model_config
-            .infer(&inference_request, clients, &evaluator.inner.model)
+            .infer(&inference_request, clients, evaluator.inner.model())
             .await
     })
-    .retry(evaluator.inner.retries.get_backoff())
+    .retry(evaluator.inner.retries().get_backoff())
     .await?;
     let model_inference_result = ModelInferenceResponseWithMetadata::new(
         model_inference_response,
-        evaluator.inner.model.clone(),
+        evaluator.inner.model().clone(),
     );
     let raw = match model_inference_result
         .output
@@ -680,18 +702,18 @@ impl BestOfNEvaluatorConfig {
         inference_params
             .chat_completion
             .backfill_with_variant_params(
-                self.inner.temperature,
-                self.inner.max_tokens,
-                self.inner.seed,
-                self.inner.top_p,
-                self.inner.presence_penalty,
-                self.inner.frequency_penalty,
-                self.inner.stop_sequences.clone(),
+                self.inner.temperature(),
+                self.inner.max_tokens(),
+                self.inner.seed(),
+                self.inner.top_p(),
+                self.inner.presence_penalty(),
+                self.inner.frequency_penalty(),
+                self.inner.stop_sequences().cloned(),
             );
         let json_mode = inference_params
             .chat_completion
             .json_mode
-            .or(self.inner.json_mode)
+            .or_else(|| self.inner.json_mode().cloned())
             .unwrap_or(JsonMode::Strict);
         let tool_config = match json_mode {
             JsonMode::ImplicitTool => Some(Cow::Borrowed(&*IMPLICIT_TOOL_CALL_CONFIG)),
@@ -705,11 +727,11 @@ impl BestOfNEvaluatorConfig {
             .into());
         }
         let extra_body = FullExtraBodyConfig {
-            extra_body: self.inner.extra_body.clone(),
+            extra_body: self.inner.extra_body().cloned(),
             inference_extra_body: Default::default(),
         };
         let extra_headers = FullExtraHeadersConfig {
-            variant_extra_headers: self.inner.extra_headers.clone(),
+            variant_extra_headers: self.inner.extra_headers().cloned(),
             inference_extra_headers: Default::default(),
         };
         Ok((

--- a/tensorzero-core/src/variant/chat_completion/mod.rs
+++ b/tensorzero-core/src/variant/chat_completion/mod.rs
@@ -57,26 +57,87 @@ pub struct TemplateWithSchema {
 #[derive(Debug, Default, Serialize)]
 #[cfg_attr(test, derive(ts_rs::TS))]
 #[cfg_attr(test, ts(export))]
-#[expect(clippy::manual_non_exhaustive)]
 pub struct ChatCompletionConfig {
-    pub weight: Option<f64>,
-    pub model: Arc<str>,
-    pub templates: ChatTemplates,
-    pub temperature: Option<f32>,
-    pub top_p: Option<f32>,
-    pub max_tokens: Option<u32>,
-    pub presence_penalty: Option<f32>,
-    pub frequency_penalty: Option<f32>,
-    pub seed: Option<u32>,
-    pub stop_sequences: Option<Vec<String>>,
-    pub json_mode: Option<JsonMode>, // Only for JSON functions, not for chat functions
-    pub retries: RetryConfig,
+    weight: Option<f64>,
+    model: Arc<str>,
+    templates: ChatTemplates,
+    temperature: Option<f32>,
+    top_p: Option<f32>,
+    max_tokens: Option<u32>,
+    presence_penalty: Option<f32>,
+    frequency_penalty: Option<f32>,
+    seed: Option<u32>,
+    stop_sequences: Option<Vec<String>>,
+    json_mode: Option<JsonMode>, // Only for JSON functions, not for chat functions
+    retries: RetryConfig,
     #[cfg_attr(test, ts(skip))]
-    pub extra_body: Option<ExtraBodyConfig>,
+    extra_body: Option<ExtraBodyConfig>,
     #[cfg_attr(test, ts(skip))]
-    pub extra_headers: Option<ExtraHeadersConfig>,
+    extra_headers: Option<ExtraHeadersConfig>,
     #[serde(skip)]
     _private: (),
+}
+
+impl ChatCompletionConfig {
+    pub fn weight(&self) -> Option<f64> {
+        self.weight
+    }
+
+    pub fn set_weight(&mut self, weight: Option<f64>) {
+        self.weight = weight;
+    }
+
+    pub fn model(&self) -> &Arc<str> {
+        &self.model
+    }
+
+    pub fn templates(&self) -> &ChatTemplates {
+        &self.templates
+    }
+
+    pub fn temperature(&self) -> Option<f32> {
+        self.temperature
+    }
+
+    pub fn top_p(&self) -> Option<f32> {
+        self.top_p
+    }
+
+    pub fn max_tokens(&self) -> Option<u32> {
+        self.max_tokens
+    }
+
+    pub fn presence_penalty(&self) -> Option<f32> {
+        self.presence_penalty
+    }
+
+    pub fn frequency_penalty(&self) -> Option<f32> {
+        self.frequency_penalty
+    }
+
+    pub fn seed(&self) -> Option<u32> {
+        self.seed
+    }
+
+    pub fn stop_sequences(&self) -> Option<&Vec<String>> {
+        self.stop_sequences.as_ref()
+    }
+
+    pub fn json_mode(&self) -> Option<&JsonMode> {
+        self.json_mode.as_ref()
+    }
+
+    pub fn retries(&self) -> &RetryConfig {
+        &self.retries
+    }
+
+    pub fn extra_body(&self) -> Option<&ExtraBodyConfig> {
+        self.extra_body.as_ref()
+    }
+
+    pub fn extra_headers(&self) -> Option<&ExtraHeadersConfig> {
+        self.extra_headers.as_ref()
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ts_rs::TS)]

--- a/tensorzero-core/src/variant/mod.rs
+++ b/tensorzero-core/src/variant/mod.rs
@@ -248,21 +248,21 @@ pub trait Variant {
 impl VariantConfig {
     pub fn weight(&self) -> Option<f64> {
         match self {
-            VariantConfig::ChatCompletion(params) => params.weight,
-            VariantConfig::BestOfNSampling(params) => params.weight,
+            VariantConfig::ChatCompletion(params) => params.weight(),
+            VariantConfig::BestOfNSampling(params) => params.weight(),
             VariantConfig::Dicl(params) => params.weight(),
-            VariantConfig::MixtureOfN(params) => params.weight,
-            VariantConfig::ChainOfThought(params) => params.inner.weight,
+            VariantConfig::MixtureOfN(params) => params.weight(),
+            VariantConfig::ChainOfThought(params) => params.inner.weight(),
         }
     }
 
     pub fn set_weight(&mut self, weight: Option<f64>) {
         match self {
-            VariantConfig::ChatCompletion(params) => params.weight = weight,
-            VariantConfig::BestOfNSampling(params) => params.weight = weight,
+            VariantConfig::ChatCompletion(params) => params.set_weight(weight),
+            VariantConfig::BestOfNSampling(params) => params.set_weight(weight),
             VariantConfig::Dicl(params) => params.set_weight(weight),
-            VariantConfig::MixtureOfN(params) => params.weight = weight,
-            VariantConfig::ChainOfThought(params) => params.inner.weight = weight,
+            VariantConfig::MixtureOfN(params) => params.set_weight(weight),
+            VariantConfig::ChainOfThought(params) => params.inner.set_weight(weight),
         }
     }
 }
@@ -841,7 +841,7 @@ impl ChatCompletionConfigPyClass {
     fn get_system_template(&self) -> PyResult<Option<String>> {
         let config = Self::extract_chat_completion_config(&self.inner)?;
         Ok(config
-            .templates
+            .templates()
             .get_implicit_system_template()
             .as_ref()
             .map(|t| t.template.contents.clone()))
@@ -851,7 +851,7 @@ impl ChatCompletionConfigPyClass {
     fn get_user_template(&self) -> PyResult<Option<String>> {
         let config = Self::extract_chat_completion_config(&self.inner)?;
         Ok(config
-            .templates
+            .templates()
             .get_implicit_template(crate::inference::types::Role::User)
             .as_ref()
             .map(|t| t.template.contents.clone()))
@@ -861,7 +861,7 @@ impl ChatCompletionConfigPyClass {
     fn get_assistant_template(&self) -> PyResult<Option<String>> {
         let config = Self::extract_chat_completion_config(&self.inner)?;
         Ok(config
-            .templates
+            .templates()
             .get_implicit_template(crate::inference::types::Role::Assistant)
             .as_ref()
             .map(|t| t.template.contents.clone()))
@@ -870,7 +870,7 @@ impl ChatCompletionConfigPyClass {
     #[getter]
     fn get_model(&self) -> PyResult<String> {
         let config = Self::extract_chat_completion_config(&self.inner)?;
-        Ok(config.model.to_string())
+        Ok(config.model().to_string())
     }
 }
 


### PR DESCRIPTION
Close #3376
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make configuration fields private and add getter methods in variant config structs for encapsulation.
> 
>   - **Behavior**:
>     - Make fields `weight`, `timeout_s`, `candidates`, `evaluator`, `fuser`, `model`, `templates`, `temperature`, `top_p`, `max_tokens`, `presence_penalty`, `frequency_penalty`, `seed`, `stop_sequences`, `json_mode`, `retries`, `extra_body`, and `extra_headers` private in `ChatCompletionConfig`, `BestOfNSamplingConfig`, `MixtureOfNConfig`, and `ChainOfThoughtConfig`.
>     - Add public getter methods for these fields in the respective structs.
>   - **Refactoring**:
>     - Update usage of these fields to use the new getter methods in `mod.rs`, `best_of_n_sampling.rs`, `chat_completion/mod.rs`, and `mixture_of_n.rs`.
>     - Modify `prepare_request` and `prepare_candidate_message` functions to use getters.
>   - **Testing**:
>     - Update tests in `tests.rs` to use getter methods for accessing private fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e7f9828992c08c79ed4a784e5fd184f842a2a668. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->