### PR TITLE
Fix flaky OpenAI web search test

### DIFF
--- a/tensorzero-core/tests/e2e/providers/openai.rs
+++ b/tensorzero-core/tests/e2e/providers/openai.rs
@@ -2229,6 +2229,8 @@ async fn test_responses_api_reasoning() {
     );
 }
 
+const WEB_SEARCH_PROMPT: &str = "Tell me some good news that happened today from around the world. Don't ask me any questions, and provide markdown citations in the form [text](url)";
+
 #[tokio::test(flavor = "multi_thread")]
 pub async fn test_openai_built_in_websearch() {
     // Create a config with the custom credential location
@@ -2267,7 +2269,7 @@ model = "test-model"
                 messages: vec![ClientInputMessage {
                     role: Role::User,
                     content: vec![ClientInputMessageContent::Text(TextKind::Text {
-                        text: "Tell me some good news that happened today".to_string(),
+                        text: WEB_SEARCH_PROMPT.to_string(),
                     })],
                 }],
             },
@@ -2381,7 +2383,7 @@ model = "test-model"
                     ClientInputMessage {
                         role: Role::User,
                         content: vec![ClientInputMessageContent::Text(TextKind::Text {
-                            text: "Tell me some good news that happened today".to_string(),
+                            text: WEB_SEARCH_PROMPT.to_string(),
                         })],
                     },
                     ClientInputMessage {
@@ -2464,7 +2466,7 @@ model = "test-model"
                 messages: vec![ClientInputMessage {
                     role: Role::User,
                     content: vec![ClientInputMessageContent::Text(TextKind::Text {
-                        text: "Tell me some good news that happened today".to_string(),
+                        text: WEB_SEARCH_PROMPT.to_string(),
                     })],
                 }],
             },
@@ -2511,8 +2513,8 @@ model = "test-model"
 
     // Assert that we have multiple streaming chunks (indicates streaming is working)
     assert!(
-        chunks.len() >= 10,
-        "Expected at least 10 streaming chunks, but got {}. Streaming may not be working properly.",
+        chunks.len() >= 3,
+        "Expected at least 3 streaming chunks, but got {}. Streaming may not be working properly.",
         chunks.len()
     );
 


### PR DESCRIPTION
The model was sometimes asking us follow-up questions instead of actually searching, and was returning fewer than 10 streaming chunks
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix flaky OpenAI web search test by updating the prompt and adjusting streaming chunk expectations in `openai.rs`.
> 
>   - **Behavior**:
>     - Updates `test_openai_built_in_websearch` in `openai.rs` to use a new prompt `WEB_SEARCH_PROMPT` to prevent follow-up questions and ensure markdown citations.
>     - Adjusts the assertion for streaming chunks from `>= 10` to `>= 3` to accommodate the new prompt behavior.
>   - **Constants**:
>     - Introduces `WEB_SEARCH_PROMPT` constant in `openai.rs` for consistent test input.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7d2a6d2ba1759d99f5ea28384ae17b9e37dc638b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->