### PR TITLE
Remove unused `total_tokens` from provider-specific usage structs

### DIFF
--- a/tensorzero-core/src/providers/azure.rs
+++ b/tensorzero-core/src/providers/azure.rs
@@ -975,7 +975,6 @@ mod tests {
             usage: OpenAIUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             },
         };
         let generic_request = ModelInferenceRequest {

--- a/tensorzero-core/src/providers/deepseek.rs
+++ b/tensorzero-core/src/providers/deepseek.rs
@@ -967,7 +967,6 @@ mod tests {
             usage: OpenAIUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             },
         };
         let generic_request = ModelInferenceRequest {

--- a/tensorzero-core/src/providers/fireworks/mod.rs
+++ b/tensorzero-core/src/providers/fireworks/mod.rs
@@ -890,7 +890,6 @@ mod tests {
             usage: OpenAIUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             },
         };
 
@@ -1078,7 +1077,6 @@ mod tests {
             usage: OpenAIUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             },
         };
         let generic_request = ModelInferenceRequest {
@@ -1215,7 +1213,6 @@ mod tests {
             usage: Some(OpenAIUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             }),
         };
         let message = fireworks_to_tensorzero_chunk(

--- a/tensorzero-core/src/providers/groq.rs
+++ b/tensorzero-core/src/providers/groq.rs
@@ -968,7 +968,6 @@ pub(super) struct GroqUsage {
     pub prompt_tokens: u32,
     #[serde(default)]
     pub completion_tokens: u32,
-    pub total_tokens: u32,
 }
 
 impl From<GroqUsage> for Usage {
@@ -1600,7 +1599,6 @@ mod tests {
             usage: GroqUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             },
         };
         let generic_request = ModelInferenceRequest {
@@ -1698,7 +1696,6 @@ mod tests {
             usage: GroqUsage {
                 prompt_tokens: 15,
                 completion_tokens: 25,
-                total_tokens: 40,
             },
         };
         let generic_request = ModelInferenceRequest {
@@ -1788,7 +1785,6 @@ mod tests {
             usage: GroqUsage {
                 prompt_tokens: 5,
                 completion_tokens: 0,
-                total_tokens: 5,
             },
         };
         let request_body = GroqRequest {
@@ -1845,7 +1841,6 @@ mod tests {
             usage: GroqUsage {
                 prompt_tokens: 10,
                 completion_tokens: 10,
-                total_tokens: 20,
             },
         };
 
@@ -2155,7 +2150,6 @@ mod tests {
             usage: Some(GroqUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             }),
         };
         let message =

--- a/tensorzero-core/src/providers/hyperbolic.rs
+++ b/tensorzero-core/src/providers/hyperbolic.rs
@@ -544,7 +544,6 @@ mod tests {
             usage: OpenAIUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             },
         };
         let generic_request = ModelInferenceRequest {

--- a/tensorzero-core/src/providers/mistral.rs
+++ b/tensorzero-core/src/providers/mistral.rs
@@ -554,7 +554,6 @@ impl<'a> MistralRequest<'a> {
 struct MistralUsage {
     prompt_tokens: u32,
     completion_tokens: u32,
-    total_tokens: u32,
 }
 
 impl From<MistralUsage> for Usage {
@@ -869,7 +868,6 @@ mod tests {
             usage: MistralUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             },
         };
 
@@ -966,7 +964,6 @@ mod tests {
             usage: MistralUsage {
                 prompt_tokens: 15,
                 completion_tokens: 25,
-                total_tokens: 40,
             },
         };
         let generic_request = ModelInferenceRequest {
@@ -1049,7 +1046,6 @@ mod tests {
             usage: MistralUsage {
                 prompt_tokens: 5,
                 completion_tokens: 0,
-                total_tokens: 5,
             },
         };
         let request_body = MistralRequest {
@@ -1102,7 +1098,6 @@ mod tests {
             usage: MistralUsage {
                 prompt_tokens: 10,
                 completion_tokens: 10,
-                total_tokens: 20,
             },
         };
         let request_body = MistralRequest {

--- a/tensorzero-core/src/providers/openai/mod.rs
+++ b/tensorzero-core/src/providers/openai/mod.rs
@@ -2114,7 +2114,6 @@ pub(super) struct OpenAIUsage {
     pub prompt_tokens: u32,
     #[serde(default)]
     pub completion_tokens: u32,
-    pub total_tokens: u32,
 }
 
 impl From<OpenAIUsage> for Usage {
@@ -3087,7 +3086,6 @@ mod tests {
             usage: OpenAIUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             },
         };
         let generic_request = ModelInferenceRequest {
@@ -3186,7 +3184,6 @@ mod tests {
             usage: OpenAIUsage {
                 prompt_tokens: 15,
                 completion_tokens: 25,
-                total_tokens: 40,
             },
         };
         let generic_request = ModelInferenceRequest {
@@ -3276,7 +3273,6 @@ mod tests {
             usage: OpenAIUsage {
                 prompt_tokens: 5,
                 completion_tokens: 0,
-                total_tokens: 5,
             },
         };
         let request_body = OpenAIRequest {
@@ -3335,7 +3331,6 @@ mod tests {
             usage: OpenAIUsage {
                 prompt_tokens: 10,
                 completion_tokens: 10,
-                total_tokens: 20,
             },
         };
 
@@ -3686,7 +3681,6 @@ mod tests {
             usage: Some(OpenAIUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             }),
         };
         let message = openai_to_tensorzero_chunk(

--- a/tensorzero-core/src/providers/openrouter.rs
+++ b/tensorzero-core/src/providers/openrouter.rs
@@ -1054,7 +1054,6 @@ pub(super) struct OpenRouterUsage {
     pub prompt_tokens: u32,
     #[serde(default)]
     pub completion_tokens: u32,
-    pub total_tokens: u32,
 }
 
 impl From<OpenRouterUsage> for Usage {
@@ -1781,7 +1780,6 @@ mod tests {
             usage: OpenRouterUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             },
         };
         let generic_request = ModelInferenceRequest {
@@ -1879,7 +1877,6 @@ mod tests {
             usage: OpenRouterUsage {
                 prompt_tokens: 15,
                 completion_tokens: 25,
-                total_tokens: 40,
             },
         };
         let generic_request = ModelInferenceRequest {
@@ -1969,7 +1966,6 @@ mod tests {
             usage: OpenRouterUsage {
                 prompt_tokens: 5,
                 completion_tokens: 0,
-                total_tokens: 5,
             },
         };
         let request_body = OpenRouterRequest {
@@ -2026,7 +2022,6 @@ mod tests {
             usage: OpenRouterUsage {
                 prompt_tokens: 10,
                 completion_tokens: 10,
-                total_tokens: 20,
             },
         };
 
@@ -2354,7 +2349,6 @@ mod tests {
             usage: Some(OpenRouterUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             }),
         };
         let message = openrouter_to_tensorzero_chunk(

--- a/tensorzero-core/src/providers/sglang.rs
+++ b/tensorzero-core/src/providers/sglang.rs
@@ -850,7 +850,6 @@ mod tests {
             usage: OpenAIUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             },
         };
         let generic_request = ModelInferenceRequest {

--- a/tensorzero-core/src/providers/tgi.rs
+++ b/tensorzero-core/src/providers/tgi.rs
@@ -595,7 +595,6 @@ struct TGIUsage {
     prompt_tokens: u32,
     #[serde(default)]
     completion_tokens: u32,
-    total_tokens: u32,
 }
 
 impl From<TGIUsage> for Usage {
@@ -1001,7 +1000,6 @@ mod tests {
             usage: TGIUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             },
         };
         let generic_request = ModelInferenceRequest {

--- a/tensorzero-core/src/providers/together.rs
+++ b/tensorzero-core/src/providers/together.rs
@@ -913,7 +913,6 @@ mod tests {
             usage: OpenAIUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             },
         };
         let generic_request = ModelInferenceRequest {
@@ -983,7 +982,6 @@ mod tests {
             usage: OpenAIUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             },
         };
         let together_response_with_metadata = TogetherResponseWithMetadata {
@@ -1032,7 +1030,6 @@ mod tests {
             usage: OpenAIUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             },
         };
         let together_response_with_metadata = TogetherResponseWithMetadata {
@@ -1087,7 +1084,6 @@ mod tests {
             usage: OpenAIUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             },
         };
 
@@ -1460,7 +1456,6 @@ mod tests {
             usage: Some(OpenAIUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             }),
         };
         let message = together_to_tensorzero_chunk(

--- a/tensorzero-core/src/providers/vllm.rs
+++ b/tensorzero-core/src/providers/vllm.rs
@@ -639,7 +639,6 @@ mod tests {
             usage: OpenAIUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             },
         };
         let generic_request = ModelInferenceRequest {

--- a/tensorzero-core/src/providers/xai.rs
+++ b/tensorzero-core/src/providers/xai.rs
@@ -668,7 +668,6 @@ mod tests {
             usage: OpenAIUsage {
                 prompt_tokens: 10,
                 completion_tokens: 20,
-                total_tokens: 30,
             },
         };
         let generic_request = ModelInferenceRequest {


### PR DESCRIPTION
Before this PR, we parsed and validated `total_tokens`, but discard and never store it. We later compute `total_tokens()` by summing input and output.

Some OpenAI-compatible providers like Databricks don't return `total_tokens` on every streaming chunk, which caused the gateway to fail.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unused `total_tokens` field from provider-specific usage structs across multiple files.
> 
>   - **Behavior**:
>     - Removes `total_tokens` field from usage structs in `azure.rs`, `deepseek.rs`, and `fireworks/mod.rs`.
>     - Affects `OpenAIUsage`, `GroqUsage`, `MistralUsage`, `OpenRouterUsage`, `TGIUsage`, and `VLLMUsage` structs.
>     - Updates test cases to remove `total_tokens` in `azure.rs`, `deepseek.rs`, `fireworks/mod.rs`, `groq.rs`, `hyperbolic.rs`, `mistral.rs`, `openai/mod.rs`, `openrouter.rs`, `sglang.rs`, `tgi.rs`, `together.rs`, `vllm.rs`, and `xai.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2b7ebc6c797eaafd0dd0b19d85805ba992f64289. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->