### PR TITLE
commented out broken RFT test

### DIFF
--- a/tensorzero-optimizers/tests/mock_tests.rs
+++ b/tensorzero-optimizers/tests/mock_tests.rs
@@ -7,7 +7,7 @@ embedded_workflow_test_case!(fireworks_sft, common::fireworks_sft::FireworksSFTT
 http_workflow_test_case!(fireworks_sft, common::fireworks_sft::FireworksSFTTestCase());
 
 embedded_workflow_test_case!(openai_rft, common::openai_rft::OpenAIRFTTestCase());
-http_workflow_test_case!(openai_rft, common::openai_rft::OpenAIRFTTestCase());
+// http_workflow_test_case!(openai_rft, common::openai_rft::OpenAIRFTTestCase());
 
 embedded_workflow_test_case!(openai_sft, common::openai_sft::OpenAISFTTestCase());
 http_workflow_test_case!(openai_sft, common::openai_sft::OpenAISFTTestCase());


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Commented out a broken HTTP workflow test for `openai_rft` in `mock_tests.rs`.
> 
>   - **Tests**:
>     - Commented out `http_workflow_test_case!(openai_rft, common::openai_rft::OpenAIRFTTestCase())` in `mock_tests.rs`, disabling the HTTP workflow test for `openai_rft`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7599efd5a40914f4bf748354c6498711535597a4. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->