### PR TITLE
Rename test-e2e-no-creds => test-clickhouse

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,21 +5,45 @@ rustflags = [
 ]
 
 [target.x86_64-apple-darwin]
-rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]  # for NAPI
+rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"] # for NAPI
 
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]  # for NAPI
+rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"] # for NAPI
 
 [alias]
 test-unit = "nextest run --lib --bins"
 test-unit-fast = "nextest run --lib --bins --retries 0 --no-fail-fast"
 test-all = "nextest run --features e2e_tests"
-# Note - 'test-batch', 'test-e2e', and 'test-e2e-no-creds' must be kept in sync
+# Note - 'test-batch', 'test-e2e', and 'test-clickhouse' must be kept in sync
 # Running all of them should cover all of our tests, and not miss any
-test-live-batch = ["nextest", "run", "--features", "e2e_tests", "--profile", "live-batch"]
-test-mock-batch = ["nextest", "run", "--features", "e2e_tests", "--profile", "mock-batch"]
+test-live-batch = [
+    "nextest",
+    "run",
+    "--features",
+    "e2e_tests",
+    "--profile",
+    "live-batch",
+]
+test-mock-batch = [
+    "nextest",
+    "run",
+    "--features",
+    "e2e_tests",
+    "--profile",
+    "mock-batch",
+]
 test-e2e = ["nextest", "run", "--features", "e2e_tests", "--profile", "e2e"]
-test-e2e-fast = ["nextest", "run", "--features", "e2e_tests", "--profile", "e2e", "--retries", "0", "--no-fail-fast"]
+test-e2e-fast = [
+    "nextest",
+    "run",
+    "--features",
+    "e2e_tests",
+    "--profile",
+    "e2e",
+    "--retries",
+    "0",
+    "--no-fail-fast",
+]
 test-optimization = [
     "nextest",
     "run",
@@ -40,17 +64,17 @@ test-optimization-mock = [
     "--profile",
     "optimization-mock",
 ]
-# Runs e2e tests that don't require any credentials available.
+# Runs Clickhouse-related e2e tests that don't require any inference credentials available.
 # This is useful for both running on PR CI (where we don't have creds at all),
 # and for testing against several different ClickHouse versions (to avoid spending lots of money on inference).
-test-e2e-no-creds = [
+test-clickhouse = [
     "nextest",
     "run",
     "--features",
     "e2e_tests",
     "--profile",
     "clickhouse",
-    ]
+]
 test-rate-limit-load = [
     "run",
     "--release",

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -850,7 +850,7 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/tensorzero-e2e-tests
           TENSORZERO_POSTGRES_URL: postgres://postgres:postgres@localhost:5432/tensorzero-e2e-tests
-        run: cargo test-e2e-no-creds
+        run: cargo test-clickhouse
 
       - name: Print docker compose logs (replicated)
         if: always() && matrix.replicated == true

--- a/ci/buildkite/test-clickhouse-cloud.sh
+++ b/ci/buildkite/test-clickhouse-cloud.sh
@@ -107,5 +107,5 @@ cd ui/fixtures
 cd ../..
 sleep 2
 
-cargo test-e2e-no-creds --no-fail-fast -- --skip test_concurrent_clickhouse_migrations
+cargo test-clickhouse --no-fail-fast -- --skip test_concurrent_clickhouse_migrations
 cat e2e_logs.txt


### PR DESCRIPTION
`test-e2e-no-creds` actually runs clickhouse-related tests, and it's not a subset of `test-e2e`, so I'm renaming it to avoid confusion.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rename `test-e2e-no-creds` to `test-clickhouse` to clarify its purpose of running ClickHouse-related tests.
> 
>   - **Alias Renaming**:
>     - Rename `test-e2e-no-creds` to `test-clickhouse` in `.cargo/config.toml` to reflect its purpose of running ClickHouse-related tests.
>     - Update references in `general.yml` and `test-clickhouse-cloud.sh` to use `test-clickhouse` instead of `test-e2e-no-creds`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0f01e1149f6c9531f4bc098a4d5b64e931189162. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->