### PR TITLE
Group all opentelemetry updates together in Dependabot prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,11 @@ updates:
       interval: "weekly"
     labels: []
     groups:
+      opentelemetry-dependencies:
+        patterns:
+          - "*opentelemetry*"
+          - "tonic"
       rust-dependencies:
         patterns:
           - "*"
-    open-pull-requests-limit: 1 # This does not affect the security update PR limit
+    open-pull-requests-limit: 2 # This does not affect the security update PR limit


### PR DESCRIPTION
There are lots of dependency edges between these crates (along with 'tonic'), so it can take a while before we're actually able to upgrade any of them. Let's separate them out so that other dependency bumps can succeed
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Group OpenTelemetry and tonic dependencies separately in `dependabot.yml` and increase Rust dependencies PR limit to 2.
> 
>   - **Dependabot Configuration**:
>     - Adds `opentelemetry-dependencies` group in `dependabot.yml` for dependencies matching `*opentelemetry*` and `tonic`.
>     - Increases `open-pull-requests-limit` for Rust dependencies from 1 to 2 in `dependabot.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6dc7d1255e391bb6c53bf38f8b987f7d4ae21d83. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->