### PR TITLE
added defaults for track and stop variant configuration

### DIFF
--- a/tensorzero-core/src/experimentation/track_and_stop/mod.rs
+++ b/tensorzero-core/src/experimentation/track_and_stop/mod.rs
@@ -256,12 +256,35 @@ impl Nursery {
 pub struct UninitializedTrackAndStopConfig {
     metric: String,
     candidate_variants: Vec<String>,
+    #[serde(default)]
     fallback_variants: Vec<String>,
+    #[serde(default = "default_min_samples_per_variant")]
     min_samples_per_variant: u64,
+    #[serde(default = "default_delta")]
     delta: f64,
+    #[serde(default)]
     epsilon: f64,
+    #[serde(default = "default_update_period_s")]
     update_period_s: u64,
+    #[serde(default = "default_min_prob")]
     min_prob: Option<f64>,
+}
+
+fn default_min_samples_per_variant() -> u64 {
+    10
+}
+
+fn default_delta() -> f64 {
+    0.05
+}
+
+fn default_update_period_s() -> u64 {
+    300
+}
+
+#[expect(clippy::unnecessary_wraps)]
+fn default_min_prob() -> Option<f64> {
+    Some(1e-6)
 }
 
 impl UninitializedTrackAndStopConfig {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added default values for several fields in `UninitializedTrackAndStopConfig` to simplify configuration.
> 
>   - **Defaults Added**:
>     - Added default values for `fallback_variants`, `min_samples_per_variant`, `delta`, `epsilon`, `update_period_s`, and `min_prob` in `UninitializedTrackAndStopConfig`.
>     - Default functions: `default_min_samples_per_variant()`, `default_delta()`, `default_update_period_s()`, `default_min_prob()`.
>   - **Functions**:
>     - `default_min_samples_per_variant()` returns `10`.
>     - `default_delta()` returns `0.05`.
>     - `default_update_period_s()` returns `300`.
>     - `default_min_prob()` returns `Some(1e-6)`.
>   - **Misc**:
>     - Added `#[serde(default)]` attribute to relevant fields in `UninitializedTrackAndStopConfig`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f092c5219100ec81452f898577c605357092eff3. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->