### PR TITLE
Fix clippy: cloned_instead_of_copied

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ unused_self = "deny"
 unwrap_used = "deny"
 large_futures = "deny"
 explicit_into_iter_loop = "deny"
+cloned_instead_of_copied = "deny"
 
 # The following pedantic lints are explicitly set to "allow" to give authors discretion on their use.
 default_trait_access = "allow"

--- a/tensorzero-core/src/cache.rs
+++ b/tensorzero-core/src/cache.rs
@@ -392,7 +392,7 @@ pub fn start_cache_write_streaming(
             finish_reason = Some(chunk_finish_reason);
         }
     }
-    let finish_reason = finish_reason.cloned();
+    let finish_reason = finish_reason.copied();
     let output = StreamingCacheData {
         chunks: chunks
             .into_iter()

--- a/tensorzero-core/src/evaluations/mod.rs
+++ b/tensorzero-core/src/evaluations/mod.rs
@@ -1124,7 +1124,7 @@ fn check_convert_variant_to_llm_judge_variant(
                 frequency_penalty: variant.frequency_penalty(),
                 max_tokens: variant.max_tokens(),
                 seed: variant.seed(),
-                json_mode: variant.json_mode().cloned(),
+                json_mode: variant.json_mode().copied(),
                 extra_body: variant.extra_body().cloned(),
                 extra_headers: variant.extra_headers().cloned(),
                 retries: *variant.retries(),

--- a/tensorzero-core/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-core/src/variant/best_of_n_sampling.rs
@@ -765,7 +765,7 @@ impl BestOfNEvaluatorConfig {
         let json_mode = inference_params
             .chat_completion
             .json_mode
-            .or_else(|| self.inner.json_mode().cloned())
+            .or_else(|| self.inner.json_mode().copied())
             .unwrap_or(JsonMode::Strict);
         let tool_config = match json_mode {
             JsonMode::Tool => Some(Cow::Borrowed(&*JSON_MODE_TOOL_CALL_CONFIG)),

--- a/tensorzero-core/src/variant/dicl.rs
+++ b/tensorzero-core/src/variant/dicl.rs
@@ -859,7 +859,7 @@ impl DiclConfig {
             inference_config,
             stream,
             inference_params,
-            self.json_mode().cloned(),
+            self.json_mode().copied(),
             extra_body,
             extra_headers,
         )

--- a/tensorzero-core/src/variant/mixture_of_n.rs
+++ b/tensorzero-core/src/variant/mixture_of_n.rs
@@ -919,7 +919,7 @@ impl FuserConfig {
             inference_config,
             stream,
             inference_params,
-            self.inner.json_mode().cloned(),
+            self.inner.json_mode().copied(),
             extra_body,
             extra_headers,
         )?;

--- a/tensorzero-core/src/variant/mod.rs
+++ b/tensorzero-core/src/variant/mod.rs
@@ -1795,7 +1795,7 @@ mod tests {
         full_response.push_str(&received_text);
 
         // Verify the full response
-        let expected_response: String = DUMMY_STREAMING_RESPONSE.iter().cloned().collect();
+        let expected_response: String = DUMMY_STREAMING_RESPONSE.concat();
         assert_eq!(full_response, expected_response);
     }
 
@@ -1972,7 +1972,7 @@ mod tests {
         full_response.push_str(&received_text);
 
         // Verify the full response
-        let expected_response: String = DUMMY_STREAMING_RESPONSE.iter().cloned().collect();
+        let expected_response: String = DUMMY_STREAMING_RESPONSE.concat();
         assert_eq!(full_response, expected_response);
 
         assert!(logs_contain(

--- a/tensorzero-core/tests/e2e/providers/batch.rs
+++ b/tensorzero-core/tests/e2e/providers/batch.rs
@@ -1450,7 +1450,7 @@ pub async fn test_tool_use_batch_inference_request_with_provider(provider: E2ETe
         .collect();
     assert_eq!(inference_ids.len(), 5);
     let mut inference_id_to_index: HashMap<Uuid, usize> =
-        inference_ids.iter().cloned().zip(0..).collect();
+        inference_ids.iter().copied().zip(0..).collect();
 
     let response_episode_ids = response_json
         .get("episode_ids")


### PR DESCRIPTION
Feeds clippy, part of https://github.com/tensorzero/tensorzero/issues/1961
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix Clippy lint by replacing `cloned()` with `copied()` for `Copy` types in multiple files.
> 
>   - **Lint Configuration**:
>     - Add `cloned_instead_of_copied` to `Cargo.toml` to enforce using `copied()` instead of `cloned()` for `Copy` types.
>   - **Code Changes**:
>     - Replace `cloned()` with `copied()` in `tensorzero-core/src/cache.rs` for `finish_reason`.
>     - Replace `cloned()` with `copied()` in `tensorzero-core/src/evaluations/mod.rs` for `json_mode`.
>     - Replace `cloned()` with `copied()` in `tensorzero-core/src/variant/best_of_n_sampling.rs`, `dicl.rs`, and `mixture_of_n.rs` for `json_mode`.
>     - Replace `cloned()` with `concat()` in `tensorzero-core/src/variant/mod.rs` tests for `DUMMY_STREAMING_RESPONSE`.
>     - Replace `cloned()` with `copied()` in `tensorzero-core/tests/e2e/providers/batch.rs` for `inference_ids`.
>   - **Misc**:
>     - Part of issue #1961 to improve code quality by adhering to Clippy lints.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 246e1d5e311d0651615f011f603bda8e34365563. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->