### PR TITLE
Add dataset data attribute for e2e selectors

### DIFF
--- a/ui/app/components/dataset/DatasetSelector.tsx
+++ b/ui/app/components/dataset/DatasetSelector.tsx
@@ -155,6 +155,7 @@ export function DatasetSelector({
                           setOpen(false);
                         }}
                         className="group flex w-full items-center gap-2"
+                        data-dataset-name={dataset.name}
                       >
                         <div className="flex min-w-0 flex-1 items-center gap-2">
                           {selected === dataset.name ? (

--- a/ui/e2e_tests/evaluations.deleted-dataset.spec.ts
+++ b/ui/e2e_tests/evaluations.deleted-dataset.spec.ts
@@ -73,7 +73,7 @@ test.describe("Launch Evaluation Modal - Deleted Dataset", () => {
     // Type to filter/search for our dataset
     const datasetInput = page.getByPlaceholder("Find a dataset...");
     await datasetInput.fill(datasetName);
-    const datasetOption = page.getByRole("option", { name: datasetName });
+    const datasetOption = page.locator(`[data-dataset-name="${datasetName}"]`);
     await expect(datasetOption).toBeVisible();
 
     // Click on our dataset

--- a/ui/e2e_tests/evaluations.spec.ts
+++ b/ui/e2e_tests/evaluations.spec.ts
@@ -22,7 +22,7 @@ test("push the new run button, launch an evaluation", async ({ page }) => {
   await page.waitForTimeout(500);
   await page.getByText("Select a dataset").click();
   await page.waitForTimeout(500);
-  await page.getByRole("option", { name: "foo" }).click();
+  await page.locator('[data-dataset-name="foo"]').click();
   await page.waitForTimeout(500);
   await page.getByText("Select a variant").click();
   await page.waitForTimeout(500);
@@ -69,7 +69,7 @@ test("push the new run button, launch an image evaluation", async ({
   await page.waitForTimeout(500);
   await page.getByText("Select a dataset").click();
   await page.waitForTimeout(500);
-  await page.getByRole("option", { name: "baz" }).click();
+  await page.locator('[data-dataset-name="baz"]').click();
   await page.waitForTimeout(500);
   await page.getByText("Select a variant").click();
   await page.waitForTimeout(500);
@@ -116,7 +116,7 @@ test("run evaluation with dataset with no output", async ({ page }) => {
   await page.waitForTimeout(500);
   await page.getByText("Select a dataset").click();
   await page.waitForTimeout(500);
-  await page.getByRole("option", { name: "no_output" }).click();
+  await page.locator('[data-dataset-name="no_output"]').click();
   await page.waitForTimeout(500);
   await page.getByText("Select a variant").click();
   await page.waitForTimeout(500);

--- a/ui/e2e_tests/playground.spec.ts
+++ b/ui/e2e_tests/playground.spec.ts
@@ -14,7 +14,7 @@ test("playground should work for a chat function that sets 2 variants", async ({
   // Select dataset 'foo'
   await page.getByText("Select a dataset").click();
   await page.getByPlaceholder(/dataset/i).fill("foo");
-  await page.getByRole("option", { name: "foo" }).click();
+  await page.locator('[data-dataset-name="foo"]').click();
 
   // Select variant 'initial_prompt_gpt4o_mini'
   await page
@@ -64,7 +64,7 @@ test("playground should work for extract_entities JSON function with 2 variants"
   // Select dataset 'foo'
   await page.getByText("Select a dataset").click();
   await page.getByPlaceholder(/dataset/i).fill("foo");
-  await page.getByRole("option", { name: "foo" }).click();
+  await page.locator('[data-dataset-name="foo"]').click();
 
   // Select variants 'baseline' and 'gpt4o_mini_initial_prompt'
   await page.getByPlaceholder("Filter by variant...").fill("baseline");
@@ -122,7 +122,7 @@ test("playground should work for image_judger function with images in input", as
   // Select dataset 'baz'
   await page.getByText("Select a dataset").click();
   await page.getByPlaceholder(/dataset/i).fill("baz");
-  await page.getByRole("option", { name: "baz" }).click();
+  await page.locator('[data-dataset-name="baz"]').click();
 
   // Select variant 'honest_answer'
   await page.getByPlaceholder("Filter by variant...").fill("honest_answer");


### PR DESCRIPTION
This fixes a rare issue where a randomly-generated dataset name contains 'foo', which causes the selector to match multiple entries and fail the test.

## Summary
- add a data-dataset-name attribute to dataset command items so tests can target the raw dataset name
- update the playground and evaluations end-to-end tests to click dataset options via the new data attribute

## Testing
- pnpm run format
- pnpm run lint
- pnpm run typecheck *(fails: Cannot find module 'tensorzero-node')*


------
https://chatgpt.com/codex/tasks/task_b_68f7d2738fb4832988bf5f93a03483df
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `data-dataset-name` attribute to dataset items and update tests to use it for better targeting.
> 
>   - **Behavior**:
>     - Add `data-dataset-name` attribute to dataset command items in `DatasetSelector.tsx` for targeting raw dataset names.
>     - Update end-to-end tests in `evaluations.deleted-dataset.spec.ts`, `evaluations.spec.ts`, and `playground.spec.ts` to use the new `data-dataset-name` attribute for selecting datasets.
>   - **Testing**:
>     - Ran `pnpm run format`, `pnpm run lint`, and `pnpm run typecheck` (typecheck fails due to missing module 'tensorzero-node').
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e505a9920fdc2c6998c7c6af09bf5abc7e4a69fa. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->