### PR TITLE
clippy: explicit_into_iter_loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ unreachable = "deny"
 unused_self = "deny"
 unwrap_used = "deny"
 large_futures = "deny"
+explicit_into_iter_loop = "deny"
 
 # The following pedantic lints are explicitly set to "allow" to give authors discretion on their use.
 default_trait_access = "allow"

--- a/tensorzero-core/src/config/mod.rs
+++ b/tensorzero-core/src/config/mod.rs
@@ -699,10 +699,7 @@ fn find_matching_files(base_path: &Path, matcher: &globset::GlobMatcher) -> Vec<
     }
 
     // If base_path is a directory, walk it
-    for entry in walkdir::WalkDir::new(base_path)
-        .follow_links(false)
-        .into_iter()
-    {
+    for entry in walkdir::WalkDir::new(base_path).follow_links(false) {
         match entry {
             Ok(entry) => {
                 let path = entry.path();

--- a/tensorzero-core/src/inference/types/mod.rs
+++ b/tensorzero-core/src/inference/types/mod.rs
@@ -2167,7 +2167,7 @@ pub async fn parse_chat_output(
     }
 
     let mut output = Vec::new();
-    for content in content.into_iter() {
+    for content in content {
         match content {
             ContentBlockOutput::Text(text) => {
                 output.push(ContentBlockChatOutput::Text(text));

--- a/tensorzero-core/src/inference/types/streams.rs
+++ b/tensorzero-core/src/inference/types/streams.rs
@@ -166,7 +166,7 @@ impl From<ProviderInferenceResponseChunk> for JsonInferenceResultChunk {
     fn from(chunk: ProviderInferenceResponseChunk) -> Self {
         let mut raw = None;
         let mut thought = None;
-        for content in chunk.content.into_iter() {
+        for content in chunk.content {
             match content {
                 ContentBlockChunk::ToolCall(tool_call) => {
                     raw = Some(tool_call.raw_arguments.to_owned());


### PR DESCRIPTION
A small hello world PR, contributing towards https://github.com/tensorzero/tensorzero/issues/1961
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Clippy lint rule to deny `explicit_into_iter_loop` and refactor code to comply with it.
> 
>   - **Lint Rule**:
>     - Adds `explicit_into_iter_loop = "deny"` to `Cargo.toml` to enforce idiomatic Rust code.
>   - **Code Refactoring**:
>     - Removes explicit `into_iter()` in `for` loops in `mod.rs` in `config` and `types` directories.
>     - Specifically, refactors `for entry in walkdir::WalkDir::new(base_path).follow_links(false)` in `mod.rs` in `config`.
>     - Refactors `for content in content` in `mod.rs` in `types` and `streams.rs` in `types`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for dd614ffb997b9e9f6dc2b03fa6940db4f2e73e25. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->