### PR TITLE
Pass in `raw_request` when constructing stream errors

### DIFF
--- a/tensorzero-core/src/inference/mod.rs
+++ b/tensorzero-core/src/inference/mod.rs
@@ -93,5 +93,6 @@ pub trait WrappedProvider: Debug {
             Box<dyn Stream<Item = Result<Event, TensorZeroEventError>> + Send + 'static>,
         >,
         start_time: Instant,
+        raw_request: &str,
     ) -> ProviderInferenceResponseStreamInner;
 }

--- a/tensorzero-core/src/providers/anthropic.rs
+++ b/tensorzero-core/src/providers/anthropic.rs
@@ -304,6 +304,7 @@ impl InferenceProvider for AnthropicProvider {
             model_provider,
             model_name,
             provider_name,
+            &raw_request,
         )
         .peekable();
         let chunk = peek_first_chunk(&mut stream, &raw_request, PROVIDER_TYPE).await?;
@@ -351,7 +352,9 @@ fn stream_anthropic(
     model_provider: &ModelProvider,
     model_name: &str,
     provider_name: &str,
+    raw_request: &str,
 ) -> ProviderInferenceResponseStreamInner {
+    let raw_request = raw_request.to_string();
     let discard_unknown_chunks = model_provider.discard_unknown_chunks;
     let model_name = model_name.to_string();
     let provider_name = provider_name.to_string();
@@ -362,7 +365,7 @@ fn stream_anthropic(
         while let Some(ev) = event_source.next().await {
             match ev {
                 Err(e) => {
-                    yield Err(convert_stream_error(PROVIDER_TYPE.to_string(), e).await);
+                    yield Err(convert_stream_error(raw_request.clone(), PROVIDER_TYPE.to_string(), e).await);
                 }
                 Ok(event) => match event {
                     Event::Open => continue,
@@ -374,7 +377,7 @@ fn stream_anthropic(
                                     e, message.data
                                 ),
                                 provider_type: PROVIDER_TYPE.to_string(),
-                                raw_request: None,
+                                raw_request: Some(raw_request.to_string()),
                                 raw_response: Some(message.data.clone()),
                             }));
                         // Anthropic streaming API docs specify that this is the last message

--- a/tensorzero-core/src/providers/aws_sagemaker.rs
+++ b/tensorzero-core/src/providers/aws_sagemaker.rs
@@ -257,7 +257,7 @@ impl InferenceProvider for AWSSagemakerProvider {
         );
         let stream = self
             .hosted_provider
-            .stream_events(Box::pin(event_stream), start_time.into())
+            .stream_events(Box::pin(event_stream), start_time.into(), &raw_request)
             .peekable();
         Ok((stream, raw_request))
     }

--- a/tensorzero-core/src/providers/azure.rs
+++ b/tensorzero-core/src/providers/azure.rs
@@ -336,6 +336,7 @@ impl InferenceProvider for AzureProvider {
             PROVIDER_TYPE.to_string(),
             event_source.map_err(TensorZeroEventError::EventSource),
             start_time,
+            &raw_request,
         )
         .peekable();
         Ok((stream, raw_request))

--- a/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
@@ -334,6 +334,7 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
             model_provider,
             model_name,
             provider_name,
+            &raw_request,
         )
         .peekable();
         let chunk = peek_first_chunk(&mut stream, &raw_request, PROVIDER_TYPE).await?;
@@ -381,7 +382,9 @@ fn stream_anthropic(
     model_provider: &ModelProvider,
     model_name: &str,
     provider_name: &str,
+    raw_request: &str,
 ) -> ProviderInferenceResponseStreamInner {
+    let raw_request = raw_request.to_string();
     let discard_unknown_chunks = model_provider.discard_unknown_chunks;
     let model_name = model_name.to_string();
     let provider_name = provider_name.to_string();
@@ -390,7 +393,7 @@ fn stream_anthropic(
         while let Some(ev) = event_source.next().await {
             match ev {
                 Err(e) => {
-                    yield Err(convert_stream_error(PROVIDER_TYPE.to_string(), e).await);
+                    yield Err(convert_stream_error(raw_request.clone(), PROVIDER_TYPE.to_string(), e).await);
                 }
                 Ok(event) => match event {
                     Event::Open => continue,
@@ -402,7 +405,7 @@ fn stream_anthropic(
                                     e, message.data
                                 ),
                                 provider_type: PROVIDER_TYPE.to_string(),
-                                raw_request: None,
+                                raw_request: Some(raw_request.clone()),
                                 raw_response: None,
                             }));
                         // Anthropic streaming API docs specify that this is the last message

--- a/tensorzero-core/src/providers/helpers.rs
+++ b/tensorzero-core/src/providers/helpers.rs
@@ -32,7 +32,11 @@ pub struct JsonlBatchFileInfo {
     pub file_id: String,
 }
 
-pub async fn convert_stream_error(provider_type: String, e: reqwest_eventsource::Error) -> Error {
+pub async fn convert_stream_error(
+    raw_request: String,
+    provider_type: String,
+    e: reqwest_eventsource::Error,
+) -> Error {
     let message = e.to_string();
     // If we get an invalid status code, content type, or generic transport error,
     // then we assume that we're never going to be able to read more chunks from the stream,
@@ -45,7 +49,7 @@ pub async fn convert_stream_error(provider_type: String, e: reqwest_eventsource:
             ErrorDetails::FatalStreamError {
                 message,
                 provider_type,
-                raw_request: None,
+                raw_request: Some(raw_request),
                 raw_response: resp.text().await.ok(),
             }
             .into()
@@ -53,13 +57,13 @@ pub async fn convert_stream_error(provider_type: String, e: reqwest_eventsource:
         reqwest_eventsource::Error::Transport(_) => ErrorDetails::FatalStreamError {
             message,
             provider_type,
-            raw_request: None,
+            raw_request: Some(raw_request),
             raw_response: None,
         }
         .into(),
         _ => ErrorDetails::InferenceServer {
             message,
-            raw_request: None,
+            raw_request: Some(raw_request),
             raw_response: None,
             provider_type,
         }

--- a/tensorzero-core/src/providers/hyperbolic.rs
+++ b/tensorzero-core/src/providers/hyperbolic.rs
@@ -279,6 +279,7 @@ impl InferenceProvider for HyperbolicProvider {
             PROVIDER_TYPE.to_string(),
             event_source.map_err(TensorZeroEventError::EventSource),
             start_time,
+            &raw_request,
         )
         .peekable();
         Ok((stream, raw_request))

--- a/tensorzero-core/src/providers/openai/responses.rs
+++ b/tensorzero-core/src/providers/openai/responses.rs
@@ -1002,7 +1002,9 @@ pub fn stream_openai_responses(
     discard_unknown_chunks: bool,
     model_name: &str,
     provider_name: &str,
+    raw_request: &str,
 ) -> ProviderInferenceResponseStreamInner {
+    let raw_request = raw_request.to_string();
     let mut current_tool_id: Option<String> = None;
     let mut current_tool_name: Option<String> = None;
     let model_name = model_name.to_string();
@@ -1018,7 +1020,7 @@ pub fn stream_openai_responses(
                             yield Err(e);
                         }
                         TensorZeroEventError::EventSource(e) => {
-                            yield Err(convert_stream_error(provider_type.clone(), e).await);
+                            yield Err(convert_stream_error(raw_request.clone(), provider_type.clone(), e).await);
                         }
                     }
                 }
@@ -1061,6 +1063,7 @@ pub fn stream_openai_responses(
                             discard_unknown_chunks,
                             &model_name,
                             &provider_name,
+                            &raw_request,
                         );
 
                         match stream_message {
@@ -1098,6 +1101,7 @@ pub(super) fn openai_responses_to_tensorzero_chunk(
     discard_unknown_chunks: bool,
     model_name: &str,
     provider_name: &str,
+    raw_request: &str,
 ) -> Result<Option<ProviderInferenceResponseChunk>, Error> {
     match event {
         // Text delta - the main content streaming event
@@ -1146,7 +1150,7 @@ pub(super) fn openai_responses_to_tensorzero_chunk(
                             message: "Got function_call_arguments.delta without current tool id"
                                 .to_string(),
                             provider_type: PROVIDER_TYPE.to_string(),
-                            raw_request: None,
+                            raw_request: Some(raw_request.to_string()),
                             raw_response: Some(raw_message.clone()),
                         })
                     })?,
@@ -1266,7 +1270,7 @@ pub(super) fn openai_responses_to_tensorzero_chunk(
             Err(Error::new(ErrorDetails::InferenceServer {
                 message: error_msg.to_string(),
                 provider_type: PROVIDER_TYPE.to_string(),
-                raw_request: None,
+                raw_request: Some(raw_request.to_string()),
                 raw_response: Some(raw_message),
             }))
         }
@@ -1297,7 +1301,7 @@ pub(super) fn openai_responses_to_tensorzero_chunk(
             Err(Error::new(ErrorDetails::InferenceServer {
                 message: format!("Model refused to respond: {delta}"),
                 provider_type: PROVIDER_TYPE.to_string(),
-                raw_request: None,
+                raw_request: Some(raw_request.to_string()),
                 raw_response: Some(raw_message),
             }))
         }
@@ -1307,7 +1311,7 @@ pub(super) fn openai_responses_to_tensorzero_chunk(
             Err(Error::new(ErrorDetails::InferenceServer {
                 message: error.to_string(),
                 provider_type: PROVIDER_TYPE.to_string(),
-                raw_request: None,
+                raw_request: Some(raw_request.to_string()),
                 raw_response: Some(raw_message),
             }))
         }
@@ -1596,6 +1600,7 @@ mod tests {
             false,
             "test_model",
             "test_provider",
+            "",
         )
         .unwrap()
         .unwrap();
@@ -1631,6 +1636,7 @@ mod tests {
             false,
             "test_model",
             "test_provider",
+            "",
         )
         .unwrap()
         .unwrap();
@@ -1677,6 +1683,7 @@ mod tests {
             false,
             "test_model",
             "test_provider",
+            "",
         )
         .unwrap()
         .unwrap();
@@ -1718,6 +1725,7 @@ mod tests {
             false,
             "test_model",
             "test_provider",
+            "",
         )
         .unwrap()
         .unwrap();
@@ -1756,6 +1764,7 @@ mod tests {
             false,
             "test_model",
             "test_provider",
+            "",
         )
         .unwrap()
         .unwrap();
@@ -1801,6 +1810,7 @@ mod tests {
             false,
             "test_model",
             "test_provider",
+            "",
         )
         .unwrap()
         .unwrap();
@@ -1834,6 +1844,7 @@ mod tests {
             false,
             "test_model",
             "test_provider",
+            "",
         )
         .unwrap()
         .unwrap();
@@ -1864,6 +1875,7 @@ mod tests {
             false,
             "test_model",
             "test_provider",
+            "",
         )
         .unwrap()
         .unwrap();
@@ -1892,6 +1904,7 @@ mod tests {
             false,
             "test_model",
             "test_provider",
+            "",
         )
         .unwrap()
         .unwrap();
@@ -1930,6 +1943,7 @@ mod tests {
             false,
             "test_model",
             "test_provider",
+            "",
         );
 
         assert!(result.is_err());
@@ -1962,6 +1976,7 @@ mod tests {
             false,
             "test_model",
             "test_provider",
+            "",
         )
         .unwrap()
         .unwrap();
@@ -2007,6 +2022,7 @@ mod tests {
             false,
             "test_model",
             "test_provider",
+            "",
         )
         .unwrap()
         .unwrap();
@@ -2048,6 +2064,7 @@ mod tests {
             false,
             "test_model",
             "test_provider",
+            "",
         );
 
         assert!(result.is_err());
@@ -2074,6 +2091,7 @@ mod tests {
             false,
             "test_model",
             "test_provider",
+            "",
         );
 
         assert!(result.is_err());
@@ -2100,6 +2118,7 @@ mod tests {
             false,
             "test_model",
             "test_provider",
+            "",
         );
 
         assert!(result.is_err());
@@ -2139,6 +2158,7 @@ mod tests {
                 false,
                 "test_model",
                 "test_provider",
+                "",
             )
             .unwrap();
 
@@ -2166,6 +2186,7 @@ mod tests {
             false,
             "test_model",
             "test_provider",
+            "",
         )
         .unwrap()
         .unwrap();
@@ -2205,6 +2226,7 @@ mod tests {
             true,
             "test_model",
             "test_provider",
+            "",
         )
         .unwrap();
 

--- a/tensorzero-core/src/providers/vllm.rs
+++ b/tensorzero-core/src/providers/vllm.rs
@@ -271,6 +271,7 @@ impl InferenceProvider for VLLMProvider {
             PROVIDER_TYPE.to_string(),
             event_source.map_err(TensorZeroEventError::EventSource),
             start_time,
+            &raw_request,
         )
         .peekable();
         Ok((stream, raw_request))

--- a/tensorzero-core/src/providers/xai.rs
+++ b/tensorzero-core/src/providers/xai.rs
@@ -281,6 +281,7 @@ impl InferenceProvider for XAIProvider {
             PROVIDER_TYPE.to_string(),
             event_source.map_err(TensorZeroEventError::EventSource),
             start_time,
+            &raw_request,
         )
         .peekable();
         Ok((stream, raw_request))


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Pass `raw_request` to error handling functions across multiple providers for improved logging and error handling.
> 
>   - **Behavior**:
>     - Pass `raw_request` to `convert_stream_error` in `helpers.rs` and various provider implementations (e.g., `anthropic.rs`, `aws_sagemaker.rs`, `azure.rs`).
>     - Update `stream_*` functions in multiple providers to include `raw_request` (e.g., `stream_anthropic`, `stream_openai`).
>   - **Functions**:
>     - Modify `convert_stream_error` in `helpers.rs` to accept `raw_request`.
>     - Update `stream_*` functions to handle `raw_request` in `anthropic.rs`, `aws_sagemaker.rs`, `azure.rs`, and others.
>   - **Misc**:
>     - Update tests in `openai/responses.rs` to include `raw_request` parameter.
>     - Minor updates to logging and error handling across various provider files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5ae5b09ec0e12538314650625209aa89f0e2e64e. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->