### PR TITLE
Make empty and/or/not filter groups generate correct sql

### DIFF
--- a/tensorzero-core/src/db/clickhouse/query_builder/mod.rs
+++ b/tensorzero-core/src/db/clickhouse/query_builder/mod.rs
@@ -282,6 +282,10 @@ impl InferenceFilter {
                 ))
             }
             InferenceFilter::And { children } => {
+                // Empty AND is vacuously true - all zero conditions are met
+                if children.is_empty() {
+                    return Ok("TRUE".to_string());
+                }
                 let child_sqls: Vec<String> = children
                     .iter()
                     .map(|child| {
@@ -303,6 +307,10 @@ impl InferenceFilter {
                 Ok(format!("({child_sqls_str})"))
             }
             InferenceFilter::Or { children } => {
+                // Empty OR is false - no conditions can be met
+                if children.is_empty() {
+                    return Ok("FALSE".to_string());
+                }
                 let child_sqls: Vec<String> = children
                     .iter()
                     .map(|child| {
@@ -1111,6 +1119,36 @@ FORMAT JSONEachRow";
             },
         ];
         assert_eq!(params, expected_params);
+    }
+
+    /// Tests that an empty AND filter generates valid SQL (returns 1, meaning all rows match)
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_empty_and_filter() {
+        let config = get_e2e_config().await;
+        let filter_node = InferenceFilter::And { children: vec![] };
+        let opts = ListInferencesParams {
+            function_name: Some("extract_entities"),
+            filters: Some(&filter_node),
+            ..Default::default()
+        };
+        let (sql, _params) = generate_list_inferences_sql(&config, &opts).unwrap();
+        // Empty AND is vacuously true
+        assert_query_contains(&sql, "WHERE i.function_name = {p0:String} AND TRUE");
+    }
+
+    /// Tests that an empty OR filter generates valid SQL (returns 0, meaning no rows match)
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_empty_or_filter() {
+        let config = get_e2e_config().await;
+        let filter_node = InferenceFilter::Or { children: vec![] };
+        let opts = ListInferencesParams {
+            function_name: Some("extract_entities"),
+            filters: Some(&filter_node),
+            ..Default::default()
+        };
+        let (sql, _params) = generate_list_inferences_sql(&config, &opts).unwrap();
+        // Empty OR is vacuously false
+        assert_query_contains(&sql, "WHERE i.function_name = {p0:String} AND FALSE");
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
This is a good finding from #5050.

Fixes #5052.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix SQL generation for empty `AND` and `OR` filter groups in `InferenceFilter` to return `TRUE` and `FALSE` respectively.
> 
>   - **Behavior**:
>     - `InferenceFilter::And` with empty `children` returns `TRUE` SQL in `mod.rs`.
>     - `InferenceFilter::Or` with empty `children` returns `FALSE` SQL in `mod.rs`.
>   - **Tests**:
>     - Add `test_empty_and_filter` to verify `TRUE` SQL generation for empty `AND` in `tests`.
>     - Add `test_empty_or_filter` to verify `FALSE` SQL generation for empty `OR` in `tests`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for becb3f2452d958b15b98da2244cad7934ac7cb5a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->