### PR TITLE
Cleanup 'cancel-on-status-failure.yml'

### DIFF
--- a/.github/workflows/cancel-on-status-failure.yml
+++ b/.github/workflows/cancel-on-status-failure.yml
@@ -2,7 +2,7 @@ name: Cancel workflows on status failure
 
 # Note that Github does not fire 'check_run' events for job fails in other Github Actions workflows,
 # so this job only cancels workflows when external statuses like Buildkite report a failure.
-# We use '.github/workflows/cancel-on-status-failure.yml' to cancel workflows when other checks fail.
+# We use '.github/workflows/cancel-merge-queue-on-job-failure.yml' to cancel workflows when other checks fail.
 on:
   status:
 


### PR DESCRIPTION
This workflow only works for 'status' events (from external sources like Buildkite), so delete all of the 'check_run' code
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies `cancel-on-status-failure.yml` by removing `check_run` event handling, focusing on `status` events for external failures.
> 
>   - **Behavior**:
>     - Removes handling of `check_run` events in `cancel-on-status-failure.yml`, focusing solely on `status` events.
>     - Workflow now only cancels on external status failures (e.g., Buildkite), not on GitHub Actions job failures.
>   - **Code Simplification**:
>     - Deletes `print-event` job and related debug steps.
>     - Removes conditional logic for `check_run` events in `cancel-on-failure` job.
>     - Simplifies SHA determination logic to only consider `status` events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0049209d3d141dd4592a3d4443756b41f768ab51. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->