### PR TITLE
UpdateDatapointMetadataRequest should require the update field

### DIFF
--- a/internal/tensorzero-node/lib/bindings/UpdateDatapointMetadataRequest.ts
+++ b/internal/tensorzero-node/lib/bindings/UpdateDatapointMetadataRequest.ts
@@ -10,7 +10,7 @@ export type UpdateDatapointMetadataRequest = {
    */
   id: string;
   /**
-   * Metadata fields to update. If omitted, no metadata changes will be made.
+   * Metadata fields to update.
    */
-  metadata?: DatapointMetadataUpdate;
+  metadata: DatapointMetadataUpdate;
 };

--- a/tensorzero-core/src/endpoints/datasets/v1/types.rs
+++ b/tensorzero-core/src/endpoints/datasets/v1/types.rs
@@ -185,9 +185,8 @@ pub struct UpdateDatapointMetadataRequest {
     /// The ID of the datapoint to update. Required.
     pub id: Uuid,
 
-    /// Metadata fields to update. If omitted, no metadata changes will be made.
-    #[serde(default)]
-    pub metadata: Option<DatapointMetadataUpdate>,
+    /// Metadata fields to update.
+    pub metadata: DatapointMetadataUpdate,
 }
 
 /// Request to list datapoints from a dataset with pagination and filters.

--- a/tensorzero-core/src/endpoints/datasets/v1/update_datapoints.rs
+++ b/tensorzero-core/src/endpoints/datasets/v1/update_datapoints.rs
@@ -476,10 +476,8 @@ async fn update_datapoints_metadata(
                     }));
                 }
 
-                if let Some(metadata) = update.metadata {
-                    if let Some(new_name) = metadata.name {
-                        existing_datapoint.name = new_name;
-                    }
+                if let Some(new_name) = update.metadata.name {
+                    existing_datapoint.name = new_name;
                 }
 
                 datapoints.push(DatapointInsert::Chat(existing_datapoint.into()));
@@ -494,10 +492,8 @@ async fn update_datapoints_metadata(
                     }));
                 }
 
-                if let Some(metadata) = update.metadata {
-                    if let Some(new_name) = metadata.name {
-                        existing_datapoint.name = new_name;
-                    }
+                if let Some(new_name) = update.metadata.name {
+                    existing_datapoint.name = new_name;
                 }
 
                 datapoints.push(DatapointInsert::Json(existing_datapoint.into()));
@@ -1873,9 +1869,9 @@ mod tests {
             let request = UpdateDatapointsMetadataRequest {
                 datapoints: vec![UpdateDatapointMetadataRequest {
                     id: datapoint_id,
-                    metadata: Some(DatapointMetadataUpdate {
+                    metadata: DatapointMetadataUpdate {
                         name: Some(Some("new_name".to_string())),
-                    }),
+                    },
                 }],
             };
 
@@ -1927,9 +1923,9 @@ mod tests {
             let request = UpdateDatapointsMetadataRequest {
                 datapoints: vec![UpdateDatapointMetadataRequest {
                     id: datapoint_id,
-                    metadata: Some(DatapointMetadataUpdate {
+                    metadata: DatapointMetadataUpdate {
                         name: Some(Some("updated_json_name".to_string())),
-                    }),
+                    },
                 }],
             };
 
@@ -1963,39 +1959,7 @@ mod tests {
             let request = UpdateDatapointsMetadataRequest {
                 datapoints: vec![UpdateDatapointMetadataRequest {
                     id: datapoint_id,
-                    metadata: Some(DatapointMetadataUpdate { name: Some(None) }),
-                }],
-            };
-
-            let result = update_datapoints_metadata(&mock_db, dataset_name, request).await;
-            assert!(result.is_ok());
-        }
-
-        #[tokio::test]
-        async fn test_update_metadata_no_metadata_provided() {
-            let dataset_name = "test_dataset";
-            let existing_datapoint = create_sample_chat_datapoint(dataset_name);
-            let datapoint_id = existing_datapoint.id;
-            let original_name = existing_datapoint.name.clone();
-
-            let mut mock_db = MockDatasetQueries::new();
-            let existing_datapoint_clone = existing_datapoint.clone();
-            mock_db.expect_get_datapoints().returning(move |_| {
-                let dp = existing_datapoint_clone.clone();
-                Box::pin(async move { Ok(vec![StoredDatapoint::Chat(dp)]) })
-            });
-            mock_db
-                .expect_insert_datapoints()
-                .withf(move |datapoints| {
-                    datapoints.len() == 1
-                        && matches!(&datapoints[0], DatapointInsert::Chat(dp) if dp.name == original_name)
-                })
-                .returning(|_| Box::pin(async move { Ok(1) }));
-
-            let request = UpdateDatapointsMetadataRequest {
-                datapoints: vec![UpdateDatapointMetadataRequest {
-                    id: datapoint_id,
-                    metadata: None,
+                    metadata: DatapointMetadataUpdate { name: Some(None) },
                 }],
             };
 
@@ -2016,9 +1980,9 @@ mod tests {
             let request = UpdateDatapointsMetadataRequest {
                 datapoints: vec![UpdateDatapointMetadataRequest {
                     id: non_existent_id,
-                    metadata: Some(DatapointMetadataUpdate {
+                    metadata: DatapointMetadataUpdate {
                         name: Some(Some("new_name".to_string())),
-                    }),
+                    },
                 }],
             };
 
@@ -2041,15 +2005,15 @@ mod tests {
                 datapoints: vec![
                     UpdateDatapointMetadataRequest {
                         id: duplicate_id,
-                        metadata: Some(DatapointMetadataUpdate {
+                        metadata: DatapointMetadataUpdate {
                             name: Some(Some("name1".to_string())),
-                        }),
+                        },
                     },
                     UpdateDatapointMetadataRequest {
                         id: duplicate_id,
-                        metadata: Some(DatapointMetadataUpdate {
+                        metadata: DatapointMetadataUpdate {
                             name: Some(Some("name2".to_string())),
-                        }),
+                        },
                     },
                 ],
             };
@@ -2109,15 +2073,15 @@ mod tests {
                 datapoints: vec![
                     UpdateDatapointMetadataRequest {
                         id: id1,
-                        metadata: Some(DatapointMetadataUpdate {
+                        metadata: DatapointMetadataUpdate {
                             name: Some(Some("updated_name1".to_string())),
-                        }),
+                        },
                     },
                     UpdateDatapointMetadataRequest {
                         id: id2,
-                        metadata: Some(DatapointMetadataUpdate {
+                        metadata: DatapointMetadataUpdate {
                             name: Some(Some("updated_name2".to_string())),
-                        }),
+                        },
                     },
                 ],
             };


### PR DESCRIPTION
I don't know why I missed this but this `DatapointMetadataUpdate` should be required in the API that's supposed to update it.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Make `metadata` field required in `UpdateDatapointMetadataRequest` to ensure updates are always provided.
> 
>   - **Behavior**:
>     - Make `metadata` field required in `UpdateDatapointMetadataRequest` in `UpdateDatapointMetadataRequest.ts` and `types.rs`.
>     - Remove handling of `None` metadata in `update_datapoints_metadata()` in `update_datapoints.rs`.
>   - **Tests**:
>     - Update tests in `update_datapoints.rs` to reflect required `metadata` field.
>     - Remove test `test_update_metadata_no_metadata_provided()` in `update_datapoints.rs` as it is no longer applicable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f5834b797350b24196d0865bb1b44be3fa8b8e7f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->