### PR TITLE
Remove disk cleanup from 'check-production-docker-container'

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -369,10 +369,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Cleanup disk space
-        timeout-minutes: 30
-        run: ./ci/free-disk-space.sh
-
       - name: Build Docker container for production deployment tests
         run: docker build -t tensorzero/gateway -f gateway/Dockerfile .
 


### PR DESCRIPTION
Now that we're not downloading our large fixtures, we should have plenty of disk space
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove disk cleanup step from `check-production-docker-container` job in `merge-queue.yml` due to no longer downloading large fixtures.
> 
>   - **Workflow Changes**:
>     - Remove disk cleanup step from `check-production-docker-container` job in `merge-queue.yml`.
>     - Disk cleanup was previously handled by `./ci/free-disk-space.sh`.
>   - **Reason**:
>     - Large fixtures are no longer downloaded, freeing up disk space.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 603660f747484b2aa670ee223c13b326e2c12c4a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->