### PR TITLE
Improve ClickHouse log printing in ui test job

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -113,6 +113,11 @@ jobs:
         working-directory: ui
         run: docker compose -f fixtures/docker-compose.yml logs -t
 
+      - name: Print Docker Compose status
+        if: always()
+        working-directory: ui
+        run: docker compose -f fixtures/docker-compose.yml ps --all
+
       - name: Make sure the current commit short hash is in the Docker Compose gateway logs
         if: always()
         working-directory: ui
@@ -125,8 +130,10 @@ jobs:
 
       - name: Print ClickHouse error logs
         if: always()
-        run: docker exec fixtures-clickhouse-1 cat /var/log/clickhouse-server/clickhouse-server.err.log
+        working-directory: ui
+        run: docker cp fixtures-clickhouse-1:/var/log/clickhouse-server/clickhouse-server.err.log -
 
       - name: Print ClickHouse trace logs
         if: always()
-        run: docker exec fixtures-clickhouse-1 cat /var/log/clickhouse-server/clickhouse-server.log
+        working-directory: ui
+        run: docker cp fixtures-clickhouse-1:/var/log/clickhouse-server/clickhouse-server.log -


### PR DESCRIPTION
We can now print the logs even if the container stops for some reason
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve ClickHouse log retrieval in UI test job by using `docker cp` and adding Docker Compose status printing.
> 
>   - **Logging Improvements**:
>     - Use `docker cp` instead of `docker exec` to print ClickHouse error and trace logs in `.github/workflows/ui-tests.yml`.
>     - Add step to print Docker Compose status with `docker compose ps --all` in `.github/workflows/ui-tests.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d51183be1ad19dcfe7f4eac4523e22909619ee6b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->