### PR TITLE
Re-use credential location when output model config for vertex SFT

### DIFF
--- a/tensorzero-core/src/optimization/gcp_vertex_gemini_sft/mod.rs
+++ b/tensorzero-core/src/optimization/gcp_vertex_gemini_sft/mod.rs
@@ -470,6 +470,11 @@ impl JobHandle for GCPVertexGeminiSFTJobHandle {
                 })
             })?;
 
-        convert_to_optimizer_status(job, self.region.clone(), self.project_id.clone())
+        convert_to_optimizer_status(
+            job,
+            self.region.clone(),
+            self.project_id.clone(),
+            self.credential_location.clone(),
+        )
     }
 }


### PR DESCRIPTION
This will probably be a more useful default for users, especially if they're using the 'sdk' location. This will also fix our optimization cron tests
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `credential_location` parameter to `convert_to_optimizer_status` and update related classes and tests for improved default behavior.
> 
>   - **Behavior**:
>     - Update `convert_to_optimizer_status` in `optimization.rs` to include `credential_location` parameter.
>     - Modify `GCPVertexGeminiSFTJobHandle` in `mod.rs` to pass `credential_location` to `convert_to_optimizer_status`.
>   - **Tests**:
>     - Update test cases in `optimization.rs` to pass `None` for `credential_location` in `convert_to_optimizer_status` calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f5edbd8d5fb87773cc02b3982d9706d07312ec26. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->