### PR TITLE
Check for 'merge_group' event in 'merge-queue.yml' workflow

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.ref == 'refs/heads/main' && github.run_id || format('{0}-{1}', github.workflow, github.ref) }}
+  group: ${{ github.ref == 'refs/heads/main' && github.run_id || format('general-{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -13,7 +13,7 @@ on:
 # Otherwise, use the unique run id for the concurrency group, to prevent anything from getting cancelled
 # Note that the event will be 'merge_group' when general.yml calls this workflow via a 'workflow_call' event
 concurrency:
-  group: ${{ github.event_name == 'merge_group' && format('{0}-{1}', github.workflow, github.ref) || github.run_id }}
+  group: ${{ github.event_name == 'merge_group' && format('merge-queue-{0}-{1}', github.workflow, github.ref) || github.run_id }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
Apparently, when calling a 'workflow_call' workflow, the 'github.event_name' variable will be set to the original event: https://github.com/actions/runner/issues/3146

This should fix the provider-proxy cache not getting uploaded in the merge queue
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix `merge-queue.yml` to correctly handle `merge_group` event for concurrency and cache upload conditions.
> 
>   - **Behavior**:
>     - In `merge-queue.yml`, change concurrency group condition to check for `merge_group` event instead of `workflow_call`.
>     - Update cache upload conditions in `merge-queue.yml` to use `merge_group` event.
>     - Modify `check-all-general-jobs-passed` and `check-all-tests-passed` conditions to handle skipped jobs correctly when not a `pull_request` event.
>   - **Misc**:
>     - Update concurrency group format in `general.yml` to include 'general-' prefix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for af1c8eb29eedc24133df7d2619f14c817ddae586. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->