### PR TITLE
Re-use reqwest client in test_tensorzero_missing_auth

### DIFF
--- a/gateway/tests/auth.rs
+++ b/gateway/tests/auth.rs
@@ -279,10 +279,12 @@ async fn test_tensorzero_missing_auth() {
         ("GET", "/v1/datasets/get_datapoints"),
     ];
 
+    let client = reqwest::Client::new();
+
     for (method, path) in auth_required_routes {
         // Authorization runs before we do any parsing of the request parameters/body,
         // so we don't need to provide a valid request here.
-        let response = reqwest::Client::new()
+        let response = client
             .request(
                 Method::from_str(method).unwrap(),
                 format!("http://{}/{}", child_data.addr, path),
@@ -299,7 +301,7 @@ async fn test_tensorzero_missing_auth() {
         );
         assert_eq!(status, StatusCode::UNAUTHORIZED);
 
-        let bad_auth_response = reqwest::Client::new()
+        let bad_auth_response = client
             .request(
                 Method::from_str(method).unwrap(),
                 format!("http://{}/{}", child_data.addr, path),
@@ -317,7 +319,7 @@ async fn test_tensorzero_missing_auth() {
         );
         assert_eq!(status, StatusCode::UNAUTHORIZED);
 
-        let bad_key_format_response = reqwest::Client::new()
+        let bad_key_format_response = client
             .request(
                 Method::from_str(method).unwrap(),
                 format!("http://{}/{}", child_data.addr, path),
@@ -335,7 +337,7 @@ async fn test_tensorzero_missing_auth() {
         );
         assert_eq!(status, StatusCode::UNAUTHORIZED);
 
-        let missing_key_response = reqwest::Client::new()
+        let missing_key_response = client
             .request(
                 Method::from_str(method).unwrap(),
                 format!("http://{}/{}", child_data.addr, path),
@@ -356,7 +358,7 @@ async fn test_tensorzero_missing_auth() {
         );
         assert_eq!(status, StatusCode::UNAUTHORIZED);
 
-        let disabled_key_response = reqwest::Client::new()
+        let disabled_key_response = client
             .request(
                 Method::from_str(method).unwrap(),
                 format!("http://{}/{}", child_data.addr, path),


### PR DESCRIPTION
Creating a client needs to load root certificates, so reusing the client can significantly speed up the test
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reuse `reqwest::Client` in `test_tensorzero_missing_auth` to improve test speed by avoiding repeated root certificate loading.
> 
>   - **Optimization**:
>     - Reuse `reqwest::Client` in `test_tensorzero_missing_auth` in `auth.rs` to avoid repeated loading of root certificates, improving test speed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 790d1510611846df47a36c0c53062baa04696c87. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->