### PR TITLE
Bump to 2025.10.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2025.10.7"
+version = "2025.10.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2025.10.7"
+version = "2025.10.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2025.10.7"
+version = "2025.10.8"
 dependencies = [
  "axum",
  "clap",
@@ -4514,7 +4514,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2025.10.7"
+version = "2025.10.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6043,7 +6043,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2025.10.7"
+version = "2025.10.8"
 dependencies = [
  "chrono",
  "hex",
@@ -6056,7 +6056,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2025.10.7"
+version = "2025.10.8"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -6167,7 +6167,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2025.10.7"
+version = "2025.10.8"
 dependencies = [
  "evaluations",
  "napi",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.10.7"
+version = "2025.10.8"
 dependencies = [
  "evaluations",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2025.10.7"
+version = "2025.10.8"
 rust-version = "1.86.0"
 license = "Apache-2.0"
 

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2025.10.7"
+appVersion: "2025.10.8"

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2025.10.7",
+  "version": "2025.10.8",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump version to 2025.10.8 across multiple files for a new release.
> 
>   - **Version Bump**:
>     - Update version to `2025.10.8` in `Cargo.lock` for packages: `evaluations`, `feedback-load-test`, `gateway`, `rate-limit-load-test`, `tensorzero-auth`, `tensorzero-core`, `tensorzero-node`, `tensorzero-python`.
>     - Update version to `2025.10.8` in `Cargo.toml`.
>     - Update `appVersion` to `2025.10.8` in `Chart.yaml`.
>     - Update version to `2025.10.8` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 61aa1145d40685a8bfc0dc8517feedf98134ee8c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->