### PR TITLE
bumped timeout for concurrent requests test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -126,7 +126,7 @@ slow-timeout = { period = "900s", terminate-after = 1 }
 [[profile.default.overrides]]
 filter = 'test(test_concurrent_requests)'
 # This test creates and uses lots of `reqwest::Client`s, which can be slow
-slow-timeout = { period = "30s", terminate-after = 1 }
+slow-timeout = { period = "60s", terminate-after = 1 }
 
 [[profile.default.overrides]]
 # Settings for running unit tests


### PR DESCRIPTION
This failed on CI due to a timeout and it is legitimately something that could take time. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increased `slow-timeout` for `test(test_concurrent_requests)` to 60s in `.config/nextest.toml` to prevent CI timeout failures.
> 
>   - **Behavior**:
>     - Increased `slow-timeout` for `test(test_concurrent_requests)` from `30s` to `60s` in `.config/nextest.toml` to address CI timeout failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d273dde10d745aea881906b8b9ef039314066c60. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->