### PR TITLE
Don't drop the 'uint_to_uuid' function in rollback instructions

### DIFF
--- a/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0013.rs
+++ b/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0013.rs
@@ -439,6 +439,8 @@ impl Migration for Migration0013<'_> {
         Ok(())
     }
 
+    // NOTE - we do *not* drop the uint_to_uuid function here, as ClickHouse user-defined functions are globally scoped.
+    // Dropping the function can break other migrations running concurrently in our test suite.
     fn rollback_instructions(&self) -> String {
         let on_cluster_name = self.clickhouse.get_on_cluster_name();
         format!(
@@ -447,8 +449,6 @@ impl Migration for Migration0013<'_> {
             DROP VIEW IF EXISTS JsonInferenceByIdView{on_cluster_name};
             DROP VIEW IF EXISTS ChatInferenceByEpisodeIdView{on_cluster_name};
             DROP VIEW IF EXISTS JsonInferenceByEpisodeIdView{on_cluster_name};
-            /* Drop the function */\
-            DROP FUNCTION IF EXISTS uint_to_uuid{on_cluster_name};
             /* Drop the tables */\
             DROP TABLE IF EXISTS InferenceById{on_cluster_name} SYNC;
             DROP TABLE IF EXISTS InferenceByEpisodeId{on_cluster_name} SYNC;

--- a/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0020.rs
+++ b/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0020.rs
@@ -432,6 +432,8 @@ impl Migration for Migration0020<'_> {
         Ok(())
     }
 
+    // NOTE - we do *not* drop the uint_to_uuid function here, as ClickHouse user-defined functions are globally scoped.
+    // Dropping the function can break other migrations running concurrently in our test suite.
     fn rollback_instructions(&self) -> String {
         let on_cluster_name = self.clickhouse.get_on_cluster_name();
         format!(
@@ -440,8 +442,6 @@ impl Migration for Migration0020<'_> {
             DROP VIEW IF EXISTS JsonInferenceByIdView{on_cluster_name};
             DROP VIEW IF EXISTS ChatInferenceByEpisodeIdView{on_cluster_name};
             DROP VIEW IF EXISTS JsonInferenceByEpisodeIdView{on_cluster_name};
-            /* Drop the function */\
-            DROP FUNCTION IF EXISTS uint_to_uuid{on_cluster_name};
             /* Drop the tables */\
             DROP TABLE IF EXISTS InferenceById{on_cluster_name} SYNC;
             DROP TABLE IF EXISTS InferenceByEpisodeId{on_cluster_name} SYNC;


### PR DESCRIPTION
ClickHouse user-defined functions are created globally, and are not scoped to any database. As a result, trying to drop them in the rollback instructions will interfere with any other migration running currently on the same instance. In particular, this makes our migration-manager tests flaky.

We no longer drop this function - it's fine to leave a single function hanging around if the user does a manual rollback.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `DROP FUNCTION IF EXISTS uint_to_uuid` from rollback instructions in `migration_0013.rs` and `migration_0020.rs` to prevent interference with concurrent migrations.
> 
>   - **Behavior**:
>     - Remove `DROP FUNCTION IF EXISTS uint_to_uuid` from `rollback_instructions()` in `migration_0013.rs` and `migration_0020.rs`.
>     - Prevents interference with concurrent migrations by not dropping globally scoped `uint_to_uuid` function.
>   - **Comments**:
>     - Add comments in `rollback_instructions()` in both `migration_0013.rs` and `migration_0020.rs` explaining the reason for not dropping the function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6ccc55caf0a9e4b7235bd85c4c3a7e3a5b2077c3. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->