### PR TITLE
Do not prepend dataclass fields

### DIFF
--- a/clients/python/generate_schema_types.py
+++ b/clients/python/generate_schema_types.py
@@ -187,6 +187,9 @@ def generate_dataclasses_from_schema(schema_file: Path, templates_dir: Path, out
                 # Generate Literal["a", "b", "c"] for unit enum values
                 "--enum-field-as-literal",
                 "all",
+                # Do not prefix fields with anything, even if they start with an underscore
+                "--special-field-name-prefix",
+                "",
                 # Do not generate __future__ imports; they are useless
                 # and conflict with custom file headers
                 "--disable-future-imports",

--- a/clients/python/tensorzero/generated_types.py
+++ b/clients/python/tensorzero/generated_types.py
@@ -1200,7 +1200,7 @@ class Thought:
     Struct that represents a model's reasoning
     """
 
-    field_internal_provider_type: str | None = None
+    _internal_provider_type: str | None = None
     """
     When set, this 'Thought' block will only be used for providers
     matching this type (e.g. `anthropic`). Other providers will emit


### PR DESCRIPTION
Fixes #4946
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add option to prevent prefixing dataclass fields in `generate_schema_types.py` and update `Thought` class field name in `generated_types.py`.
> 
>   - **Behavior**:
>     - Add `--special-field-name-prefix` option with an empty string in `generate_dataclasses_from_schema()` in `generate_schema_types.py` to prevent prefixing dataclass fields.
>   - **Classes**:
>     - Rename `field_internal_provider_type` to `_internal_provider_type` in `Thought` class in `generated_types.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c59f8c4564b3474a8f30a8da115c17cbdf5b5a8e. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->