### PR TITLE
Fix Anthropic thought test

### DIFF
--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -2385,7 +2385,7 @@ pub async fn test_warn_ignored_thought_block_with_provider(provider: E2ETestProv
                         role: Role::Assistant,
                         content: vec![ClientInputMessageContent::Thought(Thought {
                             text: Some("My TensorZero thought".to_string()),
-                            signature: Some("My TensorZero signature".to_string()),
+                            signature: Some("My new TensorZero signature".to_string()),
                             provider_type: None,
                         })],
                     },


### PR DESCRIPTION
Anthropic now rejects thoughts with invalid signatures, which makes it easier for us to check that we actually attempted to forward a thought through to their API
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update `test_warn_ignored_thought_block_with_provider` in `common.rs` to handle Anthropic's rejection of invalid thought signatures.
> 
>   - **Behavior**:
>     - Updates `test_warn_ignored_thought_block_with_provider` in `common.rs` to handle Anthropic's rejection of invalid thought signatures.
>     - Checks for error containing "signature" when provider is Anthropic.
>   - **Tests**:
>     - Changes test signature from "My TensorZero signature" to "My new TensorZero signature" in `common.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b8e328a1111bf043532a067b155edd5fe862957a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->