### PR TITLE
Introduce new `AxumResponseError` wrapper type

### DIFF
--- a/tensorzero-core/src/endpoints/datasets/v1/list_datasets.rs
+++ b/tensorzero-core/src/endpoints/datasets/v1/list_datasets.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 use tracing::instrument;
 
 use crate::db::datasets::{DatasetQueries, GetDatasetMetadataParams};
-use crate::error::Error;
+use crate::error::AxumResponseError;
 use crate::utils::gateway::{AppState, AppStateData};
 
 use super::types::{DatasetMetadata, ListDatasetsResponse};
@@ -23,26 +23,31 @@ pub struct ListDatasetsQueryParams {
 pub async fn list_datasets_handler(
     State(app_state): AppState,
     Query(params): Query<ListDatasetsQueryParams>,
-) -> Result<Json<ListDatasetsResponse>, Error> {
-    let db_params = GetDatasetMetadataParams {
-        function_name: params.function_name,
-        limit: params.limit,
-        offset: params.offset,
-    };
-    let db_datasets = app_state
-        .clickhouse_connection_info
-        .get_dataset_metadata(&db_params)
-        .await?;
+) -> Result<Json<ListDatasetsResponse>, AxumResponseError> {
+    async {
+        let db_params = GetDatasetMetadataParams {
+            function_name: params.function_name,
+            limit: params.limit,
+            offset: params.offset,
+        };
+        let db_datasets = app_state
+            .clickhouse_connection_info
+            .get_dataset_metadata(&db_params)
+            .await?;
 
-    // Convert from DB type to API type
-    let datasets = db_datasets
-        .into_iter()
-        .map(|db_meta| DatasetMetadata {
-            dataset_name: db_meta.dataset_name,
-            datapoint_count: db_meta.count,
-            last_updated: db_meta.last_updated,
-        })
-        .collect();
+        // Convert from DB type to API type
+        let datasets = db_datasets
+            .into_iter()
+            .map(|db_meta| DatasetMetadata {
+                dataset_name: db_meta.dataset_name,
+                datapoint_count: db_meta.count,
+                last_updated: db_meta.last_updated,
+            })
+            .collect();
 
-    Ok(Json(ListDatasetsResponse { datasets }))
+        Ok(ListDatasetsResponse { datasets })
+    }
+    .await
+    .map(Json)
+    .map_err(|e| AxumResponseError::new(e, app_state))
 }

--- a/tensorzero-core/src/endpoints/inference.rs
+++ b/tensorzero-core/src/endpoints/inference.rs
@@ -29,7 +29,7 @@ use crate::config::{Config, ErrorContext, OtlpConfig, SchemaData, UninitializedV
 use crate::db::clickhouse::{ClickHouseConnectionInfo, TableName};
 use crate::db::postgres::PostgresConnectionInfo;
 use crate::embeddings::EmbeddingModelTable;
-use crate::error::{Error, ErrorDetails, IMPOSSIBLE_ERROR_MESSAGE};
+use crate::error::{AxumResponseError, Error, ErrorDetails, IMPOSSIBLE_ERROR_MESSAGE};
 use crate::experimentation::ExperimentationConfig;
 use crate::function::{FunctionConfig, FunctionConfigChat};
 use crate::http::TensorzeroHttpClient;
@@ -160,37 +160,34 @@ pub type InferenceCredentials = HashMap<String, SecretString>;
 /// A handler for the inference endpoint
 #[debug_handler(state = AppStateData)]
 pub async fn inference_handler(
-    State(AppStateData {
-        config,
-        http_client,
-        clickhouse_connection_info,
-        postgres_connection_info,
-        deferred_tasks,
-        ..
-    }): AppState,
+    State(app_state): AppState,
     api_key_ext: Option<Extension<RequestApiKeyExtension>>,
     StructuredJson(params): StructuredJson<Params>,
-) -> Result<Response<Body>, Error> {
-    let inference_output = Box::pin(inference(
-        config,
-        &http_client,
-        clickhouse_connection_info,
-        postgres_connection_info,
-        deferred_tasks,
-        params,
-        api_key_ext,
-    ))
-    .await?;
-    match inference_output {
-        InferenceOutput::NonStreaming(response) => Ok(Json(response).into_response()),
-        InferenceOutput::Streaming(stream) => {
-            let event_stream = prepare_serialized_events(stream);
+) -> Result<Response<Body>, AxumResponseError> {
+    async {
+        let inference_output = Box::pin(inference(
+            app_state.config.clone(),
+            &app_state.http_client,
+            app_state.clickhouse_connection_info.clone(),
+            app_state.postgres_connection_info.clone(),
+            app_state.deferred_tasks.clone(),
+            params,
+            api_key_ext,
+        ))
+        .await?;
+        match inference_output {
+            InferenceOutput::NonStreaming(response) => Ok(Json(response).into_response()),
+            InferenceOutput::Streaming(stream) => {
+                let event_stream = prepare_serialized_events(stream);
 
-            Ok(Sse::new(event_stream)
-                .keep_alive(axum::response::sse::KeepAlive::new())
-                .into_response())
+                Ok(Sse::new(event_stream)
+                    .keep_alive(axum::response::sse::KeepAlive::new())
+                    .into_response())
+            }
         }
     }
+    .await
+    .map_err(|e| AxumResponseError::new(e, app_state))
 }
 
 pub type InferenceStream =

--- a/tensorzero-core/src/endpoints/openai_compatible/chat_completions.rs
+++ b/tensorzero-core/src/endpoints/openai_compatible/chat_completions.rs
@@ -13,7 +13,7 @@ use axum::response::{IntoResponse, Response};
 use axum::{Extension, debug_handler};
 
 use crate::endpoints::inference::{InferenceOutput, Params, inference};
-use crate::error::{Error, ErrorDetails};
+use crate::error::{AxumResponseError, Error, ErrorDetails};
 use crate::utils::gateway::{AppState, AppStateData, StructuredJson};
 use tensorzero_auth::middleware::RequestApiKeyExtension;
 
@@ -23,97 +23,94 @@ use super::types::streaming::prepare_serialized_openai_compatible_events;
 /// A handler for the OpenAI-compatible inference endpoint
 #[debug_handler(state = AppStateData)]
 pub async fn chat_completions_handler(
-    State(AppStateData {
-        config,
-        http_client,
-        clickhouse_connection_info,
-        postgres_connection_info,
-        deferred_tasks,
-        ..
-    }): AppState,
+    State(app_state): AppState,
     api_key_ext: Option<Extension<RequestApiKeyExtension>>,
     StructuredJson(openai_compatible_params): StructuredJson<OpenAICompatibleParams>,
-) -> Result<Response<Body>, Error> {
-    // Validate `n` parameter
-    if let Some(n) = openai_compatible_params.n
-        && n != 1
-    {
-        return Err(Error::new(ErrorDetails::InvalidOpenAICompatibleRequest {
-                message: "TensorZero does not support `n` other than 1. Please omit this parameter or set it to 1.".to_string(),
-            }));
-    }
-
-    if !openai_compatible_params.unknown_fields.is_empty() {
-        if openai_compatible_params.tensorzero_deny_unknown_fields {
-            let mut unknown_field_names = openai_compatible_params
-                .unknown_fields
-                .keys()
-                .cloned()
-                .collect::<Vec<_>>();
-
-            unknown_field_names.sort();
-            let unknown_field_names = unknown_field_names.join(", ");
-
+) -> Result<Response<Body>, AxumResponseError> {
+    async {
+        // Validate `n` parameter
+        if let Some(n) = openai_compatible_params.n
+            && n != 1
+        {
             return Err(Error::new(ErrorDetails::InvalidOpenAICompatibleRequest {
-                message: format!(
-                    "`tensorzero::deny_unknown_fields` is set to true, but found unknown fields in the request: [{unknown_field_names}]"
-                ),
-            }));
+                    message: "TensorZero does not support `n` other than 1. Please omit this parameter or set it to 1.".to_string(),
+                }));
         }
-        tracing::warn!(
-            "Ignoring unknown fields in OpenAI-compatible request: {:?}",
-            openai_compatible_params
-                .unknown_fields
-                .keys()
-                .collect::<Vec<_>>()
-        );
-    }
-    let stream_options = openai_compatible_params.stream_options;
-    let params = Params::try_from_openai(openai_compatible_params)?;
 
-    // The prefix for the response's `model` field depends on the inference target
-    // (We run this disambiguation deep in the `inference` call below but we don't get the decision out, so we duplicate it here)
-    let response_model_prefix = match (&params.function_name, &params.model_name) {
-        (Some(function_name), None) => Ok::<String, Error>(format!(
-            "tensorzero::function_name::{function_name}::variant_name::",
-        )),
-        (None, Some(_model_name)) => Ok("tensorzero::model_name::".to_string()),
-        (Some(_), Some(_)) => Err(ErrorDetails::InvalidInferenceTarget {
-            message: "Only one of `function_name` or `model_name` can be provided".to_string(),
-        }
-        .into()),
-        (None, None) => Err(ErrorDetails::InvalidInferenceTarget {
-            message: "Either `function_name` or `model_name` must be provided".to_string(),
-        }
-        .into()),
-    }?;
+        if !openai_compatible_params.unknown_fields.is_empty() {
+            if openai_compatible_params.tensorzero_deny_unknown_fields {
+                let mut unknown_field_names = openai_compatible_params
+                    .unknown_fields
+                    .keys()
+                    .cloned()
+                    .collect::<Vec<_>>();
 
-    let response = Box::pin(inference(
-        config,
-        &http_client,
-        clickhouse_connection_info,
-        postgres_connection_info,
-        deferred_tasks,
-        params,
-        api_key_ext,
-    ))
-    .await?;
+                unknown_field_names.sort();
+                let unknown_field_names = unknown_field_names.join(", ");
 
-    match response {
-        InferenceOutput::NonStreaming(response) => {
-            let openai_compatible_response =
-                OpenAICompatibleResponse::from((response, response_model_prefix));
-            Ok(Json(openai_compatible_response).into_response())
-        }
-        InferenceOutput::Streaming(stream) => {
-            let openai_compatible_stream = prepare_serialized_openai_compatible_events(
-                stream,
-                response_model_prefix,
-                stream_options,
+                return Err(Error::new(ErrorDetails::InvalidOpenAICompatibleRequest {
+                    message: format!(
+                        "`tensorzero::deny_unknown_fields` is set to true, but found unknown fields in the request: [{unknown_field_names}]"
+                    ),
+                }));
+            }
+            tracing::warn!(
+                "Ignoring unknown fields in OpenAI-compatible request: {:?}",
+                openai_compatible_params
+                    .unknown_fields
+                    .keys()
+                    .collect::<Vec<_>>()
             );
-            Ok(Sse::new(openai_compatible_stream)
-                .keep_alive(axum::response::sse::KeepAlive::new())
-                .into_response())
+        }
+        let stream_options = openai_compatible_params.stream_options;
+        let params = Params::try_from_openai(openai_compatible_params)?;
+
+        // The prefix for the response's `model` field depends on the inference target
+        // (We run this disambiguation deep in the `inference` call below but we don't get the decision out, so we duplicate it here)
+        let response_model_prefix = match (&params.function_name, &params.model_name) {
+            (Some(function_name), None) => Ok::<String, Error>(format!(
+                "tensorzero::function_name::{function_name}::variant_name::",
+            )),
+            (None, Some(_model_name)) => Ok("tensorzero::model_name::".to_string()),
+            (Some(_), Some(_)) => Err(ErrorDetails::InvalidInferenceTarget {
+                message: "Only one of `function_name` or `model_name` can be provided".to_string(),
+            }
+            .into()),
+            (None, None) => Err(ErrorDetails::InvalidInferenceTarget {
+                message: "Either `function_name` or `model_name` must be provided".to_string(),
+            }
+            .into()),
+        }?;
+
+        let response = Box::pin(inference(
+            app_state.config.clone(),
+            &app_state.http_client,
+            app_state.clickhouse_connection_info.clone(),
+            app_state.postgres_connection_info.clone(),
+            app_state.deferred_tasks.clone(),
+            params,
+            api_key_ext,
+        ))
+        .await?;
+
+        match response {
+            InferenceOutput::NonStreaming(response) => {
+                let openai_compatible_response =
+                    OpenAICompatibleResponse::from((response, response_model_prefix));
+                Ok(Json(openai_compatible_response).into_response())
+            }
+            InferenceOutput::Streaming(stream) => {
+                let openai_compatible_stream = prepare_serialized_openai_compatible_events(
+                    stream,
+                    response_model_prefix,
+                    stream_options,
+                );
+                Ok(Sse::new(openai_compatible_stream)
+                    .keep_alive(axum::response::sse::KeepAlive::new())
+                    .into_response())
+            }
         }
     }
+    .await
+    .map_err(|e| AxumResponseError::new(e, app_state))
 }

--- a/tensorzero-core/src/endpoints/stored_inferences/v1/get_inferences.rs
+++ b/tensorzero-core/src/endpoints/stored_inferences/v1/get_inferences.rs
@@ -4,7 +4,7 @@ use tracing::instrument;
 
 use crate::config::Config;
 use crate::db::inferences::{InferenceQueries, ListInferencesParams};
-use crate::error::Error;
+use crate::error::{AxumResponseError, Error};
 use crate::stored_inference::StoredInferenceDatabase;
 use crate::utils::gateway::{AppState, AppStateData, StructuredJson};
 
@@ -17,14 +17,15 @@ use super::types::{GetInferencesRequest, GetInferencesResponse, ListInferencesRe
 pub async fn get_inferences_handler(
     State(app_state): AppState,
     StructuredJson(request): StructuredJson<GetInferencesRequest>,
-) -> Result<Json<GetInferencesResponse>, Error> {
-    let response = get_inferences(
+) -> Result<Json<GetInferencesResponse>, AxumResponseError> {
+    get_inferences(
         &app_state.config,
         &app_state.clickhouse_connection_info,
         request,
     )
-    .await?;
-    Ok(Json(response))
+    .await
+    .map(Json)
+    .map_err(|e| AxumResponseError::new(e, app_state))
 }
 
 pub async fn get_inferences(
@@ -63,15 +64,15 @@ pub async fn get_inferences(
 pub async fn list_inferences_handler(
     State(app_state): AppState,
     StructuredJson(request): StructuredJson<ListInferencesRequest>,
-) -> Result<Json<GetInferencesResponse>, Error> {
-    let response = list_inferences(
+) -> Result<Json<GetInferencesResponse>, AxumResponseError> {
+    list_inferences(
         &app_state.config,
         &app_state.clickhouse_connection_info,
         request,
     )
-    .await?;
-
-    Ok(Json(response))
+    .await
+    .map(Json)
+    .map_err(|e| AxumResponseError::new(e, app_state))
 }
 
 pub async fn list_inferences(

--- a/tensorzero-core/src/endpoints/variant_probabilities.rs
+++ b/tensorzero-core/src/endpoints/variant_probabilities.rs
@@ -5,7 +5,7 @@ use axum::{Json, debug_handler};
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
-use crate::error::{Error, ErrorDetails};
+use crate::error::{AxumResponseError, Error, ErrorDetails};
 use crate::utils::gateway::{AppState, AppStateData};
 
 /// Query parameters for the variant sampling probabilities endpoint
@@ -28,10 +28,11 @@ pub struct GetVariantSamplingProbabilitiesResponse {
 pub async fn get_variant_sampling_probabilities_handler(
     State(app_state): AppState,
     Query(params): Query<GetVariantSamplingProbabilitiesParams>,
-) -> Result<Json<GetVariantSamplingProbabilitiesResponse>, Error> {
-    Ok(Json(
-        get_variant_sampling_probabilities(app_state, params).await?,
-    ))
+) -> Result<Json<GetVariantSamplingProbabilitiesResponse>, AxumResponseError> {
+    get_variant_sampling_probabilities(app_state.clone(), params)
+        .await
+        .map(Json)
+        .map_err(|e| AxumResponseError::new(e, app_state))
 }
 
 /// HTTP handler for the variant sampling probabilities endpoint (path-based)
@@ -39,11 +40,12 @@ pub async fn get_variant_sampling_probabilities_handler(
 pub async fn get_variant_sampling_probabilities_by_function_handler(
     State(app_state): AppState,
     Path(function_name): Path<String>,
-) -> Result<Json<GetVariantSamplingProbabilitiesResponse>, Error> {
+) -> Result<Json<GetVariantSamplingProbabilitiesResponse>, AxumResponseError> {
     let params = GetVariantSamplingProbabilitiesParams { function_name };
-    Ok(Json(
-        get_variant_sampling_probabilities(app_state, params).await?,
-    ))
+    get_variant_sampling_probabilities(app_state.clone(), params)
+        .await
+        .map(Json)
+        .map_err(|e| AxumResponseError::new(e, app_state))
 }
 
 /// Core business logic for getting variant sampling probabilities

--- a/tensorzero-core/src/observability/mod.rs
+++ b/tensorzero-core/src/observability/mod.rs
@@ -841,7 +841,10 @@ async fn tensorzero_otel_tracing_middleware(
     let custom_tracer_key = match extract_tensorzero_headers(&tracer_wrapper, req.headers()) {
         Ok(key) => key,
         Err(e) => {
-            return e.into_response();
+            // Return a simple error response without needing AppState
+            let status_code = e.status_code();
+            let error_message = e.to_string();
+            return (status_code, error_message).into_response();
         }
     };
 
@@ -862,7 +865,10 @@ async fn tensorzero_otel_tracing_middleware(
         let span = match make_otel_http_span(&req, custom_tracer_key, &tracer_wrapper) {
             Ok(span) => span,
             Err(e) => {
-                return e.into_response();
+                // Return a simple error response without needing AppState
+                let status_code = e.status_code();
+                let error_message = e.to_string();
+                return (status_code, error_message).into_response();
             }
         };
         let response = next.run(req).instrument(span.clone()).await;


### PR DESCRIPTION
We no longer implement `IntoResponse` for `Error`. As a result, all of the top-level axum HTTP route handlers must explicitly construct `AxumResponseError` by passing in `AppStateData`.

In the future, we could add other constructors for `AppStateData` to allow passing in request-specific information that affects the json-rendered error message
(e.g. a 'forward_raw_request' option for relay mode)

There are other approaches that require less code, but require introducing global/task-local state (e.g. modifying the response body from a middleware function).

I'm opening this PR to get feedback on this particular approach