### PR TITLE
Run 'twine check' on sdist in Python build

### DIFF
--- a/.github/workflows/python-client-build.yml
+++ b/.github/workflows/python-client-build.yml
@@ -239,6 +239,10 @@ jobs:
       - name: Check local sdist
         run: |
           ./ci/check-local-wheel.sh ./clients/python/dist/tensorzero-*.tar.gz
+      - name: Run twine on sdist
+        run: |
+          uv pip install twine
+          uv run twine check ./clients/python/dist/tensorzero-*.tar.gz
 
   check-artifacts:
     needs: [linux, musllinux, windows, macos, sdist]


### PR DESCRIPTION
This should help to catch weird Python issues before we try to create a release
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `twine check` step to Python build workflow to validate sdist before release.
> 
>   - **Workflow Update**:
>     - Adds a step in `.github/workflows/python-client-build.yml` to run `twine check` on the sdist (`tensorzero-*.tar.gz`).
>     - Installs `twine` using `uv` before running the check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5d58aae2b147b0081e2d23433d8cdc48e7c86371. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->