### PR TITLE
Temporarily switch fireworks shorthand test to llama-v3p3-70b-instruct

### DIFF
--- a/tensorzero-core/tests/e2e/config/tensorzero.functions.basic_test.toml
+++ b/tensorzero-core/tests/e2e/config/tensorzero.functions.basic_test.toml
@@ -217,7 +217,7 @@ max_tokens = 100
 
 [functions.basic_test.variants.fireworks-shorthand]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/llama-v3p1-8b-instruct"
+model = "fireworks::accounts/fireworks/models/llama-v3p3-70b-instruct"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 

--- a/tensorzero-core/tests/e2e/providers/fireworks.rs
+++ b/tensorzero-core/tests/e2e/providers/fireworks.rs
@@ -86,7 +86,7 @@ async fn get_providers() -> E2ETestProviders {
     let shorthand_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks-shorthand".to_string(),
-        model_name: "fireworks::accounts/fireworks/models/llama-v3p1-8b-instruct".into(),
+        model_name: "fireworks::accounts/fireworks/models/llama-v3p3-70b-instruct".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];


### PR DESCRIPTION
The 'accounts/fireworks/models/llama-v3p1-8b-instruct' is completely broken on Fireworks (the server returns an empty response body), so let's temporarily switch models to unblock our daily merge-queue regen
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch `fireworks-shorthand` model to `llama-v3p3-70b-instruct` to address broken model response.
> 
>   - **Behavior**:
>     - Switch `fireworks-shorthand` model from `llama-v3p1-8b-instruct` to `llama-v3p3-70b-instruct` in `tensorzero.functions.basic_test.toml` and `fireworks.rs`.
>     - Temporary change to address broken model response and unblock daily merge-queue regeneration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 76778b29f16d374e74b7d95ca812bdf9d5cc4efb. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->