### PR TITLE
Fix flaky minikube tests

### DIFF
--- a/.github/workflows/minikube.yml
+++ b/.github/workflows/minikube.yml
@@ -35,12 +35,16 @@ jobs:
             # We load this from the build-gateway-container job
             tag: sha-${{ github.sha }}
             pullPolicy: Never
+          service:
+            type: NodePort
         ui:
           image:
             repository: tensorzero/ui
             # We load this from the build-ui-container job
             tag: sha-${{ github.sha }}
             pullPolicy: Never
+          service:
+            type: NodePort
         EOF
         # Fix the extra indentation caused by inlining the yaml file in our workflow
         sed -i 's/^        //' helm-ci-overrides.yaml
@@ -68,18 +72,17 @@ jobs:
         helm upgrade --install tensorzero .  -f values.yaml -f helm-ci-overrides.yaml -n tensorzero
         kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=tensorzero -n tensorzero --timeout=60s
 
-    - name: Port forward the gateway and ui services
-      run: |
-        kubectl port-forward service/tensorzero-gateway -n tensorzero 3000:3000 > gateway-port-forward.log 2>&1 &
-        kubectl port-forward service/tensorzero-ui -n tensorzero 4000:4000 > ui-port-forward.log 2>&1 &
-
     - name: Ping the gateway
       run: |
+        # Get the minikube service URL
+        GATEWAY_URL=$(minikube service tensorzero-gateway -n tensorzero --url)
+        echo "Gateway URL: $GATEWAY_URL"
+
         # TODO - add a 'startupProbe' to the gateway helm chart
         count=0
         max_attempts=40
-        while ! curl http://localhost:3000/health; do
-          echo "Waiting for gateway to be healthy..."
+        while ! curl ${GATEWAY_URL}/health; do
+          echo "Waiting for gateway to be healthy (attempt $count/$max_attempts)..."
           sleep 1
           count=$((count + 1))
           if [ $count -ge $max_attempts ]; then
@@ -87,6 +90,7 @@ jobs:
             exit 1
           fi
         done
+        echo "Gateway is healthy!"
 
     - name: Print pod statuses
       if: always()
@@ -102,16 +106,6 @@ jobs:
       if: always()
       run: |
         kubectl logs -n tensorzero --timestamps=true --all-pods=true --all-containers=true -l app.kubernetes.io/instance=tensorzero
-
-    - name: Print gateway port forward logs
-      if: always()
-      run: |
-        cat gateway-port-forward.log
-
-    - name: Print ui port forward logs
-      if: always()
-      run: |
-        cat ui-port-forward.log
 
     - name: Print logs from stopped pods
       if: always()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add debug logging and use `NodePort` service type for better health checks in minikube test workflow.
> 
>   - **Service Configuration**:
>     - Change `service` type to `NodePort` for `gateway` and `ui` in `minikube.yml`.
>   - **Health Check**:
>     - Use `minikube service` to get `GATEWAY_URL` instead of port-forwarding.
>     - Add detailed logging for gateway health check attempts in `minikube.yml`.
>   - **Misc**:
>     - Remove port-forwarding step for `gateway` and `ui` services in `minikube.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e8bfcd3070389d45c840f57c197b6f33a7da9be9. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->