### PR TITLE
Attach status/error information to top-level HTTP OTEL span

### DIFF
--- a/tensorzero-core/src/error.rs
+++ b/tensorzero-core/src/error.rs
@@ -1376,14 +1376,19 @@ impl std::fmt::Display for ErrorDetails {
 impl IntoResponse for Error {
     /// Log the error and convert it into an Axum response
     fn into_response(self) -> Response {
+        let message = self.to_string();
         let mut body = json!({
-            "error": self.to_string(),
+            "error": message,
         });
         if *UNSTABLE_ERROR_JSON.get().unwrap_or(&false) {
             body["error_json"] =
                 serde_json::to_value(self.get_details()).unwrap_or_else(|e| json!(e.to_string()));
         }
-        (self.status_code(), Json(body)).into_response()
+        let mut response = (self.status_code(), Json(body)).into_response();
+        // Attach the error to the response, so that we can set a nice message in our
+        // `apply_otel_http_trace_layer` middleware
+        response.extensions_mut().insert(self);
+        response
     }
 }
 

--- a/tensorzero-core/src/observability/mod.rs
+++ b/tensorzero-core/src/observability/mod.rs
@@ -45,6 +45,7 @@
 //!   to our `make_span` function.
 //! * The OpenTelemetry `Context`, which is captured by the `tracing-opentelemetry` library when we create a new span,
 //!   and passed along to `TracerWrapper::build_with_context` when the span is closed and exported.
+use std::borrow::Cow;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::time::Duration;
@@ -58,6 +59,7 @@ use http::HeaderMap;
 use metrics::{describe_counter, Unit};
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use moka::sync::Cache;
+use opentelemetry::trace::Status;
 use opentelemetry::trace::{Tracer, TracerProvider as _};
 use opentelemetry::{Context, KeyValue};
 use opentelemetry_otlp::tonic_types::metadata::MetadataMap;
@@ -69,9 +71,7 @@ use std::str::FromStr;
 use tokio_util::task::TaskTracker;
 use tonic::metadata::AsciiMetadataKey;
 use tonic::metadata::MetadataValue;
-use tower_http::trace::{
-    DefaultOnEos, DefaultOnFailure, DefaultOnRequest, DefaultOnResponse, TraceLayer,
-};
+use tower_http::trace::{DefaultOnEos, DefaultOnFailure, DefaultOnRequest, TraceLayer};
 use tracing::level_filters::LevelFilter;
 use tracing::{Level, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -527,6 +527,27 @@ impl<S: Clone + Send + Sync + 'static> RouterExt<S> for Router<S> {
             );
             span
         }
+
+        // This cannot be a closure due to an annoying closure lifetime inference issue
+        fn handle_response<B>(res: &Response<B>, _duration: Duration, span: &Span) {
+            // We cast this to an i64, so that tracing-opentelemetry will record it as an integer
+            // rather than a string
+            span.record("http.response.status_code", res.status().as_u16() as i64);
+            if res.status().is_server_error() {
+                if let Some(error) = res.extensions().get::<Error>() {
+                    span.set_status(Status::Error {
+                        description: Cow::Owned(error.to_string()),
+                    });
+                } else {
+                    // Don't set a description for non-TensorZero errors,
+                    // since we don't know what a nice description should look like
+                    span.set_status(Status::Error {
+                        description: Cow::Owned(String::new()),
+                    });
+                }
+            }
+        }
+
         self.layer(
             TraceLayer::new_for_http()
                 .make_span_with(make_span)
@@ -535,9 +556,13 @@ impl<S: Clone + Send + Sync + 'static> RouterExt<S> for Router<S> {
                 // (this will also suppress them from OTEL in production, which is fine)
                 .on_request(DefaultOnRequest::new().level(Level::TRACE))
                 .on_failure(DefaultOnFailure::new().level(Level::TRACE))
-                .on_response(DefaultOnResponse::new().level(Level::TRACE))
+                .on_response(handle_response)
                 .on_eos(DefaultOnEos::new().level(Level::TRACE)),
         )
+        // Note - we intentionally apply this layer *after* the `TraceLayer`
+        // As a result, if we reject a request due to a failure to parse custom OTLP headers,
+        // we will *not* create an OpenTelemetry span. Custom headers can be required to correctly
+        // process an OpenTelemetry span (e.g. to set the Arize API key), so this is correct behavior.
         .layer(middleware::from_fn(tensorzero_otlp_headers_middleware))
     }
 }

--- a/tensorzero-core/tests/e2e/otel_export.rs
+++ b/tensorzero-core/tests/e2e/otel_export.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use base64::prelude::*;
+use chrono::DateTime;
 use chrono::Utc;
 use http::StatusCode;
 use opentelemetry::SpanId;
@@ -66,14 +67,160 @@ async fn test_otel_export_trace_export_with_custom_header() {
     }
 }
 
+#[tokio::test]
+async fn test_otel_export_http_error() {
+    let client = reqwest::Client::new();
+    let episode_id = Uuid::now_v7();
+
+    let payload = json!({
+        "episode_id": episode_id,
+        "model_name": "openai::missing-model-name",
+        "input":
+            {
+               "messages": [
+                {
+                    "role": "user",
+                    "content": "What is the name of the capital city of Japan?"
+                }
+            ]},
+        "stream": false,
+        "tags": {"foo": "bar"},
+    });
+
+    let start_time = Utc::now();
+
+    let response = client
+        .post(get_gateway_endpoint("/inference"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    let _response_json = response.json::<Value>().await.unwrap();
+
+    let (function_inference_span, span_by_id) =
+        get_tempo_spans(episode_id, start_time, &Semaphore::new(1)).await;
+
+    let parent_id = function_inference_span["parentSpanId"].as_str().unwrap();
+    let parent_span = span_by_id.get(parent_id).unwrap();
+
+    let parent_attrs: HashMap<&str, serde_json::Value> = parent_span["attributes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|a| (a["key"].as_str().unwrap(), a["value"].clone()))
+        .collect();
+
+    println!("Parent attrs: {parent_attrs:?}");
+
+    assert_eq!(parent_span["name"], "POST /inference");
+    assert_eq!(parent_attrs["level"]["stringValue"], "INFO");
+    assert_eq!(parent_attrs["http.response.status_code"]["intValue"], "502");
+    assert_eq!(parent_span["status"]["code"], "STATUS_CODE_ERROR");
+    assert!(
+        parent_span["status"]["message"]
+            .as_str()
+            .unwrap()
+            .starts_with("All variants failed with errors: openai::missing-model-name"),
+        "Unexpected span error message: {}",
+        parent_span["status"]["message"].as_str().unwrap()
+    );
+}
+
+async fn get_tempo_spans(
+    episode_id: Uuid,
+    start_time: DateTime<Utc>,
+    tempo_semaphore: &Semaphore,
+) -> (Value, HashMap<String, Value>) {
+    // It takes some time for the span to show up in Tempo
+    tokio::time::sleep(std::time::Duration::from_secs(25)).await;
+
+    let start_time = start_time.timestamp();
+    let now = Utc::now().timestamp();
+
+    let client = reqwest::Client::new();
+
+    let tempo_base_url = std::env::var("TENSORZERO_TEMPO_URL")
+        .unwrap_or_else(|_| "http://localhost:3200".to_string());
+
+    let get_url = Url::parse(&format!(
+        "{tempo_base_url}/api/search?tags=episode_id={episode_id}&start={start_time}&end={now}"
+    ))
+    .unwrap();
+    println!("Requesting URL: {get_url}");
+
+    let permit = tempo_semaphore.acquire().await.unwrap();
+
+    let jaeger_result = client.get(get_url).send().await.unwrap();
+    let res = jaeger_result.text().await.unwrap();
+    println!("Tempo result: {res}");
+    let tempo_traces = serde_json::from_str::<Value>(&res).unwrap();
+    let trace_id = tempo_traces["traces"][0]["traceID"].as_str().unwrap();
+
+    let trace_res = client
+        .get(format!("{tempo_base_url}/api/traces/{trace_id}"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    drop(permit);
+
+    println!("Trace res: {trace_res}");
+    let trace_data = serde_json::from_str::<Value>(&trace_res).unwrap();
+
+    let mut span_by_id = HashMap::new();
+    let mut target_span = None;
+
+    for batch in trace_data["batches"].as_array().unwrap() {
+        for scope_span in batch["scopeSpans"].as_array().unwrap() {
+            for span in scope_span["spans"].as_array().unwrap() {
+                span_by_id.insert(span["spanId"].as_str().unwrap().to_string(), span.clone());
+                if span["name"] == "function_inference" {
+                    //println!("Found function_inference span: {span:?}");
+                    let attrs = span["attributes"].as_array().unwrap();
+                    for attr in attrs {
+                        if attr["key"].as_str().unwrap() == "function_name" {
+                            assert!(
+                                attr["value"].get("intValue").is_none(),
+                                "Bad span: {span:?}"
+                            );
+                        }
+                        if attr["key"].as_str().unwrap() == "episode_id" {
+                            let inference_id_jaeger =
+                                attr["value"]["stringValue"].as_str().unwrap();
+                            if episode_id.to_string() == inference_id_jaeger {
+                                if target_span.is_some() {
+                                    panic!("Found multiple function_inference spans with episode id: {episode_id}");
+                                } else {
+                                    target_span = Some(span.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    (
+        target_span.unwrap_or_else(|| {
+            panic!("No function_inference span found with matching episode: {episode_id}")
+        }),
+        span_by_id,
+    )
+}
+
 // TODO - investigate why this test is sometimes flaky when running locally
 async fn test_otel_export_trace_export(
     existing_trace_parent: Option<ExistingTraceData>,
     custom_header: Option<(String, String)>,
     tempo_semaphore: Arc<Semaphore>,
 ) {
-    let episode_id = Uuid::now_v7();
     let client = reqwest::Client::new();
+    let episode_id = Uuid::now_v7();
 
     let payload = json!({
         "function_name": "basic_test",
@@ -91,7 +238,7 @@ async fn test_otel_export_trace_export(
         "tags": {"foo": "bar"},
     });
 
-    let start_time = Utc::now().timestamp();
+    let start_time = Utc::now();
 
     let mut builder = client
         .post(get_gateway_endpoint("/inference"))
@@ -113,87 +260,12 @@ async fn test_otel_export_trace_export(
 
     // Check that the API response is ok
     assert_eq!(response.status(), StatusCode::OK);
-    let response_json = response.json::<Value>().await.unwrap();
-
-    let inference_id = response_json["inference_id"]
-        .as_str()
-        .expect("inference_id should be a string");
-
-    // It takes some time for the span to show up in Tempo
-    tokio::time::sleep(std::time::Duration::from_secs(25)).await;
-
-    let now = Utc::now().timestamp();
-
-    let jaeger_base_url = std::env::var("TENSORZERO_TEMPO_URL")
-        .unwrap_or_else(|_| "http://localhost:3200".to_string());
-
-    let get_url = Url::parse(&format!(
-        "{jaeger_base_url}/api/search?tags=inference_id={inference_id}&start={start_time}&end={now}"
-    ))
-    .unwrap();
-    println!("Requesting URL: {get_url}");
-
-    let permit = tempo_semaphore.acquire().await.unwrap();
-
-    let jaeger_result = client.get(get_url).send().await.unwrap();
-    let res = jaeger_result.text().await.unwrap();
-    println!("Tempo result: {res}");
-    let tempo_traces = serde_json::from_str::<Value>(&res).unwrap();
-    let trace_id = tempo_traces["traces"][0]["traceID"].as_str().unwrap();
-
-    let trace_res = client
-        .get(format!("{jaeger_base_url}/api/traces/{trace_id}"))
-        .send()
-        .await
-        .unwrap()
-        .text()
-        .await
-        .unwrap();
-
-    drop(permit);
-
-    println!("Trace res: {trace_res}");
-    let trace_data = serde_json::from_str::<Value>(&trace_res).unwrap();
-
-    let mut span_by_id = HashMap::new();
-    let mut target_span = None;
-
-    for batch in trace_data["batches"].as_array().unwrap() {
-        for scope_span in batch["scopeSpans"].as_array().unwrap() {
-            for span in scope_span["spans"].as_array().unwrap() {
-                span_by_id.insert(span["spanId"].as_str().unwrap(), span.clone());
-                if span["name"] == "function_inference" {
-                    //println!("Found function_inference span: {span:?}");
-                    let attrs = span["attributes"].as_array().unwrap();
-                    for attr in attrs {
-                        if attr["key"].as_str().unwrap() == "function_name" {
-                            assert!(
-                                attr["value"].get("intValue").is_none(),
-                                "Bad span: {span:?}"
-                            );
-                        }
-                        if attr["key"].as_str().unwrap() == "inference_id" {
-                            let inference_id_jaeger =
-                                attr["value"]["stringValue"].as_str().unwrap();
-                            if inference_id == inference_id_jaeger {
-                                if target_span.is_some() {
-                                    panic!("Found multiple function_inference spans with inference id: {inference_id}");
-                                } else {
-                                    target_span = Some(span.clone());
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+    let _response_json = response.json::<Value>().await.unwrap();
+    let (function_inference_span, span_by_id) =
+        get_tempo_spans(episode_id, start_time, &tempo_semaphore).await;
 
     // Just check a couple of spans - we already have more comprehensive tests that check the exact spans
     // send to the global `opentelemetry` exporter.
-    let function_inference_span = target_span.unwrap_or_else(|| {
-        panic!("No function_inference span found with matching inference_id: {inference_id}")
-    });
     assert_eq!(function_inference_span["name"], "function_inference");
     assert_eq!(function_inference_span["kind"], "SPAN_KIND_INTERNAL");
     let attrs: HashMap<&str, serde_json::Value> = function_inference_span["attributes"]
@@ -229,6 +301,8 @@ async fn test_otel_export_trace_export(
             "Bad parent attrs: {parent_attrs:?}"
         );
     }
+    println!("Parent attrs: {parent_attrs:?}");
+    assert_eq!(parent_attrs["http.response.status_code"]["intValue"], "200");
 
     if let Some(existing_trace_parent) = existing_trace_parent {
         // Tempo returns a base64-encoded binary trace ID, so we need to decode it


### PR DESCRIPTION
This will now cause the top-level OTEL span to be marked with an error if we produce an HTTP 5xx error (which matches the OpenTelemetry HTTP semantic conventions)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Attach error information to top-level OTEL span for HTTP 5xx errors, marking them as errors in OpenTelemetry spans.
> 
>   - **Behavior**:
>     - Attach error information to top-level OTEL span for HTTP 5xx errors in `error.rs`.
>     - Mark OTEL span with error status in `observability/mod.rs` if HTTP 5xx error occurs.
>   - **Functions**:
>     - Modify `into_response()` in `error.rs` to attach error to response extensions.
>     - Add `handle_response()` in `observability/mod.rs` to set span status based on response.
>   - **Tests**:
>     - Add `test_otel_export_http_error()` in `otel_export.rs` to verify span error marking for HTTP 5xx responses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f9006c110d51cdd39ea76c1b2be282a3a5006773. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->