### PR TITLE
Refactor tables to use Table Items components across UI

### DIFF
--- a/ui/app/routes/datasets/DatasetTable.tsx
+++ b/ui/app/routes/datasets/DatasetTable.tsx
@@ -8,8 +8,8 @@ import {
   TableEmptyState,
 } from "~/components/ui/table";
 import type { DatasetMetadata } from "tensorzero-node";
-import { Link, useFetcher } from "react-router";
-import { TableItemTime } from "~/components/ui/TableItems";
+import { useFetcher } from "react-router";
+import { TableItemShortUuid, TableItemTime } from "~/components/ui/TableItems";
 import { toDatasetUrl } from "~/utils/urls";
 import { Button } from "~/components/ui/button";
 import { Trash, ChevronUp, ChevronDown, Search } from "lucide-react";
@@ -51,14 +51,10 @@ export default function DatasetTable({
       columnHelper.accessor("dataset_name", {
         header: "Dataset Name",
         cell: (info) => (
-          <Link
-            to={toDatasetUrl(info.getValue())}
-            className="block no-underline"
-          >
-            <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-              {info.getValue()}
-            </code>
-          </Link>
+          <TableItemShortUuid
+            id={info.getValue()}
+            link={toDatasetUrl(info.getValue())}
+          />
         ),
       }),
       columnHelper.accessor("count", {

--- a/ui/app/routes/evaluations/EvaluationRunsTable.tsx
+++ b/ui/app/routes/evaluations/EvaluationRunsTable.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router";
 import {
   Table,
   TableBody,
@@ -40,24 +39,16 @@ function EvaluationRunRow({
         />
       </TableCell>
       <TableCell className="max-w-[200px]">
-        <Link
-          to={toEvaluationUrl(evaluationRun.evaluation_name)}
-          className="block no-underline"
-        >
-          <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-            {evaluationRun.evaluation_name}
-          </code>
-        </Link>
+        <TableItemShortUuid
+          id={evaluationRun.evaluation_name}
+          link={toEvaluationUrl(evaluationRun.evaluation_name)}
+        />
       </TableCell>
       <TableCell>
-        <Link
-          to={toDatasetUrl(evaluationRun.dataset_name)}
-          className="block no-underline"
-        >
-          <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-            {evaluationRun.dataset_name}
-          </code>
-        </Link>
+        <TableItemShortUuid
+          id={evaluationRun.dataset_name}
+          link={toDatasetUrl(evaluationRun.dataset_name)}
+        />
       </TableCell>
       <TableCell>
         <TableItemFunction
@@ -71,9 +62,7 @@ function EvaluationRunRow({
           variantName={evaluationRun.variant_name}
           functionName={evaluationRun.function_name}
         >
-          <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-            {evaluationRun.variant_name}
-          </code>
+          <TableItemShortUuid id={evaluationRun.variant_name} />
         </VariantLink>
       </TableCell>
       <TableCell>

--- a/ui/app/routes/observability/episodes/$episode_id/EpisodeInferenceTable.tsx
+++ b/ui/app/routes/observability/episodes/$episode_id/EpisodeInferenceTable.tsx
@@ -55,9 +55,7 @@ export default function EpisodeInferenceTable({
                   variantName={inference.variant_name}
                   functionName={inference.function_name}
                 >
-                  <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-                    {inference.variant_name}
-                  </code>
+                  <TableItemShortUuid id={inference.variant_name} />
                 </VariantLink>
               </TableCell>
               <TableCell>

--- a/ui/app/routes/observability/functions/$function_name/FunctionInferenceTable.tsx
+++ b/ui/app/routes/observability/functions/$function_name/FunctionInferenceTable.tsx
@@ -50,9 +50,7 @@ export default function FunctionInferenceTable({
                   variantName={inference.variant_name}
                   functionName={inference.function_name}
                 >
-                  <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-                    {inference.variant_name}
-                  </code>
+                  <TableItemShortUuid id={inference.variant_name} />
                 </VariantLink>
               </TableCell>
               <TableCell>

--- a/ui/app/routes/observability/functions/$function_name/FunctionVariantTable.tsx
+++ b/ui/app/routes/observability/functions/$function_name/FunctionVariantTable.tsx
@@ -10,7 +10,7 @@ import {
 } from "~/components/ui/table";
 import type { VariantCounts } from "~/utils/clickhouse/function";
 import { VariantLink } from "~/components/function/variant/VariantLink";
-import { TableItemTime } from "~/components/ui/TableItems";
+import { TableItemShortUuid, TableItemTime } from "~/components/ui/TableItems";
 import {
   useReactTable,
   getCoreRowModel,
@@ -48,9 +48,7 @@ export default function FunctionVariantTable({
             variantName={info.getValue()}
             functionName={function_name}
           >
-            <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-              {info.getValue()}
-            </code>
+            <TableItemShortUuid id={info.getValue()} />
           </VariantLink>
         ),
       }),

--- a/ui/app/routes/observability/inferences/InferencesTable.tsx
+++ b/ui/app/routes/observability/inferences/InferencesTable.tsx
@@ -63,9 +63,7 @@ export default function InferencesTable({
                     variantName={inference.variant_name}
                     functionName={inference.function_name}
                   >
-                    <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-                      {inference.variant_name}
-                    </code>
+                    <TableItemShortUuid id={inference.variant_name} />
                   </VariantLink>
                 </TableCell>
                 <TableCell>

--- a/ui/app/routes/workflow_evaluations/WorkflowEvaluationProjectsTable.tsx
+++ b/ui/app/routes/workflow_evaluations/WorkflowEvaluationProjectsTable.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router";
 import {
   Table,
   TableBody,
@@ -8,7 +7,7 @@ import {
   TableRow,
   TableEmptyState,
 } from "~/components/ui/table";
-import { formatDate } from "~/utils/date";
+import { TableItemShortUuid, TableItemTime } from "~/components/ui/TableItems";
 import type { WorkflowEvaluationProject } from "~/utils/clickhouse/workflow_evaluations";
 import { toWorkflowEvaluationProjectUrl } from "~/utils/urls";
 
@@ -34,14 +33,10 @@ export default function WorkflowEvaluationProjectsTable({
             workflowEvaluationProjects.map((project) => (
               <TableRow key={project.name}>
                 <TableCell className="max-w-[200px]">
-                  <Link
-                    to={toWorkflowEvaluationProjectUrl(project.name)}
-                    className="block no-underline"
-                  >
-                    <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-                      {project.name}
-                    </code>
-                  </Link>
+                  <TableItemShortUuid
+                    id={project.name}
+                    link={toWorkflowEvaluationProjectUrl(project.name)}
+                  />
                 </TableCell>
                 <TableCell>
                   <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
@@ -49,7 +44,7 @@ export default function WorkflowEvaluationProjectsTable({
                   </code>
                 </TableCell>
                 <TableCell>
-                  {formatDate(new Date(project.last_updated))}
+                  <TableItemTime timestamp={project.last_updated} />
                 </TableCell>
               </TableRow>
             ))

--- a/ui/app/routes/workflow_evaluations/WorkflowEvaluationRunsTable.tsx
+++ b/ui/app/routes/workflow_evaluations/WorkflowEvaluationRunsTable.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router";
 import {
   Table,
   TableBody,
@@ -8,7 +7,7 @@ import {
   TableRow,
   TableEmptyState,
 } from "~/components/ui/table";
-import { formatDate } from "~/utils/date";
+import { TableItemShortUuid, TableItemTime } from "~/components/ui/TableItems";
 import type { WorkflowEvaluationRunWithEpisodeCount } from "~/utils/clickhouse/workflow_evaluations";
 import {
   toWorkflowEvaluationRunUrl,
@@ -39,41 +38,31 @@ export default function WorkflowEvaluationRunsTable({
             workflowEvaluationRuns.map((run) => (
               <TableRow key={run.id}>
                 <TableCell className="max-w-[200px]">
-                  <Link
-                    to={toWorkflowEvaluationRunUrl(run.id)}
-                    className="block no-underline"
-                  >
-                    <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-                      {run.name}
-                    </code>
-                  </Link>
+                  <TableItemShortUuid
+                    id={run.name}
+                    link={toWorkflowEvaluationRunUrl(run.id)}
+                  />
                 </TableCell>
                 <TableCell className="max-w-[200px]">
-                  <Link
-                    to={toWorkflowEvaluationRunUrl(run.id)}
-                    className="block no-underline"
-                  >
-                    <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-                      {run.id}
-                    </code>
-                  </Link>
+                  <TableItemShortUuid
+                    id={run.id}
+                    link={toWorkflowEvaluationRunUrl(run.id)}
+                  />
                 </TableCell>
                 <TableCell>
                   {run.project_name ? (
-                    <Link
-                      to={`${toWorkflowEvaluationProjectUrl(run.project_name)}?run_ids=${run.id}`}
-                      className="block no-underline"
-                    >
-                      <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
-                        {run.project_name}
-                      </code>
-                    </Link>
+                    <TableItemShortUuid
+                      id={run.project_name}
+                      link={`${toWorkflowEvaluationProjectUrl(run.project_name)}?run_ids=${run.id}`}
+                    />
                   ) : (
                     <span className="text-gray-400">-</span>
                   )}
                 </TableCell>
                 <TableCell>{run.num_episodes}</TableCell>
-                <TableCell>{formatDate(new Date(run.timestamp))}</TableCell>
+                <TableCell>
+                  <TableItemTime timestamp={run.timestamp} />
+                </TableCell>
               </TableRow>
             ))
           )}

--- a/ui/app/routes/workflow_evaluations/projects/$project_name/WorkflowEvaluationProjectResultsTable.tsx
+++ b/ui/app/routes/workflow_evaluations/projects/$project_name/WorkflowEvaluationProjectResultsTable.tsx
@@ -26,8 +26,7 @@ import type {
   GroupedWorkflowEvaluationRunEpisodeWithFeedback,
   WorkflowEvaluationRunStatisticsByMetricName,
 } from "~/utils/clickhouse/workflow_evaluations";
-import { TableItemShortUuid } from "~/components/ui/TableItems";
-import { formatDate } from "~/utils/date";
+import { TableItemShortUuid, TableItemTime } from "~/components/ui/TableItems";
 import type { MetricConfig } from "tensorzero-node";
 
 interface WorkflowEvaluationProjectResultsTableProps {
@@ -159,7 +158,7 @@ export function WorkflowEvaluationProjectResultsTable({
 
                           {/* Timestamp cell */}
                           <TableCell className="text-center align-middle">
-                            {formatDate(new Date(result.timestamp))}
+                            <TableItemTime timestamp={result.timestamp} />
                           </TableCell>
 
                           {/* Metrics cells */}

--- a/ui/app/routes/workflow_evaluations/runs/$run_id/WorkflowEvaluationRunEpisodesTable.tsx
+++ b/ui/app/routes/workflow_evaluations/runs/$run_id/WorkflowEvaluationRunEpisodesTable.tsx
@@ -7,7 +7,6 @@ import {
   TableRow,
   TableEmptyState,
 } from "~/components/ui/table";
-import { formatDate } from "~/utils/date";
 import { toEpisodeUrl } from "~/utils/urls";
 import type {
   WorkflowEvaluationRunEpisodeWithFeedback,
@@ -17,7 +16,7 @@ import { TooltipContent, TooltipTrigger } from "~/components/ui/tooltip";
 import { Tooltip } from "~/components/ui/tooltip";
 import { useConfig } from "~/context/config";
 import { formatMetricSummaryValue } from "~/utils/config/feedback";
-import { TableItemShortUuid } from "~/components/ui/TableItems";
+import { TableItemShortUuid, TableItemTime } from "~/components/ui/TableItems";
 import KVChip from "~/components/ui/KVChip";
 import MetricValue from "~/components/metric/MetricValue";
 import FeedbackValue from "~/components/feedback/FeedbackValue";
@@ -74,7 +73,9 @@ export default function WorkflowEvaluationRunEpisodesTable({
                     link={toEpisodeUrl(episode.episode_id)}
                   />
                 </TableCell>
-                <TableCell>{formatDate(new Date(episode.timestamp))}</TableCell>
+                <TableCell>
+                  <TableItemTime timestamp={episode.timestamp} />
+                </TableCell>
                 <TableCell>
                   {(() => {
                     const filteredTags = Object.entries(episode.tags).filter(


### PR DESCRIPTION
Refactored multiple table components across the app to consistently use the `TableItemShortUuid` and `TableItemTime` components for displaying short UUIDs and timestamps, replacing custom code and manual formatting. 

Fixes: #1862 

