### PR TITLE
Attempt to make datapoint editing tests more reliable

### DIFF
--- a/ui/app/routes/datasets/$dataset_name/datapoint/$id/route.tsx
+++ b/ui/app/routes/datasets/$dataset_name/datapoint/$id/route.tsx
@@ -700,6 +700,7 @@ export default function DatapointPage({ loaderData }: Route.ComponentProps) {
         <SectionLayout>
           <SectionHeader heading="Input" />
           <InputElement
+            key={datapoint.id}
             input={input}
             isEditing={isEditing}
             onSystemChange={(system) => setInput({ ...input, system })}
@@ -714,6 +715,7 @@ export default function DatapointPage({ loaderData }: Route.ComponentProps) {
               case "chat":
                 return (
                   <ChatOutputElement
+                    key={datapoint.id}
                     output={output.value}
                     isEditing={isEditing}
                     onOutputChange={(value) => {
@@ -725,6 +727,7 @@ export default function DatapointPage({ loaderData }: Route.ComponentProps) {
               case "json":
                 return (
                   <JsonOutputElement
+                    key={datapoint.id}
                     output={output.value}
                     outputSchema={output.outputSchema}
                     isEditing={isEditing}


### PR DESCRIPTION
```
When a datapoint is edited and saved, the backend creates a new datapoint with a new UUID and redirects to it.
Without explicit key props, React reuses the existing component instances, and CodeMirror's internal DOM state
can lag behind the new prop values—causing the old content to briefly remain visible during test assertions.
Adding key={datapoint.id} forces React to fully unmount and remount these components when the ID changes,
ensuring CodeMirror reinitializes with fresh state.
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `key={datapoint.id}` to components in `route.tsx` to ensure re-mounting when datapoint ID changes, improving test reliability.
> 
>   - **Behavior**:
>     - Adds `key={datapoint.id}` to `InputElement`, `ChatOutputElement`, and `JsonOutputElement` in `route.tsx` to ensure components are re-mounted when datapoint ID changes.
>     - Fixes issue where CodeMirror's internal state could lag behind new prop values during test assertions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b82ab4b007c91a3fac774917f3a91fe066f325c1. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->