### PR TITLE
Pin jsonwebtoken to 10.1.0 to avoid cargo-deny bug

### DIFF
--- a/tensorzero-core/Cargo.toml
+++ b/tensorzero-core/Cargo.toml
@@ -48,7 +48,8 @@ futures-core = "0.3.30"
 hex = "0.4.3"
 itertools = "0.14.0"
 jsonschema = "0.33.0"
-jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
+# TODO - unpin when https://github.com/EmbarkStudios/cargo-deny/issues/803 is fixed
+jsonwebtoken = { version = "=10.1.0", features = ["aws_lc_rs"] }
 lazy_static = { workspace = true }
 metrics = "0.24.2"
 metrics-exporter-prometheus = { workspace = true }


### PR DESCRIPTION
Until https://github.com/EmbarkStudios/cargo-deny/issues/803 is fixed, bumping this crate will give a false-positive alert for `rsa`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Pin `jsonwebtoken` to version `10.1.0` in `Cargo.toml` to avoid a `cargo-deny` false-positive alert.
> 
>   - **Dependencies**:
>     - Pin `jsonwebtoken` version to `10.1.0` in `Cargo.toml` to avoid false-positive alert for `rsa` due to `cargo-deny` bug.
>     - Add TODO comment to unpin once issue `#803` in `cargo-deny` is resolved.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c8365d3c5b3d4efad9a3cf0cfd660cf6199e07b2. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->