### PR TITLE
Extract business logic from UI routes for dataset page

### DIFF
--- a/ui/app/routes/datasets/$dataset_name/datapoint/$id/datapointOperations.server.ts
+++ b/ui/app/routes/datasets/$dataset_name/datapoint/$id/datapointOperations.server.ts
@@ -71,12 +71,8 @@ export async function saveDatapoint(params: {
   const { parsedFormData, functionType } = params;
 
   // Transform input to match TensorZero client's expected format
-  const transformedInput = resolvedInputToTensorZeroInput(
-    parsedFormData.input,
-  );
-  const transformedOutput = transformOutputForTensorZero(
-    parsedFormData.output,
-  );
+  const transformedInput = resolvedInputToTensorZeroInput(parsedFormData.input);
+  const transformedOutput = transformOutputForTensorZero(parsedFormData.output);
 
   // For future reference:
   // These two calls would be a transaction but ClickHouse isn't transactional.

--- a/ui/app/routes/datasets/$dataset_name/datapoint/$id/datapointOperations.server.ts
+++ b/ui/app/routes/datasets/$dataset_name/datapoint/$id/datapointOperations.server.ts
@@ -1,0 +1,126 @@
+import { v7 as uuid } from "uuid";
+import type { ParsedDatasetRow } from "~/utils/clickhouse/datasets";
+import {
+  getDatasetCounts,
+  staleDatapoint,
+} from "~/utils/clickhouse/datasets.server";
+import { getTensorZeroClient } from "~/utils/tensorzero.server";
+import { resolvedInputToTensorZeroInput } from "~/routes/api/tensorzero/inference.utils";
+
+// ============================================================================
+// Transformation Functions
+// ============================================================================
+
+function transformOutputForTensorZero(
+  output: ParsedDatasetRow["output"],
+): string | null {
+  if (output === null || output === undefined) {
+    return null;
+  } else if ("raw" in output) {
+    if (output.raw === null) {
+      return null;
+    }
+    try {
+      return JSON.parse(output.raw);
+    } catch (error) {
+      throw new Error(
+        `Invalid JSON in output.raw: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  } else if (typeof output === "object") {
+    try {
+      return JSON.parse(JSON.stringify(output));
+    } catch (error) {
+      throw new Error(
+        `Failed to serialize output object: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  } else {
+    return output;
+  }
+}
+
+// ============================================================================
+// Core Operations
+// ============================================================================
+
+export async function deleteDatapoint(params: {
+  dataset_name: string;
+  id: string;
+  functionType: "chat" | "json";
+}): Promise<{ redirectTo: string }> {
+  const { dataset_name, id, functionType } = params;
+
+  await staleDatapoint(dataset_name, id, functionType);
+
+  const datasetCounts = await getDatasetCounts({});
+  const datasetCount = datasetCounts.find(
+    (count) => count.dataset_name === dataset_name,
+  );
+
+  if (datasetCount === undefined) {
+    return { redirectTo: "/datasets" };
+  }
+  return { redirectTo: `/datasets/${dataset_name}` };
+}
+
+export async function saveDatapoint(params: {
+  parsedFormData: ParsedDatasetRow;
+  functionType: "chat" | "json";
+}): Promise<{ newId: string }> {
+  const { parsedFormData, functionType } = params;
+
+  // Transform input to match TensorZero client's expected format
+  const transformedInput = resolvedInputToTensorZeroInput(
+    parsedFormData.input,
+  );
+  const transformedOutput = transformOutputForTensorZero(
+    parsedFormData.output,
+  );
+
+  // For future reference:
+  // These two calls would be a transaction but ClickHouse isn't transactional.
+  const baseDatapoint = {
+    function_name: parsedFormData.function_name,
+    input: transformedInput,
+    output: transformedOutput,
+    tags: parsedFormData.tags || {},
+    auxiliary: parsedFormData.auxiliary,
+    is_custom: true, // we're saving it after an edit, so it's custom
+    source_inference_id: parsedFormData.source_inference_id,
+    id: uuid(), // We generate a new ID here because we want old evaluation runs to be able to point to the correct data.
+  };
+
+  let datapoint;
+  if (functionType === "json" && "output_schema" in parsedFormData) {
+    datapoint = {
+      ...baseDatapoint,
+      output_schema: parsedFormData.output_schema,
+    };
+  } else if (functionType === "chat") {
+    datapoint = {
+      ...baseDatapoint,
+      tool_params:
+        "tool_params" in parsedFormData
+          ? parsedFormData.tool_params
+          : undefined,
+    };
+  } else {
+    throw new Error(
+      `Unexpected function type "${functionType}" or missing required properties on datapoint`,
+    );
+  }
+
+  const { id } = await getTensorZeroClient().updateDatapoint(
+    parsedFormData.dataset_name,
+    datapoint,
+  );
+
+  await staleDatapoint(
+    parsedFormData.dataset_name,
+    parsedFormData.id,
+    functionType,
+  );
+
+  return { newId: id };
+}

--- a/ui/app/routes/datasets/$dataset_name/datapoint/$id/route.tsx
+++ b/ui/app/routes/datasets/$dataset_name/datapoint/$id/route.tsx
@@ -43,10 +43,7 @@ import type {
   JsonInferenceOutput,
   ContentBlockChatOutput,
 } from "tensorzero-node";
-import {
-  deleteDatapoint,
-  saveDatapoint,
-} from "./datapointOperations.server";
+import { deleteDatapoint, saveDatapoint } from "./datapointOperations.server";
 
 function parseDatapointFormData(formData: FormData): ParsedDatasetRow {
   const rawData = {
@@ -79,7 +76,6 @@ function parseDatapointFormData(formData: FormData): ParsedDatasetRow {
   return ParsedDatasetRowSchema.parse(cleanedData);
 }
 
-
 export function validateJsonOutput(
   output: ContentBlockChatOutput[] | JsonInferenceOutput | null,
 ): { valid: true } | { valid: false; error: string } {
@@ -90,7 +86,8 @@ export function validateJsonOutput(
     } catch {
       return {
         valid: false,
-        error: "Invalid JSON in output. Please fix the JSON format before saving.",
+        error:
+          "Invalid JSON in output. Please fix the JSON format before saving.",
       };
     }
   }
@@ -117,7 +114,8 @@ export function hasDatapointChanged(params: {
   // Check if system has changed (added, removed, or modified)
   const hasSystemChanged =
     "system" in currentInput !== "system" in originalInput ||
-    JSON.stringify(currentInput.system) !== JSON.stringify(originalInput.system);
+    JSON.stringify(currentInput.system) !==
+      JSON.stringify(originalInput.system);
 
   // Check if messages changed
   const hasMessagesChanged =
@@ -277,7 +275,15 @@ export default function DatapointPage({ loaderData }: Route.ComponentProps) {
         originalTags,
       })
     );
-  }, [isEditing, input, output, tags, originalInput, originalOutput, originalTags]);
+  }, [
+    isEditing,
+    input,
+    output,
+    tags,
+    originalInput,
+    originalOutput,
+    originalTags,
+  ]);
 
   const toggleEditing = () => setIsEditing(!isEditing);
 

--- a/ui/app/routes/datasets/$dataset_name/datapoint/$id/route.tsx
+++ b/ui/app/routes/datasets/$dataset_name/datapoint/$id/route.tsx
@@ -10,7 +10,6 @@ import {
   useFetcher,
   useParams,
 } from "react-router";
-import { v7 as uuid } from "uuid";
 import InputSnippet from "~/components/inference/InputSnippet";
 import { Output } from "~/components/inference/Output";
 import { VariantResponseModal } from "~/components/inference/VariantResponseModal";
@@ -24,7 +23,6 @@ import {
 import { Badge } from "~/components/ui/badge";
 import { TagsTable } from "~/components/tags/TagsTable";
 import { useFunctionConfig } from "~/context/config";
-import { resolvedInputToTensorZeroInput } from "~/routes/api/tensorzero/inference.utils";
 import {
   prepareInferenceActionRequest,
   useInferenceActionFetcher,
@@ -35,14 +33,9 @@ import {
   ParsedDatasetRowSchema,
   type ParsedDatasetRow,
 } from "~/utils/clickhouse/datasets";
-import {
-  getDatapoint,
-  getDatasetCounts,
-  staleDatapoint,
-} from "~/utils/clickhouse/datasets.server";
+import { getDatapoint } from "~/utils/clickhouse/datasets.server";
 import { getConfig, getFunctionConfig } from "~/utils/config/index.server";
 import { logger } from "~/utils/logger";
-import { getTensorZeroClient } from "~/utils/tensorzero.server";
 import type { Route } from "./+types/route";
 import { DatapointActions } from "./DatapointActions";
 import DatapointBasicInfo from "./DatapointBasicInfo";
@@ -50,40 +43,102 @@ import type {
   JsonInferenceOutput,
   ContentBlockChatOutput,
 } from "tensorzero-node";
+import {
+  deleteDatapoint,
+  saveDatapoint,
+} from "./datapointOperations.server";
+
+function parseDatapointFormData(formData: FormData): ParsedDatasetRow {
+  const rawData = {
+    dataset_name: formData.get("dataset_name"),
+    function_name: formData.get("function_name"),
+    id: formData.get("id"),
+    episode_id: formData.get("episode_id"),
+    input: JSON.parse(formData.get("input") as string),
+    output: formData.get("output")
+      ? JSON.parse(formData.get("output") as string)
+      : undefined,
+    output_schema: formData.get("output_schema")
+      ? JSON.parse(formData.get("output_schema") as string)
+      : undefined,
+    tool_params: formData.get("tool_params")
+      ? JSON.parse(formData.get("tool_params") as string)
+      : undefined,
+    tags: JSON.parse(formData.get("tags") as string),
+    auxiliary: formData.get("auxiliary"),
+    is_deleted: formData.get("is_deleted") === "true",
+    updated_at: formData.get("updated_at"),
+    staled_at: null,
+    source_inference_id: formData.get("source_inference_id"),
+    is_custom: true,
+  };
+
+  const cleanedData = Object.fromEntries(
+    Object.entries(rawData).filter(([, value]) => value !== undefined),
+  );
+  return ParsedDatasetRowSchema.parse(cleanedData);
+}
+
+
+export function validateJsonOutput(
+  output: ContentBlockChatOutput[] | JsonInferenceOutput | null,
+): { valid: true } | { valid: false; error: string } {
+  if (output && "raw" in output && output.raw) {
+    try {
+      JSON.parse(output.raw);
+      return { valid: true };
+    } catch {
+      return {
+        valid: false,
+        error: "Invalid JSON in output. Please fix the JSON format before saving.",
+      };
+    }
+  }
+  return { valid: true };
+}
+
+export function hasDatapointChanged(params: {
+  currentInput: ParsedDatasetRow["input"];
+  originalInput: ParsedDatasetRow["input"];
+  currentOutput: ContentBlockChatOutput[] | JsonInferenceOutput | null;
+  originalOutput: ParsedDatasetRow["output"];
+  currentTags: Record<string, string>;
+  originalTags: Record<string, string>;
+}): boolean {
+  const {
+    currentInput,
+    originalInput,
+    currentOutput,
+    originalOutput,
+    currentTags,
+    originalTags,
+  } = params;
+
+  // Check if system has changed (added, removed, or modified)
+  const hasSystemChanged =
+    "system" in currentInput !== "system" in originalInput ||
+    JSON.stringify(currentInput.system) !== JSON.stringify(originalInput.system);
+
+  // Check if messages changed
+  const hasMessagesChanged =
+    JSON.stringify(currentInput.messages) !==
+    JSON.stringify(originalInput.messages);
+
+  const hasInputChanged = hasSystemChanged || hasMessagesChanged;
+
+  const hasOutputChanged =
+    JSON.stringify(currentOutput) !== JSON.stringify(originalOutput);
+  const hasTagsChanged =
+    JSON.stringify(currentTags) !== JSON.stringify(originalTags);
+
+  return hasInputChanged || hasOutputChanged || hasTagsChanged;
+}
 
 export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
 
   try {
-    const rawData = {
-      dataset_name: formData.get("dataset_name"),
-      function_name: formData.get("function_name"),
-      id: formData.get("id"),
-      episode_id: formData.get("episode_id"),
-      input: JSON.parse(formData.get("input") as string),
-      output: formData.get("output")
-        ? JSON.parse(formData.get("output") as string)
-        : undefined,
-      output_schema: formData.get("output_schema")
-        ? JSON.parse(formData.get("output_schema") as string)
-        : undefined,
-      tool_params: formData.get("tool_params")
-        ? JSON.parse(formData.get("tool_params") as string)
-        : undefined,
-      tags: JSON.parse(formData.get("tags") as string),
-      auxiliary: formData.get("auxiliary"),
-      is_deleted: formData.get("is_deleted") === "true",
-      updated_at: formData.get("updated_at"),
-      staled_at: null,
-      source_inference_id: formData.get("source_inference_id"),
-      is_custom: true,
-    };
-
-    const cleanedData = Object.fromEntries(
-      Object.entries(rawData).filter(([, value]) => value !== undefined),
-    );
-    const parsedFormData: ParsedDatasetRow =
-      ParsedDatasetRowSchema.parse(cleanedData);
+    const parsedFormData = parseDatapointFormData(formData);
     const config = await getConfig();
     const functionConfig = await getFunctionConfig(
       parsedFormData.function_name,
@@ -99,77 +154,20 @@ export async function action({ request }: ActionFunctionArgs) {
 
     const action = formData.get("action");
     if (action === "delete") {
-      await staleDatapoint(
-        parsedFormData.dataset_name,
-        parsedFormData.id,
+      const { redirectTo } = await deleteDatapoint({
+        dataset_name: parsedFormData.dataset_name,
+        id: parsedFormData.id,
         functionType,
-      );
-      const datasetCounts = await getDatasetCounts({});
-      const datasetCount = datasetCounts.find(
-        (count) => count.dataset_name === parsedFormData.dataset_name,
-      );
-
-      if (datasetCount === undefined) {
-        return redirect("/datasets");
-      }
-      return redirect(`/datasets/${parsedFormData.dataset_name}`);
+      });
+      return redirect(redirectTo);
     } else if (action === "save") {
-      // If the input changed, we should remove the source_inference_id
-      // because it will no longer be valid
-      // Transform input to match TensorZero client's expected format
-      const transformedInput = resolvedInputToTensorZeroInput(
-        parsedFormData.input,
-      );
-      const transformedOutput = transformOutputForTensorZero(
-        parsedFormData.output,
-      );
-
       try {
-        // For future reference:
-        // These two calls would be a transaction but ClickHouse doesn't support
-
-        const baseDatapoint = {
-          function_name: parsedFormData.function_name,
-          input: transformedInput,
-          output: transformedOutput,
-          tags: parsedFormData.tags || {},
-          auxiliary: parsedFormData.auxiliary,
-          is_custom: true, // we're saving it after an edit, so it's custom
-          source_inference_id: parsedFormData.source_inference_id,
-          id: uuid(), // We generate a new ID here because we want old evaluation runs to be able to point to the correct data.
-        };
-
-        let datapoint;
-        if (functionType === "json" && "output_schema" in parsedFormData) {
-          datapoint = {
-            ...baseDatapoint,
-            output_schema: parsedFormData.output_schema,
-          };
-        } else if (functionType === "chat") {
-          datapoint = {
-            ...baseDatapoint,
-            tool_params:
-              "tool_params" in parsedFormData
-                ? parsedFormData.tool_params
-                : undefined,
-          };
-        } else {
-          throw new Error(
-            `Unexpected function type "${functionType}" or missing required properties on datapoint`,
-          );
-        }
-        const { id } = await getTensorZeroClient().updateDatapoint(
-          parsedFormData.dataset_name,
-          datapoint,
-        );
-        await staleDatapoint(
-          parsedFormData.dataset_name,
-          parsedFormData.id,
+        const { newId } = await saveDatapoint({
+          parsedFormData,
           functionType,
-        );
-
+        });
         return redirect(
-          `/datasets/${parsedFormData.dataset_name}/datapoint/${id}`,
+          `/datasets/${parsedFormData.dataset_name}/datapoint/${newId}`,
         );
       } catch (error) {
         logger.error("Error updating datapoint:", error);
@@ -268,32 +266,18 @@ export default function DatapointPage({ loaderData }: Route.ComponentProps) {
   }, [datapoint]);
 
   const canSave = useMemo(() => {
-    // Check if system has changed (added, removed, or modified)
-    const hasSystemChanged =
-      "system" in input !== "system" in originalInput ||
-      JSON.stringify(input.system) !== JSON.stringify(originalInput.system);
-
-    // Check if messages changed
-    const hasMessagesChanged =
-      JSON.stringify(input.messages) !== JSON.stringify(originalInput.messages);
-
-    const hasInputChanged = hasSystemChanged || hasMessagesChanged;
-
-    const hasOutputChanged =
-      JSON.stringify(output) !== JSON.stringify(originalOutput);
-    const hasTagsChanged =
-      JSON.stringify(tags) !== JSON.stringify(originalTags);
-
-    return isEditing && (hasInputChanged || hasOutputChanged || hasTagsChanged);
-  }, [
-    isEditing,
-    input,
-    output,
-    tags,
-    originalInput,
-    originalOutput,
-    originalTags,
-  ]);
+    return (
+      isEditing &&
+      hasDatapointChanged({
+        currentInput: input,
+        originalInput,
+        currentOutput: output,
+        originalOutput,
+        currentTags: tags,
+        originalTags,
+      })
+    );
+  }, [isEditing, input, output, tags, originalInput, originalOutput, originalTags]);
 
   const toggleEditing = () => setIsEditing(!isEditing);
 
@@ -352,15 +336,10 @@ export default function DatapointPage({ loaderData }: Route.ComponentProps) {
     setValidationError(null);
 
     // Validate JSON output before submitting
-    if (output && "raw" in output && output.raw) {
-      try {
-        JSON.parse(output.raw);
-      } catch {
-        setValidationError(
-          "Invalid JSON in output. Please fix the JSON format before saving.",
-        );
-        return;
-      }
+    const validation = validateJsonOutput(output);
+    if (!validation.valid) {
+      setValidationError(validation.error);
+      return;
     }
 
     submitDatapointAction("save");
@@ -547,33 +526,4 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
       </div>
     </div>
   );
-}
-
-function transformOutputForTensorZero(
-  output: ParsedDatasetRow["output"],
-): string | null {
-  if (output === null || output === undefined) {
-    return null;
-  } else if ("raw" in output) {
-    if (output.raw === null) {
-      return null;
-    }
-    try {
-      return JSON.parse(output.raw);
-    } catch (error) {
-      throw new Error(
-        `Invalid JSON in output.raw: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-  } else if (typeof output === "object") {
-    try {
-      return JSON.parse(JSON.stringify(output));
-    } catch (error) {
-      throw new Error(
-        `Failed to serialize output object: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-  } else {
-    return output;
-  }
 }


### PR DESCRIPTION
I would like to separate the UI components, routes and loaders, and business logic in the frontend. This takes one step forward (loaders and components are still together, but business logic is split out.

Not fully set on this approach, just want to send it out to get some feedback. If this looks good we can ask the models to do a refactor later.

<!-- ELLIPSIS_HIDDEN -->

---

> [!IMPORTANT]
> Extracted business logic from UI routes into `datapointOperations.ts` for better separation of concerns and maintainability.
> - **Business Logic Extraction**:
>     - Moved validation (`validateJsonOutput`), transformation (`transformOutputForTensorZero`), and core operations (`deleteDatapoint`, `saveDatapoint`) to `datapointOperations.ts`.
>     - Updated `route.tsx` to use extracted functions for handling datapoint actions.
> - **Functionality**:
>     - `validateJsonOutput` checks JSON validity in outputs.
>     - `hasDatapointChanged` checks for changes in input, output, and tags.
>     - `deleteDatapoint` and `saveDatapoint` handle datapoint deletion and saving, respectively.
> - **UI Route Changes**:
>     - `route.tsx` now imports and uses functions from `datapointOperations.ts`.
>     - Added `parseDatapointFormData` to parse form data into `ParsedDatasetRow`.
>     - Refactored `action` function to use new operations for save and delete actions.
> <sup>This description was created by </sup>[<img src="https://img.shields.io/badge/Ellipsis-blue?color=175173" alt="Ellipsis"><sup> for 1c8dcf9663baba577d86f0179fcf3c08e060bec7. You can customize this summary. It will automatically update as commits are pushed.</sup>](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)

<!-- ELLIPSIS_HIDDEN -->