### PR TITLE
Use our existing Github PAT in check-fork workflow

### DIFF
--- a/.github/workflows/slash-command-check-fork.yml
+++ b/.github/workflows/slash-command-check-fork.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
+          # We need to use a PAT so that GitHub will let us modify workflow files when pushing to a branch
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add initial reaction
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043


### PR DESCRIPTION
Using the normal workflow github token doesn't let you push to a branch while modifying workflow files, so we need to use our existing github PAT.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use GitHub PAT in `slash-command-check-fork.yml` to allow modifying workflow files when pushing to a branch.
> 
>   - **Behavior**:
>     - Use GitHub PAT in `slash-command-check-fork.yml` to allow modifying workflow files when pushing to a branch.
>     - Replaces default GitHub token with `${{ secrets.GITHUB_TOKEN }}` in the `checkout` step.
>   - **Purpose**:
>     - Enables pushing to branches while modifying workflow files, which is restricted with the default token.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 400a16026cf4690acc91a64fcc5e0719b176ccfe. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->