### PR TITLE
[Stacked] Fix filter panel scrolling for inferences and datapoints

### DIFF
--- a/ui/app/components/querybuilder/DatapointFilterBuilder.tsx
+++ b/ui/app/components/querybuilder/DatapointFilterBuilder.tsx
@@ -49,7 +49,7 @@ export default function DatapointFilterBuilder({
     <>
       <FormLabel>Advanced</FormLabel>
       {datapointFilter ? (
-        <div className="py-1">
+        <div className="py-1 pl-4">
           <FilterNodeRenderer
             filter={datapointFilter}
             onChange={setDatapointFilter}

--- a/ui/app/components/querybuilder/InferenceFilterBuilder.tsx
+++ b/ui/app/components/querybuilder/InferenceFilterBuilder.tsx
@@ -82,7 +82,7 @@ export default function InferenceFilterBuilder({
     <>
       <FormLabel>Advanced</FormLabel>
       {inferenceFilter ? (
-        <div className="py-1">
+        <div className="py-1 pl-4">
           <FilterNodeRenderer
             filter={inferenceFilter}
             onChange={setInferenceFilter}

--- a/ui/app/routes/datasets/$dataset_name/DatasetRowTable.tsx
+++ b/ui/app/routes/datasets/$dataset_name/DatasetRowTable.tsx
@@ -21,7 +21,7 @@ import { Filter, Trash } from "lucide-react";
 import { useState, useEffect } from "react";
 import { useFetcher, useNavigate } from "react-router";
 import { useForm } from "react-hook-form";
-import { Form } from "~/components/ui/form";
+import { Form, FormLabel } from "~/components/ui/form";
 import { toFunctionUrl, toDatapointUrl, toEpisodeUrl } from "~/utils/urls";
 import {
   Dialog,
@@ -280,12 +280,12 @@ export default function DatasetRowTable({
           side="right"
           className="flex w-full flex-col md:w-5/6 xl:w-1/2"
         >
-          <Form {...filterForm}>
+          <Form {...filterForm} className="flex min-h-0 flex-1 flex-col">
             <SheetHeader>
               <SheetTitle>Filter</SheetTitle>
             </SheetHeader>
 
-            <div className="mt-4 flex-1 space-y-4">
+            <div className="mt-4 min-h-0 flex-1 space-y-4 overflow-y-auto">
               <div>
                 <label className="text-sm font-medium">Function</label>
                 <div className="mt-1 flex items-center gap-2">
@@ -338,7 +338,7 @@ export default function DatasetRowTable({
               </div>
             </div>
 
-            <SheetFooter className="mt-4">
+            <SheetFooter className="mt-4 shrink-0">
               <Button onClick={handleFilterSubmit}>Apply Filters</Button>
             </SheetFooter>
           </Form>

--- a/ui/app/routes/observability/inferences/InferencesTable.tsx
+++ b/ui/app/routes/observability/inferences/InferencesTable.tsx
@@ -212,12 +212,12 @@ export default function InferencesTable({
           side="right"
           className="flex w-full flex-col md:w-5/6 xl:w-1/2"
         >
-          <Form {...filterForm}>
+          <Form {...filterForm} className="flex min-h-0 flex-1 flex-col">
             <SheetHeader>
               <SheetTitle>Filter</SheetTitle>
             </SheetHeader>
 
-            <div className="mt-4 flex-1 space-y-4">
+            <div className="mt-4 min-h-0 flex-1 space-y-4 overflow-y-auto">
               <div>
                 <label className="text-sm font-medium">Function</label>
                 <div className="mt-1 flex items-center gap-2">
@@ -321,7 +321,7 @@ export default function InferencesTable({
               </div>
             </div>
 
-            <SheetFooter className="mt-4">
+            <SheetFooter className="mt-4 shrink-0">
               <Button onClick={handleFilterSubmit}>Apply Filters</Button>
             </SheetFooter>
           </Form>


### PR DESCRIPTION
Fixes #5049.

![inference-filter](https://github.com/user-attachments/assets/de8673c4-25cd-4049-8acb-87068681de3c)

(The datapoint one looks the same.)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes filter panel scrolling for inferences and datapoints by adjusting CSS properties in relevant components.
> 
>   - **UI Adjustments**:
>     - Add `pl-4` to `div` in `DatapointFilterBuilder.tsx` and `InferenceFilterBuilder.tsx` for consistent padding.
>     - Add `min-h-0` and `overflow-y-auto` to `div` in `DatasetRowTable.tsx` and `InferencesTable.tsx` to enable scrolling.
>     - Add `shrink-0` to `SheetFooter` in `DatasetRowTable.tsx` and `InferencesTable.tsx` to prevent footer from shrinking.
>   - **Imports**:
>     - Add `FormLabel` import in `DatasetRowTable.tsx` to support form labeling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for efcb34fc2596005a53849da129257aefadf1b616. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->