### PR TITLE
Bump to 2025.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2025.10.9"
+version = "2025.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2025.10.9"
+version = "2025.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2025.10.9"
+version = "2025.11.0"
 dependencies = [
  "axum",
  "clap",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2025.10.9"
+version = "2025.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6046,7 +6046,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2025.10.9"
+version = "2025.11.0"
 dependencies = [
  "chrono",
  "futures",
@@ -6062,7 +6062,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2025.10.9"
+version = "2025.11.0"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -6176,7 +6176,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2025.10.9"
+version = "2025.11.0"
 dependencies = [
  "evaluations",
  "napi",
@@ -6195,7 +6195,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.10.9"
+version = "2025.11.0"
 dependencies = [
  "evaluations",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2025.10.9"
+version = "2025.11.0"
 rust-version = "1.86.0"
 license = "Apache-2.0"
 

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2025.10.9"
+appVersion: "2025.11.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2025.10.9",
+  "version": "2025.11.0",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump version to 2025.11.0 across multiple files for a new release.
> 
>   - **Version Bump**:
>     - Update version to `2025.11.0` in `Cargo.lock`, `Cargo.toml`, `Chart.yaml`, and `package.json`.
>     - Affects packages: `evaluations`, `feedback-load-test`, `gateway`, `rate-limit-load-test`, `tensorzero-auth`, `tensorzero-core`, `tensorzero-node`, `tensorzero-python`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a09a489fae5632c6081503fa1f4337854c9284bd. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->