### PR TITLE
Lint 'tokio::task::spawn' and add TODO comments on existing code

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -7,4 +7,5 @@ disallowed-types = [
 ]
 disallowed-methods = [
     { path = "tracing_subscriber::layer::Layer::with_filter", reason = "Call `apply_filter_fixing_tracing_bug` instead" },
+    { path = "tokio::task::spawn", reason = "Verify that it's okay for the gateway to shut down without waiting for this task"}
 ]

--- a/evaluations/src/lib.rs
+++ b/evaluations/src/lib.rs
@@ -458,6 +458,8 @@ pub async fn run_evaluation_core_streaming(
 
     // Spawn a task to collect results and stream them
     let sender_clone = sender.clone();
+    // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+    #[expect(clippy::disallowed_methods)]
     tokio::spawn(async move {
         while let Some(result) = join_set.join_next_with_id().await {
             let update = match result {

--- a/provider-proxy/src/lib.rs
+++ b/provider-proxy/src/lib.rs
@@ -357,6 +357,8 @@ async fn run_health_server(port: u16) -> Result<(), Box<dyn std::error::Error + 
         let (stream, _) = listener.accept().await?;
         let io = hyper_util::rt::TokioIo::new(stream);
 
+        // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+        #[expect(clippy::disallowed_methods)]
         tokio::task::spawn(async move {
             if let Err(err) = http1::Builder::new()
                 .serve_connection(io, service_fn(health_check_handler))
@@ -389,6 +391,8 @@ pub async fn run_server(args: Args, server_started: oneshot::Sender<SocketAddr>)
 
     // Start health check server
     let health_port = args.health_port;
+    // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+    #[expect(clippy::disallowed_methods)]
     tokio::spawn(async move {
         if let Err(e) = run_health_server(health_port).await {
             tracing::error!("Health check server failed: {:?}", e);

--- a/provider-proxy/src/mitm_server.rs
+++ b/provider-proxy/src/mitm_server.rs
@@ -71,6 +71,8 @@ where
                 let service = service.clone();
 
                 let proxy = proxy.clone();
+                // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+                #[expect(clippy::disallowed_methods)]
                 tokio::spawn(async move {
                     if let Err(err) = server::conn::http1::Builder::new()
                         .preserve_header_case(true)
@@ -123,6 +125,8 @@ where
                             .map(|b| b.boxed().map_err(|never| match never {}).boxed()));
                     };
 
+                    // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+                    #[expect(clippy::disallowed_methods)]
                     tokio::spawn(async move {
                         let Ok(client) = hyper::upgrade::on(req).await else {
                             tracing::error!(

--- a/provider-proxy/tests/e2e/tests.rs
+++ b/provider-proxy/tests/e2e/tests.rs
@@ -45,6 +45,8 @@ async fn start_target_server(
         );
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
+    // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+    #[expect(clippy::disallowed_methods)]
     let handle = tokio::spawn(
         axum::serve(listener, app)
             .with_graceful_shutdown(shutdown_signal)
@@ -58,6 +60,8 @@ async fn test_provider_proxy() {
     let (server_started_tx, server_started_rx) = oneshot::channel();
 
     let temp_dir = tempfile::tempdir().unwrap();
+    // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+    #[expect(clippy::disallowed_methods)]
     let _proxy_handle = tokio::spawn(run_server(
         Args {
             cache_path: temp_dir.path().to_path_buf(),
@@ -180,6 +184,8 @@ async fn test_read_old_write_new() {
     let (server_started_tx, server_started_rx) = oneshot::channel();
 
     let temp_dir = tempfile::tempdir().unwrap();
+    // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+    #[expect(clippy::disallowed_methods)]
     let _proxy_handle = tokio::spawn(run_server(
         Args {
             cache_path: temp_dir.path().to_path_buf(),
@@ -261,6 +267,8 @@ async fn test_read_old_write_new() {
     // Start a new proxy server with the same settings
     let (server_started_tx, server_started_rx) = oneshot::channel();
 
+    // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+    #[expect(clippy::disallowed_methods)]
     let _proxy_handle = tokio::spawn(run_server(
         Args {
             cache_path: temp_dir.path().to_path_buf(),

--- a/tensorzero-core/src/cache.rs
+++ b/tensorzero-core/src/cache.rs
@@ -307,6 +307,8 @@ fn spawn_maybe_cache_write<T: Serialize + CacheOutput + Send + Sync + 'static>(
     clickhouse_client: ClickHouseConnectionInfo,
     cache_validation_info: CacheValidationInfo,
 ) {
+    // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+    #[expect(clippy::disallowed_methods)]
     tokio::spawn(async move {
         if row
             .data

--- a/tensorzero-core/src/endpoints/feedback/mod.rs
+++ b/tensorzero-core/src/endpoints/feedback/mod.rs
@@ -303,6 +303,8 @@ async fn write_comment(
         "tags": tags
     });
     if !dryrun {
+        // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+        #[expect(clippy::disallowed_methods)]
         tokio::spawn(async move {
             let _ = connection_info
                 .write_batched(&[payload], TableName::CommentFeedback)
@@ -344,6 +346,8 @@ async fn write_demonstration(
     })?;
     let payload = json!({"inference_id": inference_id, "value": string_value, "id": feedback_id, "tags": tags});
     if !dryrun {
+        // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+        #[expect(clippy::disallowed_methods)]
         tokio::spawn(async move {
             let _ = connection_info
                 .write_batched(&[payload], TableName::DemonstrationFeedback)
@@ -383,6 +387,8 @@ async fn write_float(
     })?;
     let payload = json!({"target_id": target_id, "value": value, "metric_name": metric_name, "id": feedback_id, "tags": tags});
     if !dryrun {
+        // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+        #[expect(clippy::disallowed_methods)]
         tokio::spawn(async move {
             let payload = payload;
             let payload_array = [payload];
@@ -433,6 +439,8 @@ async fn write_boolean(
     })?;
     let payload = json!({"target_id": target_id, "value": value, "metric_name": metric_name, "id": feedback_id, "tags": tags});
     if !dryrun {
+        // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+        #[expect(clippy::disallowed_methods)]
         tokio::spawn(async move {
             let payload_array = [payload];
             let clickhouse = connection_info;

--- a/tensorzero-core/src/endpoints/inference.rs
+++ b/tensorzero-core/src/endpoints/inference.rs
@@ -633,6 +633,8 @@ async fn infer_variant(args: InferVariantArgs<'_>) -> Result<InferenceOutput, Er
             // not be cancelled partway through execution if the outer '/inference' request
             // is cancelled. This reduces the chances that we only write to some tables and not others
             // (but this is inherently best-effort due to ClickHouse's lack of transactions).
+            // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+            #[expect(clippy::disallowed_methods)]
             let write_future = tokio::spawn(async move {
                 let _: () = write_inference(
                     &clickhouse_connection_info,
@@ -904,6 +906,8 @@ fn create_stream(
                 drop(clickhouse_connection_info);
             };
             if async_write {
+                // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+                #[expect(clippy::disallowed_methods)]
                 tokio::spawn(write_future);
             } else {
                 write_future.await;

--- a/tensorzero-core/src/experimentation/track_and_stop/mod.rs
+++ b/tensorzero-core/src/experimentation/track_and_stop/mod.rs
@@ -334,6 +334,8 @@ impl VariantSampler for TrackAndStopConfig {
         // 3. Computes new optimal sampling probabilities based on observed performance
         // 4. Updates the shared `self.state` via ArcSwap (lock-free concurrent updates)
         // 5. Concurrent `sample()` calls read the latest state without blocking
+        // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+        #[expect(clippy::disallowed_methods)]
         tokio::spawn(probability_update_task(ProbabilityUpdateTaskArgs {
             db,
             candidate_variants: self.candidate_variants.clone().into(),

--- a/tensorzero-core/src/howdy.rs
+++ b/tensorzero-core/src/howdy.rs
@@ -59,6 +59,8 @@ pub fn setup_howdy(
     if clickhouse.client_type() == ClickHouseClientType::Disabled {
         return;
     }
+    // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+    #[expect(clippy::disallowed_methods)]
     tokio::spawn(howdy_loop(clickhouse, token));
 }
 
@@ -82,6 +84,8 @@ pub async fn howdy_loop(clickhouse: ClickHouseConnectionInfo, token: Cancellatio
             }
             _ = interval.tick() => {}
         }
+        // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+        #[expect(clippy::disallowed_methods)]
         tokio::spawn(async move {
             if let Err(e) =
                 send_howdy(&copied_clickhouse, &copied_client, &copied_deployment_id).await

--- a/tensorzero-core/src/http.rs
+++ b/tensorzero-core/src/http.rs
@@ -524,6 +524,8 @@ mod tests {
             );
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
+        // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+        #[expect(clippy::disallowed_methods)]
         let handle = tokio::spawn(axum::serve(listener, app).into_future());
         (addr, handle)
     }

--- a/tensorzero-core/src/jsonschema_util.rs
+++ b/tensorzero-core/src/jsonschema_util.rs
@@ -160,6 +160,8 @@ impl DynamicJSONSchema {
         // Kick off the schema compilation in the background.
         // The first call to `validate` will either get the compiled schema (if the task finished),
         // or wait on the task to complete via the `OnceCell`
+        // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+        #[expect(clippy::disallowed_methods)]
         tokio::spawn(async move {
             // If this errors, then we'll just get the error when we call 'validate'
             let _ = this_clone.get_or_init_compiled_schema().await;

--- a/tensorzero-core/src/model.rs
+++ b/tensorzero-core/src/model.rs
@@ -687,6 +687,8 @@ async fn wrap_provider_stream(
     // This ensures that we keep processing chunks (and call `return_tickets` to update rate-limiting information)
     // even if the top-level HTTP request is later dropped.
     let (send, recv) = tokio::sync::mpsc::unbounded_channel();
+    // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+    #[expect(clippy::disallowed_methods)]
     tokio::spawn(async move {
         futures::pin_mut!(base_stream);
         while let Some(chunk) = base_stream.next().await {

--- a/tensorzero-core/src/utils/gateway.rs
+++ b/tensorzero-core/src/utils/gateway.rs
@@ -414,6 +414,8 @@ pub async fn start_openai_compatible_gateway(
         let _ = recv.await;
     };
 
+    // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+    #[expect(clippy::disallowed_methods)]
     tokio::spawn(
         axum::serve(listener, router)
             .with_graceful_shutdown(shutdown_fut)

--- a/tensorzero-core/tests/e2e/clickhouse.rs
+++ b/tensorzero-core/tests/e2e/clickhouse.rs
@@ -1039,6 +1039,8 @@ async fn test_concurrent_clickhouse_migrations() {
     let mut handles = Vec::with_capacity(num_concurrent_starts);
     for _ in 0..num_concurrent_starts {
         let clickhouse_clone = clickhouse.clone();
+        // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+        #[expect(clippy::disallowed_methods)]
         handles.push(tokio::spawn(async move {
             migration_manager::run(RunMigrationManagerArgs {
                 clickhouse: &clickhouse_clone,

--- a/tensorzero-core/tests/e2e/db/experimentation_queries.rs
+++ b/tensorzero-core/tests/e2e/db/experimentation_queries.rs
@@ -152,6 +152,8 @@ async fn test_cas_concurrency_and_atomicity(pool: PgPool) {
             let barrier_clone = barrier.clone();
             let variant_name = format!("concurrent_variant_{i}");
 
+            // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+            #[expect(clippy::disallowed_methods)]
             tokio::spawn(async move {
                 // Wait for all tasks to be ready for maximum contention
                 barrier_clone.wait().await;
@@ -324,6 +326,8 @@ async fn test_cas_stress_test(pool: PgPool) {
                 let function_name = function_name.clone();
                 let variant_name = format!("stress_var_{ep_idx}_{fn_idx}_{op_num}");
 
+                // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+                #[expect(clippy::disallowed_methods)]
                 let handle = tokio::spawn(async move {
                     let result = conn_clone
                         .check_and_set_variant_by_episode(episode_id, &function_name, &variant_name)

--- a/tensorzero-core/tests/e2e/db/rate_limit_queries.rs
+++ b/tensorzero-core/tests/e2e/db/rate_limit_queries.rs
@@ -93,6 +93,8 @@ async fn test_atomic_consistency_under_load(pool: PgPool) {
     let handles: Vec<_> = (0..20)
         .map(|i| {
             let conn_clone = conn.clone();
+            // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+            #[expect(clippy::disallowed_methods)]
             tokio::spawn(async move {
                 let requests = vec![
                     create_consume_request(
@@ -141,6 +143,8 @@ async fn test_race_condition_no_over_consumption(pool: PgPool) {
     let handles: Vec<_> = (0..50)
         .map(|_| {
             let conn_clone = conn.clone();
+            // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+            #[expect(clippy::disallowed_methods)]
             tokio::spawn(async move {
                 let request = create_consume_request(key, 5, 100, 10, Duration::seconds(60));
                 conn_clone.consume_tickets(&[request]).await.unwrap()
@@ -200,6 +204,8 @@ async fn test_race_condition_interleaved_consume_return(pool: PgPool) {
     // 15 concurrent consumers requesting 10 each
     for _ in 0..15 {
         let conn_clone = conn.clone();
+        // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+        #[expect(clippy::disallowed_methods)]
         let handle = tokio::spawn(async move {
             let request = create_consume_request(key, 10, 100, 10, Duration::seconds(60));
             conn_clone.consume_tickets(&[request]).await.unwrap()
@@ -210,6 +216,8 @@ async fn test_race_condition_interleaved_consume_return(pool: PgPool) {
     // 10 concurrent returners returning 5 each
     for _ in 0..10 {
         let conn_clone = conn.clone();
+        // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+        #[expect(clippy::disallowed_methods)]
         let handle = tokio::spawn(async move {
             let request = create_return_request(key, 5, 100, 10, Duration::seconds(60));
             conn_clone.return_tickets(vec![request]).await.unwrap()
@@ -428,6 +436,8 @@ async fn test_concurrent_stress(pool: PgPool) {
     let handles: Vec<_> = (0..100)
         .map(|i| {
             let conn_clone = conn.clone();
+            // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+            #[expect(clippy::disallowed_methods)]
             tokio::spawn(async move {
                 let key = format!("stress_key_{}", i % 10); // 10 different keys
                 let request = create_consume_request(&key, 15, 200, 10, Duration::seconds(60));

--- a/tensorzero-core/tests/e2e/feedback.rs
+++ b/tensorzero-core/tests/e2e/feedback.rs
@@ -1500,6 +1500,8 @@ async fn test_fast_inference_then_feedback() {
     let tasks: Vec<_> = (0..20)
         .map(|_| {
             let client = Arc::clone(&client);
+            // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+            #[expect(clippy::disallowed_methods)]
             tokio::spawn(async move {
                 let inference_payload = tensorzero::ClientInferenceParams {
                     function_name: Some("basic_test".to_string()),

--- a/tensorzero-core/tests/e2e/human_feedback.rs
+++ b/tensorzero-core/tests/e2e/human_feedback.rs
@@ -1209,6 +1209,8 @@ async fn test_fast_inference_then_feedback() {
     let tasks: Vec<_> = (0..20)
         .map(|_| {
             let client = Arc::clone(&client);
+            // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+            #[expect(clippy::disallowed_methods)]
             tokio::spawn(async move {
                 let inference_payload = tensorzero::ClientInferenceParams {
                     function_name: Some("basic_test".to_string()),

--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -1593,6 +1593,8 @@ async fn make_temp_image_server() -> (SocketAddr, tokio::sync::oneshot::Sender<(
         let _ = recv.await;
     };
 
+    // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+    #[expect(clippy::disallowed_methods)]
     tokio::spawn(
         axum::serve(listener, app)
             .with_graceful_shutdown(shutdown_fut)

--- a/tensorzero-core/tests/e2e/rate_limiting.rs
+++ b/tensorzero-core/tests/e2e/rate_limiting.rs
@@ -579,6 +579,8 @@ scope = [
         .map(|_| {
             let client_clone = client.clone();
             let tags_clone = tags.clone();
+            // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+            #[expect(clippy::disallowed_methods)]
             tokio::spawn(
                 async move { make_request_with_tags(&client_clone, tags_clone, stream).await },
             )
@@ -662,6 +664,8 @@ scope = [
         .map(|i| {
             let client_clone = client.clone();
             let tags = HashMap::from([(format!("user_id_{id}"), format!("user{}", i % 3))]);
+            // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+            #[expect(clippy::disallowed_methods)]
             tokio::spawn(async move {
                 (
                     i % 3,

--- a/tensorzero-core/tests/mock-inference-provider/src/main.rs
+++ b/tensorzero-core/tests/mock-inference-provider/src/main.rs
@@ -634,6 +634,8 @@ mod tests {
             listener.local_addr().unwrap()
         );
 
+        // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+        #[expect(clippy::disallowed_methods)]
         tokio::spawn(async {
             axum::serve(listener, router).await.unwrap();
         });
@@ -692,6 +694,8 @@ mod tests {
             listener.local_addr().unwrap()
         );
 
+        // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+        #[expect(clippy::disallowed_methods)]
         tokio::spawn(async {
             axum::serve(listener, router).await.unwrap();
         });
@@ -765,6 +769,8 @@ mod tests {
             listener.local_addr().unwrap()
         );
 
+        // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
+        #[expect(clippy::disallowed_methods)]
         tokio::spawn(async {
             axum::serve(listener, router).await.unwrap();
         });


### PR DESCRIPTION
Whenever we call 'tokio::task::spawn', we need to make sure that it's okay for the gateway to shut down without waiting on the task to finish. This lint cannot catch all cases (we might call a wrapper from another crate), but it's a significant improvement.

I've suppressed the lint at all existing callsites, leaving a TODO at each callsite. Over time, we should update each comment to explain why it's safe, or use a `TaskTracker` that we wait on during gateway shutdown.

All new usages of 'tokio::task::spawn' should come with an explanation of why we don't need to wait on the task during shutdown.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add lint for `tokio::task::spawn` and TODO comments to audit existing call sites for safe shutdown handling.
> 
>   - **Lint Rule**:
>     - Add `tokio::task::spawn` to `clippy.toml` disallowed methods to ensure tasks can be ignored during shutdown.
>   - **TODO Comments**:
>     - Add `#[expect(clippy::disallowed_methods)]` and TODO comments to audit `tokio::task::spawn` call sites in `evaluations/src/lib.rs`, `provider-proxy/src/lib.rs`, and `tensorzero-core/src/cache.rs`.
>   - **Guidance**:
>     - New `tokio::task::spawn` usages must include an explanation for not waiting on task completion during shutdown.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7d88085f463139c804286c6597e120ec014bf7f5. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->