### PR TITLE
Bump clickhouse sleep in mock_batch test

### DIFF
--- a/tensorzero-core/tests/e2e/providers/mock_batch.rs
+++ b/tensorzero-core/tests/e2e/providers/mock_batch.rs
@@ -844,7 +844,7 @@ pub async fn test_multi_turn_tool_use_unified_mock_batch_with_provider(
     // Step 4: Verify ClickHouse storage
     let clickhouse = get_clickhouse().await;
     // Sleep to allow ClickHouse async_insert to become visible
-    sleep(Duration::from_millis(200)).await;
+    sleep(Duration::from_millis(1000)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(


### PR DESCRIPTION
We saw a stale read in a ci run, so let's sleep for even longer
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase sleep duration in `mock_batch.rs` test to ensure ClickHouse async inserts are visible before verification.
> 
>   - **Tests**:
>     - Increase sleep duration from 200ms to 1000ms in `test_multi_turn_tool_use_unified_mock_batch_with_provider()` in `mock_batch.rs` to ensure ClickHouse async inserts are visible before verification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8a5dca8e97b9b3da28882c2c8524519fdbfbf152. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->