### PR TITLE
Gateway should fail on startup if rate limits are set but Postgres is missing

### DIFF
--- a/tensorzero-core/src/rate_limiting/mod.rs
+++ b/tensorzero-core/src/rate_limiting/mod.rs
@@ -93,12 +93,10 @@ pub struct ScopeInfo<'a> {
 }
 
 impl RateLimitingConfig {
-    #[cfg(test)]
     pub fn rules(&self) -> &Vec<RateLimitingConfigRule> {
         &self.rules
     }
 
-    #[cfg(test)]
     pub fn enabled(&self) -> bool {
         self.enabled
     }

--- a/tensorzero-core/src/utils/gateway.rs
+++ b/tensorzero-core/src/utils/gateway.rs
@@ -236,6 +236,12 @@ pub async fn setup_postgres(
     postgres_url: Option<String>,
 ) -> Result<PostgresConnectionInfo, Error> {
     let Some(postgres_url) = postgres_url else {
+        // Check if rate limiting is configured but Postgres is not available
+        if config.rate_limiting.enabled() && !config.rate_limiting.rules().is_empty() {
+            return Err(Error::new(ErrorDetails::Config {
+                message: "Rate limiting is configured but PostgreSQL is not available. Rate limiting requires PostgreSQL to be configured. Please set the TENSORZERO_POSTGRES_URL environment variable or disable rate limiting.".to_string(),
+            }));
+        }
         return Ok(PostgresConnectionInfo::Disabled);
     };
 

--- a/tensorzero-core/tests/e2e/rate_limiting_startup.rs
+++ b/tensorzero-core/tests/e2e/rate_limiting_startup.rs
@@ -1,0 +1,164 @@
+//! Tests for rate limiting startup validation
+
+use tempfile::NamedTempFile;
+use tensorzero::ClientBuilder;
+use tensorzero::ClientBuilderMode;
+use tensorzero_core::db::clickhouse::test_helpers::CLICKHOUSE_URL;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting_requires_postgres() {
+    // Configuration with rate limiting but no Postgres
+    let config = r#"
+[rate_limiting]
+enabled = true
+
+[[rate_limiting.rules]]
+model_inferences_per_minute = 10
+always = true
+
+[models]
+
+[models."dummy"]
+routing = ["dummy"]
+
+[models."dummy".providers.dummy]
+type = "dummy"
+model_name = "dummy"
+
+[functions]
+
+[functions.basic_test]
+type = "chat"
+
+[functions.basic_test.variants.default]
+type = "chat_completion"
+model = "dummy"
+"#;
+
+    let tmp_config = NamedTempFile::new().unwrap();
+    std::fs::write(tmp_config.path(), config).unwrap();
+
+    // Try to create a gateway without Postgres - this should fail
+    let result = ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
+        config_file: Some(tmp_config.path().to_owned()),
+        clickhouse_url: Some(CLICKHOUSE_URL.clone()),
+        postgres_url: None, // No Postgres URL
+        timeout: None,
+        verify_credentials: true,
+        allow_batch_writes: true,
+    })
+    .build()
+    .await;
+
+    // Assert that the gateway failed to start
+    assert!(
+        result.is_err(),
+        "Gateway should fail to start when rate limiting is configured but Postgres is missing"
+    );
+
+    // Check that the error message is helpful
+    let error_message = result.unwrap_err().to_string();
+    assert!(
+        error_message.contains("Rate limiting") || error_message.contains("rate limiting"),
+        "Error message should mention rate limiting, got: {error_message}"
+    );
+    assert!(
+        error_message.contains("PostgreSQL") || error_message.contains("Postgres"),
+        "Error message should mention PostgreSQL, got: {error_message}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_no_rate_limiting_no_postgres_ok() {
+    // Configuration without rate limiting and no Postgres - should work fine
+    let config = r#"
+[models]
+
+[models."dummy"]
+routing = ["dummy"]
+
+[models."dummy".providers.dummy]
+type = "dummy"
+model_name = "dummy"
+
+[functions]
+
+[functions.basic_test]
+type = "chat"
+
+[functions.basic_test.variants.default]
+type = "chat_completion"
+model = "dummy"
+"#;
+
+    let tmp_config = NamedTempFile::new().unwrap();
+    std::fs::write(tmp_config.path(), config).unwrap();
+
+    // Try to create a gateway without Postgres or rate limiting - this should succeed
+    let result = ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
+        config_file: Some(tmp_config.path().to_owned()),
+        clickhouse_url: Some(CLICKHOUSE_URL.clone()),
+        postgres_url: None, // No Postgres URL
+        timeout: None,
+        verify_credentials: true,
+        allow_batch_writes: true,
+    })
+    .build()
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "Gateway should start successfully without rate limiting and without Postgres, got: {result:?}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_disabled_rate_limiting_no_postgres_ok() {
+    // Configuration with disabled rate limiting and no Postgres - should work fine
+    let config = r#"
+[rate_limiting]
+enabled = false
+
+[[rate_limiting.rules]]
+model_inferences_per_minute = 10
+always = true
+
+[models]
+
+[models."dummy"]
+routing = ["dummy"]
+
+[models."dummy".providers.dummy]
+type = "dummy"
+model_name = "dummy"
+
+[functions]
+
+[functions.basic_test]
+type = "chat"
+
+[functions.basic_test.variants.default]
+type = "chat_completion"
+model = "dummy"
+"#;
+
+    let tmp_config = NamedTempFile::new().unwrap();
+    std::fs::write(tmp_config.path(), config).unwrap();
+
+    // Try to create a gateway with disabled rate limiting and no Postgres - this should succeed
+    let result = ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
+        config_file: Some(tmp_config.path().to_owned()),
+        clickhouse_url: Some(CLICKHOUSE_URL.clone()),
+        postgres_url: None, // No Postgres URL
+        timeout: None,
+        verify_credentials: true,
+        allow_batch_writes: true,
+    })
+    .build()
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "Gateway should start successfully with disabled rate limiting and without Postgres, got: {result:?}",
+    );
+}

--- a/tensorzero-core/tests/e2e/tests.rs
+++ b/tensorzero-core/tests/e2e/tests.rs
@@ -28,6 +28,7 @@ mod prometheus;
 mod providers;
 mod proxy;
 mod rate_limiting;
+mod rate_limiting_startup;
 mod render_inferences;
 mod retries;
 mod streaming_errors;


### PR DESCRIPTION
Fix https://github.com/tensorzero/tensorzero/issues/3643
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure gateway fails to start if rate limiting is enabled but PostgreSQL is not configured, with tests for various configurations.
> 
>   - **Behavior**:
>     - `setup_postgres` in `gateway.rs` now returns an error if rate limiting is enabled but PostgreSQL is not configured.
>     - Error message advises setting `TENSORZERO_POSTGRES_URL` or disabling rate limiting.
>   - **Tests**:
>     - Adds `rate_limiting_startup.rs` to test gateway startup behavior with various rate limiting and PostgreSQL configurations.
>     - Tests include scenarios with rate limiting enabled without PostgreSQL, no rate limiting without PostgreSQL, and disabled rate limiting without PostgreSQL.
>   - **Misc**:
>     - Removes `#[cfg(test)]` from `rules()` and `enabled()` in `rate_limiting/mod.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f2257bbc95f31c614994c7350185e666df1967a1. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->