### PR TITLE
Bump our pytest timeout to 10 minutes

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -311,8 +311,8 @@ jobs:
           TEST_PID=$!
           echo "Started test.sh with PID: $TEST_PID"
 
-          # Wait for 6 minutes (360 seconds)
-          for i in {1..360}; do
+          # Wait for 10 minutes (600 seconds)
+          for i in {1..600}; do
             if ! kill -0 $TEST_PID 2>/dev/null; then
               echo "Test completed normally"
               wait $TEST_PID
@@ -321,7 +321,7 @@ jobs:
             sleep 1
           done
 
-          echo "Test has been running for 6 minutes, capturing backtraces..."
+          echo "Test has been running for 10 minutes, capturing backtraces..."
 
           # Get all processes related to our test
           echo "=== Process tree ==="


### PR DESCRIPTION
The test execution time is now exceeding 6 minutes when running without provider-proxy cache (even though it's not hanging). Let's bump it to 10 minutes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase test wait time from 6 to 10 minutes in `merge-queue.yml` to accommodate longer test execution.
> 
>   - **Behavior**:
>     - Increase test wait time from 6 to 10 minutes in `merge-queue.yml`.
>     - Adjusts the loop iteration count from 360 to 600 seconds for test completion check.
>     - Updates log message to reflect the new 10-minute wait time.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 24fe5dfcbbfb184045660acda1c279468979b60c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->