### PR TITLE
Fix flakiness in short response test

### DIFF
--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -11607,6 +11607,11 @@ async fn check_short_inference_response(
     assert_eq!(variant_name, provider.variant_name);
 
     let content = response_json.get("content").unwrap().as_array().unwrap();
+    // Some providers return empty thoughts - exclude thought blocks here
+    let content = content
+        .iter()
+        .filter(|c| c.get("type").unwrap().as_str().unwrap() != "thought")
+        .collect::<Vec<_>>();
     assert_eq!(content.len(), 1);
     let content_block = content.first().unwrap();
     let content_block_type = content_block.get("type").unwrap().as_str().unwrap();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes test flakiness by filtering out irrelevant `"thought"` type blocks in `check_short_inference_response()` in `common.rs`.
> 
>   - **Test Fix**:
>     - In `common.rs`, `check_short_inference_response()` now filters out `"thought"` type blocks from `content` before asserting its length.
>     - Ensures only relevant content is considered, fixing test flakiness.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e13e928e18e8d47765c343257d4b33c7875621be. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->