### PR TITLE
Re-add 'Deprecation Warning' check in ci, but only for rust

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -228,6 +228,12 @@ jobs:
         run: |
           TENSORZERO_E2E_PROXY="http://localhost:3003" cargo test-e2e ${{ vars.CARGO_NEXTEST_EXTRA_ARGS }} -E "not (${{ vars.CARGO_NEXTEST_FLAKY_TESTS }})" ${{ github.event_name == 'schedule' && '--no-fail-fast' || '' }}
 
+      # TODO(https://github.com/tensorzero/tensorzero/issues/3989) - move this back to the end of the job
+      # For now, we only check for deprecation warnings after running the Rust e2e tests
+      - name: Check e2e logs for deprecation warnings (gateway e2e tests only)
+        run: |
+          ! grep -i "Deprecation Warning" e2e_logs.txt
+
       # As a separate step, we run just the flaky tests, and allow them to fail.
       # This lets us see if any flaky tests have started succeeding (by looking at the job output),
       # so that we can decide to mark them as non-flaky.


### PR DESCRIPTION
Re-enabling this for Python will require more work
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Re-adds 'Deprecation Warning' check for Rust e2e tests in CI workflow, excluding Python.
> 
>   - **CI Workflow**:
>     - Re-adds 'Deprecation Warning' check in `merge-queue.yml` for Rust e2e test logs.
>     - The check is performed after running Rust e2e tests.
>     - Python deprecation warning check is not re-enabled; requires more work.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b55dbf177b32c7970e4df98e0d41df4deec08611. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->