### PR TITLE
Don't force container rebuild when regenerating inference cache

### DIFF
--- a/ui/fixtures/regenerate-model-inference-cache.sh
+++ b/ui/fixtures/regenerate-model-inference-cache.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$0")"/../
 
 docker compose -f ./fixtures/docker-compose.e2e.yml -f ./fixtures/docker-compose.ui.yml down
 docker compose -f ./fixtures/docker-compose.e2e.yml -f ./fixtures/docker-compose.ui.yml rm -f
-OPENAI_BASE_URL=http://mock-inference-provider:3030/openai/ FIREWORKS_BASE_URL=http://mock-inference-provider:3030/fireworks/ FIREWORKS_ACCOUNT_ID=fake_fireworks_account TOGETHER_BASE_URL=http://mock-inference-provider:3030/together/ TENSORZERO_SKIP_LARGE_FIXTURES=1 VITE_TENSORZERO_FORCE_CACHE_ON=1 docker compose -f ./fixtures/docker-compose.e2e.yml -f ./fixtures/docker-compose.ui.yml up --build --force-recreate -d
+OPENAI_BASE_URL=http://mock-inference-provider:3030/openai/ FIREWORKS_BASE_URL=http://mock-inference-provider:3030/fireworks/ FIREWORKS_ACCOUNT_ID=fake_fireworks_account TOGETHER_BASE_URL=http://mock-inference-provider:3030/together/ TENSORZERO_SKIP_LARGE_FIXTURES=1 VITE_TENSORZERO_FORCE_CACHE_ON=1 docker compose -f ./fixtures/docker-compose.e2e.yml -f ./fixtures/docker-compose.ui.yml up --force-recreate -d
 docker compose -f ./fixtures/docker-compose.e2e.yml -f ./fixtures/docker-compose.ui.yml wait fixtures
 # Wipe the ModelInferenceCache table to ensure that we regenerate everything
 docker run --add-host=host.docker.internal:host-gateway clickhouse/clickhouse-server clickhouse-client --host host.docker.internal --user chuser --password chpassword --database tensorzero_ui_fixtures 'TRUNCATE TABLE ModelInferenceCache SYNC'


### PR DESCRIPTION
This should allow us to re-use the contaner images built before we started the merge-queue job
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `--build` flag from `docker compose up` in `regenerate-model-inference-cache.sh` to prevent forced container rebuilds and allow reuse of existing images.
> 
>   - **Behavior**:
>     - Removes `--build` flag from `docker compose up` in `regenerate-model-inference-cache.sh` to prevent forced container rebuilds.
>     - Allows reuse of existing container images when regenerating inference cache.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8462b996e4db7086f25f3e5c42dbd34b27068ae6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->