### PR TITLE
Delete ClickhouseFormat option in list inferences

### DIFF
--- a/tensorzero-core/src/db/clickhouse/inference_queries.rs
+++ b/tensorzero-core/src/db/clickhouse/inference_queries.rs
@@ -13,7 +13,6 @@ use crate::db::inferences::{
 use crate::function::FunctionConfigType;
 use crate::{
     config::Config,
-    db::clickhouse::ClickhouseFormat,
     error::{Error, ErrorDetails},
     stored_inference::StoredInference,
 };
@@ -218,11 +217,7 @@ pub(crate) fn generate_list_inferences_sql(
         );
         sql.push_str(&format!("\nOFFSET {offset_param_placeholder}"));
     }
-    match opts.format {
-        ClickhouseFormat::JsonEachRow => {
-            sql.push_str("\nFORMAT JSONEachRow");
-        }
-    }
+    sql.push_str("\nFORMAT JSONEachRow");
 
     Ok((sql, query_params))
 }

--- a/tensorzero-core/src/db/clickhouse/mod.rs
+++ b/tensorzero-core/src/db/clickhouse/mod.rs
@@ -492,17 +492,6 @@ where
     s.parse::<u64>().map_err(serde::de::Error::custom)
 }
 
-/// The format of the data that will be returned from / sent to ClickHouse.
-/// Currently only used in the query builder.
-/// TODO: use across the codebase.
-#[cfg_attr(test, derive(ts_rs::TS))]
-#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(test, ts(export))]
-pub enum ClickhouseFormat {
-    #[default]
-    JsonEachRow,
-}
-
 #[cfg(test)]
 mod tests {
 

--- a/tensorzero-core/src/db/inferences.rs
+++ b/tensorzero-core/src/db/inferences.rs
@@ -11,7 +11,6 @@ use mockall::automock;
 
 use crate::config::Config;
 use crate::db::clickhouse::query_builder::{InferenceFilter, OrderBy};
-use crate::db::clickhouse::ClickhouseFormat;
 use crate::error::{Error, ErrorDetails};
 use crate::inference::types::{ContentBlockChatOutput, JsonInferenceOutput, StoredInput};
 use crate::serde_util::{deserialize_defaulted_string, deserialize_json_string};
@@ -191,7 +190,6 @@ pub struct ListInferencesParams<'a> {
     /// Number of inferences to skip.
     pub offset: Option<u64>,
     pub order_by: Option<&'a [OrderBy]>,
-    pub format: ClickhouseFormat,
 }
 
 impl Default for ListInferencesParams<'_> {
@@ -206,7 +204,6 @@ impl Default for ListInferencesParams<'_> {
             limit: None,
             offset: None,
             order_by: None,
-            format: ClickhouseFormat::JsonEachRow,
         }
     }
 }

--- a/tensorzero-core/src/endpoints/optimization.rs
+++ b/tensorzero-core/src/endpoints/optimization.rs
@@ -15,7 +15,7 @@ use crate::{
     db::{
         clickhouse::{
             query_builder::{InferenceFilter, OrderBy},
-            ClickHouseConnectionInfo, ClickhouseFormat,
+            ClickHouseConnectionInfo,
         },
         inferences::{InferenceOutputSource, InferenceQueries, ListInferencesParams},
     },
@@ -47,8 +47,6 @@ pub struct LaunchOptimizationWorkflowParams {
     #[serde(deserialize_with = "deserialize_option_u64")]
     pub offset: Option<u64>,
     pub val_fraction: Option<f64>,
-    #[serde(default)]
-    pub format: ClickhouseFormat,
     pub optimizer_config: UninitializedOptimizerInfo,
 }
 
@@ -89,7 +87,6 @@ pub async fn launch_optimization_workflow(
         limit,
         offset,
         val_fraction,
-        format,
         optimizer_config,
     } = params;
     // Query the database for the stored inferences
@@ -105,7 +102,6 @@ pub async fn launch_optimization_workflow(
                 output_source,
                 limit,
                 offset,
-                format,
                 order_by: order_by.as_deref(),
             },
         )

--- a/tensorzero-core/tests/optimization/common/dicl.rs
+++ b/tensorzero-core/tests/optimization/common/dicl.rs
@@ -13,12 +13,9 @@ use tensorzero::{
 };
 use tensorzero_core::{
     config::{Config, ConfigFileGlob, UninitializedVariantConfig},
-    db::clickhouse::{
-        test_helpers::{
-            get_clickhouse, select_chat_inference_clickhouse, select_json_inference_clickhouse,
-            select_model_inferences_clickhouse, CLICKHOUSE_URL,
-        },
-        ClickhouseFormat,
+    db::clickhouse::test_helpers::{
+        get_clickhouse, select_chat_inference_clickhouse, select_json_inference_clickhouse,
+        select_model_inferences_clickhouse, CLICKHOUSE_URL,
     },
     http::TensorzeroHttpClient,
     inference::types::{
@@ -1067,7 +1064,6 @@ pub async fn run_dicl_workflow_with_client(client: &tensorzero::Client) {
         limit: Some(10),
         offset: None,
         val_fraction: None,
-        format: ClickhouseFormat::JsonEachRow,
         // We always mock the client tests since this is tested above
         optimizer_config: UninitializedOptimizerInfo {
             inner: UninitializedOptimizerConfig::Dicl(UninitializedDiclOptimizationConfig {

--- a/tensorzero-core/tests/optimization/common/mod.rs
+++ b/tensorzero-core/tests/optimization/common/mod.rs
@@ -15,7 +15,7 @@ use tensorzero_core::{
     cache::CacheOptions,
     config::{provider_types::ProviderTypesConfig, Config, ConfigFileGlob},
     db::{
-        clickhouse::{test_helpers::CLICKHOUSE_URL, ClickHouseConnectionInfo, ClickhouseFormat},
+        clickhouse::{test_helpers::CLICKHOUSE_URL, ClickHouseConnectionInfo},
         postgres::PostgresConnectionInfo,
     },
     endpoints::inference::InferenceClients,
@@ -241,7 +241,6 @@ pub async fn run_workflow_test_case_with_tensorzero_client(
         limit: Some(10),
         offset: None,
         val_fraction: None,
-        format: ClickhouseFormat::JsonEachRow,
         // We always mock the client tests since this is tested above
         optimizer_config: test_case.get_optimizer_info(true),
     };


### PR DESCRIPTION
Cleanup only. `ClickhouseFormat` is only used internally when building ClickHouse SQL, and we only ever use the JsonEachRow format. We always return strongly-typed structs across the API boundary and across the ClickhouseClient boundary, so there's no reason for us to expose this in the API.

This is a back-compatible change, because the only structs affected here are `ListInferencesParams` and `LaunchOptimizationWorkflowParams`, and in both cases serde ignores unknown fields.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove `ClickhouseFormat` enum and hardcode `JsonEachRow` format in ClickHouse SQL generation, updating related structs and tests.
> 
>   - **Behavior**:
>     - Remove `ClickhouseFormat` enum and its usage in `inference_queries.rs`, `mod.rs`, and `inferences.rs`.
>     - Hardcode `FORMAT JSONEachRow` in `generate_list_inferences_sql()` in `inference_queries.rs`.
>   - **Structs**:
>     - Remove `format` field from `ListInferencesParams` and `LaunchOptimizationWorkflowParams`.
>   - **Tests**:
>     - Update tests in `dicl.rs` and `mod.rs` to reflect removal of `ClickhouseFormat`.
>   - **Misc**:
>     - Remove `ClickhouseFormat` related imports and default settings in `mod.rs` and `optimization.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5f8e11098346bbb87056943c050ee49d8b0ef7c3. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->