### PR TITLE
Add inference fixture for orphaned model inference without token usage

### DIFF
--- a/ui/e2e_tests/observability.inferences.$inference_id.spec.ts
+++ b/ui/e2e_tests/observability.inferences.$inference_id.spec.ts
@@ -539,3 +539,37 @@ test("should display inferences with thought block output", async ({
     page.locator(".text-fg-tertiary").getByText("Thought"),
   ).toBeVisible();
 });
+
+test("should handle model inference with null input and output tokens", async ({
+  page,
+}) => {
+  await page.goto(
+    "/observability/inferences/01954435-76a5-7331-8a3a-16296a0ba5b6",
+  );
+
+  // Wait for the page to load
+  await page.waitForLoadState("networkidle");
+
+  // Verify the inference page loads
+  await expect(
+    page.getByText("01954435-76a5-7331-8a3a-16296a0ba5b6").first(),
+  ).toBeVisible();
+
+  // Click on the model inference ID to open the model inference detail sheet
+  await page.getByText("01954435-76ab-78b1-a76e-d5676b0dd2f9").click();
+
+  // Wait for the sheet/dialog to appear
+  const sheet = page.locator('[role="dialog"]');
+  await sheet.waitFor({ state: "visible" });
+
+  // Verify we're on the model inference page (use exact match to avoid matching "Model Inferences")
+  await expect(
+    sheet.getByText("Model Inference", { exact: true }),
+  ).toBeVisible();
+
+  // Verify that null tokens are displayed in the sheet (they should show as "null tok")
+  await expect(sheet.getByText("null tok")).toHaveCount(2);
+
+  // Verify the crab description output is visible in the sheet
+  await expect(sheet.getByText("cartoon-style crab").first()).toBeVisible();
+});


### PR DESCRIPTION
`observability/inferences/01954435-76a5-7331-8a3a-16296a0ba5b6`

Fix https://github.com/tensorzero/tensorzero/issues/3310
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add test for handling model inference with null tokens and update fixture in `chat_inference_examples.jsonl`.
> 
>   - **Behavior**:
>     - Adds test `should handle model inference with null input and output tokens` in `observability.inferences.$inference_id.spec.ts` to verify handling of null tokens.
>     - Verifies inference page loads, model inference detail sheet opens, and null tokens display as "null tok".
>   - **Fixtures**:
>     - Adds inference fixture to `chat_inference_examples.jsonl` for model `image_judger` with null input/output tokens.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 09de4fdf29e1a1aa4841e5e0aad1bc13b6a3145f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->