### PR TITLE
Only run 'build-gateway-e2e-container' in the merge queue

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -762,9 +762,7 @@ jobs:
 
   build-gateway-e2e-container:
     uses: ./.github/workflows/build-gateway-e2e-container.yml
-    # Skip running this on PR ci for forks, since it needs secrets.
-    # TensorZero organization members can use `/check-fork` to manually run all checks for a PR from a fork.
-    if: ${{!(github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]'))}}
+    if: (github.repository == 'tensorzero/tensorzero' && github.event_name == 'merge_group')
     permissions:
       # Permission to checkout the repository
       contents: read


### PR DESCRIPTION
We don't need this for PR CI at the moment
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `build-gateway-e2e-container` job in `general.yml` to run only on `merge_group` events for `tensorzero/tensorzero`.
> 
>   - **CI/CD Workflow**:
>     - Modify `if` condition for `build-gateway-e2e-container` in `general.yml` to only run on `merge_group` events for the `tensorzero/tensorzero` repository.
>     - Removes previous condition that excluded PRs from forks and dependabot.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8bab8896cf7e86c863f9d2f5f60727086e3b6a45. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->