### PR TITLE
Finish deprecating `datapoint_name` → `task_name` (except DB schema)

### DIFF
--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -862,23 +862,19 @@ impl TensorZeroGateway {
     ///
     /// :param run_id: The run ID to use for the dynamic evaluation run.
     /// :param task_name: The name of the task to use for the dynamic evaluation run.
-    /// :param datapoint_name: The name of the datapoint to use for the dynamic evaluation run.
-    ///                     Deprecated: use `task_name` instead.
     /// :param tags: A dictionary of tags to add to the dynamic evaluation run.
     /// :return: A `DynamicEvaluationRunEpisodeResponse` object.
-    #[pyo3(signature = (*, run_id, task_name=None, datapoint_name=None, tags=None))]
+    #[pyo3(signature = (*, run_id, task_name=None, tags=None))]
     fn dynamic_evaluation_run_episode(
         this: PyRef<'_, Self>,
         run_id: Bound<'_, PyAny>,
         task_name: Option<String>,
-        datapoint_name: Option<String>,
         tags: Option<HashMap<String, String>>,
     ) -> PyResult<Py<PyAny>> {
         let run_id = python_uuid_to_uuid("run_id", run_id)?;
         let client = this.as_super().client.clone();
         let params = DynamicEvaluationRunEpisodeParams {
             task_name,
-            datapoint_name,
             tags: tags.unwrap_or_default(),
         };
         let fut = client.dynamic_evaluation_run_episode(run_id, params);
@@ -1535,23 +1531,19 @@ impl AsyncTensorZeroGateway {
     ///
     /// :param run_id: The run ID to use for the dynamic evaluation run.
     /// :param task_name: The name of the task to use for the dynamic evaluation run.
-    /// :param datapoint_name: The name of the datapoint to use for the dynamic evaluation run.
-    ///                     Deprecated: use `task_name` instead.
     /// :param tags: A dictionary of tags to add to the dynamic evaluation run.
     /// :return: A `DynamicEvaluationRunEpisodeResponse` object.
-    #[pyo3(signature = (*, run_id, task_name=None, datapoint_name=None, tags=None))]
+    #[pyo3(signature = (*, run_id, task_name=None, tags=None))]
     fn dynamic_evaluation_run_episode<'a>(
         this: PyRef<'a, Self>,
         run_id: Bound<'_, PyAny>,
         task_name: Option<String>,
-        datapoint_name: Option<String>,
         tags: Option<HashMap<String, String>>,
     ) -> PyResult<Bound<'a, PyAny>> {
         let run_id = python_uuid_to_uuid("run_id", run_id)?;
         let client = this.as_super().client.clone();
         let params = DynamicEvaluationRunEpisodeParams {
             task_name,
-            datapoint_name,
             tags: tags.unwrap_or_default(),
         };
 

--- a/clients/python/tensorzero/tensorzero.pyi
+++ b/clients/python/tensorzero/tensorzero.pyi
@@ -539,7 +539,6 @@ class TensorZeroGateway(BaseTensorZeroGateway):
         *,
         run_id: str | UUID | uuid_utils.UUID,
         task_name: Optional[str] = None,
-        datapoint_name: Optional[str] = None,
         tags: Optional[Dict[str, str]] = None,
     ) -> DynamicEvaluationRunEpisodeResponse:
         """
@@ -547,8 +546,6 @@ class TensorZeroGateway(BaseTensorZeroGateway):
 
         :param run_id: The run ID to use for the dynamic evaluation run.
         :param task_name: The name of the task to use for the dynamic evaluation run.
-        :param datapoint_name: The name of the datapoint to use for the dynamic evaluation run.
-                    Deprecated: use `task_name` instead.
         :param tags: A dictionary of tags to add to the dynamic evaluation run.
         :return: A `DynamicEvaluationRunEpisodeResponse` instance ({"episode_id": str}).
         """
@@ -883,7 +880,6 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         *,
         run_id: str | UUID | uuid_utils.UUID,
         task_name: Optional[str] = None,
-        datapoint_name: Optional[str] = None,
         tags: Optional[Dict[str, str]] = None,
     ) -> DynamicEvaluationRunEpisodeResponse:
         """
@@ -891,8 +887,6 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
 
         :param run_id: The run ID to use for the dynamic evaluation run.
         :param task_name: The name of the task to use for the dynamic evaluation run.
-        :param datapoint_name: The name of the datapoint to use for the dynamic evaluation run.
-                    Deprecated: use `task_name` instead.
         :param tags: A dictionary of tags to add to the dynamic evaluation run.
         :return: A `DynamicEvaluationRunEpisodeResponse` instance ({"episode_id": str}).
         """

--- a/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0025.rs
+++ b/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0025.rs
@@ -73,7 +73,7 @@ impl Migration for Migration0025<'_> {
                 episode_id_uint UInt128, -- UUID encoded as a UInt128
                 -- this is duplicated so that we can look it up without joining at inference time
                 variant_pins Map(String, String),
-                datapoint_name Nullable(String),
+                datapoint_name Nullable(String), -- externally: task_name (TODO: rename in a future migration)
                 tags Map(String, String),
                 is_deleted Bool DEFAULT false,
                 updated_at DateTime64(6, 'UTC') DEFAULT now()

--- a/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0026.rs
+++ b/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0026.rs
@@ -88,7 +88,7 @@ impl Migration for Migration0026<'_> {
                     episode_id_uint UInt128, -- UUID encoded as a UInt128
                     variant_pins Map(String, String),
                     tags Map(String, String),
-                    datapoint_name Nullable(String),
+                    datapoint_name Nullable(String), -- externally: task_name (TODO: rename in a future migration)
                     is_deleted Bool DEFAULT false,
                     updated_at DateTime64(6, 'UTC') DEFAULT now()
                 ) ENGINE = {table_engine_name}

--- a/tensorzero-core/src/db/clickhouse/test_helpers.rs
+++ b/tensorzero-core/src/db/clickhouse/test_helpers.rs
@@ -535,7 +535,7 @@ pub async fn select_dynamic_evaluation_run_episode_clickhouse(
     episode_id: Uuid,
 ) -> Option<DynamicEvaluationRunEpisodeRow> {
     let query = format!(
-        "SELECT run_id, uint_to_uuid(episode_id_uint) as episode_id, variant_pins, datapoint_name, tags FROM DynamicEvaluationRunEpisode WHERE run_id = '{run_id}' AND episode_id_uint = toUInt128(toUUID('{episode_id}')) FORMAT JSONEachRow",
+        "SELECT run_id, uint_to_uuid(episode_id_uint) as episode_id, variant_pins, datapoint_name AS task_name, tags FROM DynamicEvaluationRunEpisode WHERE run_id = '{run_id}' AND episode_id_uint = toUInt128(toUUID('{episode_id}')) FORMAT JSONEachRow",
     );
 
     let text = clickhouse_connection_info

--- a/tensorzero-core/src/endpoints/dynamic_evaluation_run.rs
+++ b/tensorzero-core/src/endpoints/dynamic_evaluation_run.rs
@@ -83,9 +83,6 @@ pub struct DynamicEvaluationRunEpisodePathParams {
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct DynamicEvaluationRunEpisodeParams {
-    // This has been deprecated in favor of `task_name`.
-    #[serde(default)]
-    pub datapoint_name: Option<String>,
     #[serde(default)]
     pub task_name: Option<String>,
     #[serde(default)]
@@ -125,10 +122,9 @@ pub async fn dynamic_evaluation_run_episode(
         "tensorzero::dynamic_evaluation_run_id".to_string(),
         run_id_str,
     );
-    let task_name = get_task_name(params.task_name, params.datapoint_name)?;
     write_dynamic_evaluation_run_episode(
         &clickhouse_connection_info,
-        task_name.as_deref(),
+        params.task_name.as_deref(),
         tags,
         run_id,
         episode_id,
@@ -227,13 +223,13 @@ pub struct DynamicEvaluationRunEpisodeRow {
     pub run_id: Uuid,
     pub episode_id: Uuid,
     pub variant_pins: HashMap<String, String>,
-    pub datapoint_name: Option<String>,
+    pub task_name: Option<String>, // For legacy reasons, stored as `task_name` in the database
     pub tags: HashMap<String, String>,
 }
 
 async fn write_dynamic_evaluation_run_episode(
     clickhouse: &ClickHouseConnectionInfo,
-    datapoint_name: Option<&str>,
+    task_name: Option<&str>,
     tags: HashMap<String, String>,
     run_id: Uuid,
     episode_id: Uuid,
@@ -244,15 +240,15 @@ async fn write_dynamic_evaluation_run_episode(
         run_id,
         episode_id_uint,
         variant_pins,
-        datapoint_name,
+        datapoint_name, -- for legacy reasons, `task_name` is stored as `datapoint_name` in the database
         tags
     )
     SELECT
-        {run_id:UUID} as run_id,
-        toUInt128({episode_id:UUID}) as episode_id_uint,
+        {run_id:UUID} AS run_id,
+        toUInt128({episode_id:UUID}) AS episode_id_uint,
         variant_pins,
-        {datapoint_name:Nullable(String)} as datapoint_name,
-        mapUpdate(tags, {tags:Map(String, String)}) as tags -- merge the tags in the params on top of tags in the dynamic evaluation run
+        {datapoint_name:Nullable(String)} AS datapoint_name, -- for legacy reasons, `task_name` is stored as `datapoint_name` in the database
+        mapUpdate(tags, {tags:Map(String, String)}) AS tags -- merge the tags in the params on top of tags in the dynamic evaluation run
     FROM DynamicEvaluationRun
     WHERE run_id_uint = toUInt128({run_id:UUID})
     ";
@@ -261,7 +257,7 @@ async fn write_dynamic_evaluation_run_episode(
     let episode_id_str = episode_id.to_string();
     query_params.insert("run_id", run_id_str.as_str());
     query_params.insert("episode_id", episode_id_str.as_str());
-    query_params.insert("datapoint_name", datapoint_name.unwrap_or("\\N")); // Use \\N to indicate NULL
+    query_params.insert("datapoint_name", task_name.unwrap_or("\\N")); // Use \\N to indicate NULL; for legacy reasons, stored as `datapoint_name` in the database
     let tags_str = to_map_literal(&tags);
     query_params.insert("tags", tags_str.as_str());
     clickhouse
@@ -348,58 +344,4 @@ async fn lookup_dynamic_evaluation_run(
         })
     })?;
     Ok(Some(dynamic_evaluation_run))
-}
-
-fn get_task_name(
-    task_name: Option<String>,
-    datapoint_name: Option<String>,
-) -> Result<Option<String>, Error> {
-    match (task_name, datapoint_name) {
-        (Some(task_name), None) => Ok(Some(task_name)),
-        (None, Some(datapoint_name)) => {
-            tracing::warn!("`datapoint_name` is deprecated in favor of `task_name`. Please change your usage to `task_name`");
-            Ok(Some(datapoint_name))
-        }
-        (None, None) => Ok(None),
-        (Some(_), Some(_)) => Err(Error::new(ErrorDetails::InvalidRequest {
-            message: "task_name and datapoint_name cannot both be provided".to_string(),
-        })),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use tracing_test::traced_test;
-
-    use super::*;
-
-    #[test]
-    #[traced_test]
-    fn test_get_task_name() {
-        let task_name = get_task_name(Some("task_name".to_string()), None);
-        assert_eq!(task_name, Ok(Some("task_name".to_string())));
-
-        assert_eq!(
-            get_task_name(
-                Some("task_name".to_string()),
-                Some("datapoint_name".to_string())
-            ),
-            Err(Error::new(ErrorDetails::InvalidRequest {
-                message: "task_name and datapoint_name cannot both be provided".to_string(),
-            }))
-        );
-        assert!(!logs_contain(
-            "`datapoint_name` is deprecated in favor of `task_name`. Please change your usage to `task_name`"
-        ));
-    }
-
-    #[test]
-    #[traced_test]
-    fn test_get_task_name_deprecation_warning() {
-        let task_name = get_task_name(None, Some("datapoint_name".to_string()));
-        assert_eq!(task_name, Ok(Some("datapoint_name".to_string())));
-        assert!(logs_contain(
-            "`datapoint_name` is deprecated in favor of `task_name`. Please change your usage to `task_name`"
-        ));
-    }
 }

--- a/tensorzero-core/tests/e2e/dynamic_evaluations.rs
+++ b/tensorzero-core/tests/e2e/dynamic_evaluations.rs
@@ -52,7 +52,6 @@ async fn test_dynamic_evaluation() {
                 run_id,
                 DynamicEvaluationRunEpisodeParams {
                     task_name: Some(format!("test_datapoint_{i}")),
-                    datapoint_name: None,
                     tags: HashMap::from([
                         ("baz".to_string(), format!("baz_{i}")),
                         ("zoo".to_string(), format!("zoo_{i}")),
@@ -152,10 +151,7 @@ async fn test_dynamic_evaluation() {
             episode_row.variant_pins,
             HashMap::from([("basic_test".to_string(), "test2".to_string())])
         );
-        assert_eq!(
-            episode_row.datapoint_name,
-            Some(format!("test_datapoint_{i}"))
-        );
+        assert_eq!(episode_row.task_name, Some(format!("test_datapoint_{i}")));
         let expected_tags = HashMap::from([
             ("foo".to_string(), "bar".to_string()),
             ("baz".to_string(), format!("baz_{i}")),
@@ -232,7 +228,6 @@ async fn test_dynamic_evaluation_other_function() {
             run_id,
             DynamicEvaluationRunEpisodeParams {
                 task_name: None,
-                datapoint_name: None,
                 tags: HashMap::new(),
             },
         )
@@ -305,7 +300,6 @@ async fn test_dynamic_evaluation_variant_error() {
             run_id,
             DynamicEvaluationRunEpisodeParams {
                 task_name: None,
-                datapoint_name: None,
                 tags: HashMap::new(),
             },
         )
@@ -361,7 +355,6 @@ async fn test_dynamic_evaluation_override_variant_tags() {
             run_id,
             DynamicEvaluationRunEpisodeParams {
                 task_name: None,
-                datapoint_name: None,
                 tags: HashMap::new(),
             },
         )

--- a/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/EvaluationDatapointBasicInfo.tsx
+++ b/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/EvaluationDatapointBasicInfo.tsx
@@ -13,14 +13,14 @@ interface BasicInfoProps {
   evaluation_name: string;
   evaluation_config: StaticEvaluationConfig;
   dataset_name: string;
-  datapoint_name: string | null;
+  task_name: string | null;
 }
 
 export default function BasicInfo({
   evaluation_name,
   evaluation_config,
   dataset_name,
-  datapoint_name,
+  task_name,
 }: BasicInfoProps) {
   const functionName = evaluation_config.function_name;
   const functionConfig = useFunctionConfig(functionName);
@@ -35,7 +35,7 @@ export default function BasicInfo({
         <BasicInfoItemTitle>Name</BasicInfoItemTitle>
         <BasicInfoItemContent>
           {/* TODO: support editing names */}
-          <Chip label={datapoint_name || "-"} font="mono" />
+          <Chip label={task_name || "-"} font="mono" />
         </BasicInfoItemContent>
       </BasicInfoItem>
       <BasicInfoItem>

--- a/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/route.tsx
+++ b/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/route.tsx
@@ -246,7 +246,7 @@ export default function EvaluationDatapointPage({
             evaluation_name={evaluation_name}
             evaluation_config={evaluation_config}
             dataset_name={consolidatedEvaluationResults[0].dataset_name}
-            datapoint_name={consolidatedEvaluationResults[0].name}
+            task_name={consolidatedEvaluationResults[0].name}
           />
           <EvalRunSelector
             evaluationName={evaluation_name}

--- a/ui/app/utils/clickhouse/dynamic_evaluations.server.ts
+++ b/ui/app/utils/clickhouse/dynamic_evaluations.server.ts
@@ -146,7 +146,7 @@ export async function getDynamicEvaluationRunEpisodesByRunIdWithFeedback(
           run_id_uint,
           tags,
           updated_at,
-          datapoint_name as task_name,
+          datapoint_name AS task_name, -- for legacy reasons, \`task_name\` is stored as \`datapoint_name\` in the database
           ifNull(datapoint_name, concat('NULL_EPISODE_', toString(episode_id_uint))) as group_key
         FROM DynamicEvaluationRunEpisodeByRunId
         WHERE toUInt128(toUUID({run_id:String})) = run_id_uint
@@ -246,7 +246,7 @@ export async function getDynamicEvaluationRunStatisticsByMetricName(
           episode_id_uint,
           run_id_uint,
           tags,
-          datapoint_name
+          datapoint_name -- for legacy reasons, \`task_name\` is stored as \`datapoint_name\` in the database
         FROM DynamicEvaluationRunEpisodeByRunId
         WHERE toUInt128(toUUID({run_id:String})) = run_id_uint
         ORDER BY episode_id_uint DESC
@@ -419,7 +419,7 @@ export async function getDynamicEvaluationRunEpisodesByTaskName(
           run_id_uint,
           tags,
           updated_at,
-          datapoint_name AS task_name
+          datapoint_name AS task_name -- for legacy reasons, \`task_name\` is stored as \`datapoint_name\` in the database
         FROM DynamicEvaluationRunEpisodeByRunId
         WHERE run_id_uint IN (
           SELECT arrayJoin(
@@ -552,7 +552,7 @@ export async function countDynamicEvaluationRunEpisodesByTaskName(
           run_id_uint,
           tags,
           updated_at,
-          datapoint_name AS task_name
+          datapoint_name AS task_name -- for legacy reasons, \`task_name\` is stored as \`datapoint_name\` in the database
         FROM DynamicEvaluationRunEpisodeByRunId
         WHERE run_id_uint IN (
           SELECT arrayJoin(


### PR DESCRIPTION
Fix #2012