### PR TITLE
Add UI flow to copy datapoints between datasets

### DIFF
--- a/ui/app/routes/datasets/$dataset_name/datapoint/$id/CopyToDatasetButton.tsx
+++ b/ui/app/routes/datasets/$dataset_name/datapoint/$id/CopyToDatasetButton.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { Link, useFetcher } from "react-router";
+import { DatasetSelector } from "~/components/dataset/DatasetSelector";
+import { ReadOnlyGuard } from "~/components/utils/read-only-guard";
+import { useReadOnly } from "~/context/read-only";
+import { useToast } from "~/hooks/use-toast";
+import { ToastAction } from "~/components/ui/toast";
+
+interface CopyToDatasetButtonProps {
+  currentDataset: string;
+  datapointId: string;
+  functionName: string;
+}
+
+type CopyDatapointActionData =
+  | {
+      success: true;
+      redirectTo: string;
+      dataset: string;
+    }
+  | {
+      success: false;
+      error: string;
+    };
+
+export function CopyToDatasetButton({
+  currentDataset,
+  datapointId,
+  functionName,
+}: CopyToDatasetButtonProps) {
+  const [selectedDataset, setSelectedDataset] = useState("");
+  const fetcher = useFetcher<CopyDatapointActionData>();
+  const { toast } = useToast();
+  const isReadOnly = useReadOnly();
+
+  useEffect(() => {
+    if (fetcher.state !== "idle" || !fetcher.data) {
+      return;
+    }
+
+    if (fetcher.data.success) {
+      toast({
+        title: "Datapoint copied",
+        description: `Copied to dataset ${fetcher.data.dataset}.`,
+        action: (
+          <ToastAction altText="View datapoint" asChild>
+            <Link to={fetcher.data.redirectTo}>View</Link>
+          </ToastAction>
+        ),
+      });
+      setSelectedDataset("");
+    } else {
+      toast({
+        title: "Failed to copy datapoint",
+        description: fetcher.data.error,
+        variant: "destructive",
+      });
+    }
+  }, [fetcher.state, fetcher.data, toast]);
+
+  const isSubmitting =
+    fetcher.state === "submitting" || fetcher.state === "loading";
+
+  return (
+    <ReadOnlyGuard asChild>
+      <DatasetSelector
+        selected={selectedDataset}
+        onSelect={(dataset) => {
+          setSelectedDataset(dataset);
+          const formData = new FormData();
+          formData.append("_action", "copy_to_dataset");
+          formData.append("target_dataset", dataset);
+          formData.append("datapoint_id", datapointId);
+          fetcher.submit(formData, { method: "post", action: "." });
+        }}
+        placeholder="Copy to dataset"
+        buttonProps={{
+          size: "sm",
+          disabled: isSubmitting || isReadOnly,
+        }}
+        disabled={isSubmitting || isReadOnly}
+        exclude={[currentDataset]}
+        functionName={functionName}
+      />
+    </ReadOnlyGuard>
+  );
+}

--- a/ui/app/routes/datasets/$dataset_name/datapoint/$id/DatapointActions.tsx
+++ b/ui/app/routes/datasets/$dataset_name/datapoint/$id/DatapointActions.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { ActionBar } from "~/components/layout/ActionBar";
 import { TryWithButton } from "~/components/inference/TryWithButton";
 import { EditButton } from "~/components/utils/EditButton";
@@ -19,6 +20,7 @@ interface DatapointActionsProps {
   onReset: () => void;
   showTryWithButton: boolean;
   isStale: boolean;
+  copyAction?: ReactNode;
 }
 
 export function DatapointActions({
@@ -34,6 +36,7 @@ export function DatapointActions({
   onReset,
   showTryWithButton,
   isStale,
+  copyAction,
 }: DatapointActionsProps) {
   const isReadOnly = useReadOnly();
   const handleCancel = () => {
@@ -79,6 +82,7 @@ export function DatapointActions({
               : "Delete"
         }
       />
+      {copyAction}
     </ActionBar>
   );
 }


### PR DESCRIPTION
## Summary
- hide the active dataset from the dataset selector so copy targets cannot include it
- add a CopyToDatasetButton fetcher and route action to duplicate datapoints through the gateway API
- extend the tensorzero client with getDatapoint/createDatapoints helpers and cover the flow with an e2e test

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck` *(fails: TypeScript cannot resolve tensorzero-node bindings in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_69069c62e17c83289ebb025a12756f50