### PR TITLE
Use '--log-format json' in production deployment example

### DIFF
--- a/examples/production-deployment/docker-compose.yml
+++ b/examples/production-deployment/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     volumes:
       - ./config:/app/config:ro
       - ${GCP_VERTEX_CREDENTIALS_PATH:-/dev/null}:/app/gcp-credentials.json:ro
-    command: --config-file /app/config/tensorzero.toml
+    command: --config-file /app/config/tensorzero.toml --log-format json
     environment:
       GCP_VERTEX_CREDENTIALS_PATH: ${GCP_VERTEX_CREDENTIALS_PATH:+/app/gcp-credentials.json}
     env_file:


### PR DESCRIPTION
This will allow services to AWS CloudWatch to more easily parse the log output
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `--log-format json` to `docker-compose.yml` for JSON log output in production.
> 
>   - **Behavior**:
>     - Adds `--log-format json` to the `command` in `docker-compose.yml` for the `gateway` service to enable JSON log output.
>   - **Purpose**:
>     - Facilitates easier log parsing by AWS CloudWatch in production environments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a325b15bcfcd196830c7e9cd13379b345c9d6bd2. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->