### PR TITLE
Add link to LLM judge inference and fix hover behavior

### DIFF
--- a/ui/app/components/utils/InferenceButton.tsx
+++ b/ui/app/components/utils/InferenceButton.tsx
@@ -1,0 +1,47 @@
+import { Link } from "react-router";
+import { Button } from "~/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "~/components/ui/tooltip";
+import { Inferences } from "~/components/icons/Icons";
+
+interface InferenceButtonProps {
+  inferenceId: string;
+  className?: string;
+  tooltipText?: string;
+}
+
+export function InferenceButton({
+  inferenceId,
+  className,
+  tooltipText = "View inference",
+}: InferenceButtonProps) {
+  return (
+    <TooltipProvider>
+      <Tooltip delayDuration={100}>
+        <TooltipTrigger asChild>
+          <Button
+            variant="outline"
+            size="iconSm"
+            className={className}
+            aria-label={tooltipText}
+            title={tooltipText}
+          >
+            <Link
+              to={`/observability/inferences/${inferenceId}`}
+              target="_blank"
+            >
+              <Inferences className="h-4 w-4" />
+            </Link>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>{tooltipText}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/ui/app/components/utils/InferenceButton.tsx
+++ b/ui/app/components/utils/InferenceButton.tsx
@@ -23,20 +23,17 @@ export function InferenceButton({
     <TooltipProvider>
       <Tooltip delayDuration={100}>
         <TooltipTrigger asChild>
-          <Button
-            variant="outline"
-            size="iconSm"
-            className={className}
-            aria-label={tooltipText}
-            title={tooltipText}
-          >
-            <Link
-              to={`/observability/inferences/${inferenceId}`}
-              target="_blank"
+          <Link to={`/observability/inferences/${inferenceId}`} target="_blank">
+            <Button
+              variant="outline"
+              size="iconSm"
+              className={className}
+              aria-label={tooltipText}
+              title={tooltipText}
             >
               <Inferences className="h-4 w-4" />
-            </Link>
-          </Button>
+            </Button>
+          </Link>
         </TooltipTrigger>
         <TooltipContent>
           <p>{tooltipText}</p>

--- a/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/route.tsx
+++ b/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/route.tsx
@@ -51,6 +51,7 @@ import type {
   JsonInferenceOutput,
 } from "tensorzero-node";
 import EvaluationFeedbackEditor from "~/components/evaluations/EvaluationFeedbackEditor";
+import { InferenceButton } from "~/components/utils/InferenceButton";
 import { addEvaluationHumanFeedback } from "~/utils/tensorzero.server";
 import { Toaster } from "~/components/ui/toaster";
 import { useToast } from "~/hooks/use-toast";
@@ -390,7 +391,7 @@ const MetricRow = ({
         className="text-sm"
       />
       {inferenceId !== null && evaluationType === "llm_judge" && (
-        <div className="opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+        <div className="flex gap-1 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
           <EvaluationFeedbackEditor
             inferenceId={inferenceId}
             datapointId={datapointId}
@@ -400,6 +401,12 @@ const MetricRow = ({
             evaluatorInferenceId={evaluatorInferenceId}
             variantName={variantName}
           />
+          {evaluatorInferenceId && (
+            <InferenceButton
+              inferenceId={evaluatorInferenceId}
+              tooltipText="View LLM judge inference"
+            />
+          )}
         </div>
       )}
     </div>

--- a/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/route.tsx
+++ b/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/route.tsx
@@ -343,7 +343,7 @@ const MetricRow = ({
   }
   const evaluationType = evaluatorConfig.type;
   return (
-    <div className="flex items-center gap-2">
+    <div className="group flex items-center gap-2">
       <TooltipProvider delayDuration={300}>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -390,7 +390,7 @@ const MetricRow = ({
         className="text-sm"
       />
       {inferenceId !== null && evaluationType === "llm_judge" && (
-        <div className="opacity-0 transition-opacity duration-200 hover:opacity-100">
+        <div className="opacity-0 transition-opacity duration-200 group-hover:opacity-100">
           <EvaluationFeedbackEditor
             inferenceId={inferenceId}
             datapointId={datapointId}

--- a/ui/app/routes/evaluations/$evaluation_name/EvaluationTable.tsx
+++ b/ui/app/routes/evaluations/$evaluation_name/EvaluationTable.tsx
@@ -43,6 +43,7 @@ import {
 } from "~/hooks/evaluations/ColorAssigner";
 import MetricValue, { isCutoffFailed } from "~/components/metric/MetricValue";
 import EvaluationFeedbackEditor from "~/components/evaluations/EvaluationFeedbackEditor";
+import { InferenceButton } from "~/components/utils/InferenceButton";
 import InputSnippet from "~/components/inference/InputSnippet";
 import { logger } from "~/utils/logger";
 
@@ -511,7 +512,7 @@ export function EvaluationTable({
                                         {evaluatorConfig.type ===
                                           "llm_judge" && (
                                           <div
-                                            className="ml-2 opacity-0 transition-opacity duration-200 group-hover:opacity-100"
+                                            className="ml-2 flex gap-1 opacity-0 transition-opacity duration-200 group-hover:opacity-100"
                                             // Stop click event propagation so the row navigation is not triggered
                                             onClick={(e) => e.stopPropagation()}
                                           >
@@ -531,6 +532,14 @@ export function EvaluationTable({
                                                 "Unknown"
                                               }
                                             />
+                                            {metricValue.evaluator_inference_id && (
+                                              <InferenceButton
+                                                inferenceId={
+                                                  metricValue.evaluator_inference_id
+                                                }
+                                                tooltipText="View LLM judge inference"
+                                              />
+                                            )}
                                           </div>
                                         )}
                                       </>


### PR DESCRIPTION
Fix #3656


https://github.com/user-attachments/assets/3db78e1d-0e51-496f-b81a-9e4dccae03f2




<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `InferenceButton` component for LLM judge inferences and improve hover behavior in evaluation components.
> 
>   - **Components**:
>     - Add `InferenceButton` component in `InferenceButton.tsx` to link to LLM judge inferences with a tooltip.
>     - Integrate `InferenceButton` into `MetricRow` in `route.tsx` and `EvaluationTable` in `EvaluationTable.tsx`.
>   - **UI Behavior**:
>     - Modify hover behavior in `MetricRow` and `EvaluationTable` to show `InferenceButton` and `EvaluationFeedbackEditor` on hover.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 94b82decbdf81b2e4ab61d0601d42ff5449b2701. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->