### PR TITLE
Print success message for `--run-*-migrations`

### DIFF
--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -111,6 +111,7 @@ async fn main() {
         manual_run_clickhouse_migrations()
             .await
             .expect_pretty("Failed to run ClickHouse migrations");
+        tracing::info!("ClickHouse is ready.");
         return;
     }
 
@@ -118,6 +119,7 @@ async fn main() {
         manual_run_postgres_migrations()
             .await
             .expect_pretty("Failed to run PostgreSQL migrations");
+        tracing::info!("Postgres is ready.");
         return;
     }
 


### PR DESCRIPTION
Fix #3646
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add success messages after running ClickHouse and PostgreSQL migrations in `main.rs`.
> 
>   - **Logging**:
>     - Add success message `"ClickHouse is ready."` after `manual_run_clickhouse_migrations()` in `main.rs`.
>     - Add success message `"Postgres is ready."` after `manual_run_postgres_migrations()` in `main.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 23e0facd436dcf8cf74c8760f9fa1f0e5226e6f9. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->