### PR TITLE
Use dataset-scoped getDatapoint API in UI

### DIFF
--- a/internal/tensorzero-node/lib/index.ts
+++ b/internal/tensorzero-node/lib/index.ts
@@ -28,8 +28,6 @@ import type {
   CountFeedbackByTargetIdParams,
   QueryDemonstrationFeedbackByInferenceIdParams,
   DemonstrationFeedbackRow,
-  GetDatapointParams,
-  Datapoint,
   GetCumulativeFeedbackTimeseriesParams,
   KeyInfo,
 } from "./bindings";
@@ -237,12 +235,6 @@ export class DatabaseClient {
     return new DatabaseClient(
       await NativeDatabaseClient.fromClickhouseUrl(url),
     );
-  }
-
-  async getDatapoint(params: GetDatapointParams): Promise<Datapoint> {
-    const paramsString = safeStringify(params);
-    const result = await this.nativeDatabaseClient.getDatapoint(paramsString);
-    return JSON.parse(result) as Datapoint;
   }
 
   async getModelUsageTimeseries(

--- a/internal/tensorzero-node/src/database.rs
+++ b/internal/tensorzero-node/src/database.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 use tensorzero::{
     setup_clickhouse_without_config, ClickHouseConnection, CountDatapointsForDatasetFunctionParams,
-    DatasetQueryParams, GetDatapointParams, GetDatasetMetadataParams, TimeWindow,
+    DatasetQueryParams, GetDatasetMetadataParams, TimeWindow,
 };
 use uuid::Uuid;
 
@@ -176,11 +176,6 @@ impl DatabaseClient {
                 limit
             }
         )
-    }
-
-    #[napi]
-    pub async fn get_datapoint(&self, params: String) -> Result<String, napi::Error> {
-        napi_call!(&self, get_datapoint, params, GetDatapointParams)
     }
 
     #[napi]

--- a/ui/app/routes/datasets/$dataset_name/datapoint/$id/route.tsx
+++ b/ui/app/routes/datasets/$dataset_name/datapoint/$id/route.tsx
@@ -291,20 +291,11 @@ export async function loader({
       status: 404,
     });
   }
-  const datapoint = await getTensorZeroClient().getDatapoint(id);
+  const datapoint = await getTensorZeroClient().getDatapoint(id, dataset_name);
   if (!datapoint) {
     throw data(`No datapoint found for ID \`${id}\`.`, {
       status: 404,
     });
-  }
-  // Note (GabrielBianconi): `getDatapoint` no longer depends on the dataset name, but maybe it should?
-  if (datapoint.dataset_name !== dataset_name) {
-    throw data(
-      `The datapoint \`${id}\` does not belong to dataset \`${dataset_name}\`.`,
-      {
-        status: 400,
-      },
-    );
   }
 
   // Load file data for InputElement component

--- a/ui/app/routes/datasets/$dataset_name/route.tsx
+++ b/ui/app/routes/datasets/$dataset_name/route.tsx
@@ -19,7 +19,6 @@ import { DeleteButton } from "~/components/utils/DeleteButton";
 import { getTensorZeroClient } from "~/utils/tensorzero.server";
 import { getConfig, getFunctionConfig } from "~/utils/config/index.server";
 import { useReadOnly } from "~/context/read-only";
-import { listDatapoints } from "~/utils/tensorzero.server";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
   const { dataset_name } = params;
@@ -36,9 +35,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw data("Limit cannot exceed 100", { status: 400 });
   }
 
-  const [counts, rows] = await Promise.all([
+  const [counts, getDatapointsResponse] = await Promise.all([
     getDatasetMetadata({}),
-    listDatapoints(dataset_name, /*function_name=*/ undefined, limit, offset),
+    getTensorZeroClient().listDatapoints(dataset_name, { limit, offset }),
   ]);
   const count_info = counts.find(
     (count) => count.dataset_name === dataset_name,
@@ -46,6 +45,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   if (!count_info) {
     throw data("Dataset not found", { status: 404 });
   }
+  const rows = getDatapointsResponse.datapoints;
   return { rows, count_info, limit, offset, rowsAdded, rowsSkipped };
 }
 

--- a/ui/app/routes/playground/route.tsx
+++ b/ui/app/routes/playground/route.tsx
@@ -17,7 +17,7 @@ import {
 } from "~/context/config";
 import { getConfig, getFunctionConfig } from "~/utils/config/index.server";
 import type { Route } from "./+types/route";
-import { listDatapoints } from "~/utils/tensorzero.server";
+import { getTensorZeroClient } from "~/utils/tensorzero.server";
 import { datapointInputToZodInput } from "~/routes/api/tensorzero/inference.utils";
 import { resolveInput } from "~/utils/resolve.server";
 import { X } from "lucide-react";
@@ -152,11 +152,15 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
   const datasetName = searchParams.get("datasetName");
 
-  let datapoints, totalDatapoints;
+  let getDatapointsResponse, totalDatapoints;
   try {
-    [datapoints, totalDatapoints] = datasetName
+    [getDatapointsResponse, totalDatapoints] = datasetName
       ? await Promise.all([
-          listDatapoints(datasetName, functionName ?? undefined, limit, offset),
+          getTensorZeroClient().listDatapoints(datasetName, {
+            function_name: functionName ?? undefined,
+            limit,
+            offset,
+          }),
           functionName
             ? countDatapointsForDatasetFunction(datasetName, functionName)
             : null,
@@ -171,9 +175,12 @@ export async function loader({ request }: Route.LoaderArgs) {
     );
   }
 
+  const datapoints: TensorZeroDatapoint[] =
+    getDatapointsResponse?.datapoints ?? [];
+
   let inputs;
   try {
-    inputs = datapoints
+    inputs = getDatapointsResponse
       ? await Promise.all(
           datapoints.map(async (datapoint) => {
             const inputData = datapointInputToZodInput(datapoint.input);

--- a/ui/app/utils/tensorzero.server.ts
+++ b/ui/app/utils/tensorzero.server.ts
@@ -8,7 +8,6 @@ import {
 import type { JsonValue } from "~/types/tensorzero";
 import { getEnv } from "./env.server";
 import { getFeedbackConfig } from "./config/feedback";
-import type { Datapoint as TensorZeroDatapoint } from "~/types/tensorzero";
 
 let _tensorZeroClient: TensorZeroClient | undefined;
 
@@ -164,18 +163,4 @@ export async function addJudgeDemonstration(formData: FormData) {
   });
   const response = await getTensorZeroClient().feedback(feedbackRequest);
   return response;
-}
-
-export async function listDatapoints(
-  datasetName: string,
-  functionName?: string,
-  limit?: number,
-  offset?: number,
-): Promise<TensorZeroDatapoint[]> {
-  const response = await getTensorZeroClient().listDatapoints(datasetName, {
-    function_name: functionName,
-    limit: limit,
-    offset: offset,
-  });
-  return response.datapoints;
 }

--- a/ui/app/utils/tensorzero.test.ts
+++ b/ui/app/utils/tensorzero.test.ts
@@ -24,12 +24,13 @@ describe("update datapoints", () => {
     // Verify initial state: is_custom should be false, source_inference_id should match
     const initialDatapoint = await tensorZeroClient.getDatapoint(
       createResult.id,
+      /*datasetName=*/ "test",
     );
-    expect(initialDatapoint).not.toBeNull();
+    expect(initialDatapoint).toBeDefined();
     expect(initialDatapoint?.is_custom).toBe(false);
     expect(initialDatapoint?.source_inference_id).toBe(inferenceId);
 
-    // TypeScript refinement: we've verified initialDatapoint is not null
+    // TypeScript refinement: we've verified initialDatapoint is defined
     if (!initialDatapoint || initialDatapoint.type !== "json") {
       throw new Error("Expected JSON datapoint");
     }
@@ -45,9 +46,7 @@ describe("update datapoints", () => {
     const updateResult = await tensorZeroClient.updateDatapoint("test", {
       type: "json",
       id: initialDatapoint.id,
-      // TODO (#4674 #4675): fix this casting
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      input: initialDatapoint.input as any, // Type conversion needed: StoredInput has ObjectStoragePointer files, Input expects full file types
+      input: initialDatapoint.input,
       output: {
         raw: JSON.stringify(updatedOutput),
       },
@@ -57,6 +56,7 @@ describe("update datapoints", () => {
     // Verify updated state
     const updatedDatapoint = await tensorZeroClient.getDatapoint(
       updateResult.id,
+      /*datasetName=*/ "test",
     );
 
     // New ID should be created

--- a/ui/app/utils/tensorzero/tensorzero.ts
+++ b/ui/app/utils/tensorzero/tensorzero.ts
@@ -447,8 +447,14 @@ export class TensorZeroClient {
     return { id: body.ids[0] };
   }
 
-  async getDatapoint(datapointId: string): Promise<Datapoint | null> {
-    const endpoint = `/v1/datasets/get_datapoints`;
+  async getDatapoint(
+    datapointId: string,
+    datasetName?: string,
+  ): Promise<Datapoint | undefined> {
+    // We currently maintain 2 endpoints for getting a datapoint, with/without the dataset name.
+    const endpoint = datasetName
+      ? `/v1/datasets/${encodeURIComponent(datasetName)}/get_datapoints`
+      : `/v1/datasets/get_datapoints`;
     const requestBody: GetDatapointsRequest = {
       ids: [datapointId],
     };
@@ -464,7 +470,10 @@ export class TensorZeroClient {
     }
 
     const body = (await response.json()) as GetDatapointsResponse;
-    return body.datapoints[0] ?? null;
+    if (body.datapoints.length === 0) {
+      return undefined;
+    }
+    return body.datapoints[0];
   }
 
   async listDatapoints(


### PR DESCRIPTION
Fixes #4774.

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update UI to use dataset-scoped `getDatapoint` API, removing old method and updating calls to include dataset names.
> 
>   - **Backend Changes**:
>     - Remove `getDatapoint` method from `DatabaseClient` in `internal/tensorzero-node/lib/index.ts` and `internal/tensorzero-node/src/database.rs`.
>     - Remove `GetDatapointParams` and `Datapoint` types from `bindings`.
>   - **Frontend Changes**:
>     - Update `getDatapoint` calls in `route.tsx` to include `dataset_name` parameter.
>     - Replace `listDatapoints` function with `getTensorZeroClient().listDatapoints` in `route.tsx` and `playground/route.tsx`.
>     - Remove `listDatapoints` function from `tensorzero.server.ts`.
>   - **Testing**:
>     - Update tests in `tensorzero.test.ts` to use new `getDatapoint` API with `dataset_name`.
>   - **Misc**:
>     - Minor updates to comments and error messages in `route.tsx` and `playground/route.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 41fac584aaa5ea249832e8d90fd9d1e9b0dca83a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->