### PR TITLE
Remove some unused deps from tensorzero-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6146,7 +6146,6 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "ts-rs",
- "typed-builder",
  "url",
  "urlencoding",
  "uuid",
@@ -6853,26 +6852,6 @@ dependencies = [
  "ratatui",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "typed-builder"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398a3a3c918c96de527dc11e6e846cd549d4508030b8a33e1da12789c856b81a"
-dependencies = [
- "typed-builder-macro",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e48cea23f68d1f78eb7bc092881b6bb88d3d6b5b7e6234f6f9c911da1ffb221"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.107",
 ]
 
 [[package]]

--- a/tensorzero-core/Cargo.toml
+++ b/tensorzero-core/Cargo.toml
@@ -131,7 +131,6 @@ globset = "0.4.17"
 walkdir = "2.5.0"
 enum-map = "2.7.3"
 tokio-util = { version = "0.7.15", features = ["rt"] }
-tempfile = "3.21.0"
 ts-rs = { workspace = true }
 moka = { version = "0.12.10", features = ["sync"] }
 tonic = { version = "0.14.2", default-features = false }
@@ -139,14 +138,14 @@ sqlx = { workspace = true }
 pin-project = { workspace = true }
 once_cell = "1.21.3"
 clarabel = { version = "0", default-features = false, features = ["serde"] }
-typed-builder = "0.22.0"
 arc-swap = "1.7.1"
-rand_distr = "0.5.1"
 infer = "0.19.0"
 urlencoding = "2.1.3"
 
 [dev-dependencies]
 tracing-test = { workspace = true }
+tempfile = "3.21.0"
+rand_distr = "0.5.1"
 tensorzero = { path = "../clients/rust", features = ["e2e_tests"] }
 paste = "1.0.15"
 base64 = "0.22.1"


### PR DESCRIPTION
This lets us avoid an MSRV bump for now when updating our dependencies
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unused `typed-builder` and move `tempfile` to dev-dependencies in `tensorzero-core` to avoid MSRV bump.
> 
>   - **Dependencies**:
>     - Remove `typed-builder` from `Cargo.lock` and `Cargo.toml`.
>     - Remove `tempfile` from dependencies in `Cargo.toml` and add to `dev-dependencies`.
>   - **Misc**:
>     - Update `Cargo.lock` to reflect dependency changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d7ce6de34c25c0e15c9c4dc4fcc548285b21116a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->