### PR TITLE
Document default credentials by provider type

### DIFF
--- a/docs/gateway/configuration-reference.mdx
+++ b/docs/gateway/configuration-reference.mdx
@@ -1554,15 +1554,17 @@ api_key_location = "dynamic::openai_api_key"
 
 ## `[provider_types]`
 
-The `provider_types` section of the configuration allows users to specify global settings that are related to the handling of a
-particular inference provider type (like `"openai"` or `"anthropic"`), such as where to look by default for credentials.
+The `provider_types` section of the configuration allows users to specify global settings that are related to the handling of a particular inference provider type (like `"openai"` or `"anthropic"`), such as where to look by default for credentials.
 
 <Accordion title="[provider_types.anthropic]">
+
 ##### `defaults.api_key_location`
+
 - **Type:** string
 - **Required:** no (default: `env::ANTHROPIC_API_KEY`)
 
-Defines the default location of the API key for Anthropic models. The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
+Defines the default location of the API key for Anthropic models.
+The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.anthropic.defaults]
@@ -1575,11 +1577,14 @@ api_key_location = "dynamic::anthropic_api_key"
 </Accordion>
 
 <Accordion title="[provider_types.azure]">
+
 ##### `defaults.api_key_location`
+
 - **Type:** string
 - **Required:** no (default: `env::AZURE_OPENAI_API_KEY`)
 
-Defines the default location of the API key for Azure models. The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
+Defines the default location of the API key for Azure models.
+The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.azure.defaults]
@@ -1591,11 +1596,14 @@ api_key_location = "dynamic::azure_openai_api_key"
 </Accordion>
 
 <Accordion title="[provider_types.deepseek]">
+
 ##### `defaults.api_key_location`
+
 - **Type:** string
 - **Required:** no (default: `env::DEEPSEEK_API_KEY`)
 
-Defines the location of the API key for the DeepSeek provider. The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
+Defines the location of the API key for the DeepSeek provider.
+The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.deepseek.defaults]
@@ -1607,11 +1615,14 @@ api_key_location = "dynamic::deepseek_api_key"
 </Accordion>
 
 <Accordion title="[provider_types.fireworks]">
+
 ##### `defaults.api_key_location`
+
 - **Type:** string
 - **Required:** no (default: `env::FIREWORKS_API_KEY`)
 
-Defines the location of the API key for the Fireworks provider. The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
+Defines the location of the API key for the Fireworks provider.
+The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.fireworks.defaults]
@@ -1623,12 +1634,14 @@ api_key_location = "dynamic::fireworks_api_key"
 </Accordion>
 
 <Accordion title="[provider_types.gcp_vertex_anthropic]">
+
 ##### `defaults.credential_location`
 
 - **Type:** string
 - **Required:** no (default: `env::GCP_CREDENTIALS_PATH`)
 
-Defines the location of the credentials for the GCP Vertex Anthropic provider. The supported locations are `env::PATH_TO_CREDENTIALS_FILE`, `dynamic::CREDENTIALS_ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details), and `file::PATH_TO_CREDENTIALS_FILE`.
+Defines the location of the credentials for the GCP Vertex Anthropic provider.
+The supported locations are `env::PATH_TO_CREDENTIALS_FILE`, `dynamic::CREDENTIALS_ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details), and `file::PATH_TO_CREDENTIALS_FILE`.
 
 ```toml title="tensorzero.toml"
 [provider_types.gcp_vertex_anthropic.defaults]
@@ -1642,6 +1655,7 @@ credential_location = "dynamic::gcp_credentials_path"
 </Accordion>
 
 <Accordion title="[provider_types.gcp_vertex_gemini]">
+
 #### `batch`
 
 - **Type:** object
@@ -1681,7 +1695,6 @@ Defines the Google Cloud Storage URI prefix where batch input files will be stor
 
 Defines the Google Cloud Storage URI prefix where batch output files will be stored.
 
-
 ##### `defaults.credential_location`
 
 - **Type:** string
@@ -1701,11 +1714,14 @@ credential_location = "dynamic::gcp_credentials_path"
 </Accordion>
 
 <Accordion title="[provider_types.google_ai_studio]">
+
 ##### `defaults.api_key_location`
+
 - **Type:** string
 - **Required:** no (default: `env::GOOGLE_AI_STUDIO_API_KEY`)
 
-Defines the location of the API key for the Google AI Studio provider. The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
+Defines the location of the API key for the Google AI Studio provider.
+The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.google_ai_studio.defaults]
@@ -1717,11 +1733,14 @@ api_key_location = "dynamic::google_ai_studio_api_key"
 </Accordion>
 
 <Accordion title="[provider_types.groq]">
+
 ##### `defaults.api_key_location`
+
 - **Type:** string
 - **Required:** no (default: `env::GROQ_API_KEY`)
 
-Defines the location of the API key for the Groq provider. The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
+Defines the location of the API key for the Groq provider.
+The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.groq.defaults]
@@ -1732,13 +1751,15 @@ api_key_location = "dynamic::groq_api_key"
 
 </Accordion>
 
-
 <Accordion title="[provider_types.hyperbolic]">
+
 ##### `defaults.api_key_location`
+
 - **Type:** string
 - **Required:** no (default: `env::HYPERBOLIC_API_KEY`)
 
-Defines the location of the API key for the Hyperbolic provider. The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
+Defines the location of the API key for the Hyperbolic provider.
+The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.hyperbolic.defaults]
@@ -1750,11 +1771,14 @@ api_key_location = "dynamic::hyperbolic_api_key"
 </Accordion>
 
 <Accordion title="[provider_types.mistral]">
+
 ##### `defaults.api_key_location`
+
 - **Type:** string
 - **Required:** no (default: `env::MISTRAL_API_KEY`)
 
-Defines the location of the API key for the Mistral provider. The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
+Defines the location of the API key for the Mistral provider.
+The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.mistral.defaults]
@@ -1766,11 +1790,14 @@ api_key_location = "dynamic::mistral_api_key"
 </Accordion>
 
 <Accordion title="[provider_types.openai]">
+
 ##### `defaults.api_key_location`
+
 - **Type:** string
 - **Required:** no (default: `env::OPENAI_API_KEY`)
 
-Defines the location of the API key for the OpenAI provider. The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
+Defines the location of the API key for the OpenAI provider.
+The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.openai.defaults]
@@ -1782,11 +1809,14 @@ api_key_location = "dynamic::openai_api_key"
 </Accordion>
 
 <Accordion title="[provider_types.openrouter]">
+
 ##### `defaults.api_key_location`
+
 - **Type:** string
 - **Required:** no (default: `env::OPENROUTER_API_KEY`)
 
-Defines the location of the API key for the OpenRouter provider. The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
+Defines the location of the API key for the OpenRouter provider.
+The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.openrouter.defaults]
@@ -1798,11 +1828,14 @@ api_key_location = "dynamic::openrouter_api_key"
 </Accordion>
 
 <Accordion title="[provider_types.together]">
+
 ##### `defaults.api_key_location`
+
 - **Type:** string
 - **Required:** no (default: `env::TOGETHER_API_KEY`)
 
-Defines the location of the API key for the Together provider. The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
+Defines the location of the API key for the Together provider.
+The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.together.defaults]
@@ -1814,11 +1847,14 @@ api_key_location = "dynamic::together_api_key"
 </Accordion>
 
 <Accordion title="[provider_types.xai]">
+
 ##### `defaults.api_key_location`
+
 - **Type:** string
 - **Required:** no (default: `env::XAI_API_KEY`)
 
-Defines the location of the API key for the xAI provider. The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
+Defines the location of the API key for the xAI provider.
+The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials)) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.xai.defaults]
@@ -1828,7 +1864,6 @@ api_key_location = "dynamic::xai_api_key"
 ```
 
 </Accordion>
-
 
 ## `[functions.function_name]`
 

--- a/docs/operations/manage-credentials.mdx
+++ b/docs/operations/manage-credentials.mdx
@@ -145,15 +145,21 @@ with TensorZeroGateway.build_http(gateway_url="http://localhost:3000") as client
 print(response)
 ```
 
-### Default credentials for a provider type
-For most providers, we support overriding the default location for a particular provider type.
-This override will be used if the `api_key_location` or `credential_location` is not specified for a particular model provider.
-It will also be used when calling the default function.
-See the [configuration reference](/gateway/configuration-reference) for more details.
+### Set default credentials for a provider type
+
+Most model providers have default credential locations.
+For example, OpenAI's `api_key_location` defaults to `env::OPENAI_API_KEY`.
+These credentials apply to the default function and shorthand models (e.g. calling the model `openai::gpt-5`).
+
+You can override the default location for a particular provider using `[provider_types.YOUR_PROVIDER_TYPE.defaults]`.
+For example, we can override the default location for the OpenAI provider type to require a dynamic API key:
+
 ```toml title="tensorzero.toml"
-[provider_types.anthropic.defaults]
-# ...
-api_key_location = "dynamic::anthropic_api_key"
-# api_key_location = "env::ALTERNATE_ANTHROPIC_API_KEY"
+[provider_types.openai.defaults]
+api_key_location = "dynamic::customer_openai_api_key"
 # ...
 ```
+
+Unless otherwise specified, every model provider of type `openai` will require the `customer_openai_api_key` credential.
+
+See the [Configuration Reference](/gateway/configuration-reference) for more details.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> This PR updates documentation to include default credential locations for various provider types and introduces a new configuration section for global credential settings by provider type.
> 
>   - **Documentation Updates**:
>     - Updated `configuration-reference.mdx` to document default credential locations for various provider types, including Anthropic, Azure, DeepSeek, Fireworks, GCP Vertex, Google AI Studio, Groq, Hyperbolic, Mistral, OpenAI, OpenRouter, Together, and xAI.
>     - Added a new section `[provider_types]` in `configuration-reference.mdx` to specify global settings for credential handling by provider type.
>     - Updated `manage-credentials.mdx` to explain how to set default credentials for a provider type and override them using `[provider_types.YOUR_PROVIDER_TYPE.defaults]`.
>   - **Behavior**:
>     - Default credential locations can now be overridden by specifying `api_key_location` or `credential_location` in `[provider_types.YOUR_PROVIDER_TYPE.defaults]`.
>     - Supports dynamic and static credential configurations for load balancing and fallback strategies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 414aabd594919a845f4ee1fe9f216aa4edc6689d. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->