### PR TITLE
Give 'contents: write' to check-fork workflow

### DIFF
--- a/.github/workflows/slash-command-check-fork.yml
+++ b/.github/workflows/slash-command-check-fork.yml
@@ -14,7 +14,7 @@ on:
 
 permissions:
   pull-requests: write
-  contents: read
+  contents: write
   actions: write
 
 env:


### PR DESCRIPTION
We need this to push to a branch on 'tensorzero/tensorzero'
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `contents` permission to `write` in `slash-command-check-fork.yml` to enable branch pushing.
> 
>   - **Permissions**:
>     - Change `contents` permission from `read` to `write` in `.github/workflows/slash-command-check-fork.yml` to allow pushing to a branch on `tensorzero/tensorzero`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6f6a4af2cd36e3a1cc1fa027f8f27d8d137bd7fe. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->