### PR TITLE
Pin google-cloud-auth instead of jsonwebtoken

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3038,9 +3038,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.1.0"
+version = "10.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d119c6924272d16f0ab9ce41f7aa0bfef9340c00b0bb7ca3dd3b263d4a9150b"
+checksum = "c76e1c7d7df3e34443b3621b459b066a7b79644f059fc8b2db7070c825fd417e"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,8 @@ minijinja = { version = "2.12.0", features = [
     "unstable_machinery",
 ] }
 url = "2.5.4"
-google-cloud-auth = "1.1.0"
+# TODO - unpin when https://github.com/EmbarkStudios/cargo-deny/issues/803 is fixed
+google-cloud-auth = "=1.1.0"
 serde-untagged = "0.1.8"
 object_store = { version = "0.12.2", features = ["serde", "aws", "gcp"] }
 rand = "0.9.1"

--- a/tensorzero-core/Cargo.toml
+++ b/tensorzero-core/Cargo.toml
@@ -48,8 +48,7 @@ futures-core = "0.3.30"
 hex = "0.4.3"
 itertools = "0.14.0"
 jsonschema = "0.33.0"
-# TODO - unpin when https://github.com/EmbarkStudios/cargo-deny/issues/803 is fixed
-jsonwebtoken = { version = "=10.1.0", features = ["aws_lc_rs"] }
+jsonwebtoken = { version = "10.2", features = ["aws_lc_rs"] }
 lazy_static = { workspace = true }
 metrics = "0.24.2"
 metrics-exporter-prometheus = { workspace = true }


### PR DESCRIPTION
Older versions of jsonwebtoken still depend on 'rsa' behind a feature, so pinning it doesn't help.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `jsonwebtoken` to version `10.2.0` and pin `google-cloud-auth` to `1.1.0` to address dependency issues.
> 
>   - **Dependencies**:
>     - Update `jsonwebtoken` version from `10.1.0` to `10.2.0` in `Cargo.lock` and `tensorzero-core/Cargo.toml`.
>     - Pin `google-cloud-auth` to version `1.1.0` in `Cargo.toml` to address issue #803.
>   - **Misc**:
>     - Update checksum for `jsonwebtoken` in `Cargo.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 15e04bda4473eb8c3325d4e1ee3d9638ceacbd30. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->