### PR TITLE
Display a Gateway Required error on initial load

### DIFF
--- a/ui/app/components/ui/GatewayRequiredState.tsx
+++ b/ui/app/components/ui/GatewayRequiredState.tsx
@@ -1,0 +1,31 @@
+import { AlertCircle } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+
+export function GatewayRequiredState() {
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <Card className="max-w-md">
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <AlertCircle className="h-5 w-5 text-red-500" />
+            <CardTitle>Cannot Connect to TensorZero Gateway</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-sm">
+            The TensorZero UI could not connect to the gateway. Please ensure:
+          </p>
+          <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-4 text-sm">
+            <li>The TensorZero gateway is running</li>
+            <li>
+              <code className="bg-muted rounded px-1 py-0.5 font-mono">
+                TENSORZERO_GATEWAY_URL
+              </code>{" "}
+              is correctly configured
+            </li>
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/ui/app/utils/tensorzero/errors.ts
+++ b/ui/app/utils/tensorzero/errors.ts
@@ -1,6 +1,34 @@
 import { StatusCodes as HttpStatusCode } from "http-status-codes";
 import { isErrorLike } from "~/utils/common";
 
+/**
+ * Error thrown when the UI cannot connect to the TensorZero gateway.
+ * This is distinct from TensorZeroServerError which represents errors
+ * returned by the gateway itself.
+ */
+export class GatewayConnectionError extends Error {
+  constructor(cause?: unknown) {
+    super("Cannot connect to TensorZero gateway", { cause });
+    this.name = "GatewayConnectionError";
+  }
+}
+
+export function isGatewayConnectionError(
+  error: unknown,
+): error is GatewayConnectionError {
+  // Check instanceof for server-side errors
+  if (error instanceof GatewayConnectionError) {
+    return true;
+  }
+  // Check serialized object properties (works if thrown from server loader)
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    error.name === "GatewayConnectionError"
+  );
+}
+
 export class TensorZeroServerError extends Error {
   readonly status: number;
   readonly statusText: string | null;


### PR DESCRIPTION
After we start loading the config from the gateway, if on initial connection the request fails, we get a very ugly error in the `ErrorBoundary`. This PR shows a nicer error:

After:
<img width="614" height="374" alt="image" src="https://github.com/user-attachments/assets/c2d09501-bbb4-4ef0-b8b8-3b8efcb6e438" />

Before:
<img width="1539" height="899" alt="image" src="https://github.com/user-attachments/assets/6589030b-e967-4103-a855-3193bf8e0be3" />

A step towards #5002.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds user-friendly error handling for initial gateway connection failures in the TensorZero UI.
> 
>   - **Behavior**:
>     - Adds `GatewayRequiredState` component to display a user-friendly error when the UI cannot connect to the TensorZero gateway.
>     - Updates `ErrorBoundary` in `root.tsx` to render `GatewayRequiredState` for `GatewayConnectionError`.
>     - Modifies `loader` in `root.tsx` to throw a 503 error with `GATEWAY_UNAVAILABLE_ERROR` if `isGatewayConnectionError` is true.
>   - **Error Handling**:
>     - Introduces `GatewayConnectionError` class in `errors.ts` for network errors.
>     - Adds `isGatewayConnectionError` function in `errors.ts` to identify `GatewayConnectionError` instances.
>     - Updates `fetch` method in `TensorZeroClient` in `tensorzero.ts` to throw `GatewayConnectionError` on network failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6f198e2e7859b44f16a358688f4bd067c7e7da0c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->