### PR TITLE
Fix a bug where tool_call round trips are dropping ids

### DIFF
--- a/clients/python/tests/test_datapoints.py
+++ b/clients/python/tests/test_datapoints.py
@@ -72,6 +72,7 @@ def test_sync_insert_delete_datapoints(sync_client: TensorZeroGateway):
                 {
                     "type": "tool_call",
                     "name": "get_temperature",
+                    "id": "tool_call_id",
                     "arguments": {
                         "location": "New York",
                         "units": "fahrenheit",
@@ -194,6 +195,7 @@ async def test_async_insert_delete_datapoints(
             output=[
                 {
                     "type": "tool_call",
+                    "id": "tool_call_id",
                     "name": "get_temperature",
                     "arguments": {
                         "location": "New York",

--- a/tensorzero-core/tests/e2e/feedback.rs
+++ b/tensorzero-core/tests/e2e/feedback.rs
@@ -339,7 +339,7 @@ async fn e2e_test_demonstration_feedback_with_payload(inference_payload: serde_j
 
     // Try a tool call demonstration
     // This should fail because the inference was made for a function that doesn't support tool calls
-    let tool_call = json!({"type": "tool_call", "name": "tool_name", "arguments": "tool_input"});
+    let tool_call = json!({"type": "tool_call", "id": "tool_call_id", "name": "tool_name", "arguments": "tool_input"});
     let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
@@ -460,7 +460,7 @@ async fn e2e_test_demonstration_feedback_json() {
 
     // Try a tool call demonstration
     // This should fail because the inference was made for a function that doesn't support tool calls
-    let tool_call = json!({"type": "tool_call", "name": "tool_name", "arguments": "tool_input"});
+    let tool_call = json!({"type": "tool_call", "id": "tool_call_id", "name": "tool_name", "arguments": "tool_input"});
     let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
@@ -668,7 +668,7 @@ async fn e2e_test_demonstration_feedback_dynamic_json() {
 
     // Try a tool call demonstration
     // This should fail because the inference was made for a function that doesn't support tool calls
-    let tool_call = json!({"type": "tool_call", "name": "tool_name", "arguments": "tool_input"});
+    let tool_call = json!({"type": "tool_call", "id": "tool_call_id", "name": "tool_name", "arguments": "tool_input"});
     let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
@@ -790,7 +790,7 @@ async fn e2e_test_demonstration_feedback_tool() {
 
     // Try a tool call demonstration
     // This should fail because the name is incorrect
-    let tool_call = json!({"type": "tool_call", "name": "tool_name", "arguments": "tool_input"});
+    let tool_call = json!({"type": "tool_call", "id": "tool_call_id", "name": "tool_name", "arguments": "tool_input"});
     let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
@@ -804,8 +804,7 @@ async fn e2e_test_demonstration_feedback_tool() {
     assert_eq!(error_message, "Demonstration contains invalid tool name");
 
     // Try a tool call demonstration with correct name incorrect args
-    let tool_call =
-        json!({"type": "tool_call", "name": "get_temperature", "arguments": "tool_input"});
+    let tool_call = json!({"type": "tool_call", "id": "tool_call_id", "name": "get_temperature", "arguments": "tool_input"});
     let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
@@ -822,7 +821,7 @@ async fn e2e_test_demonstration_feedback_tool() {
     );
 
     // Try a tool call demonstration with correct name and args
-    let tool_call = json!({"type": "tool_call", "name": "get_temperature", "arguments": {"location": "Tokyo", "units": "celsius"}});
+    let tool_call = json!({"type": "tool_call", "id": "tool_call_id", "name": "get_temperature", "arguments": {"location": "Tokyo", "units": "celsius"}});
     let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
@@ -849,7 +848,7 @@ async fn e2e_test_demonstration_feedback_tool() {
     assert_eq!(retrieved_inference_id_uuid, inference_id);
     let retrieved_value = result.get("value").unwrap().as_str().unwrap();
     let retrieved_value = serde_json::from_str::<Value>(retrieved_value).unwrap();
-    let expected_value = json!([{"type": "tool_call", "name": "get_temperature", "arguments": {"location": "Tokyo", "units": "celsius"}, "raw_name": "get_temperature", "raw_arguments": "{\"location\":\"Tokyo\",\"units\":\"celsius\"}", "id": "" }]);
+    let expected_value = json!([{"type": "tool_call", "name": "get_temperature", "arguments": {"location": "Tokyo", "units": "celsius"}, "raw_name": "get_temperature", "raw_arguments": "{\"location\":\"Tokyo\",\"units\":\"celsius\"}", "id": "tool_call_id" }]);
     assert_eq!(retrieved_value, expected_value);
 }
 
@@ -950,7 +949,7 @@ async fn e2e_test_demonstration_feedback_dynamic_tool() {
 
     // Try a tool call demonstration
     // This should fail because the name is incorrect
-    let tool_call = json!({"type": "tool_call", "name": "tool_name", "arguments": "tool_input"});
+    let tool_call = json!({"type": "tool_call", "id": "tool_call_id", "name": "tool_name", "arguments": "tool_input"});
     let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
@@ -964,7 +963,7 @@ async fn e2e_test_demonstration_feedback_dynamic_tool() {
     assert_eq!(error_message, "Demonstration contains invalid tool name");
 
     // Try a tool call demonstration with the dynamic tool name and incorrect args
-    let tool_call = json!({"type": "tool_call", "name": "get_humidity", "arguments": "tool_input"});
+    let tool_call = json!({"type": "tool_call", "id": "tool_call_id", "name": "get_humidity", "arguments": "tool_input"});
     let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
@@ -981,8 +980,7 @@ async fn e2e_test_demonstration_feedback_dynamic_tool() {
     );
 
     // Try a tool call demonstration with the dynamic tool name and correct args
-    let tool_call =
-        json!({"type": "tool_call", "name": "get_humidity", "arguments": {"location": "Tokyo"}});
+    let tool_call = json!({"type": "tool_call", "id": "tool_call_id", "name": "get_humidity", "arguments": {"location": "Tokyo"}});
     let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
@@ -1009,7 +1007,7 @@ async fn e2e_test_demonstration_feedback_dynamic_tool() {
     assert_eq!(retrieved_inference_id_uuid, inference_id);
     let retrieved_value = result.get("value").unwrap().as_str().unwrap();
     let retrieved_value = serde_json::from_str::<Value>(retrieved_value).unwrap();
-    let expected_value = json!([{"type": "tool_call", "name": "get_humidity", "arguments": {"location": "Tokyo"}, "raw_name": "get_humidity", "raw_arguments": "{\"location\":\"Tokyo\"}", "id": "" }]);
+    let expected_value = json!([{"type": "tool_call", "name": "get_humidity", "arguments": {"location": "Tokyo"}, "raw_name": "get_humidity", "raw_arguments": "{\"location\":\"Tokyo\"}", "id": "tool_call_id" }]);
     assert_eq!(retrieved_value, expected_value);
 }
 

--- a/tensorzero-core/tests/e2e/human_feedback.rs
+++ b/tensorzero-core/tests/e2e/human_feedback.rs
@@ -248,7 +248,7 @@ async fn e2e_test_demonstration_feedback() {
 
     // Try a tool call demonstration
     // This should fail because the inference was made for a function that doesn't support tool calls
-    let tool_call = json!({"type": "tool_call", "name": "tool_name", "arguments": "tool_input"});
+    let tool_call = json!({"type": "tool_call", "id": "tool_call_id", "name": "tool_name", "arguments": "tool_input"});
     let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
@@ -369,7 +369,7 @@ async fn e2e_test_demonstration_feedback_json() {
 
     // Try a tool call demonstration
     // This should fail because the inference was made for a function that doesn't support tool calls
-    let tool_call = json!({"type": "tool_call", "name": "tool_name", "arguments": "tool_input"});
+    let tool_call = json!({"type": "tool_call", "id": "tool_call_id", "name": "tool_name", "arguments": "tool_input"});
     let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
@@ -495,7 +495,7 @@ async fn e2e_test_demonstration_feedback_dynamic_json() {
 
     // Try a tool call demonstration
     // This should fail because the inference was made for a function that doesn't support tool calls
-    let tool_call = json!({"type": "tool_call", "name": "tool_name", "arguments": "tool_input"});
+    let tool_call = json!({"type": "tool_call", "id": "tool_call_id", "name": "tool_name", "arguments": "tool_input"});
     let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
@@ -617,7 +617,7 @@ async fn e2e_test_demonstration_feedback_tool() {
 
     // Try a tool call demonstration
     // This should fail because the name is incorrect
-    let tool_call = json!({"type": "tool_call", "name": "tool_name", "arguments": "tool_input"});
+    let tool_call = json!({"type": "tool_call", "id": "tool_call_id", "name": "tool_name", "arguments": "tool_input"});
     let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
@@ -631,8 +631,7 @@ async fn e2e_test_demonstration_feedback_tool() {
     assert_eq!(error_message, "Demonstration contains invalid tool name");
 
     // Try a tool call demonstration with correct name incorrect args
-    let tool_call =
-        json!({"type": "tool_call", "name": "get_temperature", "arguments": "tool_input"});
+    let tool_call = json!({"type": "tool_call", "id": "tool_call_id", "name": "get_temperature", "arguments": "tool_input"});
     let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
@@ -649,7 +648,7 @@ async fn e2e_test_demonstration_feedback_tool() {
     );
 
     // Try a tool call demonstration with correct name and args
-    let tool_call = json!({"type": "tool_call", "name": "get_temperature", "arguments": {"location": "Tokyo", "units": "celsius"}});
+    let tool_call = json!({"type": "tool_call", "id": "tool_call_id", "name": "get_temperature", "arguments": {"location": "Tokyo", "units": "celsius"}});
     let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
@@ -676,7 +675,7 @@ async fn e2e_test_demonstration_feedback_tool() {
     assert_eq!(retrieved_inference_id_uuid, inference_id);
     let retrieved_value = result.get("value").unwrap().as_str().unwrap();
     let retrieved_value = serde_json::from_str::<Value>(retrieved_value).unwrap();
-    let expected_value = json!([{"type": "tool_call", "name": "get_temperature", "arguments": {"location": "Tokyo", "units": "celsius"}, "raw_name": "get_temperature", "raw_arguments": "{\"location\":\"Tokyo\",\"units\":\"celsius\"}", "id": "" }]);
+    let expected_value = json!([{"type": "tool_call", "name": "get_temperature", "arguments": {"location": "Tokyo", "units": "celsius"}, "raw_name": "get_temperature", "raw_arguments": "{\"location\":\"Tokyo\",\"units\":\"celsius\"}", "id": "tool_call_id" }]);
     assert_eq!(retrieved_value, expected_value);
 }
 
@@ -777,7 +776,7 @@ async fn e2e_test_demonstration_feedback_dynamic_tool() {
 
     // Try a tool call demonstration
     // This should fail because the name is incorrect
-    let tool_call = json!({"type": "tool_call", "name": "tool_name", "arguments": "tool_input"});
+    let tool_call = json!({"type": "tool_call", "id": "tool_call_id", "name": "tool_name", "arguments": "tool_input"});
     let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
@@ -791,7 +790,7 @@ async fn e2e_test_demonstration_feedback_dynamic_tool() {
     assert_eq!(error_message, "Demonstration contains invalid tool name");
 
     // Try a tool call demonstration with the dynamic tool name and incorrect args
-    let tool_call = json!({"type": "tool_call", "name": "get_humidity", "arguments": "tool_input"});
+    let tool_call = json!({"type": "tool_call", "id": "tool_call_id", "name": "get_humidity", "arguments": "tool_input"});
     let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
@@ -808,8 +807,7 @@ async fn e2e_test_demonstration_feedback_dynamic_tool() {
     );
 
     // Try a tool call demonstration with the dynamic tool name and correct args
-    let tool_call =
-        json!({"type": "tool_call", "name": "get_humidity", "arguments": {"location": "Tokyo"}});
+    let tool_call = json!({"type": "tool_call", "id": "tool_call_id", "name": "get_humidity", "arguments": {"location": "Tokyo"}});
     let payload = json!({"inference_id": inference_id, "metric_name": "demonstration", "value": vec![tool_call]});
     let response = client
         .post(get_gateway_endpoint("/feedback"))
@@ -836,7 +834,7 @@ async fn e2e_test_demonstration_feedback_dynamic_tool() {
     assert_eq!(retrieved_inference_id_uuid, inference_id);
     let retrieved_value = result.get("value").unwrap().as_str().unwrap();
     let retrieved_value = serde_json::from_str::<Value>(retrieved_value).unwrap();
-    let expected_value = json!([{"type": "tool_call", "name": "get_humidity", "arguments": {"location": "Tokyo"}, "raw_name": "get_humidity", "raw_arguments": "{\"location\":\"Tokyo\"}", "id": "" }]);
+    let expected_value = json!([{"type": "tool_call", "name": "get_humidity", "arguments": {"location": "Tokyo"}, "raw_name": "get_humidity", "raw_arguments": "{\"location\":\"Tokyo\"}", "id": "tool_call_id" }]);
     assert_eq!(retrieved_value, expected_value);
 }
 


### PR DESCRIPTION
This is a **breaking change** that now requires all `DemonstrationToolCall`s to pass a tool call `id`.

Fixes #4058
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes bug by requiring `id` in `DemonstrationToolCall` to prevent loss during round trips, with updates to tests for validation.
> 
>   - **Behavior**:
>     - Requires `id` for all `DemonstrationToolCall` instances to prevent loss during round trips.
>     - Updates `DemonstrationToolCall` struct in `mod.rs` to include `id`.
>   - **Tests**:
>     - Adds `id` to `tool_call` objects in `test_datapoints.py` and `datasets.rs`.
>     - Updates tests in `feedback.rs` and `human_feedback.rs` to include `id` in `tool_call` demonstrations.
>     - Adds regression test `test_update_datapoint_preserves_tool_call_ids` in `datasets.rs` to ensure `id` preservation across updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2e1247a62536780acc4f430a88172708059fc5a5. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->