### PR TITLE
[DO NOT MERGE] For comparison only, minimal evaluations configs

### DIFF
--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -11,7 +11,9 @@
 /// and defines methods on them.
 use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
 
-use evaluations::{EvaluationCoreArgs, EvaluationVariant, run_evaluation_core_streaming};
+use evaluations::{
+    EvaluationCoreArgs, EvaluationFunctionConfig, EvaluationVariant, run_evaluation_core_streaming,
+};
 use futures::StreamExt;
 use pyo3::{
     IntoPyObjectExt,
@@ -1446,15 +1448,17 @@ impl TensorZeroGateway {
 
         // Get function name and look up function config
         let EvaluationConfig::Inference(ref inference_eval_config) = *evaluation_config;
-        let function_config = app_state
+        let function_config_arc = app_state
             .config
             .get_function(&inference_eval_config.function_name)
             .map_err(|e| {
                 pyo3::exceptions::PyValueError::new_err(format!(
                     "Failed to get function config: {e}"
                 ))
-            })?
-            .into_owned();
+            })?;
+        let function_config = Arc::new(EvaluationFunctionConfig::from(
+            function_config_arc.as_ref().as_ref(),
+        ));
 
         let core_args = EvaluationCoreArgs {
             tensorzero_client: client.clone(),
@@ -2686,15 +2690,17 @@ impl AsyncTensorZeroGateway {
 
             // Get function name and look up function config
             let EvaluationConfig::Inference(ref inference_eval_config) = *evaluation_config;
-            let function_config = app_state
+            let function_config_arc = app_state
                 .config
                 .get_function(&inference_eval_config.function_name)
                 .map_err(|e| {
                     pyo3::exceptions::PyValueError::new_err(format!(
                         "Failed to get function config: {e}"
                     ))
-                })?
-                .into_owned();
+                })?;
+            let function_config = Arc::new(EvaluationFunctionConfig::from(
+                function_config_arc.as_ref().as_ref(),
+            ));
 
             let core_args = EvaluationCoreArgs {
                 tensorzero_client: client.clone(),

--- a/evaluations/tests/tests.rs
+++ b/evaluations/tests/tests.rs
@@ -27,8 +27,8 @@ use url::Url;
 use crate::common::write_json_fixture_to_dataset;
 use common::{get_config, get_tensorzero_client, write_chat_fixture_to_dataset};
 use evaluations::{
-    Args, EvaluationCoreArgs, EvaluationVariant, OutputFormat, run_evaluation,
-    run_evaluation_core_streaming,
+    Args, EvaluationCoreArgs, EvaluationFunctionConfig, EvaluationVariant, OutputFormat,
+    run_evaluation, run_evaluation_core_streaming,
     stats::{EvaluationUpdate, PerEvaluatorStats},
 };
 use std::collections::HashMap;
@@ -466,10 +466,12 @@ async fn test_datapoint_ids_and_max_datapoints_mutually_exclusive_core_streaming
 
     // Get function name and look up function config
     let EvaluationConfig::Inference(ref inference_eval_config) = *evaluation_config;
-    let function_config = config
+    let function_config_arc = config
         .get_function(&inference_eval_config.function_name)
-        .expect("Failed to get function config")
-        .into_owned();
+        .expect("Failed to get function config");
+    let function_config = Arc::new(EvaluationFunctionConfig::from(
+        function_config_arc.as_ref().as_ref(),
+    ));
 
     // Test: Both datapoint_ids and max_datapoints provided should fail
     let core_args = EvaluationCoreArgs {
@@ -2685,10 +2687,12 @@ async fn test_evaluation_with_dynamic_variant() {
         .expect("evaluation config should exist")
         .clone();
     let EvaluationConfig::Inference(ref inference_eval_config) = *evaluation_config;
-    let function_config = config
+    let function_config_arc = config
         .get_function(&inference_eval_config.function_name)
-        .expect("function config should exist")
-        .into_owned();
+        .expect("function config should exist");
+    let function_config = Arc::new(EvaluationFunctionConfig::from(
+        function_config_arc.as_ref().as_ref(),
+    ));
 
     let core_args = EvaluationCoreArgs {
         tensorzero_client,
@@ -2744,10 +2748,12 @@ async fn test_max_datapoints_parameter() {
         .expect("evaluation config should exist")
         .clone();
     let EvaluationConfig::Inference(ref inference_eval_config) = *evaluation_config;
-    let function_config = config
+    let function_config_arc = config
         .get_function(&inference_eval_config.function_name)
-        .expect("function config should exist")
-        .into_owned();
+        .expect("function config should exist");
+    let function_config = Arc::new(EvaluationFunctionConfig::from(
+        function_config_arc.as_ref().as_ref(),
+    ));
 
     // Test with max_datapoints = 3 (should only process 3 datapoints)
     let core_args = EvaluationCoreArgs {
@@ -2821,10 +2827,12 @@ async fn test_precision_targets_parameter() {
         .expect("evaluation config should exist")
         .clone();
     let EvaluationConfig::Inference(ref inference_eval_config) = *evaluation_config;
-    let function_config = config
+    let function_config_arc = config
         .get_function(&inference_eval_config.function_name)
-        .expect("function config should exist")
-        .into_owned();
+        .expect("function config should exist");
+    let function_config = Arc::new(EvaluationFunctionConfig::from(
+        function_config_arc.as_ref().as_ref(),
+    ));
 
     // Set precision targets for both evaluators
     // exact_match: CI half-width <= 0.10

--- a/internal/tensorzero-node/lib/index.ts
+++ b/internal/tensorzero-node/lib/index.ts
@@ -139,7 +139,10 @@ export { getQuantiles };
 interface RunEvaluationStreamingParams {
   gatewayUrl: string;
   clickhouseUrl: string;
-  configPath: string;
+  /** JSON-serialized EvaluationConfig */
+  evaluationConfig: string;
+  /** JSON-serialized EvaluationFunctionConfig */
+  functionConfig: string;
   evaluationName: string;
   datasetName: string;
   variantName: string;

--- a/internal/tensorzero-node/src/lib.rs
+++ b/internal/tensorzero-node/src/lib.rs
@@ -5,7 +5,9 @@ use tensorzero_core::endpoints::datasets::StaleDatasetResponse;
 use url::Url;
 
 use evaluations::stats::{EvaluationInfo, EvaluationUpdate};
-use evaluations::{EvaluationCoreArgs, EvaluationVariant, run_evaluation_core_streaming};
+use evaluations::{
+    EvaluationCoreArgs, EvaluationFunctionConfig, EvaluationVariant, run_evaluation_core_streaming,
+};
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use serde::Serialize;
 use serde_json::Value;
@@ -14,9 +16,7 @@ use tensorzero::{
     OptimizationJobHandle, QUANTILES,
 };
 use tensorzero_core::{
-    cache::CacheEnabledMode,
-    config::{Config, ConfigFileGlob},
-    db::clickhouse::ClickHouseConnectionInfo,
+    cache::CacheEnabledMode, config::BatchWritesConfig, db::clickhouse::ClickHouseConnectionInfo,
     evaluations::EvaluationConfig,
 };
 use uuid::Uuid;
@@ -112,7 +112,10 @@ fn send_event(
 pub struct RunEvaluationStreamingParams {
     pub gateway_url: String,
     pub clickhouse_url: String,
-    pub config_path: String,
+    /// JSON-serialized EvaluationConfig
+    pub evaluation_config: String,
+    /// JSON-serialized EvaluationFunctionConfig
+    pub function_config: String,
     pub evaluation_name: String,
     pub dataset_name: Option<String>,
     pub datapoint_ids: Option<Vec<String>>,
@@ -133,52 +136,26 @@ pub async fn run_evaluation_streaming(
     let url = Url::parse(&params.gateway_url)
         .map_err(|e| napi::Error::from_reason(format!("Invalid gateway URL: {e}")))?;
 
-    let config_glob =
-        ConfigFileGlob::new_from_path(Path::new(&params.config_path)).map_err(|e| {
-            napi::Error::from_reason(format!(
-                "Failed to resolve config glob from {}: {e}",
-                params.config_path
-            ))
-        })?;
-
-    let unwritten_config = Config::load_from_path_optional_verify_credentials(&config_glob, false)
-        .await
+    // Deserialize configs from JSON strings
+    let evaluation_config: EvaluationConfig = serde_json::from_str(&params.evaluation_config)
         .map_err(|e| {
-            napi::Error::from_reason(format!(
-                "Failed to load configuration from {}: {e}",
-                params.config_path
-            ))
+            napi::Error::from_reason(format!("Failed to deserialize evaluation_config: {e}"))
         })?;
-    let clickhouse_client = ClickHouseConnectionInfo::new(
-        &params.clickhouse_url,
-        unwritten_config.gateway.observability.batch_writes.clone(),
-    )
-    .await
-    .map_err(|e| napi::Error::from_reason(format!("Failed to connect to ClickHouse: {e}")))?;
-    let config = unwritten_config
-        .into_config(&clickhouse_client)
-        .await
-        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
-    let config = Arc::new(config);
+    let evaluation_config = Arc::new(evaluation_config);
 
-    // Extract evaluation config from the loaded config
-    let evaluation_config = config
-        .evaluations
-        .get(&params.evaluation_name)
-        .ok_or_else(|| {
-            napi::Error::from_reason(format!(
-                "Failed to get evaluation config '{}'",
-                params.evaluation_name
-            ))
-        })?
-        .clone();
+    let function_config: EvaluationFunctionConfig = serde_json::from_str(&params.function_config)
+        .map_err(|e| {
+        napi::Error::from_reason(format!("Failed to deserialize function_config: {e}"))
+    })?;
+    let function_config = Arc::new(function_config);
 
-    // Get function name and look up function config
-    let EvaluationConfig::Inference(ref inference_eval_config) = *evaluation_config;
-    let function_config = config
-        .get_function(&inference_eval_config.function_name)
-        .map_err(|e| napi::Error::from_reason(format!("Failed to get function config: {e}")))?
-        .into_owned();
+    // Create ClickHouse client with default batch writes config (no config file available)
+    let clickhouse_client =
+        ClickHouseConnectionInfo::new(&params.clickhouse_url, BatchWritesConfig::default())
+            .await
+            .map_err(|e| {
+                napi::Error::from_reason(format!("Failed to connect to ClickHouse: {e}"))
+            })?;
 
     let tensorzero_client = ClientBuilder::new(ClientBuilderMode::HTTPGateway { url })
         .build()

--- a/tensorzero-optimizers/tests/e2e/gepa/mutate.rs
+++ b/tensorzero-optimizers/tests/e2e/gepa/mutate.rs
@@ -59,7 +59,7 @@ async fn test_mutate_variant_chat() {
     let evaluation_params = EvaluateVariantParams {
         gateway_client: gateway_client.clone(),
         clickhouse_connection_info: clickhouse.clone(),
-        tensorzero_config: config.clone(),
+        functions: config.functions.clone(),
         evaluation_config: Arc::clone(&function_context.evaluation_config),
         evaluation_name: gepa_config.evaluation_name.clone(),
         variant_name: parent_name.to_string(),
@@ -194,7 +194,7 @@ async fn test_mutate_variant_json() {
     let evaluation_params = EvaluateVariantParams {
         gateway_client: gateway_client.clone(),
         clickhouse_connection_info: clickhouse.clone(),
-        tensorzero_config: config.clone(),
+        functions: config.functions.clone(),
         evaluation_config: Arc::clone(&function_context.evaluation_config),
         evaluation_name: gepa_config.evaluation_name.clone(),
         variant_name: parent_name.to_string(),
@@ -303,7 +303,7 @@ async fn test_mutate_variant_preserves_variables() {
     let evaluation_params = EvaluateVariantParams {
         gateway_client: gateway_client.clone(),
         clickhouse_connection_info: clickhouse.clone(),
-        tensorzero_config: config.clone(),
+        functions: config.functions.clone(),
         evaluation_config: Arc::clone(&function_context.evaluation_config),
         evaluation_name: gepa_config.evaluation_name.clone(),
         variant_name: parent_name.to_string(),
@@ -400,7 +400,7 @@ async fn test_mutate_variant_preserves_schema_references() {
     let evaluation_params = EvaluateVariantParams {
         gateway_client: gateway_client.clone(),
         clickhouse_connection_info: clickhouse.clone(),
-        tensorzero_config: config.clone(),
+        functions: config.functions.clone(),
         evaluation_config: Arc::clone(&function_context.evaluation_config),
         evaluation_name: gepa_config.evaluation_name.clone(),
         variant_name: parent_name.to_string(),
@@ -515,7 +515,7 @@ async fn test_mutate_variant_naming() {
     let evaluation_params = EvaluateVariantParams {
         gateway_client: gateway_client.clone(),
         clickhouse_connection_info: clickhouse.clone(),
-        tensorzero_config: config.clone(),
+        functions: config.functions.clone(),
         evaluation_config: Arc::clone(&function_context.evaluation_config),
         evaluation_name: gepa_config.evaluation_name.clone(),
         variant_name: parent_name.to_string(),

--- a/tensorzero-optimizers/tests/e2e/gepa/pareto.rs
+++ b/tensorzero-optimizers/tests/e2e/gepa/pareto.rs
@@ -108,7 +108,7 @@ async fn test_pareto_frontier_update_with_initial_variants() {
         let evaluation_params = EvaluateVariantParams {
             gateway_client: gateway_client.clone(),
             clickhouse_connection_info: clickhouse.clone(),
-            tensorzero_config: config.clone(),
+            functions: config.functions.clone(),
             evaluation_config: Arc::clone(&function_context.evaluation_config),
             evaluation_name: gepa_config.evaluation_name.clone(),
             variant_name: variant_name.to_string(),
@@ -226,7 +226,7 @@ async fn test_pareto_frontier_sample_by_frequency() {
         let evaluation_params = EvaluateVariantParams {
             gateway_client: gateway_client.clone(),
             clickhouse_connection_info: clickhouse.clone(),
-            tensorzero_config: config.clone(),
+            functions: config.functions.clone(),
             evaluation_config: Arc::clone(&function_context.evaluation_config),
             evaluation_name: gepa_config.evaluation_name.clone(),
             variant_name: variant_name.to_string(),
@@ -341,7 +341,7 @@ async fn test_pareto_frontier_maintains_valid_state() {
         let evaluation_params = EvaluateVariantParams {
             gateway_client: gateway_client.clone(),
             clickhouse_connection_info: clickhouse.clone(),
-            tensorzero_config: config.clone(),
+            functions: config.functions.clone(),
             evaluation_config: Arc::clone(&function_context.evaluation_config),
             evaluation_name: gepa_config.evaluation_name.clone(),
             variant_name: variant_name.to_string(),

--- a/ui/app/utils/evaluations.server.ts
+++ b/ui/app/utils/evaluations.server.ts
@@ -6,14 +6,20 @@ import {
 import { logger } from "~/utils/logger";
 import { getEnv } from "./env.server";
 import { runNativeEvaluationStreaming } from "./tensorzero/native_client.server";
-import type { EvaluationRunEvent } from "~/types/tensorzero";
+import type { EvaluationRunEvent, FunctionConfig } from "~/types/tensorzero";
+import { getConfig } from "./config/index.server";
 
-function getConfigPath(): string {
-  const configPath = getEnv().TENSORZERO_UI_CONFIG_PATH;
-  if (!configPath) {
-    throw new Error("TENSORZERO_UI_CONFIG_PATH is not set");
+/**
+ * Converts a FunctionConfig to the minimal EvaluationFunctionConfig format
+ * required by the evaluation runner.
+ */
+function toEvaluationFunctionConfig(
+  config: FunctionConfig,
+): { type: "chat" } | { type: "json"; output_schema: unknown } {
+  if (config.type === "chat") {
+    return { type: "chat" };
   }
-  return configPath;
+  return { type: "json", output_schema: config.output_schema };
 }
 
 const INFERENCE_CACHE_SETTINGS = [
@@ -96,7 +102,7 @@ export function parseEvaluationFormData(
   return result.success ? result.data : null;
 }
 
-export function runEvaluation(
+export async function runEvaluation(
   evaluationName: string,
   datasetName: string,
   variantName: string,
@@ -109,6 +115,25 @@ export function runEvaluation(
   const startTime = new Date();
   let evaluationRunId: string | null = null;
   let startResolved = false;
+
+  // Get config and look up evaluation and function configs
+  const config = await getConfig();
+  const evaluationConfig = config.evaluations[evaluationName];
+  if (!evaluationConfig) {
+    throw new Error(`Evaluation '${evaluationName}' not found in config`);
+  }
+  // eslint-disable-next-line no-restricted-syntax
+  const functionConfig = config.functions[evaluationConfig.function_name];
+  if (!functionConfig) {
+    throw new Error(
+      `Function '${evaluationConfig.function_name}' not found in config`,
+    );
+  }
+
+  // Convert to minimal EvaluationFunctionConfig and serialize
+  const evaluationFunctionConfig = toEvaluationFunctionConfig(functionConfig);
+  const serializedEvaluationConfig = JSON.stringify(evaluationConfig);
+  const serializedFunctionConfig = JSON.stringify(evaluationFunctionConfig);
 
   let resolveStart: (value: EvaluationStartInfo) => void = () => {};
   let rejectStart: (reason?: unknown) => void = () => {};
@@ -190,7 +215,8 @@ export function runEvaluation(
   const nativePromise = runNativeEvaluationStreaming({
     gatewayUrl: env.TENSORZERO_GATEWAY_URL,
     clickhouseUrl: env.TENSORZERO_CLICKHOUSE_URL,
-    configPath: getConfigPath(),
+    evaluationConfig: serializedEvaluationConfig,
+    functionConfig: serializedFunctionConfig,
     evaluationName,
     datasetName,
     variantName,

--- a/ui/app/utils/tensorzero/native_client.server.ts
+++ b/ui/app/utils/tensorzero/native_client.server.ts
@@ -35,7 +35,10 @@ export async function getNativeDatabaseClient(): Promise<DatabaseClient> {
 export function runNativeEvaluationStreaming(params: {
   gatewayUrl: string;
   clickhouseUrl: string;
-  configPath: string;
+  /** JSON-serialized EvaluationConfig */
+  evaluationConfig: string;
+  /** JSON-serialized EvaluationFunctionConfig */
+  functionConfig: string;
   evaluationName: string;
   datasetName: string;
   variantName: string;


### PR DESCRIPTION
This shows the diff between "making evaluation logic take a minimal version of function configs" vs " just make everything in function configs deserializable".