### PR TITLE
Use Namespace cache volume for large clickhouse fixtures

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -773,6 +773,12 @@ jobs:
         if: matrix.replicated == true
         run: echo "TENSORZERO_CLICKHOUSE_CLUSTER_NAME=tensorzero_e2e_tests_cluster" >> $GITHUB_ENV
 
+      - name: Setup Namespace caching for Clickhouse fixtures
+        uses: namespacelabs/nscloud-cache-action@446d8f390563cd54ca27e8de5bdb816f63c0b706
+        with:
+          path: |
+            ./ui/fixtures/s3-fixtures/
+
       - name: Install uv
         run: curl -LsSf --retry 2 --retry-delay 10 --retry-max-time 60 https://astral.sh/uv/0.6.17/install.sh | sh
 


### PR DESCRIPTION
Our './ui/fixtures/download-fixtures.py' script compares the remote ETag against the on-disk file, so this is safe to use. This should allow us to avoid re-downloading the large fixtures from Cloudflare R2 on every run
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Namespace caching for Clickhouse fixtures in GitHub Actions to avoid re-downloading large files.
> 
>   - **Workflow**:
>     - Add Namespace caching setup for Clickhouse fixtures in `general.yml` under `clickhouse-tests` job.
>     - Uses `namespacelabs/nscloud-cache-action` to cache `./ui/fixtures/s3-fixtures/`.
>   - **Scripts**:
>     - `download-fixtures.py` script compares remote ETag with on-disk file to ensure safe caching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c2c59b974091ab51880a5da7e7e4616151a08cfb. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->