### PR TITLE
Use 'wait-for-builder: true' with 'nscloud-setup-buildx-action'

### DIFF
--- a/.github/workflows/build-gateway-container.yml
+++ b/.github/workflows/build-gateway-container.yml
@@ -27,7 +27,9 @@ jobs:
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx
-        uses: namespacelabs/nscloud-setup-buildx-action@84ca8c58fdf372d6a4750476cd09b7b96ee778ca
+        uses: namespacelabs/nscloud-setup-buildx-action@91c2e6537780e3b092cb8476406be99a8f91bd5e
+        with:
+          wait-for-builder: true
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Build `gateway` container

--- a/.github/workflows/build-ui-container.yml
+++ b/.github/workflows/build-ui-container.yml
@@ -27,7 +27,9 @@ jobs:
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx
-        uses: namespacelabs/nscloud-setup-buildx-action@84ca8c58fdf372d6a4750476cd09b7b96ee778ca
+        uses: namespacelabs/nscloud-setup-buildx-action@91c2e6537780e3b092cb8476406be99a8f91bd5e
+        with:
+          wait-for-builder: true
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Build `ui` container

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -98,7 +98,9 @@ jobs:
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx
-        uses: namespacelabs/nscloud-setup-buildx-action@84ca8c58fdf372d6a4750476cd09b7b96ee778ca
+        uses: namespacelabs/nscloud-setup-buildx-action@91c2e6537780e3b092cb8476406be99a8f91bd5e
+        with:
+          wait-for-builder: true
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Create the `object_storage` directory for the multimodal-vision-finetuning example

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -105,7 +105,9 @@ jobs:
         shell: bash
 
       - name: Configure Namespace-powered Buildx
-        uses: namespacelabs/nscloud-setup-buildx-action@84ca8c58fdf372d6a4750476cd09b7b96ee778ca
+        uses: namespacelabs/nscloud-setup-buildx-action@91c2e6537780e3b092cb8476406be99a8f91bd5e
+        with:
+          wait-for-builder: true
 
       - name: Install Rust toolchain
         run: |


### PR DESCRIPTION
This is a new option added by Namespace, which should prevent the occasionaly spurious timeouts that we're seeing when starting docker builds
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `nscloud-setup-buildx-action` to use `wait-for-builder: true` in multiple workflows to prevent Docker build timeouts.
> 
>   - **Workflows**:
>     - Update `nscloud-setup-buildx-action` to version `91c2e6537780e3b092cb8476406be99a8f91bd5e` in `build-gateway-container.yml`, `build-ui-container.yml`, `general.yml`, and `merge-queue.yml`.
>     - Add `wait-for-builder: true` option to `nscloud-setup-buildx-action` in the same files to prevent spurious timeouts during Docker builds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1a0a4c7909e6a1ff89c1693ba0d6cb138fb2bb43. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->