### PR TITLE
improved error message for too few postgres migrations

### DIFF
--- a/tensorzero-core/src/db/postgres/mod.rs
+++ b/tensorzero-core/src/db/postgres/mod.rs
@@ -76,7 +76,8 @@ impl PostgresConnectionInfo {
         if applied_migrations != expected_migrations {
             return Err(Error::new(ErrorDetails::PostgresConnectionInitialization {
                 message: format!(
-                    "Applied migrations do not match expected migrations. Applied: {applied_migrations:?}, Expected: {expected_migrations:?}",
+                    "Applied migrations do not match expected migrations. Applied: {applied_migrations:?}, Expected: {expected_migrations:?}. Please run the migrations with `{}`",
+                    get_run_migrations_command()
                 ),
             }));
         }


### PR DESCRIPTION
We were not telling the user the correct command.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improved error message in `check_migrations()` to include a command suggestion for running migrations.
> 
>   - **Behavior**:
>     - Improved error message in `check_migrations()` in `mod.rs` to include a command suggestion for running migrations when applied migrations do not match expected migrations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 981f66eedd45553e983787f7e0686ff3fc15f77d. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->