### PR TITLE
Ignore 'rustls-pemfile is unmaintained' error from cargo-deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,7 @@ ignore = [
     "RUSTSEC-2024-0436", # We don't care that 'paste' is unmaintained
     "RUSTSEC-2025-0057", # fxhash is unmaintained, used by rlt crate
     "RUSTSEC-2024-0370", # proc-macro-error is unmaintained, used by rlt crate
+    "RUSTSEC-2025-0134", # rustls-pemfile is unmaintained, used by google-cloud-auth crate
 ]
 
 [licenses]


### PR DESCRIPTION
There's nothing that we can actually do about this, since google-cloud-auth depends on it
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `RUSTSEC-2025-0134` to `deny.toml` to ignore 'rustls-pemfile is unmaintained' error due to dependency by `google-cloud-auth`.
> 
>   - **Configuration**:
>     - Add `RUSTSEC-2025-0134` to `ignore` list in `deny.toml` to ignore 'rustls-pemfile is unmaintained' error.
>     - This is necessary because `google-cloud-auth` depends on `rustls-pemfile`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 12abc4bb893aac479fb34964ab22330f342fecca. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->