### PR TITLE
Added thought signature tool call handling to GCP vertex

### DIFF
--- a/tensorzero-core/src/providers/gcp_vertex_gemini/optimization.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_gemini/optimization.rs
@@ -258,7 +258,6 @@ mod tests {
             ContentBlockChatOutput, ModelInput, ResolvedContentBlock, ResolvedRequestMessage, Role,
             StoredInput, StoredInputMessage, StoredInputMessageContent, System, Text,
         },
-        providers::gcp_vertex_gemini::GCPVertexGeminiContentPart,
         stored_inference::{RenderedSample, StoredOutput},
         tool::DynamicToolParams,
     };


### PR DESCRIPTION
Google includes thoughts and thought signatures inline with their content parts; notably, tool calls. This brings the Vertex implementation to parity with Google AI studio in that aspect. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add thought signature tool call handling to GCP Vertex, aligning it with Google AI Studio.
> 
>   - **Behavior**:
>     - Add handling for thought signature tool calls in `stream_gcp_vertex_gemini()` and `tensorzero_to_gcp_vertex_gemini_content()`.
>     - Update `content_part_to_tensorzero_chunk()` and `convert_to_output()` to process thought signatures.
>   - **Models**:
>     - Modify `GCPVertexGeminiContentPart` to include `thought_signature` and `thought` fields.
>     - Update `GCPVertexGeminiContent` and `GCPVertexGeminiPartData` to support new content structure.
>   - **Tests**:
>     - Add `test_gcp_vertex_multi_turn_thought_non_streaming()` in `gcp_vertex_gemini.rs` to validate thought signature handling.
>     - Update existing tests to reflect changes in content processing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8048fbf3f9cffecaba7abd5984cba714af303755. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->