### PR TITLE
Add a 500ms sleep into datapoint creation ui e2e test

### DIFF
--- a/ui/e2e_tests/evaluations.eval_name.datapoint_id.spec.ts
+++ b/ui/e2e_tests/evaluations.eval_name.datapoint_id.spec.ts
@@ -140,6 +140,9 @@ test("should be able to add a datapoint from the evaluation page", async ({
   await viewButton.waitFor({ state: "visible" });
   await viewButton.click();
 
+  // Wait for 500ms. TODO - figure out why waitForURL and waitForLoadState("networkidle") are not enough.
+  await page.waitForTimeout(500);
+
   // Wait for navigation to the new datapoint page
   await page.waitForURL(`/datasets/${datasetName}/datapoint/**`, {
     timeout: 5000,


### PR DESCRIPTION
Waiting for "networkidle" is not actually enough to fix the race condition - in https://github.com/tensorzero/tensorzero/actions/runs/19840316340/job/56847597903 the Playwright trace and video show the events firing after the page URL has changed, but before we've actually navigated to the new page.

I suspect that this is related to the special react-router navigation logic - let's just add a sleep for now
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add a 500ms delay in `evaluations.eval_name.datapoint_id.spec.ts` to address a race condition during page navigation.
> 
>   - **Behavior**:
>     - Adds a 500ms delay in `evaluations.eval_name.datapoint_id.spec.ts` to address race condition during page navigation.
>     - Temporary fix due to `waitForURL` and `waitForLoadState("networkidle")` being insufficient.
>   - **Misc**:
>     - Adds a TODO comment to investigate the root cause of the issue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4660b308f5ec92935335f24a807e236dbaafdcd6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->