### PR TITLE
Add 'spawn_ignoring_shutdown' helper function

### DIFF
--- a/tensorzero-core/src/cache.rs
+++ b/tensorzero-core/src/cache.rs
@@ -13,6 +13,7 @@ use crate::inference::types::{
 use crate::model::StreamResponse;
 use crate::serde_util::{deserialize_json_string, serialize_json_string};
 use crate::tool::{InferenceResponseToolCall, ToolCallConfig};
+use crate::utils::spawn_ignoring_shutdown;
 use blake3::Hash;
 use clap::ValueEnum;
 use serde::de::{DeserializeOwned, IgnoredAny};
@@ -306,9 +307,7 @@ fn spawn_maybe_cache_write<T: Serialize + CacheOutput + Send + Sync + 'static>(
     clickhouse_client: ClickHouseConnectionInfo,
     cache_validation_info: CacheValidationInfo,
 ) {
-    // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
-    #[expect(clippy::disallowed_methods)]
-    tokio::spawn(async move {
+    spawn_ignoring_shutdown(async move {
         if row
             .data
             .output

--- a/tensorzero-core/src/experimentation/track_and_stop/mod.rs
+++ b/tensorzero-core/src/experimentation/track_and_stop/mod.rs
@@ -68,6 +68,7 @@ use crate::{
         ExperimentationQueries, HealthCheckable,
     },
     error::{Error, ErrorDetails, IMPOSSIBLE_ERROR_MESSAGE},
+    utils::spawn_ignoring_shutdown,
     variant::VariantInfo,
 };
 
@@ -492,9 +493,7 @@ impl VariantSampler for TrackAndStopConfig {
         // 3. Computes new optimal sampling probabilities based on observed performance
         // 4. Updates the shared `self.state` via ArcSwap (lock-free concurrent updates)
         // 5. Concurrent `sample()` calls read the latest state without blocking
-        // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
-        #[expect(clippy::disallowed_methods)]
-        tokio::spawn(probability_update_task(ProbabilityUpdateTaskArgs {
+        spawn_ignoring_shutdown(probability_update_task(ProbabilityUpdateTaskArgs {
             db,
             candidate_variants: self.candidate_variants.clone().into(),
             metric_name: self.metric.clone(),

--- a/tensorzero-core/src/jsonschema_util.rs
+++ b/tensorzero-core/src/jsonschema_util.rs
@@ -7,6 +7,7 @@ use tracing::instrument;
 
 use crate::config::path::ResolvedTomlPathData;
 use crate::error::{Error, ErrorDetails};
+use crate::utils::spawn_ignoring_shutdown;
 
 #[derive(Debug, Serialize)]
 pub enum JsonSchemaRef<'a> {
@@ -157,9 +158,7 @@ impl DynamicJSONSchema {
         // Kick off the schema compilation in the background.
         // The first call to `validate` will either get the compiled schema (if the task finished),
         // or wait on the task to complete via the `OnceCell`
-        // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
-        #[expect(clippy::disallowed_methods)]
-        tokio::spawn(async move {
+        spawn_ignoring_shutdown(async move {
             // If this errors, then we'll just get the error when we call 'validate'
             let _ = this_clone.get_or_init_compiled_schema().await;
         });

--- a/tensorzero-core/src/utils/mod.rs
+++ b/tensorzero-core/src/utils/mod.rs
@@ -49,3 +49,14 @@ pub async fn unbounded_recursion_wrapper<R: Send + 'static>(
 pub fn deprecation_warning(message: &str) {
     tracing::warn!("Deprecation warning: {message}");
 }
+
+/// Spawns a background task that does not interact with gateway shutdown -
+/// it will be cancelled at some arbitrary `.await` point when the gateway shuts down.
+/// This method should only be used for 'best-effort' background tasks (e.g. cache writes,
+/// Howdy, etc) where we don't care if they finish or not (so they don't need to block
+/// the gateway shutdown).
+pub fn spawn_ignoring_shutdown(fut: impl Future<Output = ()> + Send + 'static) {
+    // The `spawn_ignoring_shutdown` function is an explicit way of invoking `tokio::spawn`
+    #[expect(clippy::disallowed_methods)]
+    tokio::spawn(fut);
+}


### PR DESCRIPTION
We use this to explicitly mark locations where we don't care about how the background task interacts with gateway shutdown (e.g. cache writes, Howdy, track-and-stop updates)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `spawn_ignoring_shutdown` helper to spawn non-blocking tasks and refactor existing code to use it.
> 
>   - **New Functionality**:
>     - Add `spawn_ignoring_shutdown` in `utils/mod.rs` to spawn non-blocking background tasks.
>   - **Refactoring**:
>     - Replace `tokio::spawn` with `spawn_ignoring_shutdown` in `cache.rs` for cache write tasks.
>     - Replace `tokio::spawn` with `spawn_ignoring_shutdown` in `track_and_stop/mod.rs` for probability update tasks.
>     - Replace `tokio::spawn` with `spawn_ignoring_shutdown` in `howdy.rs` for Howdy service tasks.
>     - Replace `tokio::spawn` with `spawn_ignoring_shutdown` in `jsonschema_util.rs` for schema compilation tasks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6e88092a646490b6e5930a514da93864e7e3e4d6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->