### PR TITLE
Exclude more thought blocks in test_short_inference_request

### DIFF
--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -11739,6 +11739,11 @@ async fn check_short_inference_response(
 
     let content_blocks = result.get("output").unwrap().as_str().unwrap();
     let content_blocks: Vec<Value> = serde_json::from_str(content_blocks).unwrap();
+    // Some providers return empty thoughts - exclude thought blocks here
+    let content_blocks = content_blocks
+        .iter()
+        .filter(|c| c.get("type").unwrap().as_str().unwrap() != "thought")
+        .collect::<Vec<_>>();
     assert_eq!(content_blocks.len(), 1);
     let content_block = content_blocks.first().unwrap();
     let content_block_type = content_block.get("type").unwrap().as_str().unwrap();
@@ -11823,6 +11828,11 @@ async fn check_short_inference_response(
     assert_eq!(input_messages, expected_input_messages);
     let output = result.get("output").unwrap().as_str().unwrap();
     let output: Vec<StoredContentBlock> = serde_json::from_str(output).unwrap();
+    // Some providers return empty thoughts - exclude thought blocks here
+    let output = output
+        .iter()
+        .filter(|c| !matches!(c, StoredContentBlock::Thought(_)))
+        .collect::<Vec<_>>();
     assert_eq!(output.len(), 1);
     let finish_reason = result.get("finish_reason").unwrap().as_str().unwrap();
     assert_eq!(finish_reason, "length");


### PR DESCRIPTION
This should reduce the flakiness of this test (we were previously only discarding the thought blocks in some cases)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Exclude thought blocks in `check_short_inference_response` in `common.rs` to reduce test flakiness.
> 
>   - **Behavior**:
>     - In `check_short_inference_response` in `common.rs`, filters out thought blocks from `content_blocks` and `output` to reduce test flakiness.
>     - Ensures only non-thought blocks are considered, stabilizing test results.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 03760b87ba0de1c98d08b18545f0c7d0e020d4f5. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->