### PR TITLE
Clean up UI Dockerfile [v2]

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -83,7 +83,7 @@ FROM base AS ui
 
 RUN useradd -m -s /bin/sh ui
 
-RUN apt-get update && apt-get install -y curl wget && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y wget && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/ui/entrypoint.sh
+++ b/ui/entrypoint.sh
@@ -19,7 +19,7 @@ DISPLAY_BASE_URL=$(
 
 # Attempt to ping ClickHouse and check for OK response
 echo "Pinging ClickHouse at $DISPLAY_BASE_URL/ping to verify connectivity..."
-if ! curl -s --connect-timeout 5 "$BASE_URL/ping" > /dev/null; then
+if ! wget -q --timeout=5 -O /dev/null "$BASE_URL/ping"; then
   echo "Error: Failed to connect to ClickHouse at $DISPLAY_BASE_URL/ping"
   exit 1
 fi


### PR DESCRIPTION
Smaller image = faster CI downloads. Should save 1-2% of CI costs (less than anticipated).