### PR TITLE
Exclude 'tests' and 'fixtures' directory

### DIFF
--- a/tensorzero-core/Cargo.toml
+++ b/tensorzero-core/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 rust-version.workspace = true
 edition = "2021"
 license.workspace = true
+exclude = ["tests/", "fixtures/"]
 
 
 [features]


### PR DESCRIPTION
This works around a bug in Python's 'tarfile' module that prevents PyPI from parsing our sdist archive
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add exclusion for 'tests/' and 'fixtures/' in Cargo.toml to fix PyPI sdist parsing issue.
> 
>   - **Cargo.toml**:
>     - Add `exclude = ["tests/", "fixtures/"]` to work around a Python 'tarfile' module bug affecting PyPI's sdist parsing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b6a7bce2315c70a3d7c21b89cc4fbc070780f180. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->