### PR TITLE
Use fresh ClickHouse db for test_count_datasets

### DIFF
--- a/tensorzero-core/tests/e2e/db/dataset_queries.rs
+++ b/tensorzero-core/tests/e2e/db/dataset_queries.rs
@@ -575,7 +575,7 @@ async fn test_get_dataset_rows_pages_correctly() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_count_datasets() {
+async fn test_clickhouse_count_datasets() {
     let (clickhouse, _guard) = get_clean_clickhouse(false).await;
     let is_manual = clickhouse.is_cluster_configured();
     migration_manager::run(RunMigrationManagerArgs {


### PR DESCRIPTION
This prevents concurrent test executions from affecting the final count
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `test_count_datasets` now uses a fresh ClickHouse instance to prevent interference from concurrent test executions, ensuring accurate dataset count verification.
> 
>   - **Behavior**:
>     - `test_count_datasets` now uses a fresh ClickHouse instance via `get_clean_clickhouse` to prevent interference from concurrent test executions.
>     - Asserts initial dataset count is 0 and verifies count increases to 2 after inserting datasets.
>   - **Functions**:
>     - Uses `get_clean_clickhouse` in `test_count_datasets` to ensure a clean database state.
>     - Runs migrations using `migration_manager::run` with `RunMigrationManagerArgs` in `test_count_datasets`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7ff0715f99b47d900be20b105e3c1cb0c1d3d75e. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->