### PR TITLE
Use TensorzeroHttpClient in `aws_http_client` module

### DIFF
--- a/tensorzero-core/src/http.rs
+++ b/tensorzero-core/src/http.rs
@@ -6,6 +6,7 @@ use std::{
         Arc,
     },
     task::{Context, Poll},
+    time::Duration,
 };
 use tracing::Span;
 use tracing_futures::Instrument;
@@ -102,7 +103,7 @@ const CONCURRENCY_LIMIT: u8 = 100;
 
 /// A wrapper for `reqwest::Client` that adds extra features:
 /// * Improved connection pooling support for HTTP/2
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct TensorzeroHttpClient {
     // A 'waterfall' of clients for connecting pooling.
     // When we try to obtain a client with `take_ticket`, we iterate over
@@ -318,6 +319,13 @@ impl<'a> TensorzeroRequestBuilder<'a> {
     {
         Self {
             builder: self.builder.header(key, value),
+            ticket: self.ticket,
+        }
+    }
+
+    pub fn timeout(self, timeout: Duration) -> TensorzeroRequestBuilder<'a> {
+        Self {
+            builder: self.builder.timeout(timeout),
             ticket: self.ticket,
         }
     }

--- a/tensorzero-core/src/providers/aws_bedrock.rs
+++ b/tensorzero-core/src/providers/aws_bedrock.rs
@@ -172,16 +172,10 @@ impl InferenceProvider for AWSBedrockProvider {
             get_raw_response,
         } = build_interceptor(request, model_provider, model_name.to_string());
 
-        // We need to use the `aws_http_client::Client` wrapper type, which currently
-        // doesn't work with the `TensorzeroHttpClient` type.
-        // This causes us to lose out on things like connection pooling and outgoing OTEL headers.
-        // TODO: make this use `TensorzeroHttpClient`
         let new_config = self
             .base_config
             .clone()
-            .http_client(super::aws_http_client::Client::new(
-                http_client.dangerous_get_fallback_client().clone(),
-            ));
+            .http_client(super::aws_http_client::Client::new(http_client.clone()));
         let start_time = Instant::now();
         let output = bedrock_request
             .customize()
@@ -320,16 +314,10 @@ impl InferenceProvider for AWSBedrockProvider {
             get_raw_response,
         } = build_interceptor(request, model_provider, model_name.to_string());
 
-        // We need to use the `aws_http_client::Client` wrapper type, which currently
-        // doesn't work with the `TensorzeroHttpClient` type.
-        // This causes us to lose out on things like connection pooling and outgoing OTEL headers.
-        // TODO: make this use `TensorzeroHttpClient`
         let new_config = self
             .base_config
             .clone()
-            .http_client(super::aws_http_client::Client::new(
-                http_client.dangerous_get_fallback_client().clone(),
-            ));
+            .http_client(super::aws_http_client::Client::new(http_client.clone()));
 
         let start_time = Instant::now();
         let stream = bedrock_request

--- a/tensorzero-core/src/providers/aws_http_client.rs
+++ b/tensorzero-core/src/providers/aws_http_client.rs
@@ -1,4 +1,4 @@
-// Copied from https://github.com/aws/amazon-q-developer-cli/blob/858f9417dcc131e140dfc6cce5a4b657af56616a/crates/fig_aws_common/src/http_client.rs
+// Based on https://github.com/aws/amazon-q-developer-cli/blob/858f9417dcc131e140dfc6cce5a4b657af56616a/crates/fig_aws_common/src/http_client.rs
 // (MIT-licensed)
 
 use std::time::Duration;
@@ -10,18 +10,19 @@ use aws_smithy_runtime_api::client::result::ConnectorError;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_runtime_api::http::Request;
 use aws_smithy_types::body::SdkBody;
-use reqwest::Client as ReqwestClient;
 
-/// A wrapper around [reqwest::Client] that implements [HttpClient].
+use crate::http::TensorzeroHttpClient;
+
+/// A wrapper around [TensorzeroHttpClient] that implements [HttpClient].
 ///
 /// This is required to support using proxy servers with the AWS SDK.
 #[derive(Debug, Clone)]
 pub struct Client {
-    inner: ReqwestClient,
+    inner: TensorzeroHttpClient,
 }
 
 impl Client {
-    pub fn new(client: ReqwestClient) -> Self {
+    pub fn new(client: TensorzeroHttpClient) -> Self {
         Self { inner: client }
     }
 }
@@ -132,7 +133,7 @@ enum CallErrorKind {
 
 #[derive(Debug)]
 struct ReqwestConnector {
-    client: ReqwestClient,
+    client: TensorzeroHttpClient,
     timeout: Option<Duration>,
 }
 

--- a/tensorzero-core/src/providers/aws_sagemaker.rs
+++ b/tensorzero-core/src/providers/aws_sagemaker.rs
@@ -82,16 +82,10 @@ impl InferenceProvider for AWSSagemakerProvider {
         // This ensures that our HTTP proxy (TENSORZERO_E2E_PROXY) is used
         // here when it's enabled.
 
-        // We need to use the `aws_http_client::Client` wrapper type, which currently
-        // doesn't work with the `TensorzeroHttpClient` type.
-        // This causes us to lose out on things like connection pooling and outgoing OTEL headers.
-        // TODO: make this use `TensorzeroHttpClient`
         let new_config = self
             .base_config
             .clone()
-            .http_client(super::aws_http_client::Client::new(
-                http_client.dangerous_get_fallback_client().clone(),
-            ));
+            .http_client(super::aws_http_client::Client::new(http_client.clone()));
         let start_time = Instant::now();
         let res = self
             .client
@@ -167,17 +161,10 @@ impl InferenceProvider for AWSSagemakerProvider {
         );
 
         // See `infer` for more details
-
-        // We need to use the `aws_http_client::Client` wrapper type, which currently
-        // doesn't work with the `TensorzeroHttpClient` type.
-        // This causes us to lose out on things like connection pooling and outgoing OTEL headers.
-        // TODO: make this use `TensorzeroHttpClient`
         let new_config = self
             .base_config
             .clone()
-            .http_client(super::aws_http_client::Client::new(
-                http_client.dangerous_get_fallback_client().clone(),
-            ));
+            .http_client(super::aws_http_client::Client::new(http_client.clone()));
         let start_time = Instant::now();
         let res = self
             .client


### PR DESCRIPTION
This ensures that all of our extra HTTP functionality (e.g. preventing long-lived `h2` spans from blocking shutdown) is available when making AWS bedrock/sagemaker requests
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `reqwest::Client` with `TensorzeroHttpClient` in `aws_http_client` to enhance AWS Bedrock/Sagemaker requests with improved HTTP functionalities.
> 
>   - **Behavior**:
>     - Replace `reqwest::Client` with `TensorzeroHttpClient` in `aws_http_client` module to enhance AWS Bedrock/Sagemaker requests.
>     - `AWSBedrockProvider` and `AWSSagemakerProvider` now use `TensorzeroHttpClient` in `infer` and `infer_stream` methods.
>   - **Classes and Structs**:
>     - Update `Client` in `aws_http_client.rs` to wrap `TensorzeroHttpClient`.
>     - Modify `ReqwestConnector` to use `TensorzeroHttpClient`.
>   - **Misc**:
>     - Add `timeout` method to `TensorzeroRequestBuilder` in `http.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3078de9ab147a39d29c7696fd9c25322fc8549ba. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->