### PR TITLE
Only use fail-fast in live-tests for merge queue

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -77,6 +77,8 @@ jobs:
     strategy:
       matrix:
         batch_writes: [true, false]
+      # Don't fail-fast for manual/cron runs, so that we get the full picture of what broke
+      fail-fast: ${{ github.event_name == 'merge_group' }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
When running manually on in a cron job, we'll no longer cancel the other live-tess job if one of them (batch-mode or non-batch-mode) fails
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modifies `fail-fast` behavior in `merge-queue.yml` to only apply for `merge_group` events, allowing full test completion in manual/cron runs.
> 
>   - **Behavior**:
>     - Modifies `fail-fast` behavior in `live-tests` job in `merge-queue.yml`.
>     - `fail-fast` is now only enabled for `merge_group` events, allowing manual/cron runs to complete all tests.
>   - **Workflow**:
>     - Ensures both batch-mode and non-batch-mode tests run to completion in manual/cron runs, even if one fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 27382beef953553f94c2bf8857b927ce946b0264. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->