### PR TITLE
Re-use `handle_anthropic_error` in gcp_vertex_anthropic

### DIFF
--- a/tensorzero-core/src/providers/anthropic.rs
+++ b/tensorzero-core/src/providers/anthropic.rs
@@ -1192,7 +1192,7 @@ impl<'a> TryFrom<AnthropicResponseWithMetadata<'a>> for ProviderInferenceRespons
     }
 }
 
-fn handle_anthropic_error(
+pub(super) fn handle_anthropic_error(
     response_code: StatusCode,
     raw_request: String,
     raw_response: String,

--- a/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
@@ -41,6 +41,7 @@ use crate::inference::InferenceProvider;
 use crate::model::CredentialLocationWithFallback;
 use crate::model::{fully_qualified_name, ModelProvider};
 use crate::model_table::{GCPVertexAnthropicKind, ProviderType, ProviderTypeDefaultCredentials};
+use crate::providers::anthropic::handle_anthropic_error;
 use crate::providers::gcp_vertex_gemini::location_subdomain_prefix;
 use crate::tool::{ToolCall, ToolCallChunk, ToolChoice, ToolConfig};
 
@@ -271,17 +272,7 @@ impl InferenceProvider for GCPVertexAnthropicProvider {
 
             Ok(response_with_latency.try_into()?)
         } else {
-            let error_body: GCPVertexAnthropicError =
-                serde_json::from_str(&raw_response).map_err(|e| {
-                    Error::new(ErrorDetails::InferenceServer {
-                        message: format!("Error parsing JSON response: {e}: {raw_response}"),
-                        provider_type: PROVIDER_TYPE.to_string(),
-                        raw_request: Some(raw_request.clone()),
-                        raw_response: Some(raw_response.clone()),
-                    })
-                })?;
-
-            handle_anthropic_error(response_status, error_body.error)
+            handle_anthropic_error(response_status, raw_request, raw_response)
         }
     }
 
@@ -922,18 +913,6 @@ fn prefill_json_message(messages: &mut Vec<GCPVertexAnthropicMessage>) {
     });
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
-struct GCPVertexAnthropicError {
-    error: GCPVertexAnthropicErrorBody,
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-struct GCPVertexAnthropicErrorBody {
-    r#type: Option<String>,
-    code: Option<u32>,
-    message: String,
-}
-
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum GCPVertexAnthropicContentBlock {
@@ -1088,34 +1067,6 @@ impl<'a> TryFrom<GCPVertexAnthropicResponseWithMetadata<'a>> for ProviderInferen
                 finish_reason: response.stop_reason.map(AnthropicStopReason::into),
             },
         ))
-    }
-}
-
-fn handle_anthropic_error(
-    response_code: StatusCode,
-    response_body: GCPVertexAnthropicErrorBody,
-) -> Result<ProviderInferenceResponse, Error> {
-    match response_code {
-        StatusCode::UNAUTHORIZED
-        | StatusCode::BAD_REQUEST
-        | StatusCode::PAYLOAD_TOO_LARGE
-        | StatusCode::TOO_MANY_REQUESTS => Err(ErrorDetails::InferenceClient {
-            raw_response: Some(serde_json::to_string(&response_body).unwrap_or_default()),
-            message: response_body.message,
-            status_code: Some(response_code),
-            provider_type: PROVIDER_TYPE.to_string(),
-            raw_request: None,
-        }
-        .into()),
-        // StatusCode::NOT_FOUND | StatusCode::FORBIDDEN | StatusCode::INTERNAL_SERVER_ERROR | 529: Overloaded
-        // These are all captured in _ since they have the same error behavior
-        _ => Err(ErrorDetails::InferenceServer {
-            raw_response: Some(serde_json::to_string(&response_body).unwrap_or_default()),
-            message: response_body.message,
-            provider_type: PROVIDER_TYPE.to_string(),
-            raw_request: None,
-        }
-        .into()),
     }
 }
 
@@ -2230,94 +2181,6 @@ mod tests {
             ],
         }];
         assert_eq!(prepare_messages(messages.clone()).unwrap(), expected);
-    }
-
-    #[test]
-    fn test_handle_anthropic_error() {
-        let error_body = GCPVertexAnthropicErrorBody {
-            r#type: None,
-            code: None,
-            message: "test_message".to_string(),
-        };
-        let response_code = StatusCode::BAD_REQUEST;
-        let result = handle_anthropic_error(response_code, error_body.clone());
-        let error = result.unwrap_err();
-        let details = error.get_details();
-        assert_eq!(
-            *details,
-            ErrorDetails::InferenceClient {
-                message: "test_message".to_string(),
-                status_code: Some(response_code),
-                provider_type: PROVIDER_TYPE.to_string(),
-                raw_request: None,
-                raw_response: Some(
-                    "{\"type\":null,\"code\":null,\"message\":\"test_message\"}".to_string()
-                ),
-            }
-        );
-        let response_code = StatusCode::UNAUTHORIZED;
-        let result = handle_anthropic_error(response_code, error_body.clone());
-        let error = result.unwrap_err();
-        let details = error.get_details();
-        assert_eq!(
-            *details,
-            ErrorDetails::InferenceClient {
-                message: "test_message".to_string(),
-                status_code: Some(response_code),
-                provider_type: PROVIDER_TYPE.to_string(),
-                raw_request: None,
-                raw_response: Some(
-                    "{\"type\":null,\"code\":null,\"message\":\"test_message\"}".to_string()
-                ),
-            }
-        );
-        let response_code = StatusCode::TOO_MANY_REQUESTS;
-        let result = handle_anthropic_error(response_code, error_body.clone());
-        let error = result.unwrap_err();
-        let details = error.get_details();
-        assert_eq!(
-            *details,
-            ErrorDetails::InferenceClient {
-                message: "test_message".to_string(),
-                status_code: Some(response_code),
-                provider_type: PROVIDER_TYPE.to_string(),
-                raw_request: None,
-                raw_response: Some(
-                    "{\"type\":null,\"code\":null,\"message\":\"test_message\"}".to_string()
-                ),
-            }
-        );
-        let response_code = StatusCode::NOT_FOUND;
-        let result = handle_anthropic_error(response_code, error_body.clone());
-        assert!(result.is_err());
-        let error = result.unwrap_err();
-        let details = error.get_details();
-        assert_eq!(
-            *details,
-            ErrorDetails::InferenceServer {
-                message: "test_message".to_string(),
-                raw_request: None,
-                raw_response: Some(
-                    "{\"type\":null,\"code\":null,\"message\":\"test_message\"}".to_string()
-                ),
-                provider_type: PROVIDER_TYPE.to_string()
-            }
-        );
-        let response_code = StatusCode::INTERNAL_SERVER_ERROR;
-        let result = handle_anthropic_error(response_code, error_body.clone());
-        let error = result.unwrap_err();
-        let details = error.get_details();
-        assert_eq!(
-            *details,
-            ErrorDetails::InferenceServer {
-                message: "test_message".to_string(),
-                raw_request: None,
-                raw_response: Some(
-                    "{\"type\":null,\"code\":null,\"message\":\"test_message\"}".to_string()
-                ),
-                provider_type: PROVIDER_TYPE.to_string()
-            }
-        );
     }
 
     #[test]


### PR DESCRIPTION
This makes gcp_vertex_anthropic match the error behavior that we decided on for the 'anthropic' provider. We now also include raw_request in the error message
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `gcp_vertex_anthropic.rs` to reuse `handle_anthropic_error` from `anthropic.rs`, ensuring consistent error handling and simplifying code.
> 
>   - **Error Handling**:
>     - Reuse `handle_anthropic_error` from `anthropic.rs` in `gcp_vertex_anthropic.rs` for consistent error handling.
>     - Remove `GCPVertexAnthropicError` and `GCPVertexAnthropicErrorBody` structs and related error handling code in `gcp_vertex_anthropic.rs`.
>     - Include `raw_request` in error messages for better debugging.
>   - **Code Simplification**:
>     - Remove `handle_anthropic_error` function specific to `gcp_vertex_anthropic.rs`.
>     - Delete `test_handle_anthropic_error` test in `gcp_vertex_anthropic.rs` as it's no longer needed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ccb09c926ae7c747bf668c0c015c3f4b721b9128. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->