### PR TITLE
Document adaptive stopping for evals in CLI reference

### DIFF
--- a/docs/evaluations/inference-evaluations/cli-reference.mdx
+++ b/docs/evaluations/inference-evaluations/cli-reference.mdx
@@ -92,7 +92,7 @@ If adaptive stopping is enabled for all evaluators, then the evaluation will sto
 This flag specifies the path to the TensorZero configuration file.
 You should use the same configuration file for your entire project.
 
-#### `--concurrency N`
+#### `--concurrency N` (`-c`)
 
 - **Example:** `--concurrency 5`
 - **Required:** no (default: `1`)


### PR DESCRIPTION
- Also add short flag indicator for `--concurrency`, and add **Example** and **Required** lines for `--variant-name`.