### PR TITLE
Better documentation of `UNSET` and `None` in Python

### DIFF
--- a/clients/python/tensorzero/generated_types.py
+++ b/clients/python/tensorzero/generated_types.py
@@ -90,7 +90,10 @@ class DatapointMetadataUpdate:
 
     name: str | None | UnsetType = UNSET
     """
-    Datapoint name. If omitted, it will be left unchanged. If specified as `null`, it will be set to `null`. If specified as a value, it will be set to the provided value.
+    Datapoint name.
+
+    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared. If specified as a value, it will
+    be set to the provided value.
     """
 
 
@@ -574,18 +577,16 @@ class InputMessageContentUnknown:
 class JsonDatapointOutputUpdate:
     """
     A request to update the output of a JSON datapoint.
-    We intentionally only accept the `raw` field (in a JSON-serialized string), because datapoints can contain invalid outputs, and it's desirable
-    for users to run evals against them.
 
-    The possible values for `output` are:
-    - `None`: don't update `output`
-    - `Some(None)`: set output to `None` (represents edge case where inference succeeded but model didn't output relevant content blocks)
-    - `Some(String)`: set the output to the string (= JSON-serialized string)
+    We intentionally only accept the `raw` field, because JSON datapoints can contain invalid or malformed JSON for eval purposes.
     """
 
     raw: str | None = None
     """
     The raw output of the datapoint. For valid JSON outputs, this should be a JSON-serialized string.
+
+    This will be parsed and validated against the datapoint's `output_schema`. Valid `raw` values will be parsed and stored as `parsed`, and
+    invalid `raw` values will be stored as-is, because we allow invalid outputs in datapoints by design.
     """
 
 
@@ -924,7 +925,10 @@ class UpdateDatapointMetadataRequest:
     """
     name: str | None | UnsetType = UNSET
     """
-    Datapoint name. If omitted, it will be left unchanged. If specified as `null`, it will be set to `null`. If specified as a value, it will be set to the provided value.
+    Datapoint name.
+
+    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared. If specified as a value, it will
+    be set to the provided value.
     """
 
 
@@ -1336,13 +1340,16 @@ class UpdateDynamicToolParamsRequest:
     allowed_tools: list[str] | None | UnsetType = UNSET
     """
     A subset of static tools configured for the function that the inference is explicitly allowed to use.
-    If omitted, it will be left unchanged. If specified as `null`, it will be cleared (we allow function-configured tools plus additional tools
-    provided at inference time). If specified as a value, it will be set to the provided value.
+
+    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (we allow function-configured tools
+    plus additional tools provided at inference time). If specified as a value, it will be set to the provided value.
     """
     parallel_tool_calls: bool | None | UnsetType = UNSET
     """
     Whether to use parallel tool calls in the inference.
-    If omitted, it will be left unchanged. If specified as `null`, it will be set to `null`. If specified as a value, it will be set to the provided value.
+
+    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (we will use function-configured
+    parallel tool calls). If specified as a value, it will be set to the provided value.
     """
     provider_tools: list[ProviderTool] | None = None
     """
@@ -1352,7 +1359,9 @@ class UpdateDynamicToolParamsRequest:
     tool_choice: ToolChoice | None | UnsetType = UNSET
     """
     User-specified tool choice strategy.
-    If omitted, it will be left unchanged. If specified as `null`, we will clear the dynamic tool choice and use function-configured tool choice.
+
+    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (we will use function-configured
+    tool choice). If specified as a value, it will be set to the provided value.
     """
 
 
@@ -1542,12 +1551,6 @@ class StoredJsonInference:
 class UpdateChatDatapointRequestInternal:
     """
     An update request for a chat datapoint.
-    For any fields that are optional in ChatInferenceDatapoint, the request field distinguishes between an omitted field, `null`, and a value:
-    - If the field is omitted, it will be left unchanged.
-    - If the field is specified as `null`, it will be set to `null`.
-    - If the field has a value, it will be set to the provided value.
-
-    In Rust this is modeled as an `Option<Option<T>>`, where `None` means "unchanged" and `Some(None)` means "set to `null`" and `Some(Some(T))` means "set to the provided value".
     """
 
     id: str
@@ -1564,8 +1567,9 @@ class UpdateChatDatapointRequestInternal:
     allowed_tools: list[str] | None | UnsetType = UNSET
     """
     A subset of static tools configured for the function that the inference is explicitly allowed to use.
-    If omitted, it will be left unchanged. If specified as `null`, it will be cleared (we allow function-configured tools plus additional tools
-    provided at inference time). If specified as a value, it will be set to the provided value.
+
+    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (we allow function-configured tools
+    plus additional tools provided at inference time). If specified as a value, it will be set to the provided value.
     """
     input: Input | None = None
     """
@@ -1578,17 +1582,24 @@ class UpdateChatDatapointRequestInternal:
     """
     name: str | None | UnsetType = UNSET
     """
-    Datapoint name. If omitted, it will be left unchanged. If specified as `null`, it will be set to `null`. If specified as a value, it will be set to the provided value.
+    Datapoint name.
+
+    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared. If specified as a value, it will
+    be set to the provided value.
     """
     output: list[ContentBlockChatOutput] | None | UnsetType = UNSET
     """
-    Chat datapoint output. If omitted, it will be left unchanged. If specified as `null`, it will be set to
-    `null`. Otherwise, it will overwrite the existing output (and can be an empty array).
+    Chat datapoint output.
+
+    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared.
+    Otherwise, it will overwrite the existing output (and can be an empty list).
     """
     parallel_tool_calls: bool | None | UnsetType = UNSET
     """
     Whether to use parallel tool calls in the inference.
-    If omitted, it will be left unchanged. If specified as `null`, it will be set to `null`. If specified as a value, it will be set to the provided value.
+
+    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (we will use function-configured
+    parallel tool calls). If specified as a value, it will be set to the provided value.
     """
     provider_tools: list[ProviderTool] | None = None
     """
@@ -1597,13 +1608,17 @@ class UpdateChatDatapointRequestInternal:
     """
     tags: dict[str, Any] | None = None
     """
-    Datapoint tags. If omitted, it will be left unchanged. If empty, it will be cleared. Otherwise,
-    it will be overwrite the existing tags.
+    Datapoint tags.
+
+    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared.
+    Otherwise, it will overwrite the existing tags.
     """
     tool_choice: ToolChoice | None | UnsetType = UNSET
     """
     User-specified tool choice strategy.
-    If omitted, it will be left unchanged. If specified as `null`, we will clear the dynamic tool choice and use function-configured tool choice.
+
+    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (we will use function-configured
+    tool choice). If specified as a value, it will be set to the provided value.
     """
     tool_params: UpdateDynamicToolParamsRequest | None = None
     """
@@ -1625,12 +1640,6 @@ class UpdateChatDatapointRequest(UpdateChatDatapointRequestInternal):
 class UpdateJsonDatapointRequestInternal:
     """
     An update request for a JSON datapoint.
-    For any fields that are optional in JsonInferenceDatapoint, the request field distinguishes between an omitted field, `null`, and a value:
-    - If the field is omitted, it will be left unchanged.
-    - If the field is specified as `null`, it will be set to `null`.
-    - If the field has a value, it will be set to the provided value.
-
-    In Rust this is modeled as an `Option<Option<T>>`, where `None` means "unchanged" and `Some(None)` means "set to `null`" and `Some(Some(T))` means "set to the provided value".
     """
 
     id: str
@@ -1648,13 +1657,16 @@ class UpdateJsonDatapointRequestInternal:
     """
     name: str | None | UnsetType = UNSET
     """
-    Datapoint name. If omitted, it will be left unchanged. If specified as `null`, it will be set to `null`. If specified as a value, it will be set to the provided value.
+    Datapoint name.
+
+    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared. If specified as a value, it will
+    be set to the provided value.
     """
     output: JsonDatapointOutputUpdate | None | UnsetType = UNSET
     """
-    JSON datapoint output. If omitted, it will be left unchanged. If `null`, it will be set to `null`. If specified as a value, it will be set to the provided value.
-    This will be parsed and validated against output_schema, and valid `raw` values will be parsed and stored as `parsed`. Invalid `raw` values will
-    also be stored, because we allow invalid outputs in datapoints by design.
+    JSON datapoint output.
+    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (represents edge case where
+    inference succeeded but model didn't output relevant content blocks). Otherwise, it will overwrite the existing output.
     """
     output_schema: Any | None = None
     """
@@ -1805,8 +1817,6 @@ class CreateJsonDatapointRequest:
     output: JsonDatapointOutputUpdate | None = None
     """
     JSON datapoint output. Optional.
-    If provided, it will be validated against the output_schema. Invalid raw outputs will be stored as-is (not parsed), because we allow
-    invalid outputs in datapoints by design.
     """
     output_schema: Any | None = None
     """

--- a/internal/tensorzero-node/lib/bindings/CreateJsonDatapointRequest.ts
+++ b/internal/tensorzero-node/lib/bindings/CreateJsonDatapointRequest.ts
@@ -21,8 +21,6 @@ export type CreateJsonDatapointRequest = {
   input: Input;
   /**
    * JSON datapoint output. Optional.
-   * If provided, it will be validated against the output_schema. Invalid raw outputs will be stored as-is (not parsed), because we allow
-   * invalid outputs in datapoints by design.
    */
   output?: JsonDatapointOutputUpdate;
   /**

--- a/internal/tensorzero-node/lib/bindings/JsonDatapointOutputUpdate.ts
+++ b/internal/tensorzero-node/lib/bindings/JsonDatapointOutputUpdate.ts
@@ -2,17 +2,15 @@
 
 /**
  * A request to update the output of a JSON datapoint.
- * We intentionally only accept the `raw` field (in a JSON-serialized string), because datapoints can contain invalid outputs, and it's desirable
- * for users to run evals against them.
  *
- * The possible values for `output` are:
- * - `None`: don't update `output`
- * - `Some(None)`: set output to `None` (represents edge case where inference succeeded but model didn't output relevant content blocks)
- * - `Some(String)`: set the output to the string (= JSON-serialized string)
+ * We intentionally only accept the `raw` field, because JSON datapoints can contain invalid or malformed JSON for eval purposes.
  */
 export type JsonDatapointOutputUpdate = {
   /**
    * The raw output of the datapoint. For valid JSON outputs, this should be a JSON-serialized string.
+   *
+   * This will be parsed and validated against the datapoint's `output_schema`. Valid `raw` values will be parsed and stored as `parsed`, and
+   * invalid `raw` values will be stored as-is, because we allow invalid outputs in datapoints by design.
    */
   raw: string | null;
 };

--- a/internal/tensorzero-node/lib/bindings/UpdateChatDatapointRequest.ts
+++ b/internal/tensorzero-node/lib/bindings/UpdateChatDatapointRequest.ts
@@ -7,12 +7,6 @@ import type { ToolChoice } from "./ToolChoice";
 
 /**
  * An update request for a chat datapoint.
- * For any fields that are optional in ChatInferenceDatapoint, the request field distinguishes between an omitted field, `null`, and a value:
- * - If the field is omitted, it will be left unchanged.
- * - If the field is specified as `null`, it will be set to `null`.
- * - If the field has a value, it will be set to the provided value.
- *
- * In Rust this is modeled as an `Option<Option<T>>`, where `None` means "unchanged" and `Some(None)` means "set to `null`" and `Some(Some(T))` means "set to the provided value".
  */
 export type UpdateChatDatapointRequest = {
   /**

--- a/internal/tensorzero-node/lib/bindings/UpdateJsonDatapointRequest.ts
+++ b/internal/tensorzero-node/lib/bindings/UpdateJsonDatapointRequest.ts
@@ -5,12 +5,6 @@ import type { JsonValue } from "./serde_json/JsonValue";
 
 /**
  * An update request for a JSON datapoint.
- * For any fields that are optional in JsonInferenceDatapoint, the request field distinguishes between an omitted field, `null`, and a value:
- * - If the field is omitted, it will be left unchanged.
- * - If the field is specified as `null`, it will be set to `null`.
- * - If the field has a value, it will be set to the provided value.
- *
- * In Rust this is modeled as an `Option<Option<T>>`, where `None` means "unchanged" and `Some(None)` means "set to `null`" and `Some(Some(T))` means "set to the provided value".
  */
 export type UpdateJsonDatapointRequest = {
   /**
@@ -23,8 +17,6 @@ export type UpdateJsonDatapointRequest = {
   input?: Input;
   /**
    * JSON datapoint output. If omitted, it will be left unchanged. If `null`, it will be set to `null`. If specified as a value, it will be set to the provided value.
-   * This will be parsed and validated against output_schema, and valid `raw` values will be parsed and stored as `parsed`. Invalid `raw` values will
-   * also be stored, because we allow invalid outputs in datapoints by design.
    */
   output?: JsonDatapointOutputUpdate | null;
   /**

--- a/tensorzero-core/src/endpoints/API_TYPES.md
+++ b/tensorzero-core/src/endpoints/API_TYPES.md
@@ -1,0 +1,43 @@
+# A note about API types
+
+We currently use Rust as the source of truth for API types. 
+
+
+## Patch semantics
+
+For APIs that update data in our database, we use patch semantics where the request represents a partial update, so users are not forced to
+specify every data field. We also allow users to clear a field in many cases.
+
+In Rust, we represent these types as `Option<Option<T>>`s, and use these custom annotations to support Python and TypeScript:
+
+```rust
+pub struct UpdateChatDatapointRequest {
+    // ... omitted ...
+    
+    /// Chat datapoint output. If omitted, it will be left unchanged. If specified as `null`, it will be set to
+    /// `null`. Otherwise, it will overwrite the existing output (and can be an empty array).
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    #[schemars(extend("x-double-option" = true), description = "Chat datapoint output.
+
+If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared.
+Otherwise, it will overwrite the existing output (and can be an empty list).")]
+    pub output: Option<Option<Vec<ContentBlockChatOutput>>>,
+
+    // ... omitted ...
+}
+```
+
+The 3 semantics of this field are represented as follows in each language:
+
+- Semantic: replace the field with a given value.
+    - JSON: the key is set to the given value.
+    - Python: the field is set to the given value.
+    - Rust: the field is set to `Some(Some(value))`.
+- Semantic: clear the field.
+    - JSON: the key is set to `null`.
+    - Python: the field is set to `None`.
+    - Rust: the field is set to `Some(None)`.
+- Semantic: leave as-is, do not update the field.
+    - JSON: the key is omitted in the object.
+    - Python: the field is not set (and takes the default value `UNSET`). We have serialization logic that removes fields with the default value `UNSET`.
+    - Rust: the field is set to `None`, or use `..Default::default()` if supported.

--- a/tensorzero-core/src/endpoints/datasets/v1/types.rs
+++ b/tensorzero-core/src/endpoints/datasets/v1/types.rs
@@ -38,12 +38,6 @@ pub enum UpdateDatapointRequest {
 }
 
 /// An update request for a chat datapoint.
-/// For any fields that are optional in ChatInferenceDatapoint, the request field distinguishes between an omitted field, `null`, and a value:
-/// - If the field is omitted, it will be left unchanged.
-/// - If the field is specified as `null`, it will be set to `null`.
-/// - If the field has a value, it will be set to the provided value.
-///
-/// In Rust this is modeled as an `Option<Option<T>>`, where `None` means "unchanged" and `Some(None)` means "set to `null`" and `Some(Some(T))` means "set to the provided value".
 #[derive(Clone, Debug, JsonSchema, Serialize, ts_rs::TS)]
 #[ts(export, optional_fields)]
 #[export_schema]
@@ -59,7 +53,10 @@ pub struct UpdateChatDatapointRequest {
     /// Chat datapoint output. If omitted, it will be left unchanged. If specified as `null`, it will be set to
     /// `null`. Otherwise, it will overwrite the existing output (and can be an empty array).
     #[serde(default, deserialize_with = "deserialize_double_option")]
-    #[schemars(extend("x-double-option" = true))]
+    #[schemars(extend("x-double-option" = true), description = "Chat datapoint output.
+
+If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared.
+Otherwise, it will overwrite the existing output (and can be an empty list).")]
     pub output: Option<Option<Vec<ContentBlockChatOutput>>>,
 
     /// Datapoint tool parameters.
@@ -81,6 +78,10 @@ pub struct UpdateChatDatapointRequest {
     /// Datapoint tags. If omitted, it will be left unchanged. If empty, it will be cleared. Otherwise,
     /// it will be overwrite the existing tags.
     #[serde(default)]
+    #[schemars(description = "Datapoint tags.
+
+If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared.
+Otherwise, it will overwrite the existing tags.")]
     pub tags: Option<HashMap<String, String>>,
 
     /// Metadata fields to update.
@@ -204,7 +205,10 @@ pub struct UpdateDynamicToolParamsRequest {
     /// If omitted, it will be left unchanged. If specified as `null`, it will be cleared (we allow function-configured tools plus additional tools
     /// provided at inference time). If specified as a value, it will be set to the provided value.
     #[serde(default, deserialize_with = "deserialize_double_option")]
-    #[schemars(extend("x-double-option" = true))]
+    #[schemars(extend("x-double-option" = true), description = "A subset of static tools configured for the function that the inference is explicitly allowed to use.
+
+If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (we allow function-configured tools
+plus additional tools provided at inference time). If specified as a value, it will be set to the provided value.")]
     pub allowed_tools: Option<Option<Vec<String>>>,
 
     /// Tools that the user provided at inference time (not in function config), in addition to the function-configured tools, that are also allowed.
@@ -216,13 +220,19 @@ pub struct UpdateDynamicToolParamsRequest {
     /// User-specified tool choice strategy.
     /// If omitted, it will be left unchanged. If specified as `null`, we will clear the dynamic tool choice and use function-configured tool choice.
     #[serde(default, deserialize_with = "deserialize_double_option")]
-    #[schemars(extend("x-double-option" = true))]
+    #[schemars(extend("x-double-option" = true), description = "User-specified tool choice strategy.
+
+If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (we will use function-configured
+tool choice). If specified as a value, it will be set to the provided value.")]
     pub tool_choice: Option<Option<ToolChoice>>,
 
     /// Whether to use parallel tool calls in the inference.
     /// If omitted, it will be left unchanged. If specified as `null`, it will be set to `null`. If specified as a value, it will be set to the provided value.
     #[serde(default, deserialize_with = "deserialize_double_option")]
-    #[schemars(extend("x-double-option" = true))]
+    #[schemars(extend("x-double-option" = true), description = "Whether to use parallel tool calls in the inference.
+
+If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (we will use function-configured
+parallel tool calls). If specified as a value, it will be set to the provided value.")]
     pub parallel_tool_calls: Option<Option<bool>>,
 
     /// Provider-specific tool configurations
@@ -231,12 +241,6 @@ pub struct UpdateDynamicToolParamsRequest {
 }
 
 /// An update request for a JSON datapoint.
-/// For any fields that are optional in JsonInferenceDatapoint, the request field distinguishes between an omitted field, `null`, and a value:
-/// - If the field is omitted, it will be left unchanged.
-/// - If the field is specified as `null`, it will be set to `null`.
-/// - If the field has a value, it will be set to the provided value.
-///
-/// In Rust this is modeled as an `Option<Option<T>>`, where `None` means "unchanged" and `Some(None)` means "set to `null`" and `Some(Some(T))` means "set to the provided value".
 #[derive(Clone, Debug, JsonSchema, Serialize, ts_rs::TS)]
 #[ts(export, optional_fields)]
 #[export_schema]
@@ -250,10 +254,10 @@ pub struct UpdateJsonDatapointRequest {
     pub input: Option<Input>,
 
     /// JSON datapoint output. If omitted, it will be left unchanged. If `null`, it will be set to `null`. If specified as a value, it will be set to the provided value.
-    /// This will be parsed and validated against output_schema, and valid `raw` values will be parsed and stored as `parsed`. Invalid `raw` values will
-    /// also be stored, because we allow invalid outputs in datapoints by design.
     #[serde(default, deserialize_with = "deserialize_double_option")]
-    #[schemars(extend("x-double-option" = true))]
+    #[schemars(extend("x-double-option" = true), description = "JSON datapoint output.
+If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (represents edge case where
+inference succeeded but model didn't output relevant content blocks). Otherwise, it will overwrite the existing output.")]
     pub output: Option<Option<JsonDatapointOutputUpdate>>,
 
     /// The output schema of the JSON datapoint. If omitted, it will be left unchanged. If specified as `null`, it will be set to `null`. If specified as a value, it will be set to the provided value.
@@ -341,18 +345,16 @@ impl<'de> Deserialize<'de> for UpdateJsonDatapointRequest {
 }
 
 /// A request to update the output of a JSON datapoint.
-/// We intentionally only accept the `raw` field (in a JSON-serialized string), because datapoints can contain invalid outputs, and it's desirable
-/// for users to run evals against them.
 ///
-/// The possible values for `output` are:
-/// - `None`: don't update `output`
-/// - `Some(None)`: set output to `None` (represents edge case where inference succeeded but model didn't output relevant content blocks)
-/// - `Some(String)`: set the output to the string (= JSON-serialized string)
+/// We intentionally only accept the `raw` field, because JSON datapoints can contain invalid or malformed JSON for eval purposes.
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ts_rs::TS)]
 #[ts(export)]
 #[export_schema]
 pub struct JsonDatapointOutputUpdate {
     /// The raw output of the datapoint. For valid JSON outputs, this should be a JSON-serialized string.
+    ///
+    /// This will be parsed and validated against the datapoint's `output_schema`. Valid `raw` values will be parsed and stored as `parsed`, and
+    /// invalid `raw` values will be stored as-is, because we allow invalid outputs in datapoints by design.
     pub raw: Option<String>,
 }
 
@@ -363,7 +365,10 @@ pub struct JsonDatapointOutputUpdate {
 pub struct DatapointMetadataUpdate {
     /// Datapoint name. If omitted, it will be left unchanged. If specified as `null`, it will be set to `null`. If specified as a value, it will be set to the provided value.
     #[serde(default, deserialize_with = "deserialize_double_option")]
-    #[schemars(extend("x-double-option" = true))]
+    #[schemars(extend("x-double-option" = true), description = "Datapoint name.
+
+If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared. If specified as a value, it will
+be set to the provided value.")]
     pub name: Option<Option<String>>,
 }
 
@@ -590,8 +595,6 @@ pub struct CreateJsonDatapointRequest {
     pub input: Input,
 
     /// JSON datapoint output. Optional.
-    /// If provided, it will be validated against the output_schema. Invalid raw outputs will be stored as-is (not parsed), because we allow
-    /// invalid outputs in datapoints by design.
     pub output: Option<JsonDatapointOutputUpdate>,
 
     /// The output schema of the JSON datapoint. Optional.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improved documentation for handling `UNSET` and `None` in Python and TypeScript, clarifying behavior in datapoint updates.
> 
>   - **Documentation**:
>     - Clarified handling of `UNSET` and `None` in `DatapointMetadataUpdate` and `JsonDatapointOutputUpdate` in `generated_types.py`.
>     - Updated comments in `API_TYPES.md` to explain patch semantics and handling of `Option<Option<T>>` in Rust, Python, and TypeScript.
>     - Improved docstrings in `types.rs` for `UpdateChatDatapointRequest` and `UpdateJsonDatapointRequest` to specify behavior when fields are omitted, set to `None`, or given a value.
>   - **TypeScript Bindings**:
>     - Updated `CreateJsonDatapointRequest.ts`, `JsonDatapointOutputUpdate.ts`, `UpdateChatDatapointRequest.ts`, and `UpdateJsonDatapointRequest.ts` to reflect changes in handling `null` and omitted fields.
>   - **Rust Code**:
>     - Removed redundant comments in `types.rs` regarding `Option<Option<T>>` handling, as this is now covered in `API_TYPES.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f3cb67be9f80e771d976f71062f4d07bdcc85909. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->