### PR TITLE
fixed the FinishReason enum in the python client to match the Rust one

### DIFF
--- a/clients/python/tensorzero/types.py
+++ b/clients/python/tensorzero/types.py
@@ -150,6 +150,7 @@ class UnknownContentBlock(ContentBlock):
 
 class FinishReason(str, Enum):
     STOP = "stop"
+    STOP_SEQUENCE = "stop_sequence"
     LENGTH = "length"
     TOOL_CALL = "tool_call"
     CONTENT_FILTER = "content_filter"


### PR DESCRIPTION
It seems that the FinishReason enum in Python has diverged from the Rust one. We should solve the more general version of this problem so that this can't happen in future.

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added `STOP_SEQUENCE` to `FinishReason` enum in `types.py` to match Rust client.
> 
>   - **Enums**:
>     - Added `STOP_SEQUENCE` to `FinishReason` enum in `types.py` to match Rust client.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6adeb0ae332e95a130800b156a137c52c7138f9c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->