### PR TITLE
Fix `_internal_provider_type` in Python SDK

### DIFF
--- a/clients/python/tensorzero/generated_types.py
+++ b/clients/python/tensorzero/generated_types.py
@@ -1202,7 +1202,7 @@ class Thought:
 
     field_internal_provider_type: str | None = None
     """
-    When set, this 'Thought' block will only be used for providers
+    When set, this `Thought` block will only be used for providers
     matching this type (e.g. `anthropic`). Other providers will emit
     a warning and discard the block.
     """

--- a/clients/python/tensorzero/types.py
+++ b/clients/python/tensorzero/types.py
@@ -288,6 +288,7 @@ def parse_content_block(block: Dict[str, Any]) -> ContentBlock:
             signature=block.get("signature"),
             summary=summary,
             type=block_type,
+            _internal_provider_type=block.get("_internal_provider_type"),
         )
     elif block_type == "unknown":
         return UnknownContentBlock(

--- a/internal/tensorzero-node/lib/bindings/Thought.ts
+++ b/internal/tensorzero-node/lib/bindings/Thought.ts
@@ -13,7 +13,7 @@ export type Thought = {
   signature?: string;
   summary?: Array<ThoughtSummaryBlock>;
   /**
-   * When set, this 'Thought' block will only be used for providers
+   * When set, this `Thought` block will only be used for providers
    * matching this type (e.g. `anthropic`). Other providers will emit
    * a warning and discard the block.
    */

--- a/tensorzero-core/src/config/mod.rs
+++ b/tensorzero-core/src/config/mod.rs
@@ -1278,7 +1278,6 @@ pub struct UninitializedConfig {
     #[serde(default)]
     pub rate_limiting: UninitializedRateLimitingConfig,
     pub object_storage: Option<StorageKind>,
-
     #[serde(default)]
     pub models: HashMap<Arc<str>, UninitializedModelConfig>, // model name => model config
     #[serde(default)]

--- a/tensorzero-core/src/inference/types/mod.rs
+++ b/tensorzero-core/src/inference/types/mod.rs
@@ -1008,7 +1008,7 @@ pub struct Thought {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub summary: Option<Vec<ThoughtSummaryBlock>>,
-    /// When set, this 'Thought' block will only be used for providers
+    /// When set, this `Thought` block will only be used for providers
     /// matching this type (e.g. `anthropic`). Other providers will emit
     /// a warning and discard the block.
     #[serde(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `_internal_provider_type` handling in `Thought` class across Python and TypeScript SDKs.
> 
>   - **Behavior**:
>     - Fix `_internal_provider_type` handling in `Thought` class in `types.py` and `generated_types.py`.
>     - Update `parse_content_block()` in `types.py` to include `_internal_provider_type`.
>   - **TypeScript**:
>     - Update `Thought.ts` to include `_internal_provider_type` field.
>   - **Misc**:
>     - Fix comment style in `generated_types.py` and `Thought.ts` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 23222ce4e6ffccd1686d2feccdb387ca0df135ff. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->