### PR TITLE
Fix stale notice in docs

### DIFF
--- a/docs/gateway/api-reference/inference.mdx
+++ b/docs/gateway/api-reference/inference.mdx
@@ -395,14 +395,6 @@ For example, the following hypothetical unknown content block will send the `day
 }
 ```
 
-<Warning>
-
-Certain reasoning models (e.g. DeepSeek R1) can include `thought` content blocks in the response.
-These content blocks can't directly be used as inputs to subsequent inferences in multi-turn scenarios.
-If you need to provide `thought` content blocks to a model, you should convert them to `text` content blocks.
-
-</Warning>
-
 This is the most complex field in the entire API. See this example for more details.
 
 <Accordion title="Example">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove stale warning about `thought` content blocks in `inference.mdx` documentation.
> 
>   - **Docs Update**:
>     - Remove stale warning about `thought` content blocks in `inference.mdx`. This warning was related to certain reasoning models like DeepSeek R1 and their handling in multi-turn scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 87510ec13b1607940c30f8f99f7134f14630c56a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->