### PR TITLE
Also listen for 'check_run' event in cancel-on-status-failure

### DIFF
--- a/.github/workflows/cancel-on-status-failure.yml
+++ b/.github/workflows/cancel-on-status-failure.yml
@@ -2,6 +2,8 @@ name: Cancel workflows on status failure
 
 on:
   status:
+  check_run:
+    types: [completed]
 
 permissions:
   actions: write
@@ -11,19 +13,33 @@ jobs:
   cancel-on-failure:
     name: Cancel General Checks on Failure
     runs-on: ubuntu-latest
-    if: github.repository == 'tensorzero/tensorzero' && (github.event.state == 'failure' || github.event.state == 'error')
+    if: |
+      github.repository == 'tensorzero/tensorzero' && (
+        (github.event_name == 'status' && (github.event.state == 'failure' || github.event.state == 'error')) ||
+        (github.event_name == 'check_run' && (github.event.check_run.conclusion == 'failure' || github.event.check_run.conclusion == 'cancelled'))
+      )
     steps:
       - name: Find workflows to cancel
         id: find-workflows
         run: |
-          echo "Status event details:"
-          echo "SHA: ${{ github.event.sha }}"
-          echo "State: ${{ github.event.state }}"
-          echo "Context: ${{ github.event.context }}"
+          # Determine the SHA based on event type
+          if [ "${{ github.event_name }}" = "status" ]; then
+            SHA="${{ github.event.sha }}"
+            echo "Status event details:"
+            echo "SHA: $SHA"
+            echo "State: ${{ github.event.state }}"
+            echo "Context: ${{ github.event.context }}"
+          else
+            SHA="${{ github.event.check_run.head_sha }}"
+            echo "Check run event details:"
+            echo "SHA: $SHA"
+            echo "Conclusion: ${{ github.event.check_run.conclusion }}"
+            echo "Name: ${{ github.event.check_run.name }}"
+          fi
 
           # Get all workflow runs for the specific SHA
           workflow_runs=$(curl -s -H "Authorization: Bearer ${{ github.token }}" \
-            "https://api.github.com/repos/${{ github.repository }}/actions/runs?head_sha=${{ github.event.sha }}")
+            "https://api.github.com/repos/${{ github.repository }}/actions/runs?head_sha=$SHA")
 
           # Find running general.yml workflows on merge queue branches
           current_run_id="${{ github.run_id }}"
@@ -43,10 +59,17 @@ jobs:
       - name: Cancel workflows
         if: steps.find-workflows.outputs.workflows != ''
         run: |
+          # Determine the SHA based on event type
+          if [ "${{ github.event_name }}" = "status" ]; then
+            SHA="${{ github.event.sha }}"
+          else
+            SHA="${{ github.event.check_run.head_sha }}"
+          fi
+
           echo "Cancelling workflows..."
           echo "${{ steps.find-workflows.outputs.workflows }}" | while read -r run_id branch; do
             if [ -n "$run_id" ]; then
-              echo "Cancelling general.yml workflow run $run_id on branch $branch for SHA ${{ github.event.sha }}"
+              echo "Cancelling general.yml workflow run $run_id on branch $branch for SHA $SHA"
               curl -X POST -H "Authorization: Bearer ${{ github.token }}" \
                 "https://api.github.com/repos/${{ github.repository }}/actions/runs/$run_id/cancel"
             fi


### PR DESCRIPTION
A Github Action run creates a 'check_run', not a 'status': https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks#types-of-status-checks-on-github

We still want to listen for both, so that we can cancel a merge queue workflow when an external provider (e.g. Buildkite) reports a failure
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `check_run` event handling to cancel workflows on failure in `.github/workflows/cancel-on-status-failure.yml`.
> 
>   - **Behavior**:
>     - Add `check_run` event listener to `.github/workflows/cancel-on-status-failure.yml` to handle completed check runs.
>     - Modify condition to cancel workflows on `status` failure or `check_run` failure/cancellation.
>   - **Implementation**:
>     - Determine SHA based on event type (`status` or `check_run`) for workflow cancellation.
>     - Log event details for both `status` and `check_run` events.
>     - Use SHA to fetch and cancel running workflows in `cancel-on-status-failure.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 9b6021ec86e2b3030ab17916ad5fefef85941074. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->