### PR TITLE
Allow null chat datapoint updates

### DIFF
--- a/clients/python/tensorzero/generated_types.py
+++ b/clients/python/tensorzero/generated_types.py
@@ -1555,10 +1555,10 @@ class UpdateChatDatapointRequestInternal:
     """
     Datapoint name. If omitted, it will be left unchanged. If specified as `null`, it will be set to `null`. If specified as a value, it will be set to the provided value.
     """
-    output: list[ContentBlockChatOutput] | None = None
+    output: list[ContentBlockChatOutput] | None | UnsetType = UNSET
     """
-    Chat datapoint output. If omitted, it will be left unchanged. If empty, it will be cleared. Otherwise,
-    it will overwrite the existing output.
+    Chat datapoint output. If omitted, it will be left unchanged. If specified as `null`, it will be set to
+    `null`. Otherwise, it will overwrite the existing output (and can be an empty array).
     """
     parallel_tool_calls: bool | None | UnsetType = UNSET
     """

--- a/clients/rust/tests/test_datasets.rs
+++ b/clients/rust/tests/test_datasets.rs
@@ -312,7 +312,7 @@ async fn test_update_datapoints(client: Client) {
     let chat_update = UpdateDatapointRequest::Chat(UpdateChatDatapointRequest {
         id: datapoint_ids[0],
         input: None,
-        output: Some(updated_output),
+        output: Some(Some(updated_output)),
         #[expect(deprecated)]
         deprecated_do_not_use_tool_params: Default::default(),
         tags: None,

--- a/internal/tensorzero-node/lib/bindings/UpdateChatDatapointRequest.ts
+++ b/internal/tensorzero-node/lib/bindings/UpdateChatDatapointRequest.ts
@@ -24,10 +24,10 @@ export type UpdateChatDatapointRequest = {
    */
   input?: Input;
   /**
-   * Chat datapoint output. If omitted, it will be left unchanged. If empty, it will be cleared. Otherwise,
-   * it will overwrite the existing output.
+   * Chat datapoint output. If omitted, it will be left unchanged. If specified as `null`, it will be set to
+   * `null`. Otherwise, it will overwrite the existing output (and can be an empty array).
    */
-  output?: Array<ContentBlockChatOutput>;
+  output?: Array<ContentBlockChatOutput> | null;
   /**
    * Datapoint tags. If omitted, it will be left unchanged. If empty, it will be cleared. Otherwise,
    * it will be overwrite the existing tags.

--- a/tensorzero-core/src/endpoints/datasets/v1/types.rs
+++ b/tensorzero-core/src/endpoints/datasets/v1/types.rs
@@ -56,10 +56,11 @@ pub struct UpdateChatDatapointRequest {
     #[serde(default)]
     pub input: Option<Input>,
 
-    /// Chat datapoint output. If omitted, it will be left unchanged. If empty, it will be cleared. Otherwise,
-    /// it will overwrite the existing output.
-    #[serde(default)]
-    pub output: Option<Vec<ContentBlockChatOutput>>,
+    /// Chat datapoint output. If omitted, it will be left unchanged. If specified as `null`, it will be set to
+    /// `null`. Otherwise, it will overwrite the existing output (and can be an empty array).
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    #[schemars(extend("x-double-option" = true))]
+    pub output: Option<Option<Vec<ContentBlockChatOutput>>>,
 
     /// Datapoint tool parameters.
     #[serde(flatten)]
@@ -106,8 +107,8 @@ impl<'de> Deserialize<'de> for UpdateChatDatapointRequest {
             id: Uuid,
             #[serde(default)]
             input: Option<Input>,
-            #[serde(default)]
-            output: Option<Vec<ContentBlockChatOutput>>,
+            #[serde(default, deserialize_with = "deserialize_double_option")]
+            output: Option<Option<Vec<ContentBlockChatOutput>>>,
             #[serde(flatten)]
             tool_params_new: UpdateDynamicToolParamsRequest,
             #[serde(default)]

--- a/tensorzero-core/src/endpoints/datasets/v1/update_datapoints.rs
+++ b/tensorzero-core/src/endpoints/datasets/v1/update_datapoints.rs
@@ -232,7 +232,7 @@ async fn prepare_chat_update(
     }
 
     if let Some(new_output) = update.output {
-        updated_datapoint.output = Some(new_output);
+        updated_datapoint.output = new_output;
     }
 
     // Apply the dynamic tool params update to the tool call config.
@@ -1068,7 +1068,7 @@ mod tests {
             let update = UpdateChatDatapointRequest {
                 id: existing.id,
                 input: None,
-                output: Some(new_output.clone()),
+                output: Some(Some(new_output.clone())),
                 tool_params: UpdateDynamicToolParamsRequest::default(),
                 #[expect(deprecated)]
                 deprecated_do_not_use_tool_params: None,
@@ -1095,6 +1095,45 @@ mod tests {
 
             // Output should be updated
             assert_eq!(updated.output, Some(new_output));
+        }
+
+        #[tokio::test]
+        async fn test_prepare_chat_update_output_set_to_null() {
+            let app_state = create_test_app_state();
+            let fetch_context = create_fetch_context(&app_state.http_client);
+            let dataset_name = "test_dataset";
+            let existing = create_sample_chat_datapoint(dataset_name);
+
+            let update = UpdateChatDatapointRequest {
+                id: existing.id,
+                input: None,
+                output: Some(None),
+                tool_params: Default::default(),
+                #[expect(deprecated)]
+                deprecated_do_not_use_tool_params: None,
+                tags: None,
+                metadata: Default::default(),
+                #[expect(deprecated)]
+                deprecated_do_not_use_metadata: None,
+            };
+
+            let result = prepare_chat_update(
+                &app_state,
+                &fetch_context,
+                dataset_name,
+                update,
+                existing.clone(),
+                "2025-01-01 00:00:00",
+            )
+            .await
+            .unwrap();
+
+            let DatapointInsert::Chat(updated) = result.updated else {
+                panic!("Expected Chat insert");
+            };
+
+            // Output should be cleared
+            assert_eq!(updated.output, None);
         }
 
         #[tokio::test]
@@ -1441,7 +1480,7 @@ mod tests {
             let update = UpdateChatDatapointRequest {
                 id: existing.id,
                 input: Some(new_input),
-                output: Some(new_output.clone()),
+                output: Some(Some(new_output.clone())),
                 tool_params: UpdateDynamicToolParamsRequest {
                     allowed_tools: Some(Some(vec![])),
                     additional_tools: None,
@@ -1931,9 +1970,9 @@ mod tests {
             let update = UpdateChatDatapointRequest {
                 id: existing.id,
                 input: None,
-                output: Some(vec![ContentBlockChatOutput::Text(Text {
+                output: Some(Some(vec![ContentBlockChatOutput::Text(Text {
                     text: "edited output".to_string(),
-                })]),
+                })])),
                 tool_params: UpdateDynamicToolParamsRequest::default(),
                 #[expect(deprecated)]
                 deprecated_do_not_use_tool_params: None,
@@ -1978,9 +2017,9 @@ mod tests {
             let update = UpdateChatDatapointRequest {
                 id: existing.id,
                 input: None,
-                output: Some(vec![ContentBlockChatOutput::Text(Text {
+                output: Some(Some(vec![ContentBlockChatOutput::Text(Text {
                     text: "edited output".to_string(),
-                })]),
+                })])),
                 tool_params: UpdateDynamicToolParamsRequest::default(),
                 #[expect(deprecated)]
                 deprecated_do_not_use_tool_params: None,


### PR DESCRIPTION
## Summary
- allow `UpdateChatDatapointRequest` to differentiate between omitted, null, and value outputs and update the handler/tests accordingly
- regenerate the TypeScript bindings and Python generated types so SDKs expose the nullable output semantics

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test-unit` *(fails: cargo-nextest command is not installed in the environment)*
- `pnpm build-bindings`
- `pnpm generate-python-schemas`

Fixes #4734.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691dfc96be78832daf3b2653243c5289)