### PR TITLE
Correctly invoke force-merge-queue-helper

### DIFF
--- a/.github/workflows/force-merge-queue.yml
+++ b/.github/workflows/force-merge-queue.yml
@@ -28,12 +28,7 @@ jobs:
   # which would incorrectly cause the branch protection rule to succeed, allowing all PRs to be added to the merge queue without running
   # the real 'check-all-general-jobs-passed' job.
   trigger-force-merge-queue-helper:
-    runs-on: ubuntu-latest
+    name: Invoke helper workflow
     # Only run this job if the force-add-to-merge-queue label is present
     if: contains(github.event.pull_request.labels.*.name, 'force-add-to-merge-queue') && github.event.action == 'labeled'
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-
-      - name: Invoke helper workflow
-        uses: ./.github/workflows/force-merge-queue-helper.yml
+    uses: ./.github/workflows/force-merge-queue-helper.yml


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Simplify `force-merge-queue.yml` by directly invoking the helper workflow without redundant steps.
> 
>   - **Workflow Simplification**:
>     - In `.github/workflows/force-merge-queue.yml`, remove redundant `runs-on` and `steps` for `trigger-force-merge-queue-helper` job.
>     - Directly use `uses: ./.github/workflows/force-merge-queue-helper.yml` to invoke the helper workflow.
>   - **Behavior**:
>     - Ensures the job only runs if `force-add-to-merge-queue` label is present and action is `labeled`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e40af4fc6433dfe3c6674ce4cafc9ef20f798f8c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->