### PR TITLE
Increase timeout for gcp vertex gemini image inference

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -106,6 +106,11 @@ slow-timeout = { period = "60s", terminate-after = 2 }
 filter = 'test(websearch)'
 slow-timeout = { period = "120s", terminate-after = 2 }
 
+# Image inference seems to be slow on GCP Vertex Gemini, so we give it a longer timeout
+[[profile.default.overrides]]
+filter = 'test(providers::gcp_vertex_gemini::test_image_inference)'
+slow-timeout = { period = "60s", terminate-after = 2 }
+
 [[profile.default.overrides]]
 filter = 'binary(e2e) and test(providers::sglang::)'
 # The model we run on SGLang often fails to emit valid tool calls, so we need many retries

--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -1551,7 +1551,10 @@ pub async fn test_image_inference_with_provider_s3_compatible(
         Err(object_store::Error::NotFound { .. }) => {
             // Expected - object should not exist
         }
-        _ => {
+        Err(e) => {
+            panic!("Unexpected error: {e}");
+        }
+        Ok(_) => {
             panic!("Object should not exist after deletion");
         }
     }


### PR DESCRIPTION
This test is repeatedly timing out in the daily cron run
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase timeout for GCP Vertex Gemini image inference test and improve error handling in related test function.
> 
>   - **Timeout Adjustment**:
>     - Increases timeout for `test(providers::gcp_vertex_gemini::test_image_inference)` in `.config/nextest.toml` to 60s due to slow performance on GCP Vertex Gemini.
>   - **Error Handling**:
>     - Improves error handling in `test_image_inference_with_provider_s3_compatible` in `common.rs` by adding a panic for unexpected errors and handling `Ok(_)` case.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e4c59d9e046dfd3bef759b2369bdd81ef365d74b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->