### PR TITLE
Forward R2 credentials into all 'fixtures' docker compose services

### DIFF
--- a/tensorzero-core/tests/e2e/docker-compose.clickhouse.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.clickhouse.yml
@@ -71,6 +71,8 @@ services:
       - CLICKHOUSE_HOST=clickhouse
       - CLICKHOUSE_PASSWORD=chpassword
       - CLICKHOUSE_USER=chuser
+      - R2_ACCESS_KEY_ID
+      - R2_SECRET_ACCESS_KEY
       # - TENSORZERO_SKIP_LARGE_FIXTURES=1
     depends_on:
       gateway:

--- a/tensorzero-core/tests/e2e/docker-compose.live.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.live.yml
@@ -154,6 +154,8 @@ services:
       - CLICKHOUSE_HOST=clickhouse
       - CLICKHOUSE_PASSWORD=chpassword
       - CLICKHOUSE_USER=chuser
+      - R2_ACCESS_KEY_ID
+      - R2_SECRET_ACCESS_KEY
       - TENSORZERO_SKIP_LARGE_FIXTURES=1
     depends_on:
       gateway:

--- a/tensorzero-core/tests/e2e/docker-compose.replicated.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.replicated.yml
@@ -181,6 +181,8 @@ services:
       - CLICKHOUSE_HOST=clickhouse-01
       - CLICKHOUSE_PASSWORD=chpassword
       - CLICKHOUSE_USER=chuser
+      - R2_ACCESS_KEY_ID
+      - R2_SECRET_ACCESS_KEY
       - TENSORZERO_SKIP_LARGE_FIXTURES
     depends_on:
       gateway:

--- a/ui/fixtures/docker-compose.e2e.ci.yml
+++ b/ui/fixtures/docker-compose.e2e.ci.yml
@@ -71,11 +71,13 @@ services:
       - .:/fixtures
       - ~/.aws:/root/.aws
     environment:
-      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
-      CLICKHOUSE_HOST: clickhouse
-      CLICKHOUSE_PASSWORD: chpassword
-      CLICKHOUSE_USER: chuser
-      TENSORZERO_SKIP_LARGE_FIXTURES: 1
+      - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
+      - CLICKHOUSE_HOST=clickhouse
+      - CLICKHOUSE_PASSWORD=chpassword
+      - CLICKHOUSE_USER=chuser
+      - TENSORZERO_SKIP_LARGE_FIXTURES=1
+      - R2_ACCESS_KEY_ID
+      - R2_SECRET_ACCESS_KEY
     depends_on:
       gateway:
         condition: service_healthy

--- a/ui/fixtures/docker-compose.e2e.yml
+++ b/ui/fixtures/docker-compose.e2e.yml
@@ -77,6 +77,8 @@ services:
       - CLICKHOUSE_PASSWORD=chpassword
       - CLICKHOUSE_USER=chuser
       - TENSORZERO_SKIP_LARGE_FIXTURES
+      - R2_ACCESS_KEY_ID
+      - R2_SECRET_ACCESS_KEY
     depends_on:
       gateway:
         condition: service_healthy

--- a/ui/fixtures/docker-compose.unit.yml
+++ b/ui/fixtures/docker-compose.unit.yml
@@ -70,10 +70,12 @@ services:
       - .:/fixtures
       - ~/.aws:/root/.aws
     environment:
-      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
-      CLICKHOUSE_HOST: clickhouse
-      CLICKHOUSE_PASSWORD: chpassword
-      CLICKHOUSE_USER: chuser
+      - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
+      - CLICKHOUSE_HOST=clickhouse
+      - CLICKHOUSE_PASSWORD=chpassword
+      - CLICKHOUSE_USER=chuser
+      - R2_ACCESS_KEY_ID
+      - R2_SECRET_ACCESS_KEY
     depends_on:
       gateway:
         condition: service_healthy

--- a/ui/fixtures/docker-compose.yml
+++ b/ui/fixtures/docker-compose.yml
@@ -70,10 +70,12 @@ services:
     env_file:
       - .env
     environment:
-      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
-      CLICKHOUSE_HOST: clickhouse
-      CLICKHOUSE_PASSWORD: chpassword
-      CLICKHOUSE_USER: chuser
+      - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
+      - CLICKHOUSE_HOST=clickhouse
+      - CLICKHOUSE_PASSWORD=chpassword
+      - CLICKHOUSE_USER=chuser
+      - R2_ACCESS_KEY_ID
+      - R2_SECRET_ACCESS_KEY
     depends_on:
       gateway:
         condition: service_healthy


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add R2 credentials to environment variables in multiple Docker Compose files for consistent service access.
> 
>   - **Environment Variables**:
>     - Add `R2_ACCESS_KEY_ID` and `R2_SECRET_ACCESS_KEY` to `environment` sections in `docker-compose.clickhouse.yml`, `docker-compose.live.yml`, and `docker-compose.replicated.yml`.
>     - Add `R2_ACCESS_KEY_ID` and `R2_SECRET_ACCESS_KEY` to `environment` sections in `docker-compose.e2e.ci.yml`, `docker-compose.e2e.yml`, `docker-compose.unit.yml`, and `docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7c916e40545e87bbdf5f4da16dcd93f9f0830d3f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->