### PR TITLE
Split out Clippy linting into a separate CI job

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -227,7 +227,7 @@ jobs:
           cargo hack clippy --all-targets --each-feature -- -D warnings
 
   validate:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-tensorzero-8x16
 
     timeout-minutes: 30
     if: github.repository == 'tensorzero/tensorzero'
@@ -274,6 +274,14 @@ jobs:
 
       - name: Install uv
         run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
+
+      - name: Configure Namespace cache for Rust, Python (pip), and pnpm
+        uses: namespacelabs/nscloud-cache-action@2f50e7d0f70475e6f59a55ba0f05eec9108e77cc
+        with:
+          cache: |
+            pnpm
+            rust
+            uv
 
       - name: Install JS dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
This is by far the longest step in 'validate'.
Let's just use Namespace for this one part, and run everything else in parallel on a separate job
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Splits Clippy linting into a separate `lint-rust` CI job to improve workflow efficiency.
> 
>   - **CI Workflow Changes**:
>     - Splits Clippy linting from `validate` job into a new `lint-rust` job in `general.yml`.
>     - `lint-rust` job runs on `namespace-profile-tensorzero-8x16` and installs the latest Rust toolchain.
>     - Removes Clippy linting from `validate` job and adjusts its runner to `namespace-profile-tensorzero-8x16`.
>   - **Job Dependencies**:
>     - Adds `lint-rust` to the list of dependencies in `check-all-general-jobs-passed`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d98882f354dca66fc4e2de401ad5a922e7ff5902. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->