### PR TITLE
Bump to 2025.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2025.12.0"
+version = "2025.12.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2025.12.0"
+version = "2025.12.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2187,7 +2187,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2025.12.0"
+version = "2025.12.1"
 dependencies = [
  "axum",
  "clap",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-utils"
-version = "2025.12.0"
+version = "2025.12.1"
 dependencies = [
  "minijinja",
  "serde",
@@ -4566,7 +4566,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2025.12.0"
+version = "2025.12.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6085,7 +6085,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2025.12.0"
+version = "2025.12.1"
 dependencies = [
  "axum",
  "chrono",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2025.12.0"
+version = "2025.12.1"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -6218,7 +6218,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2025.12.0"
+version = "2025.12.1"
 dependencies = [
  "evaluations",
  "napi",
@@ -6237,7 +6237,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-optimizers"
-version = "2025.12.0"
+version = "2025.12.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -6270,7 +6270,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.12.0"
+version = "2025.12.1"
 dependencies = [
  "evaluations",
  "futures",
@@ -6288,7 +6288,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-unsafe-helpers"
-version = "2025.12.0"
+version = "2025.12.1"
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2025.12.0"
+version = "2025.12.1"
 rust-version = "1.88.0"
 license = "Apache-2.0"
 edition = "2024"

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2025.12.0"
+appVersion: "2025.12.1"

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2025.12.0",
+  "version": "2025.12.1",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump version to `2025.12.1` across `Cargo.lock`, `Cargo.toml`, `Chart.yaml`, and `package.json`.
> 
>   - **Version Bump**:
>     - Update version to `2025.12.1` in `Cargo.lock` for packages: `evaluations`, `feedback-load-test`, `gateway`, `minijinja-utils`, `rate-limit-load-test`, `tensorzero-auth`, `tensorzero-core`, `tensorzero-node`, `tensorzero-optimizers`, `tensorzero-python`, `tensorzero-unsafe-helpers`.
>     - Update version to `2025.12.1` in `Cargo.toml`.
>     - Update `appVersion` to `2025.12.1` in `Chart.yaml`.
>     - Update version to `2025.12.1` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for aeefff4f2c2a0e58a63567b4cefb7b09fc7b7c7c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->