### PR TITLE
removed weight column from function detail page

### DIFF
--- a/ui/app/routes/observability/functions/$function_name/FunctionVariantTable.tsx
+++ b/ui/app/routes/observability/functions/$function_name/FunctionVariantTable.tsx
@@ -25,7 +25,6 @@ import { ChevronUp, ChevronDown, Search } from "lucide-react";
 
 type VariantCountsWithMetadata = VariantCounts & {
   type: string;
-  weight: number | null;
 };
 
 const columnHelper = createColumnHelper<VariantCountsWithMetadata>();
@@ -58,10 +57,6 @@ export default function FunctionVariantTable({
       columnHelper.accessor("type", {
         header: "Type",
         cell: (info) => <Code>{info.getValue()}</Code>,
-      }),
-      columnHelper.accessor("weight", {
-        header: "Weight",
-        cell: (info) => info.getValue(),
       }),
       columnHelper.accessor("count", {
         header: "Count",

--- a/ui/e2e_tests/observability.functions.function_name.variants.variant_name.spec.ts
+++ b/ui/e2e_tests/observability.functions.function_name.variants.variant_name.spec.ts
@@ -2,8 +2,6 @@ import { test, expect } from "@playwright/test";
 
 test("should show the DICL variant detail page", async ({ page }) => {
   await page.goto("/observability/functions/extract_entities/variants/dicl");
-  // Weight only will show up if it is set in the config
-  await expect(page.getByText("Weight")).toBeVisible();
 
   // Verify DICL-specific fields
   await expect(page.getByText("k (Neighbors)")).toBeVisible();


### PR DESCRIPTION
Now that we have a standalone experimentation section we do not need to include this and it is potentially misleading.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `weight` column from function detail page and update related tests.
> 
>   - **UI Changes**:
>     - Remove `weight` column from `FunctionVariantTable.tsx`.
>     - Update `VariantCountsWithMetadata` type to exclude `weight`.
>   - **Tests**:
>     - Remove test for `weight` visibility in `variant_name.spec.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 00674e88bea033da47b1ac3dbccf34521df6c807. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->