### PR TITLE
Always download container images in model-inference-cache tests

### DIFF
--- a/.github/workflows/ui-tests-e2e-model-inference-cache.yml
+++ b/.github/workflows/ui-tests-e2e-model-inference-cache.yml
@@ -81,10 +81,7 @@ jobs:
       - name: Setup Playwright
         run: pnpm --filter=tensorzero-ui exec playwright install --with-deps chromium
 
-      # When we're regenerating the model inference cache, don't download the container images
-      # The images will get built by `regenerate-model-inference-cache.sh`
       - name: Download container images
-        if: inputs.regen_cache == false
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:
           pattern: build-*-container


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Always download container images in `ui-tests-e2e-model-inference-cache.yml` by removing conditional check.
> 
>   - **Workflow Changes**:
>     - In `.github/workflows/ui-tests-e2e-model-inference-cache.yml`, always download container images by removing the condition `if: inputs.regen_cache == false` from the `Download container images` step.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1de4922f2236f32af70da62ef87a1fda521c83a9. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->