### PR TITLE
Use 'dev' profile when performing non-e2e gateway build in CI

### DIFF
--- a/.github/workflows/build-gateway-container.yml
+++ b/.github/workflows/build-gateway-container.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build `gateway` container
         run: |
-          docker buildx build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f gateway/Dockerfile . -t tensorzero/gateway:sha-${{ github.sha }}
+          docker buildx build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 --build-arg PROFILE=dev -f gateway/Dockerfile . -t tensorzero/gateway:sha-${{ github.sha }}
 
       - name: Save `gateway` container
         run: docker save tensorzero/gateway:sha-${{ github.sha }} > gateway-container.tar


### PR DESCRIPTION
This only affects running tests - we'll still build a 'performance' profile image when we release to Docker Hub
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use 'dev' profile for non-e2e gateway builds in CI, keeping 'performance' profile for releases.
> 
>   - **CI Build**:
>     - Adds `--build-arg PROFILE=dev` to the `docker buildx build` command in `.github/workflows/build-gateway-container.yml`.
>     - Affects non-e2e test builds, using 'dev' profile instead of 'performance'.
>     - Release builds to Docker Hub remain unchanged, using 'performance' profile.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e73982a0386c8b5efd67680a74ba3f6e0fb4f330. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->