### PR TITLE
Add Replace File to AudioContentBlock and GenericFileContentBlock

### DIFF
--- a/ui/app/components/input_output/content_blocks/FileContentBlock.tsx
+++ b/ui/app/components/input_output/content_blocks/FileContentBlock.tsx
@@ -274,6 +274,28 @@ function ImageContentBlock({
   isEditing,
   onChange,
 }: ImageContentBlockProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      const base64Data = result.split(",")[1] ?? "";
+      onChange?.({
+        file_type: "base64",
+        data: base64Data,
+        mime_type: file.type || block.mime_type,
+        filename: block.filename || file.name,
+        detail: block.detail,
+      });
+    };
+    reader.readAsDataURL(file);
+    e.target.value = "";
+  }
+
   return (
     <div className="flex flex-col gap-1">
       <ContentBlockLabel
@@ -292,6 +314,27 @@ function ImageContentBlock({
         >
           <img src={block.data} alt="Image" />
         </Link>
+        {isEditing && (
+          <div className="flex items-center gap-2 mt-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              accept="image/*"
+              onChange={handleFileSelect}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => fileInputRef.current?.click()}
+              className="text-xs"
+            >
+              <Upload className="mr-1 h-3 w-3" />
+              Replace File
+            </Button>
+          </div>
+        )}
         <FileAdvancedAccordion
           filename={block.filename}
           mimeType={block.mime_type}
@@ -325,7 +368,27 @@ function AudioContentBlock({
   isEditing,
   onChange,
 }: AudioContentBlockProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const blobUrl = useBase64UrlToBlobUrl(block.data, block.mime_type);
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      const base64Data = result.split(",")[1] ?? "";
+      onChange?.({
+        file_type: "base64",
+        data: base64Data,
+        mime_type: file.type || block.mime_type,
+        filename: block.filename || file.name,
+        detail: block.detail,
+      });
+    };
+    reader.readAsDataURL(file);
+    e.target.value = "";
+  };
 
   return (
     <div className="flex flex-col gap-1">
@@ -344,6 +407,27 @@ function AudioContentBlock({
         <audio controls preload="none" className="w-full">
           <source src={blobUrl} type={block.mime_type} />
         </audio>
+        {isEditing && (
+          <div className="flex items-center gap-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              accept="audio/*"
+              onChange={handleFileSelect}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => fileInputRef.current?.click()}
+              className="text-xs"
+            >
+              <Upload className="mr-1 h-3 w-3" />
+              Replace File
+            </Button>
+          </div>
+        )}
         <FileAdvancedAccordion
           filename={block.filename}
           mimeType={block.mime_type}
@@ -377,7 +461,28 @@ function GenericFileContentBlock({
   isEditing,
   onChange,
 }: GenericFileContentBlockProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const blobUrl = useBase64UrlToBlobUrl(block.data, block.mime_type);
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      const base64Data = result.split(",")[1] ?? "";
+      onChange?.({
+        file_type: "base64",
+        data: base64Data,
+        mime_type: file.type || block.mime_type,
+        filename: block.filename || file.name,
+        detail: block.detail,
+      });
+    };
+    reader.readAsDataURL(file);
+    e.target.value = "";
+  };
 
   return (
     <div className="flex flex-col gap-1">
@@ -413,6 +518,26 @@ function GenericFileContentBlock({
             <ExternalLink className="h-5 w-5" />
           </Link>
         </div>
+        {isEditing && (
+          <div className="flex items-center gap-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              onChange={handleFileSelect}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => fileInputRef.current?.click()}
+              className="text-xs"
+            >
+              <Upload className="mr-1 h-3 w-3" />
+              Replace File
+            </Button>
+          </div>
+        )}
         <FileAdvancedAccordion
           filename={block.filename}
           mimeType={block.mime_type}
@@ -445,6 +570,28 @@ function FileErrorContentBlock({
   isEditing,
   onChange,
 }: FileErrorContentBlockProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      const base64Data = result.split(",")[1] ?? "";
+      onChange?.({
+        file_type: "base64",
+        data: base64Data,
+        mime_type: file.type || block.mime_type,
+        filename: block.filename || file.name,
+        detail: block.detail,
+      });
+    };
+    reader.readAsDataURL(file);
+    e.target.value = "";
+  };
+
   const errorMessage = block.error || "Failed to retrieve file";
 
   return (
@@ -471,6 +618,26 @@ function FileErrorContentBlock({
             </Tooltip>
           </div>
         </div>
+        {isEditing && (
+          <div className="flex items-center gap-2 mt-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              onChange={handleFileSelect}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => fileInputRef.current?.click()}
+              className="text-xs"
+            >
+              <Upload className="mr-1 h-3 w-3" />
+              Replace File
+            </Button>
+          </div>
+        )}
         <FileAdvancedAccordion
           filename={block.filename}
           mimeType={block.mime_type}

--- a/ui/app/routes/datasets/$dataset_name/datapoint/$id/formDataUtils.ts
+++ b/ui/app/routes/datasets/$dataset_name/datapoint/$id/formDataUtils.ts
@@ -47,7 +47,7 @@ export const UpdateDatapointFormDataSchema = z.object({
   dataset_name: z.string().min(1, "Dataset name is required"),
   function_name: z.string().min(1, "Function name is required"),
   id: z.string().uuid("Invalid datapoint ID format"),
-  episode_id: z.string().uuid("Invalid episode ID format").optional(),
+  episode_id: z.string().uuid("Invalid episode ID format").nullish(),
   input: z.custom<Input>((val) => val !== null && typeof val === "object", {
     message: "Input must be a valid object",
   }),


### PR DESCRIPTION
Fixes #4909 

 file replacement capability to `AudioContentBlock` (audio files)
- Add file replacement capability to `GenericFileContentBlock` (PDFs, text, etc.)
- Fix `episode_id` validation bug (`.optional()` → `.nullish()` to allow null values)
- 
<img width="1084" height="698" alt="Screenshot 2025-12-01 at 4 39 27 PM" src="https://github.com/user-attachments/assets/a0462ff9-31e8-476a-8555-c9f2cf5f59d7" />

<img width="1076" height="650" alt="Screenshot 2025-12-01 at 4 38 49 PM" src="https://github.com/user-attachments/assets/7c20967f-1513-4a14-8937-5cf24aec2dc4" />

Thoughts on the UI? Can maybe place the 'replace file' -> on hover, click and select file with dashed border.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add file replacement to `AudioContentBlock`, `GenericFileContentBlock`, and `FileErrorContentBlock`, and fix `episode_id` validation in `formDataUtils.ts`.
> 
>   - **File Replacement**:
>     - Add file replacement to `AudioContentBlock`, `GenericFileContentBlock`, and `FileErrorContentBlock` in `FileContentBlock.tsx`.
>     - Uses `FileReader` to convert files to base64 and update the content block.
>   - **Validation Fix**:
>     - Change `episode_id` validation from `.optional()` to `.nullish()` in `formDataUtils.ts` to allow null values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d1bf1fc8b3d97f0c5f9f6549e8b71e71ff553f10. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->