### PR TITLE
Bump listInferencesWithPagination test timeout for now

### DIFF
--- a/ui/app/utils/clickhouse/inference.test.ts
+++ b/ui/app/utils/clickhouse/inference.test.ts
@@ -98,7 +98,8 @@ test("countInferencesForVariant returns correct counts", async () => {
 // Tests for listInferencesWithPagination (new cursor-based pagination API)
 test(
   "listInferencesWithPagination basic pagination",
-  { timeout: 10_000 },
+  // TODO - lower this timeout when we figure out what's wrong with clickhouse lts
+  { timeout: 20_000 },
   async () => {
     const result = await listInferencesWithPagination({
       limit: 10,


### PR DESCRIPTION
This is almost always timing out on the most recent clickhouse lts. Until we can figure out why, let's bump the timeout to unblock ci
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase timeout for `listInferencesWithPagination` test in `inference.test.ts` to address Clickhouse LTS timeout issues.
> 
>   - **Tests**:
>     - Increase timeout for `listInferencesWithPagination basic pagination` test in `inference.test.ts` from 10,000ms to 20,000ms to address timeout issues with Clickhouse LTS.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8886ff721ecefb8d7c145c4d53e261941dc409fd. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->