### PR TITLE
Make tool_choice=None override dynamic allowed tools

### DIFF
--- a/tensorzero-core/src/providers/openai/mod.rs
+++ b/tensorzero-core/src/providers/openai/mod.rs
@@ -1515,7 +1515,7 @@ pub(crate) fn prepare_allowed_tools_constraint<'a>(
     tool_config: &'a ToolCallConfig,
 ) -> Option<AllowedToolsChoice<'a>> {
     // OpenAI-compatible providers don't allow both tool-choice "none" and tool-choice "allowed_tools",
-    // since the're both set via the top-level "tool_choice" field.
+    // since they're both set via the top-level "tool_choice" field.
     // We make `ToolChoice::None` take priority - that is, we allow "none" of the allowed tools.
     if tool_config.tool_choice == ToolChoice::None {
         return None;


### PR DESCRIPTION
This seems like a more sensible behavior (the user is choosing "none" of the allowed tools), and also helps with tensorzero_relay, which forwards all of the static+dynamic tools as dynamic tools when calling the next gateway hop
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prioritize `ToolChoice::None` over `allowed_tools` in `prepare_allowed_tools_constraint` to ensure 'none' takes precedence.
> 
>   - **Behavior**:
>     - `prepare_allowed_tools_constraint` in `mod.rs` now prioritizes `ToolChoice::None` over `allowed_tools`, returning `None` if `ToolChoice::None` is set.
>   - **Tests**:
>     - Update test in `tests` module to expect `OpenAIToolChoice::String(OpenAIToolChoiceString::None)` when `ToolChoice::None` is set with `allowed_tools`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f80a58233be785d4161581fd232809a1e4a658e7. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->