### PR TITLE
send credentials to Gemini via header not query string

### DIFF
--- a/tensorzero-core/src/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-core/src/providers/google_ai_studio_gemini.rs
@@ -191,10 +191,10 @@ impl InferenceProvider for GoogleAIStudioGeminiProvider {
             .get_api_key(dynamic_api_keys)
             .map_err(|e| e.log())?;
         let start_time = Instant::now();
-        let mut url = self.request_url.clone();
-        url.query_pairs_mut()
-            .append_pair("key", api_key.expose_secret());
-        let builder = http_client.post(url);
+        let url = self.request_url.clone();
+        let builder = http_client
+            .post(url)
+            .header("x-goog-api-key", api_key.expose_secret());
         let (res, raw_request) = inject_extra_request_data_and_send(
             PROVIDER_TYPE,
             &request.extra_body,
@@ -286,10 +286,10 @@ impl InferenceProvider for GoogleAIStudioGeminiProvider {
             .get_api_key(dynamic_api_keys)
             .map_err(|e| e.log())?;
         let start_time = Instant::now();
-        let mut url = self.streaming_request_url.clone();
-        url.query_pairs_mut()
-            .append_pair("key", api_key.expose_secret());
-        let builder = http_client.post(url);
+        let url = self.streaming_request_url.clone();
+        let builder = http_client
+            .post(url)
+            .header("x-goog-api-key", api_key.expose_secret());
         let (event_source, raw_request) = inject_extra_request_data_and_send_eventsource(
             PROVIDER_TYPE,
             &request.extra_body,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change API key transmission to Gemini from query string to header in `google_ai_studio_gemini.rs`.
> 
>   - **Behavior**:
>     - Change API key transmission from query string to header in `infer()` and `infer_stream()` methods of `GoogleAIStudioGeminiProvider`.
>     - Use `x-goog-api-key` header to send API key.
>   - **Code**:
>     - Remove query string modification for API key in `google_ai_studio_gemini.rs`.
>     - Add `.header("x-goog-api-key", api_key.expose_secret())` to HTTP request builder.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1e5746d55510b8725cfef90eb7c8df8dc9474e55. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->