### PR TITLE
Finish deprecating: rename environment variable CLICKHOUSE_URL to TENSORZERO_CLICKHOUSE_URL

### DIFF
--- a/tensorzero-core/src/db/clickhouse/migration_manager/mod.rs
+++ b/tensorzero-core/src/db/clickhouse/migration_manager/mod.rs
@@ -455,9 +455,6 @@ pub struct RunMigrationArgs<'a, T: Migration + ?Sized> {
 
 pub async fn manual_run_clickhouse_migrations() -> Result<(), Error> {
     let clickhouse_url = std::env::var("TENSORZERO_CLICKHOUSE_URL").ok();
-    if clickhouse_url.as_ref().is_none() && std::env::var("CLICKHOUSE_URL").is_ok() {
-        return Err(ErrorDetails::ClickHouseConfiguration { message: "`CLICKHOUSE_URL` is deprecated and no longer accepted. Please set `TENSORZERO_CLICKHOUSE_URL`".to_string() }.into());
-    }
     let Some(clickhouse_url) = clickhouse_url else {
         return Err(ErrorDetails::ClickHouseConfiguration {
             message: "`TENSORZERO_CLICKHOUSE_URL` was not found.".to_string(),

--- a/tensorzero-core/src/utils/gateway.rs
+++ b/tensorzero-core/src/utils/gateway.rs
@@ -98,12 +98,6 @@ pub type AppState = axum::extract::State<AppStateData>;
 impl GatewayHandle {
     pub async fn new(config: Arc<Config>) -> Result<Self, Error> {
         let clickhouse_url = std::env::var("TENSORZERO_CLICKHOUSE_URL").ok();
-        if clickhouse_url.is_none()
-            && std::env::var("CLICKHOUSE_URL").is_ok()
-            && config.gateway.observability.enabled.is_none()
-        {
-            return Err(ErrorDetails::ClickHouseConfiguration { message: "`CLICKHOUSE_URL` is deprecated and no longer accepted. Please set `TENSORZERO_CLICKHOUSE_URL`".to_string() }.into());
-        }
         let postgres_url = std::env::var("TENSORZERO_POSTGRES_URL").ok();
         Self::new_with_databases(config, clickhouse_url, postgres_url).await
     }


### PR DESCRIPTION
Fix #1244 