### PR TITLE
Apply 'tensorzero::api_key_public_id' tag to inference/feedback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,6 +2175,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry-instrumentation-sdk",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -45,3 +45,4 @@ serde_json = { workspace = true }
 reqwest-eventsource = { workspace = true }
 futures = { workspace = true }
 secrecy = { workspace = true }
+uuid = { workspace = true }

--- a/gateway/tests/auth.rs
+++ b/gateway/tests/auth.rs
@@ -3,10 +3,16 @@ use std::process::Stdio;
 use std::str::FromStr;
 
 use http::{Method, StatusCode};
-use serde_json::json;
+use serde_json::{json, Value};
 use tensorzero_auth::key::TensorZeroApiKey;
-use tensorzero_core::endpoints::status::TENSORZERO_VERSION;
+use tensorzero_core::{
+    db::clickhouse::test_helpers::{
+        get_clickhouse, select_chat_inference_clickhouse, select_feedback_clickhouse,
+    },
+    endpoints::status::TENSORZERO_VERSION,
+};
 use tokio::process::Command;
+use uuid::Uuid;
 
 use crate::common::start_gateway_on_random_port;
 use secrecy::ExposeSecret;
@@ -30,10 +36,18 @@ async fn test_tensorzero_auth_enabled() {
     let pool = get_postgres_pool_for_testing().await;
     let child_data = start_gateway_on_random_port(
         "
+    [gateway.observability]
+    enabled = true
+    
     [gateway.auth]
     enabled = true
     [gateway.auth.cache]
     enabled = false
+
+    [metrics.task_success]
+    type = \"boolean\"
+    optimize = \"max\"
+    level = \"inference\"
     ",
         None,
     )
@@ -42,6 +56,8 @@ async fn test_tensorzero_auth_enabled() {
     let key = tensorzero_auth::postgres::create_key("my_org", "my_workspace", None, &pool)
         .await
         .unwrap();
+
+    let parsed_key = TensorZeroApiKey::parse(key.expose_secret()).unwrap();
 
     let inference_response = reqwest::Client::new()
         .post(format!("http://{}/inference", child_data.addr))
@@ -58,6 +74,9 @@ async fn test_tensorzero_auth_enabled() {
                         "content": "Hello, world!",
                     }
                 ]
+            },
+            "tags": {
+                "my_tag": "my_value",
             }
         }))
         .send()
@@ -68,6 +87,74 @@ async fn test_tensorzero_auth_enabled() {
     let text = inference_response.text().await.unwrap();
     println!("API response: {text}");
     assert_eq!(status, StatusCode::OK);
+    let response_json: Value = serde_json::from_str(&text).unwrap();
+    let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
+    let inference_id = Uuid::parse_str(inference_id).unwrap();
+
+    // Sleep for one second to allow time for the inference to be inserted into ClickHouse
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    // Check that we applied the API key as a tag
+    let clickhouse = get_clickhouse().await;
+    let result = select_chat_inference_clickhouse(&clickhouse, inference_id)
+        .await
+        .unwrap();
+
+    let tags = result.get("tags").unwrap();
+    assert_eq!(
+        tags,
+        &json!({
+            "my_tag": "my_value",
+            "tensorzero::api_key_public_id": parsed_key.public_id,
+        })
+    );
+
+    let feedback_response = reqwest::Client::new()
+        .post(format!("http://{}/feedback", child_data.addr))
+        .header(
+            http::header::AUTHORIZATION,
+            format!("Bearer {}", key.expose_secret()),
+        )
+        .json(&json!({
+            "inference_id": inference_id,
+            "metric_name": "task_success",
+            "value": true,
+            "tags": {
+                "my_feedback_tag": "my_feedback_value",
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    let status = feedback_response.status();
+    let text = feedback_response.text().await.unwrap();
+    assert_eq!(status, StatusCode::OK);
+    let feedback_response_json: Value = serde_json::from_str(&text).unwrap();
+    let feedback_id = feedback_response_json
+        .get("feedback_id")
+        .unwrap()
+        .as_str()
+        .unwrap();
+    let feedback_id = Uuid::parse_str(feedback_id).unwrap();
+
+    // Sleep for one second to allow time for the feedback to be inserted into ClickHouse
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    // Get the feedback from the database
+    let clickhouse = get_clickhouse().await;
+    let result = select_feedback_clickhouse(&clickhouse, "BooleanMetricFeedback", feedback_id)
+        .await
+        .unwrap();
+    let id = result.get("id").unwrap().as_str().unwrap();
+    let id_uuid = Uuid::parse_str(id).unwrap();
+    assert_eq!(id_uuid, feedback_id);
+    assert_eq!(
+        result.get("tags").unwrap(),
+        &json!({
+            "my_feedback_tag": "my_feedback_value",
+            "tensorzero::api_key_public_id": parsed_key.public_id,
+        })
+    );
 
     // The key should stop working after we disable it
     let disabled_at = tensorzero_auth::postgres::disable_key(

--- a/gateway/tests/common/mod.rs
+++ b/gateway/tests/common/mod.rs
@@ -17,7 +17,6 @@ pub async fn start_gateway_on_random_port(
     let config_str = format!(
         r#"
         [gateway]
-        observability.enabled = false
         bind_address = "0.0.0.0:0"
         {config_suffix}
     "#

--- a/tensorzero-core/src/client/mod.rs
+++ b/tensorzero-core/src/client/mod.rs
@@ -555,10 +555,16 @@ impl Client {
                 self.parse_http_response(builder.send().await).await
             }
             ClientMode::EmbeddedGateway { gateway, timeout } => {
+                // We currently ban auth-enabled configs in embedded gateway mode,
+                // so we don't have an API key here
                 Ok(with_embedded_timeout(*timeout, async {
-                    crate::endpoints::feedback::feedback(gateway.handle.app_state.clone(), params)
-                        .await
-                        .map_err(err_to_http)
+                    crate::endpoints::feedback::feedback(
+                        gateway.handle.app_state.clone(),
+                        params,
+                        None,
+                    )
+                    .await
+                    .map_err(err_to_http)
                 })
                 .await?)
             }

--- a/tensorzero-core/src/endpoints/feedback/mod.rs
+++ b/tensorzero-core/src/endpoints/feedback/mod.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use axum::extract::State;
-use axum::{debug_handler, Json};
+use axum::{debug_handler, Extension, Json};
 use human_feedback::write_static_evaluation_human_feedback_if_necessary;
 use metrics::counter;
 use serde::{Deserialize, Serialize};
@@ -15,6 +15,7 @@ use uuid::Uuid;
 
 use crate::config::{Config, MetricConfigLevel, MetricConfigType};
 use crate::db::clickhouse::{ClickHouseConnectionInfo, TableName};
+use crate::endpoints::RequestApiKeyExtension;
 use crate::error::{Error, ErrorDetails};
 use crate::function::FunctionConfig;
 use crate::inference::types::{
@@ -93,9 +94,10 @@ pub struct FeedbackResponse {
 #[debug_handler(state = AppStateData)]
 pub async fn feedback_handler(
     State(app_state): AppState,
+    api_key_ext: Option<Extension<RequestApiKeyExtension>>,
     StructuredJson(params): StructuredJson<Params>,
 ) -> Result<Json<FeedbackResponse>, Error> {
-    Ok(Json(feedback(app_state, params).await?))
+    Ok(Json(feedback(app_state, params, api_key_ext).await?))
 }
 
 // Helper function to avoid requiring axum types in the client
@@ -115,6 +117,7 @@ pub async fn feedback(
         ..
     }: AppStateData,
     mut params: Params,
+    api_key_ext: Option<Extension<RequestApiKeyExtension>>,
 ) -> Result<FeedbackResponse, Error> {
     let span = tracing::Span::current();
     if let Some(inference_id) = params.inference_id {
@@ -136,6 +139,12 @@ pub async fn feedback(
     }
     validate_tags(&params.tags, params.internal)?;
     validate_feedback_specific_tags(&params.tags)?;
+    if let Some(api_key_ext) = api_key_ext {
+        params.tags.insert(
+            "tensorzero::api_key_public_id".to_string(),
+            api_key_ext.0.api_key.get_public_id().into(),
+        );
+    }
     // Get the metric config or return an error if it doesn't exist
     let feedback_metadata = get_feedback_metadata(
         &config,
@@ -1108,6 +1117,7 @@ mod tests {
         };
         let response = feedback_handler(
             State(gateway_handle.app_state.clone()),
+            None,
             StructuredJson(params),
         )
         .await;
@@ -1143,6 +1153,7 @@ mod tests {
         };
         let response = feedback_handler(
             State(gateway_handle.app_state.clone()),
+            None,
             StructuredJson(params),
         )
         .await
@@ -1169,6 +1180,7 @@ mod tests {
         };
         let response = feedback_handler(
             State(gateway_handle.app_state.clone()),
+            None,
             StructuredJson(params),
         )
         .await;
@@ -1215,6 +1227,7 @@ mod tests {
         };
         let response = feedback_handler(
             State(gateway_handle.app_state.clone()),
+            None,
             StructuredJson(params),
         )
         .await
@@ -1239,6 +1252,7 @@ mod tests {
         };
         let response = feedback_handler(
             State(gateway_handle.app_state.clone()),
+            None,
             StructuredJson(params),
         )
         .await;
@@ -1282,6 +1296,7 @@ mod tests {
         };
         let response = feedback_handler(
             State(gateway_handle.app_state.clone()),
+            None,
             StructuredJson(params),
         )
         .await;

--- a/tensorzero-core/src/endpoints/inference.rs
+++ b/tensorzero-core/src/endpoints/inference.rs
@@ -284,6 +284,12 @@ pub async fn inference(
     if params.episode_id.is_none() {
         tracing::Span::current().record("episode_id", episode_id.to_string());
     }
+    if let Some(api_key_ext) = &api_key_ext {
+        params.tags.insert(
+            "tensorzero::api_key_public_id".to_string(),
+            api_key_ext.0.api_key.get_public_id().into(),
+        );
+    }
 
     let (function, function_name) = find_function(&params, &config)?;
     let mut candidate_variants: BTreeMap<String, Arc<VariantInfo>> =

--- a/tensorzero-core/tests/e2e/feedback.rs
+++ b/tensorzero-core/tests/e2e/feedback.rs
@@ -200,7 +200,9 @@ async fn e2e_test_comment_feedback_validation_disabled() {
         value: json!("foo bar"),
         ..Default::default()
     };
-    let val = feedback(handle.app_state.clone(), params).await.unwrap();
+    let val = feedback(handle.app_state.clone(), params, None)
+        .await
+        .unwrap();
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Check that this was correctly written to ClickHouse
@@ -1232,7 +1234,9 @@ async fn e2e_test_float_feedback_validation_disabled() {
         value: json!(3.1),
         ..Default::default()
     };
-    let val = feedback(handle.app_state.clone(), params).await.unwrap();
+    let val = feedback(handle.app_state.clone(), params, None)
+        .await
+        .unwrap();
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Check that this was correctly written to ClickHouse
@@ -1469,7 +1473,9 @@ async fn e2e_test_boolean_feedback_validation_disabled() {
         value: json!(true),
         ..Default::default()
     };
-    let val = feedback(handle.app_state.clone(), params).await.unwrap();
+    let val = feedback(handle.app_state.clone(), params, None)
+        .await
+        .unwrap();
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Check that this was correctly written to ClickHouse


### PR DESCRIPTION
This tag is only set when an API key is provided

Fixes https://github.com/tensorzero/tensorzero/issues/4364
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `tensorzero::api_key_public_id` tag to inference and feedback operations when an API key is provided.
> 
>   - **Behavior**:
>     - Add `tensorzero::api_key_public_id` tag to inference and feedback operations in `inference.rs` and `feedback/mod.rs` if an API key is provided.
>     - Update `inference_handler()` and `feedback_handler()` to include API key tag.
>   - **Tests**:
>     - Add tests in `auth.rs` to verify API key tagging for inference and feedback.
>     - Update e2e tests in `feedback.rs` to check for `tensorzero::api_key_public_id` tag.
>   - **Dependencies**:
>     - Add `uuid` dependency to `Cargo.toml` and `Cargo.lock` for UUID handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 96f847e4c594701fa2adb0dad555864bbc991f4f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->