### PR TITLE
Attempt to create a macro for reducing napi boilerplate

### DIFF
--- a/internal/tensorzero-node/src/database.rs
+++ b/internal/tensorzero-node/src/database.rs
@@ -17,66 +17,49 @@ impl DatabaseClient {
 
     #[napi]
     pub async fn get_model_usage_timeseries(&self, params: String) -> Result<String, napi::Error> {
-        // TODO: (Aaron?, Viraj?) should we serialize here?
-        // I think we could use native types if we cfged #[napi] into the core codebase.
-        // It will be potentially problematic to serialize every database call twice
-        let GetModelUsageTimeseriesParams {
-            time_window,
-            max_periods,
-        } = serde_json::from_str(&params).map_err(|e| napi::Error::from_reason(e.to_string()))?;
-        let result = self
-            .0
-            .get_model_usage_timeseries(time_window, max_periods)
-            .await
-            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
-        serde_json::to_string(&result).map_err(|e| napi::Error::from_reason(e.to_string()))
+        napi_call!(
+            &self,
+            get_model_usage_timeseries,
+            params,
+            GetModelUsageTimeseriesParams {
+                time_window,
+                max_periods
+            }
+        )
     }
 
     #[napi]
     pub async fn get_model_latency_quantiles(&self, params: String) -> Result<String, napi::Error> {
-        let GetModelLatencyQuantilesParams { time_window } =
-            serde_json::from_str(&params).map_err(|e| napi::Error::from_reason(e.to_string()))?;
-        let result = self
-            .0
-            .get_model_latency_quantiles(time_window)
-            .await
-            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
-        serde_json::to_string(&result).map_err(|e| napi::Error::from_reason(e.to_string()))
+        napi_call!(
+            &self,
+            get_model_latency_quantiles,
+            params,
+            GetModelLatencyQuantilesParams { time_window }
+        )
     }
 
     #[napi]
     pub async fn count_distinct_models_used(&self) -> Result<u32, napi::Error> {
-        let result = self
-            .0
-            .count_distinct_models_used()
-            .await
-            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
-        Ok(result)
+        napi_call_no_deserializing!(&self, count_distinct_models_used)
     }
 
     #[napi]
     pub async fn query_episode_table(&self, params: String) -> Result<String, napi::Error> {
-        let QueryEpisodeTableParams {
-            page_size,
-            before,
-            after,
-        } = serde_json::from_str(&params).map_err(|e| napi::Error::from_reason(e.to_string()))?;
-        let result = self
-            .0
-            .query_episode_table(page_size, before, after)
-            .await
-            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
-        serde_json::to_string(&result).map_err(|e| napi::Error::from_reason(e.to_string()))
+        napi_call!(
+            &self,
+            query_episode_table,
+            params,
+            QueryEpisodeTableParams {
+                page_size,
+                before,
+                after
+            }
+        )
     }
 
     #[napi]
     pub async fn query_episode_table_bounds(&self) -> Result<String, napi::Error> {
-        let bounds = self
-            .0
-            .query_episode_table_bounds()
-            .await
-            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
-        serde_json::to_string(&bounds).map_err(|e| napi::Error::from_reason(e.to_string()))
+        napi_call!(&self, query_episode_table_bounds)
     }
 }
 

--- a/internal/tensorzero-node/src/lib.rs
+++ b/internal/tensorzero-node/src/lib.rs
@@ -7,6 +7,8 @@ use tensorzero::{
     OptimizationJobHandle, QUANTILES,
 };
 
+#[macro_use]
+mod napi_bridge;
 mod database;
 
 #[macro_use]

--- a/internal/tensorzero-node/src/napi_bridge.rs
+++ b/internal/tensorzero-node/src/napi_bridge.rs
@@ -1,0 +1,81 @@
+/// Macro to reduce boilerplate when calling methods defined in tensorzero-core from NAPI
+///
+/// All methods like this exposed to Node will return a string that Node client can deserialize into a response object. They may take no parameters, or take a string serialized from the corresponding JSON request object.
+///
+/// This macro handles:
+/// - Deserializing JSON parameters into a Rust struct
+/// - Calling the method defined in tensorzero-core
+/// - Serializing the result back to JSON
+/// - Error mapping
+///
+/// # Examples
+///
+/// ```ignore
+///     #[napi]
+///     pub async fn get_model_usage_timeseries(&self, params: String) -> Result<String, napi::Error> {
+///         napi_call!(
+///             &self,
+///             get_model_usage_timeseries,
+///             params,
+///             // Rust struct that represents the JSON type exposed to Node.
+///             GetModelUsageTimeseriesParams {
+///                 time_window,
+///                 max_periods
+///             }
+///         )
+///     }
+/// ```
+#[macro_export]
+macro_rules! napi_call {
+    ($self:expr, $method:ident, $params:expr, $param_type:ty { $($field:ident),+ }) => {{
+        let params_struct: $param_type = serde_json::from_str(&$params)
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+        let result = $self.0.$method($(params_struct.$field),+)
+            .await
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+        serde_json::to_string(&result)
+            .map_err(|e| napi::Error::from_reason(e.to_string()))
+    }};
+
+    ($self:expr, $method:ident) => {{
+        let result = $self.0.$method()
+            .await
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+        serde_json::to_string(&result)
+            .map_err(|e| napi::Error::from_reason(e.to_string()))
+    }};
+}
+
+/// Macro to reduce boilerplate when calling methods defined in tensorzero-core from NAPI
+///
+/// All methods like this exposed to Node will return a native Node type. They may take no parameters, or take a string serialized from the corresponding JSON request object.
+///
+/// This macro handles:
+/// - Deserializing JSON parameters into a Rust struct
+/// - Calling the method defined in tensorzero-core
+/// - Error mapping
+///
+/// # Examples
+///
+/// ```ignore
+///     #[napi]
+///     pub async fn count_distinct_models_used(&self) -> Result<u32, napi::Error> {
+///         napi_call_no_deserializing!(&self, count_distinct_models_used)
+///     }
+/// ```
+#[macro_export]
+macro_rules! napi_call_no_deserializing {
+    ($self:expr, $method:ident, $params:expr, $param_type:ty { $($field:ident),+ }) => {{
+        let params_struct: $param_type = serde_json::from_str(&$params)
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+        $self.0.$method($(params_struct.$field),+)
+            .await
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?
+    }};
+
+    ($self:expr, $method:ident) => {
+        $self.0.$method()
+            .await
+            .map_err(|e| napi::Error::from_reason(e.to_string()))
+    };
+}

--- a/internal/tensorzero-node/src/napi_bridge.rs
+++ b/internal/tensorzero-node/src/napi_bridge.rs
@@ -2,13 +2,13 @@
 ///
 /// All methods like this exposed to Node will return a string that Node client can deserialize into a response object. They may take no parameters, or take a string serialized from the corresponding JSON request object.
 ///
-/// This macro handles:
-/// - Deserializing JSON parameters into a Rust struct
+/// This macro has two variants, and handles:
+/// - Deserializing JSON parameters into a Rust struct (if the method takes parameters)
 /// - Calling the method defined in tensorzero-core
 /// - Serializing the result back to JSON
 /// - Error mapping
 ///
-/// # Examples
+/// # Example 1: a method that takes parameters
 ///
 /// ```ignore
 ///     #[napi]
@@ -20,27 +20,87 @@
 ///             // Rust struct that represents the JSON type exposed to Node.
 ///             GetModelUsageTimeseriesParams {
 ///                 time_window,
-///                 max_periods
+///                 max_periods,
 ///             }
 ///         )
 ///     }
 /// ```
+///
+/// This expands into:
+///
+/// ```ignore
+///     #[napi]
+///     pub async fn get_model_usage_timeseries(&self, params: String) -> Result<String, napi::Error> {
+///         let params_struct: GetModelUsageTimeseriesParams = serde_json::from_str(&params)
+///             .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+///         let result = &self.0.get_model_usage_timeseries(time_window, max_periods)
+///             .await
+///             .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+///         serde_json::to_string(&result)
+///             .map_err(|e| napi::Error::from_reason(e.to_string()))
+///     }
+/// ```
+///
+/// # Example 2: a method that doesn't take parameters
+///
+/// ```ignore
+///     #[napi]
+///     pub async fn query_episode_table_bounds(&self) -> Result<String, napi::Error> {
+///         napi_call!(&self, query_episode_table_bounds)
+///     }
+/// ```
+///
+/// This expands into:
+///
+/// ```ignore
+///     #[napi]
+///     pub async fn query_episode_table_bounds(&self) -> Result<String, napi::Error> {
+///         let result = &self.0.query_episode_table_bounds()
+///             .await
+///             .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+///         serde_json::to_string(&result)
+///             .map_err(|e| napi::Error::from_reason(e.to_string()))
+///     }
+/// ```
+///
+/// Note that the order of the struct fields is important: they must match the order of the method's arguments.
 #[macro_export]
 macro_rules! napi_call {
+    // Variant 1: the Rust method takes parameters.
     ($self:expr, $method:ident, $params:expr, $param_type:ty { $($field:ident),+ }) => {{
+        // Deserialize the JSON parameters into a Rust struct.
         let params_struct: $param_type = serde_json::from_str(&$params)
             .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+        // Call the Rust method with the deserialized parameters. We pass each struct field as an argument to the method in the order they are specified.
         let result = $self.0.$method($(params_struct.$field),+)
             .await
             .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+        // Serialize the result back to JSON.
         serde_json::to_string(&result)
             .map_err(|e| napi::Error::from_reason(e.to_string()))
     }};
 
+    // Variant 2: the Rust method takes the whole struct as a parameter, and the struct is re-exported to Node.
+    ($self:expr, $method:ident, $params:expr, $param_type:ty) => {{
+        // Deserialize the JSON parameters into a Rust struct.
+        let params_struct: $param_type = serde_json::from_str(&$params)
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+        // Call the Rust method with the deserialized parameters. We pass the struct as a single argument to the method.
+        let result = $self.0.$method(&params_struct)
+            .await
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+        // Serialize the result back to JSON.
+        serde_json::to_string(&result)
+            .map_err(|e| napi::Error::from_reason(e.to_string()))
+    }};
+
+    // Variant 3: the Rust method doesn't take parameters.
     ($self:expr, $method:ident) => {{
+        // Call the Rust method with no parameters.
         let result = $self.0.$method()
             .await
             .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+        // Serialize the result back to JSON.
         serde_json::to_string(&result)
             .map_err(|e| napi::Error::from_reason(e.to_string()))
     }};
@@ -50,12 +110,14 @@ macro_rules! napi_call {
 ///
 /// All methods like this exposed to Node will return a native Node type. They may take no parameters, or take a string serialized from the corresponding JSON request object.
 ///
-/// This macro handles:
-/// - Deserializing JSON parameters into a Rust struct
+/// This macro has two variants, and handles:
+/// - Deserializing JSON parameters into a Rust struct (if the method takes parameters)
 /// - Calling the method defined in tensorzero-core
 /// - Error mapping
 ///
-/// # Examples
+/// The main difference bewteen `napi_call_no_deserializing` and `napi_call` is that `napi_call_no_deserializing` does not deserialize the response of the tensorzero-core method back into a JSON string. This is useful for methods that return a native Node type.
+///
+/// # Example: a method that doesn't take parameters
 ///
 /// ```ignore
 ///     #[napi]
@@ -63,19 +125,54 @@ macro_rules! napi_call {
 ///         napi_call_no_deserializing!(&self, count_distinct_models_used)
 ///     }
 /// ```
+///
+/// This expands into:
+///
+/// ```ignore
+///     #[napi]
+///     pub async fn count_distinct_models_used(&self) -> Result<u32, napi::Error> {
+///         $self.0.count_distinct_models_used()
+///             .await
+///             .map_err(|e| napi::Error::from_reason(e.to_string()))
+///     }
+/// ```
+///
+/// Note that the order of the struct fields is important: they must match the order of the method's arguments.
 #[macro_export]
 macro_rules! napi_call_no_deserializing {
+    // Variant 1: the Rust method takes parameters.
     ($self:expr, $method:ident, $params:expr, $param_type:ty { $($field:ident),+ }) => {{
+        // Deserialize the JSON parameters into a Rust struct.
         let params_struct: $param_type = serde_json::from_str(&$params)
             .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+        // Call the Rust method with the deserialized parameters. We pass each struct field as an argument to the method in the order they are specified.
         $self.0.$method($(params_struct.$field),+)
             .await
-            .map_err(|e| napi::Error::from_reason(e.to_string()))?
+            .map_err(|e| napi::Error::from_reason(e.to_string()))
+
+        // Result is returned directly as a native Node type.
     }};
 
+    // Variant 2: the Rust method takes the whole struct as a parameter, and the struct is re-exported to Node.
+    ($self:expr, $method:ident, $params:expr, $param_type:ty) => {{
+        // Deserialize the JSON parameters into a Rust struct.
+        let params_struct: $param_type = serde_json::from_str(&$params)
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+        // Call the Rust method with the deserialized parameters. We pass the struct as a single argument to the method.
+        $self.0.$method(&params_struct)
+            .await
+            .map_err(|e| napi::Error::from_reason(e.to_string()))
+
+        // Result is returned directly as a native Node type.
+    }};
+
+    // Variant 3: the Rust method doesn't take parameters.
     ($self:expr, $method:ident) => {
+        // Call the Rust method with no parameters.
         $self.0.$method()
             .await
             .map_err(|e| napi::Error::from_reason(e.to_string()))
+
+        // Result is returned directly as a native Node type.
     };
 }


### PR DESCRIPTION
A step towards https://github.com/tensorzero/tensorzero/issues/3812.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces macros in `napi_bridge.rs` to reduce boilerplate in NAPI functions by handling JSON serialization/deserialization and error mapping, refactoring several methods in `database.rs`.
> 
>   - **Macros**:
>     - Introduces `napi_call!` and `napi_call_no_deserializing!` macros in `napi_bridge.rs` to reduce boilerplate in NAPI functions.
>     - `napi_call!` handles JSON serialization/deserialization and error mapping for methods with and without parameters.
>     - `napi_call_no_deserializing!` is similar but returns native Node types without JSON serialization.
>   - **Refactoring**:
>     - Replaces manual JSON handling in `get_model_usage_timeseries`, `get_model_latency_quantiles`, `count_distinct_models_used`, `query_episode_table`, and `query_episode_table_bounds` in `database.rs` with macro calls.
>   - **Misc**:
>     - Adds `napi_bridge` module to `lib.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 37e0b046d79499dbc2fe5f6fc994d908f86f21c6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->