### PR TITLE
Remove custom user for provider-proxy Dockerfile

### DIFF
--- a/provider-proxy/Dockerfile
+++ b/provider-proxy/Dockerfile
@@ -26,10 +26,6 @@ RUN apt-get update && apt-get install -y ca-certificates openssl wget && rm -rf 
 
 FROM base AS provider-proxy
 
-RUN useradd -m -s /bin/bash provider-proxy
-
-USER provider-proxy
-
 COPY --from=builder /release/provider-proxy /usr/local/bin/provider-proxy
 
 WORKDIR /app


### PR DESCRIPTION
This should fix the permissions errors
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove custom user setup in `provider-proxy/Dockerfile` to fix permission errors.
> 
>   - **Dockerfile Changes**:
>     - Remove `useradd` command and `USER provider-proxy` directive from `provider-proxy/Dockerfile`.
>     - This change should fix permission errors by using the default user.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4b237ba0f5bc566ff4aa1689534b2aea67f8515c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->