### PR TITLE
By default do not run schema export tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,7 +9,7 @@ slow-timeout = { period = "10s", terminate-after = 3 }
 # We don't have a good way of isolating these tests to ensure that they pass
 # on developer machines (with AWS credentials set up), so we exclude them by default.
 # On CI, we use the 'ci' profile, which runs all tests.
-default-filter = "not test(no_aws_credentials)"
+default-filter = "not (test(no_aws_credentials) | test(export_bindings_) | test(export_schema_))"
 
 [[profile.default.overrides]]
 filter = 'test(evaluations)'
@@ -143,7 +143,7 @@ slow-timeout = { period = "60s", terminate-after = 1 }
 
 [[profile.default.overrides]]
 # Settings for running unit tests
-filter = 'not binary(e2e)'
+filter = 'not (binary(e2e) | test(export_bindings_) | test(export_schema_))'
 retries = 0
 slow-timeout = { period = "10s", terminate-after = 1 }
 


### PR DESCRIPTION
`cargo test-unit` was generating these schemas and polluting the staging area.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Exclude `export_bindings_` and `export_schema_` tests by default in `.config/nextest.toml` to prevent staging area pollution during `cargo test-unit`.
> 
>   - **Behavior**:
>     - Updates `default-filter` in `.config/nextest.toml` to exclude `export_bindings_` and `export_schema_` tests by default.
>     - Prevents schema export tests from running during `cargo test-unit`, avoiding staging area pollution.
>   - **Configuration**:
>     - Modifies `profile.default.overrides` filter to exclude `export_bindings_` and `export_schema_` tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 64e6498d21e9fd66ac0c888343570f8aebba22f5. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->