### PR TITLE
Add 'tensorzero::template' content block to openai-compatible endpoint

### DIFF
--- a/clients/python/tests/test_openai_compatibility.py
+++ b/clients/python/tests/test_openai_compatibility.py
@@ -1736,3 +1736,32 @@ async def test_async_inference_tensorzero_raw_text(async_openai_client):
         response.model
         == "tensorzero::function_name::openai_with_assistant_schema::variant_name::openai"
     )
+
+
+@pytest.mark.asyncio
+async def test_async_inference_tensorzero_template(async_openai_client):
+    """
+    Test that chat inference with a tensorzero::template block works correctly
+    """
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tensorzero::template",
+                    "name": "assistant",
+                    "arguments": {"assistant_name": "Megumin"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "What is the capital of Japan?"}],
+        },
+    ]
+    response = await async_openai_client.chat.completions.create(
+        messages=messages,
+        model="tensorzero::function_name::openai_with_assistant_schema",
+    )
+
+    assert "tokyo" in response.choices[0].message.content.lower()


### PR DESCRIPTION
This maps to the TensorZero `"type": "template"` content block
Fixes https://github.com/tensorzero/tensorzero/issues/3639
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for `tensorzero::template` content block to OpenAI-compatible endpoint and update tests.
> 
>   - **Behavior**:
>     - Add support for `tensorzero::template` content block in `openai_compatible.rs`.
>     - Update `convert_openai_message_content()` to handle `tensorzero::template`.
>     - Add test `test_async_inference_tensorzero_template` in `test_openai_compatibility.py` to verify functionality.
>   - **Misc**:
>     - Update `OpenAICompatibleContentBlock` enum to include `Template` variant.
>     - Add `TemplateInput` to `InputMessageContent` in `openai_compatible.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 9af7e9505d8462c5a74de9e32e65f559a29794a2. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->