### PR TITLE
Leave a comment if user doesn't have permission for slash command

### DIFF
--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ github.event.issue.number }}
           body: |
             ❌ Only public members of the `tensorzero` organization can use slash commands
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a comment step in GitHub Actions to notify users without permission for slash commands.
> 
>   - **Behavior**:
>     - Adds a step in `.github/workflows/slash-command-dispatch.yml` to leave a comment if the user is not a public member of the `tensorzero` organization.
>     - Uses `peter-evans/create-or-update-comment` to post a comment on the pull request when permission check fails.
>   - **Conditions**:
>     - The comment is triggered if `steps.check-permission.outputs.ACTOR_MEMBER` is not equal to '1'.
>   - **Misc**:
>     - The comment body states: "❌ Only public members of the `tensorzero` organization can use slash commands".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3d1430b03e09ada27b70ad64133c3d1ba17c138b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->