### PR TITLE
Add min prob parameter, make one of the tests less flaky

### DIFF
--- a/tensorzero-core/tests/e2e/experimentation/track_and_stop.rs
+++ b/tensorzero-core/tests/e2e/experimentation/track_and_stop.rs
@@ -132,6 +132,7 @@ pub struct TrackAndStopTestConfig<'a> {
     pub delta: f64,
     pub epsilon: f64,
     pub update_period_s: u64,
+    pub min_prob: Option<f64>,
 }
 
 impl Default for TrackAndStopTestConfig<'static> {
@@ -146,6 +147,7 @@ impl Default for TrackAndStopTestConfig<'static> {
             delta: 0.05,
             epsilon: 0.1,
             update_period_s: 300,
+            min_prob: None,
         }
     }
 }
@@ -168,6 +170,7 @@ pub fn make_track_and_stop_config(config: TrackAndStopTestConfig) -> String {
         delta,
         epsilon,
         update_period_s,
+        min_prob,
     } = config;
     // Create variant definitions for the union of candidate and fallback variants
     let all_variants: std::collections::HashSet<&str> = candidate_variants
@@ -201,6 +204,10 @@ model = "test_model"
         .collect::<Vec<_>>()
         .join(", ");
 
+    let min_prob_line = min_prob
+        .map(|value| format!("min_prob = {value}\n"))
+        .unwrap_or_default();
+
     format!(
         r#"
 gateway.unstable_disable_feedback_target_validation = true
@@ -230,7 +237,7 @@ min_samples_per_variant = {min_samples_per_variant}
 delta = {delta}
 epsilon = {epsilon}
 update_period_s = {update_period_s}
-"#,
+{min_prob_line}"#,
         variants = variant_configs.join("\n"),
     )
 }
@@ -649,6 +656,7 @@ async fn test_config_valid() {
         delta: 0.05,
         epsilon: 0.1,
         update_period_s: 300,
+        min_prob: None,
     });
 
     // This should not error
@@ -683,6 +691,7 @@ async fn test_min_pulls() {
         delta: 0.05,
         epsilon: 0.1,
         update_period_s: 1,
+        min_prob: None,
     });
 
     let (client, clickhouse, _guard) = make_embedded_gateway_with_clean_clickhouse(&config).await;
@@ -737,6 +746,7 @@ async fn test_winner_arm_pulled_after_stopping_optimize_max() {
         delta: 0.05,   // Reasonable confidence level
         epsilon: 0.01, // Very small epsilon - we want the clear best arm
         update_period_s: 1,
+        min_prob: None,
     });
 
     // Set up bandit with very clear winner (variant_c has much higher success rate)
@@ -822,6 +832,7 @@ async fn test_winner_arm_pulled_after_stopping_optimize_min() {
         delta: 0.05,   // Reasonable confidence level
         epsilon: 0.01, // Very small epsilon - we want the clear best arm
         update_period_s: 1,
+        min_prob: None,
     });
 
     // Set up bandit with very clear winner (variant_a has much lower mean)
@@ -906,6 +917,7 @@ async fn test_effect_of_delta_on_stopping() {
         delta: 0.05,
         epsilon: 0.05,
         update_period_s: 1,
+        min_prob: None,
     });
 
     let (setup_client, clickhouse, guard) =
@@ -949,6 +961,7 @@ async fn test_effect_of_delta_on_stopping() {
         delta: 0.50, // Large delta = stops easily
         epsilon: 0.05,
         update_period_s: 1,
+        min_prob: None,
     });
 
     let (client_large, _) =
@@ -980,6 +993,7 @@ async fn test_effect_of_delta_on_stopping() {
         delta: 1e-6, // Small delta = needs strong evidence
         epsilon: 0.05,
         update_period_s: 1,
+        min_prob: None,
     });
 
     let (client_small, _) =
@@ -1033,6 +1047,7 @@ async fn test_effect_of_epsilon_on_stopping() {
         delta: 0.05,
         epsilon: 0.05,
         update_period_s: 1,
+        min_prob: None,
     });
 
     let (setup_client, clickhouse, guard) =
@@ -1071,6 +1086,7 @@ async fn test_effect_of_epsilon_on_stopping() {
         delta: 0.05,
         epsilon: 0.20,
         update_period_s: 1,
+        min_prob: None,
     });
 
     let (client_large, _) =
@@ -1099,6 +1115,7 @@ async fn test_effect_of_epsilon_on_stopping() {
         delta: 0.05,
         epsilon: 1e-4,
         update_period_s: 1,
+        min_prob: None,
     });
 
     let (client_small, _) =
@@ -1158,6 +1175,7 @@ async fn test_cold_start_with_stopped_experiment() {
         delta: 0.05,
         epsilon: 0.05,
         update_period_s: 1,
+        min_prob: None,
     });
 
     let (client, clickhouse, _guard) = make_embedded_gateway_with_clean_clickhouse(&config).await;
@@ -1301,6 +1319,7 @@ async fn test_new_variant_triggers_reexploration() {
         delta: shared_delta,
         epsilon: shared_epsilon,
         update_period_s: shared_update_period_s,
+        min_prob: None,
     });
 
     let (client, clickhouse, _guard) =
@@ -1370,6 +1389,7 @@ async fn test_new_variant_triggers_reexploration() {
         delta: shared_delta,
         epsilon: shared_epsilon,
         update_period_s: shared_update_period_s,
+        min_prob: None,
     });
 
     // Create new bandit that includes the new variant
@@ -1473,6 +1493,7 @@ async fn test_remove_winner_variant_after_stopping() {
         delta: 0.05,
         epsilon: 0.05,
         update_period_s: 1,
+        min_prob: None,
     });
 
     let (client, clickhouse, _guard) =
@@ -1526,6 +1547,7 @@ async fn test_remove_winner_variant_after_stopping() {
     tokio::time::sleep(Duration::from_millis(CLICKHOUSE_FLUSH_DELAY_MS)).await;
 
     // Create new config without variant_b
+    // Set high minimum probability. Just want to confirm that neither variant gets labeled the winner.
     let new_config = make_track_and_stop_config(TrackAndStopTestConfig {
         metric_name: "performance_score",
         metric_type: "float",
@@ -1536,13 +1558,11 @@ async fn test_remove_winner_variant_after_stopping() {
         delta: 0.05,
         epsilon: 0.05,
         update_period_s: 1,
+        min_prob: Some(0.48),
     });
 
-    // Create new bandit for remaining variants (same means, different variance)
-    let new_bandit_distribution = vec![
-        ("variant_a", 0.50, 0.10),
-        ("variant_c", 0.55, 0.15), // Slightly higher mean, different variance
-    ];
+    // Create new bandit for remaining variants
+    let new_bandit_distribution = vec![("variant_a", 0.50, 0.10), ("variant_c", 0.50, 0.11)];
     let new_bandit = GaussianBandit::new(new_bandit_distribution, Some(seed));
 
     let (new_client, new_clickhouse) =
@@ -1615,6 +1635,7 @@ async fn test_remove_non_winner_variant_after_stopping() {
         delta: 0.05,
         epsilon: 0.05,
         update_period_s: 1,
+        min_prob: None,
     });
 
     let (client, clickhouse, _guard) =
@@ -1678,6 +1699,7 @@ async fn test_remove_non_winner_variant_after_stopping() {
         delta: 0.05,
         epsilon: 0.05,
         update_period_s: 1,
+        min_prob: None,
     });
 
     let (new_client, new_clickhouse) =


### PR DESCRIPTION
Lower bound exploration probabilities in one of the integration tests to make it less flaky.