### PR TITLE
Add `n` parameter handling (OpenAI compat)

### DIFF
--- a/tensorzero-core/src/endpoints/openai_compatible.rs
+++ b/tensorzero-core/src/endpoints/openai_compatible.rs
@@ -108,9 +108,9 @@ pub async fn inference_handler(
 ) -> Result<Response<Body>, Error> {
     // Validate `n` parameter
     if let Some(n) = openai_compatible_params.n {
-        if n > 1 {
+        if n != 1 {
             return Err(Error::new(ErrorDetails::InvalidOpenAICompatibleRequest {
-                message: "TensorZero does not support `n` greater than 1. Please omit this parameter or set it to 1.".to_string(),
+                message: "TensorZero does not support `n` other than 1. Please omit this parameter or set it to 1.".to_string(),
             }));
         }
     }


### PR DESCRIPTION
- Fix #4688

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add validation for `n` parameter in `inference_handler` and introduce `n` to `OpenAICompatibleParams` for OpenAI compatibility.
> 
>   - **Behavior**:
>     - Validate `n` parameter in `inference_handler()` to ensure it is not greater than 1, returning an error if it is.
>     - Add `n` parameter to `OpenAICompatibleParams` struct.
>   - **Refactoring**:
>     - Begin refactoring `openai_compatible.rs` by moving it into a folder and separating embedding-related code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e967e8cc769be02c07fb62dd9b68d242d4adaf49. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->