### PR TITLE
Use HTTP updateDatapointMetadata API in frontend

### DIFF
--- a/ui/app/routes/datasets/$dataset_name/datapoint/$id/route.tsx
+++ b/ui/app/routes/datasets/$dataset_name/datapoint/$id/route.tsx
@@ -155,10 +155,10 @@ export async function action({ request }: ActionFunctionArgs) {
       }
     } else if (action === "rename") {
       await renameDatapoint({
-        functionType: functionType,
         datasetName: parsedFormData.dataset_name,
-        datapoint: parsedFormData,
-        newName: parsedFormData.name || "",
+        datapointId: parsedFormData.id,
+        // Explicitly set to null to unset the name
+        name: parsedFormData.name ?? null,
       });
       return data({ success: true });
     }

--- a/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/route.tsx
+++ b/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/route.tsx
@@ -60,7 +60,6 @@ import { useToast } from "~/hooks/use-toast";
 import { useEffect } from "react";
 import { AddToDatasetButton } from "~/components/dataset/AddToDatasetButton";
 import { logger } from "~/utils/logger";
-import { getDatapoint } from "~/utils/clickhouse/datasets.server";
 
 export const handle: RouteHandle = {
   crumb: (match) => [
@@ -188,31 +187,11 @@ export async function action({ request }: Route.ActionArgs) {
       const dataset_name = formData.get("dataset_name") as string;
       const newName = formData.get("newName") as string;
 
-      // We need to get the datapoint to pass to renameDatapoint
-      const datapoint = await getDatapoint({
-        dataset_name,
-        datapoint_id,
-        allow_stale: true,
-      });
-      if (!datapoint) {
-        return data(
-          {
-            success: false,
-            error:
-              "Datapoint not found; please file a bug report at https://github.com/tensorzero/tensorzero/discussions/new?category=bug-reports",
-          },
-          { status: 404 },
-        );
-      }
-
-      // A bit of a hack in the evaluation page, we don't have the function type in the datapoint, so we check if the datapoint contains an output schema (which indicates it's JSON).
-      const functionType = "output_schema" in datapoint ? "json" : "chat";
       await renameDatapoint({
-        functionType,
         datasetName: dataset_name,
-        // TODO: convert to Rust-generated bindings
-        datapoint,
-        newName,
+        datapointId: datapoint_id,
+        // Explicitly set to null to unset the name
+        name: newName ?? null,
       });
 
       return data({ success: true });

--- a/ui/app/utils/tensorzero/tensorzero.ts
+++ b/ui/app/utils/tensorzero/tensorzero.ts
@@ -1,5 +1,7 @@
 /*
 TensorZero Client (for internal use only for now)
+
+TODO(shuyangli): Figure out a way to generate the HTTP client, possibly from Schema.
 */
 
 import { z } from "zod";
@@ -10,7 +12,11 @@ import {
   type StoragePath,
 } from "~/utils/clickhouse/common";
 import { TensorZeroServerError } from "./errors";
-import type { Datapoint as TensorZeroDatapoint } from "~/types/tensorzero";
+import type {
+  Datapoint as TensorZeroDatapoint,
+  UpdateDatapointsMetadataRequest,
+  UpdateDatapointsResponse,
+} from "~/types/tensorzero";
 
 /**
  * Roles for input messages.
@@ -553,6 +559,23 @@ export class TensorZeroClient {
     }
     const body = await response.json();
     return body as TensorZeroDatapoint[];
+  }
+
+  async updateDatapointsMetadata(
+    datasetName: string,
+    datapoints: UpdateDatapointsMetadataRequest,
+  ): Promise<UpdateDatapointsResponse> {
+    const endpoint = `/v1/datasets/${encodeURIComponent(datasetName)}/datapoints/metadata`;
+    const response = await this.fetch(endpoint, {
+      method: "PATCH",
+      body: JSON.stringify(datapoints),
+    });
+    if (!response.ok) {
+      const message = await this.getErrorText(response);
+      this.handleHttpError({ message, response });
+    }
+    const body = (await response.json()) as UpdateDatapointsResponse;
+    return body;
   }
 
   async getObject(storagePath: StoragePath): Promise<string> {


### PR DESCRIPTION
This implements the HTTP `updateDatapointMetadata` API in the frontend, and replaces the current `renameDatapoint`​ implementation to use it instead of doing a `getDatapoint`​ + `updateDatapoint`​.

A step towards #3922 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `renameDatapoint` to use `updateDatapointsMetadata` API, updating related logic and tests.
> 
>   - **Behavior**:
>     - Refactor `renameDatapoint` in `datapointOperations.server.ts` to use `updateDatapointsMetadata` API, removing `functionType` and `datapoint` parameters.
>     - Update `action` functions in `route.tsx` and `evaluations/route.tsx` to call `renameDatapoint` with new parameters.
>   - **Tests**:
>     - Update tests in `datapointOperations.server.test.ts` to reflect changes in `renameDatapoint` parameters and logic.
>   - **API**:
>     - Add `updateDatapointsMetadata` method to `TensorZeroClient` in `tensorzero.ts` for updating datapoint metadata via HTTP PATCH.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 63eb88da5e465b476b6388f72dabb7c6050074a7. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->