### PR TITLE
Push limit down into inference subqueries

### DIFF
--- a/tensorzero-core/src/db/clickhouse/inference_queries.rs
+++ b/tensorzero-core/src/db/clickhouse/inference_queries.rs
@@ -160,12 +160,9 @@ pub(crate) fn generate_list_inferences_sql(
             json_sql.push('\n');
             json_sql.push_str(&json_query.where_sql_fragment);
 
-            // Combine with UNION ALL
-            let combined_query = format!("{chat_sql}\nUNION ALL\n{json_sql}");
-
-            // For UNION ALL queries, use simplified ORDER BY
-            // We need to wrap in a subquery to ensure ORDER BY applies to the combined result
-            let combined = if let Some(order_by) = opts.order_by {
+            // Generate ORDER BY clause for both inner and outer queries
+            // For UNION ALL queries, we only support timestamp ordering (not metrics)
+            let order_by_sql = if let Some(order_by) = opts.order_by {
                 let order_clauses: Vec<String> = order_by
                     .iter()
                     .map(|o| {
@@ -184,37 +181,85 @@ pub(crate) fn generate_list_inferences_sql(
                     .collect::<Result<Vec<_>, Error>>()?;
 
                 if order_clauses.is_empty() {
-                    combined_query
+                    String::new()
                 } else {
-                    format!(
-                        "SELECT * FROM (\n{}\n) AS combined\nORDER BY {}",
-                        combined_query,
-                        order_clauses.join(", ")
-                    )
+                    format!("\nORDER BY {}", order_clauses.join(", "))
                 }
             } else {
-                combined_query
+                String::new()
             };
 
-            combined
+            // Push LIMIT down into each subquery before UNION ALL
+            // For UNION ALL, we need to fetch (LIMIT + OFFSET) rows from each table
+            // because we don't know which table will contribute to the final result.
+            // We then apply the final LIMIT/OFFSET on the outer query.
+            //
+            // IMPORTANT: When ORDER BY is specified, we add it to each subquery before the LIMIT.
+            // Otherwise, the LIMIT will select rows based on the physical table ordering
+            // (function_name, variant_name, episode_id), not the user's requested ordering
+            // (e.g., timestamp DESC), resulting in incorrect results.
+            let inner_limit = opts.limit + opts.offset;
+
+            if !order_by_sql.is_empty() {
+                chat_sql.push_str(&order_by_sql);
+            }
+            let chat_limit_param_placeholder = add_parameter(
+                inner_limit,
+                ClickhouseType::UInt64,
+                &mut query_params,
+                &mut param_idx_counter,
+            );
+            chat_sql.push_str(&format!("\nLIMIT {chat_limit_param_placeholder}"));
+
+            if !order_by_sql.is_empty() {
+                json_sql.push_str(&order_by_sql);
+            }
+            let json_limit_param_placeholder = add_parameter(
+                inner_limit,
+                ClickhouseType::UInt64,
+                &mut query_params,
+                &mut param_idx_counter,
+            );
+            json_sql.push_str(&format!("\nLIMIT {json_limit_param_placeholder}"));
+
+            // Combine with UNION ALL and apply outer ORDER BY and LIMIT/OFFSET
+            let outer_limit_param_placeholder = add_parameter(
+                opts.limit,
+                ClickhouseType::UInt64,
+                &mut query_params,
+                &mut param_idx_counter,
+            );
+            let outer_offset_param_placeholder = add_parameter(
+                opts.offset,
+                ClickhouseType::UInt64,
+                &mut query_params,
+                &mut param_idx_counter,
+            );
+
+            format!(
+                "SELECT * FROM (\n{chat_sql}\nUNION ALL\n{json_sql}\n) AS combined{order_by_sql}\nLIMIT {outer_limit_param_placeholder}\nOFFSET {outer_offset_param_placeholder}"
+            )
         }
     };
 
-    let limit_param_placeholder = add_parameter(
-        opts.limit,
-        ClickhouseType::UInt64,
-        &mut query_params,
-        &mut param_idx_counter,
-    );
-    sql.push_str(&format!("\nLIMIT {limit_param_placeholder}"));
+    // For single-table queries (function_name provided), apply LIMIT/OFFSET at the end
+    if opts.function_name.is_some() {
+        let limit_param_placeholder = add_parameter(
+            opts.limit,
+            ClickhouseType::UInt64,
+            &mut query_params,
+            &mut param_idx_counter,
+        );
+        sql.push_str(&format!("\nLIMIT {limit_param_placeholder}"));
 
-    let offset_param_placeholder = add_parameter(
-        opts.offset,
-        ClickhouseType::UInt64,
-        &mut query_params,
-        &mut param_idx_counter,
-    );
-    sql.push_str(&format!("\nOFFSET {offset_param_placeholder}"));
+        let offset_param_placeholder = add_parameter(
+            opts.offset,
+            ClickhouseType::UInt64,
+            &mut query_params,
+            &mut param_idx_counter,
+        );
+        sql.push_str(&format!("\nOFFSET {offset_param_placeholder}"));
+    }
 
     sql.push_str("\nFORMAT JSONEachRow");
 
@@ -418,9 +463,11 @@ mod tests {
 
         let (sql, _params) = generate_list_inferences_sql(&config, &opts).unwrap();
 
+        // Verify both tables are queried
         assert_query_contains(
             &sql,
-            "SELECT
+            "SELECT * FROM (
+        SELECT
             'chat' as type,
             formatDateTime(i.timestamp, '%Y-%m-%dT%H:%i:%SZ') as timestamp,
             i.episode_id as episode_id,
@@ -441,9 +488,8 @@ mod tests {
             ChatInference AS i
         WHERE
             i.id IN ['01234567-89ab-cdef-0123-456789abcdef','fedcba98-7654-3210-fedc-ba9876543210']
-
+        LIMIT {p0:UInt64}
         UNION ALL
-
         SELECT
             'json' as type,
             formatDateTime(i.timestamp, '%Y-%m-%dT%H:%i:%SZ') as timestamp,
@@ -464,7 +510,11 @@ mod tests {
         FROM
             JsonInference AS i
         WHERE
-            i.id IN ['01234567-89ab-cdef-0123-456789abcdef','fedcba98-7654-3210-fedc-ba9876543210']",
+            i.id IN ['01234567-89ab-cdef-0123-456789abcdef','fedcba98-7654-3210-fedc-ba9876543210']
+        LIMIT {p1:UInt64}
+        ) AS combined
+        LIMIT {p2:UInt64}
+        OFFSET {p3:UInt64}",
         );
     }
 
@@ -482,18 +532,40 @@ mod tests {
 
         let (sql, params) = generate_list_inferences_sql(&config, &opts).unwrap();
 
+        assert_query_contains(
+            &sql,
+            "SELECT
+            'json' as type,
+            formatDateTime(i.timestamp, '%Y-%m-%dT%H:%i:%SZ') as timestamp,
+            i.episode_id as episode_id,
+            i.function_name as function_name,
+            i.id as inference_id,
+            i.input as input,
+            i.output_schema as output_schema,
+            i.tags as tags,
+            '' as tool_params,
+            [] as dynamic_tools,
+            [] as dynamic_provider_tools,
+            NULL as allowed_tools,
+            NULL as tool_choice,
+            NULL as parallel_tool_calls,
+            i.variant_name as variant_name,
+            i.output as output
+        FROM
+            JsonInference AS i
+        WHERE
+            i.function_name = {p0:String}
+            AND i.id IN ['01234567-89ab-cdef-0123-456789abcdef']
+        LIMIT {p1:UInt64}
+        OFFSET {p2:UInt64}",
+        );
+
         // Verify NO UNION ALL
         assert_query_does_not_contain(&sql, "UNION ALL");
 
         // Verify only JsonInference is queried (extract_entities is a JSON function)
-        assert_query_contains(&sql, "JsonInference");
         assert_query_does_not_contain(&sql, "ChatInference");
 
-        // Verify ID is in the query with proper table alias
-        assert_query_contains(&sql, "i.id IN ['01234567-89ab-cdef-0123-456789abcdef']");
-
-        // Verify function_name filter is present
-        assert_query_contains(&sql, "i.function_name = {p0:String}");
         assert!(
             params.contains(&QueryParameter {
                 name: "p0".to_string(),
@@ -576,7 +648,27 @@ mod tests {
 
         // Verify query is wrapped in subquery with ORDER BY
         assert_query_contains(&sql, "SELECT * FROM");
-        assert_query_contains(&sql, ") AS combined ORDER BY timestamp DESC");
+        assert_query_contains(&sql, ") AS combined");
+        assert_query_contains(&sql, "ORDER BY timestamp DESC");
+
+        // Verify ORDER BY appears 3 times: 2 for inner subqueries, 1 for outer query
+        // This is critical to ensure correct results when LIMIT is pushed down
+        let order_by_count = sql.matches("ORDER BY timestamp DESC").count();
+        assert_eq!(
+            order_by_count, 3,
+            "ORDER BY should appear 3 times: 2 inner + 1 outer to ensure correct LIMIT behavior"
+        );
+
+        // Verify LIMIT appears 3 times: 2 for inner subqueries, 1 for outer query
+        let limit_count = sql.matches("LIMIT {p").count();
+        assert_eq!(
+            limit_count, 3,
+            "LIMIT should appear 3 times: 2 inner + 1 outer"
+        );
+
+        // Verify OFFSET only appears once in the outer query
+        let offset_count = sql.matches("OFFSET {p").count();
+        assert_eq!(offset_count, 1, "OFFSET should appear once in outer query");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #4608.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Optimize SQL query generation by pushing `LIMIT` and `ORDER BY` into subqueries for UNION ALL operations in `generate_list_inferences_sql()`.
> 
>   - **Behavior**:
>     - Pushes `LIMIT` and `ORDER BY` into subqueries in `generate_list_inferences_sql()` for UNION ALL queries.
>     - Ensures `LIMIT` and `OFFSET` are applied correctly in both inner and outer queries.
>     - Restricts `ORDER BY` to timestamp for UNION ALL queries, disallowing metric ordering.
>   - **Tests**:
>     - Updated tests in `inference_queries.rs` to verify `LIMIT` and `ORDER BY` appear correctly in SQL.
>     - Added checks for correct application of `LIMIT`, `OFFSET`, and `ORDER BY` in subqueries and outer queries.
>     - Ensures error is raised for unsupported metric ordering without `function_name`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 166df39cbe362e11ea78de070b84cfc6d4e29f07. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->