### PR TITLE
Bump tool call e2e test timeout to 30 seconds

### DIFF
--- a/ui/e2e_tests/playground.spec.ts
+++ b/ui/e2e_tests/playground.spec.ts
@@ -180,7 +180,7 @@ test("playground should work for data with tools", async ({ page }) => {
       .getByTestId("datapoint-playground-output")
       .getByText("Tool Call")
       .first(),
-  ).toBeVisible({ timeout: 20_000 });
+  ).toBeVisible({ timeout: 30_000 });
 
   // Verify that at least one tool call has the expected fields
   await expect(page.getByText("Name").first()).toBeVisible();
@@ -230,7 +230,7 @@ test("playground should work for data with tools", async ({ page }) => {
       .getByTestId("datapoint-playground-output")
       .getByText("Tool Call")
       .first(),
-  ).toBeVisible({ timeout: 20_000 });
+  ).toBeVisible({ timeout: 30_000 });
 
   // Verify that at least one tool call has the expected fields
   await expect(page.getByText("Name").first()).toBeVisible();


### PR DESCRIPTION
We saw another flake (and a success that took 18 seconds), so let's give this even more time
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase timeout for tool call visibility test in `playground.spec.ts` to 30 seconds.
> 
>   - **Tests**:
>     - Increase timeout from 20,000ms to 30,000ms in `playground.spec.ts` for `toBeVisible` assertions related to tool calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ab0605f2d14743c871db0eb889e1d2c5d3c20d10. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->