### PR TITLE
Add 'has-merge-conflicts' label to PRs with merge conflicts

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -1,0 +1,22 @@
+name: "Add 'has-merge-conflicts' label to PRs with merge conflicts"
+on:
+  # So that PRs touching the same files as the push are updated
+  push:
+  # So that the `dirtyLabel` is removed if conflicts are resolve
+  # We recommend `pull_request_target` so that github secrets are available.
+  # In `pull_request` we wouldn't be able to change labels of fork PRs
+  pull_request_target:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check if prs are dirty
+        uses: eps1lon/actions-label-merge-conflict@1df065ebe6e3310545d4f4c4e862e43bdca146f0
+        with:
+          dirtyLabel: "has-merge-conflicts"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add GitHub Actions workflow to label PRs with merge conflicts using `eps1lon/actions-label-merge-conflict`.
> 
>   - **Workflow**:
>     - New workflow `label-merge-conflicts.yml` to label PRs with merge conflicts using `eps1lon/actions-label-merge-conflict`.
>     - Triggers on `push` and `pull_request_target` (synchronize) events.
>   - **Permissions**:
>     - Requires `pull-requests: write` permission to modify labels.
>   - **Labeling**:
>     - Uses `dirtyLabel: "has-merge-conflicts"` to mark conflicting PRs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for cfedbb8c44f5511f49146c1b5c53e0d145971f26. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->