### PR TITLE
Fix postgres config messages

### DIFF
--- a/docs/gateway/configuration-reference.mdx
+++ b/docs/gateway/configuration-reference.mdx
@@ -4246,7 +4246,7 @@ If `true`, the gateway will throw an error on startup if it fails to connect to 
 If `false`, the gateway will not use PostgreSQL even if the `TENSORZERO_POSTGRES_URL` environment variable is set.
 If omitted, the gateway will connect to PostgreSQL if the `TENSORZERO_POSTGRES_URL` environment variable is set, otherwise it will disable PostgreSQL with a warning.
 
-If you have features that require PostgreSQL (rate limiting or Track-and-Stop experimentation) configured but set `postgres.enabled = false` or don't provide the `TENSORZERO_POSTGRES_URL` environment variable, the gateway will fail to start with a configuration error.
+If you have features that require PostgreSQL (e.g. rate limiting, adaptive experimentation) configured but set `postgres.enabled = false` or don't provide the `TENSORZERO_POSTGRES_URL` environment variable, the gateway will fail to start with a configuration error.
 
 ## `[rate_limiting]`
 

--- a/tensorzero-core/src/utils/gateway.rs
+++ b/tensorzero-core/src/utils/gateway.rs
@@ -238,7 +238,7 @@ impl GatewayHandle {
             && matches!(postgres_connection_info, PostgresConnectionInfo::Disabled)
         {
             return Err(Error::new(ErrorDetails::Config {
-                message: "Rate limiting is configured but PostgreSQL is disabled. Rate limiting requires PostgreSQL to be configured. Please set the `TENSORZERO_POSTGRES_URL` environment variable and ensure `gateway.postgres.enabled` is not set to false, or disable rate limiting.".to_string(),
+                message: "Rate limiting is configured but PostgreSQL is disabled. Rate limiting requires PostgreSQL to be configured. Please set the `TENSORZERO_POSTGRES_URL` environment variable and ensure `postgres.enabled` is not set to false, or disable rate limiting.".to_string(),
             }));
         }
 
@@ -390,9 +390,7 @@ pub async fn setup_postgres(
     let postgres_connection_info = match (config.postgres.enabled, postgres_url.as_deref()) {
         // Postgres disabled by config
         (Some(false), _) => {
-            tracing::info!(
-                "Disabling Postgres: `gateway.postgres.enabled` is set to false in config."
-            );
+            tracing::info!("Disabling Postgres: `postgres.enabled` is set to false in config.");
             PostgresConnectionInfo::Disabled
         }
         // Postgres enabled but no URL
@@ -409,7 +407,7 @@ pub async fn setup_postgres(
         // Postgres default and no URL
         (None, None) => {
             tracing::debug!(
-                "Disabling Postgres: `gateway.postgres.enabled` is not explicitly specified in config and `TENSORZERO_POSTGRES_URL` is not set."
+                "Disabling Postgres: `postgres.enabled` is not explicitly specified in config and `TENSORZERO_POSTGRES_URL` is not set."
             );
             PostgresConnectionInfo::Disabled
         }
@@ -765,7 +763,7 @@ mod tests {
             PostgresConnectionInfo::Disabled
         ));
         assert!(logs_contain(
-            "Disabling Postgres: `gateway.postgres.enabled` is set to false in config."
+            "Disabling Postgres: `postgres.enabled` is set to false in config."
         ));
 
         // Postgres disabled even with URL provided


### PR DESCRIPTION
Fix #4815
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes configuration messages for PostgreSQL in documentation and code to ensure consistency and clarity.
> 
>   - **Documentation**:
>     - Update `configuration-reference.mdx` to replace "Track-and-Stop experimentation" with "adaptive experimentation" in PostgreSQL configuration section.
>   - **Code**:
>     - In `gateway.rs`, update log messages to use `postgres.enabled` instead of `gateway.postgres.enabled` in `setup_postgres()` and related functions.
>     - Adjust log messages for disabling Postgres in `setup_postgres()` to reflect the correct configuration path.
>     - Update test assertions in `tests` module to match new log messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for fd854f6d9a538b9f07a9839a4c21829655ad322b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->