### PR TITLE
Remove 'SERIALIZE_FILE_DATA' thread-local

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5027,12 +5027,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6120,7 +6114,6 @@ dependencies = [
  "rand_distr",
  "reqwest",
  "reqwest-eventsource",
- "scoped-tls",
  "secrecy",
  "serde",
  "serde-untagged",

--- a/tensorzero-core/Cargo.toml
+++ b/tensorzero-core/Cargo.toml
@@ -103,7 +103,6 @@ aws-sdk-sagemakerruntime = { version = "1.88.0", features = [
 ], default-features = false }
 aws-smithy-runtime-api = "1.9.1"
 eventsource-stream = "0.2.3"
-scoped-tls = "1.0.1"
 opentelemetry_sdk = "0.31.0"
 opentelemetry = "0.31.0"
 tracing-opentelemetry = "0.32.0"

--- a/tensorzero-core/src/cache.rs
+++ b/tensorzero-core/src/cache.rs
@@ -6,7 +6,6 @@ use crate::config::OtlpConfig;
 use crate::db::clickhouse::{ClickHouseConnectionInfo, TableName};
 use crate::embeddings::{Embedding, EmbeddingModelResponse, EmbeddingRequest};
 use crate::error::{warn_discarded_cache_write, Error, ErrorDetails};
-use crate::inference::types::file::serialize_with_file_data;
 use crate::inference::types::{
     ContentBlockChunk, ContentBlockOutput, FinishReason, ModelInferenceRequest,
     ModelInferenceResponse, ProviderInferenceResponseChunk, Usage,
@@ -167,7 +166,7 @@ impl ModelProviderRequest<'_> {
         hasher.update(&[0]); // null byte after provider name to ensure data is prefix-free
                              // Convert the request to a JSON Value, error if serialization fails
 
-        let mut request_value = serialize_with_file_data(request).map_err(|e| {
+        let mut request_value = serde_json::to_value(request).map_err(|e| {
             Error::new(ErrorDetails::Serialization {
                 message: format!("Failed to serialize request: {e}"),
             })

--- a/tensorzero-core/src/inference/types/file.rs
+++ b/tensorzero-core/src/inference/types/file.rs
@@ -48,9 +48,7 @@ use std::borrow::Cow;
 
 use futures::FutureExt;
 use mime::MediaType;
-use scoped_tls::scoped_thread_local;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use url::Url;
 
 use super::{ContentBlock, RequestMessage};
@@ -62,8 +60,6 @@ use crate::{
 use aws_smithy_types::base64;
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
-
-scoped_thread_local!(static SERIALIZE_FILE_DATA: ());
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -206,16 +202,6 @@ impl Base64File {
     pub fn __repr__(&self) -> String {
         self.to_string()
     }
-}
-
-pub fn serialize_with_file_data<T: Serialize>(value: &T) -> Result<Value, Error> {
-    SERIALIZE_FILE_DATA.set(&(), || {
-        serde_json::to_value(value).map_err(|e| {
-            Error::new(ErrorDetails::Serialization {
-                message: format!("Error serializing value: {e}"),
-            })
-        })
-    })
 }
 
 /// A file that can be located at a URL


### PR DESCRIPTION
This has done nothing since we introduced more '*Input' types
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove unused 'SERIALIZE_FILE_DATA' thread-local and related code, including 'scoped-tls' dependency, and update serialization logic in 'cache.rs'.
> 
>   - **Removal**:
>     - Remove `SERIALIZE_FILE_DATA` thread-local from `file.rs`.
>     - Remove `serialize_with_file_data()` function from `file.rs`.
>     - Remove `scoped-tls` dependency from `Cargo.toml` and `Cargo.lock`.
>   - **Code Update**:
>     - Replace `serialize_with_file_data()` with `serde_json::to_value()` in `cache.rs` for request serialization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e92af8da7fec93aa10147c7e01e25b75a5c7bae8. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->