### PR TITLE
Exclude 'gateway' and other hosts from TENSORZERO_E2E_PROXY

### DIFF
--- a/tensorzero-core/src/http.rs
+++ b/tensorzero-core/src/http.rs
@@ -520,7 +520,7 @@ fn build_client(global_outbound_http_timeout: Duration) -> Result<Client, Error>
                             })
                         })?
                         .no_proxy(NoProxy::from_string(
-                            "localhost,127.0.0.1,minio,mock-inference-provider",
+                            "localhost,127.0.0.1,minio,mock-inference-provider,gateway,provider-proxy,clickhouse",
                         )),
                 )
                 // When running e2e tests, we use `provider-proxy` as an MITM proxy


### PR DESCRIPTION
When running live tests, we make requests over Docker networking to 'http://gateway'. We don't want these to be cached by provider-proxy, since this the response might include things like job ids from mock-inference-provider
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `no_proxy` list in `http.rs` to exclude `gateway`, `provider-proxy`, and `clickhouse` from caching during live tests.
> 
>   - **Behavior**:
>     - Updated `no_proxy` list in `build_client` function in `http.rs` to include `gateway`, `provider-proxy`, and `clickhouse`.
>     - Ensures requests to these hosts are not cached by `provider-proxy` during live tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 736d5d29688032e72cea904dcbcdc20a24503f35. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->