### PR TITLE
Implement a batch get_datapoint clickhouse query

### DIFF
--- a/tensorzero-core/src/db/datasets.rs
+++ b/tensorzero-core/src/db/datasets.rs
@@ -242,4 +242,12 @@ pub trait DatasetQueries {
 
     /// Gets a single datapoint by dataset name and ID
     async fn get_datapoint(&self, params: &GetDatapointParams) -> Result<Datapoint, Error>;
+
+    /// Gets multiple datapoints by dataset name and IDs
+    async fn get_datapoints(
+        &self,
+        dataset_name: &str,
+        datapoint_ids: &[Uuid],
+        allow_stale: bool,
+    ) -> Result<Vec<Datapoint>, Error>;
 }

--- a/tensorzero-core/tests/e2e/db/dataset_queries.rs
+++ b/tensorzero-core/tests/e2e/db/dataset_queries.rs
@@ -1714,3 +1714,468 @@ async fn test_get_adjacent_datapoint_ids() {
         "Should return None as next id for the last datapoint"
     );
 }
+
+#[tokio::test]
+async fn test_get_datapoints_with_empty_ids() {
+    let clickhouse = get_clickhouse().await;
+
+    let result = clickhouse
+        .get_datapoints("test_dataset", &[], false)
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 0, "Should return empty vector for empty IDs");
+}
+
+#[tokio::test]
+async fn test_get_datapoints_with_single_chat_datapoint() {
+    let clickhouse = get_clickhouse().await;
+    let dataset_name = format!("test_get_datapoints_{}", Uuid::now_v7());
+    let datapoint_id = Uuid::now_v7();
+
+    // Insert a chat datapoint
+    let datapoint = ChatInferenceDatapointInsert {
+        dataset_name: dataset_name.clone(),
+        function_name: "test_function".to_string(),
+        id: datapoint_id,
+        name: Some("test_chat".to_string()),
+        episode_id: None,
+        input: StoredInput {
+            system: None,
+            messages: vec![],
+        },
+        output: Some(vec![ContentBlockChatOutput::Text(Text {
+            text: "test response".to_string(),
+        })]),
+        tool_params: None,
+        tags: None,
+        auxiliary: String::new(),
+        staled_at: None,
+        source_inference_id: None,
+        is_custom: true,
+    };
+
+    clickhouse
+        .insert_datapoint(&DatapointInsert::Chat(datapoint))
+        .await
+        .unwrap();
+
+    // Retrieve using get_datapoints
+    let result = clickhouse
+        .get_datapoints(&dataset_name, &[datapoint_id], false)
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 1, "Should return exactly one datapoint");
+
+    if let Datapoint::Chat(dp) = &result[0] {
+        assert_eq!(dp.id, datapoint_id);
+        assert_eq!(dp.function_name, "test_function");
+        assert_eq!(dp.name, Some("test_chat".to_string()));
+    } else {
+        panic!("Expected chat datapoint");
+    }
+}
+
+#[tokio::test]
+async fn test_get_datapoints_with_single_json_datapoint() {
+    let clickhouse = get_clickhouse().await;
+    let dataset_name = format!("test_get_datapoints_{}", Uuid::now_v7());
+    let datapoint_id = Uuid::now_v7();
+
+    // Insert a json datapoint
+    let datapoint = JsonInferenceDatapointInsert {
+        dataset_name: dataset_name.clone(),
+        function_name: "test_function".to_string(),
+        id: datapoint_id,
+        name: Some("test_json".to_string()),
+        episode_id: None,
+        input: StoredInput {
+            system: None,
+            messages: vec![],
+        },
+        output: Some(JsonInferenceOutput {
+            parsed: Some(json!({"key": "value"})),
+            raw: Some("{\"key\":\"value\"}".to_string()),
+        }),
+        output_schema: json!({"type": "object"}),
+        tags: None,
+        auxiliary: String::new(),
+        staled_at: None,
+        source_inference_id: None,
+        is_custom: true,
+    };
+
+    clickhouse
+        .insert_datapoint(&DatapointInsert::Json(datapoint))
+        .await
+        .unwrap();
+
+    // Retrieve using get_datapoints
+    let result = clickhouse
+        .get_datapoints(&dataset_name, &[datapoint_id], false)
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 1, "Should return exactly one datapoint");
+
+    if let Datapoint::Json(dp) = &result[0] {
+        assert_eq!(dp.id, datapoint_id);
+        assert_eq!(dp.function_name, "test_function");
+        assert_eq!(dp.name, Some("test_json".to_string()));
+    } else {
+        panic!("Expected json datapoint");
+    }
+}
+
+#[tokio::test]
+async fn test_get_datapoints_with_multiple_mixed_datapoints() {
+    let clickhouse = get_clickhouse().await;
+    let dataset_name = format!("test_get_datapoints_{}", Uuid::now_v7());
+
+    // Create IDs
+    let chat_id1 = Uuid::now_v7();
+    let json_id = Uuid::now_v7();
+    let chat_id2 = Uuid::now_v7();
+
+    // Insert chat datapoint 1
+    let chat_dp1 = ChatInferenceDatapointInsert {
+        dataset_name: dataset_name.clone(),
+        function_name: "test_chat_function".to_string(),
+        id: chat_id1,
+        name: Some("chat1".to_string()),
+        episode_id: None,
+        input: StoredInput {
+            system: None,
+            messages: vec![],
+        },
+        output: Some(vec![ContentBlockChatOutput::Text(Text {
+            text: "chat response 1".to_string(),
+        })]),
+        tool_params: None,
+        tags: None,
+        auxiliary: String::new(),
+        staled_at: None,
+        source_inference_id: None,
+        is_custom: true,
+    };
+
+    clickhouse
+        .insert_datapoint(&DatapointInsert::Chat(chat_dp1))
+        .await
+        .unwrap();
+
+    // Insert json datapoint
+    let json_dp = JsonInferenceDatapointInsert {
+        dataset_name: dataset_name.clone(),
+        function_name: "test_json_function".to_string(),
+        id: json_id,
+        name: Some("json1".to_string()),
+        episode_id: None,
+        input: StoredInput {
+            system: None,
+            messages: vec![],
+        },
+        output: Some(JsonInferenceOutput {
+            parsed: Some(json!({"data": "test"})),
+            raw: Some("{\"data\":\"test\"}".to_string()),
+        }),
+        output_schema: json!({"type": "object"}),
+        tags: None,
+        auxiliary: String::new(),
+        staled_at: None,
+        source_inference_id: None,
+        is_custom: true,
+    };
+
+    clickhouse
+        .insert_datapoint(&DatapointInsert::Json(json_dp))
+        .await
+        .unwrap();
+
+    // Insert chat datapoint 2
+    let chat_dp2 = ChatInferenceDatapointInsert {
+        dataset_name: dataset_name.clone(),
+        function_name: "test_chat_function".to_string(),
+        id: chat_id2,
+        name: Some("chat2".to_string()),
+        episode_id: None,
+        input: StoredInput {
+            system: None,
+            messages: vec![],
+        },
+        output: Some(vec![ContentBlockChatOutput::Text(Text {
+            text: "chat response 2".to_string(),
+        })]),
+        tool_params: None,
+        tags: None,
+        auxiliary: String::new(),
+        staled_at: None,
+        source_inference_id: None,
+        is_custom: true,
+    };
+
+    clickhouse
+        .insert_datapoint(&DatapointInsert::Chat(chat_dp2))
+        .await
+        .unwrap();
+
+    // Retrieve all three datapoints
+    let result = clickhouse
+        .get_datapoints(&dataset_name, &[chat_id1, json_id, chat_id2], false)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.len(),
+        3,
+        "Should return all three datapoints (2 chat, 1 json)"
+    );
+
+    // Verify we got all the expected IDs
+    let returned_ids: Vec<Uuid> = result.iter().map(Datapoint::id).collect();
+    assert!(returned_ids.contains(&chat_id1));
+    assert!(returned_ids.contains(&json_id));
+    assert!(returned_ids.contains(&chat_id2));
+
+    // Count types
+    let chat_count = result
+        .iter()
+        .filter(|dp| matches!(dp, Datapoint::Chat(_)))
+        .count();
+    let json_count = result
+        .iter()
+        .filter(|dp| matches!(dp, Datapoint::Json(_)))
+        .count();
+
+    assert_eq!(chat_count, 2, "Should have 2 chat datapoints");
+    assert_eq!(json_count, 1, "Should have 1 json datapoint");
+}
+
+#[tokio::test]
+async fn test_get_datapoints_with_non_existent_ids() {
+    let clickhouse = get_clickhouse().await;
+    let dataset_name = format!("test_get_datapoints_{}", Uuid::now_v7());
+    let datapoint_id = Uuid::now_v7();
+
+    // Insert one datapoint
+    let datapoint = ChatInferenceDatapointInsert {
+        dataset_name: dataset_name.clone(),
+        function_name: "test_function".to_string(),
+        id: datapoint_id,
+        name: None,
+        episode_id: None,
+        input: StoredInput {
+            system: None,
+            messages: vec![],
+        },
+        output: Some(vec![ContentBlockChatOutput::Text(Text {
+            text: "test".to_string(),
+        })]),
+        tool_params: None,
+        tags: None,
+        auxiliary: String::new(),
+        staled_at: None,
+        source_inference_id: None,
+        is_custom: true,
+    };
+
+    clickhouse
+        .insert_datapoint(&DatapointInsert::Chat(datapoint))
+        .await
+        .unwrap();
+
+    // Query with both existing and non-existent IDs
+    let non_existent_id = Uuid::now_v7();
+    let another_non_existent_id = Uuid::now_v7();
+    let result = clickhouse
+        .get_datapoints(
+            &dataset_name,
+            &[datapoint_id, non_existent_id, another_non_existent_id],
+            false,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.len(),
+        1,
+        "Should only return the one existing datapoint"
+    );
+    assert_eq!(result[0].id(), datapoint_id);
+}
+
+#[tokio::test]
+async fn test_get_datapoints_respects_allow_stale_false() {
+    let clickhouse = get_clickhouse().await;
+    let dataset_name = format!("test_get_datapoints_{}", Uuid::now_v7());
+    let datapoint_id = Uuid::now_v7();
+
+    // Insert a datapoint
+    let datapoint = ChatInferenceDatapointInsert {
+        dataset_name: dataset_name.clone(),
+        function_name: "test_function".to_string(),
+        id: datapoint_id,
+        name: None,
+        episode_id: None,
+        input: StoredInput {
+            system: None,
+            messages: vec![],
+        },
+        output: Some(vec![ContentBlockChatOutput::Text(Text {
+            text: "test".to_string(),
+        })]),
+        tool_params: None,
+        tags: None,
+        auxiliary: String::new(),
+        staled_at: None,
+        source_inference_id: None,
+        is_custom: true,
+    };
+
+    clickhouse
+        .insert_datapoint(&DatapointInsert::Chat(datapoint))
+        .await
+        .unwrap();
+
+    // Verify we can retrieve it before staling
+    let result = clickhouse
+        .get_datapoints(&dataset_name, &[datapoint_id], false)
+        .await
+        .unwrap();
+    assert_eq!(result.len(), 1, "Should retrieve datapoint before staling");
+
+    // Stale the datapoint
+    clickhouse
+        .stale_datapoint(&StaleDatapointParams {
+            dataset_name: dataset_name.clone(),
+            datapoint_id,
+            function_type: DatapointKind::Chat,
+        })
+        .await
+        .unwrap();
+
+    // Try to retrieve with allow_stale=false
+    let result = clickhouse
+        .get_datapoints(&dataset_name, &[datapoint_id], false)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.len(),
+        0,
+        "Should not return staled datapoint when allow_stale=false"
+    );
+}
+
+#[tokio::test]
+async fn test_get_datapoints_respects_allow_stale_true() {
+    let clickhouse = get_clickhouse().await;
+    let dataset_name = format!("test_get_datapoints_{}", Uuid::now_v7());
+    let datapoint_id = Uuid::now_v7();
+
+    // Insert a datapoint
+    let datapoint = ChatInferenceDatapointInsert {
+        dataset_name: dataset_name.clone(),
+        function_name: "test_function".to_string(),
+        id: datapoint_id,
+        name: None,
+        episode_id: None,
+        input: StoredInput {
+            system: None,
+            messages: vec![],
+        },
+        output: Some(vec![ContentBlockChatOutput::Text(Text {
+            text: "test".to_string(),
+        })]),
+        tool_params: None,
+        tags: None,
+        auxiliary: String::new(),
+        staled_at: None,
+        source_inference_id: None,
+        is_custom: true,
+    };
+
+    clickhouse
+        .insert_datapoint(&DatapointInsert::Chat(datapoint))
+        .await
+        .unwrap();
+
+    // Stale the datapoint
+    clickhouse
+        .stale_datapoint(&StaleDatapointParams {
+            dataset_name: dataset_name.clone(),
+            datapoint_id,
+            function_type: DatapointKind::Chat,
+        })
+        .await
+        .unwrap();
+
+    // Try to retrieve with allow_stale=true
+    let result = clickhouse
+        .get_datapoints(&dataset_name, &[datapoint_id], true)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.len(),
+        1,
+        "Should return staled datapoint when allow_stale=true"
+    );
+
+    if let Datapoint::Chat(dp) = &result[0] {
+        assert!(
+            dp.staled_at.is_some(),
+            "Datapoint should have staled_at timestamp"
+        );
+    } else {
+        panic!("Expected chat datapoint");
+    }
+}
+
+#[tokio::test]
+async fn test_get_datapoints_with_wrong_dataset_name() {
+    let clickhouse = get_clickhouse().await;
+    let dataset_name = format!("test_get_datapoints_{}", Uuid::now_v7());
+    let datapoint_id = Uuid::now_v7();
+
+    // Insert a datapoint in one dataset
+    let datapoint = ChatInferenceDatapointInsert {
+        dataset_name: dataset_name.clone(),
+        function_name: "test_function".to_string(),
+        id: datapoint_id,
+        name: None,
+        episode_id: None,
+        input: StoredInput {
+            system: None,
+            messages: vec![],
+        },
+        output: Some(vec![ContentBlockChatOutput::Text(Text {
+            text: "test".to_string(),
+        })]),
+        tool_params: None,
+        tags: None,
+        auxiliary: String::new(),
+        staled_at: None,
+        source_inference_id: None,
+        is_custom: true,
+    };
+
+    clickhouse
+        .insert_datapoint(&DatapointInsert::Chat(datapoint))
+        .await
+        .unwrap();
+
+    // Try to retrieve with different dataset name
+    let wrong_dataset = format!("wrong_{dataset_name}");
+    let result = clickhouse
+        .get_datapoints(&wrong_dataset, &[datapoint_id], false)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.len(),
+        0,
+        "Should not return datapoint when querying wrong dataset"
+    );
+}


### PR DESCRIPTION
Add a get_datapoints method that batch gets datapoints with a list of IDs, and switch the current get_datapoint endpiont to use the new batch operation. This is useful for both the v1 batch get datapoints operation as well as the batch update (as we need to perform get + update in 2 queries).

Also added unit and integration tests for this.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `get_datapoints` method for batch fetching datapoints by IDs and update `get_datapoint` to use it, with comprehensive tests.
> 
>   - **Behavior**:
>     - Add `get_datapoints` method in `dataset_queries.rs` to fetch multiple datapoints by IDs.
>     - Update `get_datapoint` to use `get_datapoints` for batch fetching.
>   - **Tests**:
>     - Add unit tests in `dataset_queries.rs` for `get_datapoints` with various scenarios (empty IDs, single/multiple IDs, mixed types).
>     - Add integration tests in `dataset_queries.rs` to verify `get_datapoints` behavior with real data.
>   - **Misc**:
>     - Update `DatasetQueries` trait in `datasets.rs` to include `get_datapoints` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6ec5084767912c1abe570901bb592999b52915ab. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->