### PR TITLE
Document embedding provider `extra_body`

### DIFF
--- a/docs/gateway/configuration-reference.mdx
+++ b/docs/gateway/configuration-reference.mdx
@@ -1432,6 +1432,36 @@ routing = ["openai", "alternative-provider"]
 # ...
 ```
 
+### `extra_body`
+
+- **Type:** array of objects (see below)
+- **Required:** no
+
+The `extra_body` field allows you to modify the request body that TensorZero sends to the embedding model provider.
+This advanced feature is an "escape hatch" that lets you use provider-specific functionality that TensorZero hasn't implemented yet.
+
+Each object in the array must have two fields:
+
+- `pointer`: A [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) string specifying where to modify the request body
+- One of the following:
+  - `value`: The value to insert at that location; it can be of any type including nested types
+  - `delete = true`: Deletes the field at the specified location, if present.
+
+<Tip>
+
+You can also set `extra_body` at inference-time.
+The values provided at inference-time take priority over the values in the configuration file.
+
+</Tip>
+
+```toml title="tensorzero.toml"
+[embedding_models.openai-text-embedding-3-small.providers.openai]
+type = "openai"
+extra_body = [
+  { pointer = "/dimensions", value = 1536 }
+]
+```
+
 ### `type`
 
 - **Type:** string


### PR DESCRIPTION
Fix #3316
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds documentation for the `extra_body` field in embedding model provider configuration, allowing request body modifications for provider-specific functionality.
> 
>   - **Documentation**:
>     - Adds `extra_body` field documentation to `configuration-reference.mdx` for embedding model providers.
>     - Describes `extra_body` as an array of objects to modify request bodies for provider-specific functionality.
>     - Includes example usage in `tensorzero.toml` for OpenAI embedding model provider.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ae4739a4eae8ed4d6ce0c6802ca27fb5a8485358. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->