### PR TITLE
Pin ci-bot to pre-miniswe-agent version

### DIFF
--- a/.github/workflows/tensorzero-ci-bot-failure-diagnosis.yml
+++ b/.github/workflows/tensorzero-ci-bot-failure-diagnosis.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: tensorzero/experimental-ci-bot
+          ref: 'v0.1-pre-agent'
           sparse-checkout: |
             tensorzero
 
@@ -61,7 +62,7 @@ jobs:
           cat /tmp/tensorzero-for-gateway/prompt.minijinja
 
       - name: Call LLM to generate PR revision
-        uses: tensorzero/experimental-ci-bot/generate-pr-patch@main
+        uses: 'tensorzero/experimental-ci-bot/generate-pr-patch@v0.1-pre-agent'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/tensorzero-ci-bot-provide-feedback.yml
+++ b/.github/workflows/tensorzero-ci-bot-provide-feedback.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: tensorzero/experimental-ci-bot
+          ref: 'v0.1-pre-agent'
           sparse-checkout: |
             tensorzero
 
@@ -40,7 +41,7 @@ jobs:
           exit 1
 
       - name: Send PR Feedback
-        uses: tensorzero/experimental-ci-bot/create-pr-feedback@main
+        uses: 'tensorzero/experimental-ci-bot/create-pr-feedback@v0.1-pre-agent'
         with:
           tensorzero-base-url: http://localhost:3000
           tensorzero-pr-merged-metric-name: tensorzero_github_ci_bot_pr_merged


### PR DESCRIPTION
We are pinning it until we are confident that miniswe agent works.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Pin CI bot to `v0.1-pre-agent` in two GitHub workflow files for stability.
> 
>   - **Workflows**:
>     - Pin `tensorzero/experimental-ci-bot` to `v0.1-pre-agent` in `tensorzero-ci-bot-failure-diagnosis.yml` and `tensorzero-ci-bot-provide-feedback.yml`.
>     - Update `uses` attribute to `v0.1-pre-agent` for `generate-pr-patch` and `create-pr-feedback` steps in both workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 783df81c9db5a7e9c934231dd40152d60a83302f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->