### PR TITLE
Remove provider credentials from the UI

### DIFF
--- a/docs/deployment/tensorzero-ui.mdx
+++ b/docs/deployment/tensorzero-ui.mdx
@@ -23,22 +23,6 @@ For example, if the gateway is running locally, you can set `TENSORZERO_GATEWAY_
 [Deploy ClickHouse](/deployment/tensorzero-gateway/) and configure `TENSORZERO_CLICKHOUSE_URL`.
 
 </Step>
-<Step title="Configure model provider credentials">
-
-The TensorZero UI integrates with model providers like OpenAI to streamline workflows like fine-tuning.
-To use these features, you need to provide credentials for the relevant model providers as environment variables.
-You don't need to provide credentials if you're not using the fine-tuning features for those providers.
-
-The supported fine-tuning providers and their required credentials (environment variables) are:
-
-| Provider     | Required Credentials                       |
-| ------------ | ------------------------------------------ |
-| Fireworks AI | `FIREWORKS_ACCOUNT_ID` `FIREWORKS_API_KEY` |
-| GCP Vertex   | GCP account credentials                    |
-| OpenAI       | `OPENAI_API_KEY`                           |
-| Together AI  | `TOGETHER_API_KEY`                         |
-
-</Step>
 
 <Step title="Deploy the TensorZero UI">
 

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -1,14 +1,3 @@
-# For *developing* the TensorZero UI:
-#
-# TENSORZERO_CLICKHOUSE_URL="http://chuser:chpassword@localhost:8123/tensorzero_ui_fixtures"
-# TENSORZERO_POSTGRES_URL="postgres://postgres:postgres@localhost:5432/tensorzero_ui_fixtures"
+# TENSORZERO_CLICKHOUSE_URL="http://chuser:chpassword@localhost:8123/tensorzero"
 # TENSORZERO_GATEWAY_URL="http://localhost:3000"
-
-# For *testing* the TensorZero UI:
-#
-# ENABLE_TEST_WITH_OPENAI_API="true"
-# OPENAI_API_KEY="sk-..."
-
-# Read-Only Mode:
-# Set to "1" to enable read-only mode (disables all write operations)
-# TENSORZERO_UI_READ_ONLY="1"
+# TENSORZERO_POSTGRES_URL="postgres://postgres:postgres@localhost:5432/tensorzero"

--- a/ui/fixtures/.env.example
+++ b/ui/fixtures/.env.example
@@ -1,11 +1,6 @@
 # These environment variables are used to configure the TensorZero Gateway and TensorZero Evaluations.
 # See https://www.tensorzero.com/docs/gateway/deployment for more information.
 
-# Provider Credentials
-FIREWORKS_API_KEY="..."
-OPENAI_API_KEY="..."
-# ...
-
 # Object Storage
 # For AWS, regenerate with: `aws --profile your_local_profile_name configure export-credentials --format env-no-export`)
 S3_ACCESS_KEY_ID="..."

--- a/ui/fixtures/docker-compose.unit.yml
+++ b/ui/fixtures/docker-compose.unit.yml
@@ -48,7 +48,15 @@ services:
       gateway-postgres-migrations:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "${TENSORZERO_GATEWAY_URL:-http://localhost:3000}/health" ]
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "${TENSORZERO_GATEWAY_URL:-http://localhost:3000}/health",
+        ]
       start_period: 30s
       start_interval: 1s
       timeout: 1s
@@ -73,10 +81,10 @@ services:
         condition: service_healthy
       gateway-postgres-migrations:
         condition: service_healthy
-    command: [ "bash", "-c", "cd /fixtures && ./load_fixtures.sh" ]
+    command: ["bash", "-c", "cd /fixtures && ./load_fixtures.sh"]
     # Added healthcheck to wait for the marker file created by the script
     healthcheck:
-      test: [ "CMD", "test", "-f", "/load_complete.marker" ]
+      test: ["CMD", "test", "-f", "/load_complete.marker"]
       interval: 5s
       timeout: 1s
       retries: 48 # Retry for up to 4 minutes
@@ -92,8 +100,6 @@ services:
         NODE_VERSION: ${NODE_VERSION:-22}
         PNPM_VERSION: ${PNPM_VERSION:-9}
     environment:
-      OPENAI_API_KEY: ${OPENAI_API_KEY:-notused}
-      FIREWORKS_API_KEY: ${FIREWORKS_API_KEY:-notused}
       TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero_ui_fixtures
       TENSORZERO_POSTGRES_URL: postgres://postgres:postgres@postgres:5432/tensorzero_ui_fixtures
       TENSORZERO_GATEWAY_URL: http://gateway:3000


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove provider credentials from UI configuration and documentation, including environment variables and related documentation.
> 
>   - **Environment Variables**:
>     - Remove provider credentials (`OPENAI_API_KEY`, `FIREWORKS_API_KEY`) from `ui/.env.example` and `ui/fixtures/.env.example`.
>     - Remove provider credentials from `docker-compose.unit.yml` environment settings.
>   - **Documentation**:
>     - Remove section on configuring model provider credentials from `docs/deployment/tensorzero-ui.mdx`.
>   - **Misc**:
>     - Minor formatting changes in `docker-compose.unit.yml` for healthcheck commands.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 996a5bf56e1a7626cd270eba9b7fb3b72134dc93. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->