### PR TITLE
Compute stream TTFT based on first (possibly empty) chunk

### DIFF
--- a/tensorzero-core/src/inference/types/streams.rs
+++ b/tensorzero-core/src/inference/types/streams.rs
@@ -270,7 +270,6 @@ pub async fn collect_chunks(args: CollectChunksArgs) -> Result<InferenceResult, 
     });
     // `usage` is `None` until we receive a chunk with usage information
     let mut usage: Option<Usage> = None;
-    let mut ttft: Option<Duration> = None;
     let response_time = value
         .last()
         .ok_or_else(|| {
@@ -288,6 +287,15 @@ pub async fn collect_chunks(args: CollectChunksArgs) -> Result<InferenceResult, 
     // This is used to build up a thought summary list for each thought,
     // which is used to construct the final 'summary' field on Thought.
     let mut thought_summaries: IndexMap<String, IndexSet<String>> = IndexMap::new();
+
+    // Set our TTFT to the latency of the first chunk, regardless of whether the chunk actually had any content.
+    // Some models can produce entirely empty chunks - we treat this as the "first token" being the invisible
+    // end-of-response marker.
+    let ttft = value.first().map(|chunk| chunk.latency()).ok_or_else(|| {
+        Error::new(ErrorDetails::TypeConversion {
+            message: "Never got TTFT because there were no chunks in the response".to_string(),
+        })
+    })?;
 
     for chunk in value {
         if let Some(chunk_usage) = chunk.usage() {
@@ -313,8 +321,6 @@ pub async fn collect_chunks(args: CollectChunksArgs) -> Result<InferenceResult, 
                                 &mut blocks,
                                 (ContentBlockOutputType::Text, text.id),
                                 text.text,
-                                &mut ttft,
-                                chunk.latency,
                                 Into::into,
                                 |block, text| {
                                     if let ContentBlockOutput::Text(Text {
@@ -345,8 +351,6 @@ pub async fn collect_chunks(args: CollectChunksArgs) -> Result<InferenceResult, 
                                     &mut blocks,
                                     (ContentBlockOutputType::Thought, id.clone()),
                                     text,
-                                    &mut ttft,
-                                    chunk.latency,
                                     |text| {
                                         ContentBlockOutput::Thought(Thought {
                                             text: Some(text),
@@ -367,8 +371,6 @@ pub async fn collect_chunks(args: CollectChunksArgs) -> Result<InferenceResult, 
                                     &mut blocks,
                                     (ContentBlockOutputType::Thought, id.clone()),
                                     signature,
-                                    &mut ttft,
-                                    chunk.latency,
                                     |signature| {
                                         ContentBlockOutput::Thought(Thought {
                                             text: None,
@@ -411,8 +413,6 @@ pub async fn collect_chunks(args: CollectChunksArgs) -> Result<InferenceResult, 
                                     &mut blocks,
                                     (ContentBlockOutputType::Thought, id),
                                     summary_text,
-                                    &mut ttft,
-                                    chunk.latency,
                                     |summary_text| {
                                         ContentBlockOutput::Thought(Thought {
                                             text: None,
@@ -476,9 +476,6 @@ pub async fn collect_chunks(args: CollectChunksArgs) -> Result<InferenceResult, 
                                 }
                                 // If there is no tool call block, create one
                                 _ => {
-                                    if ttft.is_none() {
-                                        ttft = Some(chunk.latency);
-                                    }
                                     blocks.insert(
                                         (ContentBlockOutputType::ToolCall, tool_call.id.clone()),
                                         ContentBlockOutput::ToolCall(tool_call_chunk_to_tool_call(
@@ -494,11 +491,6 @@ pub async fn collect_chunks(args: CollectChunksArgs) -> Result<InferenceResult, 
                             model_name,
                             provider_name,
                         }) => {
-                            // Unknown chunks are not merged/coalesced - each one gets a unique entry
-                            // We use the chunk ID as part of the key to ensure uniqueness
-                            if ttft.is_none() {
-                                ttft = Some(chunk.latency);
-                            }
                             blocks.insert(
                                 (ContentBlockOutputType::Unknown, id.clone()),
                                 ContentBlockOutput::Unknown(Unknown {
@@ -526,11 +518,6 @@ pub async fn collect_chunks(args: CollectChunksArgs) -> Result<InferenceResult, 
                     }
                     // If there is no text block, create one
                     _ => {
-                        // We put this here and below rather than in the loop start because we
-                        // only want to set TTFT if there is some real content
-                        if ttft.is_none() {
-                            ttft = Some(chunk.latency);
-                        }
                         if let Some(raw) = chunk.raw {
                             blocks
                                 .insert((ContentBlockOutputType::Text, String::new()), raw.into());
@@ -563,11 +550,6 @@ pub async fn collect_chunks(args: CollectChunksArgs) -> Result<InferenceResult, 
             }
         }
     }
-    let ttft = ttft.ok_or_else(|| {
-        Error::new(ErrorDetails::TypeConversion {
-            message: "Never got TTFT because there was never content in the response.".to_string(),
-        })
-    })?;
     let latency = Latency::Streaming {
         ttft,
         response_time,
@@ -670,8 +652,6 @@ fn handle_textual_content_block<F, A>(
     blocks: &mut IndexMap<(ContentBlockOutputType, String), ContentBlockOutput>,
     key: (ContentBlockOutputType, String),
     text: String,
-    ttft: &mut Option<Duration>,
-    chunk_latency: Duration,
     create_block: F,
     append_text: A,
 ) where
@@ -683,10 +663,6 @@ fn handle_textual_content_block<F, A>(
         Some(existing_block) => append_text(existing_block, &text),
         // If there is no block, create one
         _ => {
-            // We only want to set TTFT if there is some real content
-            if ttft.is_none() {
-                *ttft = Some(chunk_latency);
-            }
             if !text.is_empty() {
                 blocks.insert(key, create_block(text));
             }
@@ -715,16 +691,12 @@ mod tests {
     fn test_handle_textual_content_block() {
         let mut blocks: IndexMap<(ContentBlockOutputType, String), ContentBlockOutput> =
             IndexMap::new();
-        let mut ttft: Option<Duration> = None;
-        let chunk_latency = Duration::from_millis(100);
 
         // Test case 1: Create new text block
         handle_textual_content_block(
             &mut blocks,
             (ContentBlockOutputType::Text, "1".to_string()),
             "Hello".to_string(),
-            &mut ttft,
-            chunk_latency,
             |text| ContentBlockOutput::Text(Text { text }),
             |block, text| {
                 if let ContentBlockOutput::Text(Text {
@@ -737,7 +709,6 @@ mod tests {
         );
 
         assert_eq!(blocks.len(), 1);
-        assert_eq!(ttft, Some(chunk_latency));
         match blocks
             .get(&(ContentBlockOutputType::Text, "1".to_string()))
             .unwrap()
@@ -751,8 +722,6 @@ mod tests {
             &mut blocks,
             (ContentBlockOutputType::Text, "1".to_string()),
             " World".to_string(),
-            &mut ttft,
-            chunk_latency,
             |text| ContentBlockOutput::Text(Text { text }),
             |block, text| {
                 if let ContentBlockOutput::Text(Text {
@@ -778,8 +747,6 @@ mod tests {
             &mut blocks,
             (ContentBlockOutputType::Text, "2".to_string()),
             String::new(),
-            &mut ttft,
-            chunk_latency,
             |text| ContentBlockOutput::Text(Text { text }),
             |block, text| {
                 if let ContentBlockOutput::Text(Text {
@@ -798,8 +765,6 @@ mod tests {
             &mut blocks,
             (ContentBlockOutputType::Thought, "3".to_string()),
             "Thinking...".to_string(),
-            &mut ttft,
-            chunk_latency,
             |text| {
                 ContentBlockOutput::Thought(Thought {
                     text: Some(text),


### PR DESCRIPTION
By prefilling with 'assistant' messages, it's possible to make some models produce a completely empty stream response (all chunks have empty content arrays). We now treat the arrival of this chunk as the first 'token' (the invisible stop-sequence token).

As a result, we now create database entries for completely empty stream responses (matching what we do in the non-streaming case)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set TTFT to the latency of the first chunk in `collect_chunks()` to handle empty stream responses, ensuring database entries are created.
> 
>   - **Behavior**:
>     - In `collect_chunks()` in `streams.rs`, set TTFT to latency of first chunk, even if empty, treating it as the first token.
>     - Ensures database entries for empty stream responses, matching non-streaming behavior.
>   - **Tests**:
>     - Add `test_empty_chunks_success()` in `anthropic.rs` to verify handling of empty chunks and TTFT calculation.
>   - **Misc**:
>     - Remove redundant TTFT setting logic in `streams.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d32bafcabce12e0749d0e0e39d3d710f36df2021. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->