### PR TITLE
Use 'pull_request_target' event for force-merge-queue workflow

### DIFF
--- a/.github/workflows/force-merge-queue.yml
+++ b/.github/workflows/force-merge-queue.yml
@@ -14,7 +14,9 @@ permissions:
 # that actually merging a PR requires the real 'check-all-general-jobs-passed' job to pass.
 
 on:
-  pull_request:
+  # We need to use 'pull_request_target' so that we have proper permissions to add statuses to the PR,
+  # even when the PR is from a fork.
+  pull_request_target:
     types: [labeled, unlabeled]
 
 jobs:


### PR DESCRIPTION
We need this to be able to add PRs from forks to the merge queue, since the 'pull_request' event will not have proper permissions
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch `pull_request` event to `pull_request_target` in `force-merge-queue.yml` for proper permissions on forked PRs.
> 
>   - **Workflow Trigger**:
>     - Change event trigger from `pull_request` to `pull_request_target` in `.github/workflows/force-merge-queue.yml`.
>     - Ensures proper permissions for adding statuses to PRs from forks.
>   - **Event Types**:
>     - Triggered on `labeled` and `unlabeled` events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4d045e313de53b40f2e96af81d1a0d4876960e97. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->