### PR TITLE
Add debug logging to 'cancel-on-status-failure.yml'

### DIFF
--- a/.github/workflows/cancel-on-status-failure.yml
+++ b/.github/workflows/cancel-on-status-failure.yml
@@ -10,6 +10,15 @@ permissions:
   contents: read
 
 jobs:
+  print-event:
+    name: Print event for debugging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print event
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Event details:"
+          echo "${{ toJson(github.event) }}"
   cancel-on-failure:
     name: Cancel General Checks on Failure
     runs-on: ubuntu-latest


### PR DESCRIPTION
This workflow is getting skipped when triggered from a 'check_run' event - let's try to figure out why
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a debugging job to `cancel-on-status-failure.yml` to log event details for diagnosing skipped workflows on 'check_run' events.
> 
>   - **Debugging**:
>     - Adds `print-event` job in `cancel-on-status-failure.yml` to log event details for debugging.
>     - Prints `github.event_name` and JSON representation of `github.event`.
>   - **Purpose**:
>     - Aims to diagnose why the workflow is skipped on 'check_run' events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2c93759b68c4fb416b6b271a5afd90d9abb3306c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->