### PR TITLE
Fork JsonInferenceDatapoint => StoredJsonInferenceDatapoint

### DIFF
--- a/evaluations/src/dataset.rs
+++ b/evaluations/src/dataset.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 use tensorzero_core::endpoints::datasets::{
-    JsonInferenceDatapoint, StoredChatInferenceDatapoint, StoredDatapoint,
+    StoredChatInferenceDatapoint, StoredDatapoint, StoredJsonInferenceDatapoint,
 };
 use tensorzero_core::{db::clickhouse::ClickHouseConnectionInfo, function::FunctionConfig};
 use tracing::{debug, info, instrument};
@@ -81,7 +81,7 @@ pub async fn query_dataset(
         FunctionConfig::Json(_) => {
             debug!("Parsing as JSON datapoints");
             let json_value: serde_json::Value = serde_json::from_str(&result.response)?;
-            let json_datapoints: Vec<JsonInferenceDatapoint> =
+            let json_datapoints: Vec<StoredJsonInferenceDatapoint> =
                 serde_json::from_value(json_value["data"].clone())?;
             let datapoints: Vec<StoredDatapoint> = json_datapoints
                 .into_iter()

--- a/evaluations/src/evaluators/exact_match.rs
+++ b/evaluations/src/evaluators/exact_match.rs
@@ -71,7 +71,7 @@ mod tests {
     use tensorzero_core::client::Role;
     use tensorzero_core::{
         endpoints::{
-            datasets::{JsonInferenceDatapoint, StoredChatInferenceDatapoint},
+            datasets::{StoredChatInferenceDatapoint, StoredJsonInferenceDatapoint},
             inference::{ChatInferenceResponse, JsonInferenceResponse},
         },
         inference::types::{
@@ -179,7 +179,7 @@ mod tests {
     #[test]
     fn test_exact_match_evaluator_json() {
         // Test a match
-        let datapoint = StoredDatapoint::Json(JsonInferenceDatapoint {
+        let datapoint = StoredDatapoint::Json(StoredJsonInferenceDatapoint {
             id: Uuid::now_v7(),
             input: StoredInput {
                 system: None,
@@ -253,7 +253,7 @@ mod tests {
         assert_eq!(result, Some(Value::Bool(false)));
 
         // Test with missing output (should be None)
-        let datapoint = StoredDatapoint::Json(JsonInferenceDatapoint {
+        let datapoint = StoredDatapoint::Json(StoredJsonInferenceDatapoint {
             id: Uuid::now_v7(),
             input: StoredInput {
                 system: None,
@@ -290,7 +290,7 @@ mod tests {
         assert_eq!(result, None);
 
         // Test with datapoint with malformed output schema (should be None)
-        let datapoint = StoredDatapoint::Json(JsonInferenceDatapoint {
+        let datapoint = StoredDatapoint::Json(StoredJsonInferenceDatapoint {
             id: Uuid::now_v7(),
             input: StoredInput {
                 system: None,

--- a/evaluations/src/evaluators/llm_judge/mod.rs
+++ b/evaluations/src/evaluators/llm_judge/mod.rs
@@ -426,8 +426,8 @@ mod tests {
 
     use serde_json::json;
     use tensorzero_core::client::{File, Role, UrlFile};
-    use tensorzero_core::endpoints::datasets::JsonInferenceDatapoint;
     use tensorzero_core::endpoints::datasets::StoredChatInferenceDatapoint;
+    use tensorzero_core::endpoints::datasets::StoredJsonInferenceDatapoint;
     use tensorzero_core::endpoints::inference::ChatInferenceResponse;
     use tensorzero_core::endpoints::inference::JsonInferenceResponse;
     use tensorzero_core::evaluations::LLMJudgeIncludeConfig;
@@ -928,7 +928,7 @@ mod tests {
         assert_eq!(result, r#"[{"type":"text","text":"Reference text"}]"#);
 
         // Test with reference output enabled and present (json)
-        let datapoint = StoredDatapoint::Json(JsonInferenceDatapoint {
+        let datapoint = StoredDatapoint::Json(StoredJsonInferenceDatapoint {
             dataset_name: "dataset".to_string(),
             function_name: "function".to_string(),
             name: None,
@@ -1149,7 +1149,7 @@ mod tests {
                 finish_reason: None,
                 episode_id: Uuid::now_v7(),
             }),
-            &StoredDatapoint::Json(JsonInferenceDatapoint {
+            &StoredDatapoint::Json(StoredJsonInferenceDatapoint {
                 dataset_name: "dataset".to_string(),
                 function_name: "function".to_string(),
                 name: None,

--- a/evaluations/tests/tests.rs
+++ b/evaluations/tests/tests.rs
@@ -13,7 +13,7 @@ use tensorzero_core::client::input_handling::resolved_input_to_client_input;
 use tensorzero_core::db::clickhouse::test_helpers::{
     select_inference_evaluation_human_feedback_clickhouse, select_model_inferences_clickhouse,
 };
-use tensorzero_core::endpoints::datasets::StoredDatapoint;
+use tensorzero_core::endpoints::datasets::{StoredDatapoint, StoredJsonInferenceDatapoint};
 use tensorzero_core::evaluations::{LLMJudgeConfig, LLMJudgeInputFormat, LLMJudgeOutputType};
 use tensorzero_core::function::{FunctionConfig, FunctionConfigJson};
 use tensorzero_core::inference::types::{
@@ -48,7 +48,7 @@ use tensorzero_core::{
 };
 use tensorzero_core::{
     endpoints::{
-        datasets::{JsonInferenceDatapoint, StoredChatInferenceDatapoint},
+        datasets::StoredChatInferenceDatapoint,
         inference::{ChatInferenceResponse, JsonInferenceResponse},
     },
     evaluations::{LLMJudgeIncludeConfig, LLMJudgeOptimize},
@@ -1462,7 +1462,7 @@ async fn test_run_llm_judge_evaluator_json() {
         },
         variant_name: "test_variant".to_string(),
     });
-    let datapoint = StoredDatapoint::Json(JsonInferenceDatapoint {
+    let datapoint = StoredDatapoint::Json(StoredJsonInferenceDatapoint {
         input: StoredInput {
             system: None,
             messages: vec![StoredInputMessage {

--- a/tensorzero-core/src/endpoints/datasets/legacy.rs
+++ b/tensorzero-core/src/endpoints/datasets/legacy.rs
@@ -236,7 +236,7 @@ async fn insert_from_existing(
                 OutputKind::None => None,
             };
             // TODO(#3957): the `put_json_datapoints` call should really take a `JsonInferenceDatapointInsert`. We'll fix it separately.
-            let datapoint = JsonInferenceDatapoint {
+            let datapoint = StoredJsonInferenceDatapoint {
                 dataset_name: path_params.dataset_name,
                 function_name: inference.function_name,
                 name: None,
@@ -531,7 +531,7 @@ pub async fn update_datapoint_handler(
                 None
             };
 
-            let datapoint = JsonInferenceDatapoint {
+            let datapoint = StoredJsonInferenceDatapoint {
                 dataset_name: path_params.dataset_name,
                 function_name: json.function_name,
                 name: json.name,
@@ -1204,13 +1204,14 @@ impl Datapoint {
 
 impl StoredDatapoint {
     /// Convert to wire type, properly handling tool params by subtracting static tools
+    /// TODO(shuyangli): Prepare for resolving
     pub fn into_datapoint(self, config: &Config) -> Result<Datapoint, Error> {
         match self {
             StoredDatapoint::Chat(chat) => {
                 let function_config = config.get_function(&chat.function_name)?;
                 Ok(Datapoint::Chat(chat.into_datapoint(&function_config)))
             }
-            StoredDatapoint::Json(json) => Ok(Datapoint::Json(json)),
+            StoredDatapoint::Json(json) => Ok(Datapoint::Json(json.into_datapoint())),
         }
     }
 }
@@ -1242,6 +1243,29 @@ impl ChatInferenceDatapoint {
             updated_at: self.updated_at,
             name: self.name,
         })
+    }
+}
+
+impl JsonInferenceDatapoint {
+    /// Convert to storage type.
+    pub fn into_storage(self) -> StoredJsonInferenceDatapoint {
+        StoredJsonInferenceDatapoint {
+            dataset_name: self.dataset_name,
+            function_name: self.function_name,
+            id: self.id,
+            episode_id: self.episode_id,
+            input: self.input,
+            output: self.output,
+            output_schema: self.output_schema,
+            tags: self.tags,
+            auxiliary: self.auxiliary,
+            is_deleted: self.is_deleted,
+            is_custom: self.is_custom,
+            source_inference_id: self.source_inference_id,
+            staled_at: self.staled_at,
+            updated_at: self.updated_at,
+            name: self.name,
+        }
     }
 }
 
@@ -1362,7 +1386,7 @@ impl Datapoint {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum StoredDatapoint {
     Chat(StoredChatInferenceDatapoint),
-    Json(JsonInferenceDatapoint),
+    Json(StoredJsonInferenceDatapoint),
 }
 
 impl StoredDatapoint {
@@ -1640,8 +1664,68 @@ impl std::fmt::Display for JsonInferenceDatapoint {
     }
 }
 
-impl From<JsonInferenceDatapoint> for JsonInferenceDatapointInsert {
-    fn from(datapoint: JsonInferenceDatapoint) -> Self {
+/// Storage variant of JsonInferenceDatapoint for database operations (no Python/TypeScript bindings).
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct StoredJsonInferenceDatapoint {
+    /// Name of the dataset to write to.
+    pub dataset_name: String,
+
+    /// Name of the function that generated this datapoint.
+    pub function_name: String,
+
+    /// Unique identifier for the datapoint.
+    pub id: Uuid,
+
+    /// Episode ID that the datapoint belongs to.
+    pub episode_id: Option<Uuid>,
+
+    /// Input type that we directly store in ClickHouse.
+    #[serde(deserialize_with = "deserialize_string_or_parsed_json")]
+    pub input: StoredInput,
+
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_string_or_parsed_json"
+    )]
+    pub output: Option<JsonInferenceOutput>,
+
+    #[serde(deserialize_with = "deserialize_string_or_parsed_json")]
+    pub output_schema: serde_json::Value,
+
+    // By default, ts_rs generates { [key in string]?: string } | undefined, which means values are string | undefined which isn't what we want.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tags: Option<HashMap<String, String>>,
+
+    /// Deprecated, do not use.
+    #[serde(skip_serializing, default)]
+    pub auxiliary: String,
+
+    /// If true, this datapoint was deleted.
+    pub is_deleted: bool,
+
+    /// If true, this datapoint was manually created or edited by the user.
+    #[serde(default)]
+    pub is_custom: bool,
+
+    /// Source inference ID that generated this datapoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_inference_id: Option<Uuid>,
+
+    /// Timestamp when the datapoint was marked as stale.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub staled_at: Option<String>,
+
+    /// Timestamp when the datapoint was updated.
+    pub updated_at: String,
+
+    /// Human-readable name of the datapoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+impl From<StoredJsonInferenceDatapoint> for JsonInferenceDatapointInsert {
+    fn from(datapoint: StoredJsonInferenceDatapoint) -> Self {
         JsonInferenceDatapointInsert {
             dataset_name: datapoint.dataset_name,
             function_name: datapoint.function_name,
@@ -1656,6 +1740,28 @@ impl From<JsonInferenceDatapoint> for JsonInferenceDatapointInsert {
             staled_at: datapoint.staled_at,
             source_inference_id: datapoint.source_inference_id,
             is_custom: datapoint.is_custom,
+        }
+    }
+}
+
+impl StoredJsonInferenceDatapoint {
+    pub fn into_datapoint(self) -> JsonInferenceDatapoint {
+        JsonInferenceDatapoint {
+            dataset_name: self.dataset_name,
+            function_name: self.function_name,
+            id: self.id,
+            episode_id: self.episode_id,
+            input: self.input,
+            output: self.output,
+            output_schema: self.output_schema,
+            tags: self.tags,
+            auxiliary: self.auxiliary,
+            is_deleted: self.is_deleted,
+            is_custom: self.is_custom,
+            source_inference_id: self.source_inference_id,
+            staled_at: self.staled_at,
+            updated_at: self.updated_at,
+            name: self.name,
         }
     }
 }

--- a/tensorzero-core/src/endpoints/datasets/v1/update_datapoints.rs
+++ b/tensorzero-core/src/endpoints/datasets/v1/update_datapoints.rs
@@ -12,8 +12,8 @@ use crate::db::datasets::{
     JsonInferenceDatapointInsert,
 };
 use crate::endpoints::datasets::{
-    validate_dataset_name, JsonInferenceDatapoint, StoredChatInferenceDatapoint, StoredDatapoint,
-    CLICKHOUSE_DATETIME_FORMAT,
+    validate_dataset_name, StoredChatInferenceDatapoint, StoredDatapoint,
+    StoredJsonInferenceDatapoint, CLICKHOUSE_DATETIME_FORMAT,
 };
 use crate::error::{Error, ErrorDetails};
 use crate::function::FunctionConfig;
@@ -262,7 +262,7 @@ async fn prepare_json_update(
     fetch_context: &FetchContext<'_>,
     dataset_name: &str,
     update: UpdateJsonDatapointRequest,
-    existing_datapoint: JsonInferenceDatapoint,
+    existing_datapoint: StoredJsonInferenceDatapoint,
     now_timestamp: &str,
 ) -> Result<PreparedUpdate, Error> {
     if existing_datapoint.dataset_name != dataset_name {
@@ -520,7 +520,7 @@ mod tests {
     use crate::endpoints::datasets::v1::types::{
         DatapointMetadataUpdate, JsonDatapointOutputUpdate,
     };
-    use crate::endpoints::datasets::{JsonInferenceDatapoint, StoredChatInferenceDatapoint};
+    use crate::endpoints::datasets::StoredChatInferenceDatapoint;
     use crate::experimentation::ExperimentationConfig;
     use crate::function::{FunctionConfigChat, FunctionConfigJson};
     use crate::http::TensorzeroHttpClient;
@@ -748,8 +748,8 @@ mod tests {
         }
 
         /// Helper to create a sample JsonInferenceDatapoint
-        pub fn create_sample_json_datapoint(dataset_name: &str) -> JsonInferenceDatapoint {
-            JsonInferenceDatapoint {
+        pub fn create_sample_json_datapoint(dataset_name: &str) -> StoredJsonInferenceDatapoint {
+            StoredJsonInferenceDatapoint {
                 id: Uuid::now_v7(),
                 dataset_name: dataset_name.to_string(),
                 function_name: "test_json_function".to_string(),
@@ -890,8 +890,8 @@ mod tests {
         }
 
         /// Helper to create a sample JsonInferenceDatapoint
-        fn create_sample_json_datapoint(dataset_name: &str) -> JsonInferenceDatapoint {
-            JsonInferenceDatapoint {
+        fn create_sample_json_datapoint(dataset_name: &str) -> StoredJsonInferenceDatapoint {
+            StoredJsonInferenceDatapoint {
                 id: Uuid::now_v7(),
                 dataset_name: dataset_name.to_string(),
                 function_name: "test_json_function".to_string(),

--- a/tensorzero-core/src/inference/types/pyo3_helpers.rs
+++ b/tensorzero-core/src/inference/types/pyo3_helpers.rs
@@ -393,7 +393,7 @@ pub fn deserialize_from_stored_sample<'a>(
                 )))
             }
             Datapoint::Json(json_wire) => Ok(StoredSampleItem::Datapoint(StoredDatapoint::Json(
-                json_wire,
+                json_wire.into_storage(),
             ))),
         };
     }

--- a/tensorzero-core/tests/e2e/render_inferences.rs
+++ b/tensorzero-core/tests/e2e/render_inferences.rs
@@ -3,10 +3,10 @@ use object_store::path::Path;
 use serde_json::json;
 use std::collections::HashMap;
 use tensorzero::{
-    ClientExt, FunctionTool, JsonInferenceDatapoint, Role, StorageKind, StoragePath,
-    StoredChatInferenceDatabase, StoredChatInferenceDatapoint, StoredDatapoint,
-    StoredInferenceDatabase, StoredJsonInference,
+    ClientExt, FunctionTool, Role, StorageKind, StoragePath, StoredChatInferenceDatabase,
+    StoredChatInferenceDatapoint, StoredDatapoint, StoredInferenceDatabase, StoredJsonInference,
 };
+use tensorzero_core::endpoints::datasets::StoredJsonInferenceDatapoint;
 use tensorzero_core::inference::types::file::ObjectStoragePointer;
 use tensorzero_core::inference::types::stored_input::StoredFile;
 use tensorzero_core::inference::types::stored_input::{
@@ -738,7 +738,7 @@ pub async fn test_render_datapoints_normal() {
             updated_at: "2025-10-13T20:17:36Z".to_string(),
             is_custom: false,
         }),
-        StoredDatapoint::Json(JsonInferenceDatapoint {
+        StoredDatapoint::Json(StoredJsonInferenceDatapoint {
             dataset_name: "test_dataset".to_string(),
             function_name: "json_success".to_string(),
             name: None,


### PR DESCRIPTION
This is to prepare for #4674 where API Datapoint types should return `Input` and not `StoredInput`.