### PR TITLE
Get clippy passing on Rust 1.92

### DIFF
--- a/tensorzero-core/src/observability/span_leak_detector.rs
+++ b/tensorzero-core/src/observability/span_leak_detector.rs
@@ -11,7 +11,7 @@ pub struct SpanLeakDetector {
 }
 
 impl SpanLeakDetector {
-    #[expect(clippy::new_without_default)]
+    #[allow(clippy::new_without_default, clippy::allow_attributes)]
     pub fn new() -> Self {
         Self {
             spans: Cache::builder().build(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Suppress clippy warnings in `SpanLeakDetector::new()` by adding `allow` attributes in `span_leak_detector.rs`.
> 
>   - **Clippy Lint Suppression**:
>     - Add `#[allow(clippy::new_without_default, clippy::allow_attributes)]` to `SpanLeakDetector::new()` in `span_leak_detector.rs` to suppress clippy warnings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 146d823ffeed9259e2f9a2e6c1145dd6ee00299d. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->