### PR TITLE
Switch client-tests job back to free Github runner

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -186,6 +186,9 @@ jobs:
           done
         shell: bash
 
+      - name: Install Namespace CLI
+        uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
+
       - name: Configure Namespace-powered Buildx
         uses: namespacelabs/nscloud-setup-buildx-action@91c2e6537780e3b092cb8476406be99a8f91bd5e
         with:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Switches `client-tests` job in `merge-queue.yml` to use `ubuntu-latest` runner and modifies related steps.
> 
>   - **Runner Change**:
>     - `client-tests` job in `merge-queue.yml` now runs on `ubuntu-latest` instead of `namespace-profile-tensorzero-8x16`.
>   - **Steps Modified**:
>     - Adds step to install Namespace CLI in `client-tests` job.
>     - Removes step to configure Namespace cache for Python and pnpm in `client-tests` job.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a2339253a53bb8e40c9f00a4312fdb34914bf615. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->