### PR TITLE
Cancel general.yml workflow in the merge queue if anything fails

### DIFF
--- a/.github/workflows/cancel-on-status-failure.yml
+++ b/.github/workflows/cancel-on-status-failure.yml
@@ -1,0 +1,53 @@
+name: Cancel workflows on status failure
+
+on:
+  status:
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cancel-on-failure:
+    name: Cancel General Checks on Failure
+    runs-on: ubuntu-latest
+    if: github.repository == 'tensorzero/tensorzero' && (github.event.state == 'failure' || github.event.state == 'error')
+    steps:
+      - name: Find workflows to cancel
+        id: find-workflows
+        run: |
+          echo "Status event details:"
+          echo "SHA: ${{ github.event.sha }}"
+          echo "State: ${{ github.event.state }}"
+          echo "Context: ${{ github.event.context }}"
+
+          # Get all workflow runs for the specific SHA
+          workflow_runs=$(curl -s -H "Authorization: Bearer ${{ github.token }}" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/runs?head_sha=${{ github.event.sha }}")
+
+          # Find running general.yml workflows on merge queue branches
+          current_run_id="${{ github.run_id }}"
+          matching_runs=$(echo "$workflow_runs" | jq -r --arg current_run "$current_run_id" '.workflow_runs[] | select(.path == ".github/workflows/general.yml" and .status != "completed" and (.head_branch // "" | test("^gh-readonly-queue/main/pr-")) and (.id | tostring) != $current_run) | "\(.id) \(.head_branch)"')
+
+          if [ -n "$matching_runs" ]; then
+            echo "Found workflows to cancel:"
+            echo "$matching_runs"
+            echo "workflows<<EOF" >> $GITHUB_OUTPUT
+            echo "$matching_runs" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            echo "No matching workflows found to cancel"
+            echo "workflows=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Cancel workflows
+        if: steps.find-workflows.outputs.workflows != ''
+        run: |
+          echo "Cancelling workflows..."
+          echo "${{ steps.find-workflows.outputs.workflows }}" | while read -r run_id branch; do
+            if [ -n "$run_id" ]; then
+              echo "Cancelling general.yml workflow run $run_id on branch $branch for SHA ${{ github.event.sha }}"
+              curl -X POST -H "Authorization: Bearer ${{ github.token }}" \
+                "https://api.github.com/repos/${{ github.repository }}/actions/runs/$run_id/cancel"
+            fi
+          done


### PR DESCRIPTION
Github doesn't let a job failure directly trigger a new action, so we instead listen for commit status changes. If a commit is on a 'gh-readonly-queue/main/pr-' branch and has a fail/error status added, we cancel all 'general.yml' workflows started on 'gh-readonly-queue/main/pr-' branches for that commit

This will allow PRs to be removed from the merge queue as soon as any jobs fail, without needing to adjust our branch protection rules
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a workflow to cancel `general.yml` workflows on status failure for merge queue branches.
> 
>   - **Behavior**:
>     - New workflow `cancel-on-status-failure.yml` added to cancel `general.yml` workflows on status failure.
>     - Triggers on status changes to `failure` or `error` for commits on `gh-readonly-queue/main/pr-` branches.
>     - Cancels all running `general.yml` workflows for the same commit.
>   - **Implementation**:
>     - Uses GitHub API to fetch workflow runs and identify those to cancel.
>     - Cancels workflows using `curl` POST requests to GitHub API.
>   - **Conditions**:
>     - Only triggers for the `tensorzero/tensorzero` repository.
>     - Excludes completed workflows and the current run from cancellation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b094da0c3026e2bab78be4d9d2279e5604021243. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->