### PR TITLE
Make provider-proxy test_read_old_write_new deterministic

### DIFF
--- a/provider-proxy/tests/e2e/tests.rs
+++ b/provider-proxy/tests/e2e/tests.rs
@@ -282,7 +282,7 @@ async fn test_read_old_write_new() {
     target_server_handle.await.unwrap().unwrap();
 
     let file_path = file_path.lock().unwrap().as_ref().unwrap().clone();
-    let file_mtime = file_mtime.lock().unwrap().as_ref().unwrap().clone();
+    let file_mtime = *file_mtime.lock().unwrap().as_ref().unwrap();
 
     // Wait for the file to be modified on disk
     loop {


### PR DESCRIPTION
Previously, we weren't waiting on the file to get updated on disk before sending a new request. As a result, the new file could get written out after the new provider-proxy server started, resulting in the file mtime being newer than than the start time.

We now wait on the file mtime to change (and for the target server to shut down) before launching a new proxy-proxy server
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `test_read_old_write_new` deterministic by waiting for file mtime change and server shutdown before starting a new server.
> 
>   - **Behavior**:
>     - In `test_read_old_write_new`, wait for file mtime to change and target server to shut down before starting a new server.
>     - Ensures deterministic behavior by checking file modification time before launching a new provider-proxy server.
>   - **Concurrency**:
>     - Use `Arc<Mutex<>>` to store file path and mtime for thread-safe access.
>   - **Misc**:
>     - Minor refactoring in `test_read_old_write_new` to improve clarity and determinism.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 25b14c3cfab7e3cdcf77a133be72f76c53f80d76. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->