### PR TITLE
max_tokens -> max_completion_tokens for azure

### DIFF
--- a/tensorzero-core/src/providers/azure.rs
+++ b/tensorzero-core/src/providers/azure.rs
@@ -593,7 +593,7 @@ struct AzureRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     frequency_penalty: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    max_tokens: Option<u32>,
+    max_completion_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     seed: Option<u32>,
     stream: bool,
@@ -630,7 +630,7 @@ impl<'a> AzureRequest<'a> {
             stop: request.borrow_stop_sequences(),
             presence_penalty: request.presence_penalty,
             frequency_penalty: request.frequency_penalty,
-            max_tokens: request.max_tokens,
+            max_completion_tokens: request.max_tokens,
             stream: request.stream,
             response_format,
             seed: request.seed,
@@ -815,7 +815,7 @@ mod tests {
 
         assert_eq!(azure_request.messages.len(), 1);
         assert_eq!(azure_request.temperature, Some(0.5));
-        assert_eq!(azure_request.max_tokens, Some(100));
+        assert_eq!(azure_request.max_completion_tokens, Some(100));
         assert!(!azure_request.stream);
         assert_eq!(azure_request.seed, Some(69));
         assert_eq!(azure_request.response_format, None);
@@ -861,7 +861,7 @@ mod tests {
 
         assert_eq!(azure_request.messages.len(), 2);
         assert_eq!(azure_request.temperature, Some(0.5));
-        assert_eq!(azure_request.max_tokens, Some(100));
+        assert_eq!(azure_request.max_completion_tokens, Some(100));
         assert_eq!(azure_request.top_p, Some(0.9));
         assert_eq!(azure_request.presence_penalty, Some(0.1));
         assert_eq!(azure_request.frequency_penalty, Some(0.2));


### PR DESCRIPTION
For now, just the fix. All azure tests were verified to pass. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rename `max_tokens` to `max_completion_tokens` in `AzureRequest` struct and update references in `azure.rs` and tests.
> 
>   - **Refactor**:
>     - Rename `max_tokens` to `max_completion_tokens` in `AzureRequest` struct in `azure.rs`.
>     - Update all references to `max_tokens` to `max_completion_tokens` in `azure.rs` and related tests.
>   - **Tests**:
>     - Update assertions in `test_azure_request_new` to check `max_completion_tokens` instead of `max_tokens`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 077fa2ccc4b6367861809b4fb164ff1be4ce245a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->