### PR TITLE
Fix deleting datapoints in clickhouse-latest

### DIFF
--- a/tensorzero-core/src/db/clickhouse/dataset_queries.rs
+++ b/tensorzero-core/src/db/clickhouse/dataset_queries.rs
@@ -711,33 +711,39 @@ impl DatasetQueries for ClickHouseConnectionInfo {
         // NOTE: in the two queries below, we don't alias to staled_at because then we won't select any rows.
         let chat_query = format!(
             r"
+            WITH existing_chat_datapoints AS (
+                SELECT *
+                FROM ChatInferenceDatapoint FINAL
+                WHERE dataset_name = {{dataset_name:String}}
+                {datapoint_ids_filter_clause}
+                AND staled_at IS NULL
+            )
             INSERT INTO ChatInferenceDatapoint
-            SELECT
-                *
-                REPLACE (
-                    now64() AS updated_at,
-                    now64() AS staled_at
-                )
-            FROM ChatInferenceDatapoint FINAL
-            WHERE dataset_name = {{dataset_name:String}}
-            {datapoint_ids_filter_clause}
-            AND staled_at IS NULL
+            SELECT *
+            REPLACE (
+                now64() AS updated_at,
+                now64() AS staled_at
+            )
+            FROM existing_chat_datapoints;
             "
         );
 
         let json_query = format!(
             r"
+            WITH existing_json_datapoints AS (
+                SELECT *
+                FROM JsonInferenceDatapoint FINAL
+                WHERE dataset_name = {{dataset_name:String}}
+                {datapoint_ids_filter_clause}
+                AND staled_at IS NULL
+            )
             INSERT INTO JsonInferenceDatapoint
-            SELECT
-                *
-                REPLACE (
-                    now64() AS updated_at,
-                    now64() AS staled_at
-                )
-            FROM JsonInferenceDatapoint FINAL
-            WHERE dataset_name = {{dataset_name:String}}
-            {datapoint_ids_filter_clause}
-            AND staled_at IS NULL
+            SELECT *
+            REPLACE (
+                now64() AS updated_at,
+                now64() AS staled_at
+            )
+            FROM existing_json_datapoints;
             "
         );
         let query_params = HashMap::from([("dataset_name", dataset_name)]);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `delete_datapoints` in `dataset_queries.rs` to use `WITH` clause for efficient datapoint deletion in ClickHouse.
> 
>   - **Behavior**:
>     - Refactor `delete_datapoints` in `dataset_queries.rs` to use `WITH` clause for selecting existing datapoints before marking them as stale.
>     - Affects both `ChatInferenceDatapoint` and `JsonInferenceDatapoint` tables.
>   - **Queries**:
>     - Use `WITH existing_chat_datapoints` and `WITH existing_json_datapoints` to select datapoints before updating `staled_at` and `updated_at` timestamps.
>     - Ensures only non-stale datapoints are selected for deletion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for bb147a4a6042756b177fe35c4121c0eb007aed30. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->