### PR TITLE
Forward dynamic credentials in TensorZero relay mode

### DIFF
--- a/gateway/tests/relay.rs
+++ b/gateway/tests/relay.rs
@@ -492,7 +492,7 @@ async fn test_relay_dynamic_api_key() {
 
     [models.my_dummy.providers.good]
     type = "dummy"
-    model_name = "good"
+    model_name = "test_key"
     api_key_location = "dynamic::my_api_key"
     "#;
     let relay_config = r#"
@@ -533,6 +533,38 @@ async fn test_relay_dynamic_api_key() {
     let response = response.text().await.unwrap();
     println!("Response: {response}");
     assert_eq!(status, http::StatusCode::OK);
+
+    let client = Client::new();
+    let response = client
+        .post(format!("http://{}/inference", env.relay.addr))
+        .json(&json!({
+            "model_name": "my_dummy",
+            "episode_id": Uuid::now_v7(),
+            "input": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Hello"
+                    }
+                ]
+            },
+            "credentials": {
+                "my_api_key": "bad_key"
+            },
+            "stream": false
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let response = response.text().await.unwrap();
+    println!("New response: {response}");
+    assert_eq!(status, http::StatusCode::BAD_GATEWAY);
+    assert!(
+        response.contains("Invalid API key for Dummy provider"),
+        "Unexpected response: {response}"
+    );
 }
 
 #[tokio::test]

--- a/tensorzero-core/src/relay.rs
+++ b/tensorzero-core/src/relay.rs
@@ -153,8 +153,9 @@ impl TensorzeroRelay {
             .await
             .map_err(|e| {
                 // TODO - fix raw_request/raw_response here
-                Error::new(ErrorDetails::InferenceServer {
+                Error::new(ErrorDetails::InferenceClient {
                     message: e.to_string(),
+                    status_code: None,
                     provider_type: "tensorzero_relay".to_string(),
                     raw_request: None,
                     raw_response: None,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Forward dynamic credentials in TensorZero relay mode and add tests to verify handling of valid and invalid API keys.
> 
>   - **Behavior**:
>     - Forward dynamic credentials in TensorZero relay mode by mapping credentials to `ClientSecretString` in `build_client_inference_params()` in `relay.rs`.
>     - Handles valid and invalid API keys, returning `OK` for valid and `BAD_GATEWAY` for invalid keys.
>   - **Tests**:
>     - Add `test_relay_dynamic_api_key()` in `relay.rs` to verify forwarding of dynamic credentials.
>     - Test checks for `OK` status with valid key and `BAD_GATEWAY` with invalid key, ensuring error message contains "Invalid API key for Dummy provider".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b28a19b4f55155e9d9b06b4e270180ce3e3c79b0. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->