### PR TITLE
Pin Rust to 1.90 when building Python clients

### DIFF
--- a/.github/workflows/python-client-build.yml
+++ b/.github/workflows/python-client-build.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 env:
-  RUST_TOOLCHAIN: 1.90
+  RUST_TOOLCHAIN: "1.90"
 
 jobs:
   linux:


### PR DESCRIPTION
This will ensure that we build a release against the same version that we test with (in the case where a Rust release happens before we do a release)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Pin Rust toolchain to version 1.90 in `python-client-build.yml` to ensure consistent builds for Python clients.
> 
>   - **Environment**:
>     - Set `RUST_TOOLCHAIN` to "1.90" in `python-client-build.yml`.
>   - **Rust Toolchain Installation**:
>     - Update Rust installation command to use `$RUST_TOOLCHAIN` instead of `stable` in `python-client-build.yml` for `linux`, `musllinux`, `windows`, and `macos` jobs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f622507c749637afbd59b763e74cb87f4a932bd4. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->