### PR TITLE
Remove deprecation warning check again

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -235,12 +235,6 @@ jobs:
         run: |
           cargo test-e2e ${{ vars.CARGO_NEXTEST_EXTRA_ARGS }} -E "not (${{ vars.CARGO_NEXTEST_FLAKY_TESTS }})" --no-fail-fast
 
-      # TODO(https://github.com/tensorzero/tensorzero/issues/3989) - move this back to the end of the job
-      # For now, we only check for deprecation warnings after running the Rust e2e tests
-      - name: Check e2e logs for deprecation warnings (gateway e2e tests only)
-        run: |
-          ! grep -i "Deprecation Warning" e2e_logs.txt
-
       # As a separate step, we run just the flaky tests, and allow them to fail.
       # This lets us see if any flaky tests have started succeeding (by looking at the job output),
       # so that we can decide to mark them as non-flaky.


### PR DESCRIPTION
This is again blocking #4244.

I think we may want a hybrid solution where deprecated rust methods are always marked with #[deprecated], so Clippy can warn us for any usage; we probably shouldn't be calling HTTP routes from the gateway itself, so hopefully this will be sufficient in preventing us emitting deprecation warning in a non-deprecated route.

Also mentioning #3990 for future reference.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove deprecation warning check step from `merge-queue.yml` after Rust e2e tests.
> 
>   - **Workflow Changes**:
>     - Remove deprecation warning check step from `merge-queue.yml` after Rust e2e tests.
>     - Affects the `Check e2e logs for deprecation warnings (gateway e2e tests only)` step.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 56c1a10afe1a858967675d69d885a0c29c08d1e7. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->