### PR TITLE
Print more information on provider-proxy cache miss

### DIFF
--- a/provider-proxy/src/lib.rs
+++ b/provider-proxy/src/lib.rs
@@ -200,15 +200,19 @@ async fn check_cache<
     let path = args.cache_path.join(filename);
     let path_str = path.to_string_lossy().into_owned();
 
-    let use_cache = || match args.mode {
+    let mut file_mtime = None;
+
+    let mut use_cache = || match args.mode {
         CacheMode::ReadOnly => Ok::<_, anyhow::Error>(true),
         CacheMode::ReadWrite => Ok(true),
         CacheMode::ReadOldWriteNew => {
-            let file_mtime = std::fs::metadata(&path)
+            let current_file_mtime = std::fs::metadata(&path)
                 .with_context(|| format!("Failed to read cache file metadata for {path_str}"))?
                 .modified()
                 .with_context(|| format!("Failed to read cache file mtime for {path_str}"))?;
-            Ok(file_mtime <= start_time)
+            let use_cache = current_file_mtime <= start_time;
+            file_mtime = Some(current_file_mtime);
+            Ok(use_cache)
         }
     };
 
@@ -231,7 +235,12 @@ async fn check_cache<
         .with_context(|| format!("Failed to await tokio spawn_blocking for {path_str_clone}"))??;
         (resp, HEADER_TRUE)
     } else {
-        tracing::info!("Cache miss: {}", path_str);
+        tracing::info!(
+            file_mtime = ?file_mtime,
+            start_time = ?start_time,
+            "Cache miss: {}",
+            path_str,
+        );
         let response = match missing().await {
             Ok(response) => response,
             Err(e) => {


### PR DESCRIPTION
We're having some suspicious cache misses on CI,
which is probably making us go over our Google AI Studio quota Let's print out the file mtime when a cache miss occurs, to see if something weird is going on with file mtimes on CI
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Log file modification time on cache miss in `check_cache()` to diagnose CI cache issues.
> 
>   - **Logging**:
>     - In `check_cache()` in `lib.rs`, log file modification time (`file_mtime`) and `start_time` on cache miss.
>     - Modify `use_cache` closure to capture `file_mtime` when `CacheMode::ReadOldWriteNew` is used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for dc83c25ae6baa66126ac305a475296a9a06af749. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->