### PR TITLE
Remove `FINAL` from list inference query

### DIFF
--- a/tensorzero-core/src/db/clickhouse/inference_queries.rs
+++ b/tensorzero-core/src/db/clickhouse/inference_queries.rs
@@ -169,7 +169,7 @@ fn generate_list_inference_metadata_sql(
             episode_id,
             function_type,
             if(isNull(snapshot_hash), NULL, lower(hex(snapshot_hash))) as snapshot_hash
-        FROM InferenceById FINAL
+        FROM InferenceById
         {where_clause}
         ORDER BY id_uint {order_direction}
         LIMIT {{limit:UInt64}}
@@ -1516,7 +1516,7 @@ mod tests {
             mock.expect_run_query_synchronous()
                 .withf(|query, _params| {
                     assert_query_contains(query, "uint_to_uuid(id_uint) as id");
-                    assert_query_contains(query, "FROM InferenceById FINAL");
+                    assert_query_contains(query, "FROM InferenceById");
                     assert_query_contains(query, "ORDER BY id_uint DESC");
                     assert_query_does_not_contain(query, "WHERE");
                     true


### PR DESCRIPTION
> YOLO
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `FINAL` keyword from SQL query in `inference_queries.rs` and update tests accordingly.
> 
>   - **Behavior**:
>     - Remove `FINAL` keyword from SQL query in `generate_list_inference_metadata_sql()` in `inference_queries.rs`.
>     - Update test in `tests` module to check for absence of `FINAL` in query.
>   - **Tests**:
>     - Modify test in `tests` module to assert query does not contain `FINAL`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f0c53abc6210d945a68ab56070d58c38045597cb. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->