### PR TITLE
Switch OpenRouter tests to gpt-4o-mini

### DIFF
--- a/tensorzero-core/tests/e2e/providers/openrouter.rs
+++ b/tensorzero-core/tests/e2e/providers/openrouter.rs
@@ -19,7 +19,7 @@ async fn get_providers() -> E2ETestProviders {
     let standard_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "openrouter".to_string(),
-        model_name: "gpt_4_1_mini_openrouter".into(),
+        model_name: "gpt_4_o_mini_openrouter".into(),
         model_provider_name: "openrouter".into(),
         credentials: HashMap::new(),
     }];
@@ -27,7 +27,7 @@ async fn get_providers() -> E2ETestProviders {
     let extra_body_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "openrouter-extra-body".to_string(),
-        model_name: "gpt_4_1_mini_openrouter".into(),
+        model_name: "gpt_4_o_mini_openrouter".into(),
         model_provider_name: "openrouter".into(),
         credentials: HashMap::new(),
     }];
@@ -35,7 +35,7 @@ async fn get_providers() -> E2ETestProviders {
     let bad_auth_extra_headers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "openrouter-extra-headers".to_string(),
-        model_name: "gpt_4_1_mini_openrouter".into(),
+        model_name: "gpt_4_o_mini_openrouter".into(),
         model_provider_name: "openrouter".into(),
         credentials: HashMap::new(),
     }];
@@ -43,7 +43,7 @@ async fn get_providers() -> E2ETestProviders {
     let inference_params_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "openrouter".to_string(),
-        model_name: "gpt_4_1_mini_openrouter".into(),
+        model_name: "gpt_4_o_mini_openrouter".into(),
         model_provider_name: "openrouter".into(),
         credentials: credentials.clone(),
     }];
@@ -51,7 +51,7 @@ async fn get_providers() -> E2ETestProviders {
     let inference_params_dynamic_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "openrouter-dynamic".to_string(),
-        model_name: "gpt_4_1_mini_openrouter_dynamic".into(),
+        model_name: "gpt_4_o_mini_openrouter_dynamic".into(),
         model_provider_name: "openrouter".into(),
         credentials,
     }];
@@ -60,21 +60,21 @@ async fn get_providers() -> E2ETestProviders {
         E2ETestProvider {
             supports_batch_inference: false,
             variant_name: "openrouter".to_string(),
-            model_name: "gpt_4_1_mini_openrouter".into(),
+            model_name: "gpt_4_o_mini_openrouter".into(),
             model_provider_name: "openrouter".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             supports_batch_inference: false,
             variant_name: "openrouter-implicit".to_string(),
-            model_name: "gpt_4_1_mini_openrouter".into(),
+            model_name: "gpt_4_o_mini_openrouter".into(),
             model_provider_name: "openrouter".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             supports_batch_inference: false,
             variant_name: "openrouter-strict".to_string(),
-            model_name: "gpt_4_1_mini_openrouter".into(),
+            model_name: "gpt_4_o_mini_openrouter".into(),
             model_provider_name: "openrouter".into(),
             credentials: HashMap::new(),
         },
@@ -83,7 +83,7 @@ async fn get_providers() -> E2ETestProviders {
     let shorthand_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "openrouter-shorthand".to_string(),
-        model_name: "openrouter::openai/gpt-4.1".to_string(),
+        model_name: "openrouter::openai/gpt-4o-mini".to_string(),
         model_provider_name: "openrouter".into(),
         credentials: HashMap::new(),
     }];

--- a/tensorzero-core/tests/e2e/tensorzero.toml
+++ b/tensorzero-core/tests/e2e/tensorzero.toml
@@ -505,19 +505,19 @@ model_name = "deepseek-ai/DeepSeek-R1"
 
 ## OpenRouter
 
-[models.gpt_4_1_mini_openrouter]
+[models.gpt_4_o_mini_openrouter]
 routing = ["openrouter"]
 
-[models.gpt_4_1_mini_openrouter.providers.openrouter]
+[models.gpt_4_o_mini_openrouter.providers.openrouter]
 type = "openrouter"
-model_name = "openai/gpt-4.1-mini"
+model_name = "openai/gpt-4o-mini"
 
-[models.gpt_4_1_mini_openrouter_dynamic]
+[models.gpt_4_o_mini_openrouter_dynamic]
 routing = ["openrouter"]
 
-[models.gpt_4_1_mini_openrouter_dynamic.providers.openrouter]
+[models.gpt_4_o_mini_openrouter_dynamic.providers.openrouter]
 type = "openrouter"
-model_name = "openai/gpt-4.1-mini"
+model_name = "openai/gpt-4o-mini"
 api_key_location = "dynamic::openrouter_api_key"
 
 [functions.inference_ttft_chat]
@@ -1388,20 +1388,20 @@ extra_body = [{ pointer = "/reasoning_effort", value = "low" }]
 
 [functions.basic_test.variants.openrouter]
 type = "chat_completion"
-model = "gpt_4_1_mini_openrouter"
+model = "gpt_4_o_mini_openrouter"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 
 [functions.basic_test.variants.openrouter-extra-body]
 type = "chat_completion"
-model = "gpt_4_1_mini_openrouter"
+model = "gpt_4_o_mini_openrouter"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 extra_body = [{ pointer = "/temperature", value = 0.123 }]
 
 [functions.basic_test.variants.openrouter-extra-headers]
 type = "chat_completion"
-model = "gpt_4_1_mini_openrouter"
+model = "gpt_4_o_mini_openrouter"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 extra_headers = [
@@ -1410,13 +1410,13 @@ extra_headers = [
 
 [functions.basic_test.variants.openrouter-dynamic]
 type = "chat_completion"
-model = "gpt_4_1_mini_openrouter_dynamic"
+model = "gpt_4_o_mini_openrouter_dynamic"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 
 [functions.basic_test.variants.openrouter-shorthand]
 type = "chat_completion"
-model = "openrouter::openai/gpt-4.1"
+model = "openrouter::openai/gpt-4o-mini"
 system_template = "../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 
@@ -2114,7 +2114,7 @@ json_mode = "strict"
 
 [functions.json_success.variants.openrouter]
 type = "chat_completion"
-model = "gpt_4_1_mini_openrouter"
+model = "gpt_4_o_mini_openrouter"
 system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "implicit_tool"
@@ -2122,7 +2122,7 @@ max_tokens = 100
 
 [functions.json_success.variants.openrouter-implicit]
 type = "chat_completion"
-model = "gpt_4_1_mini_openrouter"
+model = "gpt_4_o_mini_openrouter"
 system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "implicit_tool"
@@ -2130,7 +2130,7 @@ max_tokens = 100
 
 [functions.json_success.variants.openrouter-strict]
 type = "chat_completion"
-model = "gpt_4_1_mini_openrouter"
+model = "gpt_4_o_mini_openrouter"
 system_template = "../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "strict"
@@ -2782,7 +2782,7 @@ json_mode = "strict"
 
 [functions.dynamic_json.variants.openrouter]
 type = "chat_completion"
-model = "gpt_4_1_mini_openrouter"
+model = "gpt_4_o_mini_openrouter"
 system_template = "../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 json_mode = "on"
@@ -2790,7 +2790,7 @@ max_tokens = 100
 
 [functions.dynamic_json.variants.openrouter-strict]
 type = "chat_completion"
-model = "gpt_4_1_mini_openrouter"
+model = "gpt_4_o_mini_openrouter"
 system_template = "../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 max_tokens = 100
@@ -2798,7 +2798,7 @@ json_mode = "strict"
 
 [functions.dynamic_json.variants.openrouter-implicit]
 type = "chat_completion"
-model = "gpt_4_1_mini_openrouter"
+model = "gpt_4_o_mini_openrouter"
 system_template = "../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 json_mode = "implicit_tool"
@@ -3151,7 +3151,7 @@ max_tokens = 1000
 
 [functions.weather_helper.variants.openrouter]
 type = "chat_completion"
-model = "gpt_4_1_mini_openrouter"
+model = "gpt_4_o_mini_openrouter"
 system_template = "../../fixtures/config/functions/weather_helper/prompt/system_template.minijinja"
 max_tokens = 100
 
@@ -3203,7 +3203,7 @@ max_tokens = 1000
 [functions.weather_helper_parallel.variants.openrouter]
 type = "chat_completion"
 weight = 1
-model = "gpt_4_1_mini_openrouter"
+model = "gpt_4_o_mini_openrouter"
 system_template = "../../fixtures/config/functions/weather_helper_parallel/prompt/system_template.minijinja"
 
 [functions.weather_helper_parallel.variants.anthropic]


### PR DESCRIPTION
This fixes the stop-sequences tests, as it looks like OpenRouter has broken stop sequences for gpt-4.1-mini
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switches OpenRouter tests to use `gpt-4o-mini` model to fix stop-sequence issues.
> 
>   - **Behavior**:
>     - Switches model in OpenRouter tests from `gpt-4.1-mini` to `gpt-4o-mini` to fix stop-sequence issues.
>   - **Code Changes**:
>     - Updates `model_name` in `openrouter.rs` for multiple `E2ETestProvider` instances.
>     - Updates model configurations in `tensorzero.toml` to use `gpt-4o-mini` instead of `gpt-4.1-mini`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d568d7bfaeeba726afcd9c163369d8e7fe091d36. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->