### PR TITLE
Fix caching for base64 embeddings

### DIFF
--- a/clients/python/DEVELOPER_NOTES.md
+++ b/clients/python/DEVELOPER_NOTES.md
@@ -24,6 +24,8 @@ uv run python
 
 ## Running tests
 
+First, build the client with `uv run maturin develop --uv --features e2e_tests`.
+
 Integration tests can be run with `./test.sh` (this requires the same setup as `cargo test-e2e` - see `CONTRIBUTING.md`)
 
 This also runs all tests for OpenAI compatibility in Python.

--- a/tensorzero-core/src/embeddings.rs
+++ b/tensorzero-core/src/embeddings.rs
@@ -168,23 +168,21 @@ impl EmbeddingModelConfig {
                             }
                             .into());
                             };
-                            if let Some(float_data) = first_embedding.as_float() {
-                                let _ = start_cache_write(
-                                    clients.clickhouse_connection_info,
-                                    provider_request.get_cache_key()?,
-                                    CacheData {
-                                        output: EmbeddingCacheData {
-                                            embedding: float_data.clone(),
-                                        },
-                                        raw_request: response.raw_request.clone(),
-                                        raw_response: response.raw_response.clone(),
-                                        input_tokens: response.usage.input_tokens,
-                                        output_tokens: response.usage.output_tokens,
-                                        finish_reason: None,
+                            let _ = start_cache_write(
+                                clients.clickhouse_connection_info,
+                                provider_request.get_cache_key()?,
+                                CacheData {
+                                    output: EmbeddingCacheData {
+                                        embedding: first_embedding.clone(),
                                     },
-                                    CacheValidationInfo { tool_config: None },
-                                );
-                            }
+                                    raw_request: response.raw_request.clone(),
+                                    raw_response: response.raw_response.clone(),
+                                    input_tokens: response.usage.input_tokens,
+                                    output_tokens: response.usage.output_tokens,
+                                    finish_reason: None,
+                                },
+                                CacheValidationInfo { tool_config: None },
+                            );
                         };
                         let embedding_response =
                             EmbeddingModelResponse::new(response, provider_name.clone());
@@ -341,7 +339,7 @@ impl EmbeddingModelResponse {
             id: Uuid::now_v7(),
             created: current_timestamp(),
             input: request.request.input.clone(),
-            embeddings: vec![Embedding::Float(cache_lookup.output.embedding)],
+            embeddings: vec![cache_lookup.output.embedding],
             raw_request: cache_lookup.raw_request,
             raw_response: cache_lookup.raw_response,
             usage: Usage {

--- a/tensorzero-core/src/serde_util.rs
+++ b/tensorzero-core/src/serde_util.rs
@@ -1,5 +1,16 @@
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
+
+/// Serializes a value as a JSON string (for "doubly-serialized" fields).
+/// This is the inverse of `deserialize_json_string`.
+pub fn serialize_json_string<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize,
+{
+    let json_str = serde_json::to_string(value).map_err(serde::ser::Error::custom)?;
+    serializer.serialize_str(&json_str)
+}
 
 /// Deserializes a "doubly-serialized" field of a struct.
 /// If you have a struct like this:


### PR DESCRIPTION
Fix https://github.com/tensorzero/tensorzero/issues/3633
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix caching for base64 embeddings by updating serialization and adding tests for both float and base64 encoding formats.
> 
>   - **Caching Fixes**:
>     - Update `EmbeddingCacheData` in `cache.rs` to use `serialize_json_string` for `Embedding` serialization.
>     - Modify `embed()` in `embeddings.rs` to handle caching for both float and base64 encodings.
>   - **Tests**:
>     - Add `test_embeddings_cache_with_float_encoding` and `test_embeddings_cache_with_base64_encoding` in `test_embeddings.py` to verify caching behavior.
>   - **Serialization**:
>     - Add `serialize_json_string` function in `serde_util.rs` for JSON string serialization of `Embedding`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ef871374e79498d05ac37af73f8c2546da3ebb78. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->