### PR TITLE
Use 'lint-tables-only' instead of 'limited' for debuginfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ single_match_else = "allow"
 doc_lazy_continuation = "allow"
 
 [profile.dev]
-debug = "limited"
+debug = "line-tables-only"
 
 [profile.performance]
 inherits = "release"


### PR DESCRIPTION
This further shrinks the binary size, while still keeping backtraces working (which is the only part of debuginfo that we actually need)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `debug` setting to `line-tables-only` in `Cargo.toml` to reduce binary size while maintaining backtrace functionality.
> 
>   - **Behavior**:
>     - Change `debug` setting from `limited` to `line-tables-only` in `[profile.dev]` in `Cargo.toml` to reduce binary size while keeping backtraces functional.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1c04a0387c687ae14bbc5430280d5934ee29a397. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->