### PR TITLE
Load all datasets in the UI and sort in the frontend

### DIFF
--- a/ui/app/routes/datasets/DatasetTable.tsx
+++ b/ui/app/routes/datasets/DatasetTable.tsx
@@ -19,10 +19,13 @@ import {
   getCoreRowModel,
   getSortedRowModel,
   getFilteredRowModel,
+  getPaginationRowModel,
   createColumnHelper,
   flexRender,
   type SortingState,
+  type PaginationState,
 } from "@tanstack/react-table";
+import PageButtons from "~/components/utils/PageButtons";
 import {
   Dialog,
   DialogContent,
@@ -36,9 +39,9 @@ import { ReadOnlyGuard } from "~/components/utils/read-only-guard";
 const columnHelper = createColumnHelper<DatasetMetadata>();
 
 export default function DatasetTable({
-  counts,
+  datasets,
 }: {
-  counts: DatasetMetadata[];
+  datasets: DatasetMetadata[];
 }) {
   const fetcher = useFetcher();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -46,6 +49,10 @@ export default function DatasetTable({
 
   const [sorting, setSorting] = useState<SortingState>([]);
   const [globalFilter, setGlobalFilter] = useState("");
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 15,
+  });
 
   const columns = useMemo(
     () => [
@@ -99,17 +106,20 @@ export default function DatasetTable({
   );
 
   const table = useReactTable({
-    data: counts,
+    data: datasets,
     columns,
     state: {
       sorting,
       globalFilter,
+      pagination,
     },
     onSortingChange: setSorting,
     onGlobalFilterChange: setGlobalFilter,
+    onPaginationChange: setPagination,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
     globalFilterFn: "includesString",
   });
 
@@ -187,6 +197,13 @@ export default function DatasetTable({
           )}
         </TableBody>
       </Table>
+
+      <PageButtons
+        onPreviousPage={() => table.previousPage()}
+        onNextPage={() => table.nextPage()}
+        disablePrevious={!table.getCanPreviousPage()}
+        disableNext={!table.getCanNextPage()}
+      />
 
       <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
         <DialogContent>

--- a/ui/app/routes/datasets/route.tsx
+++ b/ui/app/routes/datasets/route.tsx
@@ -1,9 +1,7 @@
-import { countDatasets } from "~/utils/clickhouse/datasets.server";
 import type { Route } from "./+types/route";
 import DatasetTable from "./DatasetTable";
 import { data, isRouteErrorResponse } from "react-router";
 import { useNavigate } from "react-router";
-import PageButtons from "~/components/utils/PageButtons";
 import {
   PageHeader,
   PageLayout,
@@ -14,21 +12,9 @@ import { logger } from "~/utils/logger";
 import { getNativeTensorZeroClient } from "~/utils/tensorzero/native_client.server";
 import { getTensorZeroClient } from "~/utils/tensorzero.server";
 
-export async function loader({ request }: Route.LoaderArgs) {
-  const url = new URL(request.url);
-  const limit = Number(url.searchParams.get("limit")) || 15;
-  const offset = Number(url.searchParams.get("offset")) || 0;
-  if (limit > 100) {
-    throw data("Limit cannot exceed 100", { status: 400 });
-  }
-  const [datasetMetadata, numberOfDatasets] = await Promise.all([
-    getTensorZeroClient().listDatasets({
-      limit,
-      offset,
-    }),
-    countDatasets(),
-  ]);
-  return { counts: datasetMetadata.datasets, limit, offset, numberOfDatasets };
+export async function loader() {
+  const datasetMetadata = await getTensorZeroClient().listDatasets({});
+  return { datasets: datasetMetadata.datasets };
 }
 
 export async function action({ request }: Route.ActionArgs) {
@@ -47,30 +33,14 @@ export async function action({ request }: Route.ActionArgs) {
 }
 
 export default function DatasetListPage({ loaderData }: Route.ComponentProps) {
-  const { counts, limit, offset, numberOfDatasets } = loaderData;
+  const { datasets } = loaderData;
   const navigate = useNavigate();
-  const handleNextPage = () => {
-    const searchParams = new URLSearchParams(window.location.search);
-    searchParams.set("offset", String(offset + limit));
-    navigate(`?${searchParams.toString()}`, { preventScrollReset: true });
-  };
-  const handlePreviousPage = () => {
-    const searchParams = new URLSearchParams(window.location.search);
-    searchParams.set("offset", String(offset - limit));
-    navigate(`?${searchParams.toString()}`, { preventScrollReset: true });
-  };
   return (
     <PageLayout>
-      <PageHeader heading="Datasets" count={numberOfDatasets} />
+      <PageHeader heading="Datasets" count={datasets.length} />
       <SectionLayout>
         <DatasetsActions onBuildDataset={() => navigate("/datasets/builder")} />
-        <DatasetTable counts={counts} />
-        <PageButtons
-          onPreviousPage={handlePreviousPage}
-          onNextPage={handleNextPage}
-          disablePrevious={offset === 0}
-          disableNext={offset + limit >= numberOfDatasets}
-        />
+        <DatasetTable datasets={datasets} />
       </SectionLayout>
     </PageLayout>
   );


### PR DESCRIPTION
Datasets were paginated in the backend but that doesn't work with the frontend sorting. This loads all datasets into the UI and sorts on the frontend. Scale should be less than ~10k datasets so this should be performant (tanstack table can handle 100K rows - https://tanstack.com/table/latest/docs/guide/pagination#should-you-use-client-side-pagination)

Fixes #4927.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Switch dataset loading to client-side pagination and sorting in the UI, removing server-side pagination logic.
> 
>   - **Behavior**:
>     - Load all datasets in the UI by fetching all dataset metadata in `loader()` in `route.tsx`.
>     - Implement client-side pagination and sorting in `DatasetTable.tsx` using `@tanstack/react-table`.
>     - Remove server-side pagination logic from `loader()` in `route.tsx`.
>   - **UI Components**:
>     - Add `PageButtons` for pagination controls in `DatasetTable.tsx`.
>     - Update `DatasetTable` to use `datasets` prop instead of `counts`.
>   - **Misc**:
>     - Update `PageHeader` in `DatasetListPage` to display dataset count from `datasets.length`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 83194968fccfffadf201c22568fd2130f90b0ec0. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->