### PR TITLE
Suppress 'multiple-versions' warnings from 'cargo deny'

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,9 @@ deny = [
     { name = "openssl" },
     { name = "openssl-sys"}
 ]
+# We have lots of transitive dependencies with multiple versions,
+# so this check isn't useful for us.
+multiple-versions = "allow"
 
 [advisories]
 ignore = [


### PR DESCRIPTION
We can't do anything about these warnings, as we have many transitive dependencies that depend on different versions of the sames crates.