### PR TITLE
Disable test_streaming_invalid_request on Fireworks

### DIFF
--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -3621,6 +3621,10 @@ pub async fn check_simple_image_inference_response(
 }
 
 pub async fn test_streaming_invalid_request_with_provider(provider: E2ETestProvider) {
+    // This test is very flaky on Fireworks for some reason
+    if provider.model_provider_name == "fireworks" {
+        return;
+    }
     let extra_headers = if provider.is_modal_provider() {
         get_modal_extra_headers()
     } else {


### PR DESCRIPTION
This test is constantly flaking
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disable `test_streaming_invalid_request_with_provider` for 'fireworks' provider in `common.rs` due to flakiness.
> 
>   - **Behavior**:
>     - Disables `test_streaming_invalid_request_with_provider` for the 'fireworks' provider in `common.rs` due to flakiness.
>     - The test returns early if `provider.model_provider_name` is 'fireworks'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 0d1daaa91b96971abfaacf7e418e00e765c5d12f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->