### PR TITLE
Remove animations from experimentation charts

### DIFF
--- a/ui/app/components/experimentation/PieChart.tsx
+++ b/ui/app/components/experimentation/PieChart.tsx
@@ -87,6 +87,7 @@ export const ExperimentationPieChart = memo(function ExperimentationPieChart({
               cy="50%"
               outerRadius={100}
               label={({ percentage }) => percentage}
+              isAnimationActive={false}
             >
               {data.map((entry) => (
                 <Cell

--- a/ui/app/components/function/variant/FeedbackCountsTimeseries.tsx
+++ b/ui/app/components/function/variant/FeedbackCountsTimeseries.tsx
@@ -168,6 +168,7 @@ export function FeedbackCountsTimeseries({
                 stroke={chartConfig[variantName].color}
                 strokeWidth={0}
                 stackId="1"
+                isAnimationActive={false}
               />
             ))}
           </AreaChart>


### PR DESCRIPTION
- The Variant Weights and Feedback Count charts in the Experimentation card in the UI re-render every time you switch to those tabs, which makes it annoying to tab back and forth.
- The Estimated Performance chart already has no animation, so this makes the other two charts match.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disables animations in `ExperimentationPieChart` and `FeedbackCountsTimeseries` to improve tab-switching experience.
> 
>   - **Behavior**:
>     - Disables animations in `ExperimentationPieChart` in `PieChart.tsx` by setting `isAnimationActive={false}`.
>     - Disables animations in `FeedbackCountsTimeseries` in `FeedbackCountsTimeseries.tsx` by setting `isAnimationActive={false}` for `Area` components.
>   - **Consistency**:
>     - Aligns `Variant Weights` and `Feedback Count` charts with `Estimated Performance` chart, which already has no animations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 76d8dae24474b6edf43fd85650257338fb93d6b6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->