### PR TITLE
Use more workers on CI when running pytest

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -306,7 +306,7 @@ jobs:
         working-directory: clients/python
         run: |
           # Start the test in background and capture its PID
-          bash ./test.sh --verbose &
+          bash ./test.sh --verbose -n 8 &
           TEST_PID=$!
           echo "Started test.sh with PID: $TEST_PID"
 


### PR DESCRIPTION
These tests should be IO-bound, so let's try to speed things up now that we've back on free github runners. This should also prevent things from timing out in our daily regen cron job
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase pytest workers to 8 in CI to speed up IO-bound tests and prevent timeouts.
> 
>   - **CI Workflow**:
>     - In `.github/workflows/merge-queue.yml`, modify `bash ./test.sh --verbose` to `bash ./test.sh --verbose -n 8` to use 8 workers for pytest.
>     - Affects the `client-tests` job, specifically the "Python: PyO3 Client: pytest" step.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5980f94f3b4d1a2513ed77b48992a029ceca096b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->