### PR TITLE
Increase default body limit to 100MB for `patch_openai_client`

### DIFF
--- a/tensorzero-core/src/utils/gateway.rs
+++ b/tensorzero-core/src/utils/gateway.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::db::postgres::PostgresConnectionInfo;
 use crate::endpoints::openai_compatible::RouterExt;
-use axum::extract::{rejection::JsonRejection, FromRequest, Json, Request};
+use axum::extract::{rejection::JsonRejection, DefaultBodyLimit, FromRequest, Json, Request};
 use axum::Router;
 use serde::de::DeserializeOwned;
 use sqlx::postgres::PgPoolOptions;
@@ -345,6 +345,7 @@ pub async fn start_openai_compatible_gateway(
     let router = Router::new()
         .register_openai_compatible_routes()
         .fallback(endpoints::fallback::handle_404)
+        .layer(DefaultBodyLimit::max(100 * 1024 * 1024)) // increase the default body limit from 2MB to 100MB
         .with_state(gateway_handle.app_state.clone());
 
     let (sender, recv) = tokio::sync::oneshot::channel::<()>();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase default body limit from 2MB to 100MB in `start_openai_compatible_gateway()` in `gateway.rs`.
> 
>   - **Behavior**:
>     - Increase default body limit from 2MB to 100MB in `start_openai_compatible_gateway()` in `gateway.rs`.
>   - **Imports**:
>     - Add `DefaultBodyLimit` to imports in `gateway.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 44e318426dca2c842dc32336802c65cd48352616. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->