### PR TITLE
Bump to 2025.11.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2025.11.4"
+version = "2025.11.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2025.11.4"
+version = "2025.11.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2147,7 +2147,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2025.11.4"
+version = "2025.11.5"
 dependencies = [
  "axum",
  "clap",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-utils"
-version = "2025.11.4"
+version = "2025.11.5"
 dependencies = [
  "minijinja",
  "serde",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2025.11.4"
+version = "2025.11.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6059,7 +6059,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2025.11.4"
+version = "2025.11.5"
 dependencies = [
  "chrono",
  "futures",
@@ -6075,7 +6075,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2025.11.4"
+version = "2025.11.5"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -6185,7 +6185,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2025.11.4"
+version = "2025.11.5"
 dependencies = [
  "evaluations",
  "napi",
@@ -6204,7 +6204,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-optimizers"
-version = "2025.11.4"
+version = "2025.11.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -6236,7 +6236,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.11.4"
+version = "2025.11.5"
 dependencies = [
  "evaluations",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2025.11.4"
+version = "2025.11.5"
 rust-version = "1.88.0"
 license = "Apache-2.0"
 

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2025.11.4"
+appVersion: "2025.11.5"

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2025.11.4",
+  "version": "2025.11.5",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump version to 2025.11.5 across multiple project files for consistency.
> 
>   - **Version Bump**:
>     - Update version to `2025.11.5` in `Cargo.lock`, `Cargo.toml`, `Chart.yaml`, and `package.json`.
>     - Affects packages: `evaluations`, `feedback-load-test`, `gateway`, `minijinja-utils`, `rate-limit-load-test`, `tensorzero-auth`, `tensorzero-core`, `tensorzero-node`, `tensorzero-optimizers`, `tensorzero-python`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2708f6b57c1bdca9ea0806a5db7180af456dd6cf. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->