### PR TITLE
Helm: Enable optionally setting deployment service account

### DIFF
--- a/examples/production-deployment-k8s-helm/README.md
+++ b/examples/production-deployment-k8s-helm/README.md
@@ -66,36 +66,38 @@ The following table lists the configurable parameters of the chart and their def
 
 ### Gateway Configuration
 
-| Parameter                    | Description                | Default                         |
-| ---------------------------- | -------------------------- | ------------------------------- |
-| `gateway.replicaCount`       | Number of gateway replicas | `1`                             |
-| `gateway.image.repository`   | Gateway image repository   | `tensorzero/gateway`            |
-| `gateway.image.tag`          | Gateway image tag          | `latest`                        |
-| `gateway.image.pullPolicy`   | Gateway image pull policy  | `IfNotPresent`                  |
-| `gateway.service.type`       | Gateway service type       | `ClusterIP`                     |
-| `gateway.service.port`       | Gateway service port       | `3000`                          |
-| `gateway.resources.limits`   | Gateway resource limits    | `cpu: 2000m, memory: 4096Mi`    |
-| `gateway.resources.requests` | Gateway resource requests  | `cpu: 2000m, memory: 4096Mi`    |
-| `gateway.ingress.enabled`    | Enable gateway ingress     | `true`                          |
-| `gateway.ingress.className`  | Gateway ingress class      | `traefik-ingress-controller-v3` |
-| `gateway.ingress.hosts`      | Gateway ingress hosts      | `tensorzero-gateway.local`      |
+| Parameter                    | Description                      | Default                         |
+| ---------------------------- | -------------------------------- | ------------------------------- |
+| `gateway.replicaCount`       | Number of gateway replicas       | `1`                             |
+| `gateway.serviceAccountName` | Service account for gateway pods | `""`                            |
+| `gateway.image.repository`   | Gateway image repository         | `tensorzero/gateway`            |
+| `gateway.image.tag`          | Gateway image tag                | `latest`                        |
+| `gateway.image.pullPolicy`   | Gateway image pull policy        | `IfNotPresent`                  |
+| `gateway.service.type`       | Gateway service type             | `ClusterIP`                     |
+| `gateway.service.port`       | Gateway service port             | `3000`                          |
+| `gateway.resources.limits`   | Gateway resource limits          | `cpu: 2000m, memory: 4096Mi`    |
+| `gateway.resources.requests` | Gateway resource requests        | `cpu: 2000m, memory: 4096Mi`    |
+| `gateway.ingress.enabled`    | Enable gateway ingress           | `true`                          |
+| `gateway.ingress.className`  | Gateway ingress class            | `traefik-ingress-controller-v3` |
+| `gateway.ingress.hosts`      | Gateway ingress hosts            | `tensorzero-gateway.local`      |
 
 ### UI Configuration
 
-| Parameter               | Description              | Default                         |
-| ----------------------- | ------------------------ | ------------------------------- |
-| `ui.deploy`             | Whether to deploy the UI | `true`                          |
-| `ui.replicaCount`       | Number of UI replicas    | `1`                             |
-| `ui.image.repository`   | UI image repository      | `tensorzero/ui`                 |
-| `ui.image.tag`          | UI image tag             | `latest`                        |
-| `ui.image.pullPolicy`   | UI image pull policy     | `IfNotPresent`                  |
-| `ui.service.type`       | UI service type          | `ClusterIP`                     |
-| `ui.service.port`       | UI service port          | `4000`                          |
-| `ui.resources.limits`   | UI resource limits       | `cpu: 1000m, memory: 1024Mi`    |
-| `ui.resources.requests` | UI resource requests     | `cpu: 500m, memory: 512Mi`      |
-| `ui.ingress.enabled`    | Enable UI ingress        | `true`                          |
-| `ui.ingress.className`  | UI ingress class         | `traefik-ingress-controller-v3` |
-| `ui.ingress.hosts`      | UI ingress hosts         | `tensorzero-ui.local`           |
+| Parameter               | Description                 | Default                         |
+|-------------------------|-----------------------------|---------------------------------|
+| `ui.deploy`             | Whether to deploy the UI    | `true`                          |
+| `ui.replicaCount`       | Number of UI replicas       | `1`                             |
+| `ui.serviceAccountName` | Service account for UI pods | `""`                            |
+| `ui.image.repository`   | UI image repository         | `tensorzero/ui`                 |
+| `ui.image.tag`          | UI image tag                | `latest`                        |
+| `ui.image.pullPolicy`   | UI image pull policy        | `IfNotPresent`                  |
+| `ui.service.type`       | UI service type             | `ClusterIP`                     |
+| `ui.service.port`       | UI service port             | `4000`                          |
+| `ui.resources.limits`   | UI resource limits          | `cpu: 1000m, memory: 1024Mi`    |
+| `ui.resources.requests` | UI resource requests        | `cpu: 500m, memory: 512Mi`      |
+| `ui.ingress.enabled`    | Enable UI ingress           | `true`                          |
+| `ui.ingress.className`  | UI ingress class            | `traefik-ingress-controller-v3` |
+| `ui.ingress.hosts`      | UI ingress hosts            | `tensorzero-ui.local`           |
 
 ### Persistence Configuration
 

--- a/examples/production-deployment-k8s-helm/templates/gateway.yaml
+++ b/examples/production-deployment-k8s-helm/templates/gateway.yaml
@@ -19,6 +19,9 @@ spec:
         {{- include "tensorzero.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: gateway
     spec:
+      {{- if .Values.gateway.serviceAccountName }}
+      serviceAccountName: {{ .Values.gateway.serviceAccountName }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag | default .Chart.AppVersion }}"

--- a/examples/production-deployment-k8s-helm/templates/ui.yaml
+++ b/examples/production-deployment-k8s-helm/templates/ui.yaml
@@ -20,6 +20,9 @@ spec:
         {{- include "tensorzero.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: ui
     spec:
+      {{- if .Values.ui.serviceAccountName }}
+      serviceAccountName: {{ .Values.ui.serviceAccountName }}
+      {{- end }}
       containers:
         - name: ui
           image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag | default .Chart.AppVersion }}"

--- a/examples/production-deployment-k8s-helm/values.yaml
+++ b/examples/production-deployment-k8s-helm/values.yaml
@@ -21,6 +21,9 @@ gateway:
   args:
     - --config-file=/app/config/tensorzero.toml
 
+  # Optional service account name for the gateway deployment
+  serviceAccountName: ""
+
   image:
     repository: tensorzero/gateway
     tag: "" # If empty, uses Chart.appVersion
@@ -79,6 +82,10 @@ gateway:
 ui:
   deploy: true # TODO: change this to false if you don't want to deploy the UI
   replicaCount: 1
+
+  # Optional service account name for the UI deployment
+  serviceAccountName: ""
+
   image:
     repository: tensorzero/ui
     tag: "" # If empty, uses Chart.appVersion


### PR DESCRIPTION
This enables users to bind the TensorZero deployments to service accounts that,
for example, have the necessary IAM permissions to access [Bedrock](https://www.tensorzero.com/docs/integrations/model-providers/aws-bedrock) models.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds optional service account configuration for gateway and UI deployments in Helm chart to enable specific IAM permissions.
> 
>   - **Behavior**:
>     - Adds `serviceAccountName` option for `gateway` and `ui` in `values.yaml` to bind deployments to specific service accounts.
>     - Updates `gateway.yaml` and `ui.yaml` to conditionally set `serviceAccountName` if specified in `values.yaml`.
>   - **Documentation**:
>     - Updates `README.md` to include `serviceAccountName` in the configuration tables for `gateway` and `ui`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d4ecf72eadf88dcd879a8434a34daba37e9bcfdb. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->