### PR TITLE
Ignore wikipedia fetch tests for now

### DIFF
--- a/tensorzero-core/tests/e2e/image_url.rs
+++ b/tensorzero-core/tests/e2e/image_url.rs
@@ -437,6 +437,7 @@ async fn test_base64_image_with_fetch_false() {
 }
 
 #[tokio::test]
+#[ignore = "See https://github.com/tensorzero/tensorzero/issues/5092"]
 async fn test_wikipedia_image_url_with_fetch_true() {
     let episode_id = Uuid::now_v7();
 
@@ -515,6 +516,7 @@ async fn test_wikipedia_image_url_with_fetch_true() {
 }
 
 #[tokio::test]
+#[ignore = "See https://github.com/tensorzero/tensorzero/issues/5092"]
 async fn test_wikipedia_image_url_with_fetch_false() {
     let episode_id = Uuid::now_v7();
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `#[ignore]` to Wikipedia image URL tests in `image_url.rs` due to issue #5092.
> 
>   - **Tests**:
>     - Add `#[ignore]` attribute to `test_wikipedia_image_url_with_fetch_true` and `test_wikipedia_image_url_with_fetch_false` in `image_url.rs`.
>     - Reference issue `#5092` in the `#[ignore]` attribute for both tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f603c140eaa86e1e53ac7a6fdd43a8b5a20aa5be. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->