### PR TITLE
Improve errors for evaluations

### DIFF
--- a/evaluations/src/lib.rs
+++ b/evaluations/src/lib.rs
@@ -205,9 +205,10 @@ pub async fn run_evaluation(
                     input: &input,
                     inference_cache: args.inference_cache,
                 })
-                .await?,
+                .await.map_err(|e| anyhow!("Error inferring for datapoint {datapoint_id}: {e}"))?,
             );
 
+            let inference_id = inference_response.inference_id();
             let evaluation_result = evaluate_inference(
                 EvaluateInferenceParams {
                     inference_response: inference_response.clone(),
@@ -219,7 +220,7 @@ pub async fn run_evaluation(
                     evaluation_run_id: evaluation_run_id_clone,
                     inference_cache: args.inference_cache,
                 })
-                .await?;
+                .await.map_err(|e| anyhow!("Error evaluating inference {inference_id} for datapoint {datapoint_id}: {e}"))?;
             debug!(datapoint_id = %datapoint.id(), evaluations_count = evaluation_result.len(), "Evaluations completed");
 
             Ok::<(Datapoint, InferenceResponse, evaluators::EvaluationResult), anyhow::Error>((


### PR DESCRIPTION
We add the datapoint id and inference ID as appropriate when errors are thrown by either of those steps.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve error messages in `run_evaluation` by including `datapoint_id` and `inference_id`.
> 
>   - **Error Handling**:
>     - In `run_evaluation` in `lib.rs`, errors in `infer_datapoint` now include `datapoint_id`.
>     - Errors in `evaluate_inference` now include both `inference_id` and `datapoint_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5bd650545df8ad603c34cda477c4faf3eae5e017. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->