### PR TITLE
Add `Error.underlying_status_code`

### DIFF
--- a/tensorzero-core/Cargo.toml
+++ b/tensorzero-core/Cargo.toml
@@ -124,7 +124,7 @@ pyo3 = { workspace = true, optional = true }
 google-cloud-auth = "1.1.0"
 mime = { workspace = true }
 mime_guess = "2.0.5"
-indexmap = "2.12.0"
+indexmap = { version = "2.12.0", features = ["serde"] }
 base64 = "0.22.1"
 thiserror = "2.0.16"
 globset = "0.4.18"

--- a/tensorzero-core/src/embeddings.rs
+++ b/tensorzero-core/src/embeddings.rs
@@ -1,6 +1,9 @@
+use std::collections::HashMap;
 use std::future::Future;
+use std::sync::Arc;
 use std::time::Duration;
-use std::{collections::HashMap, sync::Arc};
+
+use indexmap::IndexMap;
 
 use crate::cache::{
     embedding_cache_lookup, start_cache_write, CacheData, CacheValidationInfo, EmbeddingCacheData,
@@ -171,7 +174,7 @@ impl EmbeddingModelConfig {
         model_name: &str,
         clients: &InferenceClients,
     ) -> Result<EmbeddingModelResponse, Error> {
-        let mut provider_errors: HashMap<String, Error> = HashMap::new();
+        let mut provider_errors: IndexMap<String, Error> = IndexMap::new();
         let run_all_embedding_models = async {
             for provider_name in &self.routing {
                 let provider_config = self.providers.get(provider_name).ok_or_else(|| {

--- a/tensorzero-core/src/endpoints/batch_inference.rs
+++ b/tensorzero-core/src/endpoints/batch_inference.rs
@@ -3,6 +3,7 @@ use axum::extract::{Path, State};
 use axum::response::{IntoResponse, Response};
 use axum::{debug_handler, Extension, Json};
 use futures::future::{join_all, try_join_all};
+use indexmap::IndexMap;
 use itertools::{izip, Itertools};
 use metrics::counter;
 use serde::{Deserialize, Serialize};
@@ -222,7 +223,7 @@ pub async fn start_batch_inference(
     .increment(num_inferences as u64);
 
     // Keep track of which variants failed
-    let mut variant_errors = std::collections::HashMap::new();
+    let mut variant_errors = IndexMap::new();
 
     let cache_options = CacheOptions {
         max_age_s: None,

--- a/tensorzero-core/src/endpoints/inference.rs
+++ b/tensorzero-core/src/endpoints/inference.rs
@@ -6,6 +6,7 @@ use axum::{debug_handler, Extension, Json};
 use futures::stream::Stream;
 use futures::FutureExt;
 use futures_core::FusedStream;
+use indexmap::IndexMap;
 use metrics::counter;
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
@@ -352,7 +353,7 @@ pub async fn inference(
     let stream = params.stream.unwrap_or(false);
 
     // Keep track of which variants failed
-    let mut variant_errors: HashMap<String, Error> = HashMap::new();
+    let mut variant_errors: IndexMap<String, Error> = IndexMap::new();
 
     // Set up inference config
     let output_schema = params.output_schema.map(DynamicJSONSchema::new);

--- a/tensorzero-core/src/error/mod.rs
+++ b/tensorzero-core/src/error/mod.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
+use indexmap::IndexMap;
 use opentelemetry::trace::Status;
 use serde::{Serialize, Serializer};
 use serde_json::{json, Value};
@@ -134,6 +134,10 @@ impl Error {
         self.0.status_code()
     }
 
+    pub fn underlying_status_code(&self) -> Option<StatusCode> {
+        self.0.underlying_status_code()
+    }
+
     pub fn get_details(&self) -> &ErrorDetails {
         &self.0
     }
@@ -197,7 +201,8 @@ impl From<ErrorDetails> for Error {
 #[cfg_attr(any(test, feature = "e2e_tests"), derive(PartialEq))]
 pub enum ErrorDetails {
     AllVariantsFailed {
-        errors: HashMap<String, Error>,
+        // We use an `IndexMap` to preserve the insertion order for `underlying_status_code`
+        errors: IndexMap<String, Error>,
     },
     TensorZeroAuth {
         message: String,
@@ -466,7 +471,8 @@ pub enum ErrorDetails {
         model_name: String,
     },
     ModelProvidersExhausted {
-        provider_errors: HashMap<String, Error>,
+        // We use an `IndexMap` to preserve the insertion order for `underlying_status_code`
+        provider_errors: IndexMap<String, Error>,
     },
     ModelValidation {
         message: String,
@@ -585,7 +591,6 @@ pub enum ErrorDetails {
         method: String,
     },
 }
-
 impl ErrorDetails {
     /// Defines the error level for logging this error
     fn level(&self) -> tracing::Level {
@@ -708,6 +713,26 @@ impl ErrorDetails {
             ErrorDetails::UnsupportedVariantForStreamingInference { .. } => tracing::Level::WARN,
             ErrorDetails::UuidInFuture { .. } => tracing::Level::WARN,
             ErrorDetails::RouteNotFound { .. } => tracing::Level::WARN,
+        }
+    }
+
+    /// Returns the most recent 'underlying' status code for this error.
+    /// For example, if an inference fails due to all models failing, this will
+    /// return the status code of the last model that failed.
+    ///
+    /// Returns `None` if the error doesn't have a concept of a 'last' status code.
+    fn underlying_status_code(&self) -> Option<StatusCode> {
+        match self {
+            ErrorDetails::AllVariantsFailed { errors } => errors
+                .values()
+                .last()
+                .and_then(|error| error.underlying_status_code()),
+            ErrorDetails::InferenceClient { status_code, .. } => *status_code,
+            ErrorDetails::ModelProvidersExhausted { provider_errors } => provider_errors
+                .values()
+                .last()
+                .and_then(|error| error.underlying_status_code()),
+            _ => None,
         }
     }
 

--- a/tensorzero-core/src/model.rs
+++ b/tensorzero-core/src/model.rs
@@ -1,5 +1,6 @@
 use futures::future::try_join_all;
 use futures::StreamExt;
+use indexmap::IndexMap;
 use secrecy::SecretString;
 use serde_json::Value;
 use std::borrow::Cow;
@@ -393,7 +394,7 @@ impl ModelConfig {
         let span = tracing::Span::current();
         clients.otlp_config.mark_openinference_chain_span(&span);
 
-        let mut provider_errors: HashMap<String, Error> = HashMap::new();
+        let mut provider_errors: IndexMap<String, Error> = IndexMap::new();
         let run_all_models = async {
             for provider_name in &self.routing {
                 let provider = self.providers.get(provider_name).ok_or_else(|| {
@@ -498,7 +499,7 @@ impl ModelConfig {
         clients
             .otlp_config
             .mark_openinference_chain_span(&tracing::Span::current());
-        let mut provider_errors: HashMap<String, Error> = HashMap::new();
+        let mut provider_errors: IndexMap<String, Error> = IndexMap::new();
         let run_all_models = async {
             for provider_name in &self.routing {
                 let provider = self.providers.get(provider_name).ok_or_else(|| {
@@ -569,7 +570,7 @@ impl ModelConfig {
         client: &'request TensorzeroHttpClient,
         api_keys: &'request InferenceCredentials,
     ) -> Result<StartBatchModelInferenceResponse, Error> {
-        let mut provider_errors: HashMap<String, Error> = HashMap::new();
+        let mut provider_errors: IndexMap<String, Error> = IndexMap::new();
         for provider_name in &self.routing {
             let provider = self.providers.get(provider_name).ok_or_else(|| {
                 Error::new(ErrorDetails::ProviderNotFound {
@@ -2545,7 +2546,7 @@ mod tests {
         assert_eq!(
             response,
             ErrorDetails::ModelProvidersExhausted {
-                provider_errors: HashMap::from([(
+                provider_errors: IndexMap::from([(
                     "error".to_string(),
                     ErrorDetails::InferenceClient {
                         message: "Error sending request to Dummy provider for model 'error'."
@@ -2935,7 +2936,7 @@ mod tests {
         assert_eq!(
             error,
             ErrorDetails::ModelProvidersExhausted {
-                provider_errors: HashMap::from([(
+                provider_errors: IndexMap::from([(
                     "error".to_string(),
                     ErrorDetails::InferenceClient {
                         message: "Error sending request to Dummy provider for model 'error'."
@@ -3153,7 +3154,7 @@ mod tests {
         assert_eq!(
             error,
             ErrorDetails::ModelProvidersExhausted {
-                provider_errors: HashMap::from([(
+                provider_errors: IndexMap::from([(
                     "model".to_string(),
                     ErrorDetails::ApiKeyMissing {
                         provider_name: "Dummy".to_string(),
@@ -3194,7 +3195,7 @@ mod tests {
         assert_eq!(
             response,
             ErrorDetails::ModelProvidersExhausted {
-                provider_errors: HashMap::from([(
+                provider_errors: IndexMap::from([(
                     "model".to_string(),
                     ErrorDetails::InferenceClient {
                         message: "Invalid API key for Dummy provider".to_string(),
@@ -3276,7 +3277,7 @@ mod tests {
         assert_eq!(
             error,
             ErrorDetails::ModelProvidersExhausted {
-                provider_errors: HashMap::from([(
+                provider_errors: IndexMap::from([(
                     "model".to_string(),
                     ErrorDetails::ApiKeyMissing {
                         provider_name: "Dummy".to_string(),

--- a/tensorzero-core/src/variant/chat_completion/mod.rs
+++ b/tensorzero-core/src/variant/chat_completion/mod.rs
@@ -802,6 +802,7 @@ pub fn validate_all_schemas_have_templates(
 #[cfg(test)]
 mod tests {
     use crate::rate_limiting::ScopeInfo;
+    use indexmap::IndexMap;
     use std::collections::HashMap;
     use std::path::PathBuf;
 
@@ -1534,7 +1535,7 @@ mod tests {
         assert_eq!(
             *details,
             ErrorDetails::ModelProvidersExhausted {
-                provider_errors: HashMap::from([(
+                provider_errors: IndexMap::from([(
                     "error".to_string(),
                     Error::new(ErrorDetails::InferenceClient {
                         message: "Error sending request to Dummy provider for model 'error'."


### PR DESCRIPTION
This gives us the last error status in the case of a 'nested' error. For example, if all of the models fail with an HTTP error, then we'll return the status code of the last model request.

We don't use this yet, but we'll eventually expose those in some way in our error messages (either directly setting the HTTP response status, or exposing it as a field)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `underlying_status_code` to `Error` for retrieving last error status in nested errors and replace `HashMap` with `IndexMap` to preserve order.
> 
>   - **Error Handling**:
>     - Add `underlying_status_code()` to `Error` in `tensorzero-core/src/error/mod.rs` to retrieve the last error status code in nested errors.
>     - Implement `underlying_status_code()` in `ErrorDetails` for `AllVariantsFailed`, `InferenceClient`, and `ModelProvidersExhausted`.
>   - **Data Structures**:
>     - Replace `HashMap` with `IndexMap` in `tensorzero-core/src/embeddings.rs`, `tensorzero-core/src/endpoints/batch_inference.rs`, and `tensorzero-core/src/endpoints/inference.rs` to preserve insertion order for error tracking.
>   - **Miscellaneous**:
>     - Update `Cargo.toml` to include `serde` feature for `indexmap`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 137bbdc955451336d97e3ff5a0e1db55bb012534. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->