### PR TITLE
Remove experimental_render_inferences from Python client

### DIFF
--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -1517,46 +1517,6 @@ impl TensorZeroGateway {
         )
     }
 
-    /// DEPRECATED: use `experimental_render_samples` instead.
-    /// Render a list of stored inferences into a list of rendered stored inferences.
-    /// There are two things that need to happen in this function:
-    /// 1. We need to resolve all network resources (e.g. images) in the stored inferences.
-    /// 2. We need to prepare all messages into "simple" messages that have been templated for a particular variant.
-    ///    To do this, we need to know what variant to use for each function that might appear in the data.
-    ///
-    /// IMPORTANT: For now, this function drops datapoints which are bad, e.g. ones where templating fails, the function
-    ///            has no variant specified, or where the process of downloading resources fails.
-    ///            In future we will make this behavior configurable by the caller.
-    ///
-    /// :param stored_inferences: A list of stored inferences to render.
-    /// :param variants: A map from function name to variant name.
-    /// :return: A list of rendered stored inferences.
-    #[pyo3(signature = (*, stored_inferences, variants))]
-    fn experimental_render_inferences(
-        this: PyRef<'_, Self>,
-        stored_inferences: Vec<Bound<'_, PyAny>>,
-        variants: HashMap<String, String>,
-    ) -> PyResult<Vec<RenderedSample>> {
-        tracing::warn!("experimental_render_inferences is deprecated. Use experimental_render_samples instead. See https://github.com/tensorzero/tensorzero/issues/2675");
-        let client = this.as_super().client.clone();
-        let config = client.config().ok_or_else(|| {
-            PyValueError::new_err(
-                "Config not available in HTTP gateway mode. Use embedded mode for render_samples.",
-            )
-        })?;
-        // Enter the Tokio runtime context while still holding the GIL
-        // This is needed because deserialize_from_stored_sample may use tokio::spawn internally
-        // for JSON schema compilation
-        // TODO (#4259): remove the tokio spawn from that function and remove this guard.
-        let _guard = pyo3_async_runtimes::tokio::get_runtime().enter();
-        let stored_inferences = stored_inferences
-            .iter()
-            .map(|x| deserialize_from_stored_sample(this.py(), x, config))
-            .collect::<Result<Vec<_>, _>>()?;
-        let fut = client.experimental_render_samples(stored_inferences, variants);
-        tokio_block_on_without_gil(this.py(), fut).map_err(|e| convert_error(this.py(), e))
-    }
-
     /// Render a list of stored samples (datapoints or inferences) into a list of rendered stored samples.
     /// There are two things that need to happen in this function:
     /// 1. We need to resolve all network resources (e.g. images) in the stored samples.
@@ -2723,40 +2683,6 @@ impl AsyncTensorZeroGateway {
     ///
     /// :param stored_inferences: A list of stored inferences to render.
     /// :param variants: A map from function name to variant name.
-    /// :return: A list of rendered stored inferences.
-    #[pyo3(signature = (*, stored_inferences, variants))]
-    fn experimental_render_inferences<'a>(
-        this: PyRef<'a, Self>,
-        stored_inferences: Vec<Bound<'a, PyAny>>,
-        variants: HashMap<String, String>,
-    ) -> PyResult<Bound<'a, PyAny>> {
-        tracing::warn!("experimental_render_inferences is deprecated. Use experimental_render_samples instead. See https://github.com/tensorzero/tensorzero/issues/2675");
-        let client = this.as_super().client.clone();
-        let config = client.config().ok_or_else(|| {
-            PyValueError::new_err(
-                "Config not available in HTTP gateway mode. Use embedded mode for render_samples.",
-            )
-        })?;
-        // Enter the Tokio runtime context while still holding the GIL
-        // This is needed because deserialize_from_stored_sample may use tokio::spawn internally
-        // for JSON schema compilation
-        // TODO (#4259): remove the tokio spawn from that function and remove this guard.
-        let _guard = pyo3_async_runtimes::tokio::get_runtime().enter();
-        let stored_inferences = stored_inferences
-            .iter()
-            .map(|x| deserialize_from_stored_sample(this.py(), x, config))
-            .collect::<Result<Vec<_>, _>>()?;
-        pyo3_async_runtimes::tokio::future_into_py(this.py(), async move {
-            let res = client
-                .experimental_render_samples(stored_inferences, variants)
-                .await;
-            Python::attach(|py| match res {
-                Ok(inferences) => Ok(PyList::new(py, inferences)?.unbind()),
-                Err(e) => Err(convert_error(py, e)),
-            })
-        })
-    }
-
     /// Render a list of stored samples into a list of rendered stored samples.
     ///
     /// This function performs two main tasks:

--- a/clients/python/tensorzero/tensorzero.pyi
+++ b/clients/python/tensorzero/tensorzero.pyi
@@ -965,30 +965,6 @@ class TensorZeroGateway(BaseTensorZeroGateway):
         :return: A list of `StoredInference` instances.
         """
 
-    def experimental_render_inferences(
-        self,
-        *,
-        stored_inferences: List[StoredInference],
-        variants: Dict[str, str],
-    ) -> List[RenderedSample]:
-        """
-        DEPRECATED: use `experimental_render_samples` instead.
-        Render a list of stored samples into a list of rendered stored samples.
-
-        This function performs two main tasks:
-        1. Resolves all network resources (e.g., images) in the stored samples.
-        2. Prepares all messages into "simple" messages that have been templated for a particular variant.
-           To do this, the function needs to know which variant to use for each function that might appear in the data.
-
-        IMPORTANT: For now, this function drops datapoints that are invalid, such as those where templating fails,
-        the function has no variant specified, or the process of downloading resources fails.
-        In the future, this behavior may be made configurable by the caller.
-
-        :param stored_inferences: A list of stored samples to render.
-        :param variants: A mapping from function name to variant name.
-        :return: A list of rendered samples.
-        """
-
     def experimental_render_samples(
         self,
         *,
@@ -1525,31 +1501,6 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         :param limit: The maximum number of inferences to return. Optional
         :param offset: The offset to start from. Optional
         :return: A list of `StoredInference` instances.
-        """
-
-    async def experimental_render_inferences(
-        self,
-        *,
-        stored_inferences: List[StoredInference],
-        variants: Dict[str, str],
-    ) -> List[RenderedSample]:
-        """
-        DEPRECATED: use `experimental_render_samples` instead.
-
-        Render a list of stored samples into a list of rendered stored samples.
-
-        This function performs two main tasks:
-        1. Resolves all network resources (e.g., images) in the stored samples.
-        2. Prepares all messages into "simple" messages that have been templated for a particular variant.
-           To do this, the function needs to know which variant to use for each function that might appear in the data.
-
-        IMPORTANT: For now, this function drops datapoints that are invalid, such as those where templating fails,
-        the function has no variant specified, or the process of downloading resources fails.
-        In the future, this behavior may be made configurable by the caller.
-
-        :param stored_inferences: A list of stored samples to render.
-        :param variants: A mapping from function name to variant name.
-        :return: A list of rendered samples.
         """
 
     async def experimental_render_samples(

--- a/recipes/supervised_fine_tuning/gcp-vertex-gemini/gcp_vertex_gemini.ipynb
+++ b/recipes/supervised_fine_tuning/gcp-vertex-gemini/gcp_vertex_gemini.ipynb
@@ -206,7 +206,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rendered_samples = tensorzero_client.experimental_render_inferences(\n",
+    "rendered_samples = tensorzero_client.experimental_render_samples(\n",
     "    stored_inferences=stored_inferences,\n",
     "    variants={FUNCTION_NAME: TEMPLATE_VARIANT_NAME},\n",
     ")"

--- a/recipes/supervised_fine_tuning/gcp-vertex-gemini/gcp_vertex_gemini_nb.py
+++ b/recipes/supervised_fine_tuning/gcp-vertex-gemini/gcp_vertex_gemini_nb.py
@@ -129,7 +129,7 @@ stored_inferences = tensorzero_client.experimental_list_inferences(
 #
 
 # %%
-rendered_samples = tensorzero_client.experimental_render_inferences(
+rendered_samples = tensorzero_client.experimental_render_samples(
     stored_inferences=stored_inferences,
     variants={FUNCTION_NAME: TEMPLATE_VARIANT_NAME},
 )

--- a/recipes/supervised_fine_tuning/openai/openai.ipynb
+++ b/recipes/supervised_fine_tuning/openai/openai.ipynb
@@ -178,7 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rendered_samples = tensorzero_client.experimental_render_inferences(\n",
+    "rendered_samples = tensorzero_client.experimental_render_samples(\n",
     "    stored_inferences=stored_inferences,\n",
     "    variants={FUNCTION_NAME: TEMPLATE_VARIANT_NAME},\n",
     ")"

--- a/recipes/supervised_fine_tuning/openai/openai_nb.py
+++ b/recipes/supervised_fine_tuning/openai/openai_nb.py
@@ -110,7 +110,7 @@ stored_inferences = tensorzero_client.experimental_list_inferences(
 #
 
 # %%
-rendered_samples = tensorzero_client.experimental_render_inferences(
+rendered_samples = tensorzero_client.experimental_render_samples(
     stored_inferences=stored_inferences,
     variants={FUNCTION_NAME: TEMPLATE_VARIANT_NAME},
 )

--- a/recipes/supervised_fine_tuning/together/together.ipynb
+++ b/recipes/supervised_fine_tuning/together/together.ipynb
@@ -198,7 +198,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rendered_samples = tensorzero_client.experimental_render_inferences(\n",
+    "rendered_samples = tensorzero_client.experimental_render_samples(\n",
     "    stored_inferences=stored_inferences,\n",
     "    variants={FUNCTION_NAME: TEMPLATE_VARIANT_NAME},\n",
     ")"

--- a/recipes/supervised_fine_tuning/together/together_nb.py
+++ b/recipes/supervised_fine_tuning/together/together_nb.py
@@ -117,7 +117,7 @@ stored_inferences = tensorzero_client.experimental_list_inferences(
 #
 
 # %%
-rendered_samples = tensorzero_client.experimental_render_inferences(
+rendered_samples = tensorzero_client.experimental_render_samples(
     stored_inferences=stored_inferences,
     variants={FUNCTION_NAME: TEMPLATE_VARIANT_NAME},
 )

--- a/recipes/supervised_fine_tuning/unsloth/unsloth.ipynb
+++ b/recipes/supervised_fine_tuning/unsloth/unsloth.ipynb
@@ -286,7 +286,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rendered_samples = tensorzero_client.experimental_render_inferences(\n",
+    "rendered_samples = tensorzero_client.experimental_render_samples(\n",
     "    stored_inferences=stored_inferences,\n",
     "    variants={FUNCTION_NAME: TEMPLATE_VARIANT_NAME},\n",
     ")"

--- a/recipes/supervised_fine_tuning/unsloth/unsloth_nb.py
+++ b/recipes/supervised_fine_tuning/unsloth/unsloth_nb.py
@@ -171,7 +171,7 @@ stored_inferences = tensorzero_client.experimental_list_inferences(
 # Render the stored inferences
 
 # %%
-rendered_samples = tensorzero_client.experimental_render_inferences(
+rendered_samples = tensorzero_client.experimental_render_samples(
     stored_inferences=stored_inferences,
     variants={FUNCTION_NAME: TEMPLATE_VARIANT_NAME},
 )


### PR DESCRIPTION
## Summary
- remove the deprecated `experimental_render_inferences` bindings from the Python client
- update generated type stubs and all supervised fine tuning recipes to use `experimental_render_samples`

## Testing
- `cargo fmt`
- `cargo check --package tensorzero-python`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691a33d2a214832db5371bf5856d2395)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove deprecated `experimental_render_inferences` and update to `experimental_render_samples` in Python client and recipes.
> 
>   - **Behavior**:
>     - Remove deprecated `experimental_render_inferences` from `lib.rs` and `tensorzero.pyi`.
>     - Update all supervised fine-tuning recipes (`gcp_vertex_gemini_nb.py`, `openai_nb.py`, `together_nb.py`, `unsloth_nb.py`) to use `experimental_render_samples`.
>   - **Testing**:
>     - Ran `cargo fmt` and `cargo check --package tensorzero-python`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 44dc2a835cde2c0fdd1e912bc02bb8faf852d784. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->