### PR TITLE
added documentation that we only support gRPC endpoints for Otel

### DIFF
--- a/docs/operations/export-opentelemetry-traces.mdx
+++ b/docs/operations/export-opentelemetry-traces.mdx
@@ -46,6 +46,10 @@ export.otlp.traces.enabled = true
 
 Set the `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` environment variable in the gateway container to the endpoint of your OpenTelemetry service.
 
+<Note>
+TensorZero only supports gRPC endpoints for OTLP trace export. HTTP endpoints are not supported.
+</Note>
+
 <Accordion title="Example: TensorZero Gateway and Jaeger with Docker Compose">
 
 For example, if you're deploying the TensorZero Gateway and Jaeger in Docker Compose, you can set the following environment variable:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added documentation note that TensorZero only supports gRPC endpoints for OTLP trace export, not HTTP.
> 
>   - **Documentation**:
>     - Added note in `export-opentelemetry-traces.mdx` that TensorZero only supports gRPC endpoints for OTLP trace export. HTTP endpoints are not supported.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 13b198a99d238818a101e477d788b8d220310fa6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->