### PR TITLE
Use an 8x32 runner for 'validate' job

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -240,7 +240,7 @@ jobs:
           cargo hack clippy --all-targets --each-feature -- -D warnings
 
   validate:
-    runs-on: namespace-profile-tensorzero-8x16
+    runs-on: namespace-profile-tensorzero-8x32
 
     timeout-minutes: 30
     if: github.repository == 'tensorzero/tensorzero'


### PR DESCRIPTION
The 8x16 runner is normally fast enough, but occasionally runs out of memory and crashses depending on exactly what crates end up getting built in parallel. Let's double the runner memory (which is the smallest increment possible on Namespace) to prevent this from happening without limiting build concurrency.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase memory for `validate` job runner in `.github/workflows/general.yml` to prevent crashes during parallel builds.
> 
>   - **Workflow Configuration**:
>     - Update `validate` job in `.github/workflows/general.yml` to use `namespace-profile-tensorzero-8x32` runner instead of `namespace-profile-tensorzero-8x16`.
>     - This change aims to prevent memory crashes during parallel crate builds by doubling the runner's memory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d368d12ade069b896b16f3f21f4efe8f14b1dd3d. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->