### PR TITLE
Switch ui-tests-e2e-model-inference-cache runner back to ubuntu

### DIFF
--- a/.github/workflows/ui-tests-e2e-model-inference-cache.yml
+++ b/.github/workflows/ui-tests-e2e-model-inference-cache.yml
@@ -305,7 +305,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
-          name: playwright-report-auth-${{ matrix.auth_enabled }}-merge-group-${{ inputs.is_merge_group }}
+          name: playwright-report-auth-${{ matrix.auth_enabled }}-merge-group-${{ inputs.is_merge_group }}-regen-cache-${{ inputs.regen_cache }}
           path: |
             ui/playwright-report/
             ui/test-results/


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Switches `ui-tests-e2e-model-inference-cache` runner to `ubuntu-latest` and updates artifact upload action and conditions.
> 
>   - **Runner Change**:
>     - Switches `runs-on` from `namespace-profile-tensorzero-8x16` to `ubuntu-latest` in `ui-tests-e2e-model-inference-cache.yml`.
>   - **Artifact Upload**:
>     - Updates `upload-artifact` action from `namespace-actions` to `actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4`.
>     - Modifies condition for uploading Playwright artifacts to `if: always()` and updates artifact naming to include `merge-group` and `regen-cache` inputs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e9bad08f15495df05162c406d6244e6748f3ee3c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->