### PR TITLE
Double timeout for 'test_concurrent_requests_helper'

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -139,7 +139,7 @@ slow-timeout = { period = "900s", terminate-after = 1 }
 [[profile.default.overrides]]
 filter = 'test(test_concurrent_requests)'
 # This test creates and uses lots of `reqwest::Client`s, which can be slow
-slow-timeout = { period = "60s", terminate-after = 1 }
+slow-timeout = { period = "60s", terminate-after = 2 }
 
 [[profile.default.overrides]]
 # Settings for running unit tests


### PR DESCRIPTION
This test has been randomly timing out on CI, so let's give it more time
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Doubled `terminate-after` value for `test_concurrent_requests` in `.config/nextest.toml` to address CI timeouts.
> 
>   - **Configuration**:
>     - Doubled `terminate-after` value from 1 to 2 for `test_concurrent_requests` in `.config/nextest.toml` to address CI timeouts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4f2d042017d99aa2cf24ad7f300a3df7c728f240. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->