### PR TITLE
Don't insert clickhouse fixtures in client-tests job

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -283,10 +283,6 @@ jobs:
         run: |
           ./ci/run-provider-proxy.sh ci
 
-      # TODO - get rid of this when the merge queue has a freshly-build gateway image available
-      - name: Manually run the latest postgres migrations
-        run: cargo run-e2e --run-postgres-migrations
-
       - name: Launch the gateway for E2E tests
         timeout-minutes: 2
         run: |


### PR DESCRIPTION
We don't need or want these - this allows us to switch to a smaller runner
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Optimizes `client-tests` job in `merge-queue.yml` by removing ClickHouse fixtures and changing runner configuration.
> 
>   - **Workflow Changes**:
>     - In `merge-queue.yml`, removed ClickHouse fixtures download step from `client-tests` job.
>     - Changed runner for `client-tests` from `namespace-profile-tensorzero-16x32` to `namespace-profile-tensorzero-8x16`.
>     - Removed unnecessary steps like warming up Modal instances and cleaning up disk space in `client-tests` job.
>   - **Service Launch**:
>     - Updated `Launch dependency services for E2E tests` step to exclude unnecessary services like 'fixtures'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8d3077ed028a1312130f8dd34942c2116b96fde3. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->