### PR TITLE
Correctly set 'all_explicit_template_names' for json functions

### DIFF
--- a/tensorzero-core/src/config/mod.rs
+++ b/tensorzero-core/src/config/mod.rs
@@ -1441,7 +1441,7 @@ impl UninitializedFunctionConfig {
                     output_schema,
                     implicit_tool_call_config,
                     description: params.description,
-                    all_template_names: HashSet::new(),
+                    all_explicit_template_names: all_template_names,
                 }))
             }
         }

--- a/tensorzero-core/src/endpoints/feedback/mod.rs
+++ b/tensorzero-core/src/endpoints/feedback/mod.rs
@@ -1422,7 +1422,7 @@ mod tests {
             output_schema: StaticJSONSchema::from_value(output_schema.clone()).unwrap(),
             implicit_tool_call_config,
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         })));
 
         // Case 5: a JSON function with correct output

--- a/tensorzero-core/src/evaluations/mod.rs
+++ b/tensorzero-core/src/evaluations/mod.rs
@@ -421,7 +421,7 @@ impl UninitializedEvaluatorConfig {
                     output_schema,
                     implicit_tool_call_config,
                     description: None,
-                    all_template_names,
+                    all_explicit_template_names: all_template_names,
                 });
                 Ok((
                     EvaluatorConfig::LLMJudge(LLMJudgeConfig {
@@ -1006,7 +1006,7 @@ mod tests {
             output_schema: create_test_schema(),
             implicit_tool_call_config: create_implicit_tool_call_config(create_test_schema()),
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         });
         functions.insert(function_name.to_string(), Arc::new(function_config));
 
@@ -1444,7 +1444,7 @@ mod tests {
                         create_test_schema(),
                     ),
                     description: None,
-                    all_template_names: HashSet::new(),
+                    all_explicit_template_names: HashSet::new(),
                 })),
             );
 

--- a/tensorzero-core/src/function.rs
+++ b/tensorzero-core/src/function.rs
@@ -247,8 +247,9 @@ pub struct FunctionConfigJson {
     pub output_schema: StaticJSONSchema, // schema is mandatory for JSON functions
     pub implicit_tool_call_config: ToolCallConfig,
     pub description: Option<String>,
+    // See `FunctionConfigChat.all_explicit_templates_names`.
     #[serde(skip)]
-    pub all_template_names: HashSet<String>,
+    pub all_explicit_template_names: HashSet<String>,
 }
 
 impl FunctionConfig {
@@ -290,7 +291,11 @@ impl FunctionConfig {
                 )?;
             }
             FunctionConfig::Json(params) => {
-                validate_all_text_input(&params.schemas, input, &params.all_template_names)?;
+                validate_all_text_input(
+                    &params.schemas,
+                    input,
+                    &params.all_explicit_template_names,
+                )?;
             }
         }
         Ok(())
@@ -1271,7 +1276,7 @@ mod tests {
             output_schema: StaticJSONSchema::from_value(json!({})).unwrap(),
             implicit_tool_call_config,
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         };
         let function_config = FunctionConfig::Json(tool_config);
 
@@ -1350,7 +1355,7 @@ mod tests {
             output_schema: StaticJSONSchema::from_value(output_schema).unwrap(),
             implicit_tool_call_config,
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         };
         let function_config = FunctionConfig::Json(tool_config);
 
@@ -1419,7 +1424,7 @@ mod tests {
             output_schema: StaticJSONSchema::from_value(output_schema).unwrap(),
             implicit_tool_call_config,
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         };
         let function_config = FunctionConfig::Json(tool_config);
 
@@ -1489,7 +1494,7 @@ mod tests {
             output_schema: StaticJSONSchema::from_value(output_schema).unwrap(),
             implicit_tool_call_config,
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         };
         let function_config = FunctionConfig::Json(tool_config);
 
@@ -1563,7 +1568,7 @@ mod tests {
             output_schema: StaticJSONSchema::from_value(output_schema).unwrap(),
             implicit_tool_call_config,
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         };
         let function_config = FunctionConfig::Json(tool_config);
 
@@ -1773,7 +1778,7 @@ mod tests {
             output_schema,
             implicit_tool_call_config,
             description: Some("A JSON function description".to_string()),
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         };
         let function_config = FunctionConfig::Json(json_config);
         assert_eq!(
@@ -1823,7 +1828,7 @@ mod tests {
             output_schema,
             implicit_tool_call_config,
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         });
         let raw_request = "raw_request".to_string();
 
@@ -2388,7 +2393,7 @@ mod tests {
             output_schema,
             implicit_tool_call_config,
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         });
         let inference_id = Uuid::now_v7();
         let content_blocks = vec![r#"{"answer": "42"}"#.to_string().into()];

--- a/tensorzero-core/src/inference/types/mod.rs
+++ b/tensorzero-core/src/inference/types/mod.rs
@@ -3253,7 +3253,7 @@ mod tests {
             implicit_tool_call_config,
             output_schema,
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         }));
         let usage1 = Usage {
             input_tokens: 10,
@@ -3540,7 +3540,7 @@ mod tests {
             implicit_tool_call_config,
             output_schema,
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         }));
         let usage1 = Usage {
             input_tokens: 10,
@@ -3641,7 +3641,7 @@ mod tests {
             implicit_tool_call_config,
             output_schema,
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         }));
         let usage1 = Usage {
             input_tokens: 10,

--- a/tensorzero-core/src/optimization/dicl.rs
+++ b/tensorzero-core/src/optimization/dicl.rs
@@ -1271,7 +1271,7 @@ mod tests {
             output_schema,
             implicit_tool_call_config,
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         })
     }
 
@@ -1307,7 +1307,7 @@ mod tests {
             output_schema,
             implicit_tool_call_config: invalid_tool_call_config,
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         })
     }
 

--- a/tensorzero-core/src/variant/chat_completion/mod.rs
+++ b/tensorzero-core/src/variant/chat_completion/mod.rs
@@ -1691,7 +1691,7 @@ mod tests {
             output_schema,
             implicit_tool_call_config,
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         });
         let inference_config = InferenceConfig {
             templates: &templates,
@@ -1867,7 +1867,7 @@ mod tests {
             output_schema: hardcoded_output_schema,
             implicit_tool_call_config,
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         });
         let inference_params = InferenceParams {
             chat_completion: ChatCompletionInferenceParams {
@@ -1997,7 +1997,7 @@ mod tests {
             output_schema: hardcoded_output_schema,
             implicit_tool_call_config,
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         });
         let inference_params = InferenceParams::default();
         // Will dynamically set "response" instead of "answer"
@@ -2524,7 +2524,7 @@ mod tests {
                 parallel_tool_calls: None,
             },
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         });
         let inference_config = InferenceConfig {
             ids: InferenceIds {

--- a/tensorzero-core/src/variant/mixture_of_n.rs
+++ b/tensorzero-core/src/variant/mixture_of_n.rs
@@ -1277,7 +1277,7 @@ mod tests {
             output_schema: StaticJSONSchema::from_value(json!({})).unwrap(),
             implicit_tool_call_config: ToolCallConfig::default(),
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         });
         // Prepare some candidate InferenceResults
         let model_inference_response0 = ModelInferenceResponseWithMetadata {

--- a/tensorzero-core/src/variant/mod.rs
+++ b/tensorzero-core/src/variant/mod.rs
@@ -1012,7 +1012,7 @@ mod tests {
             output_schema: output_schema.clone(),
             implicit_tool_call_config: implicit_tool_call_config.clone(),
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         });
 
         let json_mode = JsonMode::On;
@@ -1287,7 +1287,7 @@ mod tests {
                 parallel_tool_calls: None,
             },
             description: None,
-            all_template_names: HashSet::new(),
+            all_explicit_template_names: HashSet::new(),
         });
         let output_schema = json!({
             "type": "object",

--- a/tensorzero-core/tests/e2e/inference.rs
+++ b/tensorzero-core/tests/e2e/inference.rs
@@ -3154,6 +3154,35 @@ async fn test_dummy_only_inference_invalid_default_function_arg() {
         ),
         "Unexpected error message: {response_text}",
     );
+
+    let bad_system_prompt_json_function = json!({
+        "function_name": "null_json",
+        "input":{
+            "system": {"assistant_name": "Dr. Mehta"},
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "What is the name of the capital city of Japan?"
+                }
+            ]},
+    });
+
+    let response = Client::new()
+        .post(get_gateway_endpoint("/inference"))
+        .json(&bad_system_prompt_json_function)
+        .send()
+        .await
+        .unwrap();
+
+    // Should fail with 400 Bad Request
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_text = response.text().await.unwrap();
+    assert!(
+        response_text.contains(
+            "System message has non-string content but there is no template `system` in any variant"
+        ),
+        "Unexpected error message: {response_text}",
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
I've renmaed to from 'all_templates_names' to
'all_explicit_template_names' for consistency with chat functions