### PR TITLE
Remove 'execution_time' check in migration-manager tests

### DIFF
--- a/tensorzero-core/tests/e2e/clickhouse.rs
+++ b/tensorzero-core/tests/e2e/clickhouse.rs
@@ -744,7 +744,7 @@ async fn test_clickhouse_migration_manager() {
             migration_name,
             gateway_version,
             gateway_git_sha,
-            execution_time_ms,
+            execution_time_ms: _,
             applied_at,
         } = migration_record;
         assert_eq!(*migration_id, migration.migration_num().unwrap());


### PR DESCRIPTION
This is sometimes 0 for fast migrations, so let's just remove the check
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove `execution_time_ms` check in `test_clickhouse_migration_manager()` in `clickhouse.rs` to handle fast migrations.
> 
>   - **Tests**:
>     - Remove `execution_time_ms` check in `test_clickhouse_migration_manager()` in `clickhouse.rs` as it can be 0 for fast migrations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f20f82ab058d089201e72fe02c0dd226a18af039. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->