### PR TITLE
Set OTel/OpenInference status + kind for function+variant+model inference

### DIFF
--- a/tensorzero-core/src/config/mod.rs
+++ b/tensorzero-core/src/config/mod.rs
@@ -378,6 +378,20 @@ impl OtlpConfig {
             }
         }
     }
+
+    /// Marks a span as being an OpenInference 'CHAIN' span.
+    /// We use this for function/variant/model spans (but not model provider spans).
+    /// At the moment, there doesn't seem to be a similar concept in the OpenTelemetry GenAI semantic conventions.
+    pub fn mark_openinference_chain_span(&self, span: &Span) {
+        if self.traces.enabled {
+            match self.traces.format {
+                OtlpTracesFormat::OpenInference => {
+                    span.set_attribute("openinference.span.kind", "CHAIN");
+                }
+                OtlpTracesFormat::OpenTelemetry => {}
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]

--- a/tensorzero-core/src/endpoints/inference.rs
+++ b/tensorzero-core/src/endpoints/inference.rs
@@ -22,9 +22,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 use uuid::Uuid;
 
 use crate::cache::{CacheOptions, CacheParamsOptions};
-use crate::config::{
-    Config, ErrorContext, OtlpConfig, OtlpTracesFormat, SchemaData, UninitializedVariantInfo,
-};
+use crate::config::{Config, ErrorContext, OtlpConfig, SchemaData, UninitializedVariantInfo};
 use crate::db::clickhouse::{ClickHouseConnectionInfo, TableName};
 use crate::db::postgres::PostgresConnectionInfo;
 use crate::embeddings::EmbeddingModelTable;
@@ -240,16 +238,11 @@ pub async fn inference(
         span.record("episode_id", episode_id.to_string());
     }
 
-    let traces_config = &config.gateway.export.otlp.traces;
-
-    if traces_config.enabled {
-        match traces_config.format {
-            OtlpTracesFormat::OpenTelemetry => {}
-            OtlpTracesFormat::OpenInference => {
-                span.set_attribute("openinference.span.kind", "CHAIN");
-            }
-        }
-    }
+    config
+        .gateway
+        .export
+        .otlp
+        .mark_openinference_chain_span(&span);
 
     // Automatically add internal tag when internal=true
     if params.internal {

--- a/tensorzero-core/src/model.rs
+++ b/tensorzero-core/src/model.rs
@@ -399,16 +399,7 @@ impl ModelConfig {
         model_name: &'request str,
     ) -> Result<ModelInferenceResponse, Error> {
         let span = tracing::Span::current();
-
-        let traces_config = &clients.otlp_config.traces;
-        if traces_config.enabled {
-            match traces_config.format {
-                OtlpTracesFormat::OpenTelemetry => {}
-                OtlpTracesFormat::OpenInference => {
-                    span.set_attribute("openinference.span.kind", "CHAIN");
-                }
-            }
-        }
+        clients.otlp_config.mark_openinference_chain_span(&span);
 
         let mut provider_errors: HashMap<String, Error> = HashMap::new();
         let run_all_models = async {
@@ -512,6 +503,9 @@ impl ModelConfig {
         clients: &InferenceClients,
         model_name: &'request str,
     ) -> Result<StreamResponseAndMessages, Error> {
+        clients
+            .otlp_config
+            .mark_openinference_chain_span(&tracing::Span::current());
         let mut provider_errors: HashMap<String, Error> = HashMap::new();
         let run_all_models = async {
             for provider_name in &self.routing {

--- a/tensorzero-core/tests/e2e/otel.rs
+++ b/tensorzero-core/tests/e2e/otel.rs
@@ -428,6 +428,8 @@ pub async fn test_capture_simple_inference_spans(
             assert!(!model_provider_attr_map.contains_key("llm.token_count.total"));
         }
         OtlpTracesFormat::OpenInference => {
+            assert_eq!(root_attr_map["openinference.span.kind"], "CHAIN".into());
+            assert_eq!(variant_attr_map["openinference.span.kind"], "CHAIN".into());
             assert_eq!(
                 model_provider_attr_map["openinference.span.kind"],
                 "LLM".into()


### PR DESCRIPTION
This PR marks the spans covering function, variant, and model inference as "CHAIN" kind -- one of the known [span kind values in OpenInference
conventions](https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md#span-kinds). Similarly, we explicitly set the [status](https://opentelemetry.io/docs/concepts/signals/traces/#span-status) on the resulting trace on successful execution.

These changes in particular result in meaningful UI display in OTel/OpenInference-based monitoring platforms such as Arize (see `function_inference` span in screenshot).

<img width="513" height="474" alt="image" src="https://github.com/user-attachments/assets/65a4a26a-0f1a-4fb4-8c7a-90bc729096de" />
<img width="692" height="363" alt="image" src="https://github.com/user-attachments/assets/c387d9f7-53d0-416f-90f5-cfb8ea511ed3" />



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sets OpenInference span kind to 'CHAIN' and updates span status to 'Ok' in `inference.rs` for improved traceability.
> 
>   - **Behavior**:
>     - Sets `openinference.span.kind` to `CHAIN` in `inference()` in `inference.rs` for OpenInference format.
>     - Sets span status to `Status::Ok` in `inference()` upon successful execution.
>   - **Config**:
>     - Adds `OtlpTracesFormat` to `config` imports in `inference.rs`.
>   - **Misc**:
>     - Adds `opentelemetry::trace::Status` to imports in `inference.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b4b10c85e2625aab1f32c22a257df27eef369421. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->