### PR TITLE
Fix flaky ui datapoint creation page

### DIFF
--- a/ui/e2e_tests/evaluations.eval_name.datapoint_id.spec.ts
+++ b/ui/e2e_tests/evaluations.eval_name.datapoint_id.spec.ts
@@ -144,6 +144,8 @@ test("should be able to add a datapoint from the evaluation page", async ({
   await page.waitForURL(`/datasets/${datasetName}/datapoint/**`, {
     timeout: 5000,
   });
+  // Wait for the page to load
+  await page.waitForLoadState("networkidle");
 
   // Assert that the page URL starts with /datasets/test_eval_dataset/datapoint/
   expect(page.url()).toMatch(


### PR DESCRIPTION
We were waiting for the url to change, but the test trace shows that this happens before we actually load the new page (probably due to remix-react-router)

We now wait for 'networkidle' in an additional place
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix flaky test by waiting for page load state 'networkidle' after URL change in `evaluations.eval_name.datapoint_id.spec.ts`.
> 
>   - **Behavior**:
>     - Adds `await page.waitForLoadState("networkidle")` after `waitForURL` in `evaluations.eval_name.datapoint_id.spec.ts` to ensure the page is fully loaded before proceeding.
>   - **Tests**:
>     - Stabilizes the test "should be able to add a datapoint from the evaluation page" by waiting for the page to load completely after URL change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c96e25bddcd3a54b726074608d094413e84a2c9a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->