### PR TITLE
Don't filter empty messages in gcp_vertex_anthropic

### DIFF
--- a/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
@@ -525,7 +525,6 @@ impl<'a> GCPVertexAnthropicRequestBody<'a> {
             }))
             .await?
             .into_iter()
-            .filter(|m| !m.content.is_empty())
             .collect::<Vec<_>>();
         if matches!(
             request.json_mode,


### PR DESCRIPTION
Filtering out empty messages breaks indexing the message array in user-written 'extra_body'. It's also inconsistent with what we do in the 'anthropic' provider
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove filtering of empty messages in `gcp_vertex_anthropic.rs` and add test for handling empty message content.
> 
>   - **Behavior**:
>     - Remove filtering of empty messages in `GCPVertexAnthropicRequestBody` in `gcp_vertex_anthropic.rs` to prevent indexing issues in 'extra_body'.
>     - Aligns behavior with 'anthropic' provider.
>   - **Testing**:
>     - Add `test_empty_message_content_with_provider` in `common.rs` to verify handling of empty message content.
>     - Integrate new test in `generate_provider_tests!` macro in `common.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8b54ecff951b8841661cde611cbea7d215b2b932. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->