### PR TITLE
Implement provider_tools support for all model providers

### DIFF
--- a/tensorzero-core/src/providers/anthropic.rs
+++ b/tensorzero-core/src/providers/anthropic.rs
@@ -176,8 +176,13 @@ impl InferenceProvider for AnthropicProvider {
         model_provider: &'a ModelProvider,
     ) -> Result<ProviderInferenceResponse, Error> {
         let request_body = serde_json::to_value(
-            AnthropicRequestBody::new(&self.model_name, request, self.beta_structured_outputs)
-                .await?,
+            AnthropicRequestBody::new(
+                &self.model_name,
+                &model_provider.name,
+                request,
+                self.beta_structured_outputs,
+            )
+            .await?,
         )
         .map_err(|e| {
             Error::new(ErrorDetails::Serialization {
@@ -279,8 +284,13 @@ impl InferenceProvider for AnthropicProvider {
         model_provider: &'a ModelProvider,
     ) -> Result<(PeekableProviderInferenceResponseStream, String), Error> {
         let request_body = serde_json::to_value(
-            AnthropicRequestBody::new(&self.model_name, request, self.beta_structured_outputs)
-                .await?,
+            AnthropicRequestBody::new(
+                &self.model_name,
+                &model_provider.name,
+                request,
+                self.beta_structured_outputs,
+            )
+            .await?,
         )
         .map_err(|e| {
             Error::new(ErrorDetails::Serialization {
@@ -485,7 +495,7 @@ impl<'a> TryFrom<&'a ToolCallConfig> for AnthropicToolChoice<'a> {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
-pub(super) struct AnthropicTool<'a> {
+pub(super) struct AnthropicFunctionTool<'a> {
     pub(super) name: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) description: Option<&'a str>,
@@ -494,15 +504,24 @@ pub(super) struct AnthropicTool<'a> {
     pub(super) strict: Option<bool>,
 }
 
+/// A tool that can be either a function tool or a provider-specific tool (raw JSON).
+/// Provider tools are passed through as-is to the provider's API.
+#[derive(Debug, PartialEq, Serialize)]
+#[serde(untagged)]
+pub(super) enum AnthropicTool<'a> {
+    Function(AnthropicFunctionTool<'a>),
+    ProviderTool(&'a Value),
+}
+
 impl<'a> AnthropicTool<'a> {
     pub fn new(tool: &'a FunctionToolConfig, beta_structured_outputs: bool) -> Self {
         // In case we add more tool types in the future, the compiler will complain here.
-        Self {
+        AnthropicTool::Function(AnthropicFunctionTool {
             name: tool.name(),
             description: Some(tool.description()),
             input_schema: tool.parameters(),
             strict: beta_structured_outputs.then_some(tool.strict()),
-        }
+        })
     }
 }
 
@@ -782,6 +801,7 @@ fn needs_json_prefill(request: &ModelInferenceRequest<'_>, beta_structured_outpu
 impl<'a> AnthropicRequestBody<'a> {
     async fn new(
         model_name: &'a str,
+        model_provider_name: &'a str,
         request: &'a ModelInferenceRequest<'_>,
         beta_structured_outputs: bool,
     ) -> Result<AnthropicRequestBody<'a>, Error> {
@@ -817,11 +837,28 @@ impl<'a> AnthropicRequestBody<'a> {
         // for tool choice. When ToolChoice::None is specified, we don't send any tools in the
         // request payload to achieve the same effect.
         let tools = match &request.tool_config {
-            Some(c) if !matches!(c.tool_choice, ToolChoice::None) => Some(
-                c.strict_tools_available()?
+            Some(c) if !matches!(c.tool_choice, ToolChoice::None) => {
+                // Get scoped provider tools
+                let provider_tools = c.get_scoped_provider_tools(model_name, model_provider_name);
+
+                let mut tools: Vec<AnthropicTool> = c
+                    .strict_tools_available()?
                     .map(|tool| AnthropicTool::new(tool, beta_structured_outputs))
-                    .collect::<Vec<_>>(),
-            ),
+                    .collect();
+
+                // Add provider tools
+                tools.extend(
+                    provider_tools
+                        .iter()
+                        .map(|t| AnthropicTool::ProviderTool(&t.tool)),
+                );
+
+                if tools.is_empty() {
+                    None
+                } else {
+                    Some(tools)
+                }
+            }
             _ => None,
         };
 
@@ -1671,12 +1708,12 @@ mod tests {
         let anthropic_tool: AnthropicTool = AnthropicTool::new(&tool, false);
         assert_eq!(
             anthropic_tool,
-            AnthropicTool {
+            AnthropicTool::Function(AnthropicFunctionTool {
                 name: "test",
                 description: Some("test"),
                 input_schema: &parameters,
                 strict: None,
-            }
+            })
         );
     }
 
@@ -1837,7 +1874,7 @@ mod tests {
             ..Default::default()
         };
         let anthropic_request_body =
-            AnthropicRequestBody::new(&model, &inference_request, false).await;
+            AnthropicRequestBody::new(&model, "test_provider", &inference_request, false).await;
         let error = anthropic_request_body.unwrap_err();
         let details = error.get_details();
         assert_eq!(
@@ -1871,7 +1908,7 @@ mod tests {
             ..Default::default()
         };
         let anthropic_request_body =
-            AnthropicRequestBody::new(&model, &inference_request, false).await;
+            AnthropicRequestBody::new(&model, "test_provider", &inference_request, false).await;
         assert!(anthropic_request_body.is_ok());
         assert_eq!(
             anthropic_request_body.unwrap(),
@@ -1929,7 +1966,7 @@ mod tests {
             ..Default::default()
         };
         let anthropic_request_body =
-            AnthropicRequestBody::new(&model, &inference_request, false).await;
+            AnthropicRequestBody::new(&model, "test_provider", &inference_request, false).await;
         assert!(anthropic_request_body.is_ok());
         assert_eq!(
             anthropic_request_body.unwrap(),
@@ -2000,7 +2037,7 @@ mod tests {
             ..Default::default()
         };
         let anthropic_request_body =
-            AnthropicRequestBody::new(&model, &inference_request, false).await;
+            AnthropicRequestBody::new(&model, "test_provider", &inference_request, false).await;
         assert!(anthropic_request_body.is_ok());
         // Convert messages asynchronously
         let expected_messages = try_join_all(inference_request.messages.iter().map(|m| {
@@ -2060,7 +2097,7 @@ mod tests {
             ..Default::default()
         };
         let anthropic_request_body =
-            AnthropicRequestBody::new(&model, &inference_request, false).await;
+            AnthropicRequestBody::new(&model, "test_provider", &inference_request, false).await;
         assert!(anthropic_request_body.is_ok());
         let result = anthropic_request_body.unwrap();
         assert_eq!(result.messages.len(), 4); // Original 2 messages + listening message + JSON prefill
@@ -2119,105 +2156,139 @@ mod tests {
         };
 
         let model = "claude-opus-4-1-20250805".to_string();
-        let body = AnthropicRequestBody::new(&model, &request, false).await;
+        let body = AnthropicRequestBody::new(&model, "test_provider", &request, false).await;
         assert_eq!(body.unwrap().max_tokens, 32_000);
-        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens, false).await;
+        let body =
+            AnthropicRequestBody::new(&model, "test_provider", &request_with_max_tokens, false)
+                .await;
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-opus-4-20250514".to_string();
-        let body = AnthropicRequestBody::new(&model, &request, false).await;
+        let body = AnthropicRequestBody::new(&model, "test_provider", &request, false).await;
         assert_eq!(body.unwrap().max_tokens, 32_000);
-        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens, false).await;
+        let body =
+            AnthropicRequestBody::new(&model, "test_provider", &request_with_max_tokens, false)
+                .await;
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-sonnet-4-20250514".to_string();
-        let body = AnthropicRequestBody::new(&model, &request, false).await;
+        let body = AnthropicRequestBody::new(&model, "test_provider", &request, false).await;
         assert_eq!(body.unwrap().max_tokens, 64_000);
-        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens, false).await;
+        let body =
+            AnthropicRequestBody::new(&model, "test_provider", &request_with_max_tokens, false)
+                .await;
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-7-sonnet-20250219".to_string();
-        let body = AnthropicRequestBody::new(&model, &request, false).await;
+        let body = AnthropicRequestBody::new(&model, "test_provider", &request, false).await;
         assert_eq!(body.unwrap().max_tokens, 64_000);
-        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens, false).await;
+        let body =
+            AnthropicRequestBody::new(&model, "test_provider", &request_with_max_tokens, false)
+                .await;
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-5-sonnet-20241022".to_string();
-        let body = AnthropicRequestBody::new(&model, &request, false).await;
+        let body = AnthropicRequestBody::new(&model, "test_provider", &request, false).await;
         assert_eq!(body.unwrap().max_tokens, 8_192);
-        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens, false).await;
+        let body =
+            AnthropicRequestBody::new(&model, "test_provider", &request_with_max_tokens, false)
+                .await;
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-5-haiku-20241022".to_string();
-        let body = AnthropicRequestBody::new(&model, &request, false).await;
+        let body = AnthropicRequestBody::new(&model, "test_provider", &request, false).await;
         assert_eq!(body.unwrap().max_tokens, 8_192);
-        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens, false).await;
+        let body =
+            AnthropicRequestBody::new(&model, "test_provider", &request_with_max_tokens, false)
+                .await;
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-opus-4-1".to_string();
-        let body = AnthropicRequestBody::new(&model, &request, false).await;
+        let body = AnthropicRequestBody::new(&model, "test_provider", &request, false).await;
         assert_eq!(body.unwrap().max_tokens, 32_000);
-        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens, false).await;
+        let body =
+            AnthropicRequestBody::new(&model, "test_provider", &request_with_max_tokens, false)
+                .await;
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-opus-4-0".to_string();
-        let body = AnthropicRequestBody::new(&model, &request, false).await;
+        let body = AnthropicRequestBody::new(&model, "test_provider", &request, false).await;
         assert_eq!(body.unwrap().max_tokens, 32_000);
-        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens, false).await;
+        let body =
+            AnthropicRequestBody::new(&model, "test_provider", &request_with_max_tokens, false)
+                .await;
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-sonnet-4-0".to_string();
-        let body = AnthropicRequestBody::new(&model, &request, false).await;
+        let body = AnthropicRequestBody::new(&model, "test_provider", &request, false).await;
         assert_eq!(body.unwrap().max_tokens, 64_000);
-        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens, false).await;
+        let body =
+            AnthropicRequestBody::new(&model, "test_provider", &request_with_max_tokens, false)
+                .await;
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-7-sonnet-latest".to_string();
-        let body = AnthropicRequestBody::new(&model, &request, false).await;
+        let body = AnthropicRequestBody::new(&model, "test_provider", &request, false).await;
         assert_eq!(body.unwrap().max_tokens, 64_000);
-        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens, false).await;
+        let body =
+            AnthropicRequestBody::new(&model, "test_provider", &request_with_max_tokens, false)
+                .await;
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-5-sonnet-latest".to_string();
-        let body = AnthropicRequestBody::new(&model, &request, false).await;
+        let body = AnthropicRequestBody::new(&model, "test_provider", &request, false).await;
         assert_eq!(body.unwrap().max_tokens, 8_192);
-        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens, false).await;
+        let body =
+            AnthropicRequestBody::new(&model, "test_provider", &request_with_max_tokens, false)
+                .await;
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-5-haiku-latest".to_string();
-        let body = AnthropicRequestBody::new(&model, &request, false).await;
+        let body = AnthropicRequestBody::new(&model, "test_provider", &request, false).await;
         assert_eq!(body.unwrap().max_tokens, 8_192);
-        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens, false).await;
+        let body =
+            AnthropicRequestBody::new(&model, "test_provider", &request_with_max_tokens, false)
+                .await;
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-haiku-20240307".to_string();
-        let body = AnthropicRequestBody::new(&model, &request, false).await;
+        let body = AnthropicRequestBody::new(&model, "test_provider", &request, false).await;
         assert_eq!(body.unwrap().max_tokens, 4_096);
-        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens, false).await;
+        let body =
+            AnthropicRequestBody::new(&model, "test_provider", &request_with_max_tokens, false)
+                .await;
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-haiku-4-5-20251001".to_string();
-        let body = AnthropicRequestBody::new(&model, &request, false).await;
+        let body = AnthropicRequestBody::new(&model, "test_provider", &request, false).await;
         assert_eq!(body.unwrap().max_tokens, 64_000);
-        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens, false).await;
+        let body =
+            AnthropicRequestBody::new(&model, "test_provider", &request_with_max_tokens, false)
+                .await;
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-sonnet-4-5-20250929".to_string();
-        let body = AnthropicRequestBody::new(&model, &request, false).await;
+        let body = AnthropicRequestBody::new(&model, "test_provider", &request, false).await;
         assert_eq!(body.unwrap().max_tokens, 64_000);
-        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens, false).await;
+        let body =
+            AnthropicRequestBody::new(&model, "test_provider", &request_with_max_tokens, false)
+                .await;
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-3-5-ballad-latest".to_string(); // fake model
-        let body = AnthropicRequestBody::new(&model, &request, false).await;
+        let body = AnthropicRequestBody::new(&model, "test_provider", &request, false).await;
         assert!(body.is_err());
-        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens, false).await;
+        let body =
+            AnthropicRequestBody::new(&model, "test_provider", &request_with_max_tokens, false)
+                .await;
         assert_eq!(body.unwrap().max_tokens, 100);
 
         let model = "claude-4-5-haiku-20260101".to_string(); // fake model
-        let body = AnthropicRequestBody::new(&model, &request, false).await;
+        let body = AnthropicRequestBody::new(&model, "test_provider", &request, false).await;
         assert!(body.is_err());
-        let body = AnthropicRequestBody::new(&model, &request_with_max_tokens, false).await;
+        let body =
+            AnthropicRequestBody::new(&model, "test_provider", &request_with_max_tokens, false)
+                .await;
         assert_eq!(body.unwrap().max_tokens, 100);
     }
 
@@ -3453,6 +3524,11 @@ mod tests {
 
         // Verify only the allowed tool is included
         assert_eq!(tools.len(), 1);
-        assert_eq!(tools[0].name, "get_temperature");
+        match &tools[0] {
+            AnthropicTool::Function(f) => {
+                assert_eq!(f.name, "get_temperature");
+            }
+            AnthropicTool::ProviderTool(_) => panic!("Expected Function variant"),
+        }
     }
 }

--- a/tensorzero-core/src/providers/aws_bedrock.rs
+++ b/tensorzero-core/src/providers/aws_bedrock.rs
@@ -193,7 +193,7 @@ impl InferenceProvider for AWSBedrockProvider {
         &'a self,
         ModelProviderRequest {
             request,
-            provider_name: _,
+            provider_name,
             model_name,
             otlp_config: _,
         }: ModelProviderRequest<'a>,
@@ -254,6 +254,14 @@ impl InferenceProvider for AWSBedrockProvider {
 
         if let Some(tool_config) = &request.tool_config {
             if !matches!(tool_config.tool_choice, ToolChoice::None) {
+                // Get scoped provider tools
+                // Note: AWS Bedrock doesn't support arbitrary JSON provider_tools like other providers
+                // because the AWS SDK uses strongly-typed Tool enums (ToolSpec, SystemTool, CachePoint).
+                // We call get_scoped_provider_tools for consistency with other providers,
+                // but we cannot actually use them.
+                let _provider_tools =
+                    tool_config.get_scoped_provider_tools(model_name, provider_name);
+
                 let tools: Vec<Tool> = tool_config
                     .strict_tools_available()?
                     .map(Tool::try_from)
@@ -334,7 +342,7 @@ impl InferenceProvider for AWSBedrockProvider {
         &'a self,
         ModelProviderRequest {
             request,
-            provider_name: _,
+            provider_name,
             model_name,
             otlp_config: _,
         }: ModelProviderRequest<'a>,
@@ -395,6 +403,14 @@ impl InferenceProvider for AWSBedrockProvider {
 
         if let Some(tool_config) = &request.tool_config {
             if !matches!(tool_config.tool_choice, ToolChoice::None) {
+                // Get scoped provider tools
+                // Note: AWS Bedrock doesn't support arbitrary JSON provider_tools like other providers
+                // because the AWS SDK uses strongly-typed Tool enums (ToolSpec, SystemTool, CachePoint).
+                // We call get_scoped_provider_tools for consistency with other providers,
+                // but we cannot actually use them.
+                let _provider_tools =
+                    tool_config.get_scoped_provider_tools(model_name, provider_name);
+
                 let tools: Vec<Tool> = tool_config
                     .strict_tools_available()?
                     .map(Tool::try_from)

--- a/tensorzero-core/src/providers/openai/responses.rs
+++ b/tensorzero-core/src/providers/openai/responses.rs
@@ -271,17 +271,19 @@ pub(super) fn get_responses_url(base_url: &Url) -> Result<Url, Error> {
 impl<'a> OpenAITool<'a> {
     pub fn into_openai_responses_tool(self) -> OpenAIResponsesTool<'a> {
         match self {
-            OpenAITool::Function { function, strict } => {
-                OpenAIResponsesTool::Function(OpenAIResponsesFunctionTool {
-                    name: function.name,
-                    description: function.description,
-                    parameters: function.parameters,
-                    strict,
-                })
-            }
+            OpenAITool::Function {
+                function, strict, ..
+            } => OpenAIResponsesTool::Function(OpenAIResponsesFunctionTool {
+                name: function.name,
+                description: function.description,
+                parameters: function.parameters,
+                strict,
+            }),
             OpenAITool::Custom {
                 custom: custom_tool,
+                ..
             } => OpenAIResponsesTool::Custom(custom_tool.into()),
+            OpenAITool::ProviderTool(value) => OpenAIResponsesTool::BuiltIn(value),
         }
     }
 }


### PR DESCRIPTION
This adds the ability to pass arbitrary provider-specific tools (like OpenAI's
web_search) to all inference providers via the tool_config.provider_tools field.

Changes by provider:
- OpenAI Chat Completions: Added ProviderTool variant to OpenAITool enum
- Anthropic: Added ProviderTool variant to AnthropicTool enum
- Mistral: Added ProviderTool variant to MistralTool enum
- Google AI Studio Gemini: Added ProviderTool variant to GeminiTool enum
- GCP Vertex Gemini: Added ProviderTool variant to GCPVertexGeminiTool enum
- Groq: Added ProviderTool variant to GroqTool enum
- OpenRouter: Added ProviderTool variant to OpenRouterTool enum
- sglang/vllm: Updated to use OpenAITool::ProviderTool
- AWS Bedrock: Documented limitation (SDK doesn't support arbitrary JSON tools)
- Azure, DeepSeek, Together, TGI, XAI: Updated via chat_completions.rs

All prepare_*_tools functions now accept model_name and provider_name to scope
provider tools appropriately.

Closes #4858
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for provider-specific tools across multiple model providers by introducing a `ProviderTool` variant to tool enums and updating related functions and tests.
> 
>   - **Behavior**:
>     - Adds `ProviderTool` variant to tool enums for multiple providers, including `OpenAITool`, `AnthropicTool`, `MistralTool`, `GeminiTool`, `GCPVertexGeminiTool`, `GroqTool`, `OpenRouterTool`, and `ChatCompletionTool`.
>     - Updates `prepare_*_tools` functions to accept `model_name` and `provider_name` for scoping provider tools.
>     - Documents AWS Bedrock limitation (SDK doesn't support arbitrary JSON tools).
>   - **Providers**:
>     - Updates `anthropic.rs`, `aws_bedrock.rs`, `azure.rs`, `deepseek.rs`, `gcp_vertex_anthropic.rs`, `gcp_vertex_gemini/mod.rs`, `google_ai_studio_gemini.rs`, `groq.rs`, `mistral.rs`, `openai/mod.rs`, `openrouter.rs`, `sglang.rs`, `tgi.rs`, `together.rs`, `vllm.rs`, `xai.rs` to handle `ProviderTool`.
>   - **Misc**:
>     - Updates tests across multiple files to validate new `ProviderTool` functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 893169eb1f9dab48ab4f073af63eceea791f95a4. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->