### PR TITLE
Add refresh button to variant modal

### DIFF
--- a/ui/app/components/inference/VariantResponseModal.tsx
+++ b/ui/app/components/inference/VariantResponseModal.tsx
@@ -25,7 +25,6 @@ interface ResponseColumnProps {
   inferenceId?: string | null;
   onClose?: () => void;
   actions?: React.ReactNode;
-  requestDurationMs?: number;
   refreshButton?: React.ReactNode;
 }
 
@@ -36,7 +35,6 @@ function ResponseColumn({
   inferenceId,
   onClose,
   actions,
-  requestDurationMs,
   refreshButton,
 }: ResponseColumnProps) {
   return (
@@ -81,27 +79,17 @@ function ResponseColumn({
             <div className="mt-4">{actions}</div>
 
             <div className="mt-4 grid grid-cols-2 justify-end gap-4">
-              <div>
-                <h4 className="mb-1 text-xs font-semibold">Usage</h4>
-                <p className="text-xs">
-                  Input Tokens:{" "}
-                  {response.usage !== undefined
-                    ? response.usage.input_tokens
-                    : "?"}
-                </p>
-                <p className="text-xs">
-                  Output Tokens:{" "}
-                  {response.usage !== undefined
-                    ? response.usage.output_tokens
-                    : "?"}
-                </p>
-                <p className="text-xs">
-                  Request Duration:{" "}
-                  {requestDurationMs !== undefined
-                    ? `${Math.round(requestDurationMs).toLocaleString()} ms`
-                    : "?"}
-                </p>
-              </div>
+              {response.usage && (
+                <div>
+                  <h4 className="mb-1 text-xs font-semibold">Usage</h4>
+                  <p className="text-xs">
+                    Input tokens: {response.usage.input_tokens}
+                  </p>
+                  <p className="text-xs">
+                    Output tokens: {response.usage.output_tokens}
+                  </p>
+                </div>
+              )}
             </div>
           </>
         )
@@ -126,7 +114,6 @@ interface VariantResponseModalProps {
   rawResponse: InferenceResponse | null;
   children?: React.ReactNode;
   onRefresh?: (() => void) | null;
-  requestDurationMs?: number;
 }
 
 export function VariantResponseModal({
@@ -142,7 +129,6 @@ export function VariantResponseModal({
   rawResponse,
   children,
   onRefresh,
-  requestDurationMs,
 }: VariantResponseModalProps) {
   const [showRawResponse, setShowRawResponse] = useState(false);
 
@@ -156,11 +142,6 @@ export function VariantResponseModal({
   const originalVariant =
     source === "inference"
       ? (item as ParsedInferenceRow).variant_name
-      : undefined;
-
-  const baselineLatencyMs =
-    source === "inference"
-      ? (item as ParsedInferenceRow).processing_time_ms
       : undefined;
 
   const refreshButton = onRefresh && (
@@ -229,11 +210,7 @@ export function VariantResponseModal({
           ) : (
             <>
               <div className="flex flex-col gap-4 md:grid md:min-h-[300px] md:grid-cols-2">
-                <ResponseColumn
-                  title="Original"
-                  response={baselineResponse}
-                  requestDurationMs={baselineLatencyMs}
-                />
+                <ResponseColumn title="Original" response={baselineResponse} />
                 <ResponseColumn
                   title="New"
                   response={variantResponse}
@@ -242,7 +219,6 @@ export function VariantResponseModal({
                   onClose={onClose}
                   refreshButton={refreshButton}
                   actions={children}
-                  requestDurationMs={requestDurationMs}
                 />
               </div>
 

--- a/ui/app/routes/datasets/$dataset_name/datapoint/$id/route.tsx
+++ b/ui/app/routes/datasets/$dataset_name/datapoint/$id/route.tsx
@@ -517,7 +517,6 @@ export default function DatapointPage({ loaderData }: Route.ComponentProps) {
           selectedVariant={selectedVariant}
           source="datapoint"
           onRefresh={lastRequestArgs ? handleRefresh : null}
-          requestDurationMs={variantInferenceFetcher.requestDurationMs}
         />
       )}
     </PageLayout>

--- a/ui/app/routes/observability/inferences/$inference_id/route.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/route.tsx
@@ -543,7 +543,6 @@ export default function InferencePage({ loaderData }: Route.ComponentProps) {
           selectedVariant={selectedVariant}
           source={variantSource}
           onRefresh={lastRequestArgs ? handleRefresh : null}
-          requestDurationMs={variantInferenceFetcher.requestDurationMs}
         >
           {variantInferenceFetcher.data?.info && (
             <demonstrationFeedbackFetcher.Form method="post">


### PR DESCRIPTION
## Summary
- add a refresh button to the variant response modal and ensure it bypasses cached reads


## Testing
- pnpm run format
- pnpm run lint
- pnpm run typecheck *(fails: TypeScript cannot resolve local `tensorzero-node` declarations in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f7d52ec6608325b3e26add1c24edb7
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add refresh button and latency metrics to `VariantResponseModal`, enabling cache bypass and improved observability.
> 
>   - **UI Enhancements**:
>     - Add `refreshButton` to `VariantResponseModal` in `VariantResponseModal.tsx` to bypass cache on refresh.
>     - Display latency metrics for baseline and rerun responses in the modal.
>   - **API Changes**:
>     - Modify `action` in `inference.ts` to handle `write_only` cache option.
>   - **Route Updates**:
>     - Implement `handleRefresh` in `datapoint/$id/route.tsx` and `inferences/$inference_id/route.tsx` to support cache bypass on refresh.
>     - Track request timing in `useInferenceActionFetcher` in both routes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for cf6d89a2fdc15a3bda36fc5f7fe7a6f53b1f329f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->