### PR TITLE
Bump python to 3.10 in python-client-build workflow

### DIFF
--- a/.github/workflows/python-client-build.yml
+++ b/.github/workflows/python-client-build.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install uv
         run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
@@ -52,7 +52,7 @@ jobs:
         with:
           working-directory: ./clients/python
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.9
+          args: --release --out dist -i python3.10
           #sccache: "true"
           manylinux: auto
       - name: Upload wheels
@@ -94,7 +94,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install uv
         run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
       - name: Build wheels
@@ -102,7 +102,7 @@ jobs:
         with:
           working-directory: ./clients/python
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.9
+          args: --release --out dist -i python3.10
           #sccache: "true"
           manylinux: musllinux_1_2
       - name: Upload wheels
@@ -142,7 +142,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
-          python-version: 3.9
+          python-version: "3.10"
           architecture: ${{ matrix.platform.target }}
       - name: Install uv
         run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
@@ -152,7 +152,7 @@ jobs:
         with:
           working-directory: ./clients/python
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.9
+          args: --release --out dist -i python3.10
           #sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -196,7 +196,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install uv
         run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
@@ -206,7 +206,7 @@ jobs:
         with:
           working-directory: ./clients/python
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.9
+          args: --release --out dist -i python3.10
           #sccache: "true"
 
       - name: Upload wheels

--- a/ci/check-musl-wheel.sh
+++ b/ci/check-musl-wheel.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-docker run -v $(pwd):/wheels python:3.9-alpine /bin/sh -c "
+docker run -v $(pwd):/wheels python:3.10-alpine /bin/sh -c "
     pip install /wheels/$1
     python -c 'import tensorzero; print(tensorzero.tensorzero.__file__)'
 "


### PR DESCRIPTION
We no longer support Python 3.9.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update Python version to 3.10 in GitHub Actions workflow and shell script for Python client build.
> 
>   - **Python Version Update**:
>     - Update Python version from 3.9 to 3.10 in `.github/workflows/python-client-build.yml` for all jobs.
>     - Update Python version from 3.9 to 3.10 in `ci/check-musl-wheel.sh` for Docker run command.
>   - **Build Process**:
>     - Modify `args` in `PyO3/maturin-action` steps to use `python3.10` in `python-client-build.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5790b678f4a70a65e857a93a6a11e7ef210ba162. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->