### PR TITLE
Add instructions about clearing batch test cache

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,6 +217,10 @@ Separately, you can run headless tests with `pnpm test` and Playwright tests wit
 We also maintain a Docker Compose for e2e tests `fixtures/docker-compose.e2e.yml` that is used in CI for the Playwright tests.
 This file uses a different configuration that mandates credentials for image fetching.
 
+### Advanced
+
+- If your code affects the serialization of stored data, batch tests might fail because they'll rely on an older serialization of the request. In such cases, you might need to clear the database and re-run the tests. The TensorZero Team can clean up the cache by running `TRUNCATE TABLE tensorzero_e2e_tests.BatchModelInference; TRUNCATE TABLE tensorzero_e2e_tests.BatchRequest;` in the ClickHouse Cloud cluster `dev-tensorzero-e2e-tests`.
+
 ---
 
 Thanks again for your interest in contributing to TensorZero! We're excited to see what you build.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds instructions in `CONTRIBUTING.md` for clearing batch test cache when data serialization changes affect tests.
> 
>   - **Documentation**:
>     - Adds instructions in `CONTRIBUTING.md` under the "Advanced" section for clearing batch test cache when code affects data serialization.
>     - Provides SQL commands to truncate `BatchModelInference` and `BatchRequest` tables in ClickHouse Cloud cluster `dev-tensorzero-e2e-tests`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 911a10a5f87f84de0b81117d4a787b37e87120f4. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->