### PR TITLE
Remove deprecated OpenAI-compatible API features

### DIFF
--- a/clients/python/tests/test_openai_patch.py
+++ b/clients/python/tests/test_openai_patch.py
@@ -10,45 +10,7 @@ from tensorzero.util import uuid7
 
 
 @pytest.mark.asyncio
-async def test_async_basic_inference_old_model_format_and_headers():
-    async_client = AsyncOpenAI(api_key="donotuse")
-    # Patch the client
-    async_client = await tensorzero.patch_openai_client(
-        async_client,
-        clickhouse_url="http://chuser:chpassword@localhost:8123/tensorzero_e2e_tests",
-        config_file="../../tensorzero-core/tests/e2e/tensorzero.toml",
-        async_setup=True,
-    )
-
-    messages = [
-        {"role": "system", "content": [{"assistant_name": "Alfred Pennyworth"}]},
-        {"role": "user", "content": "Hello"},
-    ]
-
-    episode_id = uuid7()
-
-    result = await async_client.chat.completions.create(
-        extra_headers={"episode_id": str(episode_id)},
-        messages=messages,
-        model="tensorzero::function_name::basic_test",
-        temperature=0.4,
-    )
-    # Verify IDs are valid UUIDs
-    UUID(result.id)  # Will raise ValueError if invalid
-    assert UUID(result.episode_id) == episode_id
-    assert (
-        result.choices[0].message.content
-        == "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."
-    )
-    usage = result.usage
-    assert usage.prompt_tokens == 10
-    assert usage.completion_tokens == 1
-    assert usage.total_tokens == 11
-    assert result.choices[0].finish_reason == "stop"
-
-
-@pytest.mark.asyncio
-async def test_dynamic_json_mode_inference_openai_deprecated():
+async def test_dynamic_json_mode_inference_openai():
     async_client = AsyncOpenAI(api_key="donotuse")
     # Patch the client
     async_client = await tensorzero.patch_openai_client(
@@ -66,10 +28,9 @@ async def test_dynamic_json_mode_inference_openai_deprecated():
         "additionalProperties": False,
     }
     serialized_output_schema = json.dumps(output_schema)
-    # This response format is deprecated and will be rejected in a future TensorZero release.
     response_format = {
         "type": "json_schema",
-        "json_schema": output_schema,
+        "json_schema": {"name": "test", "description": "test", "schema": output_schema},
     }
     messages = [
         {

--- a/tensorzero-core/src/endpoints/openai_compatible.rs
+++ b/tensorzero-core/src/endpoints/openai_compatible.rs
@@ -1411,7 +1411,7 @@ mod tests {
         let tensorzero_tags = HashMap::from([("test".to_string(), "test".to_string())]);
         let params = Params::try_from_openai(OpenAICompatibleParams {
             messages,
-            model: "tensorzero::test_function".into(),
+            model: "tensorzero::function_name::test_function".into(),
             frequency_penalty: Some(0.5),
             max_tokens: Some(100),
             max_completion_tokens: Some(50),

--- a/tensorzero-core/src/endpoints/openai_compatible.rs
+++ b/tensorzero-core/src/endpoints/openai_compatible.rs
@@ -13,7 +13,6 @@ use std::collections::HashMap;
 use axum::body::Body;
 use axum::debug_handler;
 use axum::extract::State;
-use axum::http::HeaderMap;
 use axum::response::sse::{Event, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
@@ -80,7 +79,6 @@ pub async fn inference_handler(
         postgres_connection_info,
         ..
     }): AppState,
-    headers: HeaderMap,
     StructuredJson(openai_compatible_params): StructuredJson<OpenAICompatibleParams>,
 ) -> Result<Response<Body>, Error> {
     if !openai_compatible_params.unknown_fields.is_empty() {
@@ -107,7 +105,7 @@ pub async fn inference_handler(
         );
     }
     let stream_options = openai_compatible_params.stream_options;
-    let params = Params::try_from_openai(headers, openai_compatible_params)?;
+    let params = Params::try_from_openai(openai_compatible_params)?;
 
     // The prefix for the response's `model` field depends on the inference target
     // (We run this disambiguation deep in the `inference` call below but we don't get the decision out, so we duplicate it here)
@@ -331,21 +329,8 @@ enum OpenAICompatibleMessage {
 #[serde(rename_all = "snake_case")]
 enum OpenAICompatibleResponseFormat {
     Text,
-    JsonSchema { json_schema: JsonSchemaInfoOption },
+    JsonSchema { json_schema: JsonSchemaInfo },
     JsonObject,
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(untagged)]
-enum JsonSchemaInfoOption {
-    JsonSchema(JsonSchemaInfo),
-    DeprecatedJsonSchema(Value),
-}
-
-impl std::fmt::Display for JsonSchemaInfoOption {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{self:?}")
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -642,10 +627,7 @@ const TENSORZERO_MODEL_NAME_PREFIX: &str = "tensorzero::model_name::";
 const TENSORZERO_EMBEDDING_MODEL_NAME_PREFIX: &str = "tensorzero::embedding_model_name::";
 
 impl Params {
-    fn try_from_openai(
-        headers: HeaderMap,
-        openai_compatible_params: OpenAICompatibleParams,
-    ) -> Result<Self, Error> {
+    fn try_from_openai(openai_compatible_params: OpenAICompatibleParams) -> Result<Self, Error> {
         let (function_name, model_name) = if let Some(function_name) = openai_compatible_params
             .model
             .strip_prefix(TENSORZERO_FUNCTION_NAME_PREFIX)
@@ -656,14 +638,6 @@ impl Params {
             .strip_prefix(TENSORZERO_MODEL_NAME_PREFIX)
         {
             (None, Some(model_name.to_string()))
-        } else if let Some(function_name) =
-            openai_compatible_params.model.strip_prefix("tensorzero::")
-        {
-            tracing::warn!(
-                function_name = function_name,
-                "Deprecation Warning: Please set the `model` parameter to `tensorzero::function_name::your_function` instead of `tensorzero::your_function.` The latter will be removed in a future release."
-            );
-            (Some(function_name.to_string()), None)
         } else {
             return Err(Error::new(ErrorDetails::InvalidOpenAICompatibleRequest {
                 message: "`model` field must start with `tensorzero::function_name::` or `tensorzero::model_name::`. For example, `tensorzero::function_name::my_function` for a function `my_function` defined in your config, `tensorzero::model_name::my_model` for a model `my_model` defined in your config, or default functions like `tensorzero::model_name::openai::gpt-4o-mini`.".to_string(),
@@ -690,26 +664,6 @@ impl Params {
             }
         }
 
-        let header_episode_id = headers
-            .get("episode_id")
-            .map(|h| {
-                tracing::warn!("Deprecation Warning: Please use the `tensorzero::episode_id` field instead of the `episode_id` header. The header will be removed in a future release.");
-                h.to_str()
-                    .map_err(|_| {
-                        Error::new(ErrorDetails::InvalidOpenAICompatibleRequest {
-                            message: "episode_id header is not valid UTF-8".to_string(),
-                        })
-                    })
-                    .and_then(|s| {
-                        Uuid::parse_str(s).map_err(|_| {
-                            Error::new(ErrorDetails::InvalidTensorzeroUuid {
-                                kind: "Episode".to_string(),
-                                message: "episode_id header is not a valid UUID".to_string(),
-                            })
-                        })
-                    })
-            })
-            .transpose()?;
         // If both max_tokens and max_completion_tokens are provided, we use the minimum of the two.
         // Otherwise, we use the provided value, or None if neither is provided.
         let max_tokens = match (
@@ -745,38 +699,6 @@ impl Params {
         let inference_params = InferenceParams {
             chat_completion: chat_completion_inference_params,
         };
-        let header_variant_name = headers
-            .get("variant_name")
-            .map(|h| {
-                tracing::warn!("Deprecation Warning: Please use the `tensorzero::variant_name` field instead of the `variant_name` header. The header will be removed in a future release.");
-                h.to_str()
-                    .map_err(|_| {
-                        Error::new(ErrorDetails::InvalidOpenAICompatibleRequest {
-                            message: "variant_name header is not valid UTF-8".to_string(),
-                        })
-                    })
-                    .map(str::to_string)
-            })
-            .transpose()?;
-        let header_dryrun = headers
-            .get("dryrun")
-            .map(|h| {
-                tracing::warn!("Deprecation Warning: Please use the `tensorzero::dryrun` field instead of the `dryrun` header. The header will be removed in a future release.");
-                h.to_str()
-                    .map_err(|_| {
-                        Error::new(ErrorDetails::InvalidOpenAICompatibleRequest {
-                            message: "dryrun header is not valid UTF-8".to_string(),
-                        })
-                    })
-                    .and_then(|s| {
-                        s.parse::<bool>().map_err(|_| {
-                            Error::new(ErrorDetails::InvalidOpenAICompatibleRequest {
-                                message: "dryrun header is not a valid boolean".to_string(),
-                            })
-                        })
-                    })
-            })
-            .transpose()?;
         let OpenAICompatibleToolChoiceParams {
             allowed_tools,
             tool_choice,
@@ -793,28 +715,18 @@ impl Params {
             parallel_tool_calls: openai_compatible_params.parallel_tool_calls,
         };
         let output_schema = match openai_compatible_params.response_format {
-            Some(OpenAICompatibleResponseFormat::JsonSchema { json_schema }) => match json_schema {
-                JsonSchemaInfoOption::JsonSchema(json_schema) => json_schema.schema,
-                JsonSchemaInfoOption::DeprecatedJsonSchema(value) => {
-                    tracing::warn!("Deprecation Warning: Please provide the correct `name`, `description`, `schema`, and `strict` fields in the `json_schema` field in the response format. Simply providing a JSON schema in this field will be rejected in a future TensorZero release.");
-                    Some(value)
-                }
-            },
+            Some(OpenAICompatibleResponseFormat::JsonSchema { json_schema }) => json_schema.schema,
             _ => None,
         };
         Ok(Params {
             function_name,
             model_name,
-            episode_id: openai_compatible_params
-                .tensorzero_episode_id
-                .or(header_episode_id),
+            episode_id: openai_compatible_params.tensorzero_episode_id,
             input,
             stream: openai_compatible_params.stream,
             params: inference_params,
-            variant_name: openai_compatible_params
-                .tensorzero_variant_name
-                .or(header_variant_name),
-            dryrun: openai_compatible_params.tensorzero_dryrun.or(header_dryrun),
+            variant_name: openai_compatible_params.tensorzero_variant_name,
+            dryrun: openai_compatible_params.tensorzero_dryrun,
             dynamic_tool_params,
             output_schema,
             credentials: openai_compatible_params.tensorzero_credentials,
@@ -1483,7 +1395,6 @@ fn prepare_serialized_openai_compatible_events(
 mod tests {
 
     use super::*;
-    use axum::http::header::{HeaderName, HeaderValue};
     use serde_json::json;
     use tracing_test::traced_test;
 
@@ -1494,52 +1405,39 @@ mod tests {
     #[test]
     fn test_try_from_openai_compatible_params() {
         let episode_id = Uuid::now_v7();
-        let headers = HeaderMap::from_iter(vec![
-            (
-                HeaderName::from_static("episode_id"),
-                HeaderValue::from_str(&episode_id.to_string()).unwrap(),
-            ),
-            (
-                HeaderName::from_static("variant_name"),
-                HeaderValue::from_static("test_variant"),
-            ),
-        ]);
         let messages = vec![OpenAICompatibleMessage::User(OpenAICompatibleUserMessage {
             content: Value::String("Hello, world!".to_string()),
         })];
         let tensorzero_tags = HashMap::from([("test".to_string(), "test".to_string())]);
-        let params = Params::try_from_openai(
-            headers,
-            OpenAICompatibleParams {
-                messages,
-                model: "tensorzero::test_function".into(),
-                frequency_penalty: Some(0.5),
-                max_tokens: Some(100),
-                max_completion_tokens: Some(50),
-                presence_penalty: Some(0.5),
-                response_format: None,
-                seed: Some(23),
-                stream: None,
-                temperature: Some(0.5),
-                tools: None,
-                tool_choice: None,
-                top_p: Some(0.5),
-                parallel_tool_calls: None,
-                tensorzero_episode_id: None,
-                tensorzero_variant_name: None,
-                tensorzero_dryrun: None,
-                tensorzero_cache_options: None,
-                tensorzero_extra_body: UnfilteredInferenceExtraBody::default(),
-                tensorzero_extra_headers: UnfilteredInferenceExtraHeaders::default(),
-                tensorzero_tags: tensorzero_tags.clone(),
-                tensorzero_deny_unknown_fields: false,
-                tensorzero_credentials: InferenceCredentials::default(),
-                unknown_fields: Default::default(),
-                stream_options: None,
-                stop: None,
-                tensorzero_internal_dynamic_variant_config: None,
-            },
-        )
+        let params = Params::try_from_openai(OpenAICompatibleParams {
+            messages,
+            model: "tensorzero::test_function".into(),
+            frequency_penalty: Some(0.5),
+            max_tokens: Some(100),
+            max_completion_tokens: Some(50),
+            presence_penalty: Some(0.5),
+            response_format: None,
+            seed: Some(23),
+            stream: None,
+            temperature: Some(0.5),
+            tools: None,
+            tool_choice: None,
+            top_p: Some(0.5),
+            parallel_tool_calls: None,
+            tensorzero_episode_id: Some(episode_id),
+            tensorzero_variant_name: Some("test_variant".to_string()),
+            tensorzero_dryrun: None,
+            tensorzero_cache_options: None,
+            tensorzero_extra_body: UnfilteredInferenceExtraBody::default(),
+            tensorzero_extra_headers: UnfilteredInferenceExtraHeaders::default(),
+            tensorzero_tags: tensorzero_tags.clone(),
+            tensorzero_deny_unknown_fields: false,
+            tensorzero_credentials: InferenceCredentials::default(),
+            unknown_fields: Default::default(),
+            stream_options: None,
+            stop: None,
+            tensorzero_internal_dynamic_variant_config: None,
+        })
         .unwrap();
         assert_eq!(params.function_name, Some("test_function".to_string()));
         assert_eq!(params.episode_id, Some(episode_id));
@@ -2001,84 +1899,76 @@ mod tests {
 
     #[test]
     fn test_cache_options() {
-        let headers = HeaderMap::new();
-
         // Test default cache options (should be write-only)
-        let params = Params::try_from_openai(
-            headers.clone(),
-            OpenAICompatibleParams {
-                messages: vec![OpenAICompatibleMessage::User(OpenAICompatibleUserMessage {
-                    content: Value::String("test".to_string()),
-                })],
-                model: "tensorzero::function_name::test_function".into(),
-                frequency_penalty: None,
-                max_tokens: None,
-                max_completion_tokens: None,
-                presence_penalty: None,
-                response_format: None,
-                seed: None,
-                stream: None,
-                temperature: None,
-                tools: None,
-                tool_choice: None,
-                top_p: None,
-                parallel_tool_calls: None,
-                tensorzero_variant_name: None,
-                tensorzero_dryrun: None,
-                tensorzero_episode_id: None,
-                tensorzero_cache_options: None,
-                tensorzero_extra_body: UnfilteredInferenceExtraBody::default(),
-                tensorzero_extra_headers: UnfilteredInferenceExtraHeaders::default(),
-                tensorzero_tags: HashMap::new(),
-                tensorzero_credentials: InferenceCredentials::default(),
-                unknown_fields: Default::default(),
-                stream_options: None,
-                stop: None,
-                tensorzero_deny_unknown_fields: false,
-                tensorzero_internal_dynamic_variant_config: None,
-            },
-        )
+        let params = Params::try_from_openai(OpenAICompatibleParams {
+            messages: vec![OpenAICompatibleMessage::User(OpenAICompatibleUserMessage {
+                content: Value::String("test".to_string()),
+            })],
+            model: "tensorzero::function_name::test_function".into(),
+            frequency_penalty: None,
+            max_tokens: None,
+            max_completion_tokens: None,
+            presence_penalty: None,
+            response_format: None,
+            seed: None,
+            stream: None,
+            temperature: None,
+            tools: None,
+            tool_choice: None,
+            top_p: None,
+            parallel_tool_calls: None,
+            tensorzero_variant_name: None,
+            tensorzero_dryrun: None,
+            tensorzero_episode_id: None,
+            tensorzero_cache_options: None,
+            tensorzero_extra_body: UnfilteredInferenceExtraBody::default(),
+            tensorzero_extra_headers: UnfilteredInferenceExtraHeaders::default(),
+            tensorzero_tags: HashMap::new(),
+            tensorzero_credentials: InferenceCredentials::default(),
+            unknown_fields: Default::default(),
+            stream_options: None,
+            stop: None,
+            tensorzero_deny_unknown_fields: false,
+            tensorzero_internal_dynamic_variant_config: None,
+        })
         .unwrap();
         assert_eq!(params.cache_options, CacheParamsOptions::default());
 
         // Test explicit cache options
-        let params = Params::try_from_openai(
-            headers.clone(),
-            OpenAICompatibleParams {
-                messages: vec![OpenAICompatibleMessage::User(OpenAICompatibleUserMessage {
-                    content: Value::String("test".to_string()),
-                })],
-                model: "tensorzero::function_name::test_function".into(),
-                frequency_penalty: None,
-                max_tokens: None,
-                max_completion_tokens: None,
-                presence_penalty: None,
-                response_format: None,
-                seed: None,
-                stream: None,
-                temperature: None,
-                tools: None,
-                tool_choice: None,
-                top_p: None,
-                parallel_tool_calls: None,
-                tensorzero_variant_name: None,
-                tensorzero_dryrun: None,
-                tensorzero_episode_id: None,
-                tensorzero_cache_options: Some(CacheParamsOptions {
-                    max_age_s: Some(3600),
-                    enabled: CacheEnabledMode::On,
-                }),
-                tensorzero_extra_body: UnfilteredInferenceExtraBody::default(),
-                tensorzero_extra_headers: UnfilteredInferenceExtraHeaders::default(),
-                tensorzero_tags: HashMap::new(),
-                tensorzero_credentials: InferenceCredentials::default(),
-                unknown_fields: Default::default(),
-                stream_options: None,
-                stop: None,
-                tensorzero_deny_unknown_fields: false,
-                tensorzero_internal_dynamic_variant_config: None,
-            },
-        )
+        let params = Params::try_from_openai(OpenAICompatibleParams {
+            messages: vec![OpenAICompatibleMessage::User(OpenAICompatibleUserMessage {
+                content: Value::String("test".to_string()),
+            })],
+            model: "tensorzero::function_name::test_function".into(),
+            frequency_penalty: None,
+            max_tokens: None,
+            max_completion_tokens: None,
+            presence_penalty: None,
+            response_format: None,
+            seed: None,
+            stream: None,
+            temperature: None,
+            tools: None,
+            tool_choice: None,
+            top_p: None,
+            parallel_tool_calls: None,
+            tensorzero_variant_name: None,
+            tensorzero_dryrun: None,
+            tensorzero_episode_id: None,
+            tensorzero_cache_options: Some(CacheParamsOptions {
+                max_age_s: Some(3600),
+                enabled: CacheEnabledMode::On,
+            }),
+            tensorzero_extra_body: UnfilteredInferenceExtraBody::default(),
+            tensorzero_extra_headers: UnfilteredInferenceExtraHeaders::default(),
+            tensorzero_tags: HashMap::new(),
+            tensorzero_credentials: InferenceCredentials::default(),
+            unknown_fields: Default::default(),
+            stream_options: None,
+            stop: None,
+            tensorzero_deny_unknown_fields: false,
+            tensorzero_internal_dynamic_variant_config: None,
+        })
         .unwrap();
         assert_eq!(
             params.cache_options,
@@ -2089,43 +1979,40 @@ mod tests {
         );
 
         // Test interaction with dryrun
-        let params = Params::try_from_openai(
-            headers.clone(),
-            OpenAICompatibleParams {
-                messages: vec![OpenAICompatibleMessage::User(OpenAICompatibleUserMessage {
-                    content: Value::String("test".to_string()),
-                })],
-                model: "tensorzero::function_name::test_function".into(),
-                frequency_penalty: None,
-                max_tokens: None,
-                max_completion_tokens: None,
-                presence_penalty: None,
-                response_format: None,
-                seed: None,
-                stream: None,
-                temperature: None,
-                tools: None,
-                tool_choice: None,
-                top_p: None,
-                parallel_tool_calls: None,
-                tensorzero_variant_name: None,
-                tensorzero_dryrun: Some(true),
-                tensorzero_episode_id: None,
-                tensorzero_cache_options: Some(CacheParamsOptions {
-                    max_age_s: Some(3600),
-                    enabled: CacheEnabledMode::On,
-                }),
-                tensorzero_extra_body: UnfilteredInferenceExtraBody::default(),
-                tensorzero_extra_headers: UnfilteredInferenceExtraHeaders::default(),
-                tensorzero_tags: HashMap::new(),
-                tensorzero_credentials: InferenceCredentials::default(),
-                unknown_fields: Default::default(),
-                stream_options: None,
-                stop: None,
-                tensorzero_deny_unknown_fields: false,
-                tensorzero_internal_dynamic_variant_config: None,
-            },
-        )
+        let params = Params::try_from_openai(OpenAICompatibleParams {
+            messages: vec![OpenAICompatibleMessage::User(OpenAICompatibleUserMessage {
+                content: Value::String("test".to_string()),
+            })],
+            model: "tensorzero::function_name::test_function".into(),
+            frequency_penalty: None,
+            max_tokens: None,
+            max_completion_tokens: None,
+            presence_penalty: None,
+            response_format: None,
+            seed: None,
+            stream: None,
+            temperature: None,
+            tools: None,
+            tool_choice: None,
+            top_p: None,
+            parallel_tool_calls: None,
+            tensorzero_variant_name: None,
+            tensorzero_dryrun: Some(true),
+            tensorzero_episode_id: None,
+            tensorzero_cache_options: Some(CacheParamsOptions {
+                max_age_s: Some(3600),
+                enabled: CacheEnabledMode::On,
+            }),
+            tensorzero_extra_body: UnfilteredInferenceExtraBody::default(),
+            tensorzero_extra_headers: UnfilteredInferenceExtraHeaders::default(),
+            tensorzero_tags: HashMap::new(),
+            tensorzero_credentials: InferenceCredentials::default(),
+            unknown_fields: Default::default(),
+            stream_options: None,
+            stop: None,
+            tensorzero_deny_unknown_fields: false,
+            tensorzero_internal_dynamic_variant_config: None,
+        })
         .unwrap();
         assert_eq!(
             params.cache_options,
@@ -2136,43 +2023,40 @@ mod tests {
         );
 
         // Test write-only with dryrun (should become Off)
-        let params = Params::try_from_openai(
-            headers,
-            OpenAICompatibleParams {
-                messages: vec![OpenAICompatibleMessage::User(OpenAICompatibleUserMessage {
-                    content: Value::String("test".to_string()),
-                })],
-                model: "tensorzero::function_name::test_function".into(),
-                frequency_penalty: None,
-                max_tokens: None,
-                max_completion_tokens: None,
-                presence_penalty: None,
-                response_format: None,
-                seed: None,
-                stream: None,
-                temperature: None,
-                tools: None,
-                tool_choice: None,
-                top_p: None,
-                parallel_tool_calls: None,
-                tensorzero_variant_name: None,
-                tensorzero_dryrun: Some(true),
-                tensorzero_episode_id: None,
-                tensorzero_cache_options: Some(CacheParamsOptions {
-                    max_age_s: None,
-                    enabled: CacheEnabledMode::WriteOnly,
-                }),
-                tensorzero_extra_body: UnfilteredInferenceExtraBody::default(),
-                tensorzero_extra_headers: UnfilteredInferenceExtraHeaders::default(),
-                tensorzero_tags: HashMap::new(),
-                tensorzero_credentials: InferenceCredentials::default(),
-                unknown_fields: Default::default(),
-                stream_options: None,
-                stop: None,
-                tensorzero_deny_unknown_fields: false,
-                tensorzero_internal_dynamic_variant_config: None,
-            },
-        )
+        let params = Params::try_from_openai(OpenAICompatibleParams {
+            messages: vec![OpenAICompatibleMessage::User(OpenAICompatibleUserMessage {
+                content: Value::String("test".to_string()),
+            })],
+            model: "tensorzero::function_name::test_function".into(),
+            frequency_penalty: None,
+            max_tokens: None,
+            max_completion_tokens: None,
+            presence_penalty: None,
+            response_format: None,
+            seed: None,
+            stream: None,
+            temperature: None,
+            tools: None,
+            tool_choice: None,
+            top_p: None,
+            parallel_tool_calls: None,
+            tensorzero_variant_name: None,
+            tensorzero_dryrun: Some(true),
+            tensorzero_episode_id: None,
+            tensorzero_cache_options: Some(CacheParamsOptions {
+                max_age_s: None,
+                enabled: CacheEnabledMode::WriteOnly,
+            }),
+            tensorzero_extra_body: UnfilteredInferenceExtraBody::default(),
+            tensorzero_extra_headers: UnfilteredInferenceExtraHeaders::default(),
+            tensorzero_tags: HashMap::new(),
+            tensorzero_credentials: InferenceCredentials::default(),
+            unknown_fields: Default::default(),
+            stream_options: None,
+            stop: None,
+            tensorzero_deny_unknown_fields: false,
+            tensorzero_internal_dynamic_variant_config: None,
+        })
         .unwrap();
         assert_eq!(
             params.cache_options,

--- a/tensorzero-core/tests/e2e/openai_compatible.rs
+++ b/tensorzero-core/tests/e2e/openai_compatible.rs
@@ -2,8 +2,7 @@
 
 use std::collections::HashSet;
 
-use axum::{extract::State, http::HeaderMap};
-use http::{HeaderName, HeaderValue};
+use axum::extract::State;
 use http_body_util::BodyExt;
 use reqwest::{Client, StatusCode};
 use serde_json::{json, Value};
@@ -27,18 +26,6 @@ async fn test_openai_compatible_route_new_format() {
     .await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
-#[traced_test]
-async fn test_openai_compatible_route_old_format() {
-    test_openai_compatible_route_with_function_name_as_model(
-        "tensorzero::basic_test_no_system_schema",
-    )
-    .await;
-    assert!(logs_contain(
-        "Please set the `model` parameter to `tensorzero::function_name::your_function` instead of `tensorzero::your_function.`"
-    ));
-}
-
 async fn test_openai_compatible_route_with_function_name_as_model(model: &str) {
     let client = tensorzero::test_helpers::make_embedded_gateway().await;
     let state = client.get_app_state_data().unwrap().clone();
@@ -46,7 +33,6 @@ async fn test_openai_compatible_route_with_function_name_as_model(model: &str) {
 
     let response = tensorzero_core::endpoints::openai_compatible::inference_handler(
         State(state),
-        HeaderMap::default(),
         StructuredJson(
             serde_json::from_value(serde_json::json!({
                 "model": model,
@@ -881,55 +867,11 @@ async fn test_openai_compatible_streaming_tool_call() {
 
 #[tokio::test]
 #[traced_test]
-async fn test_openai_compatible_warn_headers() {
-    let client = tensorzero::test_helpers::make_embedded_gateway_no_config().await;
-    let state = client.get_app_state_data().unwrap().clone();
-    let episode_id = Uuid::now_v7();
-    let _ = tensorzero_core::endpoints::openai_compatible::inference_handler(
-        State(state),
-        HeaderMap::from_iter(vec![
-            (
-                HeaderName::from_static("episode_id"),
-                HeaderValue::from_str(&episode_id.to_string()).unwrap(),
-            ),
-            (
-                HeaderName::from_static("variant_name"),
-                HeaderValue::from_str("test").unwrap(),
-            ),
-            (
-                HeaderName::from_static("dryrun"),
-                HeaderValue::from_str("true").unwrap(),
-            ),
-        ]),
-        StructuredJson(
-            serde_json::from_value(serde_json::json!({
-                "messages": [],
-                "model": "tensorzero::model_name::dummy::good",
-            }))
-            .unwrap(),
-        ),
-    )
-    .await;
-
-    assert!(logs_contain(
-        "Deprecation Warning: Please use the `tensorzero::episode_id` field instead of the `episode_id` header."
-    ));
-    assert!(logs_contain(
-        "Deprecation Warning: Please use the `tensorzero::variant_name` field instead of the `variant_name` header."
-    ));
-    assert!(logs_contain(
-        "Deprecation Warning: Please use the `tensorzero::dryrun` field instead of the `dryrun` header."
-    ));
-}
-
-#[tokio::test]
-#[traced_test]
 async fn test_openai_compatible_warn_unknown_fields() {
     let client = tensorzero::test_helpers::make_embedded_gateway_no_config().await;
     let state = client.get_app_state_data().unwrap().clone();
     tensorzero_core::endpoints::openai_compatible::inference_handler(
         State(state),
-        HeaderMap::default(),
         StructuredJson(
             serde_json::from_value(serde_json::json!({
                 "messages": [],
@@ -953,7 +895,6 @@ async fn test_openai_compatible_deny_unknown_fields() {
     let state = client.get_app_state_data().unwrap().clone();
     let err = tensorzero_core::endpoints::openai_compatible::inference_handler(
         State(state),
-        HeaderMap::default(),
         StructuredJson(
             serde_json::from_value(serde_json::json!({
                 "messages": [],


### PR DESCRIPTION
## Summary
- Remove deprecated `tensorzero::function_name` model format (use `tensorzero::function_name::xxx` instead)
- Remove deprecated HTTP headers (`episode_id`, `variant_name`, `dryrun`) in favor of request body fields
- Remove deprecated JSON schema response format variant
- Remove associated tests and deprecation warning code

## Changes
**`tensorzero-core/src/endpoints/openai_compatible.rs`:**
- Removed `HeaderMap` parameter from `inference_handler` and `Params::try_from_openai`
- Removed logic parsing deprecated `tensorzero::` prefix (without `function_name::` or `model_name::`)
- Removed header parsing for `episode_id`, `variant_name`, and `dryrun`
- Removed `JsonSchemaInfoOption` enum that supported both new and deprecated JSON schema formats
- Simplified parameter assignment to use only the new `tensorzero::*` request body fields

**`tensorzero-core/tests/e2e/openai_compatible.rs`:**
- Removed `test_openai_compatible_route_old_format` test that verified the deprecated format

## Breaking Changes
This is a breaking change for users still using the deprecated formats. Users must migrate to:
- Model names: `tensorzero::function_name::xxx` or `tensorzero::model_name::xxx`
- Request body fields: `tensorzero::episode_id`, `tensorzero::variant_name`, `tensorzero::dryrun` instead of headers
- New JSON schema response format

Fixes #1242
Fixes #1388
Fixes #2094

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove deprecated OpenAI-compatible API features, including model format, HTTP headers, and JSON schema response format.
> 
>   - **Behavior**:
>     - Removed deprecated `tensorzero::function_name` model format, now requires `tensorzero::function_name::xxx`.
>     - Removed deprecated HTTP headers (`episode_id`, `variant_name`, `dryrun`), now use request body fields.
>     - Removed deprecated JSON schema response format variant.
>   - **Code Changes**:
>     - In `openai_compatible.rs`, removed `HeaderMap` from `inference_handler` and `Params::try_from_openai`.
>     - Removed logic for deprecated model prefix and header parsing.
>     - Removed `JsonSchemaInfoOption` enum.
>   - **Tests**:
>     - Removed `test_openai_compatible_route_old_format` from `openai_compatible.rs`.
>     - Removed tests for deprecated headers and JSON schema format in `test_openai_patch.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f52545dae5ca6a6763304c347e13ac54ce4fd2a7. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->