### PR TITLE
Fix dataset builder query

### DIFF
--- a/tensorzero-core/src/db/clickhouse/dataset_queries.rs
+++ b/tensorzero-core/src/db/clickhouse/dataset_queries.rs
@@ -108,7 +108,8 @@ impl DatasetQueries for ClickHouseConnectionInfo {
                 null as staled_at,
                 subquery.id as source_inference_id,
                 false as is_custom,
-                subquery.name as name
+                subquery.name as name,
+                snapshot_hash
             FROM (
                 {source_query}
             ) AS subquery
@@ -1600,7 +1601,8 @@ mod tests {
                     null as staled_at,
                     subquery.id as source_inference_id,
                     false as is_custom,
-                    subquery.name as name
+                    subquery.name as name,
+                    snapshot_hash
                 FROM (",
                 );
                 assert_query_contains(


### PR DESCRIPTION
Tested locally. Problem is that datapoint tables now have a snapshot_hash column that the query wasn't inserting.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `snapshot_hash` column to dataset builder query in `dataset_queries.rs`.
> 
>   - **Behavior**:
>     - Add `snapshot_hash` column to SQL query in `insert_rows_for_dataset()` and test in `tests` module.
>   - **Misc**:
>     - Tested locally to ensure the query now inserts the `snapshot_hash` column correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 93c9b07cfd71fee0b15a5fdb8fa12bc6ba838e3a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->