### PR TITLE
Add more perms to force-merge-queue to allow 'gh workflow run'

### DIFF
--- a/.github/workflows/force-merge-queue.yml
+++ b/.github/workflows/force-merge-queue.yml
@@ -1,6 +1,7 @@
 name: Force add to merge queue
 permissions:
   contents: read
+  actions: write
 
 # This workflow allows us to add PRs to the merge queue without waiting on PR checks to pass.
 # It's activated by adding the special 'force-add-to-merge-queue' label to a PR.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `actions: write` permission to `force-merge-queue.yml` to enable running workflows via GitHub CLI.
> 
>   - **Permissions**:
>     - Add `actions: write` permission in `.github/workflows/force-merge-queue.yml` to allow running workflows via GitHub CLI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8e0973d36f22dd2308b06334c8fecae0a79fb895. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->