### PR TITLE
made sure every #instrument macro uses skip_all

### DIFF
--- a/evaluations/src/dataset.rs
+++ b/evaluations/src/dataset.rs
@@ -6,7 +6,7 @@ use tensorzero_core::endpoints::datasets::Datapoint;
 use tensorzero_core::{db::clickhouse::ClickHouseConnectionInfo, function::FunctionConfig};
 use tracing::{debug, info, instrument};
 
-#[instrument(skip(clickhouse_client), fields(dataset_name = %dataset_name, function_name = %function_name))]
+#[instrument(skip_all, fields(dataset_name = %dataset_name, function_name = %function_name))]
 pub async fn query_dataset(
     clickhouse_client: &ClickHouseConnectionInfo,
     dataset_name: &str,

--- a/evaluations/src/evaluators/exact_match.rs
+++ b/evaluations/src/evaluators/exact_match.rs
@@ -4,7 +4,7 @@ use tensorzero::InferenceResponse;
 use tensorzero_core::endpoints::datasets::Datapoint;
 use tracing::{debug, instrument, warn};
 
-#[instrument(skip(inference_response, datapoint), fields(datapoint_id = %datapoint.id()))]
+#[instrument(skip_all, fields(datapoint_id = %datapoint.id()))]
 pub(super) fn run_exact_match_evaluator(
     inference_response: &InferenceResponse,
     datapoint: &Datapoint,

--- a/evaluations/src/evaluators/llm_judge/mod.rs
+++ b/evaluations/src/evaluators/llm_judge/mod.rs
@@ -51,7 +51,7 @@ pub struct RunLLMJudgeEvaluatorParams<'a> {
     pub inference_cache: CacheEnabledMode,
 }
 
-#[instrument(skip(params), fields(datapoint_id = %params.datapoint.id(), evaluator_name = %params.evaluator_name))]
+#[instrument(skip_all, fields(datapoint_id = %params.datapoint.id(), evaluator_name = %params.evaluator_name))]
 pub async fn run_llm_judge_evaluator(
     params: RunLLMJudgeEvaluatorParams<'_>,
 ) -> Result<Option<LLMJudgeEvaluationResult>> {

--- a/evaluations/src/evaluators/mod.rs
+++ b/evaluations/src/evaluators/mod.rs
@@ -37,7 +37,7 @@ pub struct EvaluateInferenceParams {
 /// - Ok(Some(value)): The evaluator was run successfully and the result was a valid value.
 /// - Ok(None): The evaluator was run successfully but the result was None (if for example the evaluator requires a reference output but none is present).
 /// - Err(e): The evaluator failed to run due to some error (like the LLM Judge failed to infer).
-#[instrument(skip(params), fields(datapoint_id = %params.datapoint.id(), evaluation_name = %params.evaluation_name))]
+#[instrument(skip_all, fields(datapoint_id = %params.datapoint.id(), evaluation_name = %params.evaluation_name))]
 pub(crate) async fn evaluate_inference(
     params: EvaluateInferenceParams,
 ) -> Result<EvaluationResult> {
@@ -184,7 +184,7 @@ struct RunEvaluatorParams<'a> {
 /// - Err(e): The evaluator failed to run due to some error (like the LLM Judge failed to infer).
 ///
 /// NOTE: Each evaluator we implement in the match statement below should follow this contract.
-#[instrument(skip(params), fields(evaluator_name = %params.evaluator_name, datapoint_id = %params.datapoint.id()))]
+#[instrument(skip_all, fields(evaluator_name = %params.evaluator_name, datapoint_id = %params.datapoint.id()))]
 async fn run_evaluator(params: RunEvaluatorParams<'_>) -> Result<EvaluatorResult> {
     let RunEvaluatorParams {
         evaluation_config,

--- a/evaluations/src/lib.rs
+++ b/evaluations/src/lib.rs
@@ -82,7 +82,7 @@ pub struct Clients {
     pub clickhouse_client: ClickHouseConnectionInfo,
 }
 
-#[instrument(skip(writer), fields(evaluation_run_id = %evaluation_run_id, evaluation_name = %args.evaluation_name, dataset_name = %args.dataset_name, variant_name = %args.variant_name, concurrency = %args.concurrency))]
+#[instrument(skip_all, fields(evaluation_run_id = %evaluation_run_id, evaluation_name = %args.evaluation_name, dataset_name = %args.dataset_name, variant_name = %args.variant_name, concurrency = %args.concurrency))]
 pub async fn run_evaluation(
     args: Args,
     evaluation_run_id: Uuid,
@@ -369,7 +369,7 @@ struct InferDatapointParams<'a> {
     inference_cache: CacheEnabledMode,
 }
 
-#[instrument(skip(params), fields(datapoint_id = %params.datapoint.id(), function_name = %params.function_name, variant_name = %params.variant_name))]
+#[instrument(skip_all, fields(datapoint_id = %params.datapoint.id(), function_name = %params.function_name, variant_name = %params.variant_name))]
 async fn infer_datapoint(params: InferDatapointParams<'_>) -> Result<InferenceResponse> {
     let InferDatapointParams {
         clients,

--- a/evaluations/src/stats.rs
+++ b/evaluations/src/stats.rs
@@ -64,7 +64,7 @@ impl EvaluationStats {
     }
 
     /// Computes the mean and stderr for each of the evaluations observed
-    #[instrument(skip(self, evaluators), fields(evaluation_infos_count = self.evaluation_infos.len(), evaluation_errors_count = self.evaluation_errors.len()))]
+    #[instrument(skip_all, fields(evaluation_infos_count = self.evaluation_infos.len(), evaluation_errors_count = self.evaluation_errors.len()))]
     pub(crate) fn compute_stats(
         &self,
         evaluators: &HashMap<String, EvaluatorConfig>,

--- a/tensorzero-core/src/endpoints/datasets.rs
+++ b/tensorzero-core/src/endpoints/datasets.rs
@@ -304,7 +304,7 @@ struct WithFunctionName {
 ///
 /// The inference is mostly copied as-is, except for the 'output' field.
 /// Based on the 'output' parameter, the output is copied, ignored, or fetched from a demonstration.
-#[instrument(name = "insert_datapoint", skip(app_state))]
+#[instrument(name = "insert_datapoint", skip_all)]
 pub async fn insert_from_existing_datapoint_handler(
     State(app_state): AppState,
     Path(path_params): Path<InsertPathParams>,
@@ -327,7 +327,7 @@ pub async fn insert_from_existing_datapoint_handler(
 ///
 /// The input and output are validated against the function schema
 /// (retrieved from the `function_name` argument in the body).
-#[instrument(name = "update_datapoint", skip(app_state))]
+#[instrument(name = "update_datapoint", skip_all)]
 pub async fn update_datapoint_handler(
     State(app_state): AppState,
     Path(path_params): Path<UpdatePathParams>,

--- a/tensorzero-core/src/endpoints/embeddings.rs
+++ b/tensorzero-core/src/endpoints/embeddings.rs
@@ -30,11 +30,7 @@ pub struct Params {
     pub cache_options: CacheParamsOptions,
 }
 
-#[instrument(
-    name = "embeddings",
-    skip(config, http_client, params),
-    fields(model, num_inputs)
-)]
+#[instrument(name = "embeddings", skip_all, fields(model, num_inputs))]
 pub async fn embeddings(
     config: Arc<Config>,
     http_client: &TensorzeroHttpClient,

--- a/tensorzero-core/src/endpoints/inference.rs
+++ b/tensorzero-core/src/endpoints/inference.rs
@@ -203,7 +203,7 @@ pub struct InferenceIds {
 
 #[instrument(
     name="inference",
-    skip(config, http_client, clickhouse_connection_info, params),
+    skip_all
     fields(
         function_name,
         model_name,


### PR DESCRIPTION
We were letting some things through by explicitly naming with skip() so we should use skip_all here.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `instrument` macro to `skip_all` in multiple functions for consistent argument skipping in tracing.
> 
>   - **Behavior**:
>     - Change `instrument` macro to use `skip_all` in `query_dataset()` in `dataset.rs`, `run_exact_match_evaluator()` in `exact_match.rs`, `run_llm_judge_evaluator()` in `llm_judge/mod.rs`, `evaluate_inference()` and `run_evaluator()` in `mod.rs`, `run_evaluation()` and `infer_datapoint()` in `lib.rs`, `compute_stats()` in `stats.rs`, `insert_from_existing_datapoint_handler()` and `update_datapoint_handler()` in `datasets.rs`, `embeddings()` in `embeddings.rs`, and `inference()` in `inference.rs`.
>   - **Misc**:
>     - Ensure all arguments are skipped in tracing for consistency and completeness.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 765c5bfa7777eb15c6a70808fcf13c305263e780. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->