### PR TITLE
Select metric combobox in playwright test with aria label "metric"

### DIFF
--- a/ui/app/components/metric/CurationMetricSelector.tsx
+++ b/ui/app/components/metric/CurationMetricSelector.tsx
@@ -30,7 +30,7 @@ import {
 } from "~/components/ui/command";
 import { Input } from "~/components/ui/input";
 import FeedbackBadges from "~/components/feedback/FeedbackBadges";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import { useFetcher } from "react-router";
 import type { MetricsWithFeedbackData } from "~/utils/clickhouse/feedback";
 import clsx from "clsx";
@@ -119,6 +119,9 @@ export default function CurationMetricSelector<
 
   const metricsLoading = metricsFetcher.state === "loading";
 
+  const metricLabelId = useId();
+  const metricComboboxId = `${metricLabelId}-combobox`;
+
   // Inform parent when the internal metrics fetcher loading state changes
   useEffect(() => {
     onMetricsLoadingChange?.(metricsLoading);
@@ -147,7 +150,9 @@ export default function CurationMetricSelector<
       name={name}
       render={({ field }) => (
         <FormItem className="flex flex-col justify-center">
-          <FormLabel>Metric</FormLabel>
+          <FormLabel id={`${metricLabelId}-label`} htmlFor={metricComboboxId}>
+            Metric
+          </FormLabel>
           <div className="items-top grid gap-x-8 md:grid-cols-2">
             <div className="space-y-2">
               <Popover open={open} onOpenChange={setOpen}>
@@ -157,6 +162,9 @@ export default function CurationMetricSelector<
                     role="combobox"
                     aria-expanded={open}
                     aria-busy={metricsLoading}
+                    aria-label="Metric"
+                    aria-labelledby={`${metricLabelId}-label`}
+                    id={metricComboboxId}
                     className="group border-border hover:border-border-accent hover:bg-bg-primary w-full justify-between border font-normal hover:cursor-pointer"
                     disabled={!functionValue || metricsLoading}
                   >

--- a/ui/app/components/metric/MetricSelector.tsx
+++ b/ui/app/components/metric/MetricSelector.tsx
@@ -1,5 +1,5 @@
 import type { FeedbackConfig } from "~/utils/config/feedback";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { Check, ChevronsUpDown } from "lucide-react";
 
 import { Button } from "../ui/button";
@@ -33,6 +33,9 @@ export default function MetricSelector({
   const [metricInputValue, setMetricInputValue] = useState("");
 
   const metricEntries = Object.entries(metrics);
+  const hasMetrics = metricEntries.length > 0;
+  const metricLabelId = useId();
+  const metricComboboxId = `${metricLabelId}-combobox`;
 
   const filteredMetrics = metricInputValue
     ? metricEntries.filter(([name]) =>
@@ -44,7 +47,8 @@ export default function MetricSelector({
     <div>
       <div className="mt-4">
         <label
-          htmlFor="evaluation_name"
+          id={`${metricLabelId}-label`}
+          htmlFor={metricComboboxId}
           className="mb-1 block text-sm font-medium"
         >
           Metric
@@ -56,11 +60,17 @@ export default function MetricSelector({
             variant="outline"
             role="combobox"
             aria-expanded={metricPopoverOpen}
+            aria-label="Metric"
+            aria-labelledby={`${metricLabelId}-label`}
+            id={metricComboboxId}
             className="w-full justify-between font-normal"
+            disabled={!hasMetrics}
           >
             {selectedMetric
               ? selectedMetric // Display selected metric name
-              : "Select a metric"}
+              : hasMetrics
+                ? "Select a metric"
+                : "No metrics available"}
             <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>

--- a/ui/e2e_tests/observability.episodes.episode_id.spec.ts
+++ b/ui/e2e_tests/observability.episodes.episode_id.spec.ts
@@ -24,8 +24,8 @@ test("should be able to add comment feedback via the episode page", async ({
   // Click on the Add feedback button
   await page.getByText("Add feedback").click();
 
-  // Click "Select a metric"
-  await page.getByText("Select a metric").click();
+  // Open the metric combobox
+  await page.getByRole("combobox", { name: "Metric" }).click();
 
   // Explicitly wait for the item to be visible before clicking
   const metricItemLocator = page

--- a/ui/e2e_tests/observability.inferences.inference_id.spec.ts
+++ b/ui/e2e_tests/observability.inferences.inference_id.spec.ts
@@ -153,8 +153,8 @@ test("should be able to add float feedback via the inference page", async ({
   // Click on the Add feedback button
   await page.getByText("Add feedback").click();
 
-  // Click "Select a metric"
-  await page.getByText("Select a metric").click();
+  // Open the metric combobox
+  await page.getByRole("combobox", { name: "Metric" }).click();
 
   // Explicitly wait for the item to be visible before clicking
   const metricItemLocator = page
@@ -203,8 +203,8 @@ test("should be able to add boolean feedback via the inference page", async ({
   // Click on the Add feedback button
   await page.getByText("Add feedback").click();
 
-  // Click "Select a metric"
-  await page.getByText("Select a metric").click();
+  // Open the metric combobox
+  await page.getByRole("combobox", { name: "Metric" }).click();
 
   // Explicitly wait for the item to be visible before clicking
   const metricItemLocator = page
@@ -250,8 +250,8 @@ test("should be able to add json demonstration feedback via the inference page",
   // Click on the Add feedback button
   await page.getByText("Add feedback").click();
 
-  // Click "Select a metric"
-  await page.getByText("Select a metric").click();
+  // Open the metric combobox
+  await page.getByRole("combobox", { name: "Metric" }).click();
 
   // Explicitly wait for the item to be visible before clicking
   const metricItemLocator = page
@@ -300,8 +300,8 @@ test("should be able to add chat demonstration feedback via the inference page",
   // Sleep for a little bit to ensure the dialog is open
   await page.waitForTimeout(500);
 
-  // Click "Select a metric"
-  await page.getByText("Select a metric").click();
+  // Open the metric combobox
+  await page.getByRole("combobox", { name: "Metric" }).click();
 
   // Explicitly wait for the item to be visible before clicking
   const metricItemLocator = page

--- a/ui/e2e_tests/optimization.supervised-fine-tuning.spec.ts
+++ b/ui/e2e_tests/optimization.supervised-fine-tuning.spec.ts
@@ -62,10 +62,7 @@ model_name = "accounts/fake_fireworks_account/models/mock-fireworks-model"
           .filter({ hasText: "Select a function" })
           .click();
         await page.getByRole("option", { name: "extract_entities" }).click();
-        await page
-          .getByRole("combobox")
-          .filter({ hasText: "Select a metric" })
-          .click();
+        await page.getByRole("combobox", { name: "Metric" }).click();
         await page.getByText("exact_match", { exact: true }).click();
         await page
           .getByRole("combobox")
@@ -115,10 +112,7 @@ model_name = "accounts/fake_fireworks_account/models/mock-fireworks-model"
       .filter({ hasText: "Select a function" })
       .click();
     await page.getByRole("option", { name: "extract_entities" }).click();
-    await page
-      .getByRole("combobox")
-      .filter({ hasText: "Select a metric" })
-      .click();
+    await page.getByRole("combobox", { name: "Metric" }).click();
     await page.getByText("demonstration", { exact: true }).click();
     await page
       .getByRole("combobox")
@@ -174,10 +168,7 @@ model_name = "mock-inference-finetune-1234"
       .filter({ hasText: "Select a function" })
       .click();
     await page.getByRole("option", { name: "image_judger" }).click();
-    await page
-      .getByRole("combobox")
-      .filter({ hasText: "Select a metric" })
-      .click();
+    await page.getByRole("combobox", { name: "Metric" }).click();
     await page.getByRole("option", { name: "None" }).click();
     await page
       .getByRole("combobox")
@@ -233,10 +224,7 @@ model_name = "mock-inference-finetune-1234"
     await page.getByRole("option", { name: "write_haiku" }).click();
 
     // Open metric selector
-    await page
-      .getByRole("combobox")
-      .filter({ hasText: "Select a metric" })
-      .click();
+    await page.getByRole("combobox", { name: "Metric" }).click();
 
     // Verify demonstration option is visible and can be selected
     await expect(
@@ -261,10 +249,7 @@ test.describe("Error handling", () => {
       .filter({ hasText: "Select a function" })
       .click();
     await page.getByRole("option", { name: "extract_entities" }).click();
-    await page
-      .getByRole("combobox")
-      .filter({ hasText: "Select a metric" })
-      .click();
+    await page.getByRole("combobox", { name: "Metric" }).click();
     await page.getByText("exact_match", { exact: true }).click();
     await page
       .getByRole("combobox")


### PR DESCRIPTION
Fixes #4839. Instead of matching on the text in the combobox (which is "select a metric" when we have evals and "no metrics available" when we don't), use the accessibility label to select the correct combobox.

## Summary

- add accessible labeling and ids to metric selectors, disabling them when no metrics are available and showing a "No metrics available" placeholder
- update Playwright tests to target the metric combobox by accessible name instead of placeholder text
- ensure metric selection handles the empty-metrics case without relying on the "Select a metric" copy

## Testing

- Ran playwright for the failing test locally and it worked correctly without any previous evals.

---

[Codex Task](https://chatgpt.com/codex/tasks/task_b_6924d3ec3730832d9cbf32798905ded0)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add aria labels to metric selectors and update Playwright tests to improve accessibility and reliability.
> 
>   - **UI Components**:
>     - Add `aria-label` and `aria-labelledby` to metric selectors in `CurationMetricSelector.tsx` and `MetricSelector.tsx`.
>     - Disable metric selectors when no metrics are available, showing "No metrics available".
>   - **Testing**:
>     - Update Playwright tests in `observability.episodes.episode_id.spec.ts`, `observability.inferences.inference_id.spec.ts`, and `optimization.supervised-fine-tuning.spec.ts` to target metric combobox by accessible name instead of placeholder text.
>     - Ensure tests handle cases where no metrics are available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f10292f4f1426b287c2ab49b75dc738f7571535c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->