### PR TITLE
Refactor: Change Optimizer trait from `&Config` to `Arc<Config>`

### DIFF
--- a/tensorzero-core/src/endpoints/optimization.rs
+++ b/tensorzero-core/src/endpoints/optimization.rs
@@ -129,7 +129,7 @@ pub async fn launch_optimization_workflow(
             val_examples,
             &InferenceCredentials::default(),
             clickhouse_connection_info,
-            &config,
+            config.clone(),
         )
         .await
 }
@@ -169,7 +169,7 @@ pub async fn launch_optimization(
             val_examples,
             &InferenceCredentials::default(),
             clickhouse_connection_info,
-            &config,
+            config.clone(),
         )
         .await
 }

--- a/tensorzero-core/src/optimization/dicl.rs
+++ b/tensorzero-core/src/optimization/dicl.rs
@@ -242,7 +242,7 @@ impl Optimizer for DiclOptimizationConfig {
         val_examples: Option<Vec<RenderedSample>>,
         credentials: &InferenceCredentials,
         clickhouse_connection_info: &ClickHouseConnectionInfo,
-        config: &Config,
+        config: Arc<Config>,
     ) -> Result<Self::Handle, Error> {
         // Validate training examples
         validate_train_examples(&train_examples)?;
@@ -315,7 +315,7 @@ impl Optimizer for DiclOptimizationConfig {
 
         // Process embeddings with batching and concurrency control
         let all_embeddings = process_embeddings_with_batching(
-            config,
+            &config,
             &self.embedding_model,
             client,
             credentials,

--- a/tensorzero-core/src/optimization/fireworks_sft/mod.rs
+++ b/tensorzero-core/src/optimization/fireworks_sft/mod.rs
@@ -9,6 +9,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::sync::Arc;
 use std::time::Duration;
 
 use futures::future::try_join_all;
@@ -543,7 +544,7 @@ impl Optimizer for FireworksSFTConfig {
         val_examples: Option<Vec<RenderedSample>>,
         credentials: &InferenceCredentials,
         _clickhouse_connection_info: &ClickHouseConnectionInfo,
-        _config: &Config,
+        _config: Arc<Config>,
     ) -> Result<Self::Handle, Error> {
         let train_examples = train_examples
             .into_iter()

--- a/tensorzero-core/src/optimization/gcp_vertex_gemini_sft/mod.rs
+++ b/tensorzero-core/src/optimization/gcp_vertex_gemini_sft/mod.rs
@@ -4,6 +4,7 @@ use pyo3::exceptions::PyValueError;
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use url::Url;
 use uuid::Uuid;
 
@@ -238,7 +239,7 @@ impl Optimizer for GCPVertexGeminiSFTConfig {
         val_examples: Option<Vec<RenderedSample>>,
         credentials: &InferenceCredentials,
         _clickhouse_connection_info: &ClickHouseConnectionInfo,
-        _config: &Config,
+        _config: Arc<Config>,
     ) -> Result<Self::Handle, Error> {
         let train_examples = train_examples
             .into_iter()

--- a/tensorzero-core/src/optimization/mod.rs
+++ b/tensorzero-core/src/optimization/mod.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, Utc};
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::sync::Arc;
 
 use crate::config::Config;
 use crate::db::clickhouse::ClickHouseConnectionInfo;
@@ -278,7 +279,7 @@ pub trait Optimizer {
         val_examples: Option<Vec<RenderedSample>>,
         credentials: &InferenceCredentials,
         clickhouse_connection_info: &ClickHouseConnectionInfo,
-        config: &Config,
+        config: Arc<Config>,
     ) -> Result<Self::Handle, Error>;
 }
 
@@ -291,7 +292,7 @@ impl Optimizer for OptimizerInfo {
         val_examples: Option<Vec<RenderedSample>>,
         credentials: &InferenceCredentials,
         clickhouse_connection_info: &ClickHouseConnectionInfo,
-        config: &Config,
+        config: Arc<Config>,
     ) -> Result<Self::Handle, Error> {
         match &self.inner {
             OptimizerConfig::Dicl(optimizer_config) => optimizer_config
@@ -301,7 +302,7 @@ impl Optimizer for OptimizerInfo {
                     val_examples,
                     credentials,
                     clickhouse_connection_info,
-                    config,
+                    config.clone(),
                 )
                 .await
                 .map(OptimizationJobHandle::Dicl),
@@ -312,7 +313,7 @@ impl Optimizer for OptimizerInfo {
                     val_examples,
                     credentials,
                     clickhouse_connection_info,
-                    config,
+                    config.clone(),
                 )
                 .await
                 .map(OptimizationJobHandle::OpenAISFT),
@@ -323,7 +324,7 @@ impl Optimizer for OptimizerInfo {
                     val_examples,
                     credentials,
                     clickhouse_connection_info,
-                    config,
+                    config.clone(),
                 )
                 .await
                 .map(OptimizationJobHandle::OpenAIRFT),
@@ -334,7 +335,7 @@ impl Optimizer for OptimizerInfo {
                     val_examples,
                     credentials,
                     clickhouse_connection_info,
-                    config,
+                    config.clone(),
                 )
                 .await
                 .map(OptimizationJobHandle::FireworksSFT),
@@ -345,7 +346,7 @@ impl Optimizer for OptimizerInfo {
                     val_examples,
                     credentials,
                     clickhouse_connection_info,
-                    config,
+                    config.clone(),
                 )
                 .await
                 .map(OptimizationJobHandle::GCPVertexGeminiSFT),
@@ -356,7 +357,7 @@ impl Optimizer for OptimizerInfo {
                     val_examples,
                     credentials,
                     clickhouse_connection_info,
-                    config,
+                    config.clone(),
                 )
                 .await
                 .map(OptimizationJobHandle::TogetherSFT),

--- a/tensorzero-core/src/optimization/openai_rft/mod.rs
+++ b/tensorzero-core/src/optimization/openai_rft/mod.rs
@@ -12,6 +12,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use tokio::try_join;
 use url::Url;
 
@@ -263,7 +264,7 @@ impl Optimizer for OpenAIRFTConfig {
         val_examples: Option<Vec<RenderedSample>>,
         credentials: &InferenceCredentials,
         _clickhouse_connection_info: &ClickHouseConnectionInfo,
-        _config: &Config,
+        _config: Arc<Config>,
     ) -> Result<Self::Handle, Error> {
         let train_examples = train_examples
             .into_iter()

--- a/tensorzero-core/src/optimization/openai_sft/mod.rs
+++ b/tensorzero-core/src/optimization/openai_sft/mod.rs
@@ -10,6 +10,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use tokio::try_join;
 use url::Url;
 
@@ -193,7 +194,7 @@ impl Optimizer for OpenAISFTConfig {
         val_examples: Option<Vec<RenderedSample>>,
         credentials: &InferenceCredentials,
         _clickhouse_connection_info: &ClickHouseConnectionInfo,
-        _config: &Config,
+        _config: Arc<Config>,
     ) -> Result<Self::Handle, Error> {
         let train_examples = train_examples
             .into_iter()

--- a/tensorzero-core/src/optimization/together_sft/mod.rs
+++ b/tensorzero-core/src/optimization/together_sft/mod.rs
@@ -9,6 +9,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::io::Write;
+use std::sync::Arc;
 
 use crate::config::{Config, TimeoutsConfig};
 use crate::db::clickhouse::ClickHouseConnectionInfo;
@@ -706,7 +707,7 @@ impl Optimizer for TogetherSFTConfig {
         val_examples: Option<Vec<RenderedSample>>,
         credentials: &InferenceCredentials,
         _clickhouse_connection_info: &ClickHouseConnectionInfo,
-        _config: &Config,
+        _config: Arc<Config>,
     ) -> Result<Self::Handle, Error> {
         let train_examples = train_examples
             .into_iter()

--- a/tensorzero-core/tests/optimization/common/dicl.rs
+++ b/tensorzero-core/tests/optimization/common/dicl.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::unwrap_used, clippy::panic, clippy::print_stdout)]
 use serde_json::{json, Value};
-use std::{collections::HashMap, fs};
+use std::{collections::HashMap, fs, sync::Arc};
 use tempfile::TempDir;
 use tokio::time::{sleep, Duration};
 use tokio_stream::StreamExt;
@@ -123,7 +123,7 @@ pub async fn test_dicl_optimization_chat() {
             val_examples,
             &credentials,
             &clickhouse,
-            &config,
+            Arc::new(config),
         )
         .await
         .unwrap();
@@ -404,7 +404,7 @@ pub async fn test_dicl_optimization_json() {
             val_examples,
             &credentials,
             &clickhouse,
-            &config,
+            Arc::new(config),
         )
         .await
         .unwrap();

--- a/tensorzero-core/tests/optimization/common/mod.rs
+++ b/tensorzero-core/tests/optimization/common/mod.rs
@@ -119,7 +119,7 @@ pub async fn run_test_case(test_case: &impl OptimizationTestCase) {
             val_examples,
             &credentials,
             &clickhouse,
-            &config,
+            Arc::new(config),
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Summary

Refactored the `Optimizer` trait's `launch` method to accept `Arc<Config>` instead of `&Config`. This simplifies lifetime management and avoids unnecessary full `Config` clones for future optimizers that will run `evaluations`.

## Changes

### Trait Signature
Changed the `Optimizer::launch` method signature from:
```rust
config: &Config
```
to:
```rust
config: Arc<Config>
```

### Files Modified

**Core trait and implementations:**
- `tensorzero-core/src/optimization/mod.rs` - Trait definition and `OptimizerInfo` impl
- `tensorzero-core/src/optimization/dicl.rs` - DICL optimizer
- `tensorzero-core/src/optimization/openai_sft/mod.rs` - OpenAI SFT optimizer
- `tensorzero-core/src/optimization/openai_rft/mod.rs` - OpenAI RFT optimizer
- `tensorzero-core/src/optimization/fireworks_sft/mod.rs` - Fireworks SFT optimizer
- `tensorzero-core/src/optimization/gcp_vertex_gemini_sft/mod.rs` - GCP Vertex Gemini optimizer
- `tensorzero-core/src/optimization/together_sft/mod.rs` - Together SFT optimizer

**Call sites:**
- `tensorzero-core/src/endpoints/optimization.rs` - Gateway endpoints (2 call sites)

**Test files:**
- `tensorzero-core/tests/optimization/common/mod.rs`
- `tensorzero-core/tests/optimization/common/dicl.rs`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `Optimizer` trait's `launch` method to use `Arc<Config>` instead of `&Config` for improved lifetime management and efficiency.
> 
>   - **Behavior**:
>     - Refactor `Optimizer::launch` method to accept `Arc<Config>` instead of `&Config` for better lifetime management and to avoid unnecessary cloning.
>     - Affects `DiclOptimizationConfig`, `FireworksSFTConfig`, `GCPVertexGeminiSFTConfig`, `OpenAIRFTConfig`, `OpenAISFTConfig`, and `TogetherSFTConfig`.
>   - **Files Modified**:
>     - `mod.rs`: Trait definition and `OptimizerInfo` implementation.
>     - `dicl.rs`, `fireworks_sft/mod.rs`, `gcp_vertex_gemini_sft/mod.rs`: Update `launch` method signature.
>     - `endpoints/optimization.rs`: Update call sites to use `Arc<Config>`.
>     - `tests/optimization/common/mod.rs`, `tests/optimization/common/dicl.rs`: Update tests to use `Arc<Config>`.
>   - **Misc**:
>     - Minor updates to imports to include `Arc`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for dc5602b0a2d741e98147487c8600413f24770dac. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->