### PR TITLE
Implement macro for schemars-based JSON schema generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5017,9 +5017,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -5208,7 +5208,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.12.0",
  "schemars 0.9.0",
- "schemars 1.0.4",
+ "schemars 1.1.0",
  "serde_core",
  "serde_json",
  "serde_with_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
     "provider-proxy",
     "evaluations",
     "internal/tensorzero-derive",
-     "internal/tensorzero-auth",
+    "internal/tensorzero-auth",
     "examples/integrations/cursor/feedback",
 ]
 resolver = "2"
@@ -75,6 +75,7 @@ rlt = "0.2.1"
 metrics-exporter-prometheus = { version = "0.17.2", features = [
     "http-listener",
 ], default-features = false }
+schemars = "1.1.0"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/internal/tensorzero-derive/Cargo.toml
+++ b/internal/tensorzero-derive/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 rust-version.workspace = true
 edition = "2021"
 license.workspace = true
+description = "Macros for TensorZero"
+
 
 [lib]
 proc-macro = true

--- a/internal/tensorzero-derive/README.md
+++ b/internal/tensorzero-derive/README.md
@@ -9,3 +9,22 @@ Current macros:
 This is a drop-in replacement for `#[derive(serde::Deserialize)]` (only for enums). This uses `serde_path_to_error` to produce better error messages when deserializing non-externally-tagged enums (e.g. `#[serde(tag = "type")]`).
 
 See 'tests/deserialize.rs' for an example
+
+## `#[export_schema]`
+
+This macro generates tests for exporting JSON schemas (generated with `schemars`), similar to `ts-rs`.
+
+Usage:
+
+1. **In Rust:** Add the derive macros
+```rust
+use tensorzero_derive::export_schema;
+
+#[derive(JsonSchema, Serialize, Deserialize)]
+#[cfg_attr(test, export_schema)]
+pub struct NewType {
+    pub field: String,
+}
+```
+
+2. **Run schema generation:** `cargo test export_schema`. This exports the schema to `REPOSITORY_ROOT/clients/schema`.

--- a/internal/tensorzero-derive/src/lib.rs
+++ b/internal/tensorzero-derive/src/lib.rs
@@ -1,3 +1,5 @@
+//! TensorZero macros
+
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;
@@ -218,4 +220,77 @@ pub fn tensorzero_derive(input: TokenStream) -> TokenStream {
         }
     };
     res.into()
+}
+
+/// Attribute macro that exports `schemars::JsonSchema` definitions when tests run.
+///
+/// The macro generates a `#[test]` that serializes the annotated type's schema and
+/// writes it to `clients/schemas/<TypeName>.json`, similar to how `ts-rs`'s
+/// `#[ts(export)]` produces TypeScript definitions.
+///
+/// ## Usage
+///
+/// ```ignore
+/// use schemars::JsonSchema;
+/// use tensorzero_derive::export_schema;
+///
+/// #[derive(JsonSchema)]
+/// #[export_schema]
+/// pub struct MyType {
+///     field: String,
+/// }
+/// ```
+///
+/// Running `cargo test` will create or update `clients/schemas/MyType.json`.
+#[proc_macro_attribute]
+pub fn export_schema(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as DeriveInput);
+    let name = &input.ident;
+    let name_str = name.to_string();
+
+    // Generate a unique test name based on the type name
+    let test_name = syn::Ident::new(
+        &format!("export_schema_{}", name_str.to_lowercase()),
+        name.span(),
+    );
+
+    // Generate the test function
+    let expanded = quote! {
+        // Keep the original item
+        #input
+
+        // Generate a test that exports the schema
+        #[cfg(test)]
+        #[test]
+        fn #test_name() {
+            use schemars::schema_for;
+            use std::fs;
+            use std::path::{Path, PathBuf};
+            use std::borrow::Cow;
+
+            // Get the schema for this type
+            let schema = schema_for!(#name);
+
+            // Serialize to pretty JSON
+            let json = serde_json::to_string_pretty(&schema)
+                .expect(&format!("Failed to serialize schema for {}", #name_str));
+
+            let schema_output_dir = match std::env::var("SCHEMA_RS_EXPORT_DIR") {
+                Err(..) => Cow::Borrowed(Path::new("./schemas")),
+                Ok(dir) => Cow::Owned(PathBuf::from(dir)),
+            };
+
+            fs::create_dir_all(&schema_output_dir)
+                .expect(&format!("Failed to create schemas directory: {}", schema_output_dir.display()));
+
+            // Write the schema file
+            let file_path = schema_output_dir.join(format!("{}.json", #name_str));
+            fs::write(&file_path, json)
+                .expect(&format!("Failed to write schema for {}", #name_str));
+
+            println!("✓ Generated schema: {}", file_path.display());
+        }
+    };
+
+    TokenStream::from(expanded)
 }


### PR DESCRIPTION
A step towards #4489. This gives us the ability to easily do Rust struct => JSON schema generation for each `JsonSchema`-annotated struct by adding a `#[export_schema]` annotation. Internally, it generates tests that invoke `schemars`'s `schema_for!` macro and writes it to a file, similar to ts-rs.

On its own this PR doesn't do anything other than setting up the macro; in follow-ups we will annotate the types, generate the schemas, and add build steps.

Take a look at https://github.com/tensorzero/tensorzero/pull/4493/files#diff-d27c4d052ca109894bcb789f3af9ecfcf1a3b3820d67099d2ff5fad1e9f2677a at how it's used:

```rust
#[derive(Debug, Serialize, Deserialize, JsonSchema)]
#[cfg_attr(test, tensorzero_derive::export_schema)]
pub struct UpdateDatapointsRequest {
    pub datapoints: Vec<UpdateDatapointRequest>,
}
```

Then `cargo test export_schema` runs the schema generation code.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set up infrastructure for JSON schema generation from Rust structs using `schemars`, including a macro and automation script.
> 
>   - **Behavior**:
>     - Introduces `export_schema` macro in `lib.rs` to generate JSON schemas from Rust structs during tests.
>     - Adds `generate_all_schemas.sh` script to automate schema generation and Python dataclass creation.
>   - **Dependencies**:
>     - Updates `schemars` to version `1.1.0` in `Cargo.lock` and `Cargo.toml`.
>   - **Documentation**:
>     - Adds `export_schema.md` detailing the schema generation process.
>     - Updates `README.md` in `tensorzero-derive` to include `export_schema` macro information.
>   - **Misc**:
>     - Adds description to `Cargo.toml` in `tensorzero-derive`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 94bddfc3aa8925739538a92dbe5a42a6bf8bc8a4. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->