### PR TITLE
Rename page_size to limit in list inferences endpoint

### DIFF
--- a/internal/tensorzero-node/lib/bindings/ListInferencesRequest.ts
+++ b/internal/tensorzero-node/lib/bindings/ListInferencesRequest.ts
@@ -32,7 +32,7 @@ export type ListInferencesRequest = {
    * The maximum number of inferences to return.
    * Defaults to 20.
    */
-  page_size?: number;
+  limit?: number;
   /**
    * The number of inferences to skip before starting to return results.
    * Defaults to 0.

--- a/tensorzero-core/src/endpoints/stored_inferences/v1/get_inferences.rs
+++ b/tensorzero-core/src/endpoints/stored_inferences/v1/get_inferences.rs
@@ -9,7 +9,7 @@ use crate::utils::gateway::{AppState, AppStateData, StructuredJson};
 
 use super::types::{GetInferencesRequest, GetInferencesResponse, ListInferencesRequest};
 
-const DEFAULT_PAGE_SIZE: u32 = 20;
+const DEFAULT_LIMIT: u32 = 20;
 const DEFAULT_OFFSET: u32 = 0;
 
 /// Handler for the POST `/v1/inferences/get_inferences` endpoint.
@@ -80,7 +80,7 @@ async fn list_inferences(
     clickhouse: &impl InferenceQueries,
     request: ListInferencesRequest,
 ) -> Result<GetInferencesResponse, Error> {
-    let page_size = request.page_size.unwrap_or(DEFAULT_PAGE_SIZE) as u64;
+    let limit = request.limit.unwrap_or(DEFAULT_LIMIT) as u64;
     let offset = request.offset.unwrap_or(DEFAULT_OFFSET) as u64;
 
     let params = ListInferencesParams {
@@ -90,7 +90,7 @@ async fn list_inferences(
         episode_id: request.episode_id.as_ref(),
         filters: request.filter.as_ref(),
         output_source: request.output_source,
-        limit: Some(page_size),
+        limit: Some(limit),
         offset: Some(offset),
         order_by: request.order_by.as_deref(),
     };
@@ -309,7 +309,7 @@ mod tests {
             .expect_list_inferences()
             .withf(|_, params| {
                 // Verify default pagination values
-                assert_eq!(params.limit, Some(20), "Should use default page_size of 20");
+                assert_eq!(params.limit, Some(20), "Should use default limit of 20");
                 assert_eq!(params.offset, Some(0), "Should use default offset of 0");
                 assert_eq!(params.ids, None);
                 true
@@ -325,7 +325,7 @@ mod tests {
             variant_name: None,
             episode_id: None,
             output_source: InferenceOutputSource::Inference,
-            page_size: None,
+            limit: None,
             offset: None,
             filter: None,
             order_by: None,
@@ -349,7 +349,7 @@ mod tests {
             .expect_list_inferences()
             .withf(|_, params| {
                 // Verify custom pagination values
-                assert_eq!(params.limit, Some(50), "Should use custom page_size");
+                assert_eq!(params.limit, Some(50), "Should use custom limit");
                 assert_eq!(params.offset, Some(100), "Should use custom offset");
                 true
             })
@@ -364,7 +364,7 @@ mod tests {
             variant_name: None,
             episode_id: None,
             output_source: InferenceOutputSource::Inference,
-            page_size: Some(50),
+            limit: Some(50),
             offset: Some(100),
             filter: None,
             order_by: None,
@@ -420,7 +420,7 @@ mod tests {
             variant_name: Some(variant_name),
             episode_id: Some(episode_id),
             output_source: InferenceOutputSource::Inference,
-            page_size: None,
+            limit: None,
             offset: None,
             filter: None,
             order_by: None,
@@ -466,7 +466,7 @@ mod tests {
             variant_name: None,
             episode_id: None,
             output_source: InferenceOutputSource::Inference,
-            page_size: None,
+            limit: None,
             offset: None,
             filter: None,
             order_by: Some(order_by),
@@ -494,7 +494,7 @@ mod tests {
             variant_name: None,
             episode_id: None,
             output_source: InferenceOutputSource::Inference,
-            page_size: None,
+            limit: None,
             offset: None,
             filter: None,
             order_by: None,

--- a/tensorzero-core/src/endpoints/stored_inferences/v1/types.rs
+++ b/tensorzero-core/src/endpoints/stored_inferences/v1/types.rs
@@ -181,7 +181,7 @@ pub struct ListInferencesRequest {
 
     /// The maximum number of inferences to return.
     /// Defaults to 20.
-    pub page_size: Option<u32>,
+    pub limit: Option<u32>,
 
     /// The number of inferences to skip before starting to return results.
     /// Defaults to 0.

--- a/tensorzero-core/tests/e2e/endpoints/stored_inferences/get_inferences.rs
+++ b/tensorzero-core/tests/e2e/endpoints/stored_inferences/get_inferences.rs
@@ -71,7 +71,7 @@ pub async fn test_list_simple_query_json_function() {
     let request = json!({
         "function_name": "extract_entities",
         "output_source": "inference",
-        "page_size": 2,
+        "limit": 2,
         "order_by": [
             {
                 "by": "timestamp",
@@ -111,7 +111,7 @@ pub async fn test_list_simple_query_chat_function() {
     let request = json!({
         "function_name": "write_haiku",
         "output_source": "demonstration",
-        "page_size": 3,
+        "limit": 3,
         "offset": 3,
         "order_by": [
             {
@@ -152,7 +152,7 @@ pub async fn test_list_query_with_float_filter() {
     let request = json!({
         "function_name": "extract_entities",
         "output_source": "inference",
-        "page_size": 3,
+        "limit": 3,
         "filter": {
             "type": "float_metric",
             "metric_name": "jaccard_similarity",
@@ -186,7 +186,7 @@ pub async fn test_list_demonstration_output_source() {
     let request = json!({
         "function_name": "extract_entities",
         "output_source": "demonstration",
-        "page_size": 5,
+        "limit": 5,
         "offset": 1
     });
 
@@ -208,7 +208,7 @@ pub async fn test_list_boolean_metric_filter() {
     let request = json!({
         "function_name": "extract_entities",
         "output_source": "inference",
-        "page_size": 5,
+        "limit": 5,
         "offset": 1,
         "filter": {
             "type": "boolean_metric",
@@ -235,7 +235,7 @@ pub async fn test_list_and_filter_multiple_float_metrics() {
     let request = json!({
         "function_name": "extract_entities",
         "output_source": "inference",
-        "page_size": 1,
+        "limit": 1,
         "filter": {
             "type": "and",
             "children": [
@@ -273,7 +273,7 @@ async fn test_list_or_filter_mixed_metrics() {
     let request = json!({
         "function_name": "extract_entities",
         "output_source": "inference",
-        "page_size": 1,
+        "limit": 1,
         "filter": {
             "type": "or",
             "children": [
@@ -344,7 +344,7 @@ async fn test_list_simple_time_filter() {
     let request = json!({
         "function_name": "extract_entities",
         "output_source": "inference",
-        "page_size": 5,
+        "limit": 5,
         "filter": {
             "type": "time",
             "time": "2023-01-01T00:00:00Z",
@@ -390,7 +390,7 @@ async fn test_list_simple_tag_filter() {
     let request = json!({
         "function_name": "extract_entities",
         "output_source": "inference",
-        "page_size": 200,
+        "limit": 200,
         "filter": {
             "type": "tag",
             "key": "tensorzero::evaluation_name",
@@ -417,7 +417,7 @@ async fn test_list_combined_time_and_tag_filter() {
     let request = json!({
         "function_name": "write_haiku",
         "output_source": "inference",
-        "page_size": 50,
+        "limit": 50,
         "filter": {
             "type": "and",
             "children": [
@@ -457,7 +457,7 @@ pub async fn test_get_by_ids_json_only() {
     let list_request = json!({
         "function_name": "extract_entities",
         "output_source": "inference",
-        "page_size": 3
+        "limit": 3
     });
 
     let initial_res = list_inferences(list_request).await.unwrap();
@@ -491,7 +491,7 @@ pub async fn test_get_by_ids_chat_only() {
     let list_request = json!({
         "function_name": "write_haiku",
         "output_source": "inference",
-        "page_size": 2
+        "limit": 2
     });
 
     let initial_res = list_inferences(list_request).await.unwrap();
@@ -536,7 +536,7 @@ pub async fn test_get_by_ids_mixed_types() {
     let json_request = json!({
         "function_name": "extract_entities",
         "output_source": "inference",
-        "page_size": 2
+        "limit": 2
     });
     let json_res = list_inferences(json_request).await.unwrap();
 
@@ -544,7 +544,7 @@ pub async fn test_get_by_ids_mixed_types() {
     let chat_request = json!({
         "function_name": "write_haiku",
         "output_source": "inference",
-        "page_size": 2
+        "limit": 2
     });
     let chat_res = list_inferences(chat_request).await.unwrap();
 
@@ -606,7 +606,7 @@ pub async fn test_get_by_ids_duplicate_ids() {
     let list_request = json!({
         "function_name": "extract_entities",
         "output_source": "inference",
-        "page_size": 1
+        "limit": 1
     });
 
     let initial_res = list_inferences(list_request).await.unwrap();


### PR DESCRIPTION
#4397
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rename `page_size` to `limit` in list inferences endpoint across codebase and tests.
> 
>   - **Renames**:
>     - `page_size` to `limit` in `ListInferencesRequest` in `ListInferencesRequest.ts` and `types.rs`.
>     - `DEFAULT_PAGE_SIZE` to `DEFAULT_LIMIT` in `get_inferences.rs`.
>     - `page_size` to `limit` in `list_inferences()` in `get_inferences.rs` and 8 other places.
>   - **Tests**:
>     - Update tests in `get_inferences.rs` and `get_inferences.rs` to use `limit` instead of `page_size`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for cc563c076eff33b39d1ace4b24e03cacfde8b232. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->