### PR TITLE
Pin to `lts` instead of `24.12`

### DIFF
--- a/ci/buildkite/merge-queue-tests.yml
+++ b/ci/buildkite/merge-queue-tests.yml
@@ -136,8 +136,8 @@ steps:
     matrix:
       setup:
         clickhouse_version:
-          - "24.12"
-          - "25.7"
+          - "lts"
+          - "latest"
     env:
       TENSORZERO_CLICKHOUSE_VERSION: "{{matrix.clickhouse_version}}"
     depends_on:

--- a/ci/buildkite/pr-tests.yml
+++ b/ci/buildkite/pr-tests.yml
@@ -102,8 +102,8 @@ steps:
     matrix:
       setup:
         clickhouse_version:
-          - "24.12"
-          - "25.7"
+          - "lts"
+          - "latest"
     env:
       TENSORZERO_CLICKHOUSE_VERSION: "{{matrix.clickhouse_version}}"
     depends_on:

--- a/docs/gateway/guides/multimodal-inference.mdx
+++ b/docs/gateway/guides/multimodal-inference.mdx
@@ -55,7 +55,7 @@ We'll use Docker Compose to deploy the TensorZero Gateway, ClickHouse, and MinIO
 
 services:
   clickhouse:
-    image: clickhouse:24.12-alpine
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/docs/operations/set-up-auth-for-tensorzero.mdx
+++ b/docs/operations/set-up-auth-for-tensorzero.mdx
@@ -62,7 +62,7 @@ You can deploy all the requirements using the Docker Compose file below:
 
 services:
   clickhouse:
-    image: clickhouse:24.12-alpine
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -121,7 +121,7 @@ curl -LO "https://raw.githubusercontent.com/tensorzero/tensorzero/refs/heads/mai
 
 services:
   clickhouse:
-    image: clickhouse:24.12-alpine
+    image: clickhouse:lts
     environment:
       - CLICKHOUSE_USER=chuser
       - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1

--- a/examples/babyai/docker-compose.yml
+++ b/examples/babyai/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     ports:
       - "8123:8123"
     volumes:

--- a/examples/blog/bandits-in-your-llm-gateway/docker-compose.yml
+++ b/examples/blog/bandits-in-your-llm-gateway/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse/clickhouse-server:24.12-alpine
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/chess-puzzles/docker-compose.yml
+++ b/examples/chess-puzzles/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     ports:
       - "8123:8123" # HTTP port
       - "9000:9000" # Native port

--- a/examples/data-extraction-ner/docker-compose.yml
+++ b/examples/data-extraction-ner/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
@@ -73,7 +73,7 @@ services:
   # Optional: Load fixture data into ClickHouse (`docker compose up load-fixture`)
   load-fixture:
     profiles: [load-fixture]
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_PASSWORD: chpassword

--- a/examples/docs/guides/experimentation/run-adaptive-ab-tests/docker-compose.yml
+++ b/examples/docs/guides/experimentation/run-adaptive-ab-tests/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/docs/guides/gateway/call-the-openai-responses-api/docker-compose.yml
+++ b/examples/docs/guides/gateway/call-the-openai-responses-api/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/docs/guides/gateway/create-a-prompt-template/docker-compose.yml
+++ b/examples/docs/guides/gateway/create-a-prompt-template/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/docs/guides/gateway/generate-structured-outputs/docker-compose.yml
+++ b/examples/docs/guides/gateway/generate-structured-outputs/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/docs/guides/operations/enforce-custom-rate-limits/docker-compose.yml
+++ b/examples/docs/guides/operations/enforce-custom-rate-limits/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/docs/guides/operations/organize-your-configuration/docker-compose.yml
+++ b/examples/docs/guides/operations/organize-your-configuration/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/docs/guides/operations/set-up-auth-for-tensorzero/docker-compose.yml
+++ b/examples/docs/guides/operations/set-up-auth-for-tensorzero/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/dynamic_evaluations/simple-agentic-rag/docker-compose.yml
+++ b/examples/dynamic_evaluations/simple-agentic-rag/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       - CLICKHOUSE_USER=chuser
       - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1

--- a/examples/evaluations/tutorial/docker-compose.yml
+++ b/examples/evaluations/tutorial/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/gsm8k-custom-recipe-dspy/docker-compose.yml
+++ b/examples/gsm8k-custom-recipe-dspy/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/guides/batch-inference/docker-compose.yml
+++ b/examples/guides/batch-inference/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/guides/datasets-datapoints/docker-compose.yml
+++ b/examples/guides/datasets-datapoints/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/guides/episodes/docker-compose.yml
+++ b/examples/guides/episodes/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/guides/metrics-feedback/docker-compose.yml
+++ b/examples/guides/metrics-feedback/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/guides/multimodal-inference/docker-compose.yml
+++ b/examples/guides/multimodal-inference/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/guides/opentelemetry-otlp/docker-compose.yml
+++ b/examples/guides/opentelemetry-otlp/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/guides/tool-use/docker-compose.yml
+++ b/examples/guides/tool-use/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/haiku-hidden-preferences/docker-compose.yml
+++ b/examples/haiku-hidden-preferences/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
@@ -73,7 +73,7 @@ services:
   # Optional: Load fixture data into ClickHouse (`docker compose up load-fixture`)
   load-fixture:
     profiles: [load-fixture]
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_PASSWORD: chpassword

--- a/examples/integrations/crewai/example/tensorzero/docker-compose.yml
+++ b/examples/integrations/crewai/example/tensorzero/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       - CLICKHOUSE_USER=chuser
       - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1

--- a/examples/integrations/cursor/docker-compose.yml
+++ b/examples/integrations/cursor/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       - CLICKHOUSE_USER=chuser
       - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1

--- a/examples/integrations/openai-codex/docker-compose.yml
+++ b/examples/integrations/openai-codex/docker-compose.yml
@@ -35,7 +35,7 @@ services:
 
   # We use ClickHouse to store observability data from the TensorZero Gateway (optional).
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/mcp-model-context-protocol/docker-compose.yml
+++ b/examples/mcp-model-context-protocol/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: "chuser"
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"

--- a/examples/multimodal-vision-finetuning/docker-compose.yml
+++ b/examples/multimodal-vision-finetuning/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/optimization/dicl/docker-compose.yml
+++ b/examples/optimization/dicl/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       - CLICKHOUSE_USER=chuser
       - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1

--- a/examples/readme/docker-compose.yml
+++ b/examples/readme/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     ports:
       - "8123:8123"
     environment:

--- a/tensorzero-core/tests/e2e/docker-compose-common.yml
+++ b/tensorzero-core/tests/e2e/docker-compose-common.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: clickhouse:${TENSORZERO_CLICKHOUSE_VERSION:-24.12}
+    image: clickhouse:${TENSORZERO_CLICKHOUSE_VERSION:-lts}
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
@@ -8,7 +8,7 @@ services:
     volumes:
       # If the directory doesn't exist locally (i.e. we haven't defined a version-specific config),
       # an empty dir will get mounted in the container
-      - ./clickhouse-configs/${TENSORZERO_CLICKHOUSE_VERSION:-24.12}/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./clickhouse-configs/${TENSORZERO_CLICKHOUSE_VERSION:-lts}/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "8123:8123" # HTTP port
       - "9000:9000" # Native port

--- a/tensorzero-core/tests/e2e/docker-compose.clickhouse.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.clickhouse.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: clickhouse:${TENSORZERO_CLICKHOUSE_VERSION:-24.12}
+    image: clickhouse:${TENSORZERO_CLICKHOUSE_VERSION:-lts}
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
@@ -8,7 +8,7 @@ services:
     volumes:
       # If the directory doesn't exist locally (i.e. we haven't defined a version-specific config),
       # an empty dir will get mounted in the container
-      - ./clickhouse-configs/${TENSORZERO_CLICKHOUSE_VERSION:-24.12}/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./clickhouse-configs/${TENSORZERO_CLICKHOUSE_VERSION:-lts}/users.xml:/etc/clickhouse-server/users.d/users.xml
       - clickhouse-data:/var/lib/clickhouse
       # For S3 fixtures using file
       - ../../../ui/fixtures/s3-fixtures:/var/lib/clickhouse/user_files

--- a/tensorzero-core/tests/load/docker-compose.yml
+++ b/tensorzero-core/tests/load/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: clickhouse:24.12
+    image: clickhouse:lts
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/tensorzero-optimizers/tests/docker-compose.yml
+++ b/tensorzero-optimizers/tests/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: clickhouse:${TENSORZERO_CLICKHOUSE_VERSION:-24.12}
+    image: clickhouse:${TENSORZERO_CLICKHOUSE_VERSION:-lts}
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/ui/fixtures/Dockerfile
+++ b/ui/fixtures/Dockerfile
@@ -1,5 +1,5 @@
 # This Dockerfile is used to load fixtures into a (separate) ClickHouse server
-FROM clickhouse:24.12
+FROM clickhouse:lts
 
 RUN apt-get update && apt-get install -y cmake
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/

--- a/ui/fixtures/docker-compose.e2e.ci.yml
+++ b/ui/fixtures/docker-compose.e2e.ci.yml
@@ -3,7 +3,7 @@ include:
 
 services:
   clickhouse:
-    image: clickhouse:${TENSORZERO_CLICKHOUSE_VERSION:-24.12}
+    image: clickhouse:${TENSORZERO_CLICKHOUSE_VERSION:-lts}
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/ui/fixtures/docker-compose.e2e.yml
+++ b/ui/fixtures/docker-compose.e2e.yml
@@ -3,7 +3,7 @@ include:
 
 services:
   clickhouse:
-    image: clickhouse:${TENSORZERO_CLICKHOUSE_VERSION:-24.12}
+    image: clickhouse:${TENSORZERO_CLICKHOUSE_VERSION:-lts}
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/ui/fixtures/docker-compose.unit.yml
+++ b/ui/fixtures/docker-compose.unit.yml
@@ -3,7 +3,7 @@ include:
 
 services:
   clickhouse:
-    image: clickhouse:${TENSORZERO_CLICKHOUSE_VERSION:-24.12}
+    image: clickhouse:${TENSORZERO_CLICKHOUSE_VERSION:-lts}
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
@@ -48,7 +48,15 @@ services:
       gateway-postgres-migrations:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "${TENSORZERO_GATEWAY_URL:-http://localhost:3000}/health" ]
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "${TENSORZERO_GATEWAY_URL:-http://localhost:3000}/health",
+        ]
       start_period: 30s
       start_interval: 1s
       timeout: 1s
@@ -73,10 +81,10 @@ services:
         condition: service_healthy
       gateway-postgres-migrations:
         condition: service_healthy
-    command: [ "bash", "-c", "cd /fixtures && ./load_fixtures.sh" ]
+    command: ["bash", "-c", "cd /fixtures && ./load_fixtures.sh"]
     # Added healthcheck to wait for the marker file created by the script
     healthcheck:
-      test: [ "CMD", "test", "-f", "/load_complete.marker" ]
+      test: ["CMD", "test", "-f", "/load_complete.marker"]
       interval: 5s
       timeout: 1s
       retries: 48 # Retry for up to 4 minutes

--- a/ui/fixtures/docker-compose.yml
+++ b/ui/fixtures/docker-compose.yml
@@ -3,7 +3,7 @@ include:
 
 services:
   clickhouse:
-    image: clickhouse:${TENSORZERO_CLICKHOUSE_VERSION:-24.12}
+    image: clickhouse:${TENSORZERO_CLICKHOUSE_VERSION:-lts}
     environment:
       CLICKHOUSE_USER: chuser
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1


### PR DESCRIPTION
Fix #4808
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update ClickHouse version to 'lts' in Docker Compose files and CI configurations for consistency and stability.
> 
>   - **Docker Compose Changes**:
>     - Update ClickHouse image version from `24.12` to `lts` in `docker-compose.yml` files across multiple examples and guides.
>     - Affects services like `clickhouse`, `gateway`, and `ui` in various `docker-compose.yml` files.
>   - **CI Configuration Changes**:
>     - Update ClickHouse version matrix in `merge-queue-tests.yml` and `pr-tests.yml` from `24.12` and `25.7` to `lts` and `latest`.
>     - Modify `TENSORZERO_CLICKHOUSE_VERSION` default to `lts` in `docker-compose-common.yml` and `docker-compose.clickhouse.yml`.
>   - **Miscellaneous**:
>     - Update `FROM` directive in `ui/fixtures/Dockerfile` to use `clickhouse:lts`.
>     - Adjust `docker-compose.e2e.ci.yml`, `docker-compose.e2e.yml`, and `docker-compose.unit.yml` to reflect the `lts` version change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for bea750bbc389e23bec630be3d863baff9395c500. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->