### PR TITLE
Bump maturin action to latest release

### DIFF
--- a/.github/workflows/python-client-build.yml
+++ b/.github/workflows/python-client-build.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build wheels
-        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
+        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380
         with:
           working-directory: ./clients/python
           target: ${{ matrix.platform.target }}
@@ -98,7 +98,7 @@ jobs:
       - name: Install uv
         run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
       - name: Build wheels
-        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
+        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380
         with:
           working-directory: ./clients/python
           target: ${{ matrix.platform.target }}
@@ -148,7 +148,7 @@ jobs:
         run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
         shell: bash
       - name: Build wheels
-        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
+        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380
         with:
           working-directory: ./clients/python
           target: ${{ matrix.platform.target }}
@@ -202,7 +202,7 @@ jobs:
         run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
 
       - name: Build wheels
-        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
+        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380
         with:
           working-directory: ./clients/python
           target: ${{ matrix.platform.target }}
@@ -224,7 +224,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Build sdist
-        uses: PyO3/maturin-action@b3709a81b3e175ce3ede866725776fee42465311
+        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380
         with:
           working-directory: ./clients/python
           command: sdist


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `maturin-action` to latest version in GitHub Actions workflow to fix sdist publish issue on PyPI.
> 
>   - **GitHub Actions**:
>     - Update `maturin-action` to `86b9d133d34bc1b40018696f782949dac11bd380` in `python-client-build.yml` for `Build wheels` and `Build sdist` steps.
>     - Affects `linux`, `musllinux`, `windows`, `macos`, and `sdist` jobs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2ab1ddab391df3fab55a251e4c69697f1e7a72ec. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->