### PR TITLE
Unify StoredDatapoint and DatapointInsert types

### DIFF
--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -45,10 +45,13 @@ pub use tensorzero_core::db::clickhouse::query_builder::{
     TimeFilter,
 };
 pub use tensorzero_core::db::datasets::{
-    CountDatapointsForDatasetFunctionParams, DatapointInsert, DatasetQueries, DatasetQueryParams,
+    CountDatapointsForDatasetFunctionParams, DatasetQueries, DatasetQueryParams,
     GetDatapointParams, GetDatapointsParams, GetDatasetMetadataParams,
 };
 pub use tensorzero_core::db::inferences::{InferenceOutputSource, ListInferencesParams};
+pub use tensorzero_core::db::stored_datapoint::{
+    StoredChatInferenceDatapoint, StoredDatapoint, StoredJsonInferenceDatapoint,
+};
 pub use tensorzero_core::db::{ClickHouseConnection, ModelUsageTimePoint, TimeWindow};
 pub use tensorzero_core::endpoints::datasets::v1::types::{
     CreateChatDatapointRequest, CreateDatapointRequest, CreateDatapointsFromInferenceOutputSource,
@@ -61,7 +64,6 @@ pub use tensorzero_core::endpoints::datasets::v1::types::{
 };
 pub use tensorzero_core::endpoints::datasets::{
     ChatInferenceDatapoint, Datapoint, DatapointKind, JsonInferenceDatapoint,
-    StoredChatInferenceDatapoint, StoredDatapoint,
 };
 pub use tensorzero_core::endpoints::feedback::FeedbackResponse;
 pub use tensorzero_core::endpoints::feedback::Params as FeedbackParams;

--- a/evaluations/tests/common/mod.rs
+++ b/evaluations/tests/common/mod.rs
@@ -7,7 +7,7 @@ use tensorzero_core::db::clickhouse::{
     TableName,
     test_helpers::{CLICKHOUSE_URL, get_clickhouse},
 };
-use tensorzero_core::endpoints::datasets::{
+use tensorzero_core::db::stored_datapoint::{
     StoredChatInferenceDatapoint, StoredJsonInferenceDatapoint,
 };
 use uuid::Uuid;

--- a/tensorzero-core/src/db/clickhouse/mock_clickhouse_connection_info.rs
+++ b/tensorzero-core/src/db/clickhouse/mock_clickhouse_connection_info.rs
@@ -5,13 +5,12 @@ use uuid::Uuid;
 use crate::config::Config;
 use crate::config::snapshot::{ConfigSnapshot, SnapshotHash};
 use crate::db::datasets::{
-    CountDatapointsForDatasetFunctionParams, DatapointInsert, DatasetMetadata, DatasetQueries,
-    DatasetQueryParams, GetDatapointParams, GetDatapointsParams, GetDatasetMetadataParams,
-    MockDatasetQueries,
+    CountDatapointsForDatasetFunctionParams, DatasetMetadata, DatasetQueries, DatasetQueryParams,
+    GetDatapointParams, GetDatapointsParams, GetDatasetMetadataParams, MockDatasetQueries,
 };
 use crate::db::inferences::{InferenceQueries, ListInferencesParams, MockInferenceQueries};
+use crate::db::stored_datapoint::StoredDatapoint;
 use crate::db::{ConfigQueries, MockConfigQueries};
-use crate::endpoints::datasets::StoredDatapoint;
 use crate::error::Error;
 use crate::stored_inference::StoredInferenceDatabase;
 
@@ -73,7 +72,7 @@ impl DatasetQueries for MockClickHouseConnectionInfo {
         self.dataset_queries.count_datasets().await
     }
 
-    async fn insert_datapoints(&self, datapoints: &[DatapointInsert]) -> Result<u64, Error> {
+    async fn insert_datapoints(&self, datapoints: &[StoredDatapoint]) -> Result<u64, Error> {
         self.dataset_queries.insert_datapoints(datapoints).await
     }
 

--- a/tensorzero-core/src/db/clickhouse/test_helpers.rs
+++ b/tensorzero-core/src/db/clickhouse/test_helpers.rs
@@ -5,7 +5,8 @@
     clippy::unwrap_used
 )]
 use crate::config::BatchWritesConfig;
-use crate::endpoints::datasets::{JsonInferenceDatapoint, StoredChatInferenceDatapoint};
+use crate::db::stored_datapoint::StoredChatInferenceDatapoint;
+use crate::endpoints::datasets::JsonInferenceDatapoint;
 use crate::endpoints::workflow_evaluation_run::{
     WorkflowEvaluationRunEpisodeRow, WorkflowEvaluationRunRow,
 };

--- a/tensorzero-core/src/db/datasets.rs
+++ b/tensorzero-core/src/db/datasets.rs
@@ -6,161 +6,12 @@ use uuid::Uuid;
 #[cfg(test)]
 use mockall::automock;
 
-use crate::config::snapshot::SnapshotHash;
 use crate::config::{MetricConfigLevel, MetricConfigType};
 use crate::db::clickhouse::query_builder::{DatapointFilter, FloatComparisonOperator};
+use crate::db::stored_datapoint::StoredDatapoint;
+use crate::endpoints::datasets::DatapointKind;
 use crate::endpoints::datasets::v1::types::DatapointOrderBy;
-use crate::endpoints::datasets::{DatapointKind, StoredDatapoint};
 use crate::error::Error;
-use crate::inference::types::{ContentBlockChatOutput, JsonInferenceOutput, StoredInput};
-use crate::serde_util::{
-    deserialize_optional_string_or_parsed_json, deserialize_string_or_parsed_json,
-    serialize_none_as_empty_map,
-};
-use crate::tool::{ToolCallConfigDatabaseInsert, deserialize_optional_tool_info};
-
-/// Datapoint types that are directly serialized and inserted into ClickHouse.
-/// These should be internal-only types but are exposed to tensorzero-node.
-#[derive(Debug, Deserialize, Clone)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum DatapointInsert {
-    Chat(ChatInferenceDatapointInsert),
-    Json(JsonInferenceDatapointInsert),
-}
-
-impl DatapointInsert {
-    pub fn id(&self) -> Uuid {
-        match self {
-            DatapointInsert::Chat(datapoint) => datapoint.id,
-            DatapointInsert::Json(datapoint) => datapoint.id,
-        }
-    }
-}
-
-/// Type that gets serialized directly to be written to ClickHouse. Serialization should match
-/// the structure of the ChatInferenceDatapoint table in ClickHouse.
-/// Theis should be an internal-only type, but it's exposed to tensorzero-node.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct ChatInferenceDatapointInsert {
-    /// Name of the dataset to write to. Required.
-    pub dataset_name: String,
-
-    /// Name of the function that generated this datapoint. Required.
-    pub function_name: String,
-
-    /// Human-readable name of the datapoint. Optional.
-    #[serde(default)]
-    pub name: Option<String>,
-
-    /// Unique identifier for the datapoint. Required.
-    pub id: Uuid,
-
-    /// Episode ID that the datapoint belongs to. Optional.
-    #[serde(default)]
-    pub episode_id: Option<Uuid>,
-
-    /// Input to the function that generated this datapoint. Required.
-    #[serde(deserialize_with = "deserialize_string_or_parsed_json")]
-    pub input: StoredInput,
-
-    /// Output of the function that generated this datapoint. Optional.
-    /// TODO(#4405): this should be a new type StoredContentBlockChatOutput that takes the storage ToolCallOutput format.
-    #[serde(
-        default,
-        deserialize_with = "deserialize_optional_string_or_parsed_json"
-    )]
-    pub output: Option<Vec<ContentBlockChatOutput>>,
-
-    /// Tool parameters used to generate this datapoint. Optional.
-    #[serde(flatten, deserialize_with = "deserialize_optional_tool_info")]
-    pub tool_params: Option<ToolCallConfigDatabaseInsert>,
-
-    /// Tags associated with this datapoint. Optional.
-    #[serde(default, serialize_with = "serialize_none_as_empty_map")]
-    pub tags: Option<HashMap<String, String>>,
-
-    /// Deprecated, do not use.
-    pub auxiliary: String,
-
-    /// Timestamp when the datapoint was marked as stale. Optional.
-    #[serde(default)]
-    pub staled_at: Option<String>,
-
-    /// Source inference ID that generated this datapoint. Optional.
-    #[serde(default)]
-    pub source_inference_id: Option<Uuid>,
-
-    /// If true, this datapoint was manually created or edited by the user.
-    pub is_custom: bool,
-
-    /// Hash of the configuration snapshot that created this datapoint. Optional.
-    /// This should always be Some when writing (after the feature flag is removed)
-    /// but since we also read this type, it will remain an Option.
-    #[serde(default)]
-    pub snapshot_hash: Option<SnapshotHash>,
-}
-
-/// Type that gets serialized directly to be written to ClickHouse. Serialization should match
-/// the structure of the JsonInferenceDatapoint table in ClickHouse.
-/// Theis should be an internal-only type, but it's exposed to tensorzero-node.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct JsonInferenceDatapointInsert {
-    /// Name of the dataset to write to. Required.
-    pub dataset_name: String,
-
-    /// Name of the function that generated this datapoint. Required.
-    pub function_name: String,
-
-    /// Human-readable name of the datapoint. Optional.
-    #[serde(default)]
-    pub name: Option<String>,
-
-    /// Unique identifier for the datapoint. Required.
-    pub id: Uuid,
-
-    /// Episode ID that the datapoint belongs to. Optional.
-    #[serde(default)]
-    pub episode_id: Option<Uuid>,
-
-    /// Input to the function that generated this datapoint. Required.
-    #[serde(deserialize_with = "deserialize_string_or_parsed_json")]
-    pub input: StoredInput,
-
-    /// Output of the function that generated this datapoint. Optional.
-    #[serde(
-        default,
-        deserialize_with = "deserialize_optional_string_or_parsed_json"
-    )]
-    pub output: Option<JsonInferenceOutput>,
-
-    /// Schema of the output of the function that generated this datapoint. Required.
-    #[serde(deserialize_with = "deserialize_string_or_parsed_json")]
-    pub output_schema: serde_json::Value,
-
-    /// Tags associated with this datapoint. Optional.
-    #[serde(default, serialize_with = "serialize_none_as_empty_map")]
-    pub tags: Option<HashMap<String, String>>,
-
-    /// Deprecated, do not use.
-    pub auxiliary: String,
-
-    /// Timestamp when the datapoint was marked as stale. Optional.
-    #[serde(default)]
-    pub staled_at: Option<String>,
-
-    /// Source inference ID that generated this datapoint. Optional.
-    #[serde(default)]
-    pub source_inference_id: Option<Uuid>,
-
-    /// If true, this datapoint was manually created or edited by the user.
-    pub is_custom: bool,
-
-    /// Hash of the configuration snapshot that created this datapoint. Optional.
-    /// This should always be Some when writing (after the feature flag is removed)
-    /// but since we also read this type, it will remain an Option.
-    #[serde(default)]
-    pub snapshot_hash: Option<SnapshotHash>,
-}
 
 #[derive(Debug, Serialize, Deserialize, ts_rs::TS)]
 #[ts(export)]
@@ -300,7 +151,7 @@ pub trait DatasetQueries {
     /// Inserts a batch of datapoints into the database
     /// Internally separates chat and JSON datapoints and writes them to the appropriate tables
     /// Returns the number of rows written.
-    async fn insert_datapoints(&self, datapoints: &[DatapointInsert]) -> Result<u64, Error>;
+    async fn insert_datapoints(&self, datapoints: &[StoredDatapoint]) -> Result<u64, Error>;
 
     /// Counts datapoints for a specific dataset and function
     async fn count_datapoints_for_dataset_function(

--- a/tensorzero-core/src/db/mod.rs
+++ b/tensorzero-core/src/db/mod.rs
@@ -19,6 +19,7 @@ pub mod datasets;
 pub mod feedback;
 pub mod inferences;
 pub mod postgres;
+pub mod stored_datapoint;
 
 #[async_trait]
 pub trait ClickHouseConnection:

--- a/tensorzero-core/src/db/stored_datapoint.rs
+++ b/tensorzero-core/src/db/stored_datapoint.rs
@@ -1,0 +1,314 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::config::snapshot::SnapshotHash;
+use crate::endpoints::datasets::Datapoint;
+use crate::error::Error;
+use crate::inference::types::stored_input::StoredInput;
+use crate::inference::types::{ContentBlockChatOutput, JsonInferenceOutput, Text};
+use crate::serde_util::{
+    deserialize_optional_string_or_parsed_json, deserialize_string_or_parsed_json,
+    serialize_none_as_empty_map,
+};
+use crate::stored_inference::{SimpleStoredSampleInfo, StoredOutput, StoredSample};
+use crate::tool::{ToolCallConfigDatabaseInsert, deserialize_optional_tool_info};
+
+/// Tagged enum for stored datapoints, used when querying from ClickHouse.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum StoredDatapoint {
+    Chat(StoredChatInferenceDatapoint),
+    Json(StoredJsonInferenceDatapoint),
+}
+
+/// Storage variant of ChatInferenceDatapoint for database operations (no Python/TypeScript bindings).
+/// This type is used for both reading from and writing to ClickHouse.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct StoredChatInferenceDatapoint {
+    /// Name of the dataset to write to.
+    pub dataset_name: String,
+
+    /// Name of the function that generated this datapoint.
+    pub function_name: String,
+
+    /// Unique identifier for the datapoint.
+    pub id: Uuid,
+
+    /// Episode ID that the datapoint belongs to.
+    pub episode_id: Option<Uuid>,
+
+    /// Input type that we directly store in ClickHouse.
+    #[serde(deserialize_with = "deserialize_string_or_parsed_json")]
+    pub input: StoredInput,
+
+    /// Output of the function that generated this datapoint. Optional.
+    /// TODO(#4405): this should be a new type StoredContentBlockChatOutput that takes the storage ToolCallOutput format.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_string_or_parsed_json"
+    )]
+    pub output: Option<Vec<ContentBlockChatOutput>>,
+
+    /// Tool parameters used to generate this datapoint. Optional.
+    #[serde(flatten, deserialize_with = "deserialize_optional_tool_info")]
+    pub tool_params: Option<ToolCallConfigDatabaseInsert>,
+
+    /// Tags associated with this datapoint. Optional.
+    #[serde(default, serialize_with = "serialize_none_as_empty_map")]
+    pub tags: Option<HashMap<String, String>>,
+
+    /// If true, this datapoint was manually created or edited by the user.
+    #[serde(default)]
+    pub is_custom: bool,
+
+    /// Source inference ID that generated this datapoint.
+    #[serde(default)]
+    pub source_inference_id: Option<Uuid>,
+
+    /// Timestamp when the datapoint was marked as stale.
+    #[serde(default)]
+    pub staled_at: Option<String>,
+
+    /// Human-readable name of the datapoint.
+    #[serde(default)]
+    pub name: Option<String>,
+
+    /// Hash of the configuration snapshot that created this datapoint. Optional.
+    /// This should always be Some when writing (after the feature flag is removed)
+    /// but since we also read this type, it will remain an Option.
+    #[serde(default)]
+    pub snapshot_hash: Option<SnapshotHash>,
+
+    // ================================
+    // The following fields are ignored during insert.
+    // ================================
+    /// If true, this datapoint was deleted.
+    /// Do not use - we only use soft deletions via `staled_at`. It will be ignored during insert.
+    #[serde(default, skip_serializing)]
+    pub is_deleted: bool,
+
+    /// Deprecated, do not use.
+    #[serde(default, skip_serializing)]
+    pub auxiliary: String,
+
+    /// Timestamp when the datapoint was updated.
+    /// Ignored during insert.
+    #[serde(skip_serializing)]
+    pub updated_at: String,
+}
+
+impl std::fmt::Display for StoredChatInferenceDatapoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let json = serde_json::to_string_pretty(self).map_err(|_| std::fmt::Error)?;
+        write!(f, "{json}")
+    }
+}
+
+/// Storage variant of JsonInferenceDatapoint for database operations (no Python/TypeScript bindings).
+/// This type is used for both reading from and writing to ClickHouse.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct StoredJsonInferenceDatapoint {
+    /// Name of the dataset to write to.
+    pub dataset_name: String,
+
+    /// Name of the function that generated this datapoint.
+    pub function_name: String,
+
+    /// Unique identifier for the datapoint.
+    pub id: Uuid,
+
+    /// Episode ID that the datapoint belongs to.
+    pub episode_id: Option<Uuid>,
+
+    /// Input type that we directly store in ClickHouse.
+    #[serde(deserialize_with = "deserialize_string_or_parsed_json")]
+    pub input: StoredInput,
+
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_string_or_parsed_json"
+    )]
+    pub output: Option<JsonInferenceOutput>,
+
+    #[serde(deserialize_with = "deserialize_string_or_parsed_json")]
+    pub output_schema: serde_json::Value,
+
+    #[serde(default, serialize_with = "serialize_none_as_empty_map")]
+    pub tags: Option<HashMap<String, String>>,
+
+    /// If true, this datapoint was manually created or edited by the user.
+    #[serde(default)]
+    pub is_custom: bool,
+
+    /// Source inference ID that generated this datapoint.
+    #[serde(default)]
+    pub source_inference_id: Option<Uuid>,
+
+    /// Timestamp when the datapoint was marked as stale.
+    #[serde(default)]
+    pub staled_at: Option<String>,
+
+    /// Human-readable name of the datapoint.
+    #[serde(default)]
+    pub name: Option<String>,
+
+    /// Hash of the configuration snapshot that created this datapoint. Optional.
+    /// This should always be Some when writing (after the feature flag is removed)
+    /// but since we also read this type, it will remain an Option.
+    #[serde(default)]
+    pub snapshot_hash: Option<SnapshotHash>,
+
+    // ================================
+    // The following fields are ignored during insert.
+    // ================================
+    /// If true, this datapoint was deleted.
+    /// Do not use - we only use soft deletions via `staled_at`. It will be ignored during insert.
+    #[serde(default, skip_serializing)]
+    pub is_deleted: bool,
+
+    /// Deprecated, do not use.
+    #[serde(default, skip_serializing)]
+    pub auxiliary: String,
+
+    /// Timestamp when the datapoint was updated.
+    /// Ignored during insert.
+    #[serde(skip_serializing)]
+    pub updated_at: String,
+}
+
+impl std::fmt::Display for StoredJsonInferenceDatapoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let json = serde_json::to_string_pretty(self).map_err(|_| std::fmt::Error)?;
+        write!(f, "{json}")
+    }
+}
+
+impl StoredDatapoint {
+    pub fn id(&self) -> Uuid {
+        match self {
+            StoredDatapoint::Chat(datapoint) => datapoint.id,
+            StoredDatapoint::Json(datapoint) => datapoint.id,
+        }
+    }
+
+    pub fn dataset_name(&self) -> &str {
+        match self {
+            StoredDatapoint::Chat(datapoint) => &datapoint.dataset_name,
+            StoredDatapoint::Json(datapoint) => &datapoint.dataset_name,
+        }
+    }
+
+    pub fn input(&self) -> &StoredInput {
+        match self {
+            StoredDatapoint::Chat(datapoint) => &datapoint.input,
+            StoredDatapoint::Json(datapoint) => &datapoint.input,
+        }
+    }
+
+    pub fn tool_call_config(&self) -> Option<&ToolCallConfigDatabaseInsert> {
+        match self {
+            StoredDatapoint::Chat(datapoint) => datapoint.tool_params.as_ref(),
+            StoredDatapoint::Json(_) => None,
+        }
+    }
+
+    pub fn output_schema(&self) -> Option<&serde_json::Value> {
+        match self {
+            StoredDatapoint::Chat(_) => None,
+            StoredDatapoint::Json(datapoint) => Some(&datapoint.output_schema),
+        }
+    }
+
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            StoredDatapoint::Chat(datapoint) => datapoint.name.as_deref(),
+            StoredDatapoint::Json(datapoint) => datapoint.name.as_deref(),
+        }
+    }
+
+    /// Convert to wire type, properly handling tool params by subtracting static tools
+    /// TODO(shuyangli): Add parameter to optionally fetch files from object storage
+    pub fn into_datapoint(self) -> Result<Datapoint, Error> {
+        match self {
+            StoredDatapoint::Chat(chat) => Ok(Datapoint::Chat(chat.into_datapoint())),
+            StoredDatapoint::Json(json) => Ok(Datapoint::Json(json.into_datapoint())),
+        }
+    }
+}
+
+impl std::fmt::Display for StoredDatapoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StoredDatapoint::Chat(datapoint) => write!(f, "{datapoint}"),
+            StoredDatapoint::Json(datapoint) => write!(f, "{datapoint}"),
+        }
+    }
+}
+
+impl StoredSample for StoredDatapoint {
+    fn function_name(&self) -> &str {
+        match self {
+            StoredDatapoint::Chat(datapoint) => &datapoint.function_name,
+            StoredDatapoint::Json(datapoint) => &datapoint.function_name,
+        }
+    }
+
+    fn input(&self) -> &StoredInput {
+        match self {
+            StoredDatapoint::Chat(datapoint) => &datapoint.input,
+            StoredDatapoint::Json(datapoint) => &datapoint.input,
+        }
+    }
+
+    fn input_mut(&mut self) -> &mut StoredInput {
+        match self {
+            StoredDatapoint::Chat(datapoint) => &mut datapoint.input,
+            StoredDatapoint::Json(datapoint) => &mut datapoint.input,
+        }
+    }
+
+    fn into_input(self) -> StoredInput {
+        match self {
+            StoredDatapoint::Chat(datapoint) => datapoint.input,
+            StoredDatapoint::Json(datapoint) => datapoint.input,
+        }
+    }
+
+    fn owned_simple_info(self) -> SimpleStoredSampleInfo {
+        match self {
+            StoredDatapoint::Chat(datapoint) => SimpleStoredSampleInfo {
+                function_name: datapoint.function_name,
+                input: datapoint.input,
+                output: datapoint.output.clone(),
+                stored_output: datapoint.output.map(StoredOutput::Chat),
+                dispreferred_outputs: Vec::default(),
+                tool_params: datapoint.tool_params,
+                output_schema: None,
+                episode_id: None,
+                inference_id: None,
+                tags: datapoint.tags.unwrap_or_default(),
+            },
+            StoredDatapoint::Json(datapoint) => {
+                let stored_output = datapoint.output.clone().map(StoredOutput::Json);
+                let output = datapoint.output.map(|output| match output.raw {
+                    Some(raw) => vec![ContentBlockChatOutput::Text(Text { text: raw })],
+                    None => vec![],
+                });
+                SimpleStoredSampleInfo {
+                    function_name: datapoint.function_name,
+                    input: datapoint.input,
+                    output,
+                    stored_output,
+                    dispreferred_outputs: Vec::default(),
+                    tool_params: None,
+                    output_schema: Some(datapoint.output_schema),
+                    episode_id: None,
+                    inference_id: None,
+                    tags: datapoint.tags.unwrap_or_default(),
+                }
+            }
+        }
+    }
+}

--- a/tensorzero-core/src/endpoints/datasets/v1/conversion_utils.rs
+++ b/tensorzero-core/src/endpoints/datasets/v1/conversion_utils.rs
@@ -2,7 +2,7 @@ use futures::future::join_all;
 use uuid::Uuid;
 
 use crate::config::Config;
-use crate::db::datasets::{ChatInferenceDatapointInsert, JsonInferenceDatapointInsert};
+use crate::db::stored_datapoint::{StoredChatInferenceDatapoint, StoredJsonInferenceDatapoint};
 use crate::endpoints::datasets::v1::types::{
     CreateChatDatapointRequest, CreateJsonDatapointRequest, JsonDatapointOutputUpdate,
 };
@@ -13,13 +13,13 @@ use crate::jsonschema_util::{DynamicJSONSchema, JsonSchemaRef};
 use crate::tool::ToolCallConfigDatabaseInsert;
 
 impl CreateChatDatapointRequest {
-    /// Validates and converts this request into a ChatInferenceDatapointInsert struct.
+    /// Validates and converts this request into a StoredChatInferenceDatapoint struct.
     pub async fn into_database_insert(
         self,
         config: &Config,
         fetch_context: &FetchContext<'_>,
         dataset_name: &str,
-    ) -> Result<ChatInferenceDatapointInsert, Error> {
+    ) -> Result<StoredChatInferenceDatapoint, Error> {
         // Validate function exists and is a chat function
         let function_config = config.get_function(&self.function_name)?;
         let FunctionConfig::Chat(_) = &**function_config else {
@@ -53,10 +53,9 @@ impl CreateChatDatapointRequest {
             None
         };
 
-        let insert = ChatInferenceDatapointInsert {
+        let insert = StoredChatInferenceDatapoint {
             dataset_name: dataset_name.to_string(),
             function_name: self.function_name,
-            name: self.name,
             id: Uuid::now_v7(),
             episode_id: self.episode_id,
             input: stored_input,
@@ -64,10 +63,13 @@ impl CreateChatDatapointRequest {
             tool_params: tool_config.map(ToolCallConfigDatabaseInsert::from),
             tags: self.tags,
             auxiliary: String::new(),
-            staled_at: None,
-            source_inference_id: None,
+            is_deleted: false,
             is_custom: true,
+            source_inference_id: None,
+            staled_at: None,
             snapshot_hash: Some(config.hash.clone()),
+            updated_at: String::new(), // Will be set by ClickHouse
+            name: self.name,
         };
 
         Ok(insert)
@@ -75,13 +77,13 @@ impl CreateChatDatapointRequest {
 }
 
 impl CreateJsonDatapointRequest {
-    /// Validates and converts this request into a JsonInferenceDatapointInsert struct.
+    /// Validates and converts this request into a StoredJsonInferenceDatapoint struct.
     pub async fn into_database_insert(
         self,
         config: &Config,
         fetch_context: &FetchContext<'_>,
         dataset_name: &str,
-    ) -> Result<JsonInferenceDatapointInsert, Error> {
+    ) -> Result<StoredJsonInferenceDatapoint, Error> {
         // Validate function exists and is a JSON function
         let function_config = config.get_function(&self.function_name)?;
         let FunctionConfig::Json(json_function_config) = &**function_config else {
@@ -134,10 +136,9 @@ impl CreateJsonDatapointRequest {
             None => None,
         };
 
-        let insert = JsonInferenceDatapointInsert {
+        let insert = StoredJsonInferenceDatapoint {
             dataset_name: dataset_name.to_string(),
             function_name: self.function_name,
-            name: self.name,
             id: Uuid::now_v7(),
             episode_id: self.episode_id,
             input: stored_input,
@@ -145,10 +146,13 @@ impl CreateJsonDatapointRequest {
             output_schema,
             tags: self.tags,
             auxiliary: String::new(),
-            staled_at: None,
-            source_inference_id: None,
+            is_deleted: false,
             is_custom: true,
+            source_inference_id: None,
+            staled_at: None,
             snapshot_hash: Some(config.hash.clone()),
+            updated_at: String::new(), // Will be set by ClickHouse
+            name: self.name,
         };
 
         Ok(insert)

--- a/tensorzero-core/src/endpoints/datasets/v1/create_from_inferences.rs
+++ b/tensorzero-core/src/endpoints/datasets/v1/create_from_inferences.rs
@@ -141,7 +141,7 @@ mod tests {
     use crate::config::{Config, SchemaData};
     use crate::db::clickhouse::MockClickHouseConnectionInfo;
     use crate::db::clickhouse::query_builder::{InferenceFilter, TagComparisonOperator, TagFilter};
-    use crate::db::datasets::DatapointInsert;
+    use crate::db::stored_datapoint::StoredDatapoint;
     use crate::experimentation::ExperimentationConfig;
     use crate::function::{FunctionConfig, FunctionConfigChat, FunctionConfigJson};
     use crate::inference::types::{ContentBlockChatOutput, Text};
@@ -508,7 +508,7 @@ mod tests {
             .times(1)
             .withf(|datapoints| {
                 // Verify that the datapoint has no output when output_source is None
-                let Some(DatapointInsert::Chat(dp)) = datapoints.first() else {
+                let Some(StoredDatapoint::Chat(dp)) = datapoints.first() else {
                     panic!("Expected a chat datapoint")
                 };
                 assert!(dp.output.is_none(), "Datapoint output should be dropped");
@@ -557,7 +557,7 @@ mod tests {
             .times(1)
             .withf(|datapoints| {
                 // Verify that the datapoint has the output when output_source is Inference
-                let Some(DatapointInsert::Chat(dp)) = datapoints.first() else {
+                let Some(StoredDatapoint::Chat(dp)) = datapoints.first() else {
                     panic!("Expected a chat datapoint")
                 };
                 assert_eq!(

--- a/tensorzero-core/src/inference/types/pyo3_helpers.rs
+++ b/tensorzero-core/src/inference/types/pyo3_helpers.rs
@@ -8,7 +8,8 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::config::Config;
-use crate::endpoints::datasets::{Datapoint, StoredDatapoint};
+use crate::db::stored_datapoint::StoredDatapoint;
+use crate::endpoints::datasets::Datapoint;
 use crate::inference::types::stored_input::{StoredInput, StoredInputMessageContent};
 use crate::inference::types::{
     ContentBlockChatOutput, ResolvedContentBlock, ResolvedInputMessageContent, Unknown,

--- a/tensorzero-core/tests/e2e/datasets/mod.rs
+++ b/tensorzero-core/tests/e2e/datasets/mod.rs
@@ -4,9 +4,7 @@ use std::time::Duration;
 
 use reqwest::{Client, StatusCode};
 use serde_json::{Value, json};
-use tensorzero::{
-    ClientExt, InputMessageContent, JsonInferenceDatapoint, Role, StoredDatapoint, System,
-};
+use tensorzero::{ClientExt, InputMessageContent, JsonInferenceDatapoint, Role, System};
 use tensorzero_core::endpoints::datasets::ChatInferenceDatapoint;
 use tensorzero_core::{
     db::{
@@ -3067,7 +3065,8 @@ async fn test_stale_dataset_mixed_staled_fresh() {
 #[tokio::test]
 async fn test_update_datapoint_preserves_tool_call_ids() {
     use tensorzero_core::{
-        db::datasets::{ChatInferenceDatapointInsert, DatapointInsert, DatasetQueries},
+        db::datasets::DatasetQueries,
+        db::stored_datapoint::{StoredChatInferenceDatapoint, StoredDatapoint},
         inference::types::{ContentBlockChatOutput, StoredInput},
         tool::InferenceResponseToolCall,
     };
@@ -3104,7 +3103,7 @@ async fn test_update_datapoint_preserves_tool_call_ids() {
     });
 
     // Create initial datapoint using ClickHouse directly with tool calls that have IDs
-    let initial_datapoint = ChatInferenceDatapointInsert {
+    let initial_datapoint = StoredChatInferenceDatapoint {
         dataset_name: dataset_name.to_string(),
         function_name: "basic_test".to_string(),
         id: datapoint_id,
@@ -3129,11 +3128,13 @@ async fn test_update_datapoint_preserves_tool_call_ids() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     };
 
     clickhouse
-        .insert_datapoints(&[DatapointInsert::Chat(initial_datapoint)])
+        .insert_datapoints(&[StoredDatapoint::Chat(initial_datapoint)])
         .await
         .unwrap();
 

--- a/tensorzero-core/tests/e2e/datasets/tool_params.rs
+++ b/tensorzero-core/tests/e2e/datasets/tool_params.rs
@@ -13,9 +13,8 @@ use std::time::Duration;
 use tensorzero_core::db::clickhouse::test_helpers::{
     clickhouse_flush_async_insert, get_clickhouse,
 };
-use tensorzero_core::db::datasets::{
-    ChatInferenceDatapointInsert, DatapointInsert, DatasetQueries,
-};
+use tensorzero_core::db::datasets::DatasetQueries;
+use tensorzero_core::db::stored_datapoint::{StoredChatInferenceDatapoint, StoredDatapoint};
 use tensorzero_core::inference::types::{
     Arguments, ContentBlockChatOutput, Role, StoredInput, StoredInputMessage,
     StoredInputMessageContent, System, Text,
@@ -90,7 +89,7 @@ async fn test_datapoint_full_tool_params_round_trip() {
     ));
 
     // Create datapoint via ClickHouse
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "weather_helper".to_string(),
         name: Some("Test Tool Params Round-Trip".to_string()),
@@ -119,6 +118,8 @@ async fn test_datapoint_full_tool_params_round_trip() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -223,7 +224,7 @@ async fn test_datapoint_update_tool_params() {
         Some(false),
     ));
 
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "weather_helper".to_string(),
         name: Some("Update Test".to_string()),
@@ -245,6 +246,8 @@ async fn test_datapoint_update_tool_params() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -392,7 +395,7 @@ async fn test_list_datapoints_with_tool_params() {
     };
 
     // Datapoint 1: Only static tool
-    let dp1 = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let dp1 = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "weather_helper".to_string(),
         name: Some("DP1".to_string()),
@@ -423,11 +426,13 @@ async fn test_list_datapoints_with_tool_params() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
     // Datapoint 2: Static + one dynamic tool
-    let dp2 = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let dp2 = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "weather_helper".to_string(),
         name: Some("DP2".to_string()),
@@ -458,11 +463,13 @@ async fn test_list_datapoints_with_tool_params() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
     // Datapoint 3: Static + different dynamic tool with strict
-    let dp3 = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let dp3 = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "weather_helper".to_string(),
         name: Some("DP3".to_string()),
@@ -493,6 +500,8 @@ async fn test_list_datapoints_with_tool_params() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -583,7 +592,7 @@ async fn test_datapoint_only_static_tools() {
         strict: false,
     };
 
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "weather_helper".to_string(),
         name: None,
@@ -614,6 +623,8 @@ async fn test_datapoint_only_static_tools() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -685,7 +696,7 @@ async fn test_datapoint_only_dynamic_tools() {
         strict: true,
     };
 
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "weather_helper".to_string(),
         name: None,
@@ -716,6 +727,8 @@ async fn test_datapoint_only_dynamic_tools() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -780,7 +793,7 @@ async fn test_datapoint_tool_params_three_states() {
         strict: false,
     };
 
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "weather_helper".to_string(),
         name: None,
@@ -811,6 +824,8 @@ async fn test_datapoint_tool_params_three_states() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -1006,7 +1021,7 @@ async fn test_datapoint_no_tool_params() {
     let dataset_name = format!("test-dp-no-tools-{}", Uuid::now_v7());
     let datapoint_id = Uuid::now_v7();
 
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "weather_helper".to_string(),
         name: None,
@@ -1028,6 +1043,8 @@ async fn test_datapoint_no_tool_params() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 

--- a/tensorzero-core/tests/e2e/endpoints/datasets/delete_datapoints.rs
+++ b/tensorzero-core/tests/e2e/endpoints/datasets/delete_datapoints.rs
@@ -6,11 +6,10 @@ use std::time::Duration;
 use uuid::Uuid;
 
 use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
-use tensorzero_core::db::datasets::{
-    ChatInferenceDatapointInsert, DatapointInsert, DatasetQueries, GetDatapointsParams,
-    JsonInferenceDatapointInsert,
+use tensorzero_core::db::datasets::{DatasetQueries, GetDatapointsParams};
+use tensorzero_core::db::stored_datapoint::{
+    StoredChatInferenceDatapoint, StoredDatapoint, StoredJsonInferenceDatapoint,
 };
-use tensorzero_core::endpoints::datasets::StoredDatapoint;
 use tensorzero_core::endpoints::datasets::v1::types::DeleteDatapointsResponse;
 use tensorzero_core::inference::types::{
     JsonInferenceOutput, Role, StoredInput, StoredInputMessage, StoredInputMessageContent, Text,
@@ -26,7 +25,7 @@ async fn test_delete_datapoints_single_chat() {
 
     // Create a chat datapoint
     let datapoint_id = Uuid::now_v7();
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: Some("Test Datapoint".to_string()),
@@ -52,6 +51,8 @@ async fn test_delete_datapoints_single_chat() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -149,7 +150,7 @@ async fn test_delete_datapoints_multiple_mixed() {
     let chat_id2 = Uuid::now_v7();
     let json_id = Uuid::now_v7();
 
-    let chat_insert1 = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let chat_insert1 = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: None,
@@ -175,10 +176,12 @@ async fn test_delete_datapoints_multiple_mixed() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
-    let chat_insert2 = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let chat_insert2 = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: None,
@@ -204,10 +207,12 @@ async fn test_delete_datapoints_multiple_mixed() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
-    let json_insert = DatapointInsert::Json(JsonInferenceDatapointInsert {
+    let json_insert = StoredDatapoint::Json(StoredJsonInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "json_success".to_string(),
         name: None,
@@ -232,6 +237,8 @@ async fn test_delete_datapoints_multiple_mixed() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -310,7 +317,7 @@ async fn test_delete_datapoints_non_existent_id() {
 
     // Create one datapoint
     let existing_id = Uuid::now_v7();
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: None,
@@ -336,6 +343,8 @@ async fn test_delete_datapoints_non_existent_id() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -435,7 +444,7 @@ async fn test_delete_datapoints_already_stale() {
 
     // Create a datapoint
     let datapoint_id = Uuid::now_v7();
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: None,
@@ -461,6 +470,8 @@ async fn test_delete_datapoints_already_stale() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 

--- a/tensorzero-core/tests/e2e/endpoints/datasets/delete_dataset.rs
+++ b/tensorzero-core/tests/e2e/endpoints/datasets/delete_dataset.rs
@@ -6,11 +6,10 @@ use std::time::Duration;
 use uuid::Uuid;
 
 use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
-use tensorzero_core::db::datasets::{
-    ChatInferenceDatapointInsert, DatapointInsert, DatasetQueries, GetDatapointsParams,
-    JsonInferenceDatapointInsert,
+use tensorzero_core::db::datasets::{DatasetQueries, GetDatapointsParams};
+use tensorzero_core::db::stored_datapoint::{
+    StoredChatInferenceDatapoint, StoredDatapoint, StoredJsonInferenceDatapoint,
 };
-use tensorzero_core::endpoints::datasets::StoredDatapoint;
 use tensorzero_core::endpoints::datasets::v1::types::DeleteDatapointsResponse;
 use tensorzero_core::inference::types::{
     ContentBlockChatOutput, JsonInferenceOutput, Role, StoredInput, StoredInputMessage,
@@ -27,7 +26,7 @@ async fn test_delete_dataset_with_single_datapoint() {
 
     // Create a single datapoint
     let datapoint_id = Uuid::now_v7();
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: Some("Test Datapoint".to_string()),
@@ -51,6 +50,8 @@ async fn test_delete_dataset_with_single_datapoint() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -151,7 +152,7 @@ async fn test_delete_dataset_with_multiple_mixed_datapoints() {
     let mut inserts = vec![];
 
     for i in 0..3 {
-        inserts.push(DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        inserts.push(StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "basic_test".to_string(),
             name: Some(format!("Chat Datapoint {i}")),
@@ -175,12 +176,14 @@ async fn test_delete_dataset_with_multiple_mixed_datapoints() {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         }));
     }
 
     for i in 0..2 {
-        inserts.push(DatapointInsert::Json(JsonInferenceDatapointInsert {
+        inserts.push(StoredDatapoint::Json(StoredJsonInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "json_success".to_string(),
             name: Some(format!("JSON Datapoint {i}")),
@@ -205,6 +208,8 @@ async fn test_delete_dataset_with_multiple_mixed_datapoints() {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         }));
     }
@@ -333,7 +338,7 @@ async fn test_delete_dataset_twice() {
 
     // Create a datapoint
     let datapoint_id = Uuid::now_v7();
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: None,
@@ -357,6 +362,8 @@ async fn test_delete_dataset_twice() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -403,7 +410,7 @@ async fn test_delete_dataset_with_different_function_names() {
     let dataset_name = format!("test-delete-dataset-functions-{}", Uuid::now_v7());
 
     // Create datapoints with different function names in the same dataset
-    let function1_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let function1_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "function_one".to_string(),
         name: None,
@@ -427,10 +434,12 @@ async fn test_delete_dataset_with_different_function_names() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
-    let function2_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let function2_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "function_two".to_string(),
         name: None,
@@ -454,6 +463,8 @@ async fn test_delete_dataset_with_different_function_names() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 

--- a/tensorzero-core/tests/e2e/endpoints/datasets/get_datapoints.rs
+++ b/tensorzero-core/tests/e2e/endpoints/datasets/get_datapoints.rs
@@ -8,8 +8,9 @@ use std::time::Duration;
 use uuid::Uuid;
 
 use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
-use tensorzero_core::db::datasets::{
-    ChatInferenceDatapointInsert, DatapointInsert, DatasetQueries, JsonInferenceDatapointInsert,
+use tensorzero_core::db::datasets::DatasetQueries;
+use tensorzero_core::db::stored_datapoint::{
+    StoredChatInferenceDatapoint, StoredDatapoint, StoredJsonInferenceDatapoint,
 };
 use tensorzero_core::inference::types::{
     Arguments, JsonInferenceOutput, Role, StoredInput, StoredInputMessage,
@@ -33,7 +34,7 @@ mod get_datapoints_tests {
         let mut tags = HashMap::new();
         tags.insert("env".to_string(), "test".to_string());
 
-        let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "basic_test".to_string(),
             name: Some("Test Datapoint".to_string()),
@@ -64,6 +65,8 @@ mod get_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
@@ -116,7 +119,7 @@ mod get_datapoints_tests {
         let mut tags = HashMap::new();
         tags.insert("env".to_string(), "test".to_string());
 
-        let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "basic_test".to_string(),
             name: Some("Test Datapoint".to_string()),
@@ -147,6 +150,8 @@ mod get_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
@@ -205,7 +210,7 @@ mod get_datapoints_tests {
             "additionalProperties": false
         });
 
-        let datapoint_insert = DatapointInsert::Json(JsonInferenceDatapointInsert {
+        let datapoint_insert = StoredDatapoint::Json(StoredJsonInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "json_success".to_string(),
             name: None,
@@ -235,6 +240,8 @@ mod get_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
@@ -282,7 +289,7 @@ mod get_datapoints_tests {
         let chat_id2 = Uuid::now_v7();
         let json_id = Uuid::now_v7();
 
-        let chat_insert1 = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let chat_insert1 = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "basic_test".to_string(),
             name: None,
@@ -308,10 +315,12 @@ mod get_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
-        let chat_insert2 = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let chat_insert2 = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "basic_test".to_string(),
             name: None,
@@ -337,10 +346,12 @@ mod get_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
-        let json_insert = DatapointInsert::Json(JsonInferenceDatapointInsert {
+        let json_insert = StoredDatapoint::Json(StoredJsonInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "json_success".to_string(),
             name: None,
@@ -365,6 +376,8 @@ mod get_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
@@ -417,7 +430,7 @@ mod get_datapoints_tests {
 
         // Create one datapoint
         let existing_id = Uuid::now_v7();
-        let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "basic_test".to_string(),
             name: None,
@@ -443,6 +456,8 @@ mod get_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
@@ -486,7 +501,7 @@ mod get_datapoints_tests {
 
         // Create a datapoint
         let datapoint_id = Uuid::now_v7();
-        let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "basic_test".to_string(),
             name: None,
@@ -512,6 +527,8 @@ mod get_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
@@ -560,7 +577,7 @@ mod get_datapoints_tests {
 
         // Create a datapoint so we have a valid dataset name.
         let datapoint_id = Uuid::now_v7();
-        let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "basic_test".to_string(),
             name: None,
@@ -586,6 +603,8 @@ mod get_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
@@ -623,7 +642,7 @@ mod get_datapoints_tests {
 
         // Create a datapoint so we have a valid dataset name.
         let datapoint_id = Uuid::now_v7();
-        let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "basic_test".to_string(),
             name: None,
@@ -649,6 +668,8 @@ mod get_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
@@ -688,7 +709,7 @@ mod list_datapoints_tests {
         // Create 5 datapoints
         let mut inserts = vec![];
         for i in 0..5 {
-            inserts.push(DatapointInsert::Chat(ChatInferenceDatapointInsert {
+            inserts.push(StoredDatapoint::Chat(StoredChatInferenceDatapoint {
                 dataset_name: dataset_name.clone(),
                 function_name: "basic_test".to_string(),
                 name: Some(format!("Datapoint {i}")),
@@ -714,6 +735,8 @@ mod list_datapoints_tests {
                 staled_at: None,
                 source_inference_id: None,
                 is_custom: true,
+                is_deleted: false,
+                updated_at: String::new(),
                 snapshot_hash: None,
             }));
         }
@@ -799,7 +822,7 @@ mod list_datapoints_tests {
 
         // Create datapoints with different function names
         let function1_id = Uuid::now_v7();
-        let function1_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let function1_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "basic_test".to_string(),
             name: None,
@@ -825,11 +848,13 @@ mod list_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
         let function2_id = Uuid::now_v7();
-        let function2_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let function2_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "weather_helper".to_string(),
             name: None,
@@ -855,6 +880,8 @@ mod list_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
@@ -915,7 +942,7 @@ mod list_datapoints_tests {
         tags2.insert("env".to_string(), "staging".to_string());
 
         let datapoint1_id = Uuid::now_v7();
-        let datapoint1 = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let datapoint1 = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "basic_test".to_string(),
             name: None,
@@ -941,11 +968,13 @@ mod list_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
         let datapoint2_id = Uuid::now_v7();
-        let datapoint2 = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let datapoint2 = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "basic_test".to_string(),
             name: None,
@@ -971,6 +1000,8 @@ mod list_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
@@ -1036,7 +1067,7 @@ mod list_datapoints_tests {
 
         // Create a datapoint
         let datapoint_id = Uuid::now_v7();
-        let datapoint = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let datapoint = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "basic_test".to_string(),
             name: None,
@@ -1062,6 +1093,8 @@ mod list_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
@@ -1136,7 +1169,7 @@ mod list_datapoints_tests {
         tags3.insert("region".to_string(), "us-east".to_string());
 
         let datapoint1_id = Uuid::now_v7();
-        let datapoint1 = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let datapoint1 = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "basic_test".to_string(),
             name: None,
@@ -1162,11 +1195,13 @@ mod list_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
         let datapoint2_id = Uuid::now_v7();
-        let datapoint2 = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let datapoint2 = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "basic_test".to_string(),
             name: None,
@@ -1192,11 +1227,13 @@ mod list_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
         let datapoint3_id = Uuid::now_v7();
-        let datapoint3 = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let datapoint3 = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "basic_test".to_string(),
             name: None,
@@ -1222,6 +1259,8 @@ mod list_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
@@ -1330,7 +1369,7 @@ mod list_datapoints_tests {
 
         // Create a datapoint
         let datapoint_id = Uuid::now_v7();
-        let datapoint = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let datapoint = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "basic_test".to_string(),
             name: None,
@@ -1356,6 +1395,8 @@ mod list_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
@@ -1410,7 +1451,7 @@ mod list_datapoints_tests {
 
         // Create both chat and JSON datapoints
         let chat_id = Uuid::now_v7();
-        let chat_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let chat_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "basic_test".to_string(),
             name: None,
@@ -1436,11 +1477,13 @@ mod list_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
         let json_id = Uuid::now_v7();
-        let json_insert = DatapointInsert::Json(JsonInferenceDatapointInsert {
+        let json_insert = StoredDatapoint::Json(StoredJsonInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "json_success".to_string(),
             name: None,
@@ -1465,6 +1508,8 @@ mod list_datapoints_tests {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: None,
         });
 
@@ -1514,7 +1559,7 @@ mod list_datapoints_tests {
         // Create 3 datapoints
         let mut inserts = vec![];
         for i in 0..3 {
-            inserts.push(DatapointInsert::Chat(ChatInferenceDatapointInsert {
+            inserts.push(StoredDatapoint::Chat(StoredChatInferenceDatapoint {
                 dataset_name: dataset_name.clone(),
                 function_name: "basic_test".to_string(),
                 name: None,
@@ -1540,6 +1585,8 @@ mod list_datapoints_tests {
                 staled_at: None,
                 source_inference_id: None,
                 is_custom: true,
+                is_deleted: false,
+                updated_at: String::new(),
                 snapshot_hash: None,
             }));
         }

--- a/tensorzero-core/tests/e2e/endpoints/datasets/list_datasets.rs
+++ b/tensorzero-core/tests/e2e/endpoints/datasets/list_datasets.rs
@@ -5,9 +5,8 @@ use tensorzero_core::config::snapshot::SnapshotHash;
 use uuid::Uuid;
 
 use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
-use tensorzero_core::db::datasets::{
-    ChatInferenceDatapointInsert, DatapointInsert, DatasetQueries,
-};
+use tensorzero_core::db::datasets::DatasetQueries;
+use tensorzero_core::db::stored_datapoint::{StoredChatInferenceDatapoint, StoredDatapoint};
 use tensorzero_core::endpoints::datasets::v1::types::ListDatasetsResponse;
 use tensorzero_core::inference::types::{
     Role, StoredInput, StoredInputMessage, StoredInputMessageContent, Text,
@@ -24,7 +23,7 @@ async fn test_list_datasets_no_params() {
     let dataset_name = format!("test-list-datasets-{}", Uuid::now_v7());
     let datapoint_id = Uuid::now_v7();
 
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "test_function".to_string(),
         name: Some("Test Datapoint".to_string()),
@@ -50,6 +49,8 @@ async fn test_list_datasets_no_params() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: Some(SnapshotHash::new_test()),
     });
 
@@ -114,7 +115,7 @@ async fn test_list_datasets_with_function_filter() {
     let function_name_1 = format!("test_function_filter_1_{}", Uuid::now_v7());
     let function_name_2 = format!("test_function_filter_2_{}", Uuid::now_v7());
 
-    let datapoint_1 = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_1 = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name_1.clone(),
         function_name: function_name_1.clone(),
         name: None,
@@ -136,10 +137,12 @@ async fn test_list_datasets_with_function_filter() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: Some(SnapshotHash::new_test()),
     });
 
-    let datapoint_2 = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_2 = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name_2.clone(),
         function_name: function_name_2.clone(),
         name: None,
@@ -161,6 +164,8 @@ async fn test_list_datasets_with_function_filter() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: Some(SnapshotHash::new_test()),
     });
 
@@ -244,7 +249,7 @@ async fn test_list_datasets_with_pagination() {
         let dataset_name = format!("test-list-paginate-{}-{}", i, Uuid::now_v7());
         dataset_names.push(dataset_name.clone());
 
-        let datapoint = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+        let datapoint = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
             dataset_name: dataset_name.clone(),
             function_name: "test_function".to_string(),
             name: None,
@@ -266,6 +271,8 @@ async fn test_list_datasets_with_pagination() {
             staled_at: None,
             source_inference_id: None,
             is_custom: true,
+            is_deleted: false,
+            updated_at: String::new(),
             snapshot_hash: Some(SnapshotHash::new_test()),
         });
 

--- a/tensorzero-core/tests/e2e/endpoints/datasets/update_datapoints.rs
+++ b/tensorzero-core/tests/e2e/endpoints/datasets/update_datapoints.rs
@@ -5,14 +5,15 @@ use reqwest::{Client, StatusCode};
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::time::Duration;
-use tensorzero::{FunctionTool, GetDatapointParams, StoredDatapoint};
+use tensorzero::{FunctionTool, GetDatapointParams};
 use uuid::Uuid;
 
 use tensorzero_core::db::clickhouse::test_helpers::{
     clickhouse_flush_async_insert, get_clickhouse,
 };
-use tensorzero_core::db::datasets::{
-    ChatInferenceDatapointInsert, DatapointInsert, DatasetQueries, JsonInferenceDatapointInsert,
+use tensorzero_core::db::datasets::DatasetQueries;
+use tensorzero_core::db::stored_datapoint::{
+    StoredChatInferenceDatapoint, StoredDatapoint, StoredJsonInferenceDatapoint,
 };
 use tensorzero_core::inference::types::{
     Arguments, ContentBlockChatOutput, JsonInferenceOutput, Role, StoredInput, StoredInputMessage,
@@ -36,7 +37,7 @@ async fn test_update_chat_datapoint_output() {
     let mut tags = std::collections::HashMap::new();
     tags.insert("version".to_string(), "1".to_string());
 
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: None,
@@ -65,6 +66,10 @@ async fn test_update_chat_datapoint_output() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+
+        // Ignored during insert
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -169,7 +174,7 @@ async fn test_update_json_datapoint_output() {
         "additionalProperties": false
     });
 
-    let datapoint_insert = DatapointInsert::Json(JsonInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Json(StoredJsonInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "json_success".to_string(),
         name: None,
@@ -199,6 +204,10 @@ async fn test_update_json_datapoint_output() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+
+        // Ignored during insert
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -266,7 +275,7 @@ async fn test_update_multiple_datapoints() {
     let datapoint_id1 = Uuid::now_v7();
     let datapoint_id2 = Uuid::now_v7();
 
-    let datapoint_insert1 = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert1 = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: None,
@@ -295,10 +304,14 @@ async fn test_update_multiple_datapoints() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+
+        // Ignored during insert
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
-    let datapoint_insert2 = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert2 = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: None,
@@ -327,6 +340,10 @@ async fn test_update_multiple_datapoints() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+
+        // Ignored during insert
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -435,7 +452,7 @@ async fn test_update_datapoint_type_mismatch() {
     // Create a chat datapoint
     let datapoint_id = Uuid::now_v7();
 
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: None,
@@ -464,6 +481,10 @@ async fn test_update_datapoint_type_mismatch() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+
+        // Ignored during insert
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -503,7 +524,7 @@ async fn test_update_datapoint_with_metadata() {
     // Create a datapoint
     let datapoint_id = Uuid::now_v7();
 
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: None,
@@ -532,6 +553,10 @@ async fn test_update_datapoint_with_metadata() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+
+        // Ignored during insert
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -638,7 +663,7 @@ async fn test_update_chat_datapoint_set_output_to_null() {
     // Create a datapoint with output
     let datapoint_id = Uuid::now_v7();
 
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: None,
@@ -667,6 +692,10 @@ async fn test_update_chat_datapoint_set_output_to_null() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+
+        // Ignored during insert
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -725,7 +754,7 @@ async fn test_update_chat_datapoint_set_tool_params_to_null() {
     // Create a datapoint with tool_params
     let datapoint_id = Uuid::now_v7();
 
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: None,
@@ -771,6 +800,10 @@ async fn test_update_chat_datapoint_set_tool_params_to_null() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+
+        // Ignored during insert
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -837,7 +870,7 @@ async fn test_update_chat_datapoint_set_tags_to_empty() {
     tags.insert("key1".to_string(), "value1".to_string());
     tags.insert("key2".to_string(), "value2".to_string());
 
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: None,
@@ -866,6 +899,10 @@ async fn test_update_chat_datapoint_set_tags_to_empty() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+
+        // Ignored during insert
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -924,7 +961,7 @@ async fn test_update_chat_datapoint_set_name_to_null() {
     // Create a datapoint with a name
     let datapoint_id = Uuid::now_v7();
 
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: Some("Original Name".to_string()),
@@ -953,6 +990,10 @@ async fn test_update_chat_datapoint_set_name_to_null() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+
+        // Ignored during insert
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -1017,7 +1058,7 @@ async fn test_update_json_datapoint_set_output_to_null() {
         "additionalProperties": false
     });
 
-    let datapoint_insert = DatapointInsert::Json(JsonInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Json(StoredJsonInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "json_success".to_string(),
         name: None,
@@ -1047,6 +1088,10 @@ async fn test_update_json_datapoint_set_output_to_null() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+
+        // Ignored during insert
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -1115,7 +1160,7 @@ async fn test_update_json_datapoint_set_tags_to_empty() {
         "additionalProperties": false
     });
 
-    let datapoint_insert = DatapointInsert::Json(JsonInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Json(StoredJsonInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "json_success".to_string(),
         name: None,
@@ -1145,6 +1190,10 @@ async fn test_update_json_datapoint_set_tags_to_empty() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+
+        // Ignored during insert
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -1206,7 +1255,7 @@ async fn test_update_metadata_chat_datapoint() {
 
     // Create a chat datapoint
     let datapoint_id = Uuid::now_v7();
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: Some("original_name".to_string()),
@@ -1230,6 +1279,8 @@ async fn test_update_metadata_chat_datapoint() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -1306,7 +1357,7 @@ async fn test_update_metadata_json_datapoint() {
         "additionalProperties": false
     });
 
-    let datapoint_insert = DatapointInsert::Json(JsonInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Json(StoredJsonInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "json_success".to_string(),
         name: Some("original_json_name".to_string()),
@@ -1331,6 +1382,10 @@ async fn test_update_metadata_json_datapoint() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+
+        // Ignored during insert
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -1393,7 +1448,7 @@ async fn test_update_metadata_set_name_to_null() {
 
     // Create a chat datapoint with a name
     let datapoint_id = Uuid::now_v7();
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: Some("to_be_removed".to_string()),
@@ -1415,6 +1470,10 @@ async fn test_update_metadata_set_name_to_null() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+
+        // Ignored during insert
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -1472,7 +1531,7 @@ async fn test_update_metadata_batch() {
     let datapoint_id1 = Uuid::now_v7();
     let datapoint_id2 = Uuid::now_v7();
 
-    let datapoint1 = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint1 = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: Some("name1".to_string()),
@@ -1494,10 +1553,14 @@ async fn test_update_metadata_batch() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+
+        // Ignored during insert
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
-    let datapoint2 = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint2 = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: Some("name2".to_string()),
@@ -1519,6 +1582,10 @@ async fn test_update_metadata_batch() {
         staled_at: None,
         source_inference_id: None,
         is_custom: true,
+
+        // Ignored during insert
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -1652,7 +1719,7 @@ async fn test_get_chat_datapoint_modify_and_update_roundtrip() {
     let mut tags = HashMap::new();
     tags.insert("env".to_string(), "test".to_string());
 
-    let datapoint_insert = DatapointInsert::Chat(ChatInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Chat(StoredChatInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "basic_test".to_string(),
         name: Some("Original Name".to_string()),
@@ -1682,6 +1749,10 @@ async fn test_get_chat_datapoint_modify_and_update_roundtrip() {
         source_inference_id: None,
         // Make a non-custom datapoint so that it can be modified
         is_custom: false,
+
+        // Ignored during insert
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 
@@ -1798,7 +1869,7 @@ async fn test_get_json_datapoint_modify_and_update_roundtrip() {
         "additionalProperties": false
     });
 
-    let datapoint_insert = DatapointInsert::Json(JsonInferenceDatapointInsert {
+    let datapoint_insert = StoredDatapoint::Json(StoredJsonInferenceDatapoint {
         dataset_name: dataset_name.clone(),
         function_name: "json_success".to_string(),
         name: Some("Original Name".to_string()),
@@ -1830,6 +1901,10 @@ async fn test_get_json_datapoint_modify_and_update_roundtrip() {
         source_inference_id: None,
         // Mark as non-custom so that it can be modified
         is_custom: false,
+
+        // Ignored during insert
+        is_deleted: false,
+        updated_at: String::new(),
         snapshot_hash: None,
     });
 

--- a/tensorzero-core/tests/e2e/render_inferences.rs
+++ b/tensorzero-core/tests/e2e/render_inferences.rs
@@ -6,7 +6,7 @@ use tensorzero::{
     ClientExt, FunctionTool, Role, StorageKind, StoragePath, StoredChatInferenceDatabase,
     StoredChatInferenceDatapoint, StoredDatapoint, StoredInferenceDatabase, StoredJsonInference,
 };
-use tensorzero_core::endpoints::datasets::StoredJsonInferenceDatapoint;
+use tensorzero_core::db::stored_datapoint::StoredJsonInferenceDatapoint;
 use tensorzero_core::inference::types::file::ObjectStoragePointer;
 use tensorzero_core::inference::types::stored_input::StoredFile;
 use tensorzero_core::inference::types::stored_input::{

--- a/tensorzero-optimizers/src/gepa/analyze.rs
+++ b/tensorzero-optimizers/src/gepa/analyze.rs
@@ -407,8 +407,9 @@ mod tests {
     use std::collections::HashMap;
     use tensorzero_core::{
         config::{SchemaData, path::ResolvedTomlPathData},
+        db::stored_datapoint::StoredChatInferenceDatapoint,
         endpoints::{
-            datasets::{Datapoint, StoredChatInferenceDatapoint},
+            datasets::Datapoint,
             inference::{ChatInferenceResponse, InferenceResponse},
         },
         evaluations::{EvaluationConfig, InferenceEvaluationConfig},

--- a/tensorzero-optimizers/tests/e2e/gepa/analyze.rs
+++ b/tensorzero-optimizers/tests/e2e/gepa/analyze.rs
@@ -8,8 +8,9 @@ use serde_json::Value;
 use tensorzero::test_helpers::make_embedded_gateway;
 use tensorzero_core::{
     config::{SchemaData, path::ResolvedTomlPathData},
+    db::stored_datapoint::StoredChatInferenceDatapoint,
     endpoints::{
-        datasets::{Datapoint, StoredChatInferenceDatapoint},
+        datasets::Datapoint,
         inference::{ChatInferenceResponse, InferenceResponse},
     },
     evaluations::{
@@ -823,7 +824,7 @@ async fn test_analyze_input_format_scenarios() {
             Some(false), // parallel_tool_calls
         );
 
-        let datapoint = tensorzero_core::endpoints::datasets::StoredChatInferenceDatapoint {
+        let datapoint = StoredChatInferenceDatapoint {
             dataset_name: "test_dataset".to_string(),
             function_name: "test_function".to_string(),
             id: uuid::Uuid::now_v7(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Unify `StoredDatapoint` and `DatapointInsert` types across the codebase, updating functions and tests to use `StoredDatapoint`.
> 
>   - **Type Unification**:
>     - Replace `DatapointInsert` with `StoredDatapoint` in function signatures and type definitions across multiple files, including `dataset_queries.rs` and `mock_clickhouse_connection_info.rs`.
>     - Define `StoredDatapoint` and related types in a new file `stored_datapoint.rs`.
>   - **Function Changes**:
>     - Update `insert_datapoints()` in `dataset_queries.rs` and `mock_clickhouse_connection_info.rs` to use `StoredDatapoint`.
>     - Modify `build_analyze_input()` in `analyze.rs` to handle `StoredDatapoint`.
>   - **Test Updates**:
>     - Update test cases in `render_inferences.rs`, `analyze.rs`, and `analyze.rs` to use `StoredDatapoint`.
>     - Ensure all test scenarios reflect the new type usage, including error handling and input validation tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 05b1530c67d27f4e3ce85da38d69bc34f5232324. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->