### PR TITLE
Add before/after pagination to v1 list_inferences backend API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ The pre-commit hooks automatically handle this by running `uv lock` and `uv expo
 
 We use `ts-rs` and `n-api` for TypeScript-Rust interoperability.
 
-- To generate TypeScript type definitions from Rust types, run `pnpm build-bindings`. Then, rebuild `tensorzero-node` with `pnpm -r build`.
+- To generate TypeScript type definitions from Rust types, run `pnpm build-bindings`. Then, rebuild `tensorzero-node` with `pnpm -r build`. The generated type definitions will live in `internal/tensorzero-node/lib/bindings/`.
 - To generate implementations for `n-api` functions to be called in TypeScript, and package types in `internal/tensorzero-node` for UI, run `pnpm --filter=tensorzero-node run build`.
 - Remember to run `pnpm -r typecheck` to make sure TypeScript and Rust implementations agree on types. Prefer to maintain all types in Rust.
 

--- a/clients/python/tensorzero/generated_types.py
+++ b/clients/python/tensorzero/generated_types.py
@@ -2166,6 +2166,18 @@ class ListInferencesRequest:
     Source of the inference output. Determines whether to return the original
     inference output or demonstration feedback (manually-curated output) if available.
     """
+    after: str | None = None
+    """
+    Optional inference ID to paginate after (exclusive).
+    Returns inferences with IDs after this one (later in time).
+    Cannot be used together with `before` or `offset`.
+    """
+    before: str | None = None
+    """
+    Optional inference ID to paginate before (exclusive).
+    Returns inferences with IDs before this one (earlier in time).
+    Cannot be used together with `after` or `offset`.
+    """
     episode_id: str | None = None
     """
     Optional episode ID to filter inferences by.

--- a/clients/python/tests/test_list_inferences.py
+++ b/clients/python/tests/test_list_inferences.py
@@ -164,7 +164,6 @@ def test_simple_query_chat_function_with_tools(embedded_sync_client: TensorZeroG
     assert len(inferences) == limit
     for inference in inferences:
         assert inference.function_name == "multi_hop_rag_agent"
-        assert inference.variant_name == "baseline"
         input = inference.input
         messages = input.messages
         assert messages is not None

--- a/internal/tensorzero-node/lib/bindings/ListInferencesRequest.ts
+++ b/internal/tensorzero-node/lib/bindings/ListInferencesRequest.ts
@@ -39,6 +39,18 @@ export type ListInferencesRequest = {
    */
   offset?: number;
   /**
+   * Optional inference ID to paginate before (exclusive).
+   * Returns inferences with IDs before this one (earlier in time).
+   * Cannot be used together with `after` or `offset`.
+   */
+  before?: string;
+  /**
+   * Optional inference ID to paginate after (exclusive).
+   * Returns inferences with IDs after this one (later in time).
+   * Cannot be used together with `before` or `offset`.
+   */
+  after?: string;
+  /**
    * Optional filter to apply when querying inferences.
    * Supports filtering by metrics, tags, time, and logical combinations (AND/OR/NOT).
    */

--- a/tensorzero-core/src/db/clickhouse/inference_queries.rs
+++ b/tensorzero-core/src/db/clickhouse/inference_queries.rs
@@ -3,13 +3,14 @@ use itertools::Itertools;
 
 use crate::db::clickhouse::query_builder::parameters::add_parameter;
 use crate::db::clickhouse::query_builder::{
-    generate_order_by_sql, ClickhouseType, JoinRegistry, OrderByTerm, QueryParameter,
+    generate_order_by_sql, ClickhouseType, JoinRegistry, OrderByTerm, OrderDirection,
+    QueryParameter,
 };
 use crate::db::clickhouse::ClickHouseConnectionInfo;
 use crate::db::inferences::{
     ClickHouseStoredInferenceWithDispreferredOutputs, GetInferenceBoundsParams, InferenceBounds,
     InferenceMetadata, InferenceOutputSource, InferenceQueries, ListInferencesByIdParams,
-    ListInferencesParams, PaginateByIdCondition,
+    ListInferencesParams, PaginationParams,
 };
 use crate::function::FunctionConfigType;
 use crate::{
@@ -40,7 +41,7 @@ impl InferenceQueries for ClickHouseConnectionInfo {
             .map(|p| (p.name.as_str(), p.value.as_str()))
             .collect();
         let response = self.inner.run_query_synchronous(sql, &query_params).await?;
-        let inferences = response
+        let mut inferences = response
             .response
             .trim()
             .lines()
@@ -54,6 +55,13 @@ impl InferenceQueries for ClickHouseConnectionInfo {
                     .and_then(ClickHouseStoredInferenceWithDispreferredOutputs::try_into)
             })
             .collect::<Result<Vec<StoredInferenceDatabase>, Error>>()?;
+
+        // Reverse the list for "After" pagination, we queried with inverted ordering to get results after the cursor,
+        // but we want to return them in original order (most recent first).
+        if matches!(params.pagination, Some(PaginationParams::After { .. })) {
+            inferences.reverse();
+        }
+
         Ok(inferences)
     }
 
@@ -195,7 +203,7 @@ FROM InferenceById FINAL
         }
 
         match params.pagination {
-            Some(PaginateByIdCondition::Before { id }) => {
+            Some(PaginationParams::Before { id }) => {
                 let param_placeholder = add_parameter(
                     id.to_string(),
                     ClickhouseType::String,
@@ -204,7 +212,7 @@ FROM InferenceById FINAL
                 );
                 where_clauses.push(format!("id_uint < toUInt128(toUUID({param_placeholder}))"));
             }
-            Some(PaginateByIdCondition::After { id }) => {
+            Some(PaginationParams::After { id }) => {
                 let param_placeholder = add_parameter(
                     id.to_string(),
                     ClickhouseType::String,
@@ -229,7 +237,7 @@ FROM InferenceById FINAL
             &mut param_idx_counter,
         );
 
-        let query = if let Some(PaginateByIdCondition::After { .. }) = params.pagination {
+        let query = if let Some(PaginationParams::After { .. }) = params.pagination {
             // After case: select ascending then re-order descending
             format!(
                 "SELECT
@@ -312,6 +320,49 @@ fn json_escape_string_without_quotes(s: &str) -> Result<String, Error> {
     Ok(json_escaped)
 }
 
+/// Validates that before/after pagination works with the rest of the request:
+/// - If order_by is provided, only timestamp ordering is supported.
+/// - Offset must not be provided.
+///
+/// Returns an error if the request is invalid.
+fn validate_before_after_pagination(opts: &ListInferencesParams<'_>) -> Result<(), Error> {
+    if opts.pagination.is_none() {
+        return Ok(());
+    };
+    let Some(order_by) = opts.order_by else {
+        return Ok(());
+    };
+
+    for order in order_by {
+        match &order.term {
+            OrderByTerm::Timestamp => {
+                // Timestamp ordering is compatible with before/after pagination (UUIDv7 is time-ordered)
+                continue;
+            }
+            OrderByTerm::Metric { name } => {
+                return Err(Error::new(ErrorDetails::InvalidRequest {
+                    message: format!(
+                        "Cannot order by metric '{name}'; only ordering by timestamp is supported with before/after pagination.",
+                    ),
+                }));
+            }
+            OrderByTerm::SearchRelevance => {
+                return Err(Error::new(ErrorDetails::InvalidRequest {
+                    message: "Cannot order by search relevance; only ordering by timestamp is supported with before/after pagination.".to_string(),
+                }));
+            }
+        }
+    }
+
+    if opts.offset != 0 {
+        return Err(Error::new(ErrorDetails::InvalidRequest {
+            message: "OFFSET is not supported when using before/after pagination".to_string(),
+        }));
+    }
+
+    Ok(())
+}
+
 /// Generates the ClickHouse query and a list of parameters to be set.
 /// The query string will contain placeholders like `{p0:String}`.
 /// The returned `Vec<QueryParameter>` contains the mapping from placeholder names (e.g., "p0")
@@ -328,6 +379,8 @@ pub(crate) fn generate_list_inferences_sql(
     config: &Config,
     opts: &ListInferencesParams<'_>,
 ) -> Result<(String, Vec<QueryParameter>), Error> {
+    validate_before_after_pagination(opts)?;
+
     let mut query_params: Vec<QueryParameter> = Vec::new();
     let mut param_idx_counter = 0;
 
@@ -350,17 +403,14 @@ pub(crate) fn generate_list_inferences_sql(
 
             // For single-table queries, use proper ORDER BY generation that supports joining with metrics.
             // Reuse the join registry from the filter so we don't create duplicate joins
-            let order_by_sql = if opts.order_by.is_some() {
-                generate_order_by_sql(
-                    opts,
-                    config,
-                    &mut query_params,
-                    &mut param_idx_counter,
-                    &mut joins,
-                )?
-            } else {
-                String::new()
-            };
+            // generate_order_by_sql also always adds id as tie-breaker for deterministic ordering.
+            let order_by_sql = generate_order_by_sql(
+                opts,
+                config,
+                &mut query_params,
+                &mut param_idx_counter,
+                &mut joins,
+            )?;
 
             // Construct final query: SELECT/FROM + JOINs + WHERE + ORDER BY
             let mut sql = query.select_from_sql_fragment;
@@ -378,7 +428,7 @@ pub(crate) fn generate_list_inferences_sql(
         None => {
             // Otherwise, we need to query both tables with UNION ALL
             let mut chat_joins = JoinRegistry::new();
-            let chat_query = generate_single_table_query_for_type(
+            let chat_query_snippets = generate_single_table_query_for_type(
                 config,
                 opts,
                 "ChatInference",
@@ -388,16 +438,8 @@ pub(crate) fn generate_list_inferences_sql(
                 &mut param_idx_counter,
             )?;
 
-            // Construct chat query: SELECT/FROM + JOINs + WHERE
-            let mut chat_sql = chat_query.select_from_sql_fragment;
-            if !chat_joins.get_clauses().is_empty() {
-                chat_sql.push_str(&chat_joins.get_clauses().join("\n"));
-            }
-            chat_sql.push('\n');
-            chat_sql.push_str(&chat_query.where_sql_fragment);
-
             let mut json_joins = JoinRegistry::new();
-            let json_query = generate_single_table_query_for_type(
+            let json_query_snippets = generate_single_table_query_for_type(
                 config,
                 opts,
                 "JsonInference",
@@ -407,51 +449,63 @@ pub(crate) fn generate_list_inferences_sql(
                 &mut param_idx_counter,
             )?;
 
-            // Construct json query: SELECT/FROM + JOINs + WHERE
-            let mut json_sql = json_query.select_from_sql_fragment;
-            if !json_joins.get_clauses().is_empty() {
-                json_sql.push_str(&json_joins.get_clauses().join("\n"));
-            }
-            json_sql.push('\n');
-            json_sql.push_str(&json_query.where_sql_fragment);
-
             // Generate ORDER BY clause for both inner and outer queries
             // For UNION ALL queries, we only support timestamp ordering (not metrics)
             // TODO(#4181): this should support proper ORDER BY generation that supports joining with metrics.
-            let order_by_sql = if let Some(order_by) = opts.order_by {
-                let order_clauses: Vec<String> = order_by
-                    .iter()
-                    .map(|o| {
-                        let column = match &o.term {
-                            OrderByTerm::Timestamp => "timestamp",
-                            OrderByTerm::Metric { name } => {
-                                return Err(Error::new(ErrorDetails::InvalidRequest {
+            //
+            // For "After" pagination, we need to invert all ordering directions because we'll reverse the list in memory
+            let should_invert_directions =
+                matches!(opts.pagination, Some(PaginationParams::After { .. }));
+            let mut order_clauses = Vec::new();
+
+            // Add user-specified ordering if present
+            if let Some(order_by) = opts.order_by {
+                for o in order_by {
+                    let column = match &o.term {
+                        OrderByTerm::Timestamp => "timestamp",
+                        OrderByTerm::Metric { name } => {
+                            return Err(Error::new(ErrorDetails::InvalidRequest {
                                     message: format!(
-                                        "ORDER BY metric '{name}' is not supported when querying without function_name"
-                                    ),
+                                    "ORDER BY metric '{name}' is not supported when querying without function_name"
+                                ),
+                                }));
+                        }
+                        OrderByTerm::SearchRelevance => {
+                            if opts.search_query_experimental.is_none() {
+                                return Err(Error::new(ErrorDetails::InvalidRequest {
+                                    message: "ORDER BY relevance requires search_query_experimental in the request".to_string(),
                                 }));
                             }
-                            OrderByTerm::SearchRelevance => {
-                                if opts.search_query_experimental.is_none() {
-                                    return Err(Error::new(ErrorDetails::InvalidRequest {
-                                        message: "ORDER BY relevance requires search_query_experimental in the request".to_string(),
-                                    }));
-                                }
-                                "total_term_frequency"
-                            }
-                        };
-                        Ok(format!("{column} {}", o.direction.to_clickhouse_direction()))
-                    })
-                    .collect::<Result<Vec<_>, Error>>()?;
+                            "total_term_frequency"
+                        }
+                    };
+                    // Invert direction for "After" pagination since we'll reverse the list
+                    let effective_direction = if should_invert_directions {
+                        o.direction.inverted()
+                    } else {
+                        o.direction
+                    };
+                    let direction = effective_direction.to_clickhouse_direction();
+                    order_clauses.push(format!("{column} {direction}"));
+                }
+            }
 
-                if order_clauses.is_empty() {
-                    String::new()
-                } else {
-                    format!("\nORDER BY {}", order_clauses.join(", "))
+            // Always add id as tie-breaker for deterministic ordering
+            let id_direction = if let Some(pagination) = &opts.pagination {
+                match pagination {
+                    PaginationParams::After { .. } => OrderDirection::Asc,
+                    PaginationParams::Before { .. } => OrderDirection::Desc,
                 }
             } else {
-                String::new()
+                OrderDirection::Desc
             };
+
+            // For inner queries (chat/json subqueries), use "id" (the actual column name)
+            let mut inner_order_by_clauses = order_clauses.clone();
+            inner_order_by_clauses.push(format!(
+                "toUInt128(id) {}",
+                id_direction.to_clickhouse_direction()
+            ));
 
             // Push LIMIT down into each subquery before UNION ALL
             // For UNION ALL, we need to fetch (LIMIT + OFFSET) rows from each table
@@ -464,27 +518,21 @@ pub(crate) fn generate_list_inferences_sql(
             // (e.g., timestamp DESC), resulting in incorrect results.
             let inner_limit = opts.limit + opts.offset;
 
-            if !order_by_sql.is_empty() {
-                chat_sql.push_str(&order_by_sql);
-            }
-            let chat_limit_param_placeholder = add_parameter(
+            let inner_limit_param_placeholder = add_parameter(
                 inner_limit,
                 ClickhouseType::UInt64,
                 &mut query_params,
                 &mut param_idx_counter,
             );
-            chat_sql.push_str(&format!("\nLIMIT {chat_limit_param_placeholder}"));
 
-            if !order_by_sql.is_empty() {
-                json_sql.push_str(&order_by_sql);
-            }
-            let json_limit_param_placeholder = add_parameter(
-                inner_limit,
-                ClickhouseType::UInt64,
-                &mut query_params,
-                &mut param_idx_counter,
-            );
-            json_sql.push_str(&format!("\nLIMIT {json_limit_param_placeholder}"));
+            // For outer query (after UNION ALL), use "inference_id" (the aliased name)
+            let mut outer_order_by_clauses = order_clauses;
+            outer_order_by_clauses.push(format!(
+                "toUInt128(inference_id) {}",
+                id_direction.to_clickhouse_direction()
+            ));
+
+            let outer_order_by_sql = format!("\nORDER BY {}", outer_order_by_clauses.join(", "));
 
             // Combine with UNION ALL and apply outer ORDER BY and LIMIT/OFFSET
             let outer_limit_param_placeholder = add_parameter(
@@ -493,15 +541,57 @@ pub(crate) fn generate_list_inferences_sql(
                 &mut query_params,
                 &mut param_idx_counter,
             );
-            let outer_offset_param_placeholder = add_parameter(
-                opts.offset,
-                ClickhouseType::UInt64,
-                &mut query_params,
-                &mut param_idx_counter,
+
+            let outer_offset_clause = if opts.offset != 0 {
+                let param_name = add_parameter(
+                    opts.offset,
+                    ClickhouseType::UInt64,
+                    &mut query_params,
+                    &mut param_idx_counter,
+                );
+                format!("OFFSET {param_name}")
+            } else {
+                String::new()
+            };
+
+            // Build inner queries.
+            let chat_sql = format!(
+                "
+            {select_from_clause}
+            {joins_clause}
+            {where_clause}
+            ORDER BY {order_by_clause}
+            LIMIT {limit_param}",
+                select_from_clause = chat_query_snippets.select_from_sql_fragment,
+                joins_clause = chat_joins.get_clauses().join("\n"),
+                where_clause = chat_query_snippets.where_sql_fragment,
+                order_by_clause = inner_order_by_clauses.join(", "),
+                limit_param = inner_limit_param_placeholder
+            );
+            let json_sql = format!(
+                "
+            {select_from_clause}
+            {joins_clause}
+            {where_clause}
+            ORDER BY {order_by_clause}
+            LIMIT {limit_param}",
+                select_from_clause = json_query_snippets.select_from_sql_fragment,
+                joins_clause = json_joins.get_clauses().join("\n"),
+                where_clause = json_query_snippets.where_sql_fragment,
+                order_by_clause = inner_order_by_clauses.join(", "),
+                limit_param = inner_limit_param_placeholder
             );
 
+            // Build outer query.
             format!(
-                "SELECT * FROM (\n{chat_sql}\nUNION ALL\n{json_sql}\n) AS combined{order_by_sql}\nLIMIT {outer_limit_param_placeholder}\nOFFSET {outer_offset_param_placeholder}"
+                "SELECT * FROM (
+                {chat_sql}
+                UNION ALL
+                {json_sql}
+                ) AS combined
+                {outer_order_by_sql}
+                LIMIT {outer_limit_param_placeholder}
+                {outer_offset_clause}"
             )
         }
     };
@@ -516,13 +606,15 @@ pub(crate) fn generate_list_inferences_sql(
         );
         sql.push_str(&format!("\nLIMIT {limit_param_placeholder}"));
 
-        let offset_param_placeholder = add_parameter(
-            opts.offset,
-            ClickhouseType::UInt64,
-            &mut query_params,
-            &mut param_idx_counter,
-        );
-        sql.push_str(&format!("\nOFFSET {offset_param_placeholder}"));
+        if opts.offset != 0 {
+            let offset_param_placeholder = add_parameter(
+                opts.offset,
+                ClickhouseType::UInt64,
+                &mut query_params,
+                &mut param_idx_counter,
+            );
+            sql.push_str(&format!("\nOFFSET {offset_param_placeholder}"));
+        }
     }
 
     sql.push_str("\nFORMAT JSONEachRow");
@@ -633,6 +725,34 @@ fn generate_single_table_query_for_type(
             param_idx_counter,
         );
         where_clauses.push(format!("i.episode_id = {episode_id_param_placeholder}"));
+    }
+
+    // Add before/after pagination filters
+    if let Some(ref pagination) = opts.pagination {
+        match pagination {
+            PaginationParams::Before { id } => {
+                let id_param_placeholder = add_parameter(
+                    id.to_string(),
+                    ClickhouseType::String,
+                    query_params,
+                    param_idx_counter,
+                );
+                where_clauses.push(format!(
+                    "toUInt128(i.id) < toUInt128(toUUID({id_param_placeholder}))"
+                ));
+            }
+            PaginationParams::After { id } => {
+                let id_param_placeholder = add_parameter(
+                    id.to_string(),
+                    ClickhouseType::String,
+                    query_params,
+                    param_idx_counter,
+                );
+                where_clauses.push(format!(
+                    "toUInt128(i.id) > toUInt128(toUUID({id_param_placeholder}))"
+                ));
+            }
+        }
     }
 
     // Handle OutputSource
@@ -789,7 +909,7 @@ mod tests {
 
         let (sql, _params) = generate_list_inferences_sql(&config, &opts).unwrap();
 
-        // Verify both tables are queried
+        // Verify both tables are queried with ORDER BY for deterministic results
         assert_query_contains(
             &sql,
             "SELECT * FROM (
@@ -814,6 +934,7 @@ mod tests {
             ChatInference AS i
         WHERE
             i.id IN ['01234567-89ab-cdef-0123-456789abcdef','fedcba98-7654-3210-fedc-ba9876543210']
+        ORDER BY toUInt128(id) DESC
         LIMIT {p0:UInt64}
         UNION ALL
         SELECT
@@ -837,10 +958,11 @@ mod tests {
             JsonInference AS i
         WHERE
             i.id IN ['01234567-89ab-cdef-0123-456789abcdef','fedcba98-7654-3210-fedc-ba9876543210']
-        LIMIT {p1:UInt64}
+        ORDER BY toUInt128(id) DESC
+        LIMIT {p0:UInt64}
         ) AS combined
-        LIMIT {p2:UInt64}
-        OFFSET {p3:UInt64}",
+        ORDER BY toUInt128(inference_id) DESC
+        LIMIT {p1:UInt64}",
         );
     }
 
@@ -858,6 +980,7 @@ mod tests {
 
         let (sql, params) = generate_list_inferences_sql(&config, &opts).unwrap();
 
+        // ORDER BY is always present for deterministic results
         assert_query_contains(
             &sql,
             "SELECT
@@ -882,8 +1005,8 @@ mod tests {
         WHERE
             i.function_name = {p0:String}
             AND i.id IN ['01234567-89ab-cdef-0123-456789abcdef']
-        LIMIT {p1:UInt64}
-        OFFSET {p2:UInt64}",
+        ORDER BY toUInt128(i.id) DESC
+        LIMIT {p1:UInt64}",
         );
 
         // Verify NO UNION ALL
@@ -992,9 +1115,8 @@ mod tests {
             "LIMIT should appear 3 times: 2 inner + 1 outer"
         );
 
-        // Verify OFFSET only appears once in the outer query
-        let offset_count = sql.matches("OFFSET {p").count();
-        assert_eq!(offset_count, 1, "OFFSET should appear once in outer query");
+        // Verify OFFSET doesn't appear when offset is 0 (default)
+        assert_query_does_not_contain(&sql, "OFFSET");
     }
 
     #[tokio::test]
@@ -1412,9 +1534,7 @@ mod tests {
         use crate::db::clickhouse::{
             ClickHouseConnectionInfo, ClickHouseResponse, ClickHouseResponseMetadata,
         };
-        use crate::db::inferences::{
-            InferenceQueries, ListInferencesByIdParams, PaginateByIdCondition,
-        };
+        use crate::db::inferences::{InferenceQueries, ListInferencesByIdParams, PaginationParams};
         use std::sync::Arc;
 
         #[tokio::test]
@@ -1563,7 +1683,7 @@ mod tests {
                     function_name: None,
                     variant_name: None,
                     episode_id: None,
-                    pagination: Some(PaginateByIdCondition::Before { id: before_id }),
+                    pagination: Some(PaginationParams::Before { id: before_id }),
                     limit: 10,
                 })
                 .await
@@ -1627,7 +1747,7 @@ mod tests {
                     function_name: None,
                     variant_name: None,
                     episode_id: None,
-                    pagination: Some(PaginateByIdCondition::After { id: after_id }),
+                    pagination: Some(PaginationParams::After { id: after_id }),
                     limit: 10,
                 })
                 .await
@@ -1693,13 +1813,333 @@ mod tests {
                     function_name: Some("test_function".to_string()),
                     variant_name: None,
                     episode_id: None,
-                    pagination: Some(PaginateByIdCondition::After { id: after_id }),
+                    pagination: Some(PaginationParams::After { id: after_id }),
                     limit: 10,
                 })
                 .await
                 .unwrap();
 
             assert_eq!(result.len(), 0);
+        }
+    }
+
+    mod list_inferences_before_after_pagination_tests {
+        use super::*;
+        use crate::config::Config;
+        use crate::db::clickhouse::clickhouse_client::MockClickHouseClient;
+        use crate::db::clickhouse::{
+            ClickHouseConnectionInfo, ClickHouseResponse, ClickHouseResponseMetadata,
+        };
+        use crate::db::inferences::{
+            InferenceOutputSource, InferenceQueries, ListInferencesParams, PaginationParams,
+        };
+        use std::sync::Arc;
+
+        #[tokio::test]
+        async fn test_list_inferences_with_before() {
+            let mut mock_clickhouse_client = MockClickHouseClient::new();
+            let before_id = Uuid::parse_str("01234567-89ab-cdef-0123-456789abcdef").unwrap();
+
+            mock_clickhouse_client
+                .expect_run_query_synchronous()
+                .withf(move |query, params| {
+                    // Should include the before in WHERE clause
+                    assert!(
+                        query.contains("toUInt128(i.id) < toUInt128(toUUID({p"),
+                        "Query should contain before condition"
+                    );
+                    // Should not have OFFSET when using before/after pagination
+                    assert!(
+                        !query.contains("OFFSET"),
+                        "Query should not have OFFSET with before/after pagination"
+                    );
+                    // Verify the UUID parameter is set
+                    assert!(params.values().any(|v| v.contains("01234567-89ab-cdef")));
+                    true
+                })
+                .returning(|_, _| {
+                    Ok(ClickHouseResponse {
+                        response: String::new(),
+                        metadata: ClickHouseResponseMetadata {
+                            read_rows: 0,
+                            written_rows: 0,
+                        },
+                    })
+                });
+            let conn = ClickHouseConnectionInfo::new_mock(Arc::new(mock_clickhouse_client));
+            let config = get_e2e_config().await;
+
+            let result = conn
+                .list_inferences(
+                    &config,
+                    &ListInferencesParams {
+                        function_name: Some("extract_entities"),
+                        pagination: Some(PaginationParams::Before { id: before_id }),
+                        output_source: InferenceOutputSource::Inference,
+                        limit: 10,
+                        offset: 0,
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(result.len(), 0);
+        }
+
+        #[tokio::test]
+        async fn test_list_inferences_with_after() {
+            let mut mock_clickhouse_client = MockClickHouseClient::new();
+            let after_id = Uuid::parse_str("01234567-89ab-cdef-0123-456789abcdef").unwrap();
+
+            mock_clickhouse_client
+                .expect_run_query_synchronous()
+                .withf(move |query, params| {
+                    // Should include the after in WHERE clause
+                    assert!(
+                        query.contains("toUInt128(i.id) > toUInt128(toUUID({p"),
+                        "Query should contain after condition"
+                    );
+                    // Should not have OFFSET when using before/after pagination
+                    assert!(
+                        !query.contains("OFFSET"),
+                        "Query should not have OFFSET with before/after pagination"
+                    );
+                    // Verify the after UUID parameter is set
+                    assert!(params.values().any(|v| v.contains("01234567-89ab-cdef")));
+                    true
+                })
+                .returning(|_, _| {
+                    Ok(ClickHouseResponse {
+                        response: String::new(),
+                        metadata: ClickHouseResponseMetadata {
+                            read_rows: 0,
+                            written_rows: 0,
+                        },
+                    })
+                });
+            let conn = ClickHouseConnectionInfo::new_mock(Arc::new(mock_clickhouse_client));
+            let config = get_e2e_config().await;
+
+            let result = conn
+                .list_inferences(
+                    &config,
+                    &ListInferencesParams {
+                        function_name: Some("extract_entities"),
+                        pagination: Some(PaginationParams::After { id: after_id }),
+                        output_source: InferenceOutputSource::Inference,
+                        limit: 10,
+                        offset: 0,
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(result.len(), 0);
+        }
+
+        #[tokio::test]
+        async fn test_list_inferences_before_without_function_name() {
+            let mut mock_clickhouse_client = MockClickHouseClient::new();
+            let before_id = Uuid::parse_str("01234567-89ab-cdef-0123-456789abcdef").unwrap();
+
+            mock_clickhouse_client
+                .expect_run_query_synchronous()
+                .withf(move |query, params| {
+                    // Should use UNION ALL query when function_name is not provided
+                    assert!(
+                        query.contains("UNION ALL"),
+                        "Query should use UNION ALL when function_name is not provided"
+                    );
+                    // Should still include the before in WHERE clause
+                    assert!(
+                        query.contains("toUInt128(i.id) < toUInt128(toUUID({p"),
+                        "Query should contain before condition"
+                    );
+                    // Verify the before UUID parameter is set
+                    assert!(params.values().any(|v| v.contains("01234567-89ab-cdef")));
+                    true
+                })
+                .returning(|_, _| {
+                    Ok(ClickHouseResponse {
+                        response: String::new(),
+                        metadata: ClickHouseResponseMetadata {
+                            read_rows: 0,
+                            written_rows: 0,
+                        },
+                    })
+                });
+            let conn = ClickHouseConnectionInfo::new_mock(Arc::new(mock_clickhouse_client));
+            let config = Config::default();
+
+            let result = conn
+                .list_inferences(
+                    &config,
+                    &ListInferencesParams {
+                        function_name: None, // No function_name to trigger UNION ALL
+                        pagination: Some(PaginationParams::Before { id: before_id }),
+                        output_source: InferenceOutputSource::Inference,
+                        limit: 10,
+                        offset: 0,
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(result.len(), 0);
+        }
+
+        #[tokio::test]
+        async fn test_list_inferences_no_before_uses_offset() {
+            let mut mock_clickhouse_client = MockClickHouseClient::new();
+
+            mock_clickhouse_client
+                .expect_run_query_synchronous()
+                .withf(|query, params| {
+                    // Should include OFFSET when not using before/after pagination
+                    assert!(
+                        query.contains("OFFSET {p"),
+                        "Query should have OFFSET without before/after pagination"
+                    );
+                    // Should have offset parameter set to 20
+                    assert!(params.values().any(|v| *v == "20"));
+                    true
+                })
+                .returning(|_, _| {
+                    Ok(ClickHouseResponse {
+                        response: String::new(),
+                        metadata: ClickHouseResponseMetadata {
+                            read_rows: 0,
+                            written_rows: 0,
+                        },
+                    })
+                });
+            let conn = ClickHouseConnectionInfo::new_mock(Arc::new(mock_clickhouse_client));
+            let config = get_e2e_config().await;
+
+            let result = conn
+                .list_inferences(
+                    &config,
+                    &ListInferencesParams {
+                        function_name: Some("extract_entities"),
+                        pagination: None, // No before/after pagination
+                        output_source: InferenceOutputSource::Inference,
+                        limit: 10,
+                        offset: 20, // Should use offset
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(result.len(), 0);
+        }
+
+        #[tokio::test]
+        async fn test_list_inferences_before_with_timestamp_ordering_succeeds() {
+            let config = get_e2e_config().await;
+            let before_id = Uuid::parse_str("01234567-89ab-cdef-0123-456789abcdef").unwrap();
+
+            // Timestamp ordering should work with before/after pagination
+            let result = generate_list_inferences_sql(
+                &config,
+                &ListInferencesParams {
+                    function_name: Some("extract_entities"),
+                    pagination: Some(PaginationParams::Before { id: before_id }),
+                    output_source: InferenceOutputSource::Inference,
+                    limit: 10,
+                    offset: 0,
+                    order_by: Some(&[OrderBy {
+                        term: OrderByTerm::Timestamp,
+                        direction: OrderDirection::Desc,
+                    }]),
+                    ..Default::default()
+                },
+            );
+
+            assert!(
+                result.is_ok(),
+                "Timestamp ordering should work with before/after pagination"
+            );
+            let (sql, _) = result.unwrap();
+            // Should include timestamp ordering
+            assert!(
+                sql.contains("i.timestamp DESC"),
+                "SQL should include timestamp ordering"
+            );
+            // Should include id as tie-breaker
+            assert!(
+                sql.contains("toUInt128(i.id) DESC"),
+                "SQL should include id as tie-breaker"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_list_inferences_before_with_metric_ordering_fails() {
+            let config = get_e2e_config().await;
+            let before_id = Uuid::parse_str("01234567-89ab-cdef-0123-456789abcdef").unwrap();
+
+            // Metric ordering should NOT work with before/after pagination
+            let result = generate_list_inferences_sql(
+                &config,
+                &ListInferencesParams {
+                    function_name: Some("extract_entities"),
+                    pagination: Some(PaginationParams::Before { id: before_id }),
+                    output_source: InferenceOutputSource::Inference,
+                    limit: 10,
+                    offset: 0,
+                    order_by: Some(&[OrderBy {
+                        term: OrderByTerm::Metric {
+                            name: "test_metric".to_string(),
+                        },
+                        direction: OrderDirection::Desc,
+                    }]),
+                    ..Default::default()
+                },
+            );
+
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert!(
+                err.to_string().contains(
+                    "only ordering by timestamp is supported with before/after pagination"
+                ),
+                "Error should mention metric ordering conflict with before/after pagination"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_list_inferences_before_with_search_relevance_fails() {
+            let config = get_e2e_config().await;
+            let before_id = Uuid::parse_str("01234567-89ab-cdef-0123-456789abcdef").unwrap();
+
+            // Search relevance ordering should NOT work with before/after pagination
+            let result = generate_list_inferences_sql(
+                &config,
+                &ListInferencesParams {
+                    function_name: Some("extract_entities"),
+                    pagination: Some(PaginationParams::Before { id: before_id }),
+                    output_source: InferenceOutputSource::Inference,
+                    limit: 10,
+                    offset: 0,
+                    order_by: Some(&[OrderBy {
+                        term: OrderByTerm::SearchRelevance,
+                        direction: OrderDirection::Desc,
+                    }]),
+                    ..Default::default()
+                },
+            );
+
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert!(
+                err.to_string().contains(
+                    "only ordering by timestamp is supported with before/after pagination"
+                ),
+                "Error should mention search relevance ordering conflict with before/after pagination"
+            );
         }
     }
 }

--- a/tensorzero-core/src/db/clickhouse/query_builder/mod.rs
+++ b/tensorzero-core/src/db/clickhouse/query_builder/mod.rs
@@ -5,7 +5,10 @@ use std::{
 
 use crate::{
     config::{Config, MetricConfigType},
-    db::{clickhouse::query_builder::parameters::add_parameter, inferences::ListInferencesParams},
+    db::{
+        clickhouse::query_builder::parameters::add_parameter,
+        inferences::{ListInferencesParams, PaginationParams},
+    },
     error::{Error, ErrorDetails},
 };
 
@@ -63,6 +66,13 @@ impl OrderDirection {
         match self {
             OrderDirection::Asc => "ASC",
             OrderDirection::Desc => "DESC",
+        }
+    }
+
+    pub fn inverted(&self) -> Self {
+        match self {
+            OrderDirection::Asc => OrderDirection::Desc,
+            OrderDirection::Desc => OrderDirection::Asc,
         }
     }
 }
@@ -337,13 +347,28 @@ pub fn generate_order_by_sql(
     param_idx_counter: &mut usize,
     joins: &mut JoinRegistry,
 ) -> Result<String, Error> {
+    // Build a fallback "order by id" as tie-breaker for deterministic ordering
+    // For before/after pagination, the direction depends on the pagination type
+    // For offset pagination or no pagination, use DESC (most recent first)
+    let order_by_id_clause = if let Some(pagination) = &opts.pagination {
+        match pagination {
+            PaginationParams::After { .. } => "toUInt128(i.id) ASC".to_string(),
+            PaginationParams::Before { .. } => "toUInt128(i.id) DESC".to_string(),
+        }
+    } else {
+        // Add id tie-breaker when ordering to ensure deterministic results
+        "toUInt128(i.id) DESC".to_string()
+    };
+
+    // If we have cursor pagination but no user-specified ordering, just use the id clause
     let Some(order_by) = opts.order_by else {
-        return Ok(String::new());
+        return Ok(format!("\nORDER BY {order_by_id_clause}"));
     };
     if order_by.is_empty() {
-        return Ok(String::new());
+        return Ok(format!("\nORDER BY {order_by_id_clause}"));
     }
 
+    // Validate the order by clauses.
     for term in order_by {
         // TODO(shuyangli): Validate that if ORDER BY includes a metric, we should have an appropriate
         // metric inference filter.
@@ -359,6 +384,10 @@ pub fn generate_order_by_sql(
             }));
         }
     }
+
+    // Build the explicit ordering clauses.
+    // For "After" pagination, we need to invert all ordering directions because we'll reverse the list in memory
+    let should_invert_directions = matches!(opts.pagination, Some(PaginationParams::After { .. }));
 
     let mut order_by_clauses = Vec::new();
     for term in order_by {
@@ -386,9 +415,19 @@ pub fn generate_order_by_sql(
                 "total_term_frequency".to_string()
             }
         };
-        let direction = term.direction.to_clickhouse_direction();
+        // Invert direction for "After" pagination since we'll reverse the list
+        let effective_direction = if should_invert_directions {
+            term.direction.inverted()
+        } else {
+            term.direction
+        };
+        let direction = effective_direction.to_clickhouse_direction();
         order_by_clauses.push(format!("{sql_expr} {direction} NULLS LAST"));
     }
+
+    // Add the tie-breaker clause.
+    order_by_clauses.push(order_by_id_clause);
+
     let joined_clauses = order_by_clauses.join(", ");
     Ok(format!("\nORDER BY {joined_clauses}"))
 }
@@ -490,8 +529,9 @@ FROM
     JsonInference AS i
 WHERE
     i.function_name = {p0:String}
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p1:UInt64}
-OFFSET {p2:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
         let expected_params = vec![
@@ -502,10 +542,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p1".to_string(),
                 value: "20".to_string(),
-            },
-            QueryParameter {
-                name: "p2".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -541,8 +577,9 @@ FROM
     ChatInference AS i
 WHERE
     i.function_name = {p0:String}
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p1:UInt64}
-OFFSET {p2:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
         let expected_params = vec![
@@ -553,10 +590,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p1".to_string(),
                 value: "20".to_string(),
-            },
-            QueryParameter {
-                name: "p2".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -606,8 +639,9 @@ LEFT JOIN (
 ) AS j0 ON i.id = j0.target_id
 WHERE
     i.function_name = {p0:String} AND j0.value > {p2:Float64}
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p3:UInt64}
-OFFSET {p4:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
         let expected_params = vec![
@@ -626,10 +660,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p3".to_string(),
                 value: "20".to_string(),
-            },
-            QueryParameter {
-                name: "p4".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -704,8 +734,9 @@ FROM
 JOIN (SELECT inference_id, argMax(value, timestamp) as value FROM DemonstrationFeedback GROUP BY inference_id ) AS demo_f ON i.id = demo_f.inference_id
 WHERE
     i.function_name = {p0:String}
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p1:UInt64}
-OFFSET {p2:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
         let expected_params = vec![
@@ -716,10 +747,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p1".to_string(),
                 value: "20".to_string(),
-            },
-            QueryParameter {
-                name: "p2".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -768,8 +795,9 @@ LEFT JOIN (
 ) AS j0 ON i.id = j0.target_id
 WHERE
     i.function_name = {p0:String} AND j0.value = {p2:Bool}
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p3:UInt64}
-OFFSET {p4:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
         let expected_params = vec![
@@ -788,10 +816,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p3".to_string(),
                 value: "20".to_string(),
-            },
-            QueryParameter {
-                name: "p4".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -840,8 +864,9 @@ LEFT JOIN (
 ) AS j0 ON i.id = j0.target_id
 WHERE
     i.function_name = {p0:String} AND j0.value = {p2:Bool}
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p3:UInt64}
-OFFSET {p4:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
         let expected_params = vec![
@@ -860,10 +885,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p3".to_string(),
                 value: "20".to_string(),
-            },
-            QueryParameter {
-                name: "p4".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -937,8 +958,9 @@ LEFT JOIN (
 ) AS j1 ON i.id = j1.target_id
 WHERE
     i.function_name = {p0:String} AND (COALESCE(j0.value > {p2:Float64}, 0) AND COALESCE(j0.value < {p3:Float64}, 0) AND COALESCE(j1.value < {p5:Float64}, 0))
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p6:UInt64}
-OFFSET {p7:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
         let expected_params = vec![
@@ -969,10 +991,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p6".to_string(),
                 value: "20".to_string(),
-            },
-            QueryParameter {
-                name: "p7".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -1053,8 +1071,9 @@ LEFT JOIN (
 ) AS j2 ON i.episode_id = j2.target_id
 WHERE
     i.function_name = {p0:String} AND (COALESCE(j0.value >= {p2:Float64}, 0) OR COALESCE(j1.value = {p4:Bool}, 0) OR COALESCE(j2.value = {p6:Bool}, 0))
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p7:UInt64}
-OFFSET {p8:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
         let expected_params = vec![
@@ -1089,10 +1108,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p7".to_string(),
                 value: "20".to_string(),
-            },
-            QueryParameter {
-                name: "p8".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -1151,8 +1166,9 @@ LEFT JOIN (
 ) AS j0 ON i.id = j0.target_id
 WHERE
     i.function_name = {p0:String} AND NOT (COALESCE((COALESCE(j0.value = {p2:Bool}, 0) OR COALESCE(j0.value = {p3:Bool}, 0)), 1))
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p4:UInt64}
-OFFSET {p5:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
         let expected_params = vec![
@@ -1175,10 +1191,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p4".to_string(),
                 value: "20".to_string(),
-            },
-            QueryParameter {
-                name: "p5".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -1265,11 +1277,12 @@ LEFT JOIN (
 ) AS j2 ON i.id = j2.target_id
 WHERE
     i.function_name = {p0:String} AND (COALESCE((COALESCE(j0.value > {p2:Float64}, 0) OR COALESCE(j1.value <= {p4:Float64}, 0)), 0) AND COALESCE(NOT (COALESCE(j2.value = {p6:Bool}, 1)), 0))
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p7:UInt64}
-OFFSET {p8:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
-        assert_eq!(params.len(), 9); // p0 (function) + 6 metric-related params + 2 limit/offset params
+        assert_eq!(params.len(), 8); // p0 (function) + 6 metric-related params + 1 limit param (no offset when 0)
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1342,11 +1355,12 @@ LEFT JOIN (
 ) AS j0 ON i.id = j0.target_id
 WHERE
     i.function_name = {p0:String} AND (COALESCE(i.timestamp > parseDateTimeBestEffort({p1:String}), 0) AND COALESCE((COALESCE(i.timestamp < parseDateTimeBestEffort({p2:String}), 0) OR COALESCE((COALESCE(j0.value >= {p4:Float64}, 0) AND COALESCE(i.tags[{p5:String}] = {p6:String}, 0)), 0)), 0))
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p7:UInt64}
-OFFSET {p8:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
-        assert_eq!(params.len(), 9); // p0 (function) + 6 filter-related params + 2 limit/offset params
+        assert_eq!(params.len(), 8); // p0 (function) + 6 filter-related params + 1 limit param (no offset when 0)
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1381,8 +1395,9 @@ FROM
     JsonInference AS i
 WHERE
     i.function_name = {p0:String} AND i.variant_name = {p1:String}
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p2:UInt64}
-OFFSET {p3:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
         let expected_params = vec![
@@ -1397,10 +1412,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p2".to_string(),
                 value: "20".to_string(),
-            },
-            QueryParameter {
-                name: "p3".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -1438,6 +1449,7 @@ FROM
     JsonInference AS i
 WHERE
     i.function_name = {p0:String}
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p1:UInt64}
 OFFSET {p2:UInt64}
 FORMAT JSONEachRow";
@@ -1515,8 +1527,8 @@ LEFT JOIN (
 ) AS j0 ON i.id = j0.target_id
 WHERE
     i.function_name = {{p0:String}} AND j0.value {expected_op_str} {{p2:Float64}}
+ORDER BY toUInt128(i.id) DESC
 LIMIT {{p3:UInt64}}
-OFFSET {{p4:UInt64}}
 FORMAT JSONEachRow",
             );
             assert_query_equals(&sql, &expected_sql);
@@ -1536,10 +1548,6 @@ FORMAT JSONEachRow",
                 QueryParameter {
                     name: "p3".to_string(),
                     value: "20".to_string(),
-                },
-                QueryParameter {
-                    name: "p4".to_string(),
-                    value: "0".to_string(),
                 },
             ];
             assert_eq!(params, expected_params);
@@ -1582,8 +1590,9 @@ FROM
     JsonInference AS i
 WHERE
     i.function_name = {p0:String} AND i.tags[{p1:String}] = {p2:String}
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p3:UInt64}
-OFFSET {p4:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
         let expected_params = vec![
@@ -1602,10 +1611,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p3".to_string(),
                 value: "20".to_string(),
-            },
-            QueryParameter {
-                name: "p4".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -1647,8 +1652,9 @@ FROM
     ChatInference AS i
 WHERE
     i.function_name = {p0:String} AND i.tags[{p1:String}] != {p2:String}
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p3:UInt64}
-OFFSET {p4:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
         let expected_params = vec![
@@ -1667,10 +1673,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p3".to_string(),
                 value: "20".to_string(),
-            },
-            QueryParameter {
-                name: "p4".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -1721,8 +1723,9 @@ FROM
     JsonInference AS i
 WHERE
     i.function_name = {p0:String} AND (COALESCE(i.tags[{p1:String}] = {p2:String}, 0) AND COALESCE(i.tags[{p3:String}] = {p4:String}, 0))
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p5:UInt64}
-OFFSET {p6:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
         let expected_params = vec![
@@ -1749,10 +1752,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p5".to_string(),
                 value: "20".to_string(),
-            },
-            QueryParameter {
-                name: "p6".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -1811,8 +1810,9 @@ LEFT JOIN (
 ) AS j0 ON i.id = j0.target_id
 WHERE
     i.function_name = {p0:String} AND (COALESCE(i.tags[{p1:String}] = {p2:String}, 0) AND COALESCE(j0.value > {p4:Float64}, 0))
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p5:UInt64}
-OFFSET {p6:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
         let expected_params = vec![
@@ -1839,10 +1839,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p5".to_string(),
                 value: "20".to_string(),
-            },
-            QueryParameter {
-                name: "p6".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -1916,6 +1912,7 @@ LEFT JOIN (
 ) AS j1 ON i.id = j1.target_id
 WHERE
     i.function_name = {p0:String} AND i.variant_name = {p1:String} AND (COALESCE(j0.value > {p3:Float64}, 0) AND COALESCE(j1.value = {p5:Bool}, 0))
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p6:UInt64}
 OFFSET {p7:UInt64}
 FORMAT JSONEachRow";
@@ -1993,8 +1990,9 @@ FROM
     JsonInference AS i
 WHERE
     i.function_name = {p0:String} AND i.timestamp > parseDateTimeBestEffort({p1:String})
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p2:UInt64}
-OFFSET {p3:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
         let expected_params = vec![
@@ -2009,10 +2007,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p2".to_string(),
                 value: "20".to_string(),
-            },
-            QueryParameter {
-                name: "p3".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -2064,8 +2058,8 @@ FROM
     ChatInference AS i
 WHERE
     i.function_name = {{p0:String}} AND i.timestamp {expected_op_str} parseDateTimeBestEffort({{p1:String}})
+ORDER BY toUInt128(i.id) DESC
 LIMIT {{p2:UInt64}}
-OFFSET {{p3:UInt64}}
 FORMAT JSONEachRow",
             );
             assert_query_equals(&sql, &expected_sql);
@@ -2081,10 +2075,6 @@ FORMAT JSONEachRow",
                 QueryParameter {
                     name: "p2".to_string(),
                     value: "20".to_string(),
-                },
-                QueryParameter {
-                    name: "p3".to_string(),
-                    value: "0".to_string(),
                 },
             ];
             assert_eq!(params, expected_params);
@@ -2149,8 +2139,9 @@ LEFT JOIN (
 ) AS j0 ON i.id = j0.target_id
 WHERE
     i.function_name = {p0:String} AND (COALESCE(i.timestamp >= parseDateTimeBestEffort({p1:String}), 0) AND COALESCE(i.tags[{p2:String}] = {p3:String}, 0) AND COALESCE(j0.value > {p5:Float64}, 0))
+ORDER BY toUInt128(i.id) DESC
 LIMIT {p6:UInt64}
-OFFSET {p7:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
         let expected_params = vec![
@@ -2181,10 +2172,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p6".to_string(),
                 value: "10".to_string(),
-            },
-            QueryParameter {
-                name: "p7".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -2552,9 +2539,9 @@ FROM
     JsonInference AS i
 WHERE
     i.function_name = {p0:String}
-ORDER BY i.timestamp DESC NULLS LAST
+ORDER BY i.timestamp DESC NULLS LAST, toUInt128(i.id) DESC
 LIMIT {p1:UInt64}
-OFFSET {p2:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
 
@@ -2566,10 +2553,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p1".to_string(),
                 value: "20".to_string(),
-            },
-            QueryParameter {
-                name: "p2".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -2621,9 +2604,9 @@ LEFT JOIN (
 ) AS j0 ON i.id = j0.target_id
 WHERE
     i.function_name = {p0:String}
-ORDER BY j0.value ASC NULLS LAST
+ORDER BY j0.value ASC NULLS LAST, toUInt128(i.id) DESC
 LIMIT {p2:UInt64}
-OFFSET {p3:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
 
@@ -2639,10 +2622,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p2".to_string(),
                 value: "20".to_string(),
-            },
-            QueryParameter {
-                name: "p3".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -2700,9 +2679,9 @@ LEFT JOIN (
 ) AS j0 ON i.id = j0.target_id
 WHERE
     i.function_name = {p0:String}
-ORDER BY j0.value DESC NULLS LAST, i.timestamp ASC NULLS LAST
+ORDER BY j0.value DESC NULLS LAST, i.timestamp ASC NULLS LAST, toUInt128(i.id) DESC
 LIMIT {p2:UInt64}
-OFFSET {p3:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
 
@@ -2718,10 +2697,6 @@ FORMAT JSONEachRow";
             QueryParameter {
                 name: "p2".to_string(),
                 value: "20".to_string(),
-            },
-            QueryParameter {
-                name: "p3".to_string(),
-                value: "0".to_string(),
             },
         ];
         assert_eq!(params, expected_params);
@@ -2768,9 +2743,9 @@ FROM ChatInference AS i
 WHERE
     i.function_name = {p0:String}
     AND total_term_frequency > 0
-ORDER BY total_term_frequency DESC NULLS LAST
+ORDER BY total_term_frequency DESC NULLS LAST, toUInt128(i.id) DESC
 LIMIT {p2:UInt64}
-OFFSET {p3:UInt64}
+
 FORMAT JSONEachRow";
         assert_query_equals(&sql, expected_sql);
 

--- a/tensorzero-core/src/endpoints/shared_types.rs
+++ b/tensorzero-core/src/endpoints/shared_types.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// The ordering direction.
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, ts_rs::TS)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, ts_rs::TS)]
 #[ts(export)]
 pub enum OrderDirection {
     #[serde(rename = "ascending")]

--- a/tensorzero-core/src/endpoints/stored_inferences/v1/get_inferences.rs
+++ b/tensorzero-core/src/endpoints/stored_inferences/v1/get_inferences.rs
@@ -79,7 +79,7 @@ pub async fn list_inferences(
     clickhouse: &impl InferenceQueries,
     request: ListInferencesRequest,
 ) -> Result<GetInferencesResponse, Error> {
-    let params = request.as_list_inferences_params();
+    let params = request.as_list_inferences_params()?;
     let inferences_storage = clickhouse.list_inferences(config, &params).await?;
     let inferences = inferences_storage
         .into_iter()

--- a/tensorzero-core/src/endpoints/stored_inferences/v1/list_by_id.rs
+++ b/tensorzero-core/src/endpoints/stored_inferences/v1/list_by_id.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use tracing::instrument;
 use uuid::Uuid;
 
-use crate::db::inferences::{InferenceQueries, ListInferencesByIdParams, PaginateByIdCondition};
+use crate::db::inferences::{InferenceQueries, ListInferencesByIdParams, PaginationParams};
 use crate::endpoints::stored_inferences::v1::types::{
     InternalInferenceMetadata, InternalListInferencesByIdResponse,
 };
@@ -49,8 +49,8 @@ pub async fn list_inferences_by_id_handler(
                 message: "Cannot specify both before and after parameters".to_string(),
             }));
         }
-        (Some(before), None) => Some(PaginateByIdCondition::Before { id: before }),
-        (None, Some(after)) => Some(PaginateByIdCondition::After { id: after }),
+        (Some(before), None) => Some(PaginationParams::Before { id: before }),
+        (None, Some(after)) => Some(PaginationParams::After { id: after }),
         _ => None,
     };
 

--- a/tensorzero-core/src/endpoints/stored_inferences/v1/types.rs
+++ b/tensorzero-core/src/endpoints/stored_inferences/v1/types.rs
@@ -5,8 +5,9 @@ use tensorzero_derive::export_schema;
 use uuid::Uuid;
 
 use crate::db::inferences::{
-    InferenceOutputSource, ListInferencesParams, DEFAULT_INFERENCE_QUERY_LIMIT,
+    InferenceOutputSource, ListInferencesParams, PaginationParams, DEFAULT_INFERENCE_QUERY_LIMIT,
 };
+use crate::error::{Error, ErrorDetails};
 use crate::stored_inference::StoredInference;
 
 // Re-exported for backwards compatibility.
@@ -197,6 +198,16 @@ pub struct ListInferencesRequest {
     /// Defaults to 0.
     pub offset: Option<u32>,
 
+    /// Optional inference ID to paginate before (exclusive).
+    /// Returns inferences with IDs before this one (earlier in time).
+    /// Cannot be used together with `after` or `offset`.
+    pub before: Option<Uuid>,
+
+    /// Optional inference ID to paginate after (exclusive).
+    /// Returns inferences with IDs after this one (later in time).
+    /// Cannot be used together with `before` or `offset`.
+    pub after: Option<Uuid>,
+
     /// Optional filter to apply when querying inferences.
     /// Supports filtering by metrics, tags, time, and logical combinations (AND/OR/NOT).
     pub filter: Option<InferenceFilter>,
@@ -222,8 +233,28 @@ pub struct ListInferencesRequest {
 
 impl ListInferencesRequest {
     /// Convert the request to a `ListInferencesParams` struct for the database query layer.
-    pub fn as_list_inferences_params<'a>(&'a self) -> ListInferencesParams<'a> {
-        ListInferencesParams {
+    pub fn as_list_inferences_params<'a>(&'a self) -> Result<ListInferencesParams<'a>, Error> {
+        // Construct cursor-based pagination params, and validate that before and after are mutually exclusive
+        let pagination = match (self.before, self.after) {
+            (Some(_), Some(_)) => {
+                return Err(Error::new(ErrorDetails::InvalidRequest {
+                    message: "Cannot specify both 'before' and 'after' parameters".to_string(),
+                }))
+            }
+            (Some(before), None) => Some(PaginationParams::Before { id: before }),
+            (None, Some(after)) => Some(PaginationParams::After { id: after }),
+            (None, None) => None,
+        };
+
+        // Validate that offset and cursor pagination are mutually exclusive
+        if pagination.is_some() && self.offset.is_some() {
+            return Err(Error::new(ErrorDetails::InvalidRequest {
+                message: "Cannot use 'offset' with cursor pagination ('before' or 'after')"
+                    .to_string(),
+            }));
+        }
+
+        Ok(ListInferencesParams {
             ids: None,
             function_name: self.function_name.as_deref(),
             variant_name: self.variant_name.as_deref(),
@@ -232,9 +263,10 @@ impl ListInferencesRequest {
             output_source: self.output_source,
             limit: self.limit.unwrap_or(DEFAULT_INFERENCE_QUERY_LIMIT),
             offset: self.offset.unwrap_or(0),
+            pagination,
             order_by: self.order_by.as_deref(),
             search_query_experimental: self.search_query_experimental.as_deref(),
-        }
+        })
     }
 }
 

--- a/tensorzero-core/tests/e2e/endpoints/stored_inferences/get_inferences.rs
+++ b/tensorzero-core/tests/e2e/endpoints/stored_inferences/get_inferences.rs
@@ -787,3 +787,383 @@ async fn test_search_query_order_by_search_relevance() {
         }
     }
 }
+
+// Tests for cursor-based pagination
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn test_list_inferences_with_before_cursor() {
+    // First, get some inferences without cursor
+    let initial_request = json!({
+        "function_name": "write_haiku",
+        "output_source": "inference",
+        "limit": 5,
+        "order_by": [
+            {
+                "by": "timestamp",
+                "direction": "descending"
+            }
+        ]
+    });
+
+    let initial_res = list_inferences(initial_request).await.unwrap();
+    assert!(!initial_res.is_empty(), "Expected some inferences");
+
+    // Get the ID of the third inference to use as cursor
+    let cursor_id = initial_res[2]["inference_id"].as_str().unwrap();
+
+    // Now request inferences before this cursor
+    // Note: cannot use order_by with cursor pagination
+    let cursor_request = json!({
+        "function_name": "write_haiku",
+        "output_source": "inference",
+        "limit": 5,
+        "before": cursor_id,
+    });
+
+    let cursor_res = list_inferences(cursor_request).await.unwrap();
+
+    // Verify we got results
+    assert!(
+        !cursor_res.is_empty(),
+        "Expected results with before cursor"
+    );
+
+    // Verify all returned inferences have IDs less than the cursor
+    let cursor_uuid = Uuid::parse_str(cursor_id).unwrap();
+    for inference in &cursor_res {
+        let inference_id = Uuid::parse_str(inference["inference_id"].as_str().unwrap()).unwrap();
+        assert!(
+            inference_id < cursor_uuid,
+            "Inference ID should be less than cursor ID"
+        );
+    }
+
+    // Verify results are still in descending timestamp order
+    let mut prev_timestamp: Option<String> = None;
+    for inference in &cursor_res {
+        let timestamp = inference["timestamp"].as_str().unwrap().to_string();
+        if let Some(prev) = &prev_timestamp {
+            assert!(
+                timestamp <= *prev,
+                "Timestamps should be in descending order"
+            );
+        }
+        prev_timestamp = Some(timestamp);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn test_list_inferences_with_after_cursor() {
+    // First, get some inferences without cursor
+    let initial_request = json!({
+        "function_name": "write_haiku",
+        "output_source": "inference",
+        "limit": 10,
+        "order_by": [
+            {
+                "by": "timestamp",
+                "direction": "descending"
+            }
+        ]
+    });
+
+    let initial_res = list_inferences(initial_request).await.unwrap();
+    assert_eq!(initial_res.len(), 10, "Expected 10 write_haiku inferences");
+
+    // Get the ID of the (0-indexed) 4th inference to use as cursor, so we return the 5th-9th inferences.
+    let cursor_id = initial_res[4]["inference_id"].as_str().unwrap();
+
+    // Now request inferences after this cursor
+    // Note: cannot use order_by with cursor pagination
+    let cursor_request = json!({
+        "function_name": "write_haiku",
+        "output_source": "inference",
+        "limit": 5,
+        "after": cursor_id,
+    });
+
+    let cursor_res = list_inferences(cursor_request).await.unwrap();
+
+    assert!(!cursor_res.is_empty(), "Expected results with after cursor");
+
+    // Verify all returned inferences have IDs greater than the cursor
+    let cursor_uuid = Uuid::parse_str(cursor_id).unwrap();
+    for inference in &cursor_res {
+        let inference_id = Uuid::parse_str(inference["inference_id"].as_str().unwrap()).unwrap();
+        assert!(
+            inference_id > cursor_uuid,
+            "Inference ID should be greater than cursor ID"
+        );
+    }
+
+    // Verify results are still in descending timestamp order
+    let mut prev_timestamp: Option<String> = None;
+    for inference in &cursor_res {
+        let timestamp = inference["timestamp"].as_str().unwrap().to_string();
+        if let Some(prev) = &prev_timestamp {
+            assert!(
+                timestamp <= *prev,
+                "Timestamps should be in descending order"
+            );
+        }
+        prev_timestamp = Some(timestamp);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn test_list_inferences_cursor_pagination_prevents_offset() {
+    let http_client = Client::new();
+
+    // First, get an inference ID to use as cursor
+    let initial_request = json!({
+        "function_name": "write_haiku",
+        "output_source": "inference",
+        "limit": 1,
+    });
+
+    let initial_res = list_inferences(initial_request).await.unwrap();
+    assert!(!initial_res.is_empty(), "Expected at least one inference");
+    let cursor_id = initial_res[0]["inference_id"].as_str().unwrap();
+
+    // Try to use both cursor and offset - should fail
+    let invalid_request = json!({
+        "function_name": "write_haiku",
+        "output_source": "inference",
+        "limit": 5,
+        "before": cursor_id,
+        "offset": 10, // This should cause an error
+    });
+
+    let resp = http_client
+        .post(get_gateway_endpoint("/v1/inferences/list_inferences"))
+        .json(&invalid_request)
+        .send()
+        .await
+        .unwrap();
+
+    // Should return an error status
+    assert!(
+        !resp.status().is_success(),
+        "Request with both cursor and offset should fail"
+    );
+
+    let error_body = resp.text().await.unwrap();
+    assert!(
+        error_body.contains("Cannot use 'offset' with cursor pagination"),
+        "Error message should mention cursor/offset conflict"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn test_list_inferences_cursor_mutually_exclusive() {
+    let http_client = Client::new();
+
+    // First, get inference IDs to use as cursors
+    let initial_request = json!({
+        "function_name": "write_haiku",
+        "output_source": "inference",
+        "limit": 2,
+    });
+
+    let initial_res = list_inferences(initial_request).await.unwrap();
+    assert!(
+        initial_res.len() >= 2,
+        "Expected at least two inferences for test"
+    );
+    let cursor_id_1 = initial_res[0]["inference_id"].as_str().unwrap();
+    let cursor_id_2 = initial_res[1]["inference_id"].as_str().unwrap();
+
+    // Try to use both before and after - should fail
+    let invalid_request = json!({
+        "function_name": "write_haiku",
+        "output_source": "inference",
+        "limit": 5,
+        "before": cursor_id_1,
+        "after": cursor_id_2, // This should cause an error
+    });
+
+    let resp = http_client
+        .post(get_gateway_endpoint("/v1/inferences/list_inferences"))
+        .json(&invalid_request)
+        .send()
+        .await
+        .unwrap();
+
+    // Should return an error status
+    assert!(
+        !resp.status().is_success(),
+        "Request with both before and after should fail"
+    );
+
+    let error_body = resp.text().await.unwrap();
+    assert!(
+        error_body.contains("Cannot specify both 'before' and 'after'"),
+        "Error message should mention before/after conflict"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn test_list_inferences_cursor_with_filters() {
+    // Test that cursor pagination works with filters
+    let initial_request = json!({
+        "function_name": "write_haiku",
+        "output_source": "inference",
+        "limit": 3,
+        "filter": {
+            "type": "tag",
+            "key": "tensorzero::dataset_name",
+            "value": "foo",
+            "comparison_operator": "="
+        },
+        "order_by": [
+            {
+                "by": "timestamp",
+                "direction": "descending"
+            }
+        ]
+    });
+
+    let initial_res = list_inferences(initial_request).await.unwrap();
+    assert!(!initial_res.is_empty(), "Expected at least one inference");
+
+    // Get the ID of the first inference to use as cursor
+    let cursor_id = initial_res[0]["inference_id"].as_str().unwrap();
+
+    // Request inferences before this cursor with the same filter
+    let cursor_request = json!({
+        "function_name": "write_haiku",
+        "output_source": "inference",
+        "limit": 3,
+        "before": cursor_id,
+        "filter": {
+            "type": "tag",
+            "key": "tensorzero::dataset_name",
+            "value": "foo",
+            "comparison_operator": "="
+        },
+        "order_by": [
+            {
+                "by": "timestamp",
+                "direction": "descending"
+            }
+        ]
+    });
+
+    let cursor_res = list_inferences(cursor_request).await.unwrap();
+
+    assert!(
+        !cursor_res.is_empty(),
+        "Expected results with before cursor and filter"
+    );
+
+    // Verify all returned inferences have IDs less than the cursor
+    let cursor_uuid = Uuid::parse_str(cursor_id).unwrap();
+    for inference in &cursor_res {
+        let inference_id = Uuid::parse_str(inference["inference_id"].as_str().unwrap()).unwrap();
+        assert!(
+            inference_id < cursor_uuid,
+            "Inference ID should be less than cursor ID"
+        );
+        // Verify the filter is still applied
+        assert_eq!(inference["function_name"], "write_haiku");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn test_list_inferences_cursor_with_timestamp_ordering_succeeds() {
+    // First, get some inferences to use as cursor
+    let initial_request = json!({
+        "function_name": "write_haiku",
+        "output_source": "inference",
+        "limit": 5,
+        "order_by": [
+            {
+                "by": "timestamp",
+                "direction": "descending"
+            }
+        ]
+    });
+
+    let initial_res = list_inferences(initial_request).await.unwrap();
+    assert!(!initial_res.is_empty(), "Expected at least one inference");
+    let cursor_id = initial_res[2]["inference_id"].as_str().unwrap();
+
+    // Timestamp ordering should work with cursor pagination
+    let cursor_request = json!({
+        "function_name": "write_haiku",
+        "output_source": "inference",
+        "limit": 5,
+        "before": cursor_id,
+        "order_by": [
+            {
+                "by": "timestamp",
+                "direction": "descending"
+            }
+        ]
+    });
+
+    let cursor_res = list_inferences(cursor_request).await.unwrap();
+
+    // Should get results successfully
+    assert!(
+        !cursor_res.is_empty(),
+        "Should get results with timestamp ordering and cursor"
+    );
+
+    // Verify results are ordered by timestamp descending
+    let mut prev_timestamp: Option<String> = None;
+    for inference in &cursor_res {
+        let timestamp = inference["timestamp"].as_str().unwrap().to_string();
+        if let Some(prev) = &prev_timestamp {
+            assert!(
+                timestamp <= *prev,
+                "Timestamps should be in descending order"
+            );
+        }
+        prev_timestamp = Some(timestamp);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn test_list_inferences_cursor_with_metric_ordering_fails() {
+    let http_client = Client::new();
+
+    // First, get an inference ID to use as cursor
+    let initial_request = json!({
+        "function_name": "write_haiku",
+        "output_source": "inference",
+        "limit": 1,
+    });
+
+    let initial_res = list_inferences(initial_request).await.unwrap();
+    assert!(!initial_res.is_empty(), "Expected at least one inference");
+    let cursor_id = initial_res[0]["inference_id"].as_str().unwrap();
+
+    // Try to use cursor with metric ordering - should fail
+    let invalid_request = json!({
+        "function_name": "write_haiku",
+        "output_source": "inference",
+        "limit": 5,
+        "before": cursor_id,
+        "order_by": [
+            {
+                "by": "metric",
+                "name": "test_metric",
+                "direction": "descending"
+            }
+        ]
+    });
+
+    let resp = http_client
+        .post(get_gateway_endpoint("/v1/inferences/list_inferences"))
+        .json(&invalid_request)
+        .send()
+        .await
+        .unwrap();
+
+    // Should return an error status
+    assert!(
+        !resp.status().is_success(),
+        "Request with cursor and metric ordering should fail"
+    );
+}

--- a/tensorzero-optimizers/src/endpoints.rs
+++ b/tensorzero-optimizers/src/endpoints.rs
@@ -101,6 +101,7 @@ pub async fn launch_optimization_workflow(
                 output_source,
                 limit: limit.unwrap_or(DEFAULT_LIST_INFERENCES_QUERY_LIMIT_MAX_FOR_OPTIMIZATIONS),
                 offset: offset.unwrap_or(0),
+                pagination: None,
                 order_by: order_by.as_deref(),
                 search_query_experimental: None,
             },


### PR DESCRIPTION
A step towards #4905.

Support querying inferences `before`​ or `after`​ a given inference ID in `list_inferences`​ for the UI. This is a more fully-featured (although still stop-gap because of the caveat) solution for paginating inferences, and supports filtering and searching. **Important caveat:** `before`​ and `after`​ pagination does not support ordering other than timestamp, and does not support `offset`​. Requests with both `before/after`​ and one of the unsupported parameters will be rejected.

This also makes 2 minor changes:

- Add an ordering by ID by default to provide stable sorting when paginating.
- Stop including `OFFSET`​ when the offset is 0, so queries for before/after pagination are more legible without any unexpected offsets.

For paginating with `after`​, because we want to return the closest inferences after the anchor/cursor, we build the `ORDER BY`​ query **in the reverse order**, then reverse the results in memory in Rust, to avoid the complexity of building the order clauses twice (once for paginating results in the inverted order, then once for returning results in the correct order).
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add before/after pagination to `list_inferences` API with validation and tests for improved UI handling of large datasets.
> 
>   - **Behavior**:
>     - Add `before` and `after` pagination to `list_inferences` API, allowing pagination by inference ID.
>     - Reject requests with `before/after` and unsupported parameters like `offset` or non-timestamp ordering.
>     - Default ordering by ID for stable sorting.
>     - Reverse results in memory for `after` pagination to maintain order.
>   - **Validation**:
>     - Validate `before/after` pagination with timestamp ordering only.
>     - Ensure `offset` is not used with `before/after` pagination.
>   - **Tests**:
>     - Add tests for `before` and `after` pagination in `get_inferences.rs`.
>     - Verify error handling for incompatible parameters.
>   - **Misc**:
>     - Update `ListInferencesParams` and related structs to support new pagination.
>     - Minor doc updates in `AGENTS.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d77e36521454cdb0c71569cdf42f51991c8bc54b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->