### PR TITLE
Bump CI bot

### DIFF
--- a/.github/workflows/tensorzero-ci-bot-failure-diagnosis.yml
+++ b/.github/workflows/tensorzero-ci-bot-failure-diagnosis.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Generate patch
         id: generate
-        uses: tensorzero/experimental-ci-bot/generate-pr-patch@6075c5483e949af3acec76c40b755dcccd99e6b0
+        uses: tensorzero/experimental-ci-bot/generate-pr-patch@8154c016757d424138a3e70f914a81ed6ce1f76c
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/tensorzero-ci-bot-provide-feedback.yml
+++ b/.github/workflows/tensorzero-ci-bot-provide-feedback.yml
@@ -22,7 +22,7 @@ jobs:
           tags: tag:ci
 
       - name: Send PR Feedback
-        uses: tensorzero/experimental-ci-bot/create-pr-feedback@6075c5483e949af3acec76c40b755dcccd99e6b0
+        uses: tensorzero/experimental-ci-bot/create-pr-feedback@8154c016757d424138a3e70f914a81ed6ce1f76c
         with:
           tensorzero-base-url: http://ci-bot-gateway:3000
           tensorzero-pr-merged-metric-name: ci_fix_pr_merged_agent


### PR DESCRIPTION
This stops running CI bot on draft PRs: https://github.com/tensorzero/experimental-ci-bot/commit/8154c016757d424138a3e70f914a81ed6ce1f76c
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update CI bot to stop running on draft PRs by changing commit hash in workflow files.
> 
>   - **Behavior**:
>     - Updates CI bot commit hash in `tensorzero-ci-bot-failure-diagnosis.yml` and `tensorzero-ci-bot-provide-feedback.yml` to stop running on draft PRs.
>   - **Workflows**:
>     - Changes `generate-pr-patch` and `create-pr-feedback` actions to use commit `8154c016757d424138a3e70f914a81ed6ce1f76c`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4849013b69b9bc31676b1740687670fcf36bf744. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->