### PR TITLE
Improve grep regex used to find hanging pytest processes

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -273,7 +273,7 @@ jobs:
 
           echo "=== Capturing backtraces with gdb ==="
           # Find all python processes that might be related to our test
-          PYTHON_PIDS=$(pgrep -f "python.*pytest" || true)
+          PYTHON_PIDS=$(pgrep -f "tensorzero.*python" || true)
           if [ -n "$PYTHON_PIDS" ]; then
             for pid in $PYTHON_PIDS; do
               echo "--- Backtrace for Python process $pid ---"


### PR DESCRIPTION
The previous regex wasn't matching the python worker processes spawned by pytest

This will help debug the weird hang from https://github.com/tensorzero/tensorzero/pull/4155 if it occurs again
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update regex in `.github/workflows/merge-queue.yml` to better capture Python processes related to pytest for debugging hangs.
> 
>   - **Behavior**:
>     - Update regex in `.github/workflows/merge-queue.yml` to `pgrep -f "tensorzero.*python"` for capturing Python processes related to pytest.
>     - Aims to improve debugging of hanging pytest processes by accurately identifying related processes.
>   - **Context**:
>     - Addresses issues with previous regex not matching Python worker processes spawned by pytest.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 51d23670f30d9554f75b1cebcc8c2eb24a95d59f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->