### PR TITLE
Add workflow for special label 'force-add-to-merge-queue'

### DIFF
--- a/.github/workflows/force-merge-queue.yml
+++ b/.github/workflows/force-merge-queue.yml
@@ -1,4 +1,6 @@
 name: Force add to merge queue
+permissions:
+  contents: read
 
 # This workflow allows us to add PRs to the merge queue without waiting on PR checks to pass.
 # It's activated by adding the special 'force-add-to-merge-queue' label to a PR.


### PR DESCRIPTION
This allows us to manually add certain PRs to the merge queue, without waiting on PR checks to pass. It does not affect the actual checks that we run *in* the merge queue - all of the same checks are required to pass before we actually merge a PR.

This is useful when we need to merge a particular PR to unblock CI, and don't want to wait around for the initial PR ci to complete
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add workflow to allow PRs with 'force-add-to-merge-queue' label to bypass initial checks and enter merge queue.
> 
>   - **Workflow**:
>     - Adds `.github/workflows/force-merge-queue.yml` to allow PRs to be added to the merge queue without initial checks passing.
>     - Triggered by adding the 'force-add-to-merge-queue' label to a PR.
>     - Ensures all checks are still run in the merge queue.
>   - **Job**:
>     - Defines `check-all-general-jobs-passed` job in `force-merge-queue.yml`.
>     - Runs on `ubuntu-latest` and only if the special label is present.
>     - Marks check as passed to allow PR to enter merge queue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d93d9141f57b92c29e65526d7c53d3cc2fbb16a5. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->