### PR TITLE
Bump to 2025.12.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2025.12.2"
+version = "2025.12.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2025.12.2"
+version = "2025.12.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2187,7 +2187,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2025.12.2"
+version = "2025.12.3"
 dependencies = [
  "axum",
  "clap",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-utils"
-version = "2025.12.2"
+version = "2025.12.3"
 dependencies = [
  "minijinja",
  "serde",
@@ -4567,7 +4567,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2025.12.2"
+version = "2025.12.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6086,7 +6086,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2025.12.2"
+version = "2025.12.3"
 dependencies = [
  "axum",
  "chrono",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2025.12.2"
+version = "2025.12.3"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -6219,7 +6219,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2025.12.2"
+version = "2025.12.3"
 dependencies = [
  "evaluations",
  "napi",
@@ -6238,7 +6238,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-optimizers"
-version = "2025.12.2"
+version = "2025.12.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -6271,7 +6271,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.12.2"
+version = "2025.12.3"
 dependencies = [
  "evaluations",
  "futures",
@@ -6289,7 +6289,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-unsafe-helpers"
-version = "2025.12.2"
+version = "2025.12.3"
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2025.12.2"
+version = "2025.12.3"
 rust-version = "1.88.0"
 license = "Apache-2.0"
 edition = "2024"

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2025.12.2"
+appVersion: "2025.12.3"

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2025.12.2",
+  "version": "2025.12.3",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump version to 2025.12.3 across multiple files including `Cargo.lock`, `Cargo.toml`, `Chart.yaml`, and `package.json`.
> 
>   - **Version Bump**:
>     - Update version to `2025.12.3` in `Cargo.lock` for packages: `evaluations`, `feedback-load-test`, `gateway`, `minijinja-utils`, `rate-limit-load-test`, `tensorzero-auth`, `tensorzero-core`, `tensorzero-node`, `tensorzero-optimizers`, `tensorzero-python`, `tensorzero-unsafe-helpers`.
>     - Update version to `2025.12.3` in `Cargo.toml`.
>     - Update `appVersion` to `2025.12.3` in `Chart.yaml`.
>     - Update version to `2025.12.3` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 300a9a79e05f3a49b045a516772307fa1dee9ad6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->