### PR TITLE
Document filename

### DIFF
--- a/docs/gateway/api-reference/batch-inference.mdx
+++ b/docs/gateway/api-reference/batch-inference.mdx
@@ -174,10 +174,12 @@ If the content block has type `file`, it must have exactly one of the following 
   - `file_type`: must be `url`
   - `url`
   - `mime_type` (optional): override the MIME type of the file
+  - `filename` (optional): a filename to associate with the file
 - Base64-encoded Files
   - `file_type`: must be `base64`
   - `data`: `base64`-encoded data for an embedded file
   - `mime_type`: the MIME type (e.g. `image/png`, `image/jpeg`, `application/pdf`)
+  - `filename` (optional): a filename to associate with the file
 
 See the [Multimodal Inference](/gateway/guides/multimodal-inference/) guide for more details on how to use images in inference.
 

--- a/docs/gateway/api-reference/inference.mdx
+++ b/docs/gateway/api-reference/inference.mdx
@@ -358,11 +358,13 @@ If the content block has type `file`, it must have exactly one of the following 
   - `url`
   - `mime_type` (optional): override the MIME type of the file
   - `detail` (optional): controls the fidelity of image processing. Only applies to image files; ignored for other file types. Can be `low`, `high`, or `auto`. Affects token consumption and image quality. Only supported by some model providers; ignored otherwise.
+  - `filename` (optional): a filename to associate with the file
 - Base64-encoded Files
   - `file_type`: must be `base64`
   - `data`: `base64`-encoded data for an embedded file
   - `mime_type`: the MIME type (e.g. `image/png`, `image/jpeg`, `application/pdf`)
   - `detail` (optional): controls the fidelity of image processing. Only applies to image files; ignored for other file types. Can be `low`, `high`, or `auto`. Affects token consumption and image quality. Only supported by some model providers; ignored otherwise.
+  - `filename` (optional): a filename to associate with the file
 
 See the [Multimodal Inference](/gateway/guides/multimodal-inference/) guide for more details on how to use images in inference.
 


### PR DESCRIPTION
Fix #4814 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds optional `filename` field to `file` content block type in `batch-inference.mdx` and `inference.mdx` for associating filenames with files.
> 
>   - **Documentation Update**:
>     - Adds `filename` (optional) field to `file` content block type in `batch-inference.mdx` and `inference.mdx`.
>     - Applicable for both `url` and `base64` file types, allowing users to associate a filename with the file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c3f56692494fd9c8ca5eaddea32c09e9ae6aeaa9. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->