### PR TITLE
Rip GEPA e2e tests

### DIFF
--- a/tensorzero-optimizers/Cargo.toml
+++ b/tensorzero-optimizers/Cargo.toml
@@ -73,6 +73,14 @@ name = "e2e_dicl"
 path = "tests/e2e/dicl.rs"
 required-features = ["e2e_tests"]
 
+# TODO: The test configuration for tests in `tests/e2e/gepa/` has been temporarily removed due to timeout issues.
+# Once the timeout issues are resolved, re-enable the test configuration here.
+# The test files (e.g., `mod.rs`, `analyze.rs` in `tests/e2e/gepa/`) are intentionally left in place.
+# [[test]]
+# name = "e2e_gepa"
+# path = "tests/e2e/gepa/mod.rs"
+# required-features = ["e2e_tests"]
+
 # False positive (used in macro)
 [package.metadata.cargo-shear]
 ignored = ["paste"]


### PR DESCRIPTION
temporarily remove gepa e2e tests while fixing timeout
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Temporarily remove `e2e_gepa` test configuration due to timeout issues, leaving test files in place.
> 
>   - **Tests**:
>     - Temporarily remove `e2e_gepa` test configuration in `Cargo.toml` due to timeout issues.
>     - Leave test files in `tests/e2e/gepa/` (e.g., `mod.rs`, `analyze.rs`) in place for future re-enabling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0375a4aeac3dbd310e7305995cf592769f931a68. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->