### PR TITLE
Support experimental text query for inferences

### DIFF
--- a/clients/python/tensorzero/generated_types.py
+++ b/clients/python/tensorzero/generated_types.py
@@ -619,7 +619,16 @@ class OrderByMetric:
     by: Literal["metric"] = "metric"
 
 
-OrderBy = OrderByTimestamp | OrderByMetric
+@dataclass(kw_only=True)
+class OrderBySearchRelevance:
+    direction: OrderDirection
+    """
+    The ordering direction.
+    """
+    by: Literal["search_relevance"] = "search_relevance"
+
+
+OrderBy = OrderByTimestamp | OrderByMetric | OrderBySearchRelevance
 
 
 @dataclass(kw_only=True)
@@ -1200,4 +1209,19 @@ class ListInferencesRequest:
     """
     Optional ordering criteria for the results.
     Supports multiple sort criteria (e.g., sort by timestamp then by metric).
+    """
+    search_query_experimental: str | None = None
+    """
+    Text query to filter. Case-insensitive substring search over the inferences' input and output.
+
+    THIS FEATURE IS EXPERIMENTAL, and we may change or remove it at any time.
+    We recommend against depending on this feature for critical use cases.
+
+    Important limitations:
+    - This requires an exact substring match; we do not tokenize this query string.
+    - This doesn't search for any content in the template itself.
+    - Quality is based on term frequency > 0, without any relevance scoring.
+    - There are no performance guarantees (it's best effort only). Today, with no other
+      filters, it will perform a full table scan, which may be extremely slow depending
+      on the data volume.
     """

--- a/clients/python/tests/test_stored_inferences_v1.py
+++ b/clients/python/tests/test_stored_inferences_v1.py
@@ -6,6 +6,9 @@ These tests cover the new v1 endpoints:
 - list_inferences: List inferences with filters, pagination, and sorting
 """
 
+import json
+from dataclasses import asdict
+
 import pytest
 from tensorzero import (
     AsyncTensorZeroGateway,
@@ -381,3 +384,40 @@ def test_sync_list_inferences_no_function_filter(embedded_sync_client: TensorZer
 
     assert response.inferences is not None
     assert len(response.inferences) >= 1  # Should have at least some inferences
+
+
+def test_sync_list_inferences_with_search_query(embedded_sync_client: TensorZeroGateway):
+    """Test searching for inferences using search_query_experimental."""
+    test_word = "hello"
+
+    request = ListInferencesRequest(
+        function_name="basic_test",
+        output_source="inference",
+        limit=2,
+        offset=0,
+        search_query_experimental=test_word,
+    )
+    response = embedded_sync_client.list_inferences(request=request)
+
+    assert len(response.inferences) > 0
+    for inference in response.inferences:
+        assert test_word in json.dumps(asdict(inference)).lower()
+
+
+@pytest.mark.asyncio
+async def test_async_list_inferences_with_search_query(embedded_async_client: AsyncTensorZeroGateway):
+    """Test async version of search_query_experimental."""
+    test_word = "hello"
+
+    request = ListInferencesRequest(
+        function_name="basic_test",
+        output_source="inference",
+        limit=2,
+        offset=0,
+        search_query_experimental=test_word,
+    )
+    response = await embedded_async_client.list_inferences(request=request)
+
+    assert len(response.inferences) > 0
+    for inference in response.inferences:
+        assert test_word in json.dumps(asdict(inference)).lower()

--- a/clients/rust/tests/test_stored_inferences.rs
+++ b/clients/rust/tests/test_stored_inferences.rs
@@ -51,13 +51,8 @@ async fn test_get_inferences_by_ids(client: Client) {
     // First list some existing inferences
     let list_request = ListInferencesRequest {
         function_name: Some("basic_test".to_string()),
-        variant_name: None,
-        episode_id: None,
-        output_source: InferenceOutputSource::Inference,
         limit: Some(3),
-        offset: Some(0),
-        filter: None,
-        order_by: None,
+        ..Default::default()
     };
     let list_response = client.list_inferences(list_request).await.unwrap();
 
@@ -144,13 +139,8 @@ async fn test_get_inferences_with_function_name(client: Client) {
     // First, list some inferences to get their IDs
     let list_request = ListInferencesRequest {
         function_name: Some("basic_test".to_string()),
-        variant_name: None,
-        episode_id: None,
-        output_source: InferenceOutputSource::Inference,
         limit: Some(3),
-        offset: Some(0),
-        filter: None,
-        order_by: None,
+        ..Default::default()
     };
     let list_response = client.list_inferences(list_request).await.unwrap();
     assert!(
@@ -230,13 +220,8 @@ async fn test_list_inferences_with_pagination(client: Client) {
     // List all inferences with default pagination
     let request = ListInferencesRequest {
         function_name: Some("basic_test".to_string()),
-        variant_name: None,
-        episode_id: None,
-        output_source: InferenceOutputSource::Inference,
         limit: Some(100),
-        offset: Some(0),
-        filter: None,
-        order_by: None,
+        ..Default::default()
     };
     let response = client.list_inferences(request).await.unwrap();
 
@@ -249,13 +234,8 @@ async fn test_list_inferences_with_pagination(client: Client) {
     // List with limit
     let request = ListInferencesRequest {
         function_name: Some("basic_test".to_string()),
-        variant_name: None,
-        episode_id: None,
-        output_source: InferenceOutputSource::Inference,
         limit: Some(2),
-        offset: Some(0),
-        filter: None,
-        order_by: None,
+        ..Default::default()
     };
     let response = client.list_inferences(request).await.unwrap();
 
@@ -268,13 +248,9 @@ async fn test_list_inferences_with_pagination(client: Client) {
     if total_count > 2 {
         let request = ListInferencesRequest {
             function_name: Some("basic_test".to_string()),
-            variant_name: None,
-            episode_id: None,
-            output_source: InferenceOutputSource::Inference,
             limit: Some(100),
             offset: Some(2),
-            filter: None,
-            order_by: None,
+            ..Default::default()
         };
         let response = client.list_inferences(request).await.unwrap();
 
@@ -300,13 +276,8 @@ async fn test_list_inferences_by_function(client: Client) {
     // List inferences for basic_test with filtering
     let request = ListInferencesRequest {
         function_name: Some("basic_test".to_string()),
-        variant_name: None,
-        episode_id: None,
-        output_source: InferenceOutputSource::Inference,
         limit: Some(100),
-        offset: Some(0),
-        filter: None,
-        order_by: None,
+        ..Default::default()
     };
     let response = client.list_inferences(request).await.unwrap();
 
@@ -339,13 +310,8 @@ async fn test_list_inferences_by_variant(client: Client) {
     // First get existing inferences to find a variant name
     let list_request = ListInferencesRequest {
         function_name: Some("basic_test".to_string()),
-        variant_name: None,
-        episode_id: None,
-        output_source: InferenceOutputSource::Inference,
         limit: Some(1),
-        offset: Some(0),
-        filter: None,
-        order_by: None,
+        ..Default::default()
     };
     let list_response = client.list_inferences(list_request).await.unwrap();
 
@@ -364,12 +330,8 @@ async fn test_list_inferences_by_variant(client: Client) {
     let request = ListInferencesRequest {
         function_name: Some("basic_test".to_string()),
         variant_name: Some(variant_name.clone()),
-        episode_id: None,
-        output_source: InferenceOutputSource::Inference,
         limit: Some(100),
-        offset: Some(0),
-        filter: None,
-        order_by: None,
+        ..Default::default()
     };
     let response = client.list_inferences(request).await.unwrap();
 
@@ -402,13 +364,8 @@ async fn test_list_inferences_by_episode(client: Client) {
     // First get an existing inference to extract an episode_id
     let list_request = ListInferencesRequest {
         function_name: Some("basic_test".to_string()),
-        variant_name: None,
-        episode_id: None,
-        output_source: InferenceOutputSource::Inference,
         limit: Some(100),
-        offset: Some(0),
-        filter: None,
-        order_by: None,
+        ..Default::default()
     };
     let list_response = client.list_inferences(list_request).await.unwrap();
 
@@ -425,14 +382,9 @@ async fn test_list_inferences_by_episode(client: Client) {
 
     // List inferences by episode ID
     let request = ListInferencesRequest {
-        function_name: None,
-        variant_name: None,
         episode_id: Some(episode_id),
-        output_source: InferenceOutputSource::Inference,
         limit: Some(100),
-        offset: Some(0),
-        filter: None,
-        order_by: None,
+        ..Default::default()
     };
     let response = client.list_inferences(request).await.unwrap();
 
@@ -456,7 +408,7 @@ tensorzero::make_gateway_test_functions!(test_list_inferences_by_episode);
 /// Test listing inferences with ordering
 async fn test_list_inferences_with_ordering(client: Client) {
     // Create some test inferences first
-    for _ in 0..5 {
+    for _ in 0..2 {
         let _ = create_test_inference(&client).await;
         // Add a small delay to ensure different timestamps
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
@@ -468,16 +420,12 @@ async fn test_list_inferences_with_ordering(client: Client) {
     // List inferences ordered by timestamp descending
     let request = ListInferencesRequest {
         function_name: Some("basic_test".to_string()),
-        variant_name: None,
-        episode_id: None,
-        output_source: InferenceOutputSource::Inference,
         limit: Some(10),
-        offset: Some(0),
-        filter: None,
         order_by: Some(vec![tensorzero::OrderBy {
             term: tensorzero::OrderByTerm::Timestamp,
             direction: tensorzero::OrderDirection::Desc,
         }]),
+        ..Default::default()
     };
     let response = client.list_inferences(request).await.unwrap();
 
@@ -536,13 +484,8 @@ async fn test_list_inferences_with_tag_filter(client: Client) {
     // First get existing inferences to find one with tags
     let list_request = ListInferencesRequest {
         function_name: Some("basic_test".to_string()),
-        variant_name: None,
-        episode_id: None,
-        output_source: InferenceOutputSource::Inference,
         limit: Some(100),
-        offset: Some(0),
-        filter: None,
-        order_by: None,
+        ..Default::default()
     };
     let list_response = client.list_inferences(list_request).await.unwrap();
 
@@ -567,17 +510,13 @@ async fn test_list_inferences_with_tag_filter(client: Client) {
         // List inferences filtered by tag
         let request = ListInferencesRequest {
             function_name: Some("basic_test".to_string()),
-            variant_name: None,
-            episode_id: None,
-            output_source: InferenceOutputSource::Inference,
             limit: Some(100),
-            offset: Some(0),
             filter: Some(tensorzero::InferenceFilter::Tag(tensorzero::TagFilter {
                 key: key.clone(),
                 value: value.clone(),
                 comparison_operator: tensorzero::TagComparisonOperator::Equal,
             })),
-            order_by: None,
+            ..Default::default()
         };
         let response = client.list_inferences(request).await.unwrap();
 

--- a/internal/tensorzero-node/lib/bindings/ListInferencesRequest.ts
+++ b/internal/tensorzero-node/lib/bindings/ListInferencesRequest.ts
@@ -48,4 +48,19 @@ export type ListInferencesRequest = {
    * Supports multiple sort criteria (e.g., sort by timestamp then by metric).
    */
   order_by?: Array<OrderBy>;
+  /**
+   * Text query to filter. Case-insensitive substring search over the inferences' input and output.
+   *
+   * THIS FEATURE IS EXPERIMENTAL, and we may change or remove it at any time.
+   * We recommend against depending on this feature for critical use cases.
+   *
+   * Important limitations:
+   * - This requires an exact substring match; we do not tokenize this query string.
+   * - This doesn't search for any content in the template itself.
+   * - Quality is based on term frequency > 0, without any relevance scoring.
+   * - There are no performance guarantees (it's best effort only). Today, with no other
+   *   filters, it will perform a full table scan, which may be extremely slow depending
+   *   on the data volume.
+   */
+  search_query_experimental?: string;
 };

--- a/internal/tensorzero-node/lib/bindings/OrderBy.ts
+++ b/internal/tensorzero-node/lib/bindings/OrderBy.ts
@@ -18,4 +18,5 @@ export type OrderBy = {
        */
       name: string;
     }
+  | { by: "search_relevance" }
 );

--- a/internal/tensorzero-node/lib/bindings/OrderByTerm.ts
+++ b/internal/tensorzero-node/lib/bindings/OrderByTerm.ts
@@ -12,4 +12,5 @@ export type OrderByTerm =
        * The name of the metric to order by.
        */
       name: string;
-    };
+    }
+  | { by: "search_relevance" };

--- a/tensorzero-core/src/db/clickhouse/inference_queries.rs
+++ b/tensorzero-core/src/db/clickhouse/inference_queries.rs
@@ -57,6 +57,16 @@ impl InferenceQueries for ClickHouseConnectionInfo {
     }
 }
 
+/// Escapes a string for JSON without quotes.
+/// This is used to escape the text query when we doing a substring match on input and output strings, because
+/// input and output strings are JSON-escaped in ClickHouse.
+fn json_escape_string_without_quotes(s: &str) -> Result<String, Error> {
+    let mut json_escaped = serde_json::to_string(s)?;
+    json_escaped.remove(0);
+    json_escaped.pop();
+    Ok(json_escaped)
+}
+
 /// Generates the ClickHouse query and a list of parameters to be set.
 /// The query string will contain placeholders like `{p0:String}`.
 /// The returned `Vec<QueryParameter>` contains the mapping from placeholder names (e.g., "p0")
@@ -97,7 +107,7 @@ pub(crate) fn generate_list_inferences_sql(
             // Reuse the join registry from the filter so we don't create duplicate joins
             let order_by_sql = if opts.order_by.is_some() {
                 generate_order_by_sql(
-                    opts.order_by,
+                    opts,
                     config,
                     &mut query_params,
                     &mut param_idx_counter,
@@ -162,6 +172,7 @@ pub(crate) fn generate_list_inferences_sql(
 
             // Generate ORDER BY clause for both inner and outer queries
             // For UNION ALL queries, we only support timestamp ordering (not metrics)
+            // TODO(#4181): this should support proper ORDER BY generation that supports joining with metrics.
             let order_by_sql = if let Some(order_by) = opts.order_by {
                 let order_clauses: Vec<String> = order_by
                     .iter()
@@ -174,6 +185,14 @@ pub(crate) fn generate_list_inferences_sql(
                                         "ORDER BY metric '{name}' is not supported when querying without function_name"
                                     ),
                                 }));
+                            }
+                            OrderByTerm::SearchRelevance => {
+                                if opts.search_query_experimental.is_none() {
+                                    return Err(Error::new(ErrorDetails::InvalidRequest {
+                                        message: "ORDER BY relevance requires search_query_experimental in the request".to_string(),
+                                    }));
+                                }
+                                "total_term_frequency"
                             }
                         };
                         Ok(format!("{column} {}", o.direction.to_clickhouse_direction()))
@@ -405,6 +424,29 @@ fn generate_single_table_query_for_type(
         where_clauses.push(filter_condition_sql);
     }
 
+    // Add text query term frequency columns and filter
+    if let Some(search_query_experimental) = opts.search_query_experimental {
+        let json_escaped_text_query = json_escape_string_without_quotes(search_query_experimental)?;
+        let text_query_param = add_parameter(
+            json_escaped_text_query,
+            ClickhouseType::String,
+            query_params,
+            param_idx_counter,
+        );
+
+        select_clauses.push(format!(
+            "countSubstringsCaseInsensitiveUTF8(i.input, {text_query_param}) as input_term_frequency"
+        ));
+        select_clauses.push(format!(
+            "countSubstringsCaseInsensitiveUTF8(i.output, {text_query_param}) as output_term_frequency"
+        ));
+        select_clauses.push(
+            "input_term_frequency + output_term_frequency as total_term_frequency".to_string(),
+        );
+
+        where_clauses.push("total_term_frequency > 0".to_string());
+    }
+
     let select_from_sql_fragment = format!(
         r"SELECT {select_clauses} FROM {table_name} AS i",
         select_clauses = select_clauses.iter().join(",\n    "),
@@ -438,6 +480,43 @@ mod tests {
     use crate::db::inferences::{InferenceOutputSource, ListInferencesParams};
 
     use super::generate_list_inferences_sql;
+
+    mod json_escape_string_without_quotes_tests {
+        use crate::db::clickhouse::inference_queries::json_escape_string_without_quotes;
+
+        #[test]
+        fn test_json_escape_string_without_quotes() {
+            assert_eq!(
+                json_escape_string_without_quotes("").unwrap(),
+                String::new()
+            );
+            assert_eq!(
+                json_escape_string_without_quotes("test").unwrap(),
+                "test".to_string()
+            );
+            assert_eq!(
+                json_escape_string_without_quotes("123").unwrap(),
+                "123".to_string()
+            );
+            assert_eq!(
+                json_escape_string_without_quotes("he's").unwrap(),
+                "he's".to_string()
+            );
+        }
+
+        #[test]
+        fn test_json_escape_string_escapes_correctly() {
+            assert_eq!(
+                json_escape_string_without_quotes(r#""test""#).unwrap(),
+                r#"\"test\""#.to_string()
+            );
+
+            assert_eq!(
+                json_escape_string_without_quotes(r"end of line\next line").unwrap(),
+                r"end of line\\next line".to_string()
+            );
+        }
+    }
 
     async fn get_e2e_config() -> Config {
         // Read the e2e config file

--- a/tensorzero-core/src/db/inferences.rs
+++ b/tensorzero-core/src/db/inferences.rs
@@ -199,6 +199,8 @@ pub struct ListInferencesParams<'a> {
     pub offset: u32,
     /// Ordering criteria for the results.
     pub order_by: Option<&'a [OrderBy]>,
+    /// Experimental: search query to filter inferences by.
+    pub search_query_experimental: Option<&'a str>,
 }
 
 impl Default for ListInferencesParams<'_> {
@@ -213,6 +215,7 @@ impl Default for ListInferencesParams<'_> {
             limit: DEFAULT_INFERENCE_QUERY_LIMIT,
             offset: 0,
             order_by: None,
+            search_query_experimental: None,
         }
     }
 }

--- a/tensorzero-core/src/endpoints/stored_inferences/v1/get_inferences.rs
+++ b/tensorzero-core/src/endpoints/stored_inferences/v1/get_inferences.rs
@@ -3,9 +3,7 @@ use axum::Json;
 use tracing::instrument;
 
 use crate::config::Config;
-use crate::db::inferences::{
-    InferenceQueries, ListInferencesParams, DEFAULT_INFERENCE_QUERY_LIMIT,
-};
+use crate::db::inferences::{InferenceQueries, ListInferencesParams};
 use crate::error::Error;
 use crate::stored_inference::StoredInferenceDatabase;
 use crate::utils::gateway::{AppState, AppStateData, StructuredJson};
@@ -39,11 +37,11 @@ pub async fn get_inferences(
         return Ok(GetInferencesResponse { inferences: vec![] });
     }
 
+    // TODO(shuyangli): Consider restricting the number of inferences to return to avoid unbounded queries.
     let params = ListInferencesParams {
         ids: Some(&request.ids),
         function_name: request.function_name.as_deref(),
         output_source: request.output_source,
-        // Return all inferences matching the IDs.
         limit: u32::MAX,
         offset: 0,
         ..Default::default()
@@ -81,18 +79,7 @@ pub async fn list_inferences(
     clickhouse: &impl InferenceQueries,
     request: ListInferencesRequest,
 ) -> Result<GetInferencesResponse, Error> {
-    let params = ListInferencesParams {
-        ids: None, // List all inferences, not filtering by ID
-        function_name: request.function_name.as_deref(),
-        variant_name: request.variant_name.as_deref(),
-        episode_id: request.episode_id.as_ref(),
-        filters: request.filter.as_ref(),
-        output_source: request.output_source,
-        limit: request.limit.unwrap_or(DEFAULT_INFERENCE_QUERY_LIMIT),
-        offset: request.offset.unwrap_or(0),
-        order_by: request.order_by.as_deref(),
-    };
-
+    let params = request.as_list_inferences_params();
     let inferences_storage = clickhouse.list_inferences(config, &params).await?;
     let inferences = inferences_storage
         .into_iter()
@@ -106,7 +93,9 @@ pub async fn list_inferences(
 mod tests {
     use super::*;
     use crate::config::{Config, SchemaData};
-    use crate::db::inferences::{InferenceOutputSource, MockInferenceQueries};
+    use crate::db::inferences::{
+        InferenceOutputSource, MockInferenceQueries, DEFAULT_INFERENCE_QUERY_LIMIT,
+    };
     use crate::experimentation::ExperimentationConfig;
     use crate::function::{FunctionConfig, FunctionConfigChat};
     use crate::inference::types::{ContentBlockChatOutput, StoredInput, Text};

--- a/tensorzero-core/src/endpoints/stored_inferences/v1/types.rs
+++ b/tensorzero-core/src/endpoints/stored_inferences/v1/types.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 use tensorzero_derive::export_schema;
 use uuid::Uuid;
 
-use crate::db::inferences::InferenceOutputSource;
+use crate::db::inferences::{
+    InferenceOutputSource, ListInferencesParams, DEFAULT_INFERENCE_QUERY_LIMIT,
+};
 use crate::stored_inference::StoredInference;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, ts_rs::TS)]
@@ -105,13 +107,24 @@ pub enum OrderDirection {
 pub enum OrderByTerm {
     // These titles become the names of the top-level OrderBy structs in the generated
     // schema, because it's flattened.
+    /// Creation timestamp of the item.
     #[schemars(title = "OrderByTimestamp")]
     Timestamp,
+
+    /// Value of a metric.
     #[schemars(title = "OrderByMetric")]
     Metric {
         /// The name of the metric to order by.
         name: String,
     },
+
+    /// Relevance score of the search query in the input and output of the item.
+    /// Requires a search query (experimental). If it's not provided, we return an error.
+    ///
+    /// Current relevance metric is very rudimentary (just term frequency), but we plan
+    /// to improve it in the future.
+    #[schemars(title = "OrderBySearchRelevance")]
+    SearchRelevance,
 }
 
 /// Order by clauses for querying inferences.
@@ -198,6 +211,38 @@ pub struct ListInferencesRequest {
     /// Optional ordering criteria for the results.
     /// Supports multiple sort criteria (e.g., sort by timestamp then by metric).
     pub order_by: Option<Vec<OrderBy>>,
+
+    /// Text query to filter. Case-insensitive substring search over the inferences' input and output.
+    ///
+    /// THIS FEATURE IS EXPERIMENTAL, and we may change or remove it at any time.
+    /// We recommend against depending on this feature for critical use cases.
+    ///
+    /// Important limitations:
+    /// - This requires an exact substring match; we do not tokenize this query string.
+    /// - This doesn't search for any content in the template itself.
+    /// - Quality is based on term frequency > 0, without any relevance scoring.
+    /// - There are no performance guarantees (it's best effort only). Today, with no other
+    ///   filters, it will perform a full table scan, which may be extremely slow depending
+    ///   on the data volume.
+    pub search_query_experimental: Option<String>,
+}
+
+impl ListInferencesRequest {
+    /// Convert the request to a `ListInferencesParams` struct for the database query layer.
+    pub fn as_list_inferences_params<'a>(&'a self) -> ListInferencesParams<'a> {
+        ListInferencesParams {
+            ids: None,
+            function_name: self.function_name.as_deref(),
+            variant_name: self.variant_name.as_deref(),
+            episode_id: self.episode_id.as_ref(),
+            filters: self.filter.as_ref(),
+            output_source: self.output_source,
+            limit: self.limit.unwrap_or(DEFAULT_INFERENCE_QUERY_LIMIT),
+            offset: self.offset.unwrap_or(0),
+            order_by: self.order_by.as_deref(),
+            search_query_experimental: self.search_query_experimental.as_deref(),
+        }
+    }
 }
 
 /// Request to get specific inferences by their IDs.

--- a/tensorzero-optimizers/src/endpoints.rs
+++ b/tensorzero-optimizers/src/endpoints.rs
@@ -102,6 +102,7 @@ pub async fn launch_optimization_workflow(
                 limit: limit.unwrap_or(DEFAULT_LIST_INFERENCES_QUERY_LIMIT_MAX_FOR_OPTIMIZATIONS),
                 offset: offset.unwrap_or(0),
                 order_by: order_by.as_deref(),
+                search_query_experimental: None,
             },
         )
         .await?;


### PR DESCRIPTION
This adds parameters for an experimental text query that does a substring match on inference inputs and outputs. We also support ranking by term frequency (externally called "relevance" to allow for future evolution) as an additional OrderBy option.

This just works in the python library.

Fixes #3438.