### PR TITLE
Remove '--find-interpreter' when running maturin build

### DIFF
--- a/.github/workflows/python-client-build.yml
+++ b/.github/workflows/python-client-build.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           working-directory: ./clients/python
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3
+          args: --release --out dist -i python3.9
           #sccache: "true"
           manylinux: auto
       - name: Upload wheels
@@ -102,7 +102,7 @@ jobs:
         with:
           working-directory: ./clients/python
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3
+          args: --release --out dist -i python3.9
           #sccache: "true"
           manylinux: musllinux_1_2
       - name: Upload wheels
@@ -152,7 +152,7 @@ jobs:
         with:
           working-directory: ./clients/python
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3
+          args: --release --out dist -i python3.9
           #sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -206,7 +206,7 @@ jobs:
         with:
           working-directory: ./clients/python
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3
+          args: --release --out dist -i python3.9
           #sccache: "true"
 
       - name: Upload wheels


### PR DESCRIPTION
This is now picking up PyPy (which now seems to be installed by default on Github Actions runners)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replaces `--find-interpreter` with `-i python3.9` in GitHub Actions workflow to ensure Python 3.9 is used instead of default PyPy.
> 
>   - **GitHub Actions Workflow**:
>     - Replaces `--find-interpreter` with `-i python3.9` in `python-client-build.yml` to explicitly specify Python 3.9 interpreter.
>     - Applied to `linux`, `musllinux`, `windows`, and `macos` jobs to prevent default PyPy selection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for dd60331ef7249870527bd40da4789ac635eebe8f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->