### PR TITLE
Store ScopeInfo in InferenceClients

### DIFF
--- a/tensorzero-core/src/endpoints/batch_inference.rs
+++ b/tensorzero-core/src/endpoints/batch_inference.rs
@@ -41,6 +41,7 @@ use crate::inference::types::{
 };
 use crate::jsonschema_util::DynamicJSONSchema;
 use crate::model::ModelTable;
+use crate::rate_limiting::ScopeInfo;
 use crate::tool::{
     BatchDynamicToolParams, BatchDynamicToolParamsWithSize, DynamicToolParams, ToolCallConfig,
     ToolCallConfigDatabaseInsert,
@@ -225,6 +226,8 @@ pub async fn start_batch_inference(
         enabled: CacheEnabledMode::WriteOnly,
     };
 
+    let tags = Arc::new(HashMap::default()); // NOTE: we currently do not rate limit batch inference
+
     let inference_clients = InferenceClients {
         http_client: http_client.clone(),
         clickhouse_connection_info: clickhouse_connection_info.clone(),
@@ -232,9 +235,10 @@ pub async fn start_batch_inference(
         credentials: Arc::new(params.credentials.clone()),
         cache_options: cache_options.clone(),
         rate_limiting_config: Arc::new(config.rate_limiting.clone()),
-        tags: Arc::new(HashMap::default()), // NOTE: we currently do not rate limit batch inference
+        tags: tags.clone(),
         otlp_config: config.gateway.export.otlp.clone(),
         deferred_tasks,
+        scope_info: ScopeInfo { tags: tags.clone() },
     };
 
     let inference_models = InferenceModels {

--- a/tensorzero-core/src/optimization/dicl.rs
+++ b/tensorzero-core/src/optimization/dicl.rs
@@ -23,6 +23,7 @@ use crate::{
     model_table::{OpenAIKind, ProviderKind, ProviderTypeDefaultCredentials},
     optimization::{JobHandle, OptimizationJobInfo, Optimizer, OptimizerOutput},
     providers::openai::OpenAICredentials,
+    rate_limiting::ScopeInfo,
     stored_inference::RenderedSample,
     utils::retries::RetryConfig,
     variant::dicl::UninitializedDiclConfig,
@@ -536,6 +537,8 @@ async fn process_embedding_batch(
                 })
             })?;
 
+    let tags = Arc::new(HashMap::default());
+
     // Create InferenceClients context for the embedding model
     let deferred_tasks = tokio_util::task::TaskTracker::new();
     let clients = InferenceClients {
@@ -544,11 +547,12 @@ async fn process_embedding_batch(
         clickhouse_connection_info: ClickHouseConnectionInfo::new_disabled(),
         postgres_connection_info: PostgresConnectionInfo::Disabled,
         cache_options: CacheOptions::default(),
-        tags: Arc::new(HashMap::default()),
+        tags: tags.clone(),
         rate_limiting_config: Arc::new(config.rate_limiting.clone()),
         // We don't currently perform any OTLP export in optimization workflows
         otlp_config: Default::default(),
         deferred_tasks: deferred_tasks.clone(),
+        scope_info: ScopeInfo { tags: tags.clone() },
     };
 
     let response = embedding_model_config

--- a/tensorzero-core/src/rate_limiting/mod.rs
+++ b/tensorzero-core/src/rate_limiting/mod.rs
@@ -89,8 +89,9 @@ impl Default for RateLimitingConfig {
 // Utility struct to pass in at "check time"
 // This should contain the information about the current request
 // needed to determine if a rate limit is exceeded.
-pub struct ScopeInfo<'a> {
-    pub tags: &'a HashMap<String, String>,
+#[derive(Clone, Debug)]
+pub struct ScopeInfo {
+    pub tags: Arc<HashMap<String, String>>,
 }
 
 impl RateLimitingConfig {
@@ -118,7 +119,7 @@ impl RateLimitingConfig {
     pub async fn consume_tickets<'a>(
         &'a self,
         client: &impl RateLimitQueries,
-        scope_info: &'a ScopeInfo<'a>,
+        scope_info: &'a ScopeInfo,
         rate_limited_request: &impl RateLimitedRequest,
     ) -> Result<TicketBorrows, Error> {
         let limits = self.get_active_limits(scope_info);
@@ -344,7 +345,7 @@ pub struct RateLimitingConfigRule {
 impl RateLimitingConfigRule {
     fn get_rate_limits_if_match_update_priority<'a>(
         &'a self,
-        scope_info: &'a ScopeInfo<'a>,
+        scope_info: &'a ScopeInfo,
         max_priority: &mut usize,
     ) -> Option<Vec<ActiveRateLimit>> {
         let key = self.scope.get_key_if_matches(scope_info)?;
@@ -739,7 +740,9 @@ mod tests {
         let mut tags = HashMap::new();
         tags.insert("user_id".to_string(), "123".to_string());
 
-        let info = ScopeInfo { tags: &tags };
+        let info = ScopeInfo {
+            tags: Arc::new(tags),
+        };
 
         let key = scope.get_key_if_matches(&info).unwrap();
         match key {
@@ -761,7 +764,9 @@ mod tests {
         let mut tags = HashMap::new();
         tags.insert("user_id".to_string(), "456".to_string());
 
-        let info = ScopeInfo { tags: &tags };
+        let info = ScopeInfo {
+            tags: Arc::new(tags),
+        };
 
         let key = scope.get_key_if_matches(&info);
         assert!(key.is_none());
@@ -777,7 +782,9 @@ mod tests {
         let mut tags = HashMap::new();
         tags.insert("user_id".to_string(), "any_value".to_string());
 
-        let info = ScopeInfo { tags: &tags };
+        let info = ScopeInfo {
+            tags: Arc::new(tags),
+        };
 
         let key = scope.get_key_if_matches(&info).unwrap();
         match key {
@@ -799,7 +806,9 @@ mod tests {
         let mut tags = HashMap::new();
         tags.insert("user_id".to_string(), "specific_value".to_string());
 
-        let info = ScopeInfo { tags: &tags };
+        let info = ScopeInfo {
+            tags: Arc::new(tags),
+        };
 
         let key = scope.get_key_if_matches(&info).unwrap();
         match key {
@@ -819,7 +828,9 @@ mod tests {
 
         let tags = HashMap::new(); // Empty tags
 
-        let info = ScopeInfo { tags: &tags };
+        let info = ScopeInfo {
+            tags: Arc::new(tags),
+        };
 
         let key = scope.get_key_if_matches(&info);
         assert!(key.is_none());
@@ -830,7 +841,9 @@ mod tests {
         let scopes = RateLimitingConfigScopes::new(vec![]).unwrap();
 
         let tags = HashMap::new();
-        let info = ScopeInfo { tags: &tags };
+        let info = ScopeInfo {
+            tags: Arc::new(tags),
+        };
 
         let keys = scopes.get_key_if_matches(&info).unwrap();
         assert_eq!(keys.len(), 0);
@@ -847,7 +860,9 @@ mod tests {
         let mut tags = HashMap::new();
         tags.insert("user_id".to_string(), "123".to_string());
 
-        let info = ScopeInfo { tags: &tags };
+        let info = ScopeInfo {
+            tags: Arc::new(tags),
+        };
 
         let keys = scopes.get_key_if_matches(&info).unwrap();
         assert_eq!(keys.len(), 1);
@@ -872,7 +887,9 @@ mod tests {
         let mut tags = HashMap::new();
         tags.insert("user_id".to_string(), "456".to_string());
 
-        let info = ScopeInfo { tags: &tags };
+        let info = ScopeInfo {
+            tags: Arc::new(tags),
+        };
 
         let keys = scopes.get_key_if_matches(&info);
         assert!(keys.is_none());
@@ -894,7 +911,9 @@ mod tests {
         tags.insert("application_id".to_string(), "app123".to_string());
         tags.insert("user_id".to_string(), "user456".to_string());
 
-        let info = ScopeInfo { tags: &tags };
+        let info = ScopeInfo {
+            tags: Arc::new(tags),
+        };
 
         let keys = scopes.get_key_if_matches(&info).unwrap();
         assert_eq!(keys.len(), 2);
@@ -932,7 +951,9 @@ mod tests {
         tags.insert("application_id".to_string(), "app123".to_string());
         tags.insert("user_id".to_string(), "user789".to_string()); // Different value
 
-        let info = ScopeInfo { tags: &tags };
+        let info = ScopeInfo {
+            tags: Arc::new(tags),
+        };
 
         // Should return None because not all scopes match
         let keys = scopes.get_key_if_matches(&info);
@@ -957,14 +978,18 @@ mod tests {
         tags1.insert("application_id".to_string(), "app123".to_string());
         tags1.insert("user_id".to_string(), "user456".to_string());
 
-        let info1 = ScopeInfo { tags: &tags1 };
+        let info1 = ScopeInfo {
+            tags: Arc::new(tags1),
+        };
 
         // Second ScopeInfo with different tag values but same structure
         let mut tags2 = HashMap::new();
         tags2.insert("application_id".to_string(), "app789".to_string());
         tags2.insert("user_id".to_string(), "user101".to_string());
 
-        let info2 = ScopeInfo { tags: &tags2 };
+        let info2 = ScopeInfo {
+            tags: Arc::new(tags2),
+        };
 
         let keys1 = scopes.get_key_if_matches(&info1).unwrap();
         let keys2 = scopes.get_key_if_matches(&info2).unwrap();
@@ -1135,7 +1160,9 @@ mod tests {
         let mut tags = HashMap::new();
         tags.insert("user_id".to_string(), "123".to_string());
 
-        let info = ScopeInfo { tags: &tags };
+        let info = ScopeInfo {
+            tags: Arc::new(tags),
+        };
 
         // Test each scope individually to verify different key types
         let key_concrete = scope_concrete.get_key_if_matches(&info).unwrap();
@@ -1236,7 +1263,9 @@ mod tests {
         // Test get_active_limits behavior
         let mut tags = HashMap::new();
         tags.insert("user_id".to_string(), "123".to_string());
-        let scope_info = ScopeInfo { tags: &tags };
+        let scope_info = ScopeInfo {
+            tags: Arc::new(tags),
+        };
 
         // Disabled config should return empty limits
         let active_limits_disabled = config_disabled.get_active_limits(&scope_info);
@@ -1303,7 +1332,9 @@ mod tests {
     fn test_rate_limiting_config_priority_logic() {
         let mut tags = HashMap::new();
         tags.insert("user_id".to_string(), "test".to_string());
-        let scope_info = ScopeInfo { tags: &tags };
+        let scope_info = ScopeInfo {
+            tags: Arc::new(tags),
+        };
 
         let token_limit = Arc::new(RateLimit {
             resource: RateLimitResource::Token,
@@ -1735,7 +1766,9 @@ mod tests {
     #[test]
     fn test_max_tokens_validation_with_rate_limits() {
         let tags = HashMap::new();
-        let scope_info = ScopeInfo { tags: &tags };
+        let scope_info = ScopeInfo {
+            tags: Arc::new(tags),
+        };
 
         // Token rate limits active - should include Token resource
         let token_limit = Arc::new(RateLimit {

--- a/tensorzero-core/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-core/src/variant/best_of_n_sampling.rs
@@ -802,6 +802,7 @@ fn map_evaluator_to_actual_index(evaluator_idx: usize, skipped_indices: &[usize]
 
 #[cfg(test)]
 mod tests {
+    use crate::rate_limiting::ScopeInfo;
     use std::collections::HashMap;
 
     use uuid::Uuid;
@@ -1329,6 +1330,9 @@ mod tests {
             rate_limiting_config: Arc::new(Default::default()),
             otlp_config: Default::default(),
             deferred_tasks: tokio_util::task::TaskTracker::new(),
+            scope_info: ScopeInfo {
+                tags: Arc::new(HashMap::new()),
+            },
         };
         let input = LazyResolvedInput {
             system: None,

--- a/tensorzero-core/src/variant/chat_completion/mod.rs
+++ b/tensorzero-core/src/variant/chat_completion/mod.rs
@@ -762,6 +762,7 @@ pub fn validate_all_schemas_have_templates(
 
 #[cfg(test)]
 mod tests {
+    use crate::rate_limiting::ScopeInfo;
     use std::collections::HashMap;
     use std::path::PathBuf;
 
@@ -1174,6 +1175,9 @@ mod tests {
             rate_limiting_config: Arc::new(Default::default()),
             otlp_config: Default::default(),
             deferred_tasks: tokio_util::task::TaskTracker::new(),
+            scope_info: ScopeInfo {
+                tags: Arc::new(HashMap::new()),
+            },
         };
         let templates = Arc::new(get_test_template_config());
         let system_template = get_system_template();
@@ -2160,6 +2164,9 @@ mod tests {
             rate_limiting_config: Arc::new(Default::default()),
             otlp_config: Default::default(),
             deferred_tasks: tokio_util::task::TaskTracker::new(),
+            scope_info: ScopeInfo {
+                tags: Arc::new(HashMap::new()),
+            },
         };
         let templates = Box::leak(Box::new(get_test_template_config()));
         let schema_any = StaticJSONSchema::from_value(json!({ "type": "object" })).unwrap();

--- a/tensorzero-core/src/variant/mixture_of_n.rs
+++ b/tensorzero-core/src/variant/mixture_of_n.rs
@@ -898,6 +898,7 @@ impl FuserConfig {
 
 #[cfg(test)]
 mod tests {
+    use crate::rate_limiting::ScopeInfo;
     use std::collections::HashMap;
 
     use tokio_stream::StreamExt;
@@ -1407,6 +1408,9 @@ mod tests {
             rate_limiting_config: Arc::new(Default::default()),
             otlp_config: Default::default(),
             deferred_tasks: tokio_util::task::TaskTracker::new(),
+            scope_info: ScopeInfo {
+                tags: Arc::new(HashMap::new()),
+            },
         };
         let input = LazyResolvedInput {
             system: None,

--- a/tensorzero-core/src/variant/mod.rs
+++ b/tensorzero-core/src/variant/mod.rs
@@ -875,6 +875,7 @@ mod tests {
         DummyProvider, DUMMY_INFER_RESPONSE_CONTENT, DUMMY_JSON_RESPONSE_RAW,
         DUMMY_STREAMING_RESPONSE,
     };
+    use crate::rate_limiting::ScopeInfo;
     use crate::tool::{ToolCallConfig, ToolChoice};
 
     use serde_json::json;
@@ -1133,6 +1134,9 @@ mod tests {
             rate_limiting_config: Arc::new(Default::default()),
             otlp_config: Default::default(),
             deferred_tasks: tokio_util::task::TaskTracker::new(),
+            scope_info: ScopeInfo {
+                tags: Arc::new(HashMap::new()),
+            },
         };
         let templates = Arc::new(get_test_template_config());
         let inference_params = InferenceParams::default();
@@ -1439,6 +1443,9 @@ mod tests {
             rate_limiting_config: Arc::new(Default::default()),
             otlp_config: Default::default(),
             deferred_tasks: tokio_util::task::TaskTracker::new(),
+            scope_info: ScopeInfo {
+                tags: Arc::new(HashMap::new()),
+            },
         };
         let templates = Arc::new(get_test_template_config());
         let inference_params = InferenceParams::default();
@@ -1605,6 +1612,9 @@ mod tests {
             rate_limiting_config: Arc::new(Default::default()),
             otlp_config: Default::default(),
             deferred_tasks: tokio_util::task::TaskTracker::new(),
+            scope_info: ScopeInfo {
+                tags: Arc::new(HashMap::new()),
+            },
         };
         let retry_config = RetryConfig::default();
         // Create a dummy function config (chat completion)
@@ -1756,6 +1766,9 @@ mod tests {
             rate_limiting_config: Arc::new(Default::default()),
             otlp_config: Default::default(),
             deferred_tasks: tokio_util::task::TaskTracker::new(),
+            scope_info: ScopeInfo {
+                tags: Arc::new(HashMap::new()),
+            },
         };
         let inference_params = InferenceParams::default();
 

--- a/tensorzero-core/tests/e2e/dicl.rs
+++ b/tensorzero-core/tests/e2e/dicl.rs
@@ -405,12 +405,12 @@ async fn embed_insert_example(
         rate_limiting_config: Arc::new(Default::default()),
         otlp_config: Default::default(),
         deferred_tasks: tokio_util::task::TaskTracker::new(),
-    };
-    let scope_info = ScopeInfo {
-        tags: &HashMap::new(),
+        scope_info: ScopeInfo {
+            tags: Arc::new(HashMap::new()),
+        },
     };
     let response = provider_config
-        .embed(&request, &clients, &scope_info, &(&provider_config).into())
+        .embed(&request, &clients, &(&provider_config).into())
         .await
         .unwrap();
 

--- a/tensorzero-core/tests/e2e/providers/openai.rs
+++ b/tensorzero-core/tests/e2e/providers/openai.rs
@@ -1234,6 +1234,9 @@ async fn test_embedding_request() {
                 rate_limiting_config: Arc::new(Default::default()),
                 otlp_config: Default::default(),
                 deferred_tasks: tokio_util::task::TaskTracker::new(),
+                scope_info: ScopeInfo {
+                    tags: Arc::new(HashMap::new()),
+                },
             },
         )
         .await
@@ -1319,6 +1322,9 @@ async fn test_embedding_request() {
                 rate_limiting_config: Arc::new(Default::default()),
                 otlp_config: Default::default(),
                 deferred_tasks: tokio_util::task::TaskTracker::new(),
+                scope_info: ScopeInfo {
+                    tags: Arc::new(HashMap::new()),
+                },
             },
         )
         .await
@@ -1389,16 +1395,16 @@ async fn test_embedding_sanity_check() {
         rate_limiting_config: Arc::new(Default::default()),
         otlp_config: Default::default(),
         deferred_tasks: tokio_util::task::TaskTracker::new(),
-    };
-    let scope_info = ScopeInfo {
-        tags: &HashMap::new(),
+        scope_info: ScopeInfo {
+            tags: Arc::new(HashMap::new()),
+        },
     };
 
     // Compute all 3 embeddings concurrently
     let (response_a, response_b, response_c) = tokio::join!(
-        provider_config.embed(&embedding_request_a, &clients, &scope_info, &request_info),
-        provider_config.embed(&embedding_request_b, &clients, &scope_info, &request_info),
-        provider_config.embed(&embedding_request_c, &clients, &scope_info, &request_info)
+        provider_config.embed(&embedding_request_a, &clients, &request_info),
+        provider_config.embed(&embedding_request_b, &clients, &request_info),
+        provider_config.embed(&embedding_request_c, &clients, &request_info)
     );
 
     // Unwrap the results

--- a/tensorzero-core/tests/optimization/common/mod.rs
+++ b/tensorzero-core/tests/optimization/common/mod.rs
@@ -3,6 +3,7 @@ use base64::Engine;
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
+use tensorzero_core::rate_limiting::ScopeInfo;
 use tokio::time::{sleep, Duration};
 use url::Url;
 use uuid::Uuid;
@@ -204,6 +205,9 @@ pub async fn run_test_case(test_case: &impl OptimizationTestCase) {
                 rate_limiting_config: Arc::new(Default::default()),
                 otlp_config: Default::default(),
                 deferred_tasks: tokio_util::task::TaskTracker::new(),
+                scope_info: ScopeInfo {
+                    tags: Arc::new(HashMap::new()),
+                },
             };
             // We didn't produce a real model, so there's nothing to test
             if use_mock_inference_provider() {


### PR DESCRIPTION
When we add auth token support, we'll attach the auth token short-id to the `ScopeInfo`, so that it's available for rate-limiting
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Store `ScopeInfo` in `InferenceClients` for future rate-limiting enhancements, updating related functions and tests.
> 
>   - **Behavior**:
>     - `ScopeInfo` is now stored directly in `InferenceClients` and used in rate-limiting functions.
>     - Removed passing of `ScopeInfo` as a separate parameter in `embed()` and `infer()` functions in `embeddings.rs` and `model.rs`.
>   - **Structs**:
>     - Added `scope_info: ScopeInfo` to `InferenceClients` in `inference.rs`.
>     - `ScopeInfo` now uses `Arc<HashMap<String, String>>` for `tags` instead of a reference.
>   - **Tests**:
>     - Updated tests in `dicl.rs`, `openai.rs`, and `common/mod.rs` to reflect changes in `ScopeInfo` handling.
>   - **Misc**:
>     - Removed unused imports and adjusted existing imports in `embeddings.rs` and `batch_inference.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 56a286b7beca81d011ebebcb956fc28c1cc5a143. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->