### PR TITLE
Bump timeout for countFeedbacksForMetric ui test

### DIFF
--- a/ui/app/utils/clickhouse/curation.test.ts
+++ b/ui/app/utils/clickhouse/curation.test.ts
@@ -297,7 +297,7 @@ test("countFeedbacksForMetric returns correct counts", async () => {
     { type: "demonstration", level: "inference" },
   );
   expect(demoCount).toBe(100);
-});
+}, 10000);
 
 describe("handle_llm_judge_output", () => {
   it("should remove the thinking field from the output", () => {


### PR DESCRIPTION
We already bumped a 'countCuratedInferences' test to 10s, so let's bump this one as well (it timed out recently)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase timeout for `countFeedbacksForMetric` test in `curation.test.ts` to 10 seconds.
> 
>   - **Tests**:
>     - Increase timeout for `countFeedbacksForMetric` test in `curation.test.ts` to 10 seconds to prevent recent timeouts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for dd0ffd0a352eab7147d5e83a35bddacd2ba988a6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->