### PR TITLE
pinned version of CH to 25.9 to attempt to avoid issues

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -478,12 +478,13 @@ jobs:
       matrix:
         # Only include replicated: true when running in merge queue
         replicated: ${{ github.event_name == 'merge_group' && fromJSON('[true, false]') || fromJSON('[false]') }}
-        clickhouse_version: ${{ github.event_name == 'merge_group' && fromJSON('[{"tag":"24.12-alpine","prefix":"24.12","allow_failure":false},{"tag":"latest","prefix":"","allow_failure":false}]') || fromJSON('[{"tag":"latest","prefix":"","allow_failure":false}]') }}
+        # TODO: Temporarily using 25.9-alpine instead of latest
+        clickhouse_version: ${{ github.event_name == 'merge_group' && fromJSON('[{"tag":"24.12-alpine","prefix":"24.12","allow_failure":false},{"tag":"25.9-alpine","prefix":"25.9","allow_failure":false}]') || fromJSON('[{"tag":"25.9-alpine","prefix":"25.9","allow_failure":false}]') }}
         exclude:
-          # Use 25.7-alpine instead of latest for replicated tests in merge group
+          # Use 25.7-alpine instead of 25.9-alpine for replicated tests in merge group
           - replicated: true
             clickhouse_version:
-              { "tag": "latest", "prefix": "", "allow_failure": false }
+              { "tag": "25.9-alpine", "prefix": "25.9", "allow_failure": false }
           # Add 25.7-alpine for replicated tests in merge group
         include: ${{ github.event_name == 'merge_group' && fromJSON('[{"clickhouse_version":{"tag":"25.7-alpine","prefix":"25.7","allow_failure":false},"replicated":true}]') || fromJson('[]') }}
 

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -14,7 +14,8 @@ jobs:
 
     strategy:
       matrix:
-        clickhouse_version: ${{ inputs.is_merge_group && fromJSON('["24.12-alpine", "latest-alpine"]') || fromJSON('["latest-alpine"]') }}
+        # TODO: Temporarily using 25.9-alpine instead of latest-alpine
+        clickhouse_version: ${{ inputs.is_merge_group && fromJSON('["24.12-alpine", "25.9-alpine"]') || fromJSON('["25.9-alpine"]') }}
 
     steps:
       - name: Set DNS


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update ClickHouse version to 25.9-alpine in GitHub workflows to avoid issues with the latest version, with special handling for replicated tests.
> 
>   - **Workflows**:
>     - In `general.yml`, update `clickhouse_version` to use `25.9-alpine` instead of `latest` for non-replicated tests.
>     - In `ui-tests.yml`, update `clickhouse_version` to use `25.9-alpine` instead of `latest-alpine`.
>   - **Replicated Tests**:
>     - Use `25.7-alpine` instead of `25.9-alpine` for replicated tests in merge groups in `general.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3bd794f5db571d39a32abaf10a7ebcdb342c79b3. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->