### PR TITLE
Only add permissions error comment when running slash command

### DIFF
--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -21,9 +21,9 @@ jobs:
           echo "ACTOR_MEMBER=$MEMBER" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
-      - name: Leave a comment if permission check fails
-        if: ${{ steps.check-permission.outputs.ACTOR_MEMBER != '1' }}
+
+      - name: Leave a comment if permission check fails for a slash command
+        if: ${{ steps.check-permission.outputs.ACTOR_MEMBER != '1' && (startsWith(github.event.comment.body, '/')) }}
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We were previously erroring on any comments left by users outside of TensorZero
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restrict permissions error comment to only trigger on slash commands in `slash-command-dispatch.yml`.
> 
>   - **Behavior**:
>     - Modify condition in `.github/workflows/slash-command-dispatch.yml` to only leave a permissions error comment if the comment starts with a slash (`/`).
>     - Previously, any comment by non-members triggered the error comment.
>   - **Conditions**:
>     - Uses `startsWith(github.event.comment.body, '/')` to check if the comment is a slash command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3aa7630c38f61beb92e76f59b7368c862107ce4a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->