### PR TITLE
Skip running ClickHouse tests on external PR CI

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -734,7 +734,8 @@ jobs:
     # the main 'validate' job)
     runs-on: ${{ matrix.replicated && 'namespace-profile-tensorzero-8x16;ephemeral-storage.size-multiplier=2' || 'namespace-profile-tensorzero-8x16' }}
     continue-on-error: ${{ matrix.clickhouse_version.allow_failure }}
-    if: github.repository == 'tensorzero/tensorzero'
+    # This needs to pull from Docker Hub, so skip for external PR CI
+    if: ${{ (github.event.pull_request.head.repo.full_name == github.repository) || inputs.is_merge_group }}
     strategy:
       matrix:
         # Only include replicated: true when running in merge queue


### PR DESCRIPTION
This test needs to pull our freshly-pushed containers from Docker Hub, so skip it on external PRs (since the push gets skipped)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Skip ClickHouse tests on external PRs in CI to avoid Docker Hub pull issues.
> 
>   - **CI Configuration**:
>     - In `.github/workflows/general.yml`, modify `clickhouse-tests` job to skip execution on external PRs by checking if the PR is from the same repository or part of a merge group.
>     - This change is necessary because the test requires pulling containers from Docker Hub, which is not possible for external PRs as the push step is skipped.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ff42dbd3ed82b0654eaf98c82b5b6a229de33c8e. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->