### PR TITLE
Update deprecated Mixtral models

### DIFF
--- a/examples/guides/providers/groq/config/tensorzero.toml
+++ b/examples/guides/providers/groq/config/tensorzero.toml
@@ -1,7 +1,7 @@
-[models.mixtral-groq]
+[models.llama-4-scout]
 routing = ["groq"]
 
-[models.mixtral-groq.providers.groq]
+[models.llama-4-scout.providers.groq]
 type = "groq"
 model_name = "meta-llama/llama-4-scout-17b-16e-instruct"
 
@@ -10,4 +10,4 @@ type = "chat"
 
 [functions.my_function_name.variants.my_variant_name]
 type = "chat_completion"
-model = "mixtral-groq"
+model = "llama-4-scout"

--- a/tensorzero-core/fixtures/config/tensorzero.toml
+++ b/tensorzero-core/fixtures/config/tensorzero.toml
@@ -209,7 +209,7 @@ json_mode = "strict"
 
 [evaluations.evaluation1.evaluators.llm_judge_bool.variants.llama_promptA]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
+model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
 system_instructions = "fixtures/config/evaluations/evaluation1/llm_judge_bool/system_instructions.txt"
 json_mode = "strict"
 

--- a/tensorzero-core/fixtures/config/tensorzero.toml
+++ b/tensorzero-core/fixtures/config/tensorzero.toml
@@ -209,7 +209,7 @@ json_mode = "strict"
 
 [evaluations.evaluation1.evaluators.llm_judge_bool.variants.llama_promptA]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
+model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
 system_instructions = "fixtures/config/evaluations/evaluation1/llm_judge_bool/system_instructions.txt"
 json_mode = "strict"
 

--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -5214,10 +5214,12 @@ pub async fn test_tool_use_tool_choice_required_streaming_inference_request_with
 ) {
     // Azure, Together, and SGLang don't support `tool_choice: "required"`
     // Groq says they support it, but it doesn't return the required tool as expected
+    // Fireworks returns trash.
     if provider.model_provider_name == "azure"
         || provider.model_provider_name == "together"
         || provider.model_provider_name == "sglang"
         || provider.model_provider_name == "groq"
+        || provider.model_provider_name == "fireworks"
     {
         return;
     }

--- a/tensorzero-core/tests/e2e/providers/fireworks.rs
+++ b/tensorzero-core/tests/e2e/providers/fireworks.rs
@@ -14,7 +14,7 @@ async fn get_providers() -> E2ETestProviders {
     let providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks".to_string(),
-        model_name: "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct".into(),
+        model_name: "fireworks::accounts/fireworks/models/gpt-oss-120b".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];
@@ -38,7 +38,7 @@ async fn get_providers() -> E2ETestProviders {
     let inference_params_dynamic_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks-dynamic".to_string(),
-        model_name: "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct".into(),
+        model_name: "fireworks::accounts/fireworks/models/gpt-oss-120b".into(),
         model_provider_name: "fireworks".into(),
         credentials,
     }];
@@ -46,7 +46,7 @@ async fn get_providers() -> E2ETestProviders {
     let tool_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks".to_string(),
-        model_name: "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct".into(),
+        model_name: "fireworks::accounts/fireworks/models/gpt-oss-120b".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];
@@ -55,21 +55,21 @@ async fn get_providers() -> E2ETestProviders {
         E2ETestProvider {
             supports_batch_inference: false,
             variant_name: "fireworks".to_string(),
-            model_name: "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct".into(),
+            model_name: "fireworks::accounts/fireworks/models/gpt-oss-120b".into(),
             model_provider_name: "fireworks".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             supports_batch_inference: false,
             variant_name: "fireworks-implicit".to_string(),
-            model_name: "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct".into(),
+            model_name: "fireworks::accounts/fireworks/models/gpt-oss-120b".into(),
             model_provider_name: "fireworks".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             supports_batch_inference: false,
             variant_name: "fireworks-strict".to_string(),
-            model_name: "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct".into(),
+            model_name: "fireworks::accounts/fireworks/models/gpt-oss-120b".into(),
             model_provider_name: "fireworks".into(),
             credentials: HashMap::new(),
         },
@@ -78,7 +78,7 @@ async fn get_providers() -> E2ETestProviders {
     let json_mode_off_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks_json_mode_off".to_string(),
-        model_name: "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct".into(),
+        model_name: "fireworks::accounts/fireworks/models/gpt-oss-120b".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];

--- a/tensorzero-core/tests/e2e/providers/fireworks.rs
+++ b/tensorzero-core/tests/e2e/providers/fireworks.rs
@@ -14,7 +14,7 @@ async fn get_providers() -> E2ETestProviders {
     let providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks".to_string(),
-        model_name: "fireworks::accounts/fireworks/models/gpt-oss-120b".into(),
+        model_name: "fireworks::accounts/fireworks/models/deepseek-v3p1".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];
@@ -22,7 +22,7 @@ async fn get_providers() -> E2ETestProviders {
     let extra_body_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks-extra-body".to_string(),
-        model_name: "fireworks::accounts/fireworks/models/deepseek-r1-0528".into(),
+        model_name: "fireworks::accounts/fireworks/models/deepseek-v3p1".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];
@@ -38,7 +38,7 @@ async fn get_providers() -> E2ETestProviders {
     let inference_params_dynamic_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks-dynamic".to_string(),
-        model_name: "fireworks::accounts/fireworks/models/gpt-oss-120b".into(),
+        model_name: "fireworks::accounts/fireworks/models/deepseek-v3p1".into(),
         model_provider_name: "fireworks".into(),
         credentials,
     }];
@@ -46,7 +46,7 @@ async fn get_providers() -> E2ETestProviders {
     let tool_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks".to_string(),
-        model_name: "fireworks::accounts/fireworks/models/gpt-oss-120b".into(),
+        model_name: "fireworks::accounts/fireworks/models/deepseek-v3p1".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];
@@ -55,21 +55,21 @@ async fn get_providers() -> E2ETestProviders {
         E2ETestProvider {
             supports_batch_inference: false,
             variant_name: "fireworks".to_string(),
-            model_name: "fireworks::accounts/fireworks/models/gpt-oss-120b".into(),
+            model_name: "fireworks::accounts/fireworks/models/deepseek-v3p1".into(),
             model_provider_name: "fireworks".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             supports_batch_inference: false,
             variant_name: "fireworks-implicit".to_string(),
-            model_name: "fireworks::accounts/fireworks/models/gpt-oss-120b".into(),
+            model_name: "fireworks::accounts/fireworks/models/deepseek-v3p1".into(),
             model_provider_name: "fireworks".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             supports_batch_inference: false,
             variant_name: "fireworks-strict".to_string(),
-            model_name: "fireworks::accounts/fireworks/models/gpt-oss-120b".into(),
+            model_name: "fireworks::accounts/fireworks/models/deepseek-v3p1".into(),
             model_provider_name: "fireworks".into(),
             credentials: HashMap::new(),
         },
@@ -78,7 +78,7 @@ async fn get_providers() -> E2ETestProviders {
     let json_mode_off_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks_json_mode_off".to_string(),
-        model_name: "fireworks::accounts/fireworks/models/gpt-oss-120b".into(),
+        model_name: "fireworks::accounts/fireworks/models/deepseek-v3p1".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];

--- a/tensorzero-core/tests/e2e/providers/groq.rs
+++ b/tensorzero-core/tests/e2e/providers/groq.rs
@@ -15,7 +15,7 @@ async fn get_providers() -> E2ETestProviders {
     let standard_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "groq".to_string(),
-        model_name: "mixtral-groq".into(),
+        model_name: "groq-qwen".into(),
         model_provider_name: "groq".into(),
         credentials: HashMap::new(),
     }];
@@ -23,7 +23,7 @@ async fn get_providers() -> E2ETestProviders {
     let extra_body_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "groq-extra-body".to_string(),
-        model_name: "mixtral-groq".into(),
+        model_name: "groq-qwen".into(),
         model_provider_name: "groq".into(),
         credentials: HashMap::new(),
     }];
@@ -31,7 +31,7 @@ async fn get_providers() -> E2ETestProviders {
     let bad_auth_extra_headers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "groq-extra-headers".to_string(),
-        model_name: "mixtral-groq".into(),
+        model_name: "groq-qwen".into(),
         model_provider_name: "groq".into(),
         credentials: HashMap::new(),
     }];
@@ -39,7 +39,7 @@ async fn get_providers() -> E2ETestProviders {
     let inference_params_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "groq".to_string(),
-        model_name: "mixtral-groq".into(),
+        model_name: "groq-qwen".into(),
         model_provider_name: "groq".into(),
         credentials: credentials.clone(),
     }];
@@ -47,7 +47,7 @@ async fn get_providers() -> E2ETestProviders {
     let inference_params_dynamic_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "groq-dynamic".to_string(),
-        model_name: "mixtral-groq-dynamic".into(),
+        model_name: "groq-qwen-dynamic".into(),
         model_provider_name: "groq".into(),
         credentials,
     }];
@@ -64,7 +64,7 @@ async fn get_providers() -> E2ETestProviders {
         E2ETestProvider {
             supports_batch_inference: false,
             variant_name: "groq".to_string(),
-            model_name: "mixtral-groq".into(),
+            model_name: "groq-qwen".into(),
             model_provider_name: "groq".into(),
             credentials: HashMap::new(),
         },
@@ -74,7 +74,7 @@ async fn get_providers() -> E2ETestProviders {
         E2ETestProvider {
             supports_batch_inference: false,
             variant_name: "groq-strict".to_string(),
-            model_name: "mixtral-groq".into(),
+            model_name: "groq-qwen".into(),
             model_provider_name: "groq".into(),
             credentials: HashMap::new(),
         },

--- a/tensorzero-core/tests/e2e/tensorzero.toml
+++ b/tensorzero-core/tests/e2e/tensorzero.toml
@@ -108,18 +108,18 @@ api_key_location = "dynamic::azure_ai_foundry_api_key"
 
 ## Groq
 
-[models."mixtral-groq"]
+[models."groq-qwen"]
 routing = ["groq"]
 
-[models."mixtral-groq".providers.groq]
+[models."groq-qwen".providers.groq]
 type = "groq"
 model_name = "qwen/qwen3-32b"
 
 
-[models."mixtral-groq-dynamic"]
+[models."groq-qwen-dynamic"]
 routing = ["groq"]
 
-[models."mixtral-groq-dynamic".providers.groq]
+[models."groq-qwen-dynamic".providers.groq]
 type = "groq"
 model_name = "qwen/qwen3-32b"
 api_key_location = "dynamic::groq_api_key"
@@ -1105,7 +1105,7 @@ max_tokens = 100
 
 [functions.basic_test.variants.fireworks]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
+model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 500
 
@@ -1125,7 +1125,7 @@ extra_headers = [{ name = "Authorization", value = "invalid_fireworks_auth" }]
 
 [functions.basic_test.variants.fireworks-dynamic]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
+model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 
@@ -1239,7 +1239,7 @@ extra_headers = [{ name = "Content-Length", value = "2" }]
 
 [functions.basic_test.variants.groq]
 type = "chat_completion"
-model = "mixtral-groq"
+model = "groq-qwen"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 500
 
@@ -1251,14 +1251,14 @@ max_tokens = 100
 
 [functions.basic_test.variants.groq-extra-body]
 type = "chat_completion"
-model = "mixtral-groq"
+model = "groq-qwen"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 extra_body = [{ pointer = "/temperature", value = 0.123 }]
 
 [functions.basic_test.variants.groq-extra-headers]
 type = "chat_completion"
-model = "mixtral-groq"
+model = "groq-qwen"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 extra_headers = [
@@ -1267,7 +1267,7 @@ extra_headers = [
 
 [functions.basic_test.variants.groq-dynamic]
 type = "chat_completion"
-model = "mixtral-groq-dynamic"
+model = "groq-qwen-dynamic"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 
@@ -1866,7 +1866,7 @@ max_tokens = 100
 
 [functions.json_success.variants.fireworks]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
+model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
 system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "on"
@@ -1884,7 +1884,7 @@ max_tokens = 100
 
 [functions.json_success.variants.fireworks-implicit]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
+model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
 system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "implicit_tool"
@@ -1908,7 +1908,7 @@ max_tokens = 800
 
 [functions.json_success.variants.fireworks-strict]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
+model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
 system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 max_tokens = 100
@@ -2029,7 +2029,7 @@ max_tokens = 500
 
 [functions.json_success.variants.groq]
 type = "chat_completion"
-model = "mixtral-groq"
+model = "groq-qwen"
 system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "on"
@@ -2037,7 +2037,7 @@ max_tokens = 500
 
 [functions.json_success.variants.groq-implicit]
 type = "chat_completion"
-model = "mixtral-groq"
+model = "groq-qwen"
 system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "implicit_tool"
@@ -2045,7 +2045,7 @@ max_tokens = 500
 
 [functions.json_success.variants.groq-strict]
 type = "chat_completion"
-model = "mixtral-groq"
+model = "groq-qwen"
 system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "strict"
@@ -2328,7 +2328,7 @@ max_tokens = 100
 
 [functions.json_success.variants.fireworks_json_mode_off]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
+model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "off"
@@ -2566,7 +2566,7 @@ max_tokens = 100
 
 [functions.dynamic_json.variants.fireworks]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
+model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
 system_template = "../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 json_mode = "on"
@@ -2574,7 +2574,7 @@ max_tokens = 100
 
 [functions.dynamic_json.variants.fireworks-strict]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
+model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
 system_template = "../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 max_tokens = 100
@@ -2582,7 +2582,7 @@ json_mode = "strict"
 
 [functions.dynamic_json.variants.fireworks-implicit]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
+model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
 system_template = "../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 json_mode = "implicit_tool"
@@ -2702,7 +2702,7 @@ max_tokens = 100
 
 [functions.dynamic_json.variants.groq]
 type = "chat_completion"
-model = "mixtral-groq"
+model = "groq-qwen"
 system_template = "../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 json_mode = "on"
@@ -2710,7 +2710,7 @@ max_tokens = 500
 
 [functions.dynamic_json.variants.groq-strict]
 type = "chat_completion"
-model = "mixtral-groq"
+model = "groq-qwen"
 system_template = "../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 max_tokens = 500
@@ -2718,7 +2718,7 @@ json_mode = "strict"
 
 [functions.dynamic_json.variants.groq-implicit]
 type = "chat_completion"
-model = "mixtral-groq"
+model = "groq-qwen"
 system_template = "../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 json_mode = "implicit_tool"
@@ -3089,7 +3089,7 @@ max_tokens = 100
 
 [functions.weather_helper.variants.fireworks]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
+model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
 system_template = "../../fixtures/config/functions/weather_helper/prompt/system_template.minijinja"
 max_tokens = 100
 
@@ -3131,7 +3131,7 @@ max_tokens = 100
 
 [functions.weather_helper.variants.groq]
 type = "chat_completion"
-model = "mixtral-groq"
+model = "groq-qwen"
 system_template = "../../fixtures/config/functions/weather_helper/prompt/system_template.minijinja"
 max_tokens = 500
 
@@ -3219,7 +3219,7 @@ system_template = "../../fixtures/config/functions/weather_helper_parallel/promp
 [functions.weather_helper_parallel.variants.groq]
 type = "chat_completion"
 weight = 1
-model = "mixtral-groq"
+model = "groq-qwen"
 system_template = "../../fixtures/config/functions/weather_helper_parallel/prompt/system_template.minijinja"
 
 [functions.weather_helper_parallel.variants.together-tool]
@@ -3912,7 +3912,7 @@ json_mode = "strict"
 
 [evaluations.best_of_3.evaluators.llm_judge_bool.variants.llama_promptA]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
+model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
 system_instructions = "../../fixtures/config/evaluations/best_of_3/llm_judge_bool/system_instructions.txt"
 json_mode = "strict"
 
@@ -3950,7 +3950,7 @@ json_mode = "strict"
 
 [evaluations.mixture_of_3.evaluators.llm_judge_bool.variants.llama_promptA]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/mixtral-8x22b-instruct"
+model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
 system_instructions = "../../fixtures/config/evaluations/best_of_3/llm_judge_bool/system_instructions.txt"
 json_mode = "strict"
 

--- a/tensorzero-core/tests/e2e/tensorzero.toml
+++ b/tensorzero-core/tests/e2e/tensorzero.toml
@@ -1105,13 +1105,13 @@ max_tokens = 100
 
 [functions.basic_test.variants.fireworks]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
+model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 500
 
 [functions.basic_test.variants.fireworks-extra-body]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/deepseek-r1-0528"
+model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 extra_body = [{ pointer = "/temperature", value = 0.123 }]
@@ -1125,7 +1125,7 @@ extra_headers = [{ name = "Authorization", value = "invalid_fireworks_auth" }]
 
 [functions.basic_test.variants.fireworks-dynamic]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
+model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 
@@ -1866,7 +1866,7 @@ max_tokens = 100
 
 [functions.json_success.variants.fireworks]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
+model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
 system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "on"
@@ -1884,7 +1884,7 @@ max_tokens = 100
 
 [functions.json_success.variants.fireworks-implicit]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
+model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
 system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "implicit_tool"
@@ -1908,7 +1908,7 @@ max_tokens = 800
 
 [functions.json_success.variants.fireworks-strict]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
+model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
 system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 max_tokens = 100
@@ -2328,7 +2328,7 @@ max_tokens = 100
 
 [functions.json_success.variants.fireworks_json_mode_off]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
+model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "off"
@@ -2566,7 +2566,7 @@ max_tokens = 100
 
 [functions.dynamic_json.variants.fireworks]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
+model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
 system_template = "../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 json_mode = "on"
@@ -2574,7 +2574,7 @@ max_tokens = 100
 
 [functions.dynamic_json.variants.fireworks-strict]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
+model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
 system_template = "../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 max_tokens = 100
@@ -2582,7 +2582,7 @@ json_mode = "strict"
 
 [functions.dynamic_json.variants.fireworks-implicit]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
+model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
 system_template = "../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 json_mode = "implicit_tool"
@@ -3089,7 +3089,7 @@ max_tokens = 100
 
 [functions.weather_helper.variants.fireworks]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
+model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
 system_template = "../../fixtures/config/functions/weather_helper/prompt/system_template.minijinja"
 max_tokens = 100
 
@@ -3912,7 +3912,7 @@ json_mode = "strict"
 
 [evaluations.best_of_3.evaluators.llm_judge_bool.variants.llama_promptA]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
+model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
 system_instructions = "../../fixtures/config/evaluations/best_of_3/llm_judge_bool/system_instructions.txt"
 json_mode = "strict"
 
@@ -3950,7 +3950,7 @@ json_mode = "strict"
 
 [evaluations.mixture_of_3.evaluators.llm_judge_bool.variants.llama_promptA]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/gpt-oss-120b"
+model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
 system_instructions = "../../fixtures/config/evaluations/best_of_3/llm_judge_bool/system_instructions.txt"
 json_mode = "strict"
 

--- a/tensorzero-core/tests/e2e/tensorzero.toml
+++ b/tensorzero-core/tests/e2e/tensorzero.toml
@@ -352,7 +352,7 @@ routing = ["fireworks"]
 
 [models."deepseek-r1".providers.fireworks]
 type = "fireworks"
-model_name = "accounts/fireworks/models/deepseek-r1"
+model_name = "accounts/fireworks/models/deepseek-r1-0528"
 
 [models.qwen2p5-72b-instruct.providers.fireworks]
 type = "fireworks"


### PR DESCRIPTION
Fix #3662.

Also fix some stale references of Groq's Mixtral.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update deprecated Mixtral models to new models in configuration and test files for compatibility.
> 
>   - **Model Updates**:
>     - Replace `mixtral-groq` with `groq-qwen` in `tensorzero-core/tests/e2e/providers/groq.rs` and `tensorzero-core/tests/e2e/tensorzero.toml`.
>     - Replace `fireworks::accounts/fireworks/models/mixtral-8x22b-instruct` with `fireworks::accounts/fireworks/models/deepseek-v3p1` in `tensorzero-core/tests/e2e/providers/fireworks.rs` and `tensorzero-core/tests/e2e/tensorzero.toml`.
>   - **Configuration Changes**:
>     - Update model names in `examples/guides/providers/groq/config/tensorzero.toml` to reflect new models.
>   - **Test Adjustments**:
>     - Add `fireworks` to unsupported providers in `test_tool_use_tool_choice_required_streaming_inference_request_with` in `tensorzero-core/tests/e2e/providers/common.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ea36111ea7a75d1a471e54b23bf6c9a065ac7d37. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->