### PR TITLE
Fix broken workflows on forked PRs

### DIFF
--- a/.github/workflows/build-gateway-container.yml
+++ b/.github/workflows/build-gateway-container.yml
@@ -19,11 +19,16 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      # We allow the namespace builder setup to fail on Dependabot PRs and PRs from forks
+      # (where the oidc token is not available)
+
       - name: Install Namespace CLI
         uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx
         uses: namespacelabs/nscloud-setup-buildx-action@84ca8c58fdf372d6a4750476cd09b7b96ee778ca
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Build `gateway` container
         run: |

--- a/.github/workflows/build-ui-container.yml
+++ b/.github/workflows/build-ui-container.yml
@@ -19,11 +19,16 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      # We allow the namespace builder setup to fail on Dependabot PRs and PRs from forks
+      # (where the oidc token is not available)
+
       - name: Install Namespace CLI
         uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx
         uses: namespacelabs/nscloud-setup-buildx-action@84ca8c58fdf372d6a4750476cd09b7b96ee778ca
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Build `ui` container
         run: |

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -122,7 +122,8 @@ jobs:
             }
 
       - name: Send Slack notification for pull request review
-        if: steps.check-skip.outputs.should_skip == 'false' && github.event_name == 'pull_request_review'
+        # TODO - figure out how to make this work on PRs from forks. Currently, we skip it, since we don't have secrets available.
+        if: steps.check-skip.outputs.should_skip == 'false' && github.event_name == 'pull_request_review' && !(github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')
         uses: slackapi/slack-github-action@v2.1.1
         with:
           method: chat.postMessage


### PR DESCRIPTION
We needed to make a couple of changes
* Allow the Namespace builder setup to fail in more places (this will make the PR builds much slower, but they should still succeed)
* Skip runinng a Slack notification workflow
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix workflows for forked PRs by allowing certain steps to fail and skipping Slack notifications when secrets are unavailable.
> 
>   - **Workflows**:
>     - In `build-gateway-container.yml` and `build-ui-container.yml`, allow `Install Namespace CLI` and `Configure Namespace-powered Buildx` steps to fail on forked PRs and Dependabot PRs using `continue-on-error`.
>     - In `slack-notifications.yml`, skip Slack notifications for pull request reviews on forked PRs due to unavailable secrets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 229fc5a8ec97538eca99eaf7d29218ef21736f1e. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->