### PR TITLE
Adjust openrouter error message check

### DIFF
--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -2337,7 +2337,7 @@ pub async fn test_bad_auth_extra_headers_with_provider_and_stream(
                         .as_str()
                         .unwrap()
                         .to_lowercase()
-                        .contains("No cookie auth"),
+                        .contains("no cookie auth"),
                 "Unexpected error: {res}"
             );
         }


### PR DESCRIPTION
Openrouter seems to have changed their auth error message to 'No cookie auth credentials found', which broke our test
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update test in `common.rs` to handle new Openrouter auth error message format.
> 
>   - **Tests**:
>     - Update `test_bad_auth_extra_headers_with_provider_and_stream` in `common.rs` to handle new Openrouter auth error message.
>     - Check for "No cookie auth" in addition to "No auth credentials found" in error message.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b833539f95cbaa426ca01ef1a7a9d36e77431bb0. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->