### PR TITLE
bumped version to 2025.10.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2025.10.3"
+version = "2025.10.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1879,7 +1879,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2025.10.3"
+version = "2025.10.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2025.10.3"
+version = "2025.10.4"
 dependencies = [
  "axum",
  "clap",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2025.10.3"
+version = "2025.10.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2025.10.3"
+version = "2025.10.4"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2025.10.3"
+version = "2025.10.4"
 dependencies = [
  "evaluations",
  "napi",
@@ -5925,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.10.3"
+version = "2025.10.4"
 dependencies = [
  "evaluations",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2025.10.3"
+version = "2025.10.4"
 rust-version = "1.86.0"
 license = "Apache-2.0"
 

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2025.10.3"
+appVersion: "2025.10.4"

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2025.10.3",
+  "version": "2025.10.4",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump version from 2025.10.3 to 2025.10.4 across multiple project files for consistency.
> 
>   - **Version Bump**:
>     - Update version from `2025.10.3` to `2025.10.4` in `Cargo.lock` for packages: `evaluations`, `feedback-load-test`, `gateway`, `rate-limit-load-test`, `tensorzero-core`, `tensorzero-node`, `tensorzero-python`.
>     - Update version in `Cargo.toml` to `2025.10.4`.
>     - Update `appVersion` in `Chart.yaml` to `2025.10.4`.
>     - Update version in `package.json` to `2025.10.4`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0d90fb49eda7f9b47f725fb2115d90486ad14c7d. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->