### PR TITLE
documented the correct way to specify allowed tool names

### DIFF
--- a/docs/gateway/api-reference/batch-inference.mdx
+++ b/docs/gateway/api-reference/batch-inference.mdx
@@ -63,6 +63,8 @@ The tools must be defined in the configuration file or provided dynamically via 
 Each element in the outer list corresponds to a single inference in the batch.
 Each inner list contains the names of the tools that are allowed for the corresponding inference.
 
+The names should be the configuration keys (e.g. `foo` from `[tools.foo]`), not the display names shown to the LLM (e.g. `bar` from `tools.foo.name = "bar"`).
+
 Some providers (notably OpenAI) natively support restricting allowed tools.
 For these providers, we send all tools (both configured and dynamic) to the provider, and separately specify which ones are allowed to be called.
 For providers that do not natively support this feature, we filter the tool list ourselves and only send the allowed tools to the provider.

--- a/docs/gateway/api-reference/inference.mdx
+++ b/docs/gateway/api-reference/inference.mdx
@@ -132,6 +132,8 @@ The `format` field can be one of:
 A list of tool names that the model is allowed to call.
 The tools must be defined in the configuration file or provided dynamically via `additional_tools`.
 
+The names should be the configuration keys (e.g. `foo` from `[tools.foo]`), not the display names shown to the LLM (e.g. `bar` from `tools.foo.name = "bar"`).
+
 Some providers (notably OpenAI) natively support restricting allowed tools.
 For these providers, we send all tools (both configured and dynamic) to the provider, and separately specify which ones are allowed to be called.
 For providers that do not natively support this feature, we filter the tool list ourselves and only send the allowed tools to the provider.

--- a/docs/gateway/guides/tool-use.mdx
+++ b/docs/gateway/guides/tool-use.mdx
@@ -322,6 +322,8 @@ See "Advanced Usage" below for information on how to customize the tool calling 
 
 You can restrict the set of tools that can be called at inference time by using the `allowed_tools` parameter.
 
+The names should be the configuration keys (e.g. `foo` from `[tools.foo]`), not the display names shown to the LLM (e.g. `bar` from `tools.foo.name = "bar"`).
+
 For example, suppose your TensorZero function has access to several tools, but you only want to allow the `get_temperature` tool to be called during a particular inference.
 You can achieve this by setting `allowed_tools=["get_temperature"]` in your inference request.
 


### PR DESCRIPTION
Closes #5100 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Clarifies documentation on specifying allowed tool names using configuration keys instead of display names in `batch-inference.mdx`, `inference.mdx`, and `tool-use.mdx`.
> 
>   - **Documentation**:
>     - Clarifies in `batch-inference.mdx`, `inference.mdx`, and `tool-use.mdx` that tool names should be specified using configuration keys (e.g., `foo` from `[tools.foo]`), not display names (e.g., `bar` from `tools.foo.name = "bar"`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for cb10633651e972cfc8f0a2457e71f7f2f91e2981. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->