### PR TITLE
Updated Add Retry Config to Embedding Models 

### DIFF
--- a/tensorzero-core/tests/e2e/providers/azure_llama.rs
+++ b/tensorzero-core/tests/e2e/providers/azure_llama.rs
@@ -1,0 +1,99 @@
+use std::collections::HashMap;
+
+use crate::providers::common::{E2ETestProvider, E2ETestProviders};
+
+crate::generate_provider_tests!(get_providers);
+crate::generate_batch_inference_tests!(get_providers);
+
+async fn get_providers() -> E2ETestProviders {
+    let credentials = match std::env::var("AZURE_OPENAI_API_KEY") {
+        Ok(k) => HashMap::from([("azure_openai_api_key".to_string(), k)]),
+        Err(_) => HashMap::new(),
+    };
+
+    let standard_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
+        variant_name: "azure-llama".to_string(),
+        model_name: "llama-3.3-70b-instruct-azure".into(),
+        model_provider_name: "azure".into(),
+        credentials: HashMap::new(),
+    }];
+
+    let extra_body_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
+        variant_name: "azure-llama-extra-body".to_string(),
+        model_name: "llama-3.3-70b-instruct-azure".into(),
+        model_provider_name: "azure".into(),
+        credentials: HashMap::new(),
+    }];
+
+    let bad_auth_extra_headers = vec![E2ETestProvider {
+        supports_batch_inference: false,
+        variant_name: "azure-llama-extra-headers".to_string(),
+        model_name: "llama-3.3-70b-instruct-azure".into(),
+        model_provider_name: "azure".into(),
+        credentials: HashMap::new(),
+    }];
+
+    let inference_params_dynamic_providers = vec![E2ETestProvider {
+        supports_batch_inference: false,
+        variant_name: "azure-llama-dynamic".to_string(),
+        model_name: "llama-3.3-70b-instruct-azure-dynamic".into(),
+        model_provider_name: "azure".into(),
+        credentials,
+    }];
+
+    /*
+    let json_mode_inference = vec![E2ETestProvider {
+            supports_batch_inference: false,
+            variant_name: "azure-llama".to_string(), // json_mode=on
+            model_name: "llama-3.3-70b-instruct-azure".into(),
+            model_provider_name: "azure".into(),
+            credentials: HashMap::new(),
+        },
+        E2ETestProvider {
+            supports_batch_inference: false,
+            variant_name: "azure-llama-implicit".to_string(),
+            model_name: "llama-3.3-70b-instruct-azure".into(),
+            model_provider_name: "azure".into(),
+            credentials: HashMap::new(),
+        },
+        E2ETestProvider {
+            supports_batch_inference: false,
+            variant_name: "azure-llama-strict".to_string(),
+            model_name: "llama-3.3-70b-instruct-azure".into(),
+            model_provider_name: "azure".into(),
+            credentials: HashMap::new(),
+        },
+    ];
+
+    let json_mode_off_inference = vec![
+        E2ETestProvider {
+            supports_batch_inference: false,
+            variant_name: "azure-llama_json_mode_off".to_string(),
+            model_name: "llama-3.3-70b-instruct-azure".into(),
+            model_provider_name: "azure".into(),
+            credentials: HashMap::new(),
+        },
+    ];
+    */
+
+    E2ETestProviders {
+        simple_inference: standard_providers.clone(),
+        extra_body_inference: extra_body_providers,
+        bad_auth_extra_headers,
+        reasoning_inference: vec![],
+        embeddings: vec![], // No embeddings for Llama on Azure yet
+        inference_params_inference: standard_providers.clone(),
+        inference_params_dynamic_credentials: inference_params_dynamic_providers,
+        tool_use_inference: vec![],
+        tool_multi_turn_inference: vec![],
+        dynamic_tool_use_inference: vec![],
+        parallel_tool_use_inference: vec![],
+        json_mode_inference: vec![],
+        json_mode_off_inference: vec![],
+        image_inference: vec![],
+        pdf_inference: vec![],
+        shorthand_inference: vec![],
+    }
+}


### PR DESCRIPTION
Building on "Add retry config to Embedding models #3314 #3856," I rebased from origin/main and, instead of using git add . , I added only the Rust files I actively made changes to and the EmbeddingModelConfig.ts binding. This should get rid of every other TypeScript binding appearing in the changes. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add retry and timeout configurations to embedding models, updating related tests and configurations.
> 
>   - **Behavior**:
>     - Added `RetryConfig` and `TimeoutsConfig` to `EmbeddingModelConfig` in `embeddings.rs`.
>     - Updated `UninitializedEmbeddingModelConfig` to include `retries` and `timeouts`.
>     - Modified `EmbeddingModelConfig.ts` to include `retries` and `timeouts`.
>   - **Tests**:
>     - Added `test_embedding_provider_retries()` in `embeddings.rs` to verify retry logic.
>     - Updated `test_embedding_request()` in `openai.rs` to include retry configuration.
>   - **Misc**:
>     - Updated `tensorzero.toml` to reflect new endpoint configurations for Azure models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 73ae85f97d38e7302125573f30cfb859e1e65741. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->