### PR TITLE
Allow 'clippy::doc-lazy-continuation' lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,9 @@ match_same_arms = "allow"
 must_use_candidate = "allow"
 single_match_else = "allow"
 
+# This lint cannot be fixed with 'cargo fmt', and we don't currently generate docs
+doc_lazy_continuation = "allow"
+
 [profile.performance]
 inherits = "release"
 lto = "fat"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Allow `clippy::doc-lazy-continuation` lint in `Cargo.toml` to accommodate documentation formatting.
> 
>   - **Lint Configuration**:
>     - Allow `clippy::doc-lazy-continuation` lint in `Cargo.toml`.
>     - This lint cannot be fixed with `cargo fmt`, and documentation is not currently generated.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 25a7a9b674fe242285bfbec2165da0e358f302b7. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->