### PR TITLE
Explicitly wait on existing spans to finish before OTEL shutdown

### DIFF
--- a/tensorzero-core/src/observability/mod.rs
+++ b/tensorzero-core/src/observability/mod.rs
@@ -765,7 +765,7 @@ impl TracerWrapper {
         // See the docs on `InFlightSpan` for more information.
         self.in_flight_spans.close();
         self.in_flight_spans.wait().await;
-        // Now that all of our OpenTelemetry spans have closed (including spans in backgorund tasks),
+        // Now that all of our OpenTelemetry spans have closed (including spans in background tasks),
         // shut down all of our custom tracers.
         // This might happen in parallel for the same custom tracer (if moka evicts its cache entry), but opentelemetry
         // documents that it's safe to call `shutdown` multiple times.


### PR DESCRIPTION
Currently, none of our OTEL spans outlive the overall processing of the original HTTP request. However, once we introduce spans for rate-limiting and first-of-n, we'll start exporting spans for background logic (e.g. `return_tickets`).

To make sure that we don't skip exporting any spans, we now attach a `TaskTrackerToken` to the OpenTelmemetry `Context`, and wait for the parent `TaskTracker` to finish before shutting down any OpenTelemetry trackers. The `tracing-opentelemetry` crate will propagate the `Context` to child spans, ensuring that the `TaskTrackerToken` is only dropped after all of the descendant spans are cloesd (e.g. for instrumented `tokio::spawn` tasks).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure all OpenTelemetry spans are exported before shutdown by tracking in-flight spans with `TaskTrackerToken`.
> 
>   - **Behavior**:
>     - Introduces `InFlightSpan` struct to track in-flight spans in `Context`.
>     - `TracerWrapper::shutdown()` now waits for `in_flight_spans` to finish before shutting down OTEL exporters.
>   - **Implementation**:
>     - Adds `in_flight_spans: TaskTracker` to `TracerWrapper`.
>     - `make_otel_http_span()` attaches `InFlightSpan` to `Context`.
>     - `TracerWrapper::shutdown()` closes and waits on `in_flight_spans`.
>   - **Misc**:
>     - Minor comments and documentation updates in `mod.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 705db02551a2630a22a915112e1c63b80dc6665c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->