### PR TITLE
Add a check for PR base branch

### DIFF
--- a/.github/workflows/pr-base-branch-check.yml
+++ b/.github/workflows/pr-base-branch-check.yml
@@ -1,0 +1,35 @@
+name: PR Base Branch Check
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-base-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR base branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const baseBranch = pr.base.ref;
+            const prBody = pr.body || '';
+
+            // Check if the override is present in the PR body
+            if (prBody.includes('DISABLE_PR_BASE_BRANCH_CHECK')) {
+              core.notice('PR base branch check disabled by user');
+              return;
+            }
+
+            // Check if base branch is main
+            if (baseBranch !== 'main') {
+              core.setFailed(
+                `PR base branch is '${baseBranch}' but should be 'main'. ` +
+                `If this is intentional, add 'DISABLE_PR_BASE_BRANCH_CHECK' to the PR description.`
+              );
+            } else {
+              core.info('PR base branch is correctly set to main');
+            }


### PR DESCRIPTION
This allows us to unblock PR reviews on stacked PRs with different base branches and without fear of accidentally merging them into the wrong base branch.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add GitHub Action to ensure PR base branch is 'main', with override option.
> 
>   - **GitHub Action**:
>     - New workflow `pr-base-branch-check.yml` to verify PR base branch is 'main'.
>     - Triggered on PR events: opened, edited, synchronize, reopened.
>   - **Behavior**:
>     - Fails check if base branch is not 'main', unless 'DISABLE_PR_BASE_BRANCH_CHECK' is in PR description.
>     - Logs notice if check is disabled by user.
>     - Logs info if base branch is correctly set to 'main'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for be7db85ab2fefe94122abec10fb49617922b493e. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->