### PR TITLE
Smaller `mock-inference-server` image

### DIFF
--- a/tensorzero-core/tests/e2e/docker-compose.live.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.live.yml
@@ -21,11 +21,6 @@ services:
       - ${GCP_CREDENTIALS_PATH:-../../../gcp_jwt_key.json}:/app/gcp_jwt_key.json:ro
     ports:
       - "3030:3030"
-    healthcheck:
-      test: wget --spider --tries 1 http://localhost:3030/status
-      start_period: 30s
-      start_interval: 1s
-      timeout: 1s
 
   provider-proxy:
     image: tensorzero/provider-proxy:${TENSORZERO_COMMIT_TAG}

--- a/tensorzero-core/tests/e2e/docker-compose.replicated.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.replicated.yml
@@ -90,12 +90,6 @@ services:
       RUST_LOG: debug
     ports:
       - "3030:3030"
-    healthcheck:
-      test: wget --spider --tries 1 http://localhost:3030/status
-      interval: 1s
-      start_period: 30s
-      start_interval: 1s
-      timeout: 1s
 
   minio:
     image: bitnamilegacy/minio:2025.7.23

--- a/tensorzero-core/tests/e2e/docker-compose.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.yml
@@ -15,11 +15,6 @@ services:
       - ${GCP_CREDENTIALS_PATH:-../../../gcp_jwt_key.json}:/app/gcp_jwt_key.json:ro
     ports:
       - "3030:3030"
-    healthcheck:
-      test: wget --spider --tries 1 http://localhost:3030/status
-      start_period: 30s
-      start_interval: 1s
-      timeout: 1s
 
   fixtures:
     build:

--- a/tensorzero-core/tests/mock-inference-provider/Dockerfile
+++ b/tensorzero-core/tests/mock-inference-provider/Dockerfile
@@ -10,20 +10,23 @@ ARG CARGO_BUILD_FLAGS=""
 RUN cargo build --release -p mock-inference-provider $CARGO_BUILD_FLAGS && \
     cp -r /src/target/release /release
 
+# ========== health-probe ==========
+
+FROM gcr.io/grpc-ecosystem/grpc-health-probe:latest AS health-probe
+
 # ========== mock-inference-provider ==========
 
-FROM debian:bookworm-slim AS mock-inference-provider
+FROM gcr.io/distroless/cc-debian12 AS mock-inference-provider
 
-RUN apt-get update && apt-get install -y wget
-
-RUN useradd -m -s /bin/bash mock-inference-provider
-
-USER mock-inference-provider
-
+COPY --from=health-probe /ko-app/grpc-health-probe /bin/grpc-health-probe
 COPY --from=builder /release/mock-inference-provider /usr/local/bin/mock-inference-provider
 
 WORKDIR /app
 
 EXPOSE 3030
+
+USER nonroot:nonroot
+
+HEALTHCHECK --start-period=1s --start-interval=1s --timeout=1s CMD ["/bin/grpc-health-probe", "-addr=localhost:3030"]
 
 ENTRYPOINT ["mock-inference-provider"]

--- a/ui/fixtures/docker-compose-common.yml
+++ b/ui/fixtures/docker-compose-common.yml
@@ -43,8 +43,3 @@ services:
       RUST_LOG: debug
     ports:
       - "3030:3030"
-    healthcheck:
-      test: wget --spider --tries 1 http://localhost:3030/status
-      start_period: 30s
-      start_interval: 1s
-      timeout: 1s


### PR DESCRIPTION
- Debian → Distroless
- This requires getting rid of `wget` used in health checks, so we set up `grpc-health-probe` (which also does HTTP checks)

(Make CI faster)