### PR TITLE
Skip 'build-gateway-e2e-container' job on PRs from forks

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -764,7 +764,7 @@ jobs:
     uses: ./.github/workflows/build-gateway-e2e-container.yml
     # Skip running this on PR ci for forks, since it needs secrets.
     # TensorZero organization members can use `/check-fork` to manually run all checks for a PR from a fork.
-    if: ${{!(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)}}
+    if: ${{!(github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]'))}}
     permissions:
       # Permission to checkout the repository
       contents: read


### PR DESCRIPTION
This needs Docker Hub secrets, so it will fail.
We already allow jobs to be skipped in 'check-all-general-jobs-passed', so this will let us add PRs from forks to the merge queue (where all checks will run with secrets available)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Skip `build-gateway-e2e-container` job for forked PRs in `general.yml` to prevent failures due to missing secrets.
> 
>   - **Behavior**:
>     - Skip `build-gateway-e2e-container` job in `general.yml` for PRs from forks to avoid failures due to missing Docker Hub secrets.
>     - Allows TensorZero members to manually run checks for forked PRs using `/check-fork`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 147038380392c9fd95cd083077e4a3ff20ef8422. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->