### PR TITLE
Use before/after pagination in inferences table UI

### DIFF
--- a/ui/app/routes/observability/episodes/$episode_id/EpisodeInferenceTable.tsx
+++ b/ui/app/routes/observability/episodes/$episode_id/EpisodeInferenceTable.tsx
@@ -7,7 +7,7 @@ import {
   TableRow,
   TableEmptyState,
 } from "~/components/ui/table";
-import type { InternalInferenceMetadata } from "~/types/tensorzero";
+import type { StoredInference } from "~/types/tensorzero";
 import { VariantLink } from "~/components/function/variant/VariantLink";
 import {
   TableItemTime,
@@ -19,7 +19,7 @@ import { toFunctionUrl, toInferenceUrl } from "~/utils/urls";
 export default function EpisodeInferenceTable({
   inferences,
 }: {
-  inferences: InternalInferenceMetadata[];
+  inferences: StoredInference[];
 }) {
   return (
     <Table>
@@ -36,17 +36,17 @@ export default function EpisodeInferenceTable({
           <TableEmptyState message="No inferences found" />
         ) : (
           inferences.map((inference) => (
-            <TableRow key={inference.id} id={inference.id}>
+            <TableRow key={inference.inference_id} id={inference.inference_id}>
               <TableCell className="max-w-[200px]">
                 <TableItemShortUuid
-                  id={inference.id}
-                  link={toInferenceUrl(inference.id)}
+                  id={inference.inference_id}
+                  link={toInferenceUrl(inference.inference_id)}
                 />
               </TableCell>
               <TableCell>
                 <TableItemFunction
                   functionName={inference.function_name}
-                  functionType={inference.function_type}
+                  functionType={inference.type}
                   link={toFunctionUrl(inference.function_name)}
                 />
               </TableCell>

--- a/ui/app/routes/observability/functions/$function_name/FunctionInferenceTable.tsx
+++ b/ui/app/routes/observability/functions/$function_name/FunctionInferenceTable.tsx
@@ -7,7 +7,7 @@ import {
   TableRow,
   TableEmptyState,
 } from "~/components/ui/table";
-import type { InternalInferenceMetadata } from "~/types/tensorzero";
+import type { StoredInference } from "~/types/tensorzero";
 import { VariantLink } from "~/components/function/variant/VariantLink";
 import { TableItemShortUuid, TableItemTime } from "~/components/ui/TableItems";
 import { toInferenceUrl, toEpisodeUrl } from "~/utils/urls";
@@ -15,7 +15,7 @@ import { toInferenceUrl, toEpisodeUrl } from "~/utils/urls";
 export default function FunctionInferenceTable({
   inferences,
 }: {
-  inferences: InternalInferenceMetadata[];
+  inferences: StoredInference[];
 }) {
   return (
     <Table>
@@ -32,11 +32,11 @@ export default function FunctionInferenceTable({
           <TableEmptyState message="No inferences found" />
         ) : (
           inferences.map((inference) => (
-            <TableRow key={inference.id} id={inference.id}>
+            <TableRow key={inference.inference_id} id={inference.inference_id}>
               <TableCell className="max-w-[200px]">
                 <TableItemShortUuid
-                  id={inference.id}
-                  link={toInferenceUrl(inference.id)}
+                  id={inference.inference_id}
+                  link={toInferenceUrl(inference.inference_id)}
                 />
               </TableCell>
               <TableCell>

--- a/ui/app/routes/observability/functions/$function_name/route.tsx
+++ b/ui/app/routes/observability/functions/$function_name/route.tsx
@@ -1,7 +1,6 @@
 import {
   countInferencesForFunction,
-  queryInferenceTableBounds,
-  queryInferenceTable,
+  listInferencesWithPagination,
 } from "~/utils/clickhouse/inference.server";
 import type { Route } from "./+types/route";
 import {
@@ -70,14 +69,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   if (!function_config) {
     throw data(`Function ${function_name} not found`, { status: 404 });
   }
-  const inferencePromise = queryInferenceTable({
+  const inferencePromise = listInferencesWithPagination({
     function_name,
     before: beforeInference || undefined,
     after: afterInference || undefined,
     limit,
-  });
-  const tableBoundsPromise = queryInferenceTableBounds({
-    function_name,
   });
   const numInferencesPromise = countInferencesForFunction(
     function_name,
@@ -143,8 +139,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   })();
 
   const [
-    inferences,
-    inference_bounds,
+    inferenceResult,
     num_inferences,
     metricsWithFeedback,
     variant_performances,
@@ -154,7 +149,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     variant_sampling_probabilities,
   ] = await Promise.all([
     inferencePromise,
-    tableBoundsPromise,
     numInferencesPromise,
     metricsWithFeedbackPromise,
     variantPerformancesPromise,
@@ -209,8 +203,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   return {
     function_name,
-    inferences,
-    inference_bounds,
+    inferences: inferenceResult.inferences,
+    hasNextInferencePage: inferenceResult.hasNextPage,
+    hasPreviousInferencePage: inferenceResult.hasPreviousPage,
     num_inferences,
     metricsWithFeedback,
     variant_performances,
@@ -225,7 +220,8 @@ export default function InferencesPage({ loaderData }: Route.ComponentProps) {
   const {
     function_name,
     inferences,
-    inference_bounds,
+    hasNextInferencePage,
+    hasPreviousInferencePage,
     num_inferences,
     metricsWithFeedback,
     variant_performances,
@@ -251,7 +247,7 @@ export default function InferencesPage({ loaderData }: Route.ComponentProps) {
     if (!bottomInference) return;
     const searchParams = new URLSearchParams(window.location.search);
     searchParams.delete("afterInference");
-    searchParams.set("beforeInference", bottomInference.id);
+    searchParams.set("beforeInference", bottomInference.inference_id);
     navigate(`?${searchParams.toString()}`, { preventScrollReset: true });
   };
 
@@ -259,15 +255,9 @@ export default function InferencesPage({ loaderData }: Route.ComponentProps) {
     if (!topInference) return;
     const searchParams = new URLSearchParams(window.location.search);
     searchParams.delete("beforeInference");
-    searchParams.set("afterInference", topInference.id);
+    searchParams.set("afterInference", topInference.inference_id);
     navigate(`?${searchParams.toString()}`, { preventScrollReset: true });
   };
-
-  // Modify pagination disable logic to handle empty inferences
-  const disablePreviousInferencePage =
-    !topInference || inference_bounds.last_id === topInference.id;
-  const disableNextInferencePage =
-    !bottomInference || inference_bounds.first_id === bottomInference.id;
 
   const metric_name = searchParams.get("metric_name") || "";
 
@@ -349,8 +339,8 @@ export default function InferencesPage({ loaderData }: Route.ComponentProps) {
           <PageButtons
             onPreviousPage={handlePreviousInferencePage}
             onNextPage={handleNextInferencePage}
-            disablePrevious={disablePreviousInferencePage}
-            disableNext={disableNextInferencePage}
+            disablePrevious={!hasPreviousInferencePage}
+            disableNext={!hasNextInferencePage}
           />
         </SectionLayout>
       </SectionsGroup>

--- a/ui/app/routes/observability/functions/$function_name/variants/VariantInferenceTable.tsx
+++ b/ui/app/routes/observability/functions/$function_name/variants/VariantInferenceTable.tsx
@@ -7,14 +7,14 @@ import {
   TableRow,
   TableEmptyState,
 } from "~/components/ui/table";
-import type { InternalInferenceMetadata } from "~/types/tensorzero";
+import type { StoredInference } from "~/types/tensorzero";
 import { TableItemShortUuid, TableItemTime } from "~/components/ui/TableItems";
 import { toInferenceUrl, toEpisodeUrl } from "~/utils/urls";
 
 export default function VariantInferenceTable({
   inferences,
 }: {
-  inferences: InternalInferenceMetadata[];
+  inferences: StoredInference[];
 }) {
   return (
     <Table>
@@ -30,11 +30,11 @@ export default function VariantInferenceTable({
           <TableEmptyState message="No inferences found" />
         ) : (
           inferences.map((inference) => (
-            <TableRow key={inference.id} id={inference.id}>
+            <TableRow key={inference.inference_id} id={inference.inference_id}>
               <TableCell className="max-w-[200px]">
                 <TableItemShortUuid
-                  id={inference.id}
-                  link={toInferenceUrl(inference.id)}
+                  id={inference.inference_id}
+                  link={toInferenceUrl(inference.inference_id)}
                 />
               </TableCell>
               <TableCell>

--- a/ui/app/routes/observability/functions/$function_name/variants/route.tsx
+++ b/ui/app/routes/observability/functions/$function_name/variants/route.tsx
@@ -14,8 +14,7 @@ import VariantInferenceTable from "./VariantInferenceTable";
 import { getConfig, getFunctionConfig } from "~/utils/config/index.server";
 import {
   countInferencesForVariant,
-  queryInferenceTableBounds,
-  queryInferenceTable,
+  listInferencesWithPagination,
 } from "~/utils/clickhouse/inference.server";
 import { getVariantPerformances } from "~/utils/clickhouse/function";
 import type { TimeWindow } from "~/types/tensorzero";
@@ -61,17 +60,12 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     throw data(`Function ${function_name} not found`, { status: 404 });
   }
 
-  const inferencePromise = queryInferenceTable({
+  const inferencePromise = listInferencesWithPagination({
     function_name,
     variant_name,
     limit,
     before: beforeInference || undefined,
     after: afterInference || undefined,
-  });
-
-  const tableBoundsPromise = queryInferenceTableBounds({
-    function_name,
-    variant_name,
   });
 
   const numInferencesPromise = countInferencesForVariant(
@@ -99,14 +93,12 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       : undefined;
 
   const [
-    inferences,
-    inference_bounds,
+    inferenceResult,
     num_inferences,
     variant_performances,
     metricsWithFeedback,
   ] = await Promise.all([
     inferencePromise,
-    tableBoundsPromise,
     numInferencesPromise,
     variantPerformancesPromise,
     metricsWithFeedbackPromise,
@@ -116,8 +108,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     function_name,
     variant_name,
     num_inferences,
-    inferences,
-    inference_bounds,
+    inferences: inferenceResult.inferences,
+    hasNextInferencePage: inferenceResult.hasNextPage,
+    hasPreviousInferencePage: inferenceResult.hasPreviousPage,
     variant_performances,
     metricsWithFeedback,
   };
@@ -129,7 +122,8 @@ export default function VariantDetails({ loaderData }: Route.ComponentProps) {
     variant_name,
     num_inferences,
     inferences,
-    inference_bounds,
+    hasNextInferencePage,
+    hasPreviousInferencePage,
     variant_performances,
     metricsWithFeedback,
   } = loaderData;
@@ -164,7 +158,7 @@ export default function VariantDetails({ loaderData }: Route.ComponentProps) {
     if (!bottomInference) return;
     const searchParams = new URLSearchParams(window.location.search);
     searchParams.delete("afterInference");
-    searchParams.set("beforeInference", bottomInference.id);
+    searchParams.set("beforeInference", bottomInference.inference_id);
     navigate(`?${searchParams.toString()}`, { preventScrollReset: true });
   };
 
@@ -172,14 +166,9 @@ export default function VariantDetails({ loaderData }: Route.ComponentProps) {
     if (!topInference) return;
     const searchParams = new URLSearchParams(window.location.search);
     searchParams.delete("beforeInference");
-    searchParams.set("afterInference", topInference.id);
+    searchParams.set("afterInference", topInference.inference_id);
     navigate(`?${searchParams.toString()}`, { preventScrollReset: true });
   };
-
-  const disablePreviousInferencePage =
-    !topInference || inference_bounds.last_id === topInference.id;
-  const disableNextInferencePage =
-    !bottomInference || inference_bounds.first_id === bottomInference.id;
 
   const [metric_name, setMetricName] = useState(
     () => searchParams.get("metric_name") || "",
@@ -244,8 +233,8 @@ export default function VariantDetails({ loaderData }: Route.ComponentProps) {
               <PageButtons
                 onPreviousPage={handlePreviousInferencePage}
                 onNextPage={handleNextInferencePage}
-                disablePrevious={disablePreviousInferencePage}
-                disableNext={disableNextInferencePage}
+                disablePrevious={!hasPreviousInferencePage}
+                disableNext={!hasNextInferencePage}
               />
             </>
           ) : (

--- a/ui/app/routes/observability/inferences/InferencesTable.tsx
+++ b/ui/app/routes/observability/inferences/InferencesTable.tsx
@@ -1,4 +1,4 @@
-import type { InternalInferenceMetadata } from "~/types/tensorzero";
+import type { StoredInference } from "~/types/tensorzero";
 import {
   Table,
   TableBody,
@@ -19,7 +19,7 @@ import { toInferenceUrl, toEpisodeUrl, toFunctionUrl } from "~/utils/urls";
 export default function InferencesTable({
   inferences,
 }: {
-  inferences: InternalInferenceMetadata[];
+  inferences: StoredInference[];
 }) {
   return (
     <div>
@@ -38,11 +38,14 @@ export default function InferencesTable({
             <TableEmptyState message="No inferences found" />
           ) : (
             inferences.map((inference) => (
-              <TableRow key={inference.id} id={inference.id}>
+              <TableRow
+                key={inference.inference_id}
+                id={inference.inference_id}
+              >
                 <TableCell>
                   <TableItemShortUuid
-                    id={inference.id}
-                    link={toInferenceUrl(inference.id)}
+                    id={inference.inference_id}
+                    link={toInferenceUrl(inference.inference_id)}
                   />
                 </TableCell>
                 <TableCell>
@@ -54,7 +57,7 @@ export default function InferencesTable({
                 <TableCell>
                   <TableItemFunction
                     functionName={inference.function_name}
-                    functionType={inference.function_type}
+                    functionType={inference.type}
                     link={toFunctionUrl(inference.function_name)}
                   />
                 </TableCell>

--- a/ui/app/utils/clickhouse/inference.test.ts
+++ b/ui/app/utils/clickhouse/inference.test.ts
@@ -5,6 +5,7 @@ import {
   queryInferenceById,
   queryInferenceTable,
   queryInferenceTableBounds,
+  listInferencesWithPagination,
   countInferencesByFunction,
   countInferencesForVariant,
   queryModelInferencesByInferenceId,
@@ -432,6 +433,196 @@ test("queryInferenceTableBounds with variant_name", async () => {
   });
   expect(bounds.first_id).toBe("01939adf-0f50-79d0-8d55-7a009fcc5e32");
   expect(bounds.last_id).toBe("0196368e-5505-7721-88d2-654cd26483b4");
+});
+
+// Tests for listInferencesWithPagination (new cursor-based pagination API)
+test(
+  "listInferencesWithPagination basic pagination",
+  { timeout: 10_000 },
+  async () => {
+    const result = await listInferencesWithPagination({
+      limit: 10,
+    });
+    expect(result.inferences.length).toBe(10);
+    expect(result.hasPreviousPage).toBe(false); // First page has no previous
+    expect(result.hasNextPage).toBe(true); // Should have more pages
+
+    // Verify IDs are in descending order
+    for (let i = 1; i < result.inferences.length; i++) {
+      expect(
+        result.inferences[i - 1].inference_id >
+          result.inferences[i].inference_id,
+      ).toBe(true);
+    }
+
+    // Get second page using before
+    const result2 = await listInferencesWithPagination({
+      before: result.inferences[result.inferences.length - 1].inference_id,
+      limit: 10,
+    });
+    expect(result2.inferences.length).toBe(10);
+    expect(result2.hasPreviousPage).toBe(true); // We came from a newer page
+  },
+);
+
+test(
+  "listInferencesWithPagination pagination with before and after",
+  { timeout: 10_000 },
+  async () => {
+    const LIMIT = 100;
+
+    // First page (most recent)
+    const firstResult = await listInferencesWithPagination({ limit: LIMIT });
+    expect(firstResult.inferences.length).toBe(LIMIT);
+    expect(firstResult.hasPreviousPage).toBe(false);
+    expect(firstResult.hasNextPage).toBe(true);
+    for (let i = 1; i < firstResult.inferences.length; i++) {
+      expect(
+        firstResult.inferences[i - 1].inference_id >
+          firstResult.inferences[i].inference_id,
+      ).toBe(true);
+    }
+
+    // Second page using before (going to older)
+    const secondResult = await listInferencesWithPagination({
+      before:
+        firstResult.inferences[firstResult.inferences.length - 1].inference_id,
+      limit: LIMIT,
+    });
+    expect(secondResult.inferences.length).toBe(LIMIT);
+    expect(secondResult.hasPreviousPage).toBe(true);
+    for (let i = 1; i < secondResult.inferences.length; i++) {
+      expect(
+        secondResult.inferences[i - 1].inference_id >
+          secondResult.inferences[i].inference_id,
+      ).toBe(true);
+    }
+
+    // Go back to newer using after
+    const forwardResult = await listInferencesWithPagination({
+      after:
+        secondResult.inferences[secondResult.inferences.length - 1]
+          .inference_id,
+      limit: LIMIT,
+    });
+    expect(forwardResult.inferences.length).toBe(LIMIT);
+    expect(forwardResult.hasNextPage).toBe(true); // We came from older page
+    for (let i = 1; i < forwardResult.inferences.length; i++) {
+      expect(
+        forwardResult.inferences[i - 1].inference_id >
+          forwardResult.inferences[i].inference_id,
+      ).toBe(true);
+    }
+  },
+);
+
+test("listInferencesWithPagination after future timestamp is empty", async () => {
+  const futureUUID = "ffffffff-ffff-7fff-ffff-ffffffffffff";
+  const result = await listInferencesWithPagination({
+    after: futureUUID,
+    limit: 10,
+  });
+  expect(result.inferences.length).toBe(0);
+  expect(result.hasPreviousPage).toBe(false);
+  expect(result.hasNextPage).toBe(true); // We came from future, so there are older pages
+});
+
+test("listInferencesWithPagination before past timestamp is empty", async () => {
+  const pastUUID = "00000000-0000-7000-0000-000000000000";
+  const result = await listInferencesWithPagination({
+    before: pastUUID,
+    limit: 10,
+  });
+  expect(result.inferences.length).toBe(0);
+  expect(result.hasNextPage).toBe(false); // No more older pages
+  expect(result.hasPreviousPage).toBe(true); // We came from newer page
+});
+
+test("listInferencesWithPagination with function_name filter", async () => {
+  const result = await listInferencesWithPagination({
+    function_name: "extract_entities",
+    limit: 10,
+  });
+  expect(result.inferences.length).toBe(10);
+
+  // All inferences should be for the specified function
+  for (const inference of result.inferences) {
+    expect(inference.function_name).toBe("extract_entities");
+  }
+
+  // Verify IDs are in descending order
+  for (let i = 1; i < result.inferences.length; i++) {
+    expect(
+      result.inferences[i - 1].inference_id > result.inferences[i].inference_id,
+    ).toBe(true);
+  }
+
+  // Test pagination with before
+  const result2 = await listInferencesWithPagination({
+    function_name: "extract_entities",
+    before: result.inferences[result.inferences.length - 1].inference_id,
+    limit: 10,
+  });
+  expect(result2.inferences.length).toBe(10);
+  for (const inference of result2.inferences) {
+    expect(inference.function_name).toBe("extract_entities");
+  }
+});
+
+test("listInferencesWithPagination with variant_name filter", async () => {
+  const result = await listInferencesWithPagination({
+    function_name: "extract_entities",
+    variant_name: "gpt4o_initial_prompt",
+    limit: 10,
+  });
+  expect(result.inferences.length).toBe(10);
+
+  // All inferences should be for the specified function and variant
+  for (const inference of result.inferences) {
+    expect(inference.function_name).toBe("extract_entities");
+    expect(inference.variant_name).toBe("gpt4o_initial_prompt");
+  }
+
+  // Verify IDs are in descending order
+  for (let i = 1; i < result.inferences.length; i++) {
+    expect(
+      result.inferences[i - 1].inference_id > result.inferences[i].inference_id,
+    ).toBe(true);
+  }
+});
+
+test("listInferencesWithPagination with episode_id filter", async () => {
+  const episodeId = "01942e26-618b-7b80-b492-34bed9f6d872";
+  const LIMIT = 20;
+
+  // First page
+  const result = await listInferencesWithPagination({
+    episode_id: episodeId,
+    limit: LIMIT,
+  });
+  expect(result.inferences.length).toBe(LIMIT);
+  expect(result.hasPreviousPage).toBe(false);
+  expect(result.hasNextPage).toBe(true); // Episode has 35 inferences, so there's more
+
+  // All inferences should be for the specified episode
+  for (const inference of result.inferences) {
+    expect(inference.episode_id).toBe(episodeId);
+  }
+
+  // Second page
+  const result2 = await listInferencesWithPagination({
+    episode_id: episodeId,
+    before: result.inferences[result.inferences.length - 1].inference_id,
+    limit: LIMIT,
+  });
+  // Should have remaining 15 inferences
+  expect(result2.inferences.length).toBe(15);
+  expect(result2.hasPreviousPage).toBe(true);
+  expect(result2.hasNextPage).toBe(false); // Last page
+
+  for (const inference of result2.inferences) {
+    expect(inference.episode_id).toBe(episodeId);
+  }
 });
 
 test("countInferencesForEpisode", async () => {

--- a/ui/app/utils/tensorzero/tensorzero.ts
+++ b/ui/app/utils/tensorzero/tensorzero.ts
@@ -20,9 +20,11 @@ import type {
   GetDatapointsRequest,
   GetDatapointsResponse,
   GetInferenceBoundsResponse,
+  GetInferencesResponse,
   InternalListInferencesByIdResponse,
   ListDatapointsRequest,
   ListDatasetsResponse,
+  ListInferencesRequest,
   UpdateDatapointRequest,
   UpdateDatapointsMetadataRequest,
   UpdateDatapointsRequest,
@@ -687,6 +689,27 @@ export class TensorZeroClient {
       this.handleHttpError({ message, response });
     }
     return (await response.json()) as InternalListInferencesByIdResponse;
+  }
+
+  /**
+   * Lists inferences with optional filtering, pagination, and sorting.
+   * Uses the public v1 API endpoint.
+   * @param request - The list inferences request parameters
+   * @returns A promise that resolves with the inferences response
+   * @throws Error if the request fails
+   */
+  async listInferences(
+    request: ListInferencesRequest,
+  ): Promise<GetInferencesResponse> {
+    const response = await this.fetch("/v1/inferences/list_inferences", {
+      method: "POST",
+      body: JSON.stringify(request),
+    });
+    if (!response.ok) {
+      const message = await this.getErrorText(response);
+      this.handleHttpError({ message, response });
+    }
+    return (await response.json()) as GetInferencesResponse;
   }
 
   private async fetch(


### PR DESCRIPTION
A step towards #4905.

![inference_table](https://github.com/user-attachments/assets/a6d281e9-90b7-4bd4-83fb-d2daf51d1ba9)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR implements cursor-based pagination for inferences in the UI, updating components and routes to use the new `listInferencesWithPagination` function and adding tests for verification.
> 
>   - **Pagination**:
>     - Introduces `listInferencesWithPagination` in `inference.server.ts` for cursor-based pagination.
>     - Replaces `queryInferenceTable` and `queryInferenceTableBounds` with `listInferencesWithPagination` in routes like `route.tsx` for episodes, functions, and variants.
>     - Updates pagination logic in `InferencesPage` components to use `hasNextPage` and `hasPreviousPage`.
>   - **Type Changes**:
>     - Changes `InternalInferenceMetadata` to `StoredInference` in components like `EpisodeInferenceTable.tsx` and `FunctionInferenceTable.tsx`.
>   - **Tests**:
>     - Adds tests for `listInferencesWithPagination` in `inference.test.ts` to verify pagination behavior.
>   - **Misc**:
>     - Updates `TensorZeroClient` to include `listInferences` method for fetching paginated inferences.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 9d7b9d7624301e3abd5a1151465aa565ed036220. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->