### PR TITLE
Separate dataset queries trait and ClickHouse implementation

### DIFF
--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -65,7 +65,7 @@ pub use tensorzero_core::db::clickhouse::query_builder::{
     TimeComparisonOperator, TimeFilter,
 };
 pub use tensorzero_core::endpoints::datasets::{
-    ChatInferenceDatapoint, Datapoint, JsonInferenceDatapoint,
+    ChatInferenceDatapoint, Datapoint, DatapointKind, JsonInferenceDatapoint,
 };
 pub use tensorzero_core::endpoints::dynamic_evaluation_run::{
     DynamicEvaluationRunParams, DynamicEvaluationRunResponse,

--- a/tensorzero-core/src/db/clickhouse/dataset_queries.rs
+++ b/tensorzero-core/src/db/clickhouse/dataset_queries.rs
@@ -6,22 +6,13 @@ use std::num::ParseIntError;
 use crate::db::clickhouse::{ClickHouseConnectionInfo, Rows, TableName};
 // TODO: move things somewhere sensible
 use crate::db::datasets::{
-    AdjacentDatapointIds, CountDatapointsForDatasetFunctionParams, DatapointInsert, DatapointKind,
+    AdjacentDatapointIds, CountDatapointsForDatasetFunctionParams, DatapointInsert,
     DatasetDetailRow, DatasetMetadata, DatasetOutputSource, DatasetQueries, DatasetQueryParams,
     GetAdjacentDatapointIdsParams, GetDatapointParams, GetDatasetMetadataParams,
     GetDatasetRowsParams, StaleDatapointParams,
 };
-use crate::endpoints::datasets::{validate_dataset_name, Datapoint};
+use crate::endpoints::datasets::{validate_dataset_name, Datapoint, DatapointKind};
 use crate::error::{Error, ErrorDetails};
-
-impl DatapointKind {
-    pub fn table_name(&self) -> TableName {
-        match self {
-            DatapointKind::Chat => TableName::ChatInferenceDatapoint,
-            DatapointKind::Json => TableName::JsonInferenceDatapoint,
-        }
-    }
-}
 
 #[async_trait]
 impl DatasetQueries for ClickHouseConnectionInfo {
@@ -792,9 +783,7 @@ mod tests {
     use crate::db::datasets::{
         ChatInferenceDatapointInsert, JsonInferenceDatapointInsert, MetricFilter,
     };
-    use crate::inference::types::{
-        ContentBlockChatOutput, JsonInferenceOutput, StoredInput, Text,
-    };
+    use crate::inference::types::{ContentBlockChatOutput, JsonInferenceOutput, StoredInput, Text};
 
     use super::*;
 

--- a/tensorzero-core/src/db/datasets.rs
+++ b/tensorzero-core/src/db/datasets.rs
@@ -5,21 +5,13 @@ use uuid::Uuid;
 
 use crate::config::{MetricConfigLevel, MetricConfigType};
 use crate::db::clickhouse::query_builder::FloatComparisonOperator;
-use crate::endpoints::datasets::Datapoint;
+use crate::endpoints::datasets::{Datapoint, DatapointKind};
 use crate::error::Error;
 use crate::inference::types::{ContentBlockChatOutput, JsonInferenceOutput, StoredInput};
 use crate::serde_util::{
     deserialize_optional_string_or_parsed_json, deserialize_string_or_parsed_json,
 };
 use crate::tool::ToolCallConfigDatabaseInsert;
-
-#[derive(Debug, Serialize, Deserialize, ts_rs::TS)]
-#[serde(rename_all = "snake_case")]
-#[ts(export)]
-pub enum DatapointKind {
-    Chat,
-    Json,
-}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]

--- a/tensorzero-core/src/endpoints/datasets.rs
+++ b/tensorzero-core/src/endpoints/datasets.rs
@@ -13,8 +13,8 @@ use std::{collections::HashMap, future::Future, pin::Pin};
 use tracing::instrument;
 use uuid::Uuid;
 
-use crate::db::clickhouse::{ClickHouseConnectionInfo, ExternalDataInfo};
-use crate::db::datasets::{DatapointKind, DatasetQueries, GetDatapointParams};
+use crate::db::clickhouse::{ClickHouseConnectionInfo, ExternalDataInfo, TableName};
+use crate::db::datasets::{DatasetQueries, GetDatapointParams};
 use crate::function::{FunctionConfig, FunctionConfigType};
 use crate::http::TensorzeroHttpClient;
 use crate::inference::types::stored_input::StoredInput;
@@ -1069,6 +1069,23 @@ pub struct ExistingInferenceInfo {
     pub function_name: String,
     pub variant_name: String,
     pub episode_id: Uuid,
+}
+
+#[derive(Debug, Serialize, Deserialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+#[ts(export)]
+pub enum DatapointKind {
+    Chat,
+    Json,
+}
+
+impl DatapointKind {
+    pub fn table_name(&self) -> TableName {
+        match self {
+            DatapointKind::Chat => TableName::ChatInferenceDatapoint,
+            DatapointKind::Json => TableName::JsonInferenceDatapoint,
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]

--- a/tensorzero-core/tests/e2e/common.rs
+++ b/tensorzero-core/tests/e2e/common.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 
 use reqwest::Url;
 use tensorzero_core::{
-    db::{clickhouse::ClickHouseConnectionInfo, datasets::DatapointKind},
-    endpoints::datasets::CLICKHOUSE_DATETIME_FORMAT,
+    db::clickhouse::ClickHouseConnectionInfo,
+    endpoints::datasets::{DatapointKind, CLICKHOUSE_DATETIME_FORMAT},
 };
 use uuid::Uuid;
 

--- a/tensorzero-core/tests/e2e/datasets.rs
+++ b/tensorzero-core/tests/e2e/datasets.rs
@@ -6,14 +6,10 @@ use reqwest::{Client, StatusCode};
 use serde_json::{json, Value};
 use tensorzero::{ChatInferenceDatapoint, JsonInferenceDatapoint, Role};
 use tensorzero_core::{
-    db::{
-        clickhouse::test_helpers::{
-            select_chat_dataset_clickhouse, select_json_dataset_clickhouse,
-            stale_datapoint_clickhouse,
-        },
-        datasets::DatapointKind,
+    db::clickhouse::test_helpers::{
+        select_chat_dataset_clickhouse, select_json_dataset_clickhouse, stale_datapoint_clickhouse,
     },
-    endpoints::datasets::CLICKHOUSE_DATETIME_FORMAT,
+    endpoints::datasets::{DatapointKind, CLICKHOUSE_DATETIME_FORMAT},
     inference::types::{ContentBlockChatOutput, StoredInputMessageContent},
 };
 

--- a/tensorzero-core/tests/e2e/db/dataset_queries.rs
+++ b/tensorzero-core/tests/e2e/db/dataset_queries.rs
@@ -7,15 +7,13 @@ use tensorzero::{
     GetDatasetMetadataParams, Role,
 };
 use tensorzero_core::config::{MetricConfigLevel, MetricConfigType};
-use tensorzero_core::db::{
-    clickhouse::test_helpers::get_clickhouse,
-    datasets::{
-        ChatInferenceDatapointInsert, CountDatapointsForDatasetFunctionParams, DatapointInsert,
-        DatapointKind, DatasetMetadata, DatasetOutputSource, DatasetQueries,
-        GetAdjacentDatapointIdsParams, GetDatasetRowsParams, JsonInferenceDatapointInsert,
-        MetricFilter, StaleDatapointParams,
-    },
+use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
+use tensorzero_core::db::datasets::{
+    ChatInferenceDatapointInsert, CountDatapointsForDatasetFunctionParams, DatapointInsert,
+    DatasetMetadata, DatasetOutputSource, DatasetQueries, GetAdjacentDatapointIdsParams,
+    GetDatasetRowsParams, JsonInferenceDatapointInsert, MetricFilter, StaleDatapointParams,
 };
+use tensorzero_core::endpoints::datasets::DatapointKind;
 use tensorzero_core::inference::types::{
     ContentBlockChatOutput, JsonInferenceOutput, StoredInput, StoredInputMessage,
     StoredInputMessageContent, Text,


### PR DESCRIPTION
This is a pure refactor to separate the dataset trait and clickhouse SQL. `tensorzero-core/src/db/datasets.rs` now contains the `pub trait` and associated types, and `tensorzero-core/src/db/clickhouse/dataset_queries.rs` contains all the sql and real logic.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor to separate dataset trait and ClickHouse SQL logic into `datasets.rs` and `clickhouse/dataset_queries.rs`, updating imports and tests accordingly.
> 
>   - **Refactor**:
>     - Move `DatasetQueries` trait and associated types to `datasets.rs`.
>     - Move ClickHouse SQL logic to `clickhouse/dataset_queries.rs`.
>   - **Imports**:
>     - Update imports in `lib.rs`, `mod.rs`, and `endpoints/datasets.rs` to use new `datasets.rs` path.
>   - **Tests**:
>     - Update `tests/e2e/db/dataset_queries.rs` to reflect new structure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b6753144b4082f72b75b8aacd42f7c7a5562a434. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->