### PR TITLE
Create v1 ListInferences and GetInferences in Rust library

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -26,7 +26,7 @@ slow-timeout = { period = "20s", terminate-after = 3 }
 # We also define cargo aliases for common use-cases (e.g. `cargo test-e2e`)
 [profile.e2e]
 retries = { backoff = "exponential", count = 4, delay = "5s", jitter = true, max-delay = "60s" }
-default-filter = "not (test(batch)) and not (test(test_dummy_only) | test(clickhouse) | test(db::))"
+default-filter = "not (test(batch) | test(test_dummy_only) | test(clickhouse) | test(db::) | test(export_bindings_) | test(export_schema_))"
 junit.path = "junit.xml"
 
 [profile.live-batch]

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -1416,6 +1416,7 @@ impl TensorZeroGateway {
     // The text_signature is a workaround to weird behavior in pyo3 where the default for an option
     // is written as an ellipsis object.
     #[expect(clippy::too_many_arguments)]
+    #[expect(deprecated)]
     fn experimental_list_inferences(
         this: PyRef<'_, Self>,
         function_name: String,
@@ -2527,6 +2528,7 @@ impl AsyncTensorZeroGateway {
     // The text_signature is a workaround to weird behavior in pyo3 where the default for an option
     // is written as an ellipsis object.
     #[expect(clippy::too_many_arguments)]
+    #[expect(deprecated)]
     fn experimental_list_inferences<'a>(
         this: PyRef<'a, Self>,
         function_name: String,

--- a/clients/rust/tests/test_stored_inferences.rs
+++ b/clients/rust/tests/test_stored_inferences.rs
@@ -1,0 +1,603 @@
+#![cfg(feature = "e2e_tests")]
+#![expect(clippy::unwrap_used)]
+use reqwest::Client as HttpClient;
+use serde_json::json;
+use tensorzero::test_helpers::get_gateway_endpoint;
+use tensorzero::{Client, ClientExt, InferenceOutputSource, ListInferencesRequest};
+use uuid::Uuid;
+
+// Helper function to create test inferences
+async fn create_test_inference(_client: &Client) -> Uuid {
+    let payload = json!({
+        "function_name": "basic_test",
+        "input": {
+            "system": {"assistant_name": "Assistant"},
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Hello"
+                }
+            ]
+        },
+        "stream": false,
+    });
+
+    let response = HttpClient::new()
+        .post(get_gateway_endpoint("/inference"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+
+    let response_json: serde_json::Value = response.json().await.unwrap();
+    let inference_id_str = response_json["inference_id"].as_str().unwrap();
+    Uuid::parse_str(inference_id_str).unwrap()
+}
+
+// ============================================================================
+// Get Inferences Tests
+// ============================================================================
+
+/// Test retrieving inferences by IDs
+async fn test_get_inferences_by_ids(client: Client) {
+    // Create some test inferences first
+    let _id1 = create_test_inference(&client).await;
+    let _id2 = create_test_inference(&client).await;
+    let _id3 = create_test_inference(&client).await;
+
+    // Wait a bit for the inferences to be written to the database
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    // First list some existing inferences
+    let list_request = ListInferencesRequest {
+        function_name: Some("basic_test".to_string()),
+        variant_name: None,
+        episode_id: None,
+        output_source: InferenceOutputSource::Inference,
+        limit: Some(3),
+        offset: Some(0),
+        filter: None,
+        order_by: None,
+    };
+    let list_response = client.list_inferences(list_request).await.unwrap();
+
+    assert!(
+        !list_response.inferences.is_empty(),
+        "Expected at least some inferences to exist"
+    );
+
+    // Get the IDs of some existing inferences
+    let inference_ids: Vec<Uuid> = list_response
+        .inferences
+        .iter()
+        .map(|inf| match inf {
+            tensorzero::StoredInference::Chat(chat_inf) => chat_inf.inference_id,
+            tensorzero::StoredInference::Json(json_inf) => json_inf.inference_id,
+        })
+        .collect();
+
+    // Get inferences by IDs
+    let response = client
+        .get_inferences(
+            inference_ids.clone(),
+            None,
+            InferenceOutputSource::Inference,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.inferences.len(), inference_ids.len());
+
+    // Verify we got the correct inferences
+    let retrieved_ids: Vec<Uuid> = response
+        .inferences
+        .iter()
+        .map(|inf| match inf {
+            tensorzero::StoredInference::Chat(chat_inf) => chat_inf.inference_id,
+            tensorzero::StoredInference::Json(json_inf) => json_inf.inference_id,
+        })
+        .collect();
+
+    for id in &inference_ids {
+        assert!(retrieved_ids.contains(id));
+    }
+}
+
+tensorzero::make_gateway_test_functions!(test_get_inferences_by_ids);
+
+/// Test getting inferences with empty ID list
+async fn test_get_inferences_empty_ids(client: Client) {
+    let response = client
+        .get_inferences(vec![], None, InferenceOutputSource::Inference)
+        .await
+        .unwrap();
+
+    assert_eq!(response.inferences.len(), 0);
+}
+
+tensorzero::make_gateway_test_functions!(test_get_inferences_empty_ids);
+
+/// Test getting inferences with unknown IDs
+async fn test_get_inferences_unknown_ids(client: Client) {
+    let unknown_id = Uuid::now_v7();
+
+    let response = client
+        .get_inferences(vec![unknown_id], None, InferenceOutputSource::Inference)
+        .await
+        .unwrap();
+
+    assert_eq!(response.inferences.len(), 0);
+}
+
+tensorzero::make_gateway_test_functions!(test_get_inferences_unknown_ids);
+
+/// Test getting inferences with function_name parameter for better performance
+async fn test_get_inferences_with_function_name(client: Client) {
+    // Create some test inferences first
+    let _id1 = create_test_inference(&client).await;
+    let _id2 = create_test_inference(&client).await;
+    let _id3 = create_test_inference(&client).await;
+
+    // Wait a bit for the inferences to be written to the database
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    // First, list some inferences to get their IDs
+    let list_request = ListInferencesRequest {
+        function_name: Some("basic_test".to_string()),
+        variant_name: None,
+        episode_id: None,
+        output_source: InferenceOutputSource::Inference,
+        limit: Some(3),
+        offset: Some(0),
+        filter: None,
+        order_by: None,
+    };
+    let list_response = client.list_inferences(list_request).await.unwrap();
+    assert!(
+        !list_response.inferences.is_empty(),
+        "Should have at least one inference"
+    );
+
+    // Get the inference IDs
+    let inference_ids: Vec<_> = list_response
+        .inferences
+        .iter()
+        .map(|inf| match inf {
+            tensorzero::StoredInference::Chat(chat_inf) => chat_inf.inference_id,
+            tensorzero::StoredInference::Json(json_inf) => json_inf.inference_id,
+        })
+        .collect();
+
+    // Test get_inferences WITH function_name (should use optimized query)
+    let response_with_function = client
+        .get_inferences(
+            inference_ids.clone(),
+            Some("basic_test".to_string()),
+            InferenceOutputSource::Inference,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response_with_function.inferences.len(), inference_ids.len());
+
+    // Verify we got the correct inferences
+    for inference in &response_with_function.inferences {
+        let inference_id = match inference {
+            tensorzero::StoredInference::Chat(chat_inf) => chat_inf.inference_id,
+            tensorzero::StoredInference::Json(json_inf) => json_inf.inference_id,
+        };
+        assert!(inference_ids.contains(&inference_id));
+    }
+
+    // Test get_inferences WITHOUT function_name (should still work, but slower)
+    let response_without_function = client
+        .get_inferences(
+            inference_ids.clone(),
+            None,
+            InferenceOutputSource::Inference,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response_without_function.inferences.len(),
+        inference_ids.len()
+    );
+
+    // Both should return the same results
+    assert_eq!(
+        response_with_function.inferences.len(),
+        response_without_function.inferences.len()
+    );
+}
+
+tensorzero::make_gateway_test_functions!(test_get_inferences_with_function_name);
+
+// ============================================================================
+// List Inferences Tests
+// ============================================================================
+
+/// Test listing inferences with pagination
+async fn test_list_inferences_with_pagination(client: Client) {
+    // Create some test inferences first
+    for _ in 0..5 {
+        let _ = create_test_inference(&client).await;
+    }
+
+    // Wait a bit for the inferences to be written to the database
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    // List all inferences with default pagination
+    let request = ListInferencesRequest {
+        function_name: Some("basic_test".to_string()),
+        variant_name: None,
+        episode_id: None,
+        output_source: InferenceOutputSource::Inference,
+        limit: Some(100),
+        offset: Some(0),
+        filter: None,
+        order_by: None,
+    };
+    let response = client.list_inferences(request).await.unwrap();
+
+    assert!(
+        !response.inferences.is_empty(),
+        "Expected at least some inferences"
+    );
+    let total_count = response.inferences.len();
+
+    // List with limit
+    let request = ListInferencesRequest {
+        function_name: Some("basic_test".to_string()),
+        variant_name: None,
+        episode_id: None,
+        output_source: InferenceOutputSource::Inference,
+        limit: Some(2),
+        offset: Some(0),
+        filter: None,
+        order_by: None,
+    };
+    let response = client.list_inferences(request).await.unwrap();
+
+    assert!(
+        response.inferences.len() <= 2,
+        "Limit should cap the results at 2"
+    );
+
+    // List with offset (only if we have enough inferences)
+    if total_count > 2 {
+        let request = ListInferencesRequest {
+            function_name: Some("basic_test".to_string()),
+            variant_name: None,
+            episode_id: None,
+            output_source: InferenceOutputSource::Inference,
+            limit: Some(100),
+            offset: Some(2),
+            filter: None,
+            order_by: None,
+        };
+        let response = client.list_inferences(request).await.unwrap();
+
+        assert!(
+            !response.inferences.is_empty(),
+            "Expected at least some inferences with offset"
+        );
+    }
+}
+
+tensorzero::make_gateway_test_functions!(test_list_inferences_with_pagination);
+
+/// Test listing inferences by function name
+async fn test_list_inferences_by_function(client: Client) {
+    // Create some test inferences first
+    for _ in 0..3 {
+        let _ = create_test_inference(&client).await;
+    }
+
+    // Wait a bit for the inferences to be written to the database
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    // List inferences for basic_test with filtering
+    let request = ListInferencesRequest {
+        function_name: Some("basic_test".to_string()),
+        variant_name: None,
+        episode_id: None,
+        output_source: InferenceOutputSource::Inference,
+        limit: Some(100),
+        offset: Some(0),
+        filter: None,
+        order_by: None,
+    };
+    let response = client.list_inferences(request).await.unwrap();
+
+    // Verify all returned inferences are from basic_test
+    assert!(
+        !response.inferences.is_empty(),
+        "Expected at least some inferences"
+    );
+    for inference in &response.inferences {
+        let function_name = match inference {
+            tensorzero::StoredInference::Chat(chat_inf) => &chat_inf.function_name,
+            tensorzero::StoredInference::Json(json_inf) => &json_inf.function_name,
+        };
+        assert_eq!(function_name, "basic_test");
+    }
+}
+
+tensorzero::make_gateway_test_functions!(test_list_inferences_by_function);
+
+/// Test listing inferences by variant name
+async fn test_list_inferences_by_variant(client: Client) {
+    // Create some test inferences first
+    for _ in 0..3 {
+        let _ = create_test_inference(&client).await;
+    }
+
+    // Wait a bit for the inferences to be written to the database
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    // First get existing inferences to find a variant name
+    let list_request = ListInferencesRequest {
+        function_name: Some("basic_test".to_string()),
+        variant_name: None,
+        episode_id: None,
+        output_source: InferenceOutputSource::Inference,
+        limit: Some(1),
+        offset: Some(0),
+        filter: None,
+        order_by: None,
+    };
+    let list_response = client.list_inferences(list_request).await.unwrap();
+
+    assert!(
+        !list_response.inferences.is_empty(),
+        "Expected at least some inferences to exist"
+    );
+
+    // Get the variant name from the first inference
+    let variant_name = match &list_response.inferences[0] {
+        tensorzero::StoredInference::Chat(chat_inf) => &chat_inf.variant_name,
+        tensorzero::StoredInference::Json(json_inf) => &json_inf.variant_name,
+    };
+
+    // List inferences for that specific variant
+    let request = ListInferencesRequest {
+        function_name: Some("basic_test".to_string()),
+        variant_name: Some(variant_name.clone()),
+        episode_id: None,
+        output_source: InferenceOutputSource::Inference,
+        limit: Some(100),
+        offset: Some(0),
+        filter: None,
+        order_by: None,
+    };
+    let response = client.list_inferences(request).await.unwrap();
+
+    // Verify all returned inferences are from the specified variant
+    assert!(
+        !response.inferences.is_empty(),
+        "Expected at least some inferences with this variant"
+    );
+    for inference in &response.inferences {
+        let inf_variant_name = match inference {
+            tensorzero::StoredInference::Chat(chat_inf) => &chat_inf.variant_name,
+            tensorzero::StoredInference::Json(json_inf) => &json_inf.variant_name,
+        };
+        assert_eq!(inf_variant_name, variant_name);
+    }
+}
+
+tensorzero::make_gateway_test_functions!(test_list_inferences_by_variant);
+
+/// Test listing inferences by episode ID
+async fn test_list_inferences_by_episode(client: Client) {
+    // Create some test inferences first
+    for _ in 0..3 {
+        let _ = create_test_inference(&client).await;
+    }
+
+    // Wait a bit for the inferences to be written to the database
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    // First get an existing inference to extract an episode_id
+    let list_request = ListInferencesRequest {
+        function_name: Some("basic_test".to_string()),
+        variant_name: None,
+        episode_id: None,
+        output_source: InferenceOutputSource::Inference,
+        limit: Some(100),
+        offset: Some(0),
+        filter: None,
+        order_by: None,
+    };
+    let list_response = client.list_inferences(list_request).await.unwrap();
+
+    assert!(
+        !list_response.inferences.is_empty(),
+        "Expected at least some inferences to exist"
+    );
+
+    // Get an episode_id from one of the existing inferences
+    let episode_id = match &list_response.inferences[0] {
+        tensorzero::StoredInference::Chat(chat_inf) => chat_inf.episode_id,
+        tensorzero::StoredInference::Json(json_inf) => json_inf.episode_id,
+    };
+
+    // List inferences by episode ID
+    let request = ListInferencesRequest {
+        function_name: None,
+        variant_name: None,
+        episode_id: Some(episode_id),
+        output_source: InferenceOutputSource::Inference,
+        limit: Some(100),
+        offset: Some(0),
+        filter: None,
+        order_by: None,
+    };
+    let response = client.list_inferences(request).await.unwrap();
+
+    assert!(
+        !response.inferences.is_empty(),
+        "Expected at least one inference with this episode_id"
+    );
+
+    // Verify all inferences have the correct episode ID
+    for inference in &response.inferences {
+        let inf_episode_id = match inference {
+            tensorzero::StoredInference::Chat(chat_inf) => chat_inf.episode_id,
+            tensorzero::StoredInference::Json(json_inf) => json_inf.episode_id,
+        };
+        assert_eq!(inf_episode_id, episode_id);
+    }
+}
+
+tensorzero::make_gateway_test_functions!(test_list_inferences_by_episode);
+
+/// Test listing inferences with ordering
+async fn test_list_inferences_with_ordering(client: Client) {
+    // Create some test inferences first
+    for _ in 0..5 {
+        let _ = create_test_inference(&client).await;
+        // Add a small delay to ensure different timestamps
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    }
+
+    // Wait a bit for the inferences to be written to the database
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    // List inferences ordered by timestamp descending
+    let request = ListInferencesRequest {
+        function_name: Some("basic_test".to_string()),
+        variant_name: None,
+        episode_id: None,
+        output_source: InferenceOutputSource::Inference,
+        limit: Some(10),
+        offset: Some(0),
+        filter: None,
+        order_by: Some(vec![tensorzero::OrderBy {
+            term: tensorzero::OrderByTerm::Timestamp,
+            direction: tensorzero::OrderDirection::Desc,
+        }]),
+    };
+    let response = client.list_inferences(request).await.unwrap();
+
+    assert!(!response.inferences.is_empty());
+
+    // Verify timestamps are in descending order
+    let timestamps: Vec<_> = response
+        .inferences
+        .iter()
+        .map(|inf| match inf {
+            tensorzero::StoredInference::Chat(chat_inf) => chat_inf.timestamp,
+            tensorzero::StoredInference::Json(json_inf) => json_inf.timestamp,
+        })
+        .collect();
+
+    for i in 0..timestamps.len().saturating_sub(1) {
+        assert!(
+            timestamps[i] >= timestamps[i + 1],
+            "Timestamps should be in descending order"
+        );
+    }
+}
+
+tensorzero::make_gateway_test_functions!(test_list_inferences_with_ordering);
+
+/// Test listing inferences with tags filter
+async fn test_list_inferences_with_tag_filter(client: Client) {
+    // Create an inference with a specific tag
+    let payload = json!({
+        "function_name": "basic_test",
+        "input": {
+            "system": {"assistant_name": "Assistant"},
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Hello with tags"
+                }
+            ]
+        },
+        "stream": false,
+        "tags": {
+            "test_key": "test_value"
+        }
+    });
+
+    let _response = HttpClient::new()
+        .post(get_gateway_endpoint("/inference"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+
+    // Wait a bit for the inferences to be written to the database
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    // First get existing inferences to find one with tags
+    let list_request = ListInferencesRequest {
+        function_name: Some("basic_test".to_string()),
+        variant_name: None,
+        episode_id: None,
+        output_source: InferenceOutputSource::Inference,
+        limit: Some(100),
+        offset: Some(0),
+        filter: None,
+        order_by: None,
+    };
+    let list_response = client.list_inferences(list_request).await.unwrap();
+
+    assert!(
+        !list_response.inferences.is_empty(),
+        "Expected at least some inferences to exist"
+    );
+
+    // Find an inference with tags
+    let inference_with_tags = list_response.inferences.iter().find(|inf| match inf {
+        tensorzero::StoredInference::Chat(chat_inf) => !chat_inf.tags.is_empty(),
+        tensorzero::StoredInference::Json(json_inf) => !json_inf.tags.is_empty(),
+    });
+
+    // If we found an inference with tags, test filtering by one of its tags
+    if let Some(inference) = inference_with_tags {
+        let (key, value) = match inference {
+            tensorzero::StoredInference::Chat(chat_inf) => chat_inf.tags.iter().next().unwrap(),
+            tensorzero::StoredInference::Json(json_inf) => json_inf.tags.iter().next().unwrap(),
+        };
+
+        // List inferences filtered by tag
+        let request = ListInferencesRequest {
+            function_name: Some("basic_test".to_string()),
+            variant_name: None,
+            episode_id: None,
+            output_source: InferenceOutputSource::Inference,
+            limit: Some(100),
+            offset: Some(0),
+            filter: Some(tensorzero::InferenceFilter::Tag(tensorzero::TagFilter {
+                key: key.clone(),
+                value: value.clone(),
+                comparison_operator: tensorzero::TagComparisonOperator::Equal,
+            })),
+            order_by: None,
+        };
+        let response = client.list_inferences(request).await.unwrap();
+
+        // Verify all returned inferences have the tag
+        assert!(
+            !response.inferences.is_empty(),
+            "Expected at least some inferences with this tag"
+        );
+        for inference in &response.inferences {
+            let inf_tags = match inference {
+                tensorzero::StoredInference::Chat(chat_inf) => &chat_inf.tags,
+                tensorzero::StoredInference::Json(json_inf) => &json_inf.tags,
+            };
+            assert_eq!(
+                inf_tags.get(key),
+                Some(value),
+                "All returned inferences should have the {key}={value} tag",
+            );
+        }
+    }
+}
+
+tensorzero::make_gateway_test_functions!(test_list_inferences_with_tag_filter);

--- a/clients/rust/tests/tests.rs
+++ b/clients/rust/tests/tests.rs
@@ -10,6 +10,7 @@ use tensorzero::{
 use tensorzero_core::inference::types::{Arguments, StoredInput};
 
 mod test_datasets;
+mod test_stored_inferences;
 
 lazy_static::lazy_static! {
     static ref GATEWAY_URL: String = std::env::var("TENSORZERO_GATEWAY_URL").unwrap_or_else(|_|"http://localhost:3000".to_string());

--- a/internal/tensorzero-node/lib/bindings/GetInferencesRequest.ts
+++ b/internal/tensorzero-node/lib/bindings/GetInferencesRequest.ts
@@ -11,6 +11,12 @@ export type GetInferencesRequest = {
    */
   ids: Array<string>;
   /**
+   * Optional function name to filter by.
+   * Including this improves query performance since `function_name` is the first column
+   * in the ClickHouse primary key.
+   */
+  function_name?: string;
+  /**
    * Source of the inference output.
    * Determines whether to return the original inference output or demonstration feedback
    * (manually-curated output) if available.

--- a/tensorzero-core/src/endpoints/stored_inferences/v1/get_inferences.rs
+++ b/tensorzero-core/src/endpoints/stored_inferences/v1/get_inferences.rs
@@ -29,7 +29,7 @@ pub async fn get_inferences_handler(
     Ok(Json(response))
 }
 
-async fn get_inferences(
+pub async fn get_inferences(
     config: &Config,
     clickhouse: &impl InferenceQueries,
     request: GetInferencesRequest,
@@ -41,6 +41,7 @@ async fn get_inferences(
 
     let params = ListInferencesParams {
         ids: Some(&request.ids),
+        function_name: request.function_name.as_deref(),
         output_source: request.output_source,
         // Return all inferences matching the IDs.
         limit: Some(u64::MAX),
@@ -75,7 +76,7 @@ pub async fn list_inferences_handler(
     Ok(Json(response))
 }
 
-async fn list_inferences(
+pub async fn list_inferences(
     config: &Config,
     clickhouse: &impl InferenceQueries,
     request: ListInferencesRequest,
@@ -197,6 +198,7 @@ mod tests {
 
         let request = GetInferencesRequest {
             ids: vec![id1, id2],
+            function_name: None,
             output_source: InferenceOutputSource::Inference,
         };
 
@@ -217,6 +219,7 @@ mod tests {
 
         let request = GetInferencesRequest {
             ids: vec![],
+            function_name: None,
             output_source: InferenceOutputSource::Inference,
         };
 
@@ -244,6 +247,7 @@ mod tests {
 
         let request = GetInferencesRequest {
             ids: vec![id],
+            function_name: None,
             output_source: InferenceOutputSource::Inference,
         };
 
@@ -289,6 +293,7 @@ mod tests {
 
         let request = GetInferencesRequest {
             ids: vec![id],
+            function_name: None,
             output_source: InferenceOutputSource::Demonstration,
         };
 

--- a/tensorzero-core/src/endpoints/stored_inferences/v1/mod.rs
+++ b/tensorzero-core/src/endpoints/stored_inferences/v1/mod.rs
@@ -2,4 +2,6 @@ mod get_inferences;
 
 pub mod types;
 
-pub use get_inferences::{get_inferences_handler, list_inferences_handler};
+pub use get_inferences::{
+    get_inferences, get_inferences_handler, list_inferences, list_inferences_handler,
+};

--- a/tensorzero-core/src/endpoints/stored_inferences/v1/types.rs
+++ b/tensorzero-core/src/endpoints/stored_inferences/v1/types.rs
@@ -159,7 +159,7 @@ pub enum InferenceFilter {
 
 /// Request to list inferences with pagination and filters.
 /// Used by the `POST /v1/inferences/list_inferences` endpoint.
-#[derive(Debug, Deserialize, ts_rs::TS)]
+#[derive(Debug, Deserialize, Serialize, ts_rs::TS)]
 #[ts(export, optional_fields)]
 pub struct ListInferencesRequest {
     /// Optional function name to filter inferences by.
@@ -197,11 +197,17 @@ pub struct ListInferencesRequest {
 
 /// Request to get specific inferences by their IDs.
 /// Used by the `POST /v1/inferences/get_inferences` endpoint.
-#[derive(Debug, Deserialize, ts_rs::TS)]
-#[ts(export)]
+#[derive(Debug, Deserialize, Serialize, ts_rs::TS)]
+#[ts(export, optional_fields)]
 pub struct GetInferencesRequest {
     /// The IDs of the inferences to retrieve. Required.
     pub ids: Vec<Uuid>,
+
+    /// Optional function name to filter by.
+    /// Including this improves query performance since `function_name` is the first column
+    /// in the ClickHouse primary key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub function_name: Option<String>,
 
     /// Source of the inference output.
     /// Determines whether to return the original inference output or demonstration feedback
@@ -210,7 +216,7 @@ pub struct GetInferencesRequest {
 }
 
 /// Response containing the requested inferences.
-#[derive(Debug, Serialize, ts_rs::TS)]
+#[derive(Debug, Deserialize, Serialize, ts_rs::TS)]
 #[ts(export)]
 pub struct GetInferencesResponse {
     /// The retrieved inferences.

--- a/tensorzero-core/tests/e2e/experimental_list_inferences.rs
+++ b/tensorzero-core/tests/e2e/experimental_list_inferences.rs
@@ -1,3 +1,4 @@
+#![expect(deprecated)]
 /// E2E tests for the legacy experimental_list_inferences client method.
 /// TODO: fully deprecate and remove when v1 list_inferences is fully released.
 use chrono::DateTime;

--- a/tensorzero-core/tests/e2e/inference/tool_params.rs
+++ b/tensorzero-core/tests/e2e/inference/tool_params.rs
@@ -135,19 +135,19 @@ async fn test_inference_full_tool_params_round_trip() {
         &json!(false)
     );
 
-    // Step 3: Retrieve via list_inferences API (wire format with DynamicToolParams)
+    // Step 3: Retrieve via get_inferences API (wire format with DynamicToolParams)
     let client = make_embedded_gateway().await;
-    let stored_inferences = client
-        .experimental_list_inferences(tensorzero::ListInferencesParams {
-            function_name: Some("weather_helper"),
-            ids: Some(&[inference_id]),
-            ..Default::default()
-        })
+    let response = client
+        .get_inferences(
+            vec![inference_id],
+            Some("weather_helper".to_string()),
+            tensorzero::InferenceOutputSource::Inference,
+        )
         .await
         .unwrap();
 
-    assert_eq!(stored_inferences.len(), 1);
-    let tensorzero::StoredInference::Chat(stored_inference) = &stored_inferences[0] else {
+    assert_eq!(response.inferences.len(), 1);
+    let tensorzero::StoredInference::Chat(stored_inference) = &response.inferences[0] else {
         panic!("Expected Chat inference");
     };
 
@@ -225,16 +225,16 @@ async fn test_inference_only_static_tools() {
 
     // Retrieve via API
     let client = make_embedded_gateway().await;
-    let stored_inferences = client
-        .experimental_list_inferences(tensorzero::ListInferencesParams {
-            function_name: Some("weather_helper"),
-            ids: Some(&[inference_id]),
-            ..Default::default()
-        })
+    let response = client
+        .get_inferences(
+            vec![inference_id],
+            Some("weather_helper".to_string()),
+            tensorzero::InferenceOutputSource::Inference,
+        )
         .await
         .unwrap();
 
-    let tensorzero::StoredInference::Chat(stored_inference) = &stored_inferences[0] else {
+    let tensorzero::StoredInference::Chat(stored_inference) = &response.inferences[0] else {
         panic!("Expected Chat inference");
     };
 
@@ -315,16 +315,16 @@ async fn test_inference_only_dynamic_tools() {
 
     // Retrieve via API
     let client = make_embedded_gateway().await;
-    let stored_inferences = client
-        .experimental_list_inferences(tensorzero::ListInferencesParams {
-            function_name: Some("weather_helper"),
-            ids: Some(&[inference_id]),
-            ..Default::default()
-        })
+    let response = client
+        .get_inferences(
+            vec![inference_id],
+            Some("weather_helper".to_string()),
+            tensorzero::InferenceOutputSource::Inference,
+        )
         .await
         .unwrap();
 
-    let tensorzero::StoredInference::Chat(stored_inference) = &stored_inferences[0] else {
+    let tensorzero::StoredInference::Chat(stored_inference) = &response.inferences[0] else {
         panic!("Expected Chat inference");
     };
 
@@ -457,16 +457,16 @@ async fn test_provider_tools_not_persisted() {
 
     // Retrieve via API
     let client = make_embedded_gateway().await;
-    let stored_inferences = client
-        .experimental_list_inferences(tensorzero::ListInferencesParams {
-            function_name: Some("weather_helper"),
-            ids: Some(&[inference_id]),
-            ..Default::default()
-        })
+    let response = client
+        .get_inferences(
+            vec![inference_id],
+            Some("weather_helper".to_string()),
+            tensorzero::InferenceOutputSource::Inference,
+        )
         .await
         .unwrap();
 
-    let tensorzero::StoredInference::Chat(stored_inference) = &stored_inferences[0] else {
+    let tensorzero::StoredInference::Chat(stored_inference) = &response.inferences[0] else {
         panic!("Expected Chat inference");
     };
 
@@ -543,16 +543,16 @@ async fn test_tool_strict_flag_preserved() {
 
     // Retrieve via API
     let client = make_embedded_gateway().await;
-    let stored_inferences = client
-        .experimental_list_inferences(tensorzero::ListInferencesParams {
-            function_name: Some("weather_helper"),
-            ids: Some(&[inference_id]),
-            ..Default::default()
-        })
+    let response = client
+        .get_inferences(
+            vec![inference_id],
+            Some("weather_helper".to_string()),
+            tensorzero::InferenceOutputSource::Inference,
+        )
         .await
         .unwrap();
 
-    let tensorzero::StoredInference::Chat(stored_inference) = &stored_inferences[0] else {
+    let tensorzero::StoredInference::Chat(stored_inference) = &response.inferences[0] else {
         panic!("Expected Chat inference");
     };
 
@@ -639,16 +639,16 @@ async fn test_allowed_tools_restriction() {
 
     // Retrieve via API
     let client = make_embedded_gateway().await;
-    let stored_inferences = client
-        .experimental_list_inferences(tensorzero::ListInferencesParams {
-            function_name: Some("weather_helper_parallel"),
-            ids: Some(&[inference_id]),
-            ..Default::default()
-        })
+    let response = client
+        .get_inferences(
+            vec![inference_id],
+            Some("weather_helper_parallel".to_string()),
+            tensorzero::InferenceOutputSource::Inference,
+        )
         .await
         .unwrap();
 
-    let tensorzero::StoredInference::Chat(stored_inference) = &stored_inferences[0] else {
+    let tensorzero::StoredInference::Chat(stored_inference) = &response.inferences[0] else {
         panic!("Expected Chat inference");
     };
 


### PR DESCRIPTION
This PR Adds the missing `list_inferences`​ and `get_inferences`​ APIs to the rust API, and deprecates `experimental_list_inferences`​.

Also adds an optional `function_name`​ parameter to `get_inferences`​ for performance reasons, since `function_name`​ is first in the sorting keys.

Fixes #4575.