### PR TITLE
bumped version to 2025.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2025.10.1"
+version = "2025.10.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1881,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2025.10.1"
+version = "2025.10.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2025.10.1"
+version = "2025.10.2"
 dependencies = [
  "axum",
  "clap",
@@ -4412,7 +4412,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2025.10.1"
+version = "2025.10.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5756,7 +5756,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2025.10.1"
+version = "2025.10.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2025.10.1"
+version = "2025.10.2"
 dependencies = [
  "napi",
  "napi-build",
@@ -5878,7 +5878,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.10.1"
+version = "2025.10.2"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2025.10.1"
+version = "2025.10.2"
 rust-version = "1.86.0"
 license = "Apache-2.0"
 

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2025.10.1"
+appVersion: "2025.10.2"

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2025.10.1",
+  "version": "2025.10.2",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump version from `2025.10.1` to `2025.10.2` across multiple files for consistent versioning.
> 
>   - **Version Bump**:
>     - Update version from `2025.10.1` to `2025.10.2` in `Cargo.lock` for packages: `evaluations`, `feedback-load-test`, `gateway`, `rate-limit-load-test`, `tensorzero-core`, `tensorzero-node`, `tensorzero-python`.
>     - Update version from `2025.10.1` to `2025.10.2` in `Cargo.toml`.
>     - Update `appVersion` from `2025.10.1` to `2025.10.2` in `Chart.yaml`.
>     - Update version from `2025.10.1` to `2025.10.2` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 61a9149a3a9f9fe7e009d96bbc4dc19801148790. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->