### PR TITLE
Always compute usage/rate-limits for backend provider streams

### DIFF
--- a/tensorzero-core/src/providers/dummy.rs
+++ b/tensorzero-core/src/providers/dummy.rs
@@ -86,6 +86,10 @@ impl DummyProvider {
                 input_tokens: 0,
                 output_tokens: 0,
             },
+            "input_five_output_six" => Usage {
+                input_tokens: 5,
+                output_tokens: 6,
+            },
             _ => Usage {
                 input_tokens: 10,
                 output_tokens,

--- a/tensorzero-core/src/variant/mixture_of_n.rs
+++ b/tensorzero-core/src/variant/mixture_of_n.rs
@@ -22,7 +22,6 @@ use crate::inference::types::{
     JsonInferenceResultChunk, RequestMessagesOrBatch, TextChunk, ThoughtChunk, Usage,
 };
 use crate::model::ModelTable;
-use crate::rate_limiting::TicketBorrows;
 use crate::tool::ToolCallChunk;
 use crate::{
     endpoints::inference::InferenceParams,
@@ -331,7 +330,6 @@ pub fn stream_inference_from_non_stream(
             }
         },
         cached: model_inference_result.cached,
-        ticket_borrow: TicketBorrows::empty(),
     };
     let stream = make_stream_from_non_stream(inference_result, Some(usage))?;
     Ok((stream, model_used_info))

--- a/tensorzero-core/src/variant/mod.rs
+++ b/tensorzero-core/src/variant/mod.rs
@@ -39,7 +39,6 @@ use crate::minijinja_util::TemplateConfig;
 use crate::model::ModelTable;
 use crate::model::StreamResponse;
 use crate::model::StreamResponseAndMessages;
-use crate::rate_limiting::TicketBorrows;
 use crate::tool::{create_dynamic_implicit_tool_config, ToolCallConfig};
 use crate::utils::retries::RetryConfig;
 use crate::{inference::types::InferenceResult, model::ModelConfig};
@@ -198,7 +197,6 @@ pub struct ModelUsedInfo {
     pub input_messages: Vec<RequestMessage>,
     pub inference_params: InferenceParams,
     pub cached: bool,
-    pub ticket_borrow: TicketBorrows,
     // These responses will get added into the final inference result (after `collect_chunks` finishes)
     pub previous_model_inference_results: Vec<ModelInferenceResponseWithMetadata>,
 }
@@ -748,7 +746,6 @@ async fn infer_model_request_stream<'request>(
                 cached,
             },
         messages: input_messages,
-        ticket_borrow,
     } = retry_config
         .retry(|| async {
             model_config
@@ -767,7 +764,6 @@ async fn infer_model_request_stream<'request>(
         system,
         input_messages,
         cached,
-        ticket_borrow,
     };
     let config_type = function.config_type();
     let stream =

--- a/tensorzero-core/tests/e2e/rate_limiting.rs
+++ b/tensorzero-core/tests/e2e/rate_limiting.rs
@@ -1,14 +1,17 @@
 #![allow(clippy::print_stdout)]
 use std::collections::HashMap;
+use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures::StreamExt;
 use tensorzero::{
     ClientInferenceParams, ClientInput, ClientInputMessage, ClientInputMessageContent,
     InferenceOutput, Role, TensorZeroError,
 };
 use tensorzero_core::endpoints::inference::{ChatCompletionInferenceParams, InferenceParams};
 use tensorzero_core::inference::types::TextKind;
+use tracing_test::traced_test;
 use uuid::Uuid;
 
 // ===== HELPER FUNCTIONS =====
@@ -29,7 +32,7 @@ routing = ["dummy"]
 
 [models."dummy".providers.dummy]
 type = "dummy"
-model_name = "dummy"
+model_name = "input_five_output_six"
 
 [functions]
 
@@ -46,8 +49,9 @@ model = "dummy"
 async fn make_request_with_tags(
     client: &tensorzero::Client,
     tags: HashMap<String, String>,
-) -> Result<InferenceOutput, TensorZeroError> {
-    client
+    stream: bool,
+) -> Result<(), TensorZeroError> {
+    let res = client
         .inference(ClientInferenceParams {
             function_name: Some("basic_test".to_string()),
             input: ClientInput {
@@ -66,12 +70,23 @@ async fn make_request_with_tags(
                 },
             },
             tags,
+            stream: Some(stream),
             ..Default::default()
         })
-        .await
+        .await?;
+
+    if stream {
+        let InferenceOutput::Streaming(mut chunk_stream) = res else {
+            panic!("Expected a stream");
+        };
+        while let Some(chunk) = chunk_stream.next().await {
+            chunk.unwrap();
+        }
+    }
+    Ok(())
 }
 
-fn assert_rate_limit_exceeded(result: Result<InferenceOutput, TensorZeroError>) {
+fn assert_rate_limit_exceeded<T: Debug>(result: Result<T, TensorZeroError>) {
     match result {
         Err(TensorZeroError::Http {
             status_code, text, ..
@@ -117,7 +132,16 @@ fn assert_rate_limit_exceeded(result: Result<InferenceOutput, TensorZeroError>) 
 // ===== BASIC TAG-BASED TESTS =====
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_rate_limiting_concrete_tag_value() {
+async fn test_rate_limiting_concrete_tag_value_non_streaming() {
+    test_rate_limiting_concrete_tag_value_helper(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting_concrete_tag_value_streaming() {
+    test_rate_limiting_concrete_tag_value_helper(true).await;
+}
+
+async fn test_rate_limiting_concrete_tag_value_helper(stream: bool) {
     let id = Uuid::now_v7();
     let config = generate_rate_limit_config(&[&format!(
         r#"[[rate_limiting.rules]]
@@ -140,34 +164,34 @@ scope = [
     )]);
 
     // First request should succeed
-    let result1 = make_request_with_tags(&client, tags_match.clone()).await;
+    let result1 = make_request_with_tags(&client, tags_match.clone(), stream).await;
     if let Err(ref e) = result1 {
         println!("First request failed: {e:?}");
     }
     assert!(result1.is_ok(), "First request should succeed: {result1:?}",);
 
     // Second request should succeed
-    let result2 = make_request_with_tags(&client, tags_match.clone()).await;
+    let result2 = make_request_with_tags(&client, tags_match.clone(), stream).await;
     assert!(result2.is_ok(), "Second request should succeed");
 
     // Third request should succeed
-    let result3 = make_request_with_tags(&client, tags_match.clone()).await;
+    let result3 = make_request_with_tags(&client, tags_match.clone(), stream).await;
     assert!(result3.is_ok(), "Third request should succeed");
 
     // Fourth request should fail (exceeded capacity of 3, but we've only made 3 requests)
     // Let's make 2 more to reach the limit of 5
-    let result4 = make_request_with_tags(&client, tags_match.clone()).await;
+    let result4 = make_request_with_tags(&client, tags_match.clone(), stream).await;
     assert!(result4.is_ok(), "Fourth request should succeed");
 
-    let result5 = make_request_with_tags(&client, tags_match.clone()).await;
+    let result5 = make_request_with_tags(&client, tags_match.clone(), stream).await;
     assert!(result5.is_ok(), "Fifth request should succeed");
 
     // Sixth request should fail (exceeded capacity of 5)
-    let result6 = make_request_with_tags(&client, tags_match.clone()).await;
+    let result6 = make_request_with_tags(&client, tags_match.clone(), stream).await;
     assert_rate_limit_exceeded(result6);
 
     // Request with different customer_id should succeed (not affected by limit)
-    let result7 = make_request_with_tags(&client, tags_no_match).await;
+    let result7 = make_request_with_tags(&client, tags_no_match, stream).await;
     assert!(
         result7.is_ok(),
         "Request with different customer_id should succeed"
@@ -175,7 +199,16 @@ scope = [
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_rate_limiting_total_tag_value() {
+async fn test_rate_limiting_total_tag_value_non_streaming() {
+    test_rate_limiting_total_tag_value_helper(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting_total_tag_value_streaming() {
+    test_rate_limiting_total_tag_value_helper(true).await;
+}
+
+async fn test_rate_limiting_total_tag_value_helper(stream: bool) {
     let id = Uuid::now_v7();
     let config = generate_rate_limit_config(&[&format!(
         r#"[[rate_limiting.rules]]
@@ -193,26 +226,35 @@ scope = [
     let no_tags = HashMap::new();
 
     // First three requests should succeed (aggregate limit of 3)
-    let result1 = make_request_with_tags(&client, tags1.clone()).await;
+    let result1 = make_request_with_tags(&client, tags1.clone(), stream).await;
     assert!(result1.is_ok());
 
-    let result2 = make_request_with_tags(&client, tags2.clone()).await;
+    let result2 = make_request_with_tags(&client, tags2.clone(), stream).await;
     assert!(result2.is_ok());
 
-    let result3 = make_request_with_tags(&client, tags1.clone()).await;
+    let result3 = make_request_with_tags(&client, tags1.clone(), stream).await;
     assert!(result3.is_ok());
 
     // Fourth request should fail
-    let result4 = make_request_with_tags(&client, tags2.clone()).await;
+    let result4 = make_request_with_tags(&client, tags2.clone(), stream).await;
     assert_rate_limit_exceeded(result4);
 
     // Request without the tag should succeed (not subject to limit)
-    let result5 = make_request_with_tags(&client, no_tags).await;
+    let result5 = make_request_with_tags(&client, no_tags, stream).await;
     assert!(result5.is_ok());
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_rate_limiting_each_tag_value() {
+    test_rate_limiting_each_tag_value_helper(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting_each_tag_value_streaming() {
+    test_rate_limiting_each_tag_value_helper(true).await;
+}
+
+async fn test_rate_limiting_each_tag_value_helper(stream: bool) {
     let id = Uuid::now_v7();
     let config = generate_rate_limit_config(&[&format!(
         r#"[[rate_limiting.rules]]
@@ -235,31 +277,40 @@ scope = [
     )]);
 
     // Each workspace gets their own separate limit of 2
-    let result1a = make_request_with_tags(&client, tags_workspace1.clone()).await;
+    let result1a = make_request_with_tags(&client, tags_workspace1.clone(), stream).await;
     assert!(result1a.is_ok());
 
-    let result1b = make_request_with_tags(&client, tags_workspace1.clone()).await;
+    let result1b = make_request_with_tags(&client, tags_workspace1.clone(), stream).await;
     assert!(result1b.is_ok());
 
-    let result2a = make_request_with_tags(&client, tags_workspace2.clone()).await;
+    let result2a = make_request_with_tags(&client, tags_workspace2.clone(), stream).await;
     assert!(result2a.is_ok());
 
-    let result2b = make_request_with_tags(&client, tags_workspace2.clone()).await;
+    let result2b = make_request_with_tags(&client, tags_workspace2.clone(), stream).await;
     assert!(result2b.is_ok());
 
     // Third request for workspace1 should fail
-    let result1c = make_request_with_tags(&client, tags_workspace1.clone()).await;
+    let result1c = make_request_with_tags(&client, tags_workspace1.clone(), stream).await;
     assert_rate_limit_exceeded(result1c);
 
     // Third request for workspace2 should fail
-    let result2c = make_request_with_tags(&client, tags_workspace2.clone()).await;
+    let result2c = make_request_with_tags(&client, tags_workspace2.clone(), stream).await;
     assert_rate_limit_exceeded(result2c);
 }
 
 // ===== PRIORITY TESTS =====
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_rate_limiting_priority_always() {
+async fn test_rate_limiting_priority_always_non_streaming() {
+    test_rate_limiting_priority_always_helper(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting_priority_always_streaming() {
+    test_rate_limiting_priority_always_helper(true).await;
+}
+
+async fn test_rate_limiting_priority_always_helper(stream: bool) {
     let id = Uuid::now_v7();
     let config = generate_rate_limit_config(&[
         &format!(
@@ -298,30 +349,30 @@ scope = [
     )]);
 
     // Both rules apply for tags_both - most restrictive limit wins (capacity=3)
-    let result1 = make_request_with_tags(&client, tags_both.clone()).await;
+    let result1 = make_request_with_tags(&client, tags_both.clone(), stream).await;
     assert!(
         result1.is_ok(),
         "First request with both rules should succeed"
     );
 
-    let result2 = make_request_with_tags(&client, tags_both.clone()).await;
+    let result2 = make_request_with_tags(&client, tags_both.clone(), stream).await;
     assert!(
         result2.is_ok(),
         "Second request with both rules should succeed"
     );
 
-    let result3 = make_request_with_tags(&client, tags_both.clone()).await;
+    let result3 = make_request_with_tags(&client, tags_both.clone(), stream).await;
     assert!(
         result3.is_ok(),
         "Third request with both rules should succeed"
     );
 
     // Fourth request should fail due to priority=1 rule limit of 3
-    let result4 = make_request_with_tags(&client, tags_both.clone()).await;
+    let result4 = make_request_with_tags(&client, tags_both.clone(), stream).await;
     assert_rate_limit_exceeded(result4);
 
     // Request with only always rule should succeed (higher capacity=8)
-    let result5 = make_request_with_tags(&client, tags_always_only).await;
+    let result5 = make_request_with_tags(&client, tags_always_only, stream).await;
     assert!(
         result5.is_ok(),
         "Request with only always rule should succeed"
@@ -329,7 +380,16 @@ scope = [
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_rate_limiting_priority_numeric() {
+async fn test_rate_limiting_priority_numeric_non_streaming() {
+    test_rate_limiting_priority_numeric_helper(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting_priority_numeric_streaming() {
+    test_rate_limiting_priority_numeric_helper(true).await;
+}
+
+async fn test_rate_limiting_priority_numeric_helper(stream: bool) {
     // Test with different scopes that can overlap but aren't identical
     let id = Uuid::now_v7();
     let config = generate_rate_limit_config(&[
@@ -369,7 +429,7 @@ scope = [
     )]);
 
     for i in 0..5 {
-        let result = make_request_with_tags(&client, tags_highest_only.clone()).await;
+        let result = make_request_with_tags(&client, tags_highest_only.clone(), stream).await;
         assert!(
             result.is_ok(),
             "Request {} with highest priority only should succeed",
@@ -378,7 +438,7 @@ scope = [
     }
 
     // Sixth request should fail (exceeded capacity=5)
-    let result = make_request_with_tags(&client, tags_highest_only.clone()).await;
+    let result = make_request_with_tags(&client, tags_highest_only.clone(), stream).await;
     assert_rate_limit_exceeded(result);
 
     // Test 2: Request that matches multiple rules - only highest priority should apply
@@ -396,13 +456,23 @@ scope = [
 
     // Should be limited by highest priority rule (priority=3, capacity=5)
     // But we already used 5, so this should fail immediately
-    let result = make_request_with_tags(&client, tags_multiple).await;
+    let result = make_request_with_tags(&client, tags_multiple, stream).await;
     assert_rate_limit_exceeded(result);
 }
 
 // ===== RESOURCE TYPE TESTS =====
+
 #[tokio::test(flavor = "multi_thread")]
-async fn test_rate_limiting_tokens() {
+async fn test_rate_limiting_tokens_non_streaming() {
+    test_rate_limiting_tokens_helper(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting_tokens_streaming() {
+    test_rate_limiting_tokens_helper(true).await;
+}
+
+async fn test_rate_limiting_tokens_helper(stream: bool) {
     let id = Uuid::now_v7();
     let config = generate_rate_limit_config(&[&format!(
         r#"[[rate_limiting.rules]]
@@ -420,14 +490,14 @@ scope = [
     // Make several requests - should succeed until token limit is reached
     // Each request borrows roughly 100 tokens
     for i in 0..38 {
-        match make_request_with_tags(&client, tags.clone()).await {
-            Ok(_) => (),
+        match make_request_with_tags(&client, tags.clone(), stream).await {
+            Ok(()) => (),
             Err(_) => {
                 // Should hit limit after 37 requests due to token consumption
                 // (11 * 37 = 407, the borrowed amount is 102, 407 + 102 = 509 > 500)
                 assert!(
                     i == 37,
-                    "Should hit exactly 37  requests before hitting token limit (got {i})"
+                    "Should hit exactly 37 requests before hitting token limit (got {i})"
                 );
                 break;
             }
@@ -437,7 +507,16 @@ scope = [
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_rate_limiting_multiple_resources() {
+async fn test_rate_limiting_multiple_resources_non_streaming() {
+    test_rate_limiting_multiple_resources_helper(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting_multiple_resources_streaming() {
+    test_rate_limiting_multiple_resources_helper(true).await;
+}
+
+async fn test_rate_limiting_multiple_resources_helper(stream: bool) {
     let id = Uuid::now_v7();
     let config = generate_rate_limit_config(&[&format!(
         r#"[[rate_limiting.rules]]
@@ -454,24 +533,33 @@ scope = [
     let tags = HashMap::from([(format!("test_multi_user_id_{id}"), "123".to_string())]);
 
     // Should be limited by model_inferences_per_minute (3) rather than tokens (100)
-    let result1 = make_request_with_tags(&client, tags.clone()).await;
+    let result1 = make_request_with_tags(&client, tags.clone(), stream).await;
     assert!(result1.is_ok());
 
-    let result2 = make_request_with_tags(&client, tags.clone()).await;
+    let result2 = make_request_with_tags(&client, tags.clone(), stream).await;
     assert!(result2.is_ok());
 
-    let result3 = make_request_with_tags(&client, tags.clone()).await;
+    let result3 = make_request_with_tags(&client, tags.clone(), stream).await;
     assert!(result3.is_ok());
 
     // Fourth request should fail due to model inference limit
-    let result4 = make_request_with_tags(&client, tags.clone()).await;
+    let result4 = make_request_with_tags(&client, tags.clone(), stream).await;
     assert_rate_limit_exceeded(result4);
 }
 
 // ===== CONCURRENT REQUEST TESTS =====
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_rate_limiting_concurrent_requests() {
+async fn test_rate_limiting_concurrent_requests_non_streaming() {
+    test_rate_limiting_concurrent_requests_helper(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting_concurrent_requests_streaming() {
+    test_rate_limiting_concurrent_requests_helper(true).await;
+}
+
+async fn test_rate_limiting_concurrent_requests_helper(stream: bool) {
     let id = Uuid::now_v7();
     let config = generate_rate_limit_config(&[&format!(
         r#"[[rate_limiting.rules]]
@@ -492,7 +580,9 @@ scope = [
         .map(|_| {
             let client_clone = client.clone();
             let tags_clone = tags.clone();
-            tokio::spawn(async move { make_request_with_tags(&client_clone, tags_clone).await })
+            tokio::spawn(
+                async move { make_request_with_tags(&client_clone, tags_clone, stream).await },
+            )
         })
         .collect();
 
@@ -544,7 +634,16 @@ scope = [
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_rate_limiting_concurrent_different_tags() {
+async fn test_rate_limiting_concurrent_different_tags_non_streaming() {
+    test_rate_limiting_concurrent_different_tags_helper(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting_concurrent_different_tags_streaming() {
+    test_rate_limiting_concurrent_different_tags_helper(true).await;
+}
+
+async fn test_rate_limiting_concurrent_different_tags_helper(stream: bool) {
     let id = Uuid::now_v7();
     let config = generate_rate_limit_config(&[&format!(
         r#"[[rate_limiting.rules]]
@@ -564,7 +663,12 @@ scope = [
         .map(|i| {
             let client_clone = client.clone();
             let tags = HashMap::from([(format!("user_id_{id}"), format!("user{}", i % 3))]);
-            tokio::spawn(async move { (i % 3, make_request_with_tags(&client_clone, tags).await) })
+            tokio::spawn(async move {
+                (
+                    i % 3,
+                    make_request_with_tags(&client_clone, tags, stream).await,
+                )
+            })
         })
         .collect();
 
@@ -600,7 +704,16 @@ scope = [
 // ===== COMPLEX SCOPE TESTS =====
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_rate_limiting_multiple_scopes() {
+async fn test_rate_limiting_multiple_scopes_non_streaming() {
+    test_rate_limiting_multiple_scopes_helper(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting_multiple_scopes_streaming() {
+    test_rate_limiting_multiple_scopes_helper(true).await;
+}
+
+async fn test_rate_limiting_multiple_scopes_helper(stream: bool) {
     let id = Uuid::now_v7();
     let config = generate_rate_limit_config(&[&format!(
         r#"[[rate_limiting.rules]]
@@ -629,26 +742,35 @@ scope = [
 
     // Requests that match both scope requirements should be limited
     for _ in 0..3 {
-        let result = make_request_with_tags(&client, tags_match.clone()).await;
+        let result = make_request_with_tags(&client, tags_match.clone(), stream).await;
         assert!(
             result.is_ok(),
             "Matching requests within limit should succeed"
         );
     }
 
-    let result = make_request_with_tags(&client, tags_match.clone()).await;
+    let result = make_request_with_tags(&client, tags_match.clone(), stream).await;
     assert_rate_limit_exceeded(result);
 
     // Requests that don't match all scope requirements should not be limited
-    let result = make_request_with_tags(&client, tags_partial.clone()).await;
+    let result = make_request_with_tags(&client, tags_partial.clone(), stream).await;
     assert!(result.is_ok(), "Partial match should not be rate limited");
 
-    let result = make_request_with_tags(&client, tags_missing.clone()).await;
+    let result = make_request_with_tags(&client, tags_missing.clone(), stream).await;
     assert!(result.is_ok(), "Missing tag should not be rate limited");
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_rate_limiting_missing_tags() {
+async fn test_rate_limiting_missing_tags_non_streaming() {
+    test_rate_limiting_missing_tags_helper(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting_missing_tags_streaming() {
+    test_rate_limiting_missing_tags_helper(true).await;
+}
+
+async fn test_rate_limiting_missing_tags_helper(stream: bool) {
     let id = Uuid::now_v7();
     let config = generate_rate_limit_config(&[&format!(
         r#"[[rate_limiting.rules]]
@@ -669,21 +791,21 @@ scope = [
     let no_tags = HashMap::new();
 
     // Request with required tag should be limited
-    let result1 = make_request_with_tags(&client, tags_with_required.clone()).await;
+    let result1 = make_request_with_tags(&client, tags_with_required.clone(), stream).await;
     assert!(result1.is_ok());
 
-    let result2 = make_request_with_tags(&client, tags_with_required.clone()).await;
+    let result2 = make_request_with_tags(&client, tags_with_required.clone(), stream).await;
     assert_rate_limit_exceeded(result2);
 
     // Requests without the required tag should not be limited
     for _ in 0..5 {
-        let result = make_request_with_tags(&client, tags_without_required.clone()).await;
+        let result = make_request_with_tags(&client, tags_without_required.clone(), stream).await;
         assert!(
             result.is_ok(),
             "Request without required tag should not be limited"
         );
 
-        let result = make_request_with_tags(&client, no_tags.clone()).await;
+        let result = make_request_with_tags(&client, no_tags.clone(), stream).await;
         assert!(result.is_ok(), "Request with no tags should not be limited");
     }
 }
@@ -691,7 +813,16 @@ scope = [
 // ===== EDGE CASES AND ERROR HANDLING =====
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_rate_limiting_zero_limit() {
+async fn test_rate_limiting_zero_limit_non_streaming() {
+    test_rate_limiting_zero_limit_helper(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting_zero_limit_streaming() {
+    test_rate_limiting_zero_limit_helper(true).await;
+}
+
+async fn test_rate_limiting_zero_limit_helper(stream: bool) {
     let id = Uuid::now_v7();
     let config = generate_rate_limit_config(&[&format!(
         r#"[[rate_limiting.rules]]
@@ -707,12 +838,21 @@ scope = [
     let tags = HashMap::from([(format!("test8_user_id_{id}"), "123".to_string())]);
 
     // First request should fail immediately due to zero limit
-    let result = make_request_with_tags(&client, tags.clone()).await;
+    let result = make_request_with_tags(&client, tags.clone(), stream).await;
     assert_rate_limit_exceeded(result);
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_rate_limiting_disabled() {
+async fn test_rate_limiting_disabled_non_streaming() {
+    test_rate_limiting_disabled_helper(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting_disabled_streaming() {
+    test_rate_limiting_disabled_helper(true).await;
+}
+
+async fn test_rate_limiting_disabled_helper(stream: bool) {
     let id = Uuid::now_v7();
     let config = &format!(
         r#"
@@ -733,7 +873,7 @@ routing = ["dummy"]
 
 [models."dummy".providers.dummy]
 type = "dummy"
-model_name = "dummy"
+model_name = "input_five_output_six"
 
 [functions]
 
@@ -752,7 +892,7 @@ model = "dummy"
 
     // All requests should succeed when rate limiting is disabled
     for _ in 0..10 {
-        let result = make_request_with_tags(&client, tags.clone()).await;
+        let result = make_request_with_tags(&client, tags.clone(), stream).await;
         assert!(
             result.is_ok(),
             "All requests should succeed when rate limiting is disabled"
@@ -761,7 +901,16 @@ model = "dummy"
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_rate_limiting_bucket_configuration() {
+async fn test_rate_limiting_bucket_configuration_non_streaming() {
+    test_rate_limiting_bucket_configuration_helper(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting_bucket_configuration_streaming() {
+    test_rate_limiting_bucket_configuration_helper(true).await;
+}
+
+async fn test_rate_limiting_bucket_configuration_helper(stream: bool) {
     let id = Uuid::now_v7();
     let config = generate_rate_limit_config(&[&format!(
         r#"[[rate_limiting.rules]]
@@ -779,8 +928,8 @@ scope = [
     // Should be able to make requests up to the capacity (10)
     let mut success_count = 0;
     for _ in 0..15 {
-        match make_request_with_tags(&client, tags.clone()).await {
-            Ok(_) => success_count += 1,
+        match make_request_with_tags(&client, tags.clone(), stream).await {
+            Ok(()) => success_count += 1,
             Err(_) => break,
         }
     }
@@ -790,12 +939,21 @@ scope = [
     assert!(success_count <= 10, "Should not exceed capacity of 10");
 
     // Next request should fail
-    let result = make_request_with_tags(&client, tags.clone()).await;
+    let result = make_request_with_tags(&client, tags.clone(), stream).await;
     assert_rate_limit_exceeded(result);
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_rate_limiting_large_limit() {
+async fn test_rate_limiting_large_limit_non_streaming() {
+    test_rate_limiting_large_limit_helper(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting_large_limit_streaming() {
+    test_rate_limiting_large_limit_helper(true).await;
+}
+
+async fn test_rate_limiting_large_limit_helper(stream: bool) {
     let id = Uuid::now_v7();
     let config = generate_rate_limit_config(&[&format!(
         r#"[[rate_limiting.rules]]
@@ -812,13 +970,22 @@ scope = [
 
     // Should be able to make many requests without hitting the limit
     for _ in 0..100 {
-        let result = make_request_with_tags(&client, tags.clone()).await;
+        let result = make_request_with_tags(&client, tags.clone(), stream).await;
         assert!(result.is_ok(), "Should succeed with very large limit");
     }
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_rate_limiting_time_intervals() {
+async fn test_rate_limiting_time_intervals_non_streaming() {
+    test_rate_limiting_time_intervals_helper(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting_time_intervals_streaming() {
+    test_rate_limiting_time_intervals_helper(true).await;
+}
+
+async fn test_rate_limiting_time_intervals_helper(stream: bool) {
     // Test different time intervals work correctly
     let id = Uuid::now_v7();
     let config = generate_rate_limit_config(&[&format!(
@@ -835,19 +1002,28 @@ scope = [
     let tags = HashMap::from([(format!("test12_user_id_{id}"), "123".to_string())]);
 
     // Should be able to make 2 requests per second
-    let result1 = make_request_with_tags(&client, tags.clone()).await;
+    let result1 = make_request_with_tags(&client, tags.clone(), stream).await;
     assert!(result1.is_ok());
 
-    let result2 = make_request_with_tags(&client, tags.clone()).await;
+    let result2 = make_request_with_tags(&client, tags.clone(), stream).await;
     assert!(result2.is_ok());
 
     // Third request should fail
-    let result3 = make_request_with_tags(&client, tags.clone()).await;
+    let result3 = make_request_with_tags(&client, tags.clone(), stream).await;
     assert_rate_limit_exceeded(result3);
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_rate_limiting_no_rules() {
+async fn test_rate_limiting_no_rules_non_streaming() {
+    test_rate_limiting_no_rules_helper(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting_no_rules_streaming() {
+    test_rate_limiting_no_rules_helper(true).await;
+}
+
+async fn test_rate_limiting_no_rules_helper(stream: bool) {
     let config = r#"
 [rate_limiting]
 enabled = true
@@ -878,7 +1054,7 @@ model = "dummy"
 
     // Should succeed when no rules are defined
     for _ in 0..10 {
-        let result = make_request_with_tags(&client, tags.clone()).await;
+        let result = make_request_with_tags(&client, tags.clone(), stream).await;
         assert!(
             result.is_ok(),
             "Should succeed when no rate limiting rules are defined"
@@ -951,4 +1127,65 @@ retries = { num_retries = 3 }
         .await
         .unwrap_err();
     assert!(err.to_string().contains("TensorZero rate limit exceeded"));
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_rate_limiting_cancelled_stream_return_tokens() {
+    let id = Uuid::now_v7();
+    let config = generate_rate_limit_config(&[&format!(
+        r#"[[rate_limiting.rules]]
+    tokens_per_minute = {{ capacity = 100, refill_rate = 100 }}
+    always = true
+    scope = [
+        {{ tag_key = "test1_customer_id_{id}", tag_value = "customer_alpha" }}
+    ]"#
+    )]);
+
+    let tags_match = HashMap::from([(
+        format!("test1_customer_id_{id}"),
+        "customer_alpha".to_string(),
+    )]);
+
+    let client =
+        tensorzero::test_helpers::make_embedded_gateway_with_config_and_postgres(&config).await;
+    let res = client
+        .inference(ClientInferenceParams {
+            model_name: Some("dummy::slow_second_chunk".to_string()),
+            input: ClientInput {
+                system: None,
+                messages: vec![ClientInputMessage {
+                    role: Role::User,
+                    content: vec![ClientInputMessageContent::Text(TextKind::Text {
+                        text: "Hello".to_string(),
+                    })],
+                }],
+            },
+            tags: tags_match.clone(),
+            params: InferenceParams {
+                chat_completion: ChatCompletionInferenceParams {
+                    max_tokens: Some(50),
+                    ..Default::default()
+                },
+            },
+            stream: Some(true),
+
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let InferenceOutput::Streaming(mut stream) = res else {
+        panic!("Expected a stream");
+    };
+    stream.next().await.unwrap().unwrap();
+
+    // Drop the stream - we should still compute the final usage and return the tickets,
+    // even though the client is no longer interested in the stream
+    drop(stream);
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    assert!(
+        logs_contain("return_multiple_resource_tickets"),
+        "Did not find sqlx call to return_multiple_resource_tickets"
+    );
 }


### PR DESCRIPTION
Previously, we would stop processing a provider stream if the top-level HTTP connection was dropped. As a result, we would never call `return_tickets`, which could result in our rate-limiting state drifting out of sync for streaming inferences if we consistently under-borrow or over-borrow
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure rate-limiting consistency by always computing usage and returning tickets for streaming inferences, even if the HTTP connection is dropped.
> 
>   - **Behavior**:
>     - Ensures rate-limiting state consistency by always computing usage and returning tickets for streaming inferences, even if the HTTP connection is dropped.
>     - Modifies `create_stream` in `inference.rs` to handle dropped connections by continuing to process chunks and update rate limits.
>   - **Code Changes**:
>     - Removes `ticket_borrow` from `InferenceMetadata` and related functions in `inference.rs` and `types/mod.rs`.
>     - Updates `wrap_provider_stream` in `model.rs` to spawn a task for returning tickets after stream completion.
>     - Adjusts tests in `rate_limiting.rs` to verify behavior with streaming and non-streaming requests.
>   - **Misc**:
>     - Removes unused imports and fields related to `ticket_borrow` in multiple files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 80598739f9429737a0440798c499975edbe8ce08. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->