### PR TITLE
Cleanup disk space in caching-hack workflow

### DIFF
--- a/.github/workflows/caching-hack.yml
+++ b/.github/workflows/caching-hack.yml
@@ -32,6 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Cleanup disk space
+        if: runner.os == 'Linux'
         run: ./ci/free-disk-space.sh
       - name: Install Rust toolchain
         run: |


### PR DESCRIPTION
This should prevent these jobs from randomly running out of disk space on CI and failing