### PR TITLE
Document rate limiting by API key

### DIFF
--- a/docs/gateway/configuration-reference.mdx
+++ b/docs/gateway/configuration-reference.mdx
@@ -4267,7 +4267,7 @@ always = true
 - **Required:** no (default: `[]`)
 
 Defines the scope to which the rate limit applies.
-Scopes allow you to apply rate limits to specific subsets of requests based on tags.
+Scopes allow you to apply rate limits to specific subsets of requests based on tags or API keys.
 
 The following scopes are supported:
 
@@ -4277,6 +4277,11 @@ The following scopes are supported:
     - `tensorzero::each`: Apply the limit separately to each unique value of the tag.
     - `tensorzero::total`: Apply the limit to the aggregate of all requests with this tag, regardless of the tag's value.
     - Any other string: Apply the limit only when the tag has this specific value.
+
+- API Key Public ID (requires authentication to be enabled):
+  - `api_key_public_id` (string): The API key public ID to match against. This can be:
+    - `tensorzero::each`: Apply the limit separately to each API key.
+    - A specific 12-character public ID: Apply the limit only to requests authenticated with this API key.
 
 For example:
 
@@ -4295,5 +4300,21 @@ priority = 1
 model_inferences_per_minute = 5
 scope = [
     { tag_key = "user_id", tag_value = "ceo" }
+]
+
+# Each API key can make a maximum of 100 model inferences per hour
+[[rate_limiting.rules]]
+priority = 0
+model_inferences_per_hour = 100
+scope = [
+    { api_key_public_id = "tensorzero::each" }
+]
+
+# But override the limit for a specific API key
+[[rate_limiting.rules]]
+priority = 1
+model_inferences_per_hour = 1000
+scope = [
+    { api_key_public_id = "xxxxxxxxxxxx" }
 ]
 ```

--- a/docs/operations/enforce-custom-rate-limits.mdx
+++ b/docs/operations/enforce-custom-rate-limits.mdx
@@ -59,9 +59,11 @@ Each rate limiting rule can optionally have a _scope_.
 The scope restricts the rule to certain requests only.
 If you don't specify a scope, the rule will apply to all requests.
 
+You can scope rate limiting rules by tags or by API key public ID.
+
 #### By tags
 
-At the moment, only scoping by user-defined `tags` are supported.
+You can scope rate limits using user-defined `tags`.
 You can limit the scope to a specific value, to each individual value (`tensorzero::each`), or to every value collectively (`tensorzero::total`).
 
 For example, the following rule would only apply to inference requests with the tag `user_id` set to `intern`:
@@ -118,7 +120,57 @@ scope = [
 
 <Warning>
 
-The rule above does _not_ apply to requests that do not specify any `user_id` value.
+The rule above won't apply to requests that do not specify a `user_id` tag.
+
+</Warning>
+
+#### By API keys
+
+You can scope rate limits using API keys when authentication is enabled.
+This allows you to enforce different rate limits for different API keys, which is useful for implementing tiered access or preventing individual keys from consuming too many resources.
+
+You can limit the scope to each individual API key (`tensorzero::each`) or to a specific API key by providing its 12-character public ID.
+
+For example, the following rule would apply to each API key individually (i.e. each API key gets its own limit):
+
+```toml title="tensorzero.toml"
+[[rate_limiting.rules]]
+# ...
+scope = [
+    { api_key_public_id = "tensorzero::each" },
+]
+#...
+```
+
+You can also target a specific API key by providing its 12-character public ID:
+
+```toml title="tensorzero.toml"
+[[rate_limiting.rules]]
+# ...
+scope = [
+    { api_key_public_id = "xxxxxxxxxxxx" },
+]
+#...
+```
+
+<Tip>
+
+TensorZero API keys have the following format:
+
+`sk-t0-xxxxxxxxxxxx-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy`
+
+The `xxxxxxxxxxxx` portion is the 12-character public ID that you can use in rate limiting rules.
+The remaining portion of the key is secret and should be kept secure.
+
+</Tip>
+
+Unlike tag scopes, API key public ID scopes do not support `tensorzero::total`.
+Only `tensorzero::each` and concrete 12-character public IDs are supported.
+
+<Warning>
+
+Rules with `api_key_public_id` scope won't apply to unauthenticated requests.
+Learn how to [set up auth for TensorZero](/operations/set-up-auth-for-tensorzero).
 
 </Warning>
 

--- a/docs/operations/set-up-auth-for-tensorzero.mdx
+++ b/docs/operations/set-up-auth-for-tensorzero.mdx
@@ -325,3 +325,41 @@ You can customize this behavior in the configuration:
 enabled = true # boolean
 ttl_ms = 60_000 # one minute
 ```
+
+### Set up rate limiting by API key
+
+Once you have authentication enabled, you can apply rate limits on a per-API-key basis using the `api_key_public_id` scope in your rate limiting rules.
+This allows you to enforce different usage limits for different API keys, which is useful for implementing tiered access or preventing individual keys from consuming too many resources.
+
+<Tip>
+
+TensorZero API keys have the following format:
+
+`sk-t0-xxxxxxxxxxxx-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy`
+
+The `xxxxxxxxxxxx` portion is the 12-character public ID that you can use in rate limiting rules.
+The remaining portion of the key is secret and should be kept secure.
+
+</Tip>
+
+For example, you can limit each API key to 100 model inferences per hour, but allow a specific API key to make 1000 inferences:
+
+```toml
+# Each API key can make up to 100 model inferences per hour
+[[rate_limiting.rules]]
+priority = 0
+model_inferences_per_hour = 100
+scope = [
+    { api_key_public_id = "tensorzero::each" }
+]
+
+# But override the limit for a specific API key
+[[rate_limiting.rules]]
+priority = 1
+model_inferences_per_hour = 1000
+scope = [
+    { api_key_public_id = "xxxxxxxxxxxx" }
+]
+```
+
+See [Enforce custom rate limits](/operations/enforce-custom-rate-limits) for more details on configuring rate limits with API keys.


### PR DESCRIPTION
Fix #4441
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR documents how to configure rate limiting by API key in the TensorZero Gateway, including examples and detailed explanations of scoping rules by API key public ID.
> 
>   - **Documentation**:
>     - Updates `configuration-reference.mdx` to include API key-based rate limiting in the scope section.
>     - Updates `enforce-custom-rate-limits.mdx` to explain scoping rate limits by API key public ID, including examples.
>     - Updates `set-up-auth-for-tensorzero.mdx` to describe setting up rate limiting by API key, with examples and tips on API key format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5f869e58db6dc1a4665aefb6397e859fa0496b8f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->