### PR TITLE
Update bandit message on stopping

### DIFF
--- a/tensorzero-core/src/experimentation/track_and_stop/mod.rs
+++ b/tensorzero-core/src/experimentation/track_and_stop/mod.rs
@@ -737,7 +737,8 @@ impl TrackAndStopState {
                             winner = winner_variant_name,
                             competitors = ?competitors,
                             "Track-and-Stop experiment stopped: winner identified. This variant will be used exclusively
-                            going forward unless new variants are introduced."
+                            going forward, unless new variants are introduced, or unless additional feedback data suggests
+                            that this variant is not actually a winning variant."
                         );
                         Ok(TrackAndStopState::Stopped {
                             winner_variant_name,


### PR DESCRIPTION
Since we compute the bandit state every time we query the feedback data, bandits can transition from Stopped back to BanditsOnly even if new variants aren't introduced mid-experiment, if the sample statistics change in the right way.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update log message in `TrackAndStopState` to clarify conditions under which a variant may not remain a winner.
> 
>   - **Logging**:
>     - Update log message in `TrackAndStopState` to clarify that a variant identified as a winner may not remain so if additional feedback data suggests otherwise.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 097a85ebbcca303acfab1d3dddbf65ab6edb3a92. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->