### PR TITLE
Fix typo and change 'arm' to 'variant' in bandits docs

### DIFF
--- a/docs/gateway/configuration-reference.mdx
+++ b/docs/gateway/configuration-reference.mdx
@@ -3792,8 +3792,8 @@ The minimum sampling probability for each candidate variant.
 The value must be nonnegative.
 Note that `min_prob` times the number of `candidate_variants` must not exceed 1.0, since the minimum probabilities for all candidate variants must sum to at most 1.0.
 
-The aim of a `track_and_stop` experiment is to identify an epsilon-best variant, without necessarily differentiating sub-optimal variants, so the primary use for this field is to enable the user to ensure that sufficient data is gather to learn about the performance of sub-optimal variants.
-Note that this field has no effect once `track_and_stop` picks a winner arm, since at that point random sampling ceases and the winner variant is used exclusively.
+The aim of a `track_and_stop` experiment is to identify an epsilon-best variant, without necessarily differentiating sub-optimal variants, so the primary use for this field is to enable the user to ensure that sufficient data is gathered to learn about the performance of sub-optimal variants.
+Note that this field has no effect once `track_and_stop` picks a winner variant, since at that point random sampling ceases and the winner variant is used exclusively.
 
 ```toml title="tensorzero.toml"
 [functions.draft-email.experimentation]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix typo and update terminology in `configuration-reference.mdx` for clarity in bandits documentation.
> 
>   - **Documentation**:
>     - Fix typo in `configuration-reference.mdx`, changing "gather" to "gathered".
>     - Replace "arm" with "variant" in the context of `track_and_stop` experiments to improve clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 95fdebd975007119c73e311b65814d58a0205898. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->