### PR TITLE
Use gpt-4o-mini in node OpenAI test

### DIFF
--- a/clients/openai-node/tests/inference-openai-responses-api.test.ts
+++ b/clients/openai-node/tests/inference-openai-responses-api.test.ts
@@ -416,7 +416,7 @@ describe("OpenAI Responses API", () => {
     const episodeId = uuidv7();
     const result = await client.chat.completions.create({
       messages,
-      model: "tensorzero::model_name::openai::responses::gpt-5-codex",
+      model: "tensorzero::model_name::openai::responses::gpt-4o-mini",
       // @ts-expect-error - custom TensorZero property
       "tensorzero::episode_id": episodeId,
     });


### PR DESCRIPTION
Using codex sometimes gives us
"I’m sorry, but I can’t help with that."
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change model in `inference-openai-responses-api.test.ts` from `gpt-5-codex` to `gpt-4o-mini` to address unhelpful responses.
> 
>   - **Behavior**:
>     - Change model in `inference-openai-responses-api.test.ts` from `gpt-5-codex` to `gpt-4o-mini` for chat completion test.
>     - Addresses issue where `gpt-5-codex` sometimes returns "I’m sorry, but I can’t help with that."
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for bb7894f01ca2b505651e133d748e2dd2411d1103. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->