### PR TITLE
Add conversion from StoredInput to Input

### DIFF
--- a/tensorzero-core/src/inference/types/mod.rs
+++ b/tensorzero-core/src/inference/types/mod.rs
@@ -609,6 +609,19 @@ pub struct InputMessage {
     pub content: Vec<InputMessageContent>,
 }
 
+impl From<StoredInputMessage> for InputMessage {
+    fn from(stored_input_message: StoredInputMessage) -> Self {
+        InputMessage {
+            role: stored_input_message.role,
+            content: stored_input_message
+                .content
+                .into_iter()
+                .map(StoredInputMessageContent::into_input_message_content)
+                .collect(),
+        }
+    }
+}
+
 /// A newtype wrapper around Map<String, Value> for template and system arguments
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, ts_rs::TS)]
 #[ts(export)]


### PR DESCRIPTION
Add a helper as a step for #4674, plus it unblocks #4668.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add conversion from `StoredInput` to `Input` in `stored_input.rs` without fetching file data, preserving only metadata.
> 
>   - **Behavior**:
>     - Add `into_input()` method to `StoredInput` in `stored_input.rs` to convert `StoredInput` to `Input` without fetching file data.
>     - Converts files to `File::ObjectStoragePointer` variant, preserving metadata only.
>   - **Conversions**:
>     - Add `into_input_message()` to `StoredInputMessage` for conversion to `InputMessage`.
>     - Add `into_input_message_content()` to `StoredInputMessageContent` for conversion to `InputMessageContent`.
>   - **Misc**:
>     - Update imports in `stored_input.rs` to include necessary types for conversion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 3552c1eb93ca86d45771ae5246e47ac199edc9f5. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->