### PR TITLE
Use 'deferred_tasks' to spawn async write tasks

### DIFF
--- a/tensorzero-core/src/endpoints/inference.rs
+++ b/tensorzero-core/src/endpoints/inference.rs
@@ -565,6 +565,7 @@ async fn infer_variant(args: InferVariantArgs<'_>) -> Result<InferenceOutput, Er
     });
 
     if stream {
+        let deferred_tasks = inference_clients.deferred_tasks.clone();
         let result = variant
             .infer_stream(
                 resolved_input.clone(),
@@ -617,10 +618,12 @@ async fn infer_variant(args: InferVariantArgs<'_>) -> Result<InferenceOutput, Er
             inference_metadata,
             stream,
             clickhouse_connection_info.clone(),
+            deferred_tasks.clone(),
         );
 
         Ok(InferenceOutput::Streaming(Box::pin(stream)))
     } else {
+        let deferred_tasks = inference_clients.deferred_tasks.clone();
         let result = variant
             .infer(
                 Arc::clone(&resolved_input),
@@ -659,9 +662,7 @@ async fn infer_variant(args: InferVariantArgs<'_>) -> Result<InferenceOutput, Er
             // not be cancelled partway through execution if the outer '/inference' request
             // is cancelled. This reduces the chances that we only write to some tables and not others
             // (but this is inherently best-effort due to ClickHouse's lack of transactions).
-            // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
-            #[expect(clippy::disallowed_methods)]
-            let write_future = tokio::spawn(async move {
+            let write_future = deferred_tasks.spawn(async move {
                 let _: () = write_inference(
                     &clickhouse_connection_info,
                     &config,
@@ -777,6 +778,7 @@ fn create_stream(
     metadata: InferenceMetadata,
     mut stream: InferenceResultStream,
     clickhouse_connection_info: ClickHouseConnectionInfo,
+    deferred_tasks: TaskTracker,
 ) -> impl FusedStream<Item = Result<InferenceResponseChunk, Error>> + Send {
     async_stream::stream! {
         let mut buffer = vec![];
@@ -932,9 +934,7 @@ fn create_stream(
                 drop(clickhouse_connection_info);
             };
             if async_write {
-                // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
-                #[expect(clippy::disallowed_methods)]
-                tokio::spawn(write_future);
+                deferred_tasks.spawn(write_future);
             } else {
                 write_future.await;
             }


### PR DESCRIPTION
This ensures that we wait for these tasks to finish when the gateway shuts down
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use `deferred_tasks` for async write tasks in inference to ensure completion before gateway shutdown.
> 
>   - **Behavior**:
>     - Use `deferred_tasks` to spawn async write tasks in `infer_variant()` and `create_stream()`.
>     - Ensures async tasks complete before gateway shutdown.
>   - **Functions**:
>     - Modify `infer_variant()` to use `deferred_tasks.spawn()` for async writes.
>     - Update `create_stream()` to use `deferred_tasks.spawn()` for async writes.
>   - **Misc**:
>     - Remove `tokio::spawn()` in favor of `deferred_tasks.spawn()` in `inference.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 75448a2c0467060134ca6ad6cee01a3a5bc6a5cb. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->