### PR TITLE
Use workspace dependencies everywhere and enforce with 'cargo deny'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ http = "1.3.1"
 tokio-stream = "0.1.15"
 tokio = { version = "1.46.1", features = ["full"] }
 tracing = { version = "0.1.40", features = ["log"] }
+tokio-util = { version = "0.7.15" }
 pyo3 = { version = "0.26.0", features = ["experimental-async", "abi3-py39"] }
 axum = { version = "0.8", features = ["macros", "http2"] }
 anyhow = "1.0.99"
@@ -71,6 +72,18 @@ mime = { git = "https://github.com/hyperium/mime", rev = "1ef137c7358fc64e07c8a6
 ] }
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "tls-rustls", "postgres", "migrate", "chrono", "uuid"] }
 rlt = "0.2.1"
+base64 = "0.22.1"
+bytes = { version = "1.10.0" }
+eventsource-stream = "0.2.3"
+hex = "0.4.3"
+http-body-util = "0.1.3"
+mimalloc = "0.1.48"
+moka = { version = "0.12.10", features = ["sync"] }
+paste = "1.0.15"
+pin-project = "1.1.10"
+sha2 = "0.10.9"
+tempfile = "3.21.0"
+thiserror = "2.0.16"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -23,7 +23,7 @@ tokio-stream = { workspace = true }
 tensorzero-core = { path = "../../tensorzero-core" }
 ts-rs = { workspace = true }
 url = { workspace = true }
-thiserror = "2.0.16"
+thiserror = { workspace = true }
 pyo3 = { workspace = true, optional = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
@@ -32,9 +32,9 @@ git2 = { workspace = true }
 serde_path_to_error = { workspace = true }
 tensorzero-derive = { path = "../../internal/tensorzero-derive" }
 mime = { workspace = true }
-tokio-util = "0.7.15"
-tempfile = { version = "3.21.0", optional = true }
-paste = { version = "1.0.15", optional = true }
+tokio-util = { workspace = true }
+tempfile = { workspace = true, optional = true }
+paste = { workspace = true, optional = true }
 
 [lints]
 workspace = true
@@ -44,8 +44,7 @@ clap = { workspace = true }
 lazy_static = { workspace = true }
 object_store = { workspace = true }
 tokio = { workspace = true }
-tracing = "0.1.41"
-tracing-subscriber = "0.3.20"
+tracing-subscriber = { workspace = true }
 tracing-test = { workspace = true }
 
 [features]

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,12 @@ deny = [
     { name = "openssl" },
     { name = "openssl-sys"}
 ]
+# We have lots of transitive dependencies with multiple versions,
+# so this check isn't useful for us.
+multiple-versions = "allow"
+workspace-dependencies.duplicates = "deny"
+workspace-dependencies.include-path-dependencies = false
+
 
 [advisories]
 ignore = [

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -8,19 +8,19 @@ license.workspace = true
 [dependencies]
 tensorzero-core = { path = "../tensorzero-core" }
 axum = { workspace = true }
-tracing = { version = "0.1.40", features = ["log", "release_max_level_debug"] }
-tracing-subscriber = { version = "0.3.20", features = [
+tracing = { workspace = true, features = ["log", "release_max_level_debug"] }
+tracing-subscriber = { workspace = true, features = [
     "env-filter",
     "fmt",
     "json",
 ] }
 tokio = { workspace = true }
-mimalloc = "0.1.48"
+mimalloc = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 tracing-opentelemetry-instrumentation-sdk = { workspace = true }
 tower-http = { workspace = true }
-tokio-util = "0.7.15"
+tokio-util = { workspace = true }
 
 [lints]
 workspace = true
@@ -31,6 +31,6 @@ default = []
 
 [dev-dependencies]
 reqwest.workspace = true
-tempfile = "3.21.0"
+tempfile = { workspace = true }
 tensorzero = { path = "../clients/rust" }
-tracing-test = "0.2"
+tracing-test = { workspace = true }

--- a/provider-proxy/Cargo.toml
+++ b/provider-proxy/Cargo.toml
@@ -11,27 +11,27 @@ path = "tests/e2e/tests.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-bytes = { version = "1.10.0", features = ["serde"] }
-clap = { version = "4.5.46", features = ["derive"] }
-hex = "0.4.3"
-http = "1.2.0"
-http-body-util = "0.1.2"
+bytes = { workspace = true, features = ["serde"] }
+clap = { workspace = true }
+hex = { workspace = true }
+http = { workspace = true }
+http-body-util = { workspace = true }
 http-serde-ext = "1.0.2"
 hyper = { version = "1.7.0", features = ["client", "server", "http1", "http2"] }
 hyper-util = "0.1.15"
-moka = { version = "0.12.10", features = ["sync"] }
-pin-project = "1.1.10"
+moka = { workspace = true }
+pin-project = { workspace = true }
 rcgen = "0.14.2"
 reqwest.workspace = true
 rustls = "0.23.29"
 serde = { workspace = true }
 serde_json.workspace = true
-sha2 = "0.10.9"
+sha2 = { workspace = true }
 tokio.workspace = true
 tokio-rustls = "0.26.1"
-tracing = "0.1.41"
+tracing = { workspace = true }
 tracing-subscriber.workspace = true
-tempfile = "3.21.0"
+tempfile = { workspace = true }
 
 
 [lints]
@@ -39,4 +39,4 @@ workspace = true
 
 [dev-dependencies]
 axum.workspace = true
-rand = "0.9.1"
+rand = { workspace = true }

--- a/tensorzero-core/Cargo.toml
+++ b/tensorzero-core/Cargo.toml
@@ -51,12 +51,12 @@ aws-types = "1.3.6"
 axum = { workspace = true }
 backon = { version = "1.5.1", features = ["tokio-sleep"] }
 blake3 = "1.8.2"
-bytes = "1.6.1"
+bytes = { workspace = true }
 chrono = { workspace = true }
 derive_builder = "0.20.0"
 futures = { workspace = true }
 futures-core = "0.3.30"
-hex = "0.4.3"
+hex = { workspace = true }
 itertools = "0.14.0"
 jsonschema = "0.33.0"
 jsonwebtoken = "9.3.1"
@@ -82,14 +82,14 @@ serde-untagged = { workspace = true }
 serde_json = { workspace = true }
 http = { workspace = true }
 serde_path_to_error = { workspace = true }
-sha2 = "0.10.9"
+sha2 = { workspace = true }
 strum = { version = "0.27.1", features = ["derive"] }
 strum_macros = "0.27.1"
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 toml = { workspace = true }
 tracing.workspace = true
-tracing-subscriber = { version = "0.3.20", features = [
+tracing-subscriber = { workspace = true, features = [
     "env-filter",
     "fmt",
     "json",
@@ -104,7 +104,7 @@ aws-sdk-sagemakerruntime = { version = "1.84.0", features = [
     "default-https-client",
 ], default-features = false }
 aws-smithy-runtime-api = "1.9.0"
-eventsource-stream = "0.2.3"
+eventsource-stream = { workspace = true }
 scoped-tls = "1.0.1"
 opentelemetry_sdk = "0.30.0"
 opentelemetry = "0.30.0"
@@ -123,29 +123,29 @@ google-cloud-auth = "0.23.0"
 mime = { workspace = true }
 mime_guess = "2.0.5"
 indexmap = "2.11.0"
-base64 = "0.22.1"
-thiserror = "2.0.16"
+base64 = { workspace = true }
+thiserror = { workspace = true }
 glob = "0.3.3"
 enum-map = "2.7.3"
-tokio-util = { version = "0.7.15", features = ["rt"] }
-tempfile = "3.21.0"
+tokio-util = { workspace = true, features = ["rt"] }
+tempfile = { workspace = true }
 ts-rs = { workspace = true }
-moka = { version = "0.12.10", features = ["sync"] }
+moka = { workspace = true }
 tonic = { version = "0.13.1", default-features = false }
 sqlx = { workspace = true }
-pin-project = "1.1.10"
+pin-project = { workspace = true }
 once_cell = "1.21.3"
 
 
 [dev-dependencies]
 tracing-test = { workspace = true }
 tensorzero = { path = "../clients/rust", features = ["e2e_tests"] }
-paste = "1.0.15"
-base64 = "0.22.1"
+paste = { workspace = true }
+base64 = { workspace = true }
 aws-credential-types = { version = "1.2.2", features = [
     "hardcoded-credentials",
 ] }
-http-body-util = "0.1.3"
+http-body-util = { workspace = true }
 urlencoding = "2.1.3"
 image = "0.25.6"
 gag = "1.0.0"

--- a/tensorzero-core/tests/mock-inference-provider/Cargo.toml
+++ b/tensorzero-core/tests/mock-inference-provider/Cargo.toml
@@ -13,7 +13,7 @@ async-stream = { workspace = true }
 axum = { workspace = true, features = ["multipart", "http2"] }
 clap = { workspace = true }
 futures = { workspace = true }
-mimalloc = "0.1.48"
+mimalloc = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tower = { version = "0.5.2", features = ["util"] }
@@ -26,6 +26,6 @@ tower-http = { workspace = true }
 anyhow.workspace = true
 
 [dev-dependencies]
-eventsource-stream = "0.2.3"
+eventsource-stream = { workspace = true }
 reqwest = { workspace = true, features = ["stream"] }
 tokio-stream = { workspace = true }


### PR DESCRIPTION
I also turned off the multiple-versions warnings from cargo-deny, since there's nothing we can do about them