### PR TITLE
added structured output implementation for groq

### DIFF
--- a/tensorzero-core/tests/e2e/tensorzero.toml
+++ b/tensorzero-core/tests/e2e/tensorzero.toml
@@ -123,7 +123,7 @@ routing = ["groq"]
 
 [models."groq-qwen".providers.groq]
 type = "groq"
-model_name = "qwen/qwen3-32b"
+model_name = "meta-llama/llama-4-scout-17b-16e-instruct"
 
 
 [models."groq-qwen-dynamic"]
@@ -131,7 +131,7 @@ routing = ["groq"]
 
 [models."groq-qwen-dynamic".providers.groq]
 type = "groq"
-model_name = "qwen/qwen3-32b"
+model_name = "meta-llama/llama-4-scout-17b-16e-instruct"
 api_key_location = "dynamic::groq_api_key"
 
 


### PR DESCRIPTION
Closes #3956 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added structured JSON schema output support for Groq in `groq.rs` and updated model configuration in `tensorzero.toml`.
> 
>   - **Behavior**:
>     - Added `JsonSchema` variant to `GroqResponseFormat` in `groq.rs` to support structured JSON output.
>     - `GroqResponseFormat::new()` now handles `ModelInferenceRequestJsonMode::Strict` with optional schema.
>     - Updated `GroqRequest` to use new `JsonSchema` format when applicable.
>   - **Tests**:
>     - Updated tests in `groq.rs` to cover new `JsonSchema` variant and serialization.
>     - Modified test cases to reflect changes in `GroqResponseFormat` handling.
>   - **Configuration**:
>     - Updated `tensorzero.toml` to change `model_name` for Groq to `meta-llama/llama-4-scout-17b-16e-instruct`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 95748fe6a2fb89d4d7e15889e948de3ff4a29e22. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->