### PR TITLE
Increase worker count for ui e2e tests

### DIFF
--- a/.github/workflows/ui-tests-e2e-model-inference-cache.yml
+++ b/.github/workflows/ui-tests-e2e-model-inference-cache.yml
@@ -273,7 +273,7 @@ jobs:
           # These 2 vars are set so the env.server code doesn't complain
           TENSORZERO_UI_CONFIG_PATH: "ui/fixtures/config/tensorzero.toml"
           TENSORZERO_GATEWAY_URL: "placeholder"
-        run: pnpm ui:test:e2e --grep-invert "@credentials" -j 4
+        run: pnpm ui:test:e2e --grep-invert "@credentials" -j 8
 
       - name: Print Docker Compose logs
         if: always()


### PR DESCRIPTION
This job is now consistently the bottleneck for the merge queue, so let's see if we can speed it up
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase worker count from 4 to 8 for UI E2E tests in `ui-tests-e2e-model-inference-cache.yml`.
> 
>   - **Behavior**:
>     - Increase worker count from 4 to 8 in `ui-tests-e2e-model-inference-cache.yml` for `pnpm ui:test:e2e` command to potentially speed up UI E2E tests.
>   - **Misc**:
>     - No other changes or files affected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 617c774d21b81ea83dbff5bdf1cbc9c53281c702. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->