### PR TITLE
Rename Unset => Omit in Python types

### DIFF
--- a/clients/python/DEVELOPER_NOTES.md
+++ b/clients/python/DEVELOPER_NOTES.md
@@ -133,5 +133,5 @@ The generated python is:
 ```python
 @dataclass
 class DatapointMetadataUpdate:
-    name: str | None | UnsetType = UNSET
+    name: str | None | OmitType = OMIT
 ```

--- a/clients/python/generate_schema_types.py
+++ b/clients/python/generate_schema_types.py
@@ -33,7 +33,7 @@ It also sets up customizations to make them work well together:
 2.  When merging the schema files, some references are recursive (e.g. `InferenceFilter`) that point to the root schema of these
     types, so we need to rewrite the `$ref`s to point to the schema definition itself instead of the root schema (which becomes
     `Any` after python dataclass generation).
-3.  We generate a custom header file for the generated types to include the `UNSET` sentinel value.
+3.  We generate a custom header file for the generated types to include the `OMIT` sentinel value.
 
 
 To run this script: run `pnpm generate-python-schemas` from the root of the repository.

--- a/clients/python/templates/dataclass.jinja2
+++ b/clients/python/templates/dataclass.jinja2
@@ -27,7 +27,7 @@ class {{ class_name }}:
     {{ field.name }}: {{ field.type_hint }} = {{ field.field }}
     {%- else %}
     {%- if field.extras and field.extras.get('x_double_option') %}
-    {{ field.name }}: {{ field.type_hint }} | UnsetType = UNSET
+    {{ field.name }}: {{ field.type_hint }} | OmitType = OMIT
     {%- else %}
     {{ field.name }}: {{ field.type_hint }}
     {%- if not (field.required or (field.represented_default == 'None' and field.strip_default_none))

--- a/clients/python/templates/generated_types_header.py.template
+++ b/clients/python/templates/generated_types_header.py.template
@@ -11,4 +11,4 @@ To regenerate, run:
 """
 
 from __future__ import annotations
-from .unset_type import UNSET, UnsetType
+from .omit_type import OMIT, OmitType

--- a/clients/python/tensorzero/generated_types.py
+++ b/clients/python/tensorzero/generated_types.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-from .unset_type import UNSET, UnsetType
+from .omit_type import OMIT, OmitType
 
 Model = Any
 
@@ -77,11 +77,11 @@ class DatapointMetadataUpdate:
     A request to update the metadata of a datapoint.
     """
 
-    name: str | None | UnsetType = UNSET
+    name: str | None | OmitType = OMIT
     """
     Datapoint name.
 
-    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared. If specified as a value, it will
+    If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared. If specified as a value, it will
     be set to the provided value.
     """
 
@@ -871,11 +871,11 @@ class UpdateDatapointMetadataRequest:
     """
     The ID of the datapoint to update. Required.
     """
-    name: str | None | UnsetType = UNSET
+    name: str | None | OmitType = OMIT
     """
     Datapoint name.
 
-    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared. If specified as a value, it will
+    If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared. If specified as a value, it will
     be set to the provided value.
     """
 
@@ -1348,18 +1348,18 @@ class UpdateDynamicToolParamsRequest:
     new tools or exclude removed tools.
     If omitted, it will be left unchanged. If specified as a value, it will be set to the provided value.
     """
-    allowed_tools: list[str] | None | UnsetType = UNSET
+    allowed_tools: list[str] | None | OmitType = OMIT
     """
     A subset of static tools configured for the function that the inference is explicitly allowed to use.
 
-    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (we allow function-configured tools
+    If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared (we allow function-configured tools
     plus additional tools provided at inference time). If specified as a value, it will be set to the provided value.
     """
-    parallel_tool_calls: bool | None | UnsetType = UNSET
+    parallel_tool_calls: bool | None | OmitType = OMIT
     """
     Whether to use parallel tool calls in the inference.
 
-    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (we will use function-configured
+    If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared (we will use function-configured
     parallel tool calls). If specified as a value, it will be set to the provided value.
     """
     provider_tools: list[ProviderTool] | None = None
@@ -1367,11 +1367,11 @@ class UpdateDynamicToolParamsRequest:
     Provider-specific tool configurations
     If omitted, it will be left unchanged. If specified as a value, it will be set to the provided value.
     """
-    tool_choice: ToolChoice | None | UnsetType = UNSET
+    tool_choice: ToolChoice | None | OmitType = OMIT
     """
     User-specified tool choice strategy.
 
-    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (we will use function-configured
+    If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared (we will use function-configured
     tool choice). If specified as a value, it will be set to the provided value.
     """
 
@@ -1575,11 +1575,11 @@ class UpdateChatDatapointRequestInternal:
     new tools or exclude removed tools.
     If omitted, it will be left unchanged. If specified as a value, it will be set to the provided value.
     """
-    allowed_tools: list[str] | None | UnsetType = UNSET
+    allowed_tools: list[str] | None | OmitType = OMIT
     """
     A subset of static tools configured for the function that the inference is explicitly allowed to use.
 
-    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (we allow function-configured tools
+    If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared (we allow function-configured tools
     plus additional tools provided at inference time). If specified as a value, it will be set to the provided value.
     """
     input: Input | None = None
@@ -1591,25 +1591,25 @@ class UpdateChatDatapointRequestInternal:
     DEPRECATED (#4725 / 2026.2+): Metadata fields to update.
     Moving forward, don't nest these fields.
     """
-    name: str | None | UnsetType = UNSET
+    name: str | None | OmitType = OMIT
     """
     Datapoint name.
 
-    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared. If specified as a value, it will
+    If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared. If specified as a value, it will
     be set to the provided value.
     """
-    output: list[ContentBlockChatOutput] | None | UnsetType = UNSET
+    output: list[ContentBlockChatOutput] | None | OmitType = OMIT
     """
     Chat datapoint output.
 
-    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared.
+    If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared.
     Otherwise, it will overwrite the existing output (and can be an empty list).
     """
-    parallel_tool_calls: bool | None | UnsetType = UNSET
+    parallel_tool_calls: bool | None | OmitType = OMIT
     """
     Whether to use parallel tool calls in the inference.
 
-    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (we will use function-configured
+    If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared (we will use function-configured
     parallel tool calls). If specified as a value, it will be set to the provided value.
     """
     provider_tools: list[ProviderTool] | None = None
@@ -1621,14 +1621,14 @@ class UpdateChatDatapointRequestInternal:
     """
     Datapoint tags.
 
-    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared.
+    If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared.
     Otherwise, it will overwrite the existing tags.
     """
-    tool_choice: ToolChoice | None | UnsetType = UNSET
+    tool_choice: ToolChoice | None | OmitType = OMIT
     """
     User-specified tool choice strategy.
 
-    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (we will use function-configured
+    If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared (we will use function-configured
     tool choice). If specified as a value, it will be set to the provided value.
     """
     tool_params: UpdateDynamicToolParamsRequest | None = None
@@ -1666,17 +1666,17 @@ class UpdateJsonDatapointRequestInternal:
     DEPRECATED (#4725 / 2026.2+): Metadata fields to update.
     Moving forward, don't nest these fields.
     """
-    name: str | None | UnsetType = UNSET
+    name: str | None | OmitType = OMIT
     """
     Datapoint name.
 
-    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared. If specified as a value, it will
+    If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared. If specified as a value, it will
     be set to the provided value.
     """
-    output: JsonDatapointOutputUpdate | None | UnsetType = UNSET
+    output: JsonDatapointOutputUpdate | None | OmitType = OMIT
     """
     JSON datapoint output.
-    If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (represents edge case where
+    If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared (represents edge case where
     inference succeeded but model didn't output relevant content blocks). Otherwise, it will overwrite the existing output.
     """
     output_schema: Any | None = None

--- a/clients/python/tensorzero/omit_type.py
+++ b/clients/python/tensorzero/omit_type.py
@@ -1,28 +1,28 @@
 """
-Helper module for the `UNSET` sentinel value in generated dataclasses, to distinguish between omitted fields and
+Helper module for the `OMIT` sentinel value in generated dataclasses, to distinguish between omitted fields and
 values that are explicitly set to None in update APIs.
 """
 
 
-class UnsetType:
+class OmitType:
     """Sentinel value to distinguish between omitted fields and values that are explicitly set to None."""
 
     def __repr__(self):
-        return "UNSET"
+        return "OMIT"
 
 
-UNSET = UnsetType()
+OMIT = OmitType()
 """
 Sentinel value to distinguish between omitted and null in API requests.
 
 Usage:
-- UNSET: Field is omitted (don't change existing value)
+- OMIT: Field is omitted (don't change existing value)
 - None: Field is explicitly set to null
 - value: Field is set to the provided value
 
 Example:
     # Omit the field entirely (don't update it)
-    update = UpdateRequest(name=UNSET)
+    update = UpdateRequest(name=OMIT)
 
     # Set the field to null (clear the existing value)
     update = UpdateRequest(name=None)

--- a/clients/python/tensorzero/types.py
+++ b/clients/python/tensorzero/types.py
@@ -19,7 +19,7 @@ from tensorzero.generated_types import (
     InferenceFilterOr,
     InferenceFilterTag,
     InferenceFilterTime,
-    UnsetType,
+    OmitType,
 )
 
 
@@ -564,12 +564,12 @@ class TensorZeroTypeEncoder(JSONEncoder):
         elif hasattr(o, "to_dict"):
             return o.to_dict()  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType, reportAttributeAccessIssue]
         elif is_dataclass(o) and not isinstance(o, type):
-            # Convert dataclass to dict, but filter out UNSET fields
+            # Convert dataclass to dict, but filter out OMIT fields
             result = {}
             for field in fields(o):
                 value = getattr(o, field.name)
-                # Skip UNSET fields entirely (they won't be in the JSON)
-                if not isinstance(value, UnsetType):
+                # Skip OMIT fields entirely (they won't be in the JSON)
+                if not isinstance(value, OmitType):
                     # Recursively handle nested dataclasses/lists/dicts
                     result[field.name] = self._convert_value(value)
             return result  # pyright: ignore[reportUnknownVariableType]
@@ -577,8 +577,8 @@ class TensorZeroTypeEncoder(JSONEncoder):
             super().default(o)
 
     def _convert_value(self, value: Any) -> Any:
-        """Recursively convert values, filtering out UNSET."""
-        if isinstance(value, UnsetType):
+        """Recursively convert values, filtering out OMIT."""
+        if isinstance(value, OmitType):
             # This shouldn't happen at top level, but handle it just in case
             return None
         elif hasattr(value, "to_dict"):
@@ -589,7 +589,7 @@ class TensorZeroTypeEncoder(JSONEncoder):
             result: dict[str, Any] = {}
             for field in fields(value):
                 field_value = getattr(value, field.name)
-                if not isinstance(field_value, UnsetType):
+                if not isinstance(field_value, OmitType):
                     result[field.name] = self._convert_value(field_value)
             return result  # pyright: ignore[reportUnknownVariableType]
         elif isinstance(value, (list, tuple)):

--- a/tensorzero-core/src/endpoints/API_TYPES.md
+++ b/tensorzero-core/src/endpoints/API_TYPES.md
@@ -18,7 +18,7 @@ pub struct UpdateChatDatapointRequest {
     #[serde(default, deserialize_with = "deserialize_double_option")]
     #[schemars(extend("x-double-option" = true), description = "Chat datapoint output.
 
-If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared.
+If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared.
 Otherwise, it will overwrite the existing output (and can be an empty list).")]
     pub output: Option<Option<Vec<ContentBlockChatOutput>>>,
 
@@ -38,5 +38,5 @@ The 3 semantics of this field are represented as follows in each language:
   - Rust: the field is set to `Some(None)`.
 - Semantic: leave as-is, do not update the field.
   - JSON: the key is omitted in the object.
-  - Python: the field is not set (and takes the default value `UNSET`). We have serialization logic that removes fields with the default value `UNSET`.
+  - Python: the field is not set (and takes the default value `OMIT`). We have serialization logic that removes fields with the default value `OMIT`.
   - Rust: the field is set to `None`, or use `..Default::default()` if supported.

--- a/tensorzero-core/src/endpoints/datasets/v1/types.rs
+++ b/tensorzero-core/src/endpoints/datasets/v1/types.rs
@@ -87,7 +87,7 @@ pub struct UpdateChatDatapointRequest {
     #[serde(default, deserialize_with = "deserialize_double_option")]
     #[schemars(extend("x-double-option" = true), description = "Chat datapoint output.
 
-If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared.
+If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared.
 Otherwise, it will overwrite the existing output (and can be an empty list).")]
     pub output: Option<Option<Vec<ContentBlockChatOutput>>>,
 
@@ -112,7 +112,7 @@ Otherwise, it will overwrite the existing output (and can be an empty list).")]
     #[serde(default)]
     #[schemars(description = "Datapoint tags.
 
-If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared.
+If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared.
 Otherwise, it will overwrite the existing tags.")]
     pub tags: Option<HashMap<String, String>>,
 
@@ -239,7 +239,7 @@ pub struct UpdateDynamicToolParamsRequest {
     #[serde(default, deserialize_with = "deserialize_double_option")]
     #[schemars(extend("x-double-option" = true), description = "A subset of static tools configured for the function that the inference is explicitly allowed to use.
 
-If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (we allow function-configured tools
+If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared (we allow function-configured tools
 plus additional tools provided at inference time). If specified as a value, it will be set to the provided value.")]
     pub allowed_tools: Option<Option<Vec<String>>>,
 
@@ -254,7 +254,7 @@ plus additional tools provided at inference time). If specified as a value, it w
     #[serde(default, deserialize_with = "deserialize_double_option")]
     #[schemars(extend("x-double-option" = true), description = "User-specified tool choice strategy.
 
-If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (we will use function-configured
+If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared (we will use function-configured
 tool choice). If specified as a value, it will be set to the provided value.")]
     pub tool_choice: Option<Option<ToolChoice>>,
 
@@ -263,7 +263,7 @@ tool choice). If specified as a value, it will be set to the provided value.")]
     #[serde(default, deserialize_with = "deserialize_double_option")]
     #[schemars(extend("x-double-option" = true), description = "Whether to use parallel tool calls in the inference.
 
-If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (we will use function-configured
+If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared (we will use function-configured
 parallel tool calls). If specified as a value, it will be set to the provided value.")]
     pub parallel_tool_calls: Option<Option<bool>>,
 
@@ -288,7 +288,7 @@ pub struct UpdateJsonDatapointRequest {
     /// JSON datapoint output. If omitted, it will be left unchanged. If `null`, it will be set to `null`. If specified as a value, it will be set to the provided value.
     #[serde(default, deserialize_with = "deserialize_double_option")]
     #[schemars(extend("x-double-option" = true), description = "JSON datapoint output.
-If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared (represents edge case where
+If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared (represents edge case where
 inference succeeded but model didn't output relevant content blocks). Otherwise, it will overwrite the existing output.")]
     pub output: Option<Option<JsonDatapointOutputUpdate>>,
 
@@ -399,7 +399,7 @@ pub struct DatapointMetadataUpdate {
     #[serde(default, deserialize_with = "deserialize_double_option")]
     #[schemars(extend("x-double-option" = true), description = "Datapoint name.
 
-If omitted (which uses the default value `UNSET`), it will be left unchanged. If set to `None`, it will be cleared. If specified as a value, it will
+If omitted (which uses the default value `OMIT`), it will be left unchanged. If set to `None`, it will be cleared. If specified as a value, it will
 be set to the provided value.")]
     pub name: Option<Option<String>>,
 }

--- a/tensorzero-core/src/inference/types/pyo3_helpers.rs
+++ b/tensorzero-core/src/inference/types/pyo3_helpers.rs
@@ -507,7 +507,7 @@ impl StoredSample for StoredSampleItem {
 }
 
 /// Converts a Python dataclass / dictionary / list to json with `json.dumps`,
-/// then deserializes to a Rust type via serde. This handles UNSET values correctly by calling a custom
+/// then deserializes to a Rust type via serde. This handles OMIT values correctly by calling a custom
 /// `TensorZeroTypeEncoder` class from Python.
 pub fn deserialize_from_pyobj<'a, T: serde::de::DeserializeOwned>(
     py: Python<'a>,


### PR DESCRIPTION
Fixes #4989 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rename `Unset` to `Omit` in Python types for handling optional fields in API requests.
> 
>   - **Behavior**:
>     - Rename `UnsetType` to `OmitType` and `UNSET` to `OMIT` in `omit_type.py`.
>     - Update references to `UnsetType` and `UNSET` to `OmitType` and `OMIT` in `generated_types.py`, `types.py`, and `dataclass.jinja2`.
>     - Update docstrings and comments to reflect the change from `UNSET` to `OMIT` in `API_TYPES.md` and `types.rs`.
>   - **Templates**:
>     - Modify `dataclass.jinja2` to use `OmitType` and `OMIT` for fields with `x_double_option`.
>     - Update `generated_types_header.py.template` to import `OmitType` and `OMIT`.
>   - **Misc**:
>     - Update `generate_schema_types.py` to include `OMIT` in the custom header file generation.
>     - Rename `unset_type.py` to `omit_type.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7dac2f261f41e92bf343f07cb60d023b66a6c0a3. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->