### PR TITLE
Fix clickhouse tests not running in the merge queue

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1182,5 +1182,5 @@ jobs:
           echo "github.event_name: ${{ github.event_name }}"
       # When running in the merge queue, jobs should never be skipped.
       # In PR CI, some jobs may be intentionally skipped (e.g. due to running from a fork, or to save money)
-      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled' || (github.event_name == 'merge_group' && contains(needs.*.result, 'skipped'))) }}
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || (github.event_name == 'merge_group' && contains(needs.*.result, 'skipped')) }}
         run: exit 1


### PR DESCRIPTION
The 'if' check was checking a nonexistent variable, causing the job to get skipped in the merge queue. The 'check-all-general-jobs-passed' step is supposed to detect skipped jobs, but it didn't for some reason.

I've fixed the check, and added debugging to
'check-all-general-jobs-passed'