### PR TITLE
Document input_audio

### DIFF
--- a/docs/gateway/api-reference/inference-openai-compatible.mdx
+++ b/docs/gateway/api-reference/inference-openai-compatible.mdx
@@ -504,6 +504,12 @@ If a content block has type `image_url`, it must have the following additional f
   - `url`: The URL for a remote image (e.g. `"https://example.com/image.png"`) or base64-encoded data for an embedded image (e.g. `"data:image/png;base64,..."`).
   - `detail` (optional): Controls the fidelity of image processing. Only applies to image files; ignored for other file types. Can be `low`, `high`, or `auto`. Affects token consumption and image quality.
 
+If a content block has type `input_audio`, it must have the following additional field:
+
+- `input_audio`: An object containing:
+  - `data`: Base64-encoded audio data (without a `data:` prefix or MIME type header).
+  - `format`: The audio format as a string (e.g., `"mp3"`, `"wav"`). Note: The MIME type is detected from the actual audio bytes, and a warning is logged if the detected type differs from this field.
+
 The TensorZero-specific content block types are:
 
 - `tensorzero::raw_text`: Bypasses templates and schemas, sending text directly to the model. Useful for testing prompts or dynamic injection without configuration changes. Must have a `value` field containing the text.


### PR DESCRIPTION
Fix #4813 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add documentation for `input_audio` content block type in `inference-openai-compatible.mdx`.
> 
>   - **Documentation**:
>     - Adds documentation for `input_audio` content block type in `inference-openai-compatible.mdx`.
>     - Specifies `input_audio` requires `data` (base64-encoded audio) and `format` (audio format string).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f5d3230e1c982d22e98c8005cde88f01364716f6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->