### PR TITLE
Support incoming 'tensorzero-otlp-traces-extra-resource-' header

### DIFF
--- a/tensorzero-core/src/observability/mod.rs
+++ b/tensorzero-core/src/observability/mod.rs
@@ -17,8 +17,9 @@
 //! As part of our opentelemetry handling, we support forwarding custom HTTP headers to the OTLP export endpoint.
 //! This requires several interconnected steps:
 //! 1. A client makes a request to a traced-enabled TensorZero HTTP endpoint (e.g. POST /inference),
-//!    with header(s) prefixed with `tensorzero-otlp-traces-extra-header-`.
-//!    For example, `tensorzero-otlp-traces-extra-header-my-first-header: my-first-value`.
+//!    with header(s) prefixed with:
+//! * `tensorzero-otlp-traces-extra-header-`: For example, `tensorzero-otlp-traces-extra-header-my-first-header: my-first-value`.
+//! * `tensorzero-otlp-traces-extra-resource-`: For example, `tensorzero-otlp-traces-extra-resource-my-first-resource: my-first-value`.
 //! 2. Our `tensorzero_tracing_middleware` Axum middleware detects these custom headers,
 //!    and rejects the request if the headers fail to parse as a `tonic::metadata::MetadataMap`
 //!    (this is the type that we will ultimately pass to the OTLP exporter).
@@ -32,7 +33,8 @@
 //!    which triggers shutdown in our `Drop` impl for `CustomTracer`
 //! 4. When a span is exported using `TracerWrapper::build_with_context`, we inspect the `Context` for a `CustomTracerContextEntry`.
 //!    If present, we use the wrapped `CustomTracer`, which will cause the span to get exported using the correct
-//!    custom HTTP headers. Otherwise, we our default `SdkTracer`, which doesn't attach any custom headers
+//!    custom HTTP headers and OpenTelemetry resources. Otherwise, we our default `SdkTracer`, which doesn't attach any custom headers
+//!    or extra OpenTelemetry resources.
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -87,25 +89,41 @@ pub enum LogFormat {
 
 #[derive(Clone, Debug)]
 struct CustomTracerKey {
+    // Extra headers to use for outgoing OTLP export requests.
+    // These will be set as headers in the gRPc request made by `tonic`
     extra_headers: MetadataMap,
+    // Extra OpenTelemetry resources (https://opentelemetry.io/docs/languages/js/resources/)
+    // These will be set as attributes on *all* spans (not just top-level spans)
+    // exported by a `CustomTracer`
+    extra_resources: Vec<KeyValue>,
 }
 
 impl Hash for CustomTracerKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        let CustomTracerKey { extra_headers } = self;
+        let CustomTracerKey {
+            extra_headers,
+            extra_resources,
+        } = self;
+        // We add null byte separators to keep the data prefix-free: https://doc.rust-lang.org/std/hash/trait.Hash.html#prefix-collisions
         extra_headers.as_ref().iter().for_each(|(key, value)| {
             key.hash(state);
             state.write_u8(0);
             value.hash(state);
             state.write_u8(0);
         });
+        state.write_u8(0);
+        extra_resources.hash(state);
     }
 }
 
 impl PartialEq for CustomTracerKey {
     fn eq(&self, other: &Self) -> bool {
-        let CustomTracerKey { extra_headers } = self;
+        let CustomTracerKey {
+            extra_headers,
+            extra_resources,
+        } = self;
         extra_headers.as_ref() == other.extra_headers.as_ref()
+            && extra_resources == &other.extra_resources
     }
 }
 
@@ -184,8 +202,11 @@ impl TracerWrapper {
         //    lookup and nested `build_with_context` inside the closure.
         let tracer = self.custom_tracers.try_get_with_by_ref(key, || {
             // We need to provide a dummy generic parameter to satisfy the compiler
-            let (provider, tracer) =
-                build_tracer::<opentelemetry_otlp::SpanExporter>(key.extra_headers.clone(), None)?;
+            let (provider, tracer) = build_tracer::<opentelemetry_otlp::SpanExporter>(
+                key.extra_headers.clone(),
+                key.extra_resources.clone(),
+                None,
+            )?;
             Ok::<_, Error>(Arc::new(CustomTracer {
                 inner: tracer,
                 provider: Some(provider),
@@ -206,6 +227,7 @@ impl TracerWrapper {
 /// to outgoing OTLP export requests.
 fn build_tracer<T: SpanExporter + 'static>(
     metadata: MetadataMap,
+    resources: Vec<KeyValue>,
     override_exporter: Option<T>,
 ) -> Result<(SdkTracerProvider, SdkTracer), Error> {
     let exporter = opentelemetry_otlp::SpanExporter::builder()
@@ -225,6 +247,7 @@ fn build_tracer<T: SpanExporter + 'static>(
                 opentelemetry_semantic_conventions::resource::SERVICE_NAME,
                 "tensorzero-gateway",
             ))
+            .with_attributes(resources)
             .build(),
     );
 
@@ -287,8 +310,8 @@ struct OtelLayerData<T: Layer<Registry>> {
 fn internal_build_otel_layer<T: SpanExporter + 'static>(
     override_exporter: Option<T>,
 ) -> Result<OtelLayerData<impl Layer<Registry>>, Error> {
-    // Default tracer always has empty headers
-    let (provider, tracer) = build_tracer(MetadataMap::new(), override_exporter)?;
+    // Default tracer always has empty headers and no extra resources
+    let (provider, tracer) = build_tracer(MetadataMap::new(), vec![], override_exporter)?;
     opentelemetry::global::set_tracer_provider(provider.clone());
     let shutdown_tasks = TaskTracker::new();
     // Initialize empty - will be set once later via set_static_otlp_traces_extra_headers
@@ -466,6 +489,7 @@ pub trait RouterExt<S> {
 ///
 /// 5. The custom `SdkTracer` is preserved in a `moka::Cache` for subsequent requests.
 const TENSORZERO_OTLP_HEADERS_PREFIX: &str = "tensorzero-otlp-traces-extra-header-";
+const TENSORZERO_OTLP_RESOURCE_PREFIX: &str = "tensorzero-otlp-traces-extra-resource-";
 
 /// Converts a HashMap of config headers to a MetadataMap
 fn config_headers_to_metadata(
@@ -506,6 +530,7 @@ fn extract_tensorzero_headers(
         .get()
         .cloned()
         .unwrap_or_default();
+    let mut extra_resources = vec![];
     for (name, value) in headers {
         if let Some(suffix) = name.as_str().strip_prefix(TENSORZERO_OTLP_HEADERS_PREFIX) {
             let key: AsciiMetadataKey = suffix.parse().map_err(|e| {
@@ -524,11 +549,25 @@ fn extract_tensorzero_headers(
             })?;
             metadata.insert(key, value);
         }
+        if let Some(suffix) = name.as_str().strip_prefix(TENSORZERO_OTLP_RESOURCE_PREFIX) {
+            let key = suffix.to_string();
+            let value = value.to_str().map_err(|e| {
+                Error::new(ErrorDetails::Observability {
+                    message: format!("Failed to parse `{TENSORZERO_OTLP_RESOURCE_PREFIX}` header `{suffix}` value as valid string: {e}"),
+                })
+            })?.to_string();
+            extra_resources.push(KeyValue::new(key, value));
+        }
     }
-    if !metadata.is_empty() {
-        tracing::debug!("Using custom OTLP headers: {:?}", metadata);
+    if !metadata.is_empty() || !extra_resources.is_empty() {
+        tracing::debug!(
+            "Using custom OTLP configuration: metadata={:?}, extra_resources={:?}",
+            metadata,
+            extra_resources
+        );
         return Ok(Some(CustomTracerKey {
             extra_headers: metadata,
+            extra_resources,
         }));
     }
     Ok(None)

--- a/tensorzero-core/tests/e2e/otel_config_headers.rs
+++ b/tensorzero-core/tests/e2e/otel_config_headers.rs
@@ -13,7 +13,7 @@ use tensorzero_core::inference::types::TextKind;
 
 use crate::common::get_gateway_endpoint;
 use crate::otel::install_capturing_otel_exporter;
-use crate::otel_export::get_tempo_spans;
+use crate::otel_export::{get_tempo_spans, TempoSpans};
 
 /// Test that static headers from config are applied
 /// This verifies that the config parses correctly and the system works end-to-end
@@ -284,8 +284,11 @@ async fn test_otel_config_and_dynamic_header_override() {
 
     // Query Tempo to get the spans and verify the headers
     let tempo_semaphore = tokio::sync::Semaphore::new(1);
-    let (function_inference_span, span_by_id) =
-        get_tempo_spans(episode_id, start_time, &tempo_semaphore).await;
+    let TempoSpans {
+        target_span: function_inference_span,
+        span_by_id,
+        resources: _,
+    } = get_tempo_spans(episode_id, start_time, &tempo_semaphore).await;
 
     // Get the HTTP span (parent of function_inference)
     let parent_id = function_inference_span["parentSpanId"].as_str().unwrap();

--- a/tensorzero-core/tests/e2e/otel_export.rs
+++ b/tensorzero-core/tests/e2e/otel_export.rs
@@ -5,6 +5,7 @@ use base64::prelude::*;
 use chrono::DateTime;
 use chrono::Utc;
 use http::StatusCode;
+use opentelemetry::KeyValue;
 use opentelemetry::SpanId;
 use opentelemetry::TraceId;
 use opentelemetry_sdk::trace::IdGenerator;
@@ -25,7 +26,7 @@ struct ExistingTraceData {
 
 #[tokio::test]
 async fn test_otel_export_trace_export_no_parent() {
-    test_otel_export_trace_export(None, None, Arc::new(Semaphore::new(1))).await;
+    test_otel_export_trace_export(None, None, None, Arc::new(Semaphore::new(1))).await;
 }
 
 #[tokio::test]
@@ -35,6 +36,7 @@ async fn test_otel_export_trace_export_with_parent() {
     let span_id = id_gen.new_span_id();
     test_otel_export_trace_export(
         Some(ExistingTraceData { trace_id, span_id }),
+        None,
         None,
         Arc::new(Semaphore::new(1)),
     )
@@ -48,12 +50,15 @@ async fn test_otel_export_trace_export_with_custom_header() {
     let mut futures = JoinSet::new();
     let num_tasks = 100;
     for _ in 0..num_tasks {
-        let random_id = Uuid::now_v7();
         futures.spawn(test_otel_export_trace_export(
             None,
             Some((
                 "TensorZero-OTLP-Traces-Extra-Header-x-dummy-tensorzero".to_string(),
-                random_id.to_string(),
+                Uuid::now_v7().to_string(),
+            )),
+            Some(KeyValue::new(
+                "my-custom-resource",
+                Uuid::now_v7().to_string(),
             )),
             semaphore.clone(),
         ));
@@ -98,8 +103,11 @@ async fn test_otel_export_http_error() {
     assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
     let _response_json = response.json::<Value>().await.unwrap();
 
-    let (function_inference_span, span_by_id) =
-        get_tempo_spans(episode_id, start_time, &Semaphore::new(1)).await;
+    let TempoSpans {
+        target_span: function_inference_span,
+        span_by_id,
+        resources: _,
+    } = get_tempo_spans(episode_id, start_time, &Semaphore::new(1)).await;
 
     let parent_id = function_inference_span["parentSpanId"].as_str().unwrap();
     let parent_span = span_by_id.get(parent_id).unwrap();
@@ -127,11 +135,17 @@ async fn test_otel_export_http_error() {
     );
 }
 
+pub struct TempoSpans {
+    pub target_span: Value,
+    pub span_by_id: HashMap<String, Value>,
+    pub resources: Vec<Value>,
+}
+
 pub async fn get_tempo_spans(
     episode_id: Uuid,
     start_time: DateTime<Utc>,
     tempo_semaphore: &Semaphore,
-) -> (Value, HashMap<String, Value>) {
+) -> TempoSpans {
     // It takes some time for the span to show up in Tempo
     tokio::time::sleep(std::time::Duration::from_secs(25)).await;
 
@@ -173,8 +187,10 @@ pub async fn get_tempo_spans(
 
     let mut span_by_id = HashMap::new();
     let mut target_span = None;
+    let mut resources = Vec::new();
 
     for batch in trace_data["batches"].as_array().unwrap() {
+        resources.push(batch["resource"].clone());
         for scope_span in batch["scopeSpans"].as_array().unwrap() {
             for span in scope_span["spans"].as_array().unwrap() {
                 span_by_id.insert(span["spanId"].as_str().unwrap().to_string(), span.clone());
@@ -204,18 +220,20 @@ pub async fn get_tempo_spans(
             }
         }
     }
-    (
-        target_span.unwrap_or_else(|| {
+    TempoSpans {
+        target_span: target_span.unwrap_or_else(|| {
             panic!("No function_inference span found with matching episode: {episode_id}")
         }),
         span_by_id,
-    )
+        resources,
+    }
 }
 
 // TODO - investigate why this test is sometimes flaky when running locally
 async fn test_otel_export_trace_export(
     existing_trace_parent: Option<ExistingTraceData>,
     custom_header: Option<(String, String)>,
+    custom_resource: Option<KeyValue>,
     tempo_semaphore: Arc<Semaphore>,
 ) {
     let client = reqwest::Client::new();
@@ -246,6 +264,15 @@ async fn test_otel_export_trace_export(
     if let Some((custom_key, custom_value)) = &custom_header {
         builder = builder.header(custom_key, custom_value);
     }
+    if let Some(custom_resource) = &custom_resource {
+        builder = builder.header(
+            format!(
+                "tensorzero-otlp-traces-extra-resource-{}",
+                custom_resource.key
+            ),
+            custom_resource.value.to_string(),
+        );
+    }
 
     let existing_trace_header = existing_trace_parent
         // Version 00, with the 'sampled' flag set to 1
@@ -260,8 +287,30 @@ async fn test_otel_export_trace_export(
     // Check that the API response is ok
     assert_eq!(response.status(), StatusCode::OK);
     let _response_json = response.json::<Value>().await.unwrap();
-    let (function_inference_span, span_by_id) =
-        get_tempo_spans(episode_id, start_time, &tempo_semaphore).await;
+    let TempoSpans {
+        target_span: function_inference_span,
+        span_by_id,
+        resources,
+    } = get_tempo_spans(episode_id, start_time, &tempo_semaphore).await;
+
+    // Each tempo 'batch' has its own resources object
+    for batch_resources in resources {
+        let attrs: HashMap<&str, serde_json::Value> = batch_resources["attributes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|a| (a["key"].as_str().unwrap(), a["value"].clone()))
+            .collect();
+        assert_eq!(attrs["service.name"]["stringValue"], "tensorzero-gateway");
+        if let Some(custom_resource) = &custom_resource {
+            assert_eq!(
+                attrs[custom_resource.key.as_str()]["stringValue"]
+                    .as_str()
+                    .unwrap(),
+                custom_resource.value.to_string()
+            );
+        }
+    }
 
     // Just check a couple of spans - we already have more comprehensive tests that check the exact spans
     // send to the global `opentelemetry` exporter.


### PR DESCRIPTION
This is very similar to the existing 'tensorzero-otlp-traces-extra-header-' behavior, except that we set a custom 'OpenTelemetry resource' (https://opentelemetry.io/docs/languages/js/resources/) on the tracer used by all of the spans produced by the incoming HTTP request.

This will allow dynamically setting 'model_id' when exporting OpenTelemetry to Arize
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for `tensorzero-otlp-traces-extra-resource-` header to set custom OpenTelemetry resources on spans.
> 
>   - **Behavior**:
>     - Support for `tensorzero-otlp-traces-extra-resource-` header added in `mod.rs` to set custom OpenTelemetry resources on spans.
>     - `extract_tensorzero_headers()` updated to parse new resource headers.
>     - `build_tracer()` updated to accept `resources` parameter for span attributes.
>   - **Tests**:
>     - `test_otel_export.rs`: Add tests for resource headers in `test_otel_export_trace_export_with_custom_header()` and `test_otel_export_trace_export()`.
>     - `otel_config_headers.rs`: Add tests for dynamic header overrides in `test_otel_config_and_dynamic_header_override()`.
>   - **Misc**:
>     - Update `CustomTracerKey` to include `extra_resources` and update `Hash` and `PartialEq` implementations accordingly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 72a124932e841be72adc2eeb62bdc0fd6aece73d. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->