### PR TITLE
Make mime_type optional in base64 file input

### DIFF
--- a/clients/python/tensorzero/types.py
+++ b/clients/python/tensorzero/types.py
@@ -90,14 +90,14 @@ class RawText(ContentBlock):
 @dataclass
 class ImageBase64(ContentBlock):
     data: Optional[str]
-    mime_type: str
+    mime_type: Optional[str] = None
     type: str = "image"
 
 
 @dataclass
 class FileBase64(ContentBlock):
     data: Optional[str]
-    mime_type: str
+    mime_type: Optional[str] = None
     type: str = "file"
 
 

--- a/tensorzero-core/src/client/input_handling.rs
+++ b/tensorzero-core/src/client/input_handling.rs
@@ -51,7 +51,7 @@ fn resolved_input_message_content_to_client_input_message_content(
             let detail = file.detail;
             let filename = file.filename;
 
-            let base64_file = Base64File::new(None, mime_type, data, detail, filename)?;
+            let base64_file = Base64File::new(None, Some(mime_type), data, detail, filename)?;
             InputMessageContent::File(File::Base64(base64_file))
         }
         ResolvedInputMessageContent::Unknown(unknown) => InputMessageContent::Unknown(unknown),

--- a/tensorzero-core/src/endpoints/datasets/v1/update_datapoints.rs
+++ b/tensorzero-core/src/endpoints/datasets/v1/update_datapoints.rs
@@ -635,7 +635,7 @@ mod tests {
             let file = File::Base64(
                 Base64File::new(
                     None,
-                    mime::IMAGE_PNG,
+                    Some(mime::IMAGE_PNG),
                     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==".to_string(),
                     None,
                     None,

--- a/tensorzero-core/src/endpoints/inference.rs
+++ b/tensorzero-core/src/endpoints/inference.rs
@@ -1826,7 +1826,7 @@ mod tests {
             InputMessageContent::File(File::Base64(
                 Base64File::new(
                     None,
-                    mime::IMAGE_PNG,
+                    Some(mime::IMAGE_PNG),
                     "fake_base64_data".to_string(),
                     None,
                     None
@@ -1853,7 +1853,7 @@ mod tests {
         let file_base64 = File::Base64(
             Base64File::new(
                 None,
-                mime::IMAGE_PNG,
+                Some(mime::IMAGE_PNG),
                 "fake_base64_data".to_string(),
                 None,
                 None,
@@ -1925,7 +1925,7 @@ mod tests {
             InputMessageContent::File(File::Base64(
                 Base64File::new(
                     None,
-                    mime::IMAGE_PNG,
+                    Some(mime::IMAGE_PNG),
                     "fake_base64_data".to_string(),
                     None,
                     None
@@ -1993,8 +1993,14 @@ mod tests {
     fn test_file_roundtrip_serialization() {
         // Test that serialize -> deserialize maintains data integrity
         let original = File::Base64(
-            Base64File::new(None, mime::IMAGE_JPEG, "abcdef".to_string(), None, None)
-                .expect("test data should be valid"),
+            Base64File::new(
+                None,
+                Some(mime::IMAGE_JPEG),
+                "abcdef".to_string(),
+                None,
+                None,
+            )
+            .expect("test data should be valid"),
         );
 
         let serialized = serde_json::to_string(&original).unwrap();

--- a/tensorzero-core/src/endpoints/openai_compatible/types/input_files.rs
+++ b/tensorzero-core/src/endpoints/openai_compatible/types/input_files.rs
@@ -89,8 +89,13 @@ pub fn convert_image_url_to_file(image_url: OpenAICompatibleImageUrl) -> Result<
     if image_url.url.scheme() == "data" {
         let image_url_str = image_url.url.to_string();
         let (mime_type, data) = parse_base64_file_data_url(&image_url_str)?;
-        let base64_file =
-            Base64File::new(None, mime_type, data.to_string(), image_url.detail, None)?;
+        let base64_file = Base64File::new(
+            None,
+            Some(mime_type),
+            data.to_string(),
+            image_url.detail,
+            None,
+        )?;
         Ok(File::Base64(base64_file))
     } else {
         Ok(File::Url(UrlFile {
@@ -107,7 +112,8 @@ pub fn convert_image_url_to_file(image_url: OpenAICompatibleImageUrl) -> Result<
 /// Parses the data URL and extracts MIME type and base64 data.
 pub fn convert_file_to_base64(file: OpenAICompatibleFile) -> Result<File, Error> {
     let (mime_type, data) = parse_base64_file_data_url(&file.file_data)?;
-    let base64_file = Base64File::new(None, mime_type, data.to_string(), None, file.filename)?;
+    let base64_file =
+        Base64File::new(None, Some(mime_type), data.to_string(), None, file.filename)?;
     Ok(File::Base64(base64_file))
 }
 
@@ -183,7 +189,7 @@ pub fn convert_input_audio_to_file(input_audio: OpenAICompatibleInputAudio) -> R
     };
 
     // Create Base64File with the inferred MIME type and original base64 data
-    let base64_file = Base64File::new(None, mime_type, input_audio.data, None, None)?;
+    let base64_file = Base64File::new(None, Some(mime_type), input_audio.data, None, None)?;
     Ok(File::Base64(base64_file))
 }
 

--- a/tensorzero-core/src/inference/types/mod.rs
+++ b/tensorzero-core/src/inference/types/mod.rs
@@ -399,7 +399,7 @@ impl InputMessageContent {
                         let storage_kind = get_storage_kind(context)?;
                         let base64_file_for_path = Base64File::new(
                             source_url.clone(),
-                            mime_type.clone(),
+                            Some(mime_type.clone()),
                             data.to_string(),
                             // We explicitly set detail to None when computing the storage path.
                             // This is intentional for content-addressing: the detail parameter controls
@@ -627,7 +627,7 @@ impl LazyResolvedInputMessageContent {
                     let resolved_file = future.await?;
                     let base64_file = Base64File::new(
                         resolved_file.file.source_url.clone(),
-                        resolved_file.file.mime_type.clone(),
+                        Some(resolved_file.file.mime_type.clone()),
                         resolved_file.data.clone(),
                         resolved_file.file.detail.clone(),
                         resolved_file.file.filename.clone(),
@@ -648,7 +648,7 @@ impl LazyResolvedInputMessageContent {
                 LazyFile::Base64(pending) => {
                     let base64_file = Base64File::new(
                         pending.0.file.source_url.clone(),
-                        pending.0.file.mime_type.clone(),
+                        Some(pending.0.file.mime_type.clone()),
                         pending.0.data.clone(),
                         pending.0.file.detail.clone(),
                         pending.0.file.filename.clone(),

--- a/tensorzero-core/src/inference/types/resolved_input.rs
+++ b/tensorzero-core/src/inference/types/resolved_input.rs
@@ -231,7 +231,7 @@ impl ResolvedInput {
                     if let ResolvedInputMessageContent::File(resolved) = content_block {
                         let raw = match Base64File::new(
                             resolved.file.source_url.clone(),
-                            resolved.file.mime_type.clone(),
+                            Some(resolved.file.mime_type.clone()),
                             resolved.data.clone(),
                             resolved.file.detail.clone(),
                             resolved.file.filename.clone(),

--- a/tensorzero-core/tests/e2e/image_url.rs
+++ b/tensorzero-core/tests/e2e/image_url.rs
@@ -299,7 +299,7 @@ async fn test_base64_image_with_fetch_true() {
                         InputMessageContent::File(File::Base64(
                             Base64File::new(
                                 None,
-                                mime::IMAGE_PNG,
+                                Some(mime::IMAGE_PNG),
                                 IMAGE_BASE64.to_string(),
                                 None,
                                 None,
@@ -379,7 +379,7 @@ async fn test_base64_image_with_fetch_false() {
                         InputMessageContent::File(File::Base64(
                             Base64File::new(
                                 None,
-                                mime::IMAGE_PNG,
+                                Some(mime::IMAGE_PNG),
                                 IMAGE_BASE64.to_string(),
                                 None,
                                 None,

--- a/tensorzero-core/tests/e2e/inference/mod.rs
+++ b/tensorzero-core/tests/e2e/inference/mod.rs
@@ -3225,7 +3225,7 @@ async fn test_image_inference_without_object_store() {
                         InputMessageContent::File(File::Base64(
                             Base64File::new(
                                 None,
-                                mime::IMAGE_PNG,
+                                Some(mime::IMAGE_PNG),
                                 BASE64_STANDARD.encode(FERRIS_PNG),
                                 None,
                                 None,

--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -1766,7 +1766,7 @@ pub async fn test_base64_pdf_inference_with_provider_and_store(
                             InputMessageContent::File(File::Base64(
                                 Base64File::new(
                                     None,
-                                    mime::APPLICATION_PDF,
+                                    Some(mime::APPLICATION_PDF),
                                     pdf_data.clone(),
                                     None,
                                     None,
@@ -1832,7 +1832,7 @@ pub async fn test_base64_image_inference_with_provider_and_store(
                     InputMessageContent::File(File::Base64(
                         Base64File::new(
                             None,
-                            mime::IMAGE_PNG,
+                            Some(mime::IMAGE_PNG),
                             image_data.clone(),
                             Some(Detail::Low),
                             None,
@@ -1895,7 +1895,7 @@ pub async fn test_base64_image_inference_with_provider_and_store(
     let updated_base64 = BASE64_STANDARD.encode(updated_image.into_inner());
 
     params.input.messages[0].content[1] = InputMessageContent::File(File::Base64(
-        Base64File::new(None, mime::IMAGE_PNG, updated_base64, None, None)
+        Base64File::new(None, Some(mime::IMAGE_PNG), updated_base64, None, None)
             .expect("test data should be valid"),
     ));
 

--- a/tensorzero-core/tests/e2e/providers/commonv2/input_audio.rs
+++ b/tensorzero-core/tests/e2e/providers/commonv2/input_audio.rs
@@ -120,7 +120,7 @@ pub async fn test_base64_audio_inference_with_provider_and_store(
                             InputMessageContent::File(File::Base64(
                                 Base64File::new(
                                     None,
-                                    "audio/mpeg".parse().unwrap(),
+                                    Some("audio/mpeg".parse().unwrap()),
                                     audio_data.clone(),
                                     None,
                                     None,


### PR DESCRIPTION
When the user doesn't provide a mime-type, we try to detect it from the file contents, erroring if we fail to detect the file type. The rest of the file-handling code still always has a mime-type available (e.g. when reading/writing StoredFile)

Fixes https://github.com/tensorzero/tensorzero/issues/4904
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `mime_type` optional in base64 file inputs, inferring type if not provided, with error handling for undetectable types.
> 
>   - **Behavior**:
>     - `mime_type` in `ImageBase64` and `FileBase64` is now optional in `types.py`.
>     - If `mime_type` is not provided, it is inferred from file data in `Base64File::new` in `file.rs`.
>     - Errors if `mime_type` cannot be inferred.
>   - **Tests**:
>     - Added `test_file_inference_base64_infer_mime_type` and `test_file_inference_base64_bad_content_no_mime_type` in `test_client.py` to verify behavior.
>   - **Code Changes**:
>     - Updated `Base64File::new` calls to wrap `mime_type` in `Some()` in `input_handling.rs`, `update_datapoints.rs`, `inference.rs`, `input_files.rs`, `mod.rs`, `resolved_input.rs`, `image_url.rs`, `mod.rs`, `common.rs`, and `input_audio.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6b98d9b15f8db39fbe005bb5a2343a16789b6c33. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->