### PR TITLE
Load downloaded containers and set PROFILE=dev in regen-cache tests

### DIFF
--- a/.github/workflows/ui-tests-e2e-model-inference-cache.yml
+++ b/.github/workflows/ui-tests-e2e-model-inference-cache.yml
@@ -88,7 +88,9 @@ jobs:
           merge-multiple: true
 
       - name: Load `gateway` and `ui` containers
-        if: inputs.regen_cache == false
+        # These containers may not exist if we manually triggered this workflow (or merge-queue.yml),
+        # We'll automatically build the container locally if they don't exist, so let this step fail.
+        continue-on-error: true
         run: |
           docker load < gateway-container.tar
           docker load < ui-container.tar

--- a/ui/fixtures/docker-compose.e2e.yml
+++ b/ui/fixtures/docker-compose.e2e.yml
@@ -29,6 +29,8 @@ services:
       context: ../..
       dockerfile: gateway/Dockerfile
       target: gateway
+      args:
+        PROFILE: dev
     volumes:
       - ./config:/app/config:ro
     command: --config-file ${TENSORZERO_GATEWAY_CONFIG:-/app/config/tensorzero.e2e.toml}


### PR DESCRIPTION
This should help speed up the `ui-tests-e2e-regen-model-inference-cache` job, which is currently one of our slowest jobs on CI
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize CI job speed by allowing container load failures and setting `PROFILE=dev` in Docker Compose for development.
> 
>   - **CI Workflow**:
>     - In `.github/workflows/ui-tests-e2e-model-inference-cache.yml`, added `continue-on-error: true` to the step loading `gateway` and `ui` containers to allow failure if containers don't exist.
>   - **Docker Configuration**:
>     - In `docker-compose.e2e.yml`, set `PROFILE=dev` for the `gateway` service to optimize for development environment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ab5f060d6b56fa1c6153c32251c03a0270f31cf9. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->