### PR TITLE
Fix model inference rendering bug in the UI

### DIFF
--- a/ui/app/utils/clickhouse/common.ts
+++ b/ui/app/utils/clickhouse/common.ts
@@ -89,9 +89,18 @@ export type ThoughtSummaryBlock = z.infer<typeof thoughtSummaryBlockSchema>;
 
 export const thoughtContentSchema = z.object({
   type: z.literal("thought"),
-  text: z.string().optional(),
-  signature: z.string().optional(),
-  summary: z.array(thoughtSummaryBlockSchema).optional(),
+  text: z
+    .string()
+    .nullish()
+    .transform((val) => val ?? undefined),
+  signature: z
+    .string()
+    .nullish()
+    .transform((val) => val ?? undefined),
+  summary: z
+    .array(thoughtSummaryBlockSchema)
+    .nullish()
+    .transform((val) => val ?? undefined),
   _internal_provider_type: z.string().optional(),
 });
 export type ThoughtContent = z.infer<typeof thoughtContentSchema>;

--- a/ui/app/utils/clickhouse/inference.test.ts
+++ b/ui/app/utils/clickhouse/inference.test.ts
@@ -636,7 +636,7 @@ test("displayModelInferenceInputMessageContentSchema accepts thought content blo
   );
   expect(result3.success).toBe(true);
   if (result3.success && result3.data.type === "thought") {
-    expect(result3.data.text).toBeNull();
+    expect(result3.data.text).toBeUndefined();
     expect(result3.data.summary).toBeUndefined();
   }
 });


### PR DESCRIPTION
We are not rendering all kinds of content blocks for model inferences, causing the UI to explode. Legacy type which hopefully we'll remove soon...
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix UI rendering bug by updating schema to handle `thought` content blocks with summaries.
> 
>   - **Schema Updates**:
>     - Add `thoughtSummaryBlockSchema` and update `thoughtContentSchema` in `common.ts` to include `summary` field.
>     - Update `displayModelInferenceInputMessageContentSchema` in `common.ts` to include `thoughtContentSchema`.
>   - **Tests**:
>     - Add tests in `inference.test.ts` to verify `displayModelInferenceInputMessageContentSchema` handles `thought` content blocks with and without `summary`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b9d0ccba903612ef237b0918c4c08ec3bc8b9192. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->