### PR TITLE
Docs: warn about ClickHouse version

### DIFF
--- a/examples/blog/bandits-in-your-llm-gateway/docker-compose.yml
+++ b/examples/blog/bandits-in-your-llm-gateway/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse/clickhouse-server:24.12-alpine
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update documentation to recommend ClickHouse `lts` for production and modify Docker Compose to use a stable ClickHouse image.
> 
>   - **Documentation**:
>     - In `clickhouse.mdx`, added a warning to recommend using ClickHouse `lts` instead of `latest` for production due to potential bugs and breaking changes.
>     - Reorganized warnings about unsupported sharded deployments.
>   - **Docker Configuration**:
>     - In `docker-compose.yml`, changed ClickHouse image from `clickhouse/clickhouse-server:24.12-alpine` to `clickhouse:24.12` for stability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c0bfc8e2856c0f8f54527f17f7b4a4e5d0f08d12. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->