### PR TITLE
Prune docker images in ui-test-e2e job

### DIFF
--- a/.github/workflows/ui-tests-e2e-model-inference-cache.yml
+++ b/.github/workflows/ui-tests-e2e-model-inference-cache.yml
@@ -242,8 +242,8 @@ jobs:
 
       # This will skip images from the still-running containers, but will free up all of the temporary
       # images from the multi-stage builder (if we built any containers locally)
-      - name: Prune docker images to free to disk space
-        run: docker system prune -af
+      - name: Prune docker images to free up disk space
+        run: docker system prune -f
 
       - name: Start dependency Docker containers and apply fixtures
         working-directory: ui


### PR DESCRIPTION
We're running out of disk space while inserting fixtures in cases where we've built containers locally (e.g. /merge-queue or the cron job)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add Docker image pruning step in `ui-tests-e2e-model-inference-cache.yml` to free up disk space.
> 
>   - **Workflow Changes**:
>     - Adds a step to prune Docker images in `ui-tests-e2e-model-inference-cache.yml` to free up disk space.
>     - The pruning step is added before starting dependency Docker containers and applying fixtures.
>     - This step skips images from running containers but removes temporary images from multi-stage builds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d442693bb5cb581f9e3c8df48bf1308ce2dd2990. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->