### PR TITLE
Temporarily switch to Namespace for ARM runners

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -22,7 +22,7 @@ jobs:
         platform:
           - runner: ubuntu-24.04
             target: linux/amd64
-          - runner: ubuntu-24.04-arm
+          - runner: namespace-profile-tensorzero-arm-2x8
             target: linux/arm64
         container:
           # Set the container name to a '-dev' name when this workflow is invoked by a push event

--- a/.github/workflows/python-client-build.yml
+++ b/.github/workflows/python-client-build.yml
@@ -16,7 +16,7 @@ jobs:
         platform:
           - runner: ubuntu-24.04
             target: x86_64
-          - runner: ubuntu-24.04-arm
+          - runner: namespace-profile-tensorzero-arm-2x8
             target: aarch64
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -69,7 +69,7 @@ jobs:
         platform:
           - runner: ubuntu-24.04
             target: x86_64
-          - runner: ubuntu-24.04-arm
+          - runner: namespace-profile-tensorzero-arm-2x8
             target: aarch64
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
To save money, we should switch back once the Github outage is over
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Temporarily switch ARM runners to namespace runners in GitHub Actions workflows to save costs during a GitHub outage.
> 
>   - **Workflows**:
>     - In `.github/workflows/docker-hub-publish.yml`, change ARM runner from `ubuntu-24.04-arm` to `namespace-profile-tensorzero-arm-2x8`.
>     - In `.github/workflows/python-client-build.yml`, change ARM runner from `ubuntu-24.04-arm` to `namespace-profile-tensorzero-arm-2x8`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 50a07b970aedef919dd631aabe7603f709cdef8c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->