### PR TITLE
Try to fix ClickHouse cloud ubuntu package installation

### DIFF
--- a/ci/buildkite/test-clickhouse-cloud.sh
+++ b/ci/buildkite/test-clickhouse-cloud.sh
@@ -67,7 +67,7 @@ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 3E4AD4719DDE9A
 # Get the system architecture
 ARCH=$(dpkg --print-architecture)
 # Add the ClickHouse repository to apt sources
-echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg arch=${ARCH}] https://packages.clickhouse.com/deb stable main" | sudo tee /etc/apt/sources.list.d/clickhouse.list
+echo "deb https://packages.clickhouse.com/deb stable main" | sudo tee /etc/apt/sources.list.d/clickhouse.list
 # Update apt package lists
 sudo apt-get update
 sudo apt-get install -y clickhouse-client


### PR DESCRIPTION
The GPG key url just started returning 'Not Found', so let's try the other installation method from their docs: https://clickhouse.com/docs/install/debian_ubuntu
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix ClickHouse GPG key retrieval in `test-clickhouse-cloud.sh` by using `apt-key adv` with a keyserver.
> 
>   - **Behavior**:
>     - Replaces GPG key retrieval method in `test-clickhouse-cloud.sh` due to 'Not Found' error.
>     - Uses `apt-key adv` with keyserver `hkp://keyserver.ubuntu.com:80` to receive key `3E4AD4719DDE9A38`.
>     - Removes `signed-by` option from ClickHouse repository addition in `test-clickhouse-cloud.sh`.
>   - **Misc**:
>     - Comments out the old GPG key URL and adds a note about the incorrect GPG key ID in ClickHouse docs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 11da9df468e977cada4e3c43025da88fa80571c8. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->