### PR TITLE
added sleeps for consistency in mocked batch tests

### DIFF
--- a/tensorzero-core/tests/e2e/providers/mock_batch.rs
+++ b/tensorzero-core/tests/e2e/providers/mock_batch.rs
@@ -353,6 +353,8 @@ pub async fn test_simple_image_unified_mock_batch_with_provider(
 
     // Step 4: Verify ClickHouse storage
     let clickhouse = get_clickhouse().await;
+    // Sleep to allow ClickHouse async_insert to become visible
+    sleep(Duration::from_millis(200)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(
@@ -419,6 +421,8 @@ pub async fn test_json_mode_unified_mock_batch_with_provider(
     check_json_mode_inference_response(inferences_json[0].clone(), provider, None, true).await;
 
     let clickhouse = get_clickhouse().await;
+    // Sleep to allow ClickHouse async_insert to become visible
+    sleep(Duration::from_millis(200)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(
@@ -588,6 +592,8 @@ pub async fn test_tool_use_unified_mock_batch_with_provider(
     .await;
 
     let clickhouse = get_clickhouse().await;
+    // Sleep to allow ClickHouse async_insert to become visible
+    sleep(Duration::from_millis(200)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(
@@ -670,6 +676,8 @@ pub async fn test_parallel_tool_use_unified_mock_batch_with_provider(
     .await;
 
     let clickhouse = get_clickhouse().await;
+    // Sleep to allow ClickHouse async_insert to become visible
+    sleep(Duration::from_millis(200)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(
@@ -748,6 +756,8 @@ pub async fn test_inference_params_unified_mock_batch_with_provider(
 
     // Step 4: Verify ClickHouse storage
     let clickhouse = get_clickhouse().await;
+    // Sleep to allow ClickHouse async_insert to become visible
+    sleep(Duration::from_millis(200)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(
@@ -833,6 +843,8 @@ pub async fn test_multi_turn_tool_use_unified_mock_batch_with_provider(
 
     // Step 4: Verify ClickHouse storage
     let clickhouse = get_clickhouse().await;
+    // Sleep to allow ClickHouse async_insert to become visible
+    sleep(Duration::from_millis(200)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(
@@ -939,6 +951,8 @@ pub async fn test_multi_turn_parallel_tool_use_unified_mock_batch_with_provider(
 
     // Step 4: Verify ClickHouse storage
     let clickhouse = get_clickhouse().await;
+    // Sleep to allow ClickHouse async_insert to become visible
+    sleep(Duration::from_millis(200)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(
@@ -1025,6 +1039,8 @@ pub async fn test_dynamic_tool_use_unified_mock_batch_with_provider(
 
     // Step 4: Verify ClickHouse storage
     let clickhouse = get_clickhouse().await;
+    // Sleep to allow ClickHouse async_insert to become visible
+    sleep(Duration::from_millis(200)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(
@@ -1116,6 +1132,8 @@ pub async fn test_dynamic_json_mode_unified_mock_batch_with_provider(
 
     // Step 4: Verify ClickHouse storage
     let clickhouse = get_clickhouse().await;
+    // Sleep to allow ClickHouse async_insert to become visible
+    sleep(Duration::from_millis(200)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(
@@ -1186,6 +1204,8 @@ pub async fn test_allowed_tools_unified_mock_batch_with_provider(
 
     // Step 4: Verify ClickHouse storage
     let clickhouse = get_clickhouse().await;
+    // Sleep to allow ClickHouse async_insert to become visible
+    sleep(Duration::from_millis(200)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add sleep statements in `mock_batch.rs` tests to ensure ClickHouse async inserts are visible before verification.
> 
>   - **Tests**:
>     - Add `sleep(Duration::from_millis(200)).await` before `check_clickhouse_batch_request_status()` in `mock_batch.rs` to ensure ClickHouse async inserts are visible.
>     - Affected functions include `test_simple_image_unified_mock_batch_with_provider()`, `test_json_mode_unified_mock_batch_with_provider()`, and `test_tool_use_unified_mock_batch_with_provider()` among others.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 623f394c4da1f6f73f855167dfb8b8a70543c476. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->