### PR TITLE
Wait for ClickHouse to be ready in minikube test

### DIFF
--- a/.github/workflows/minikube.yml
+++ b/.github/workflows/minikube.yml
@@ -106,4 +106,4 @@ jobs:
     - name: Print logs from stopped pods
       if: always()
       run: |
-        kubectl logs -n tensorzero --timestamps=true --all-pods=true --all-containers=true -l app.kubernetes.io/instance=tensorzero -p
+        kubectl logs -n tensorzero --timestamps=true --all-pods=true --all-containers=true -l app.kubernetes.io/instance=tensorzero -p || true


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances minikube CI workflow by ensuring ClickHouse readiness and adding logs for stopped pods.
> 
>   - **Behavior**:
>     - Adds `kubectl wait` commands in `minikube.yml` to ensure ClickHouse is ready before proceeding with tests.
>     - Waits for `clickhouse-operator` deployment to be available, `clickhouseinstallation` to be completed, and pods to be ready.
>   - **Logging**:
>     - Adds a step to print logs from stopped pods in `minikube.yml` for better debugging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 04dbc3d775da57be4102bb85be5ba990da1a46d6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->