### PR TITLE
Revert "Temporarily switch to Namespace for ARM runners (#4251)"

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -22,7 +22,7 @@ jobs:
         platform:
           - runner: ubuntu-24.04
             target: linux/amd64
-          - runner: namespace-profile-tensorzero-arm-2x8
+          - runner: ubuntu-24.04-arm
             target: linux/arm64
         container:
           # Set the container name to a '-dev' name when this workflow is invoked by a push event

--- a/.github/workflows/python-client-build.yml
+++ b/.github/workflows/python-client-build.yml
@@ -16,7 +16,7 @@ jobs:
         platform:
           - runner: ubuntu-24.04
             target: x86_64
-          - runner: namespace-profile-tensorzero-arm-2x8
+          - runner: ubuntu-24.04-arm
             target: aarch64
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -69,7 +69,7 @@ jobs:
         platform:
           - runner: ubuntu-24.04
             target: x86_64
-          - runner: namespace-profile-tensorzero-arm-2x8
+          - runner: ubuntu-24.04-arm
             target: aarch64
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
This reverts commit 86aeaf2451423c0f503c12b5727a2a13c68fd7cf.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Revert ARM runner changes in GitHub workflows to use `ubuntu-24.04-arm` instead of `namespace-profile-tensorzero-arm-2x8`.
> 
>   - **Revert Runner Changes**:
>     - In `.github/workflows/docker-hub-publish.yml`, revert ARM runner from `namespace-profile-tensorzero-arm-2x8` to `ubuntu-24.04-arm`.
>     - In `.github/workflows/python-client-build.yml`, revert ARM runner from `namespace-profile-tensorzero-arm-2x8` to `ubuntu-24.04-arm`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for fa6c9a519beb76d554144bd1b210faaaedf9dd72. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->