### PR TITLE
Set batch-tests job timeout to 60 minutes

### DIFF
--- a/.github/workflows/batch-test.yml
+++ b/.github/workflows/batch-test.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'tensorzero/tensorzero'
 
-    timeout-minutes: 15
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
Now that we run 'Cleanup disk space', this job can randomly take a long time to execute
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Increase `timeout-minutes` from 15 to 60 in `batch-test.yml` to handle potential delays from 'Cleanup disk space'.
> 
>   - **Workflow Configuration**:
>     - Increase `timeout-minutes` from 15 to 60 in `.github/workflows/batch-test.yml` to accommodate potential delays from 'Cleanup disk space'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d9290183bbf9a94f81f31dac5acfff7a054be8d2. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->