### PR TITLE
Fix docs about `template_filesystem_access`

### DIFF
--- a/docs/gateway/configuration-reference.mdx
+++ b/docs/gateway/configuration-reference.mdx
@@ -256,28 +256,15 @@ If `true`, then the migrations are not applied upon launch and must instead be a
 by running `docker run --rm -e TENSORZERO_CLICKHOUSE_URL=$TENSORZERO_CLICKHOUSE_URL tensorzero/gateway:{version} --run-clickhouse-migrations` or `docker compose run --rm gateway --run-clickhouse-migrations`.
 If `false`, then the migrations are run automatically upon launch.
 
-### `template_filesystem_access`
+### `template_filesystem_access.base_path`
 
-- **Type:** object
+- **Type:** string
 - **Required:** no (default disabled)
 
-Enabling this setting will allow MiniJinja templates to load sub-templates from the file system using the `include` directive.
+Set `template_filesystem_access.base_path` to allow MiniJinja templates to load sub-templates using the `{% include %}` and `{% import %}` directives.
 
-The object has two fields:
-
-- `enabled` (boolean): Determines whether to enable file system access for templates.
-- `base_path` (string, optional): Determines the base path for template file system access.
-
-If you use a single configuration file, the `base_path` will be the directory containing the configuration file.
-If you split your configuration into multiple files, you must specify `gateway.template_filesystem_access.base_path` (see [Organize your configuration](/operations/organize-your-configuration) for details).
-The `include` paths must be relative to `base_path`, and can only access files in that directory or its sub-directories.
-
-<Warning>
-
-Make sure to sanitize all user-provided template data before using this setting.
-Otherwise, a malicious input could read unintended files in the file system.
-
-</Warning>
+The directives will be relative to `base_path` and can only access files within that directory or its subdirectories.
+The `base_path` can be absolute or relative to the configuration file's location.
 
 ## `[models.model_name]`
 

--- a/docs/gateway/create-a-prompt-template.mdx
+++ b/docs/gateway/create-a-prompt-template.mdx
@@ -239,7 +239,7 @@ templates.fun_fact_topic.path = "functions/fun_fact/gpt_5_mini/fun_fact_topic_te
 
 You can enable template file system access to reuse shared snippets in your prompts.
 
-To use the MiniJinja directives `{% include %}` and `{% import %}`, you need to enable template file system access with `gateway.template_filesystem_access`.
+To use the MiniJinja directives `{% include %}` and `{% import %}`, set `gateway.template_filesystem_access.base_path` in your configuration.
 See [Organize your configuration](/operations/organize-your-configuration#enable-template-file-system-access-to-reuse-shared-snippets) for details.
 
 ## Migrate from legacy prompt templates

--- a/docs/operations/organize-your-configuration.mdx
+++ b/docs/operations/organize-your-configuration.mdx
@@ -44,7 +44,7 @@ You can decompose your templates into smaller, reusable snippets.
 This makes it easier to maintain and reuse code across multiple templates.
 
 Templates can reference other templates using the MiniJinja directives `{% include %}` and `{% import %}`.
-To use these directives, you need to enable template file system access with `gateway.template_filesystem_access` in your configuration file.
+To use these directives, set `gateway.template_filesystem_access.base_path` in your configuration file.
 
 By default, file system access is disabled for security reasons, since template imports are evaluated dynamically and could potentially access sensitive files.
 You should ensure that only trusted templates are allowed access to the file system.
@@ -52,17 +52,9 @@ You should ensure that only trusted templates are allowed access to the file sys
 ```toml
 [gateway]
 # ...
-template_filesystem_access.enabled = true
+template_filesystem_access.base_path = "."
 # ...
 ```
 
-If you split your configuration into multiple files, you must additionally specify the base path for the template imports.
-Template imports will then be resolved relative to this base path.
-If `base_path` itself is relative, it'll be relative to the configuration file in which it's defined.
-
-```toml
-[gateway]
-# ...
-template_filesystem_access = { enabled = true, base_path = "." }
-# ...
-```
+Template imports are resolved relative to `base_path`.
+If `base_path` itself is relative, it's relative to the configuration file in which it's defined.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update documentation to clarify `template_filesystem_access` as a string `base_path` for enabling MiniJinja template file system access.
> 
>   - **Documentation Updates**:
>     - In `configuration-reference.mdx`, `template_filesystem_access` is clarified to be a string `base_path` instead of an object, simplifying the explanation of enabling MiniJinja template file system access.
>     - In `create-a-prompt-template.mdx`, instructions are updated to set `gateway.template_filesystem_access.base_path` for using MiniJinja directives.
>     - In `organize-your-configuration.mdx`, the explanation of enabling template file system access is updated to reflect the new `base_path` configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b6390188d2c77ef798c924c9755fcce8d7770db4. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->