### PR TITLE
Rename ExtraBodyReplacementKind::Value

### DIFF
--- a/clients/python/tensorzero/generated_types.py
+++ b/clients/python/tensorzero/generated_types.py
@@ -262,11 +262,11 @@ ExtraBody = (
 
 
 @dataclass(kw_only=True)
-class ExtraBodyReplacementKind1:
+class ExtraBodyReplacementKindValue:
     value: Any
 
 
-ExtraBodyReplacementKind = Literal["delete"] | ExtraBodyReplacementKind1
+ExtraBodyReplacementKind = Literal["delete"] | ExtraBodyReplacementKindValue
 
 
 @dataclass(kw_only=True)

--- a/tensorzero-core/src/inference/types/extra_body.rs
+++ b/tensorzero-core/src/inference/types/extra_body.rs
@@ -21,6 +21,7 @@ pub struct ExtraBodyReplacement {
 #[export_schema]
 #[serde(rename_all = "snake_case")]
 pub enum ExtraBodyReplacementKind {
+    #[schemars(title = "ExtraBodyReplacementKindValue")]
     Value(Value),
     // We only allow `"delete": true` to be set - deserializing `"delete": false` will error
     #[serde(


### PR DESCRIPTION
This was named incorrectly because of the tagged enum
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Rename `ExtraBodyReplacementKind1` to `ExtraBodyReplacementKindValue` and update `ExtraBodyReplacementKind` enum to include `schemars` title for `Value`.
> 
>   - **Renames**:
>     - `ExtraBodyReplacementKind1` to `ExtraBodyReplacementKindValue` in `generated_types.py`.
>     - Updates `ExtraBodyReplacementKind` in `extra_body.rs` to include `#[schemars(title = "ExtraBodyReplacementKindValue")]` for `Value` variant.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 507d98c69605a557a72a909b78997964b6535437. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->