### PR TITLE
Try to fix flaky Playwright word_wrap.spec.test

### DIFF
--- a/ui/e2e_tests/word_wrap.spec.ts
+++ b/ui/e2e_tests/word_wrap.spec.ts
@@ -29,6 +29,8 @@ test("ensure word wrap persists between pages", async ({ page }) => {
   // ensure that it is still set to false on page reload...
   {
     await page.reload();
+    // Sleep to try to fix flakiness. TODO - figure out what event we should wait for.
+    await page.waitForTimeout(1000);
 
     const button = getWordWrapToggle();
     expect(await button.getAttribute("aria-pressed")).toBe("false");


### PR DESCRIPTION
This has repeatedly flaked on CI, slowing down the model-inference-cache ui tests (since we need to re-reun every single test if any of them fail)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add a 1-second delay in `word_wrap.spec.ts` to address test flakiness after page reload.
> 
>   - **Test Stability**:
>     - Adds `await page.waitForTimeout(1000);` in `word_wrap.spec.ts` to address flakiness after page reload.
>     - Comment indicates this is a temporary fix and suggests finding a proper event to wait for.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 36331b3cd740f910d04997103d8cc72831f579b8. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->