### PR TITLE
Fail fast when regenerating ui model-inference cache

### DIFF
--- a/ui/fixtures/regenerate-model-inference-cache.sh
+++ b/ui/fixtures/regenerate-model-inference-cache.sh
@@ -15,5 +15,5 @@ export TENSORZERO_PLAYWRIGHT_RETRIES=0
 export TENSORZERO_PLAYWRIGHT_NO_WEBSERVER=1
 export TENSORZERO_GATEWAY_URL=http://localhost:3000
 export TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@localhost:8123/tensorzero_ui_fixtures
-pnpm test-e2e -j 1 --grep-invert "@credentials"
+pnpm test-e2e -j 1 --grep-invert "@credentials" --max-failures 1
 docker run --add-host=host.docker.internal:host-gateway clickhouse/clickhouse-server clickhouse-client --host host.docker.internal --user chuser --password chpassword --database tensorzero_ui_fixtures 'SELECT * FROM ModelInferenceCache ORDER BY long_cache_key ASC FORMAT JSONEachRow' > ./fixtures/model_inference_cache_e2e.jsonl


### PR DESCRIPTION
This will allow the CI run to fail (or retry the entire regeneration) faster
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `--max-failures 1` to `pnpm test-e2e` in `regenerate-model-inference-cache.sh` to fail fast on test failures.
> 
>   - **Behavior**:
>     - Add `--max-failures 1` to `pnpm test-e2e` in `regenerate-model-inference-cache.sh` to fail fast on first test failure.
>   - **Misc**:
>     - No other changes to the script or its environment setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for a19ca14833c311693d71560af4f1f7a2d8b0dbec. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->