### PR TITLE
Allow more errors in build-container jobs for external PRs

### DIFF
--- a/.github/workflows/build-gateway-container.yml
+++ b/.github/workflows/build-gateway-container.yml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Login to Namespace registry
         run: nsc docker login
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Push `gateway` container to Namespace registry
         run: docker push nscr.io/igvf4asmf8kri/gateway:sha-${{ github.sha }}
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}

--- a/.github/workflows/build-mock-inference-container.yml
+++ b/.github/workflows/build-mock-inference-container.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Login to Namespace registry
         run: nsc docker login
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Push `mock-inference` container to Namespace registry
         run: docker push nscr.io/igvf4asmf8kri/mock-inference-provider:sha-${{ github.sha }}
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}


### PR DESCRIPTION
We cannot upload to Namespace on PRs from external contributors, since credentials/OIDC-tokens will not be available

This has no effect on actually merging these PRs (since the merge queue creates temporary branches on the tensorzero/tensorzero repository)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allow `build-gateway-container.yml` and `build-mock-inference-container.yml` workflows to continue on error for external PRs and dependabot PRs.
> 
>   - **Workflows**:
>     - In `build-gateway-container.yml` and `build-mock-inference-container.yml`, added `continue-on-error` to `Login to Namespace registry` and `Push container to Namespace registry` steps.
>     - Conditions for `continue-on-error`: PRs from external repositories or by `dependabot[bot]`.
>   - **Behavior**:
>     - Allows external PRs to run workflows without failing due to missing credentials.
>     - Internal PRs and dependabot PRs remain unaffected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for fc6226736c86102b8f06d549f99419e9bb636039. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->