### PR TITLE
Allow Google AI Studio Gemini to accept PDF uploads

### DIFF
--- a/tensorzero-core/src/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-core/src/providers/google_ai_studio_gemini.rs
@@ -22,7 +22,6 @@ use crate::error::{DisplayOrDebugGateway, Error, ErrorDetails};
 use crate::http::TensorZeroEventSource;
 use crate::http::TensorzeroHttpClient;
 use crate::inference::types::batch::{BatchRequestRow, PollBatchInferenceResponse};
-use crate::inference::types::file::require_image;
 use crate::inference::types::resolved_input::FileWithPath;
 use crate::inference::types::{
     batch::StartBatchProviderInferenceResponse, serialize_or_log, ModelInferenceRequest,
@@ -584,7 +583,6 @@ async fn convert_non_thought_content_block(
                 file,
                 storage_path: _,
             } = &*resolved_file;
-            require_image(&file.mime_type, PROVIDER_TYPE)?;
             Ok(FlattenUnknown::Normal(GeminiPartData::InlineData {
                 inline_data: GeminiInlineData {
                     mime_type: file.mime_type.to_string(),

--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -700,6 +700,10 @@ model = "responses-gpt-4o-mini-2024-07-18"
 type = "chat_completion"
 model = "gcp_vertex_gemini::projects/tensorzero-public/locations/us-central1/publishers/google/models/gemini-2.0-flash-lite"
 
+[functions.pdf_test.variants.google_ai_studio]
+type = "chat_completion"
+model = "google_ai_studio_gemini::gemini-2.0-flash-lite"
+
 [functions.pdf_test.variants.anthropic]
 type = "chat_completion"
 model = "anthropic::claude-3-5-sonnet-20241022"

--- a/tensorzero-core/tests/e2e/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-core/tests/e2e/providers/google_ai_studio_gemini.rs
@@ -177,9 +177,9 @@ async fn get_providers() -> E2ETestProviders {
         parallel_tool_use_inference: vec![],
         json_mode_inference: json_providers.clone(),
         json_mode_off_inference: json_mode_off_providers.clone(),
-        image_inference: image_providers,
+        image_inference: image_providers.clone(),
         shorthand_inference: shorthand_providers.clone(),
-        pdf_inference: vec![],
+        pdf_inference: image_providers,
     }
 }
 


### PR DESCRIPTION
## Summary
- drop the image-only MIME guard in the Google AI Studio Gemini provider so non-image files can be sent to Gemini
- extend the shared PDF function config to expose the Google AI Studio Gemini model
- enable the provider's e2e suite to run the existing PDF storage test scenario

## Testing
- `cargo fmt`
- `cargo check --package tensorzero-core`


------
https://chatgpt.com/codex/tasks/task_e_68e73223adc48325a3558f8b83953ed4
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Allow Google AI Studio Gemini to accept PDF uploads by removing image-only MIME restriction and updating tests.
> 
>   - **Behavior**:
>     - Removed image-only MIME type restriction in `google_ai_studio_gemini.rs` to allow PDF uploads.
>     - Updated `convert_non_thought_content_block()` to no longer require image MIME type.
>   - **Testing**:
>     - Added PDF test variant in `common.rs` for Google AI Studio Gemini.
>     - Updated `get_providers()` in `google_ai_studio_gemini.rs` to include PDF inference in `image_providers`.
>   - **Misc**:
>     - Ran `cargo fmt` and `cargo check --package tensorzero-core` for code formatting and checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2237b7ea0d40f41d5c8e072a5e125ad1e31b8d25. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->