### PR TITLE
added a disk cleanup for check-production-docker-container

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -370,7 +370,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Cleanup disk space
-        timeout-minutes: 45
+        timeout-minutes: 30
         run: ./ci/free-disk-space.sh
 
       - name: Build Docker container for production deployment tests


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add disk cleanup step to `check-production-docker-container` job in `merge-queue.yml` to ensure sufficient disk space before Docker builds.
> 
>   - **Workflow Changes**:
>     - Add disk cleanup step in `check-production-docker-container` job in `merge-queue.yml`.
>     - Executes `./ci/free-disk-space.sh` with a 30-minute timeout before building Docker containers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 59aa3cd1ff62063f5e8e619cf2f67c5369c2d62b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->