### PR TITLE
bumped version to 2025.9.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2025.9.5"
+version = "2025.9.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1979,7 +1979,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2025.9.5"
+version = "2025.9.6"
 dependencies = [
  "axum",
  "clap",
@@ -4295,7 +4295,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2025.9.5"
+version = "2025.9.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5626,7 +5626,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2025.9.5"
+version = "2025.9.6"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5728,7 +5728,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2025.9.5"
+version = "2025.9.6"
 dependencies = [
  "napi",
  "napi-build",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.9.5"
+version = "2025.9.6"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2025.9.5"
+version = "2025.9.6"
 rust-version = "1.86.0"
 license = "Apache-2.0"
 

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.1
-appVersion: "2025.9.5"
+appVersion: "2025.9.6"

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2025.9.5",
+  "version": "2025.9.6",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump version to `2025.9.6` across multiple components including Rust packages, Helm chart, and UI package.
> 
>   - **Version Bump**:
>     - Update version to `2025.9.6` in `Cargo.lock` for packages: `evaluations`, `gateway`, `rate-limit-load-test`, `tensorzero-core`, `tensorzero-node`, `tensorzero-python`.
>     - Update version to `2025.9.6` in `Cargo.toml`.
>     - Update `appVersion` to `2025.9.6` in `Chart.yaml`.
>     - Update version to `2025.9.6` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 40db4ea64a964d2cf14ba9f2e7ebe5ffbc6dd85c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->