### PR TITLE
Stop taking function config when converting datapoints

### DIFF
--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -726,7 +726,6 @@ impl ClientExt for Client {
                 with_embedded_timeout(*timeout, async {
                     let mut response = tensorzero_core::endpoints::datasets::v1::get_datapoints(
                         &gateway.handle.app_state.clickhouse_connection_info,
-                        &gateway.handle.app_state.config,
                         Some(dataset_name.clone()),
                         GetDatapointsRequest {
                             ids: vec![datapoint_id],
@@ -882,7 +881,6 @@ impl ClientExt for Client {
                 with_embedded_timeout(*timeout, async {
                     tensorzero_core::endpoints::datasets::v1::get_datapoints(
                         &gateway.handle.app_state.clickhouse_connection_info,
-                        &gateway.handle.app_state.config,
                         dataset_name,
                         request,
                     )
@@ -914,7 +912,6 @@ impl ClientExt for Client {
                 with_embedded_timeout(*timeout, async {
                     tensorzero_core::endpoints::datasets::v1::list_datapoints(
                         &gateway.handle.app_state.clickhouse_connection_info,
-                        &gateway.handle.app_state.config,
                         dataset_name,
                         request,
                     )

--- a/evaluations/src/lib.rs
+++ b/evaluations/src/lib.rs
@@ -516,14 +516,9 @@ pub async fn run_evaluation_core_streaming(
             offset: Some(0),
             ..Default::default()
         };
-        list_datapoints(
-            &clients.clickhouse_client,
-            &args.config,
-            dataset_name.clone(),
-            request,
-        )
-        .await?
-        .datapoints
+        list_datapoints(&clients.clickhouse_client, dataset_name.clone(), request)
+            .await?
+            .datapoints
     } else {
         // Load by IDs
         let request = GetDatapointsRequest {
@@ -531,7 +526,6 @@ pub async fn run_evaluation_core_streaming(
         };
         get_datapoints(
             &clients.clickhouse_client,
-            &args.config,
             /*dataset_name=*/ None,
             request,
         )

--- a/evaluations/tests/tests.rs
+++ b/evaluations/tests/tests.rs
@@ -494,15 +494,10 @@ async fn run_evaluation_with_specific_datapoint_ids() {
         offset: Some(0),
         ..Default::default()
     };
-    let dataset = list_datapoints(
-        &clickhouse,
-        &*get_config().await,
-        dataset_name.clone(),
-        request,
-    )
-    .await
-    .unwrap()
-    .datapoints;
+    let dataset = list_datapoints(&clickhouse, dataset_name.clone(), request)
+        .await
+        .unwrap()
+        .datapoints;
 
     // Select only the first 5 datapoint IDs
     let selected_ids: Vec<Uuid> = dataset.iter().take(5).map(|dp| dp.id()).collect();
@@ -600,15 +595,10 @@ async fn run_exact_match_evaluation_chat() {
         offset: Some(0),
         ..Default::default()
     };
-    let dataset = list_datapoints(
-        &clickhouse,
-        &*get_config().await,
-        dataset_name.clone(),
-        request,
-    )
-    .await
-    .unwrap()
-    .datapoints;
+    let dataset = list_datapoints(&clickhouse, dataset_name.clone(), request)
+        .await
+        .unwrap()
+        .datapoints;
     let datapoint_ids: Vec<Uuid> = dataset.iter().map(|dp| dp.id()).collect();
 
     let config_path = PathBuf::from(&format!(
@@ -745,15 +735,10 @@ async fn run_llm_judge_evaluation_chat() {
         offset: Some(0),
         ..Default::default()
     };
-    let dataset = list_datapoints(
-        &clickhouse,
-        &*get_config().await,
-        dataset_name.clone(),
-        request,
-    )
-    .await
-    .unwrap()
-    .datapoints;
+    let dataset = list_datapoints(&clickhouse, dataset_name.clone(), request)
+        .await
+        .unwrap()
+        .datapoints;
     let datapoint_ids: Vec<Uuid> = dataset.iter().map(|dp| dp.id()).collect();
 
     let config_path = PathBuf::from(&format!(
@@ -2557,14 +2542,12 @@ async fn test_query_skips_staled_datapoints() {
     )
     .await;
 
-    let config = get_config().await;
-
     let request = ListDatapointsRequest {
         function_name: Some("extract_entities".to_string()),
         limit: Some(u32::MAX), // Get all datapoints
         ..Default::default()
     };
-    let dataset = list_datapoints(&clickhouse, &config, dataset_name.clone(), request)
+    let dataset = list_datapoints(&clickhouse, dataset_name.clone(), request)
         .await
         .unwrap()
         .datapoints;

--- a/tensorzero-core/src/endpoints/datasets/legacy.rs
+++ b/tensorzero-core/src/endpoints/datasets/legacy.rs
@@ -1046,7 +1046,7 @@ pub async fn list_datapoints(
 
     let datapoints: Result<Vec<Datapoint>, _> = result_lines
         .iter()
-        .map(|line| serde_json::from_str::<StoredDatapoint>(line)?.into_datapoint(config))
+        .map(|line| serde_json::from_str::<StoredDatapoint>(line)?.into_datapoint())
         .collect();
     let datapoints = match datapoints {
         Ok(datapoints) => datapoints,
@@ -1112,7 +1112,7 @@ pub async fn get_datapoint_handler(
         .await?;
 
     // Convert storage type to wire type
-    let wire = datapoint.into_datapoint(&app_state.config)?;
+    let wire = datapoint.into_datapoint()?;
     Ok(Json(wire))
 }
 
@@ -1234,12 +1234,9 @@ impl Datapoint {
 impl StoredDatapoint {
     /// Convert to wire type, properly handling tool params by subtracting static tools
     /// TODO(shuyangli): Add parameter to optionally fetch files from object storage
-    pub fn into_datapoint(self, config: &Config) -> Result<Datapoint, Error> {
+    pub fn into_datapoint(self) -> Result<Datapoint, Error> {
         match self {
-            StoredDatapoint::Chat(chat) => {
-                let function_config = config.get_function(&chat.function_name)?;
-                Ok(Datapoint::Chat(chat.into_datapoint(&function_config)))
-            }
+            StoredDatapoint::Chat(chat) => Ok(Datapoint::Chat(chat.into_datapoint())),
             StoredDatapoint::Json(json) => Ok(Datapoint::Json(json.into_datapoint())),
         }
     }
@@ -1512,7 +1509,7 @@ impl Datapoint {
 }
 
 /// Storage variant of Datapoint enum for database operations (no Python/TypeScript bindings)
-/// Convert to Datapoint with `.into_datapoint(config)`
+/// Convert to Datapoint with `.into_datapoint()`
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum StoredDatapoint {
@@ -1656,7 +1653,7 @@ impl std::fmt::Display for ChatInferenceDatapoint {
 impl StoredChatInferenceDatapoint {
     /// Convert to wire type, converting tool params from storage format to wire format using From<> trait
     /// TODO(shuyangli): Add parameter to optionally fetch files from object storage
-    pub fn into_datapoint(self, _function_config: &FunctionConfig) -> ChatInferenceDatapoint {
+    pub fn into_datapoint(self) -> ChatInferenceDatapoint {
         let tool_params = self.tool_params.map(|tp| tp.into()).unwrap_or_default();
 
         ChatInferenceDatapoint {

--- a/tensorzero-optimizers/src/gepa/analyze.rs
+++ b/tensorzero-optimizers/src/gepa/analyze.rs
@@ -561,9 +561,7 @@ mod tests {
             name: None,
         };
 
-        // Convert StoredDatapoint to Datapoint
-        let function_config = create_test_function_config();
-        let datapoint = Datapoint::Chat(stored_datapoint.into_datapoint(&function_config));
+        let datapoint = Datapoint::Chat(stored_datapoint.into_datapoint());
 
         EvaluationInfo {
             datapoint,

--- a/tensorzero-optimizers/tests/e2e/gepa/analyze.rs
+++ b/tensorzero-optimizers/tests/e2e/gepa/analyze.rs
@@ -342,9 +342,7 @@ pub fn create_test_evaluation_info(
         name: None,
     };
 
-    // Convert StoredDatapoint to Datapoint
-    let function_config = create_test_function_config();
-    let datapoint = Datapoint::Chat(stored_datapoint.into_datapoint(&function_config));
+    let datapoint = Datapoint::Chat(stored_datapoint.into_datapoint());
 
     let response = InferenceResponse::Chat(ChatInferenceResponse {
         inference_id: Uuid::now_v7(),
@@ -863,9 +861,7 @@ async fn test_analyze_input_format_scenarios() {
         );
 
         evaluations::stats::EvaluationInfo {
-            datapoint: Datapoint::Chat(
-                datapoint.into_datapoint(&tools_function_config_tool_params),
-            ),
+            datapoint: Datapoint::Chat(datapoint.into_datapoint()),
             response,
             evaluations: HashMap::new(),
             evaluator_errors: HashMap::new(),


### PR DESCRIPTION
This was unused and meant that list_datapoints might return errors if an old function config was deleted.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove unused function config parameter from datapoint handling functions to simplify code and prevent errors.
> 
>   - **Behavior**:
>     - Remove unused function config parameter from `list_datapoints`, `get_datapoints`, and `into_datapoint` functions.
>     - Simplifies code and prevents errors from outdated configurations.
>   - **Functions**:
>     - Update `list_datapoints` in `lib.rs` and `get_datapoints.rs` to remove function config parameter.
>     - Update `into_datapoint` in `legacy.rs` to remove function config parameter.
>   - **Tests**:
>     - Update tests in `tests.rs` to reflect changes in function signatures.
>     - Ensure tests do not rely on removed function config parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5442e33e6d8fc2389ce24c1d53625a44e3941ee7. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->