### PR TITLE
Fix default rho value to match docstring

### DIFF
--- a/tensorzero-core/src/experimentation/asymptotic_confidence_sequences.rs
+++ b/tensorzero-core/src/experimentation/asymptotic_confidence_sequences.rs
@@ -289,7 +289,7 @@ mod tests {
         assert!(result[0].cs_upper.unwrap() > result[0].mean);
         // With zero variance, bounds should be very tight
         let width = result[0].cs_upper.unwrap() - result[0].cs_lower.unwrap();
-        assert!(width < 0.1);
+        assert!(width < 0.2);
     }
 
     #[test]


### PR DESCRIPTION
- The calculation of the default value of the hyperparameter `rho` for the asymptotic confidence sequences was missing a `sqrt()`. 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix default `rho` calculation in `asymp_cs()` by adding `sqrt()` and update related test case.
> 
>   - **Behavior**:
>     - Fix default `rho` calculation in `asymp_cs()` in `asymptotic_confidence_sequences.rs` by adding `sqrt()`.
>     - Update test `test_zero_variance` to assert width < 0.2 instead of < 0.1.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c11cbbb45fcf682f57cfe374d2335e1f4b0b937c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->