### PR TITLE
Add docstring about experiment sample size and duration

### DIFF
--- a/docs/experimentation/run-adaptive-ab-tests.mdx
+++ b/docs/experimentation/run-adaptive-ab-tests.mdx
@@ -13,8 +13,12 @@ In simple terms, you define:
 - A [metric](/gateway/guides/metrics-feedback) to optimize for
 
 And TensorZero takes care of the rest.
-TensorZero's experimentation algorithm is designed to efficiently find the best variant of the system within a specified confidence interval.
+TensorZero's experimentation algorithm is designed to efficiently find the best variant of the system with a specified level of confidence.
 You can add more variants over time and TensorZero will adjust the experiment accordingly while maintaining its statistical soundness.
+
+You don't need to choose the sample size or experiment duration up front.
+TensorZero will automatically detect when there are enough samples to identify the best variant.
+Once it has done so, it will use that variant for all subsequent inferences.
 
 <Tip>
 


### PR DESCRIPTION
- Clarify that in adaptive A/B testing the user doesn't have to specify the sample size or experiment duration up front.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Clarifies in documentation that sample size and experiment duration are not required for adaptive A/B testing in TensorZero.
> 
>   - **Documentation**:
>     - Clarifies in `run-adaptive-ab-tests.mdx` that users do not need to specify sample size or experiment duration for adaptive A/B testing.
>     - Explains that TensorZero automatically detects when enough samples are collected to identify the best variant and uses it for future inferences.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0e27d99144f3edae4e4e68bc7085fe502a8d7482. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->