### PR TITLE
Start mocked-batch-tests job from general.yml

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1038,6 +1038,14 @@ jobs:
       contents: read
     uses: ./.github/workflows/minikube.yml
 
+  mocked-batch-tests:
+    permissions:
+      contents: read
+      actions: read
+    if: github.repository == 'tensorzero/tensorzero' && github.event_name == 'merge_group'
+    uses: ./.github/workflows/mocked-batch-test.yml
+    secrets: inherit
+
   # See 'ci/README.md' at the repository root for more details.
   check-all-general-jobs-passed:
     permissions: {}
@@ -1055,6 +1063,7 @@ jobs:
         build-ui-container,
         build-gateway-container,
         build-gateway-e2e-container,
+        mocked-batch-tests,
         minikube,
         rust-build,
         rust-test,

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -59,14 +59,6 @@ env:
   TENSORZERO_CI: 1
 
 jobs:
-  mocked-batch-tests:
-    permissions:
-      contents: read
-      actions: read
-    if: github.repository == 'tensorzero/tensorzero'
-    uses: ./.github/workflows/mocked-batch-test.yml
-    secrets: inherit
-
   live-tests:
     name: "live-tests (batch_writes: ${{ matrix.batch_writes }})"
     runs-on: namespace-profile-tensorzero-8x16
@@ -486,7 +478,6 @@ jobs:
         ui-tests-e2e-regen-model-inference-cache,
         client-tests,
         live-tests,
-        mocked-batch-tests,
       ]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This still only runs in the merge queue, but can now start earlier (since it no longer needs to wait on any containers being built)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move `mocked-batch-tests` job from `merge-queue.yml` to `general.yml` to start earlier without waiting for container builds.
> 
>   - **Workflow Changes**:
>     - Move `mocked-batch-tests` job from `merge-queue.yml` to `general.yml`.
>     - `mocked-batch-tests` now starts earlier in the workflow, no longer dependent on container builds.
>   - **Job Dependencies**:
>     - Add `mocked-batch-tests` to the `needs` list in `check-all-general-jobs-passed` in `general.yml`.
>     - Remove `mocked-batch-tests` from the `needs` list in `merge-queue.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d219991c6c4736f7789f244001e59904e4214670. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->