### PR TITLE
Pull out role type

### DIFF
--- a/tensorzero-core/src/inference/types/mod.rs
+++ b/tensorzero-core/src/inference/types/mod.rs
@@ -61,7 +61,6 @@ use crate::serde_util::{
     deserialize_defaulted_json_string, deserialize_json_string, deserialize_optional_json_string,
 };
 use crate::tool::ToolCallInput;
-use crate::variant::chat_completion::{ASSISTANT_TEXT_TEMPLATE_VAR, USER_TEXT_TEMPLATE_VAR};
 use derive_builder::Builder;
 use extra_body::{FullExtraBodyConfig, UnfilteredInferenceExtraBody};
 use extra_headers::FullExtraHeadersConfig;
@@ -112,11 +111,13 @@ mod input_message;
 #[cfg(feature = "pyo3")]
 pub mod pyo3_helpers;
 pub mod resolved_input;
+mod role;
 pub mod storage;
 pub mod stored_input;
 pub mod streams;
 
 pub use resolved_input::ResolvedRequestMessage;
+pub use role::Role;
 pub use stored_input::{
     StoredInput, StoredInputMessage, StoredInputMessageContent, StoredRequestMessage,
 };
@@ -642,50 +643,6 @@ impl<'de> Deserialize<'de> for TextKind {
                 "Unknown key `{key}` in text content"
             ))),
         }
-    }
-}
-
-#[derive(ts_rs::TS, Clone, Copy, Debug, Deserialize, Serialize, PartialEq)]
-#[ts(export)]
-#[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "pyo3", pyclass)]
-pub enum Role {
-    User,
-    Assistant,
-}
-
-impl Role {
-    /// The template name to use for `{"type": "text", "arguments": {}}` inputs.
-    /// This will eventually be deprecated in favor of explicit `{"type": "template", "name": "user", "arguments": {}}` inputs.
-    pub fn implicit_template_name(&self) -> &'static str {
-        match self {
-            Role::User => "user",
-            Role::Assistant => "assistant",
-        }
-    }
-
-    pub fn implicit_template_var(&self) -> &'static str {
-        match self {
-            Role::User => USER_TEXT_TEMPLATE_VAR,
-            Role::Assistant => ASSISTANT_TEXT_TEMPLATE_VAR,
-        }
-    }
-}
-
-impl std::fmt::Display for Role {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Role::User => write!(f, "user"),
-            Role::Assistant => write!(f, "assistant"),
-        }
-    }
-}
-
-#[cfg(feature = "pyo3")]
-#[pymethods]
-impl Role {
-    pub fn __repr__(&self) -> String {
-        self.to_string()
     }
 }
 

--- a/tensorzero-core/src/inference/types/role.rs
+++ b/tensorzero-core/src/inference/types/role.rs
@@ -1,0 +1,51 @@
+//! The role of a TensorZero input message: user or assistant
+
+#[cfg(feature = "pyo3")]
+use pyo3::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::variant::chat_completion::{ASSISTANT_TEXT_TEMPLATE_VAR, USER_TEXT_TEMPLATE_VAR};
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize, ts_rs::TS)]
+#[ts(export)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "pyo3", pyclass)]
+pub enum Role {
+    User,
+    Assistant,
+}
+
+impl Role {
+    /// The template name to use for `{"type": "text", "arguments": {}}` inputs.
+    /// This will eventually be deprecated in favor of explicit `{"type": "template", "name": "user", "arguments": {}}` inputs.
+    pub fn implicit_template_name(&self) -> &'static str {
+        match self {
+            Role::User => "user",
+            Role::Assistant => "assistant",
+        }
+    }
+
+    pub fn implicit_template_var(&self) -> &'static str {
+        match self {
+            Role::User => USER_TEXT_TEMPLATE_VAR,
+            Role::Assistant => ASSISTANT_TEXT_TEMPLATE_VAR,
+        }
+    }
+}
+
+impl std::fmt::Display for Role {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Role::User => write!(f, "user"),
+            Role::Assistant => write!(f, "assistant"),
+        }
+    }
+}
+
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl Role {
+    pub fn __repr__(&self) -> String {
+        self.to_string()
+    }
+}


### PR DESCRIPTION
`tensorzero-core/src/inference/types/mod.rs` is truly massive. It's an issue for LLMs and humans. Let's start breaking it down into small files. LLMs do great with small files. Similar to our binding files, except with functionality for the type self-contained.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor by moving `Role` enum and its implementations from `mod.rs` to `role.rs` for better code organization.
> 
>   - **Refactor**:
>     - Move `Role` enum and its implementations from `mod.rs` to `role.rs`.
>     - Update imports and exports in `mod.rs` to reflect the new location of `Role`.
>   - **Files**:
>     - `mod.rs`: Remove `Role` enum and related code, update imports.
>     - `role.rs`: Add `Role` enum and its implementations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2146b4f9e6a244166935d5ebcc42fdc1a8b1dd45. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->