### PR TITLE
added support for haiku/sonnet 4.5 max token defaults

### DIFF
--- a/tensorzero-core/src/providers/anthropic.rs
+++ b/tensorzero-core/src/providers/anthropic.rs
@@ -773,6 +773,8 @@ fn get_default_max_tokens(model_name: &str) -> Result<u32, Error> {
     } else if model_name.starts_with("claude-3-7-sonnet")
         || model_name.starts_with("claude-sonnet-4-202")
         || model_name == "claude-sonnet-4-0"
+        || model_name.starts_with("claude-haiku-4-5")
+        || model_name.starts_with("claude-sonnet-4-5")
     {
         Ok(64_000)
     } else if model_name.starts_with("claude-opus-4-202")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for `claude-haiku-4-5` and `claude-sonnet-4-5` models with default max tokens of 64,000 in `anthropic.rs`.
> 
>   - **Behavior**:
>     - Add support for `claude-haiku-4-5` and `claude-sonnet-4-5` models in `get_default_max_tokens()` in `anthropic.rs`.
>     - Sets default `max_tokens` to 64,000 for these models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5a5ae2a9ab285e0b0852211e94ef964648f8ee4b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->