### PR TITLE
Bump timeout for getCuratedInferences test to 10s

### DIFF
--- a/ui/app/utils/clickhouse/curation.test.ts
+++ b/ui/app/utils/clickhouse/curation.test.ts
@@ -326,7 +326,7 @@ test("getCuratedInferences retrieves correct data", async () => {
     undefined,
   );
   expect(allResults.length).toBe(604);
-});
+}, 10000);
 
 // Test countFeedbacksForMetric
 test("countFeedbacksForMetric returns correct counts", async () => {


### PR DESCRIPTION
We already have a 10s timeout for a countCuratedInferences test
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase timeout for `getCuratedInferences` test to 10 seconds in `curation.test.ts`.
> 
>   - **Tests**:
>     - Increase timeout for `getCuratedInferences` test to 10 seconds in `curation.test.ts` to match `countCuratedInferences` test timeout.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for eb0fd7615680282c31ebe42f4dd0a7648fa78996. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->