### PR TITLE
Add timeout to gateway health check loop in live-tests

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -216,6 +216,7 @@ jobs:
           ./ci/run-provider-proxy.sh ci
 
       - name: Launch the gateway for E2E tests
+        timeout-minutes: 2
         run: |
           cargo run-e2e > e2e_logs.txt 2>&1 &
           while ! curl -s -f http://localhost:3000/health >/dev/null 2>&1; do


### PR DESCRIPTION
This prevents the entire job from hanging if the gateway fails to start up
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add a 2-minute timeout to the gateway startup in E2E tests to prevent CI hanging.
> 
>   - **Behavior**:
>     - Adds a `timeout-minutes: 2` to the "Launch the gateway for E2E tests" step in `.github/workflows/merge-queue.yml` to prevent hanging if the gateway fails to start.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0edf0f3295061d7a93030dfa7066377e52e25819. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->