### PR TITLE
Fix flaky stop-sequence test

### DIFF
--- a/tensorzero-core/tests/e2e/openai_compatible.rs
+++ b/tensorzero-core/tests/e2e/openai_compatible.rs
@@ -1003,10 +1003,10 @@ async fn test_openai_compatible_stop_sequence() {
         "messages": [
             {
                 "role": "user",
-                "content": "Output 'Hello' followed by either 'zero' or 'one'. Do not output anything else"
+                "content": "Output 'Hello world' followed by either '0' or '1'. Do not output anything else"
             }
         ],
-        "stop": ["zero", "one"],
+        "stop": ["0", "1"],
         "stream": false,
     });
 


### PR DESCRIPTION
This was failing in the scheduled merge queue run - adding more characters before the stop sequence occurs makes it pass consistently locally
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes flaky test `test_openai_compatible_stop_sequence` in `openai_compatible.rs` by adjusting the stop sequence and content.
> 
>   - **Behavior**:
>     - Fixes flaky test `test_openai_compatible_stop_sequence` in `openai_compatible.rs` by changing the `content` to "Output 'Hello world' followed by either '0' or '1'. Do not output anything else" and `stop` to `["0", "1"]`.
>   - **Misc**:
>     - Improves test reliability by ensuring the stop sequence is correctly triggered.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f88609f36786999546c818ccfc637aaf321011d1. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->