### PR TITLE
Double e2e test timeout

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -34,7 +34,7 @@ junit.path = "junit.xml"
 filter = 'binary(e2e_gepa)'
 # Analysis or mutation using gpt-4.1-nano occasionally fails to generate a properly formatted output, so we add retries
 retries = { backoff = "exponential", count = 4, delay = "5s", jitter = true, max-delay = "60s" }
-slow-timeout = { period = "30s", terminate-after = 1 }
+slow-timeout = { period = "30s", terminate-after = 2 }
 
 [profile.live-batch]
 default-filter = 'test(batch) and not test(mock)'


### PR DESCRIPTION
We run lots of tests in parallel on the slower github runners (since most of the tests are io-bound), but this has resulted in some extra flakiness due to timeouts
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Doubles `terminate-after` in `slow-timeout` for `e2e_gepa` tests to reduce flakiness on GitHub runners.
> 
>   - **Behavior**:
>     - Doubles `terminate-after` from 1 to 2 in `slow-timeout` for `e2e_gepa` tests in `.config/nextest.toml` to reduce flakiness on GitHub runners.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d13df5e3e74a13ff41a8cd1868ae809013386ddc. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->