### PR TITLE
Include less debuginfo in dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,9 @@ single_match_else = "allow"
 # This lint cannot be fixed with 'cargo fmt', and we don't currently generate docs
 doc_lazy_continuation = "allow"
 
+[profile.dev]
+debug = "limited"
+
 [profile.performance]
 inherits = "release"
 lto = "fat"


### PR DESCRIPTION
This should shrink the size of the gateway binary, and all of the tests containers that include it
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `debug = "limited"` in `[profile.dev]` in `Cargo.toml` to reduce debug info in dev builds, shrinking gateway binary and test containers.
> 
>   - **Build Configuration**:
>     - Set `debug = "limited"` in `[profile.dev]` in `Cargo.toml` to reduce debug information in development builds.
>   - **Impact**:
>     - Reduces size of the gateway binary and test containers that include it.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 85ac1f899fbb5db44d58db5f235726f9936f8c63. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->