### PR TITLE
Set UID and GID when running provider-proxy

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Run live tests container via Docker Compose
         run: |
-          UID=$(id -u) GID=$(id -g) docker compose -f tensorzero-core/tests/e2e/docker-compose.live.yml run --rm -e TENSORZERO_CI=1 live-tests
+          DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) docker compose -f tensorzero-core/tests/e2e/docker-compose.live.yml run --rm -e TENSORZERO_CI=1 live-tests
 
       - name: Print live tests logs
         if: always()

--- a/tensorzero-core/tests/e2e/docker-compose.live.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.live.yml
@@ -30,7 +30,7 @@ services:
       target: provider-proxy
     ports:
       - "3003:3003"
-    user: "${UID:-1000}:${GID:-1000}"
+    user: "${DOCKER_UID:-1000}:${DOCKER_GID:-1000}"
     volumes:
       # Mount cache directory for downloading cache files separately
       - ../../../ci/provider-proxy-cache:/app/ci/provider-proxy-cache


### PR DESCRIPTION
This should ensure that the files created inside the container are accessible by the host (when we upload them)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Set UID and GID for `provider-proxy` in Docker Compose to ensure host file accessibility.
> 
>   - **Docker Compose Configuration**:
>     - Set `user` to `${DOCKER_UID:-1000}:${DOCKER_GID:-1000}` for `provider-proxy` service in `docker-compose.live.yml` to ensure file accessibility by host.
>   - **GitHub Actions**:
>     - Update `merge-queue.yml` to set `DOCKER_UID` and `DOCKER_GID` environment variables when running live tests container.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 825e9d8e794fe2f422abeac0dedad5536e54355d. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->