### PR TITLE
Delete a spuriously failing test

### DIFF
--- a/tensorzero-core/tests/e2e/endpoints/datasets/get_datapoints.rs
+++ b/tensorzero-core/tests/e2e/endpoints/datasets/get_datapoints.rs
@@ -1216,24 +1216,6 @@ mod list_datapoints_tests {
     }
 
     #[tokio::test]
-    async fn test_list_datapoints_invalid_dataset_name() {
-        let http_client = Client::new();
-
-        // Try to list from a dataset with invalid characters
-        let resp = http_client
-            .post(get_gateway_endpoint(
-                "/v1/datasets/invalid@dataset#name/list_datapoints",
-            ))
-            .json(&json!({}))
-            .send()
-            .await
-            .unwrap();
-
-        // Should return error for invalid dataset name (404 means the route doesn't match)
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-    }
-
-    #[tokio::test]
     async fn test_list_datapoints_mixed_chat_and_json() {
         let http_client = Client::new();
         let clickhouse = get_clickhouse().await;


### PR DESCRIPTION
I think this test doesn't actually make sense and it's causing failures in https://github.com/tensorzero/tensorzero/actions/runs/18887233458/job/53905598396
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove a failing test for invalid dataset names in `list_datapoints` endpoint.
> 
>   - **Tests**:
>     - Remove `test_list_datapoints_invalid_dataset_name` from `get_datapoints.rs`.
>     - The test checked for 404 error on invalid dataset names in `list_datapoints` endpoint.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e267c2970bcad20bd10a92d2e170ca76bf60d992. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->