### PR TITLE
bumped macos support from 13&14 to 14&15

### DIFF
--- a/.github/workflows/python-client-build.yml
+++ b/.github/workflows/python-client-build.yml
@@ -249,6 +249,6 @@ jobs:
       - name: Count wheels
         run: |
           ls -lh ./wheels-*/*
-          # Count the number of files named 'tensorzero-*.whl', and verify that it equals 7
+          # Count the number of files named 'tensorzero-*.whl', and verify that it equals 6
           # If we add new platforms / python versions, update this number
-          ls -lh ./wheels-*/* | grep -c 'tensorzero-.*\.whl' | grep -q 7
+          ls -lh ./wheels-*/* | grep -c 'tensorzero-.*\.whl' | grep -q 6


### PR DESCRIPTION
Closes #4410
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update macOS support in `python-client-build.yml` from versions 13 and 14 to 14 and 15, and adjust expected wheel count from 7 to 6.
> 
>   - **macOS Support**:
>     - Update macOS support in `python-client-build.yml` from versions 13 and 14 to 14 and 15.
>     - Comment out macOS 15 support due to conflicting artifact upload.
>   - **Artifact Count**:
>     - Change expected wheel count from 7 to 6 in `python-client-build.yml` to reflect platform changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 25c8cd804f7dd3266b8e4b9aba86ae8bef616532. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->