### PR TITLE
Pin datamodel-code-generator version

### DIFF
--- a/clients/python/generate_schema_types.py
+++ b/clients/python/generate_schema_types.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#   "datamodel-code-generator[http]>=0.26.0",
+#   "datamodel-code-generator[http]==0.35.0",
 # ]
 # ///
 """


### PR DESCRIPTION
#4700 meant that datamodel-code-generator's version was no longer pinned (and we're at the mercy of whatever the environment gave us) so CI tests started to fail because there's a new release 2 hours ago. This PR pins the version for stable generation.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Pin `datamodel-code-generator` version to `0.35.0` in `generate_schema_types.py` to stabilize CI tests.
> 
>   - **Dependencies**:
>     - Pin `datamodel-code-generator` version to `0.35.0` in `generate_schema_types.py` to ensure stable CI tests.
>   - **Context**:
>     - Previous unpinned version led to CI failures due to a new release.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 817f6832f6e9d480342b6199dcb89c21a7333746. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->