### PR TITLE
Extend wait time for merge queue workflow

### DIFF
--- a/.github/workflows/slash-command-merge-queue.yml
+++ b/.github/workflows/slash-command-merge-queue.yml
@@ -34,8 +34,8 @@ jobs:
           set -e
           gh workflow run merge-queue.yml --ref ${{ github.event.client_payload.pull_request.head.ref }}
 
-          # Wait a moment for the workflow to be created
-          sleep 3
+          # Wait 30s for the workflow to be created
+          sleep 30
 
           # Get the most recent workflow run for this branch
           RUN_ID=$(gh run list --workflow=merge-queue.yml --branch=${{ github.event.client_payload.pull_request.head.ref }} --limit=1 --json databaseId --jq '.[0].databaseId')


### PR DESCRIPTION
Increased wait time for workflow creation from 3 seconds to 30 seconds. We were querying before it started. Later we can consider polling/etc. but this should fix the bug for now...
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increased wait time from 3 to 30 seconds in `slash-command-merge-queue.yml` to ensure workflow creation before querying.
> 
>   - **Behavior**:
>     - Increased wait time from 3 seconds to 30 seconds in `slash-command-merge-queue.yml` to ensure workflow creation before querying.
>   - **Comments**:
>     - Updated comment to reflect the new 30-second wait time in `slash-command-merge-queue.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2230496d0be8a37877d7d98a90c8e4f27fe391d4. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->