### PR TITLE
Use 'clients.deferred_tasks' for stream processing task

### DIFF
--- a/tensorzero-core/src/model.rs
+++ b/tensorzero-core/src/model.rs
@@ -687,9 +687,9 @@ async fn wrap_provider_stream(
     // This ensures that we keep processing chunks (and call `return_tickets` to update rate-limiting information)
     // even if the top-level HTTP request is later dropped.
     let (send, recv) = tokio::sync::mpsc::unbounded_channel();
-    // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
-    #[expect(clippy::disallowed_methods)]
-    tokio::spawn(async move {
+    // Make sure that we finish processing the stream (so that we call `return_tickets` to update rate-limiting information)
+    // if the gateway shuts down.
+    clients.deferred_tasks.spawn(async move {
         futures::pin_mut!(base_stream);
         while let Some(chunk) = base_stream.next().await {
             // Intentionally ignore errors - the receiver might be dropped, but we want to keep polling


### PR DESCRIPTION
We use a tokio task to make sure that we continue processing the backend stream if the client drops the connection. However, we also want to wait for this on shutdown, so that rate-limiting information gets updated
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `tokio::spawn` with `clients.deferred_tasks.spawn` in `wrap_provider_stream()` to ensure stream processing continues if the client disconnects and waits for completion on shutdown.
> 
>   - **Behavior**:
>     - Replaces `tokio::spawn` with `clients.deferred_tasks.spawn` in `wrap_provider_stream()` to ensure stream processing continues if the client disconnects and waits for completion on shutdown for rate-limiting updates.
>   - **Misc**:
>     - Updates comments in `wrap_provider_stream()` to reflect the new behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 446fa353b713e3c6c5fb7eb22e5402b2a9d9f683. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->