### PR TITLE
Perform an exact match when clicking on 'foo' in ui e2e test

### DIFF
--- a/ui/e2e_tests/playground.spec.ts
+++ b/ui/e2e_tests/playground.spec.ts
@@ -14,7 +14,7 @@ test("playground should work for a chat function that sets 2 variants", async ({
   // Select dataset 'foo'
   await page.getByText("Select a dataset").click();
   await page.getByPlaceholder(/dataset/i).fill("foo");
-  await page.getByRole("option", { name: "foo" }).click();
+  await page.getByRole("option", { name: "foo", exact: true }).click();
 
   // Select variant 'initial_prompt_gpt4o_mini'
   await page
@@ -64,7 +64,7 @@ test("playground should work for extract_entities JSON function with 2 variants"
   // Select dataset 'foo'
   await page.getByText("Select a dataset").click();
   await page.getByPlaceholder(/dataset/i).fill("foo");
-  await page.getByRole("option", { name: "foo" }).click();
+  await page.getByRole("option", { name: "foo", exact: true }).click();
 
   // Select variants 'baseline' and 'gpt4o_mini_initial_prompt'
   await page.getByPlaceholder("Filter by variant...").fill("baseline");


### PR DESCRIPTION
This guards against cases where a randomly-generated dataset name happens to contain the string 'foo'
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure exact match for dataset 'foo' in `playground.spec.ts` to prevent accidental matches.
> 
>   - **Behavior**:
>     - Ensure exact match for dataset 'foo' in `playground.spec.ts` by adding `exact: true` to `getByRole` options in two test cases.
>     - Prevents accidental matches with dataset names containing 'foo'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2eff16e73a4444635fe721a1ccec131d28941ef1. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->