### PR TITLE
Use 'spawn_ignoring_shutdown' when spawning eval results tasks

### DIFF
--- a/evaluations/src/lib.rs
+++ b/evaluations/src/lib.rs
@@ -23,6 +23,7 @@ use tensorzero_core::client::{
 };
 use tensorzero_core::config::{ConfigFileGlob, MetricConfigOptimize, UninitializedVariantInfo};
 use tensorzero_core::evaluations::{EvaluationConfig, EvaluatorConfig};
+use tensorzero_core::utils::spawn_ignoring_shutdown;
 use tensorzero_core::{
     config::Config, db::clickhouse::ClickHouseConnectionInfo, endpoints::datasets::StoredDatapoint,
     function::FunctionConfig,
@@ -520,9 +521,9 @@ pub async fn run_evaluation_core_streaming(
     // Spawn a task to collect results and stream them
     let sender_clone = sender.clone();
     let mut num_completed_datapoints = 0;
-    // TODO(https://github.com/tensorzero/tensorzero/issues/3983): Audit this callsite
-    #[expect(clippy::disallowed_methods)]
-    tokio::spawn(async move {
+    // We don't want to block (embedded) gateway shutdown on the evaluation finishing - the `receiver`
+    // is responsible for determining if we're interested in the evaluation results.
+    spawn_ignoring_shutdown(async move {
         while let Some(result) = join_set.join_next_with_id().await {
             let update = match result {
                 Ok((_, Ok((datapoint, inference_response, evaluation_result)))) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `tokio::spawn` with `spawn_ignoring_shutdown` in `run_evaluation_core_streaming()` to prevent blocking shutdowns.
> 
>   - **Behavior**:
>     - Replaces `tokio::spawn` with `spawn_ignoring_shutdown` in `run_evaluation_core_streaming()` to prevent blocking shutdowns.
>   - **Misc**:
>     - Adds `spawn_ignoring_shutdown` import in `lib.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2422e4aa4c524f4d3b52f67cb66e124dc087c708. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->