### PR TITLE
Fix breadcrumb link bug

### DIFF
--- a/ui/app/hooks/use-breadcrumbs.ts
+++ b/ui/app/hooks/use-breadcrumbs.ts
@@ -26,7 +26,12 @@ export function useBreadcrumbs(): {
               isIdentifier,
               // Only show a link for this crumb if it's the last/only breadcrumb for the segment
               // Example: evaluation run adds two crumbs: "Runs" and the run ID. "Runs" would not be a link, since there's no dedicated runs page.
-              href: i === arr.length - 1 ? match.pathname : undefined,
+              // Also skip link if noLink is explicitly set (for routes without an index page)
+              href:
+                i === arr.length - 1 &&
+                !(typeof crumb !== "string" && crumb.noLink)
+                  ? match.pathname
+                  : undefined,
             };
           }) ?? [],
       ),

--- a/ui/app/routes/datapoints/layout.tsx
+++ b/ui/app/routes/datapoints/layout.tsx
@@ -1,7 +1,7 @@
 import { Outlet, type RouteHandle } from "react-router";
 
 export const handle: RouteHandle = {
-  crumb: () => ["Datapoints"],
+  crumb: () => [{ label: "Datapoints", noLink: true }],
 };
 
 export default function DatapointsLayout() {

--- a/ui/app/types/breadcrumbs.ts
+++ b/ui/app/types/breadcrumbs.ts
@@ -3,6 +3,7 @@ import type { UIMatch } from "react-router";
 export interface CrumbItem {
   label: string;
   isIdentifier?: boolean;
+  noLink?: boolean;
 }
 
 declare module "react-router" {


### PR DESCRIPTION
We need to refactor this whole breadcrumb thing later, it's bad.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes breadcrumb link bug by adding `noLink` property to control link generation in `use-breadcrumbs.ts`.
> 
>   - **Behavior**:
>     - Fixes breadcrumb link generation in `useBreadcrumbs()` in `use-breadcrumbs.ts` by adding a check for `noLink` property.
>     - Breadcrumbs with `noLink: true` do not generate a link, even if they are the last segment.
>   - **Routes**:
>     - Updates `Datapoints` breadcrumb in `layout.tsx` to use `noLink: true`.
>   - **Types**:
>     - Adds `noLink` property to `CrumbItem` interface in `breadcrumbs.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d05c7e6e9b5c84d82fc609411ebd913ecf027ba5. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->