### PR TITLE
bumped version to 2025.11.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2025.11.5"
+version = "2025.11.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1935,7 +1935,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2025.11.5"
+version = "2025.11.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2025.11.5"
+version = "2025.11.6"
 dependencies = [
  "axum",
  "clap",
@@ -3385,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-utils"
-version = "2025.11.5"
+version = "2025.11.6"
 dependencies = [
  "minijinja",
  "serde",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2025.11.5"
+version = "2025.11.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6077,7 +6077,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2025.11.5"
+version = "2025.11.6"
 dependencies = [
  "chrono",
  "futures",
@@ -6093,7 +6093,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2025.11.5"
+version = "2025.11.6"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -6204,7 +6204,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2025.11.5"
+version = "2025.11.6"
 dependencies = [
  "evaluations",
  "napi",
@@ -6223,7 +6223,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-optimizers"
-version = "2025.11.5"
+version = "2025.11.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -6255,7 +6255,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.11.5"
+version = "2025.11.6"
 dependencies = [
  "evaluations",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2025.11.5"
+version = "2025.11.6"
 rust-version = "1.88.0"
 license = "Apache-2.0"
 

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2025.11.5"
+appVersion: "2025.11.6"

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2025.11.5",
+  "version": "2025.11.6",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump version from 2025.11.5 to 2025.11.6 across multiple project files for consistency.
> 
>   - **Version Bump**:
>     - Update version from `2025.11.5` to `2025.11.6` in `Cargo.lock` for packages: `evaluations`, `feedback-load-test`, `gateway`, `minijinja-utils`, `rate-limit-load-test`, `tensorzero-auth`, `tensorzero-core`, `tensorzero-node`, `tensorzero-optimizers`, `tensorzero-python`.
>     - Update version in `Cargo.toml` from `2025.11.5` to `2025.11.6`.
>     - Update `appVersion` in `Chart.yaml` from `2025.11.5` to `2025.11.6`.
>     - Update version in `package.json` from `2025.11.5` to `2025.11.6`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4893db4708816b9523373c767a1df5a58c8f8353. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->