### PR TITLE
Test against clickhouse lts on CI

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -567,7 +567,7 @@ jobs:
         # Only include replicated: true when running in merge queue
         replicated: ${{ github.event_name == 'merge_group' && fromJSON('[true, false]') || fromJSON('[false]') }}
         # TODO: Temporarily using 25.9 instead of latest
-        clickhouse_version: ${{ github.event_name == 'merge_group' && fromJSON('[{"tag":"24.12","prefix":"24.12","allow_failure":false},{"tag":"25.9","prefix":"25.9","allow_failure":false}]') || fromJSON('[{"tag":"25.9","prefix":"25.9","allow_failure":false}]') }}
+        clickhouse_version: ${{ github.event_name == 'merge_group' && fromJSON('[{"tag":"lts","prefix":"lts","allow_failure":false},{"tag":"25.9","prefix":"25.9","allow_failure":false}]') || fromJSON('[{"tag":"25.9","prefix":"25.9","allow_failure":false}]') }}
         exclude:
           # Use 25.7 instead of 25.9 for replicated tests in merge group
           - replicated: true

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         # TODO: Temporarily using 25.9-alpine instead of latest-alpine
-        clickhouse_version: ${{ inputs.is_merge_group && fromJSON('["24.12", "25.9"]') || fromJSON('["25.9"]') }}
+        clickhouse_version: ${{ inputs.is_merge_group && fromJSON('["lts", "25.9"]') || fromJSON('["25.9"]') }}
 
     steps:
       - name: Set DNS


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update CI workflows to test against ClickHouse LTS version instead of 25.9, with conditional logic for merge group events.
> 
>   - **CI Configuration**:
>     - Update `clickhouse_version` to use LTS version in `general.yml` and `ui-tests.yml`.
>     - Conditional logic for `clickhouse_version` based on `merge_group` event.
>   - **Files Affected**:
>     - `.github/workflows/general.yml`: Adjusts ClickHouse version matrix.
>     - `.github/workflows/ui-tests.yml`: Updates ClickHouse version for UI tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d77cc86d7c3485d94b5684d0e78dc710b544693c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->