### PR TITLE
Split Rust build and test into separate ubuntu-latest jobs

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -626,14 +626,6 @@ jobs:
       - name: Install uv
         run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
 
-      - name: Configure Namespace cache for Rust, Python (pip), and pnpm
-        uses: namespacelabs/nscloud-cache-action@2f50e7d0f70475e6f59a55ba0f05eec9108e77cc
-        with:
-          cache: |
-            pnpm
-            rust
-            uv
-
       - name: Install JS dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
This makes the 'validate' job small enough that we can switch it to an ubuntu-latest runner as well
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Splits Rust build and test into separate jobs in GitHub Actions, allowing the 'validate' job to run on 'ubuntu-latest'.
> 
>   - **CI Workflow Changes**:
>     - Splits Rust build and test into separate jobs `rust-build` and `rust-test` in `general.yml`.
>     - Both jobs run on `ubuntu-latest`.
>     - `rust-build` handles Rust installation, tool installation, and building.
>     - `rust-test` handles Rust installation, tool installation, and testing.
>   - **Validate Job**:
>     - `validate` job now runs on `ubuntu-latest` instead of `namespace-profile-tensorzero-8x32`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 78be745f8252ba74063805bcd551918d53e140d6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->