### PR TITLE
Fix flaky datapoint creation E2E locator

### DIFF
--- a/ui/e2e_tests/evaluations.eval_name.datapoint_id.spec.ts
+++ b/ui/e2e_tests/evaluations.eval_name.datapoint_id.spec.ts
@@ -152,8 +152,10 @@ test("should be able to add a datapoint from the evaluation page", async ({
     new RegExp(`/datasets/${datasetName}/datapoint/.*`),
   );
 
-  // Verify we can see the datapoint content
-  await expect(page.getByText("Datapoint", { exact: true })).toBeVisible();
+  // Verify we can see the datapoint metadata by checking the dataset link
+  await expect(
+    page.getByRole("link", { name: datasetName, exact: true }),
+  ).toBeVisible();
 
   // Clean up: delete the dataset by going to the list datasets page
   await page.goto("/datasets");


### PR DESCRIPTION
## Summary
- tighten the datapoint creation E2E test so it asserts against the newly created dataset link instead of a non-unique "Datapoint" label

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck` *(fails: repository currently has 296 existing TS errors; see log for details)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691b5e0022348329bd729b1b682d5126)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix flaky E2E test by asserting against unique dataset link instead of non-unique label in `ui/e2e_tests/evaluations.eval_name.datapoint_id.spec.ts`.
> 
>   - **Behavior**:
>     - In `ui/e2e_tests/evaluations.eval_name.datapoint_id.spec.ts`, change assertion from checking non-unique "Datapoint" label to checking unique dataset link.
>   - **Testing**:
>     - Ran `pnpm run format`, `pnpm run lint`, and `pnpm run typecheck` (typecheck has existing errors unrelated to this change).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8fb2dbe2edc621c4145e8077245bdb822ea32da0. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->