### PR TITLE
Split out Python validation into separate ubuntu-latest job

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -351,6 +351,97 @@ jobs:
         run: |
           cargo hack --partition '${{ matrix.partition }}/${{ matrix.total_partitions }}' clippy --all-targets --each-feature -- -D warnings
 
+
+  validate-python:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      # We deliberately install our MSRV here (rather than 'stable') to ensure that everything compiles with that version
+      - name: Install Rust ${{ env.RUST_MSRV }}
+        run: |
+          for attempt in 1 2 3; do
+            if rustup install ${{ env.RUST_MSRV }} --component rustfmt && rustup default ${{ env.RUST_MSRV }}; then
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "Failed to install Rust ${{ env.RUST_MSRV }} after 3 attempts"
+              exit 1
+            fi
+            sleep $((10 * attempt))
+          done
+        shell: bash
+
+      - name: Print Rust version
+        run: rustc --version
+
+      - name: Install uv
+        run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
+
+      - name: uv-lock
+        run: |
+          bash -c '
+          git ls-files "**/pyproject.toml" \
+            | while read f; do
+                dir=$(dirname "$f")
+                (cd "$dir" && uv lock --project="pyproject.toml")
+              done
+          '
+
+      - name: uv-export
+        run: |
+          bash -c '
+          git ls-files "**/pyproject.toml" \
+            | while read f; do
+                dir=$(dirname "$f")
+                (cd "$dir" && uv export --project="pyproject.toml" --output-file=requirements.txt --quiet)
+              done
+          '
+      - name: verify uv generated files
+        run: git diff --exit-code
+
+      - name: Install Python for python async client tests
+        run: uv python install 3.9
+
+      - name: Lint (Python:ruff)
+        run: |
+          uvx ruff@0.14.0 check --output-format=github --extend-select I .
+          uvx ruff@0.14.0 format --check .
+
+      - name: "Python: Pyo3 Client: Build and install dependencies"
+        working-directory: clients/python
+        run: |
+          uv venv
+          uv pip sync requirements.txt
+
+      - name: "Python: PyO3 Client: pyright"
+        working-directory: clients/python
+        run: |
+          uv pip install pyright==1.1.394
+          uv run pyright
+
+      - name: "Python: PyO3 Client: stubtest"
+        working-directory: clients/python
+        run: |
+          uv run stubtest tensorzero.tensorzero
+
+      - name: "Python: Recipes: Install dependencies"
+        working-directory: recipes
+        run: |
+          uv venv
+          uv sync
+
+      - name: "Python: Recipes: pyright"
+        working-directory: recipes
+        run: |
+          uv run pyright
+
+      - name: Compile / validate notebooks
+        run: ci/compile-check-notebooks.sh
+
+
   validate-node:
     permissions:
       contents: read
@@ -519,28 +610,6 @@ jobs:
       # - name: trailing‑whitespace
       #   run: uv run --with pre-commit pre-commit run trailing-whitespace
 
-      - name: uv-lock
-        run: |
-          bash -c '
-          git ls-files "**/pyproject.toml" \
-            | while read f; do
-                dir=$(dirname "$f")
-                (cd "$dir" && uv lock --project="pyproject.toml")
-              done
-          '
-
-      - name: uv-export
-        run: |
-          bash -c '
-          git ls-files "**/pyproject.toml" \
-            | while read f; do
-                dir=$(dirname "$f")
-                (cd "$dir" && uv export --project="pyproject.toml" --output-file=requirements.txt --quiet)
-              done
-          '
-      - name: verify uv generated files
-        run: git diff --exit-code
-
       # TODO: Enable this if we can figure out the invocation
       # - name: Run nb-clean
       #   run: uv run --with nb-clean nb-clean check --remove-empty-cells
@@ -566,31 +635,6 @@ jobs:
         run: |
           cargo test-unit ${{ vars.CARGO_NEXTEST_EXTRA_ARGS }}
 
-      - name: Install Python for python async client tests
-        run: uv python install 3.9
-
-      - name: Lint (Python:ruff)
-        run: |
-          uvx ruff@0.14.0 check --output-format=github --extend-select I .
-          uvx ruff@0.14.0 format --check .
-
-      - name: "Python: Pyo3 Client: Build and install dependencies"
-        working-directory: clients/python
-        run: |
-          uv venv
-          uv pip sync requirements.txt
-
-      - name: "Python: PyO3 Client: pyright"
-        working-directory: clients/python
-        run: |
-          uv pip install pyright==1.1.394
-          uv run pyright
-
-      - name: "Python: PyO3 Client: stubtest"
-        working-directory: clients/python
-        run: |
-          uv run stubtest tensorzero.tensorzero
-
       - name: "Node.js: Run prettier"
         run: pnpm --filter=openai-node run format
 
@@ -600,20 +644,6 @@ jobs:
       - name: "Node.js: OpenAI Client: lint"
         working-directory: clients/openai-node
         run: pnpm --filter=openai-node run lint
-
-      - name: "Python: Recipes: Install dependencies"
-        working-directory: recipes
-        run: |
-          uv venv
-          uv sync
-
-      - name: "Python: Recipes: pyright"
-        working-directory: recipes
-        run: |
-          uv run pyright
-
-      - name: Compile / validate notebooks
-        run: ci/compile-check-notebooks.sh
 
       - name: Lint Helm charts
         run: find . -name "Chart.yaml" -exec dirname {} \; | xargs -I {} helm lint {}
@@ -970,6 +1000,7 @@ jobs:
         build-gateway-e2e-container,
         validate,
         validate-node,
+        validate-python,
         lint-rust,
         clickhouse-tests,
         ui-tests,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Splits Python validation into a separate `validate-python` job in the GitHub Actions workflow, enhancing modularity and focus.
> 
>   - **Workflow Changes**:
>     - Introduces `validate-python` job in `general.yml` to handle Python validation tasks separately.
>     - Removes Python validation steps from the `validate` job.
>   - **Python Validation**:
>     - Installs Rust MSRV and prints version.
>     - Installs `uv` and performs `uv-lock` and `uv-export` operations on `pyproject.toml` files.
>     - Installs Python 3.9 and runs `ruff` linting.
>     - Builds and installs dependencies for PyO3 client and recipes, runs `pyright` and `stubtest`.
>     - Compiles and validates notebooks.
>   - **Misc**:
>     - Adds `validate-python` to the list of jobs in `check-all-general-jobs-passed`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8901212f85f60d83bd82b27a4680d62e47b21392. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->