### PR TITLE
Auto-detect `createLegacyIngress` for the Helm chart

### DIFF
--- a/examples/production-deployment-k8s-helm/templates/gateway-ingress-legacy.yaml
+++ b/examples/production-deployment-k8s-helm/templates/gateway-ingress-legacy.yaml
@@ -1,9 +1,17 @@
-{{- if and .Values.gateway.ingress.enabled .Values.gateway.ingress.createLegacyIngress -}}
+{{- if .Values.gateway.ingress.enabled -}}
 {{- $fullName := include "tensorzero.fullname" . -}}
 {{- $svcPort := .Values.gateway.service.port -}}
-# ⚠️  DEPRECATION WARNING: Legacy gateway ingress is enabled and will be removed in a future version
+{{- $legacyIngress := lookup "networking.k8s.io/v1" "Ingress" .Release.Namespace $fullName -}}
+{{- $shouldCreateLegacy := false -}}
+{{- if hasKey .Values.gateway.ingress "createLegacyIngress" -}}
+  {{- $shouldCreateLegacy = .Values.gateway.ingress.createLegacyIngress -}}
+{{- else -}}
+  {{- $shouldCreateLegacy = not (empty $legacyIngress) -}}
+{{- end -}}
+{{- if $shouldCreateLegacy -}}
+# ⚠️  DEPRECATION WARNING: Legacy gateway ingress detected and maintained for backward compatibility
 # Please migrate to the new ingress name: {{ $fullName }}-gateway
-# Then set gateway.ingress.createLegacyIngress=false
+# After migration, manually delete this ingress: kubectl delete ingress {{ $fullName }} -n {{ .Release.Namespace }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -49,4 +57,5 @@ spec:
                   number: {{ $svcPort }}
           {{- end }}
     {{- end }}
+{{- end }}
 {{- end }}

--- a/examples/production-deployment-k8s-helm/values.yaml
+++ b/examples/production-deployment-k8s-helm/values.yaml
@@ -71,11 +71,12 @@ gateway:
     #    hosts:
     #      - tensorzero-gateway.local
 
-    # Create legacy ingress with old naming pattern for zero-downtime upgrades
-    # IMPORTANT: Only set to true if upgrading from a version that used the old ingress naming
-    # For new installations, leave this as false to avoid ingress conflicts
-    # Set to false after migrating DNS/load balancers to the new ingress name
-    createLegacyIngress: false
+    # Legacy ingress is automatically detected and maintained if it exists in your cluster
+    # You can explicitly set this to true/false to override the automatic behavior
+    # - If unset: automatically creates legacy ingress only if it already exists
+    # - If true: always creates legacy ingress (may cause conflicts on new installations)
+    # - If false: never creates legacy ingress
+    # createLegacyIngress: false
 
 # UI Configuration
 ui:


### PR DESCRIPTION
Addressing: https://github.com/tensorzero/tensorzero/discussions/4121

CC spun up Minikube to test this.

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Set default `createLegacyIngress` to auto-detect in Helm chart, with manual override option, and update documentation.
> 
>   - **Behavior**:
>     - Default `createLegacyIngress` set to auto-detect in `values.yaml`, maintaining existing legacy ingress if detected.
>     - Allows manual override of `createLegacyIngress` to `true` or `false`.
>   - **Documentation**:
>     - Updated `README.md` to explain legacy ingress migration and manual override steps.
>   - **Templates**:
>     - Modified `gateway-ingress-legacy.yaml` to use `lookup` for detecting existing legacy ingress and conditionally create it.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ae265a5f23008e7d2ed90c79b63996be93e91bc9. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->