### PR TITLE
Fix flaky `test_http_mock_optimization_openai_rft` by excluding mock provider from proxy cache

### DIFF
--- a/tensorzero-core/src/http.rs
+++ b/tensorzero-core/src/http.rs
@@ -519,7 +519,9 @@ fn build_client(global_outbound_http_timeout: Duration) -> Result<Client, Error>
                                 message: format!("Invalid proxy URL: {e}"),
                             })
                         })?
-                        .no_proxy(NoProxy::from_string("localhost,127.0.0.1,minio")),
+                        .no_proxy(NoProxy::from_string(
+                            "localhost,127.0.0.1,minio,mock-inference-provider",
+                        )),
                 )
                 // When running e2e tests, we use `provider-proxy` as an MITM proxy
                 // for caching, so we need to accept the invalid (self-signed) cert.


### PR DESCRIPTION
## Problem

The `test_http_mock_optimization_openai_rft` test was failing consistently in CI with "Could not find fine tune" errors, while passing reliably in local development. The failure occurred on multiple unrelated PRs (#4630, #4775).

## Root Cause

In CI, requests to `mock-inference-provider:3030` were routed through `provider-proxy` for caching. The cache had partial entries for OpenAI RFT endpoints (POST cached, GET not cached), causing:

1. Job creation request served from cache → mock server never registered the job
2. Job polling request forwarded to mock server → "job not found" error
3. Gateway failed to deserialize error response → test failure

## Solution

Add `mock-inference-provider` to the HTTP client's `no_proxy` list, bypassing the provider-proxy cache for mock provider requests. This ensures the mock server sees both create and poll requests, maintaining state consistency.

## Changes

- `tensorzero-core/src/http.rs`: Added `mock-inference-provider` to no_proxy list

## Why This Approach

- The mock provider returns instant synthetic responses - caching provides no benefit
- Follows established pattern (localhost, 127.0.0.1, minio already excluded)
- Low risk: no tests depend on mock provider being cached
- Future-proof: prevents similar issues with other optimization tests

## Testing

Passes locally.

[merge-queue](https://github.com/tensorzero/tensorzero/actions/runs/19577814838)
#5752