### PR TITLE
Make our 'trybuild' ui test a unit test

### DIFF
--- a/internal/tensorzero-derive/src/lib.rs
+++ b/internal/tensorzero-derive/src/lib.rs
@@ -296,3 +296,13 @@ pub fn export_schema(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     TokenStream::from(expanded)
 }
+
+#[cfg(test)]
+mod tests {
+    // Tests various errors emitted by the derive macro.
+    #[test]
+    fn ui() {
+        let t = trybuild::TestCases::new();
+        t.compile_fail("tests/ui/*.rs");
+    }
+}

--- a/internal/tensorzero-derive/tests/ui.rs
+++ b/internal/tensorzero-derive/tests/ui.rs
@@ -1,6 +1,0 @@
-// Tests various errors emitted by the derive macro.
-#[test]
-fn ui() {
-    let t = trybuild::TestCases::new();
-    t.compile_fail("tests/ui/*.rs");
-}


### PR DESCRIPTION
This will avoid the need to copy the entire Cargo registry into the 'live-tests' Docker image
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Moves `ui` test from `tests/ui.rs` to inline module in `lib.rs` to simplify testing setup.
> 
>   - **Testing**:
>     - Moves `ui` test from `tests/ui.rs` to inline module in `lib.rs`.
>     - Eliminates need to copy Cargo registry into Docker image for tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 19d335ea89e6665122535028d36edfdf48bd756c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->