### PR TITLE
Bookworm -> Trixie

### DIFF
--- a/evaluations/Dockerfile
+++ b/evaluations/Dockerfile
@@ -15,7 +15,7 @@ RUN cargo build --release -p evaluations $CARGO_BUILD_FLAGS && \
 
 # ========== base ==========
 
-FROM debian:bookworm-slim AS base
+FROM debian:trixie-slim AS base
 
 RUN apt-get update && apt-get install -y ca-certificates openssl wget && rm -rf /var/lib/apt/lists/*
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -4,7 +4,7 @@ ARG PROFILE="performance"
 
 # ========== builder ==========
 
-FROM lukemathwalker/cargo-chef:latest-rust-1.90-bookworm AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.90-trixie AS chef
 
 WORKDIR /src
 
@@ -28,7 +28,7 @@ RUN if [ "${PROFILE}" = "dev" ]; then cp -r /tensorzero/target/debug /release; e
 
 # ========== base ==========
 
-FROM debian:bookworm-slim AS base
+FROM debian:trixie-slim AS base
 
 RUN apt-get update && apt-get install -y ca-certificates openssl wget && rm -rf /var/lib/apt/lists/*
 

--- a/provider-proxy/Dockerfile
+++ b/provider-proxy/Dockerfile
@@ -16,7 +16,7 @@ RUN cargo build -p provider-proxy $CARGO_BUILD_FLAGS && \
 
 # ========== base ==========
 
-FROM debian:bookworm-slim AS base
+FROM debian:trixie-slim AS base
 
 RUN apt-get update && apt-get install -y ca-certificates openssl wget && rm -rf /var/lib/apt/lists/*
 

--- a/tensorzero-core/tests/e2e/Dockerfile.clickhouse
+++ b/tensorzero-core/tests/e2e/Dockerfile.clickhouse
@@ -1,6 +1,6 @@
 # ========== base ==========
 
-FROM rust:1.88.0-bookworm AS base
+FROM rust:1.88.0-trixie AS base
 
 # Install required system dependencies
 RUN apt-get update && \

--- a/tensorzero-core/tests/e2e/Dockerfile.gateway.e2e
+++ b/tensorzero-core/tests/e2e/Dockerfile.gateway.e2e
@@ -18,7 +18,7 @@ RUN cargo build -p gateway $CARGO_BUILD_FLAGS && \
 
 # ========== base ==========
 
-FROM debian:bookworm-slim AS base
+FROM debian:trixie-slim AS base
 
 RUN apt-get update && apt-get install -y ca-certificates openssl wget && rm -rf /var/lib/apt/lists/*
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -3,7 +3,7 @@ ARG DEBUG_BUILD=0
 
 # ========== base ==========
 
-FROM node:24.12.0-bookworm-slim AS base
+FROM node:24.12.0-trixie-slim AS base
 
 RUN npm install -g pnpm
 

--- a/ui/fixtures/Dockerfile.unit
+++ b/ui/fixtures/Dockerfile.unit
@@ -1,6 +1,6 @@
 # ========== base ==========
 
-FROM node:24.12.0-bookworm-slim AS base
+FROM node:24.12.0-trixie-slim AS base
 
 RUN npm install -g pnpm
 


### PR DESCRIPTION
Fix https://github.com/tensorzero/tensorzero/issues/3515
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Dockerfiles to use 'trixie' version instead of 'bookworm' for base images across multiple components.
> 
>   - **Dockerfiles**:
>     - Update base image from `debian:bookworm-slim` to `debian:trixie-slim` in `evaluations/Dockerfile`, `gateway/Dockerfile`, `provider-proxy/Dockerfile`, `tensorzero-core/tests/e2e/Dockerfile.gateway.e2e`, and `ui/Dockerfile`.
>     - Update base image from `node:24.12.0-bookworm-slim` to `node:24.12.0-trixie-slim` in `ui/fixtures/Dockerfile.unit`.
>     - Update base image from `rust:1.88.0-bookworm` to `rust:1.88.0-trixie` in `tensorzero-core/tests/e2e/Dockerfile.clickhouse`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 387f43da3fb9a402ae21c0e95fab2f4f8405f441. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->