### PR TITLE
Allow container download to fail on forks in ClickHouse job

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -789,6 +789,7 @@ jobs:
           # Retag the images to what we expect the names to be
           docker tag nscr.io/igvf4asmf8kri/gateway:sha-${{ github.sha }} tensorzero/gateway:sha-${{ github.sha }}
           docker tag nscr.io/igvf4asmf8kri/mock-inference-provider:sha-${{ github.sha }} tensorzero/mock-inference-provider:sha-${{ github.sha }}
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Download ClickHouse fixtures
         run: uv run ./ui/fixtures/download-fixtures.py


### PR DESCRIPTION
We don't push to Namespace on prs from forks, so let this step fail
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allows container download step in `clickhouse-tests` job to fail for PRs from forks or when actor is 'dependabot[bot]'.
> 
>   - **Behavior**:
>     - Allows container download step in `clickhouse-tests` job to fail for PRs from forks or when actor is 'dependabot[bot]'.
>     - Uses `continue-on-error` with condition: `github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]'`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0a239edc1dea159e91b1c72bfd2b0b0d36c7b91b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->