### PR TITLE
Increase openai web_search timeout in openai-node tests

### DIFF
--- a/clients/openai-node/tests/inference-openai-responses-api.test.ts
+++ b/clients/openai-node/tests/inference-openai-responses-api.test.ts
@@ -152,7 +152,7 @@ describe("OpenAI Responses API", () => {
       expect(result.usage?.prompt_tokens).toBeGreaterThan(0);
       expect(result.usage?.completion_tokens).toBeGreaterThan(0);
     },
-    90000
+    120_000
   );
 
   it.concurrent(
@@ -218,7 +218,7 @@ describe("OpenAI Responses API", () => {
 
       // TODO (#4044): check for unknown web search events when we start returning them
     },
-    90000
+    120_000
   );
 
   it.concurrent("should handle tool calls", async () => {
@@ -402,7 +402,7 @@ describe("OpenAI Responses API", () => {
       expect(result.usage?.prompt_tokens).toBeGreaterThan(0);
       expect(result.usage?.completion_tokens).toBeGreaterThan(0);
     },
-    90000
+    120_000
   );
 
   it.concurrent("should handle shorthand model name", async () => {


### PR DESCRIPTION
This timed out in the no-provider-proxy-cache daily cron job run
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase test timeouts in `inference-openai-responses-api.test.ts` to prevent cron job timeouts.
> 
>   - **Tests**:
>     - Increase timeout from `90,000` to `120,000` milliseconds in `inference-openai-responses-api.test.ts` for three test cases: "should perform basic inference using OpenAI Responses API", "should perform basic inference using OpenAI Responses API (streaming)", and "should handle web search".
>   - **Purpose**:
>     - Prevent timeouts in the no-provider-proxy-cache daily cron job run.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e1891ff12185a6d7013b2fbb48ed5777138f0791. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->