### PR TITLE
Fix clippy: assigning_clones

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ large_futures = "deny"
 explicit_into_iter_loop = "deny"
 cloned_instead_of_copied = "deny"
 inefficient_to_string = "deny"
+assigning_clones = "deny"
 
 # The following pedantic lints are explicitly set to "allow" to give authors discretion on their use.
 default_trait_access = "allow"

--- a/tensorzero-core/src/providers/azure.rs
+++ b/tensorzero-core/src/providers/azure.rs
@@ -645,7 +645,7 @@ fn apply_inference_params(
     } = inference_params;
 
     if reasoning_effort.is_some() {
-        request.reasoning_effort = reasoning_effort.clone();
+        request.reasoning_effort.clone_from(reasoning_effort);
     }
 
     // Azure supports auto and default, but not flex and priority
@@ -673,7 +673,7 @@ fn apply_inference_params(
     }
 
     if verbosity.is_some() {
-        request.verbosity = verbosity.clone();
+        request.verbosity.clone_from(verbosity);
     }
 }
 

--- a/tensorzero-core/src/providers/fireworks/mod.rs
+++ b/tensorzero-core/src/providers/fireworks/mod.rs
@@ -425,7 +425,7 @@ fn apply_inference_params(
     } = inference_params;
 
     if reasoning_effort.is_some() {
-        request.reasoning_effort = reasoning_effort.clone();
+        request.reasoning_effort.clone_from(reasoning_effort);
     }
 
     if service_tier.is_some() {

--- a/tensorzero-core/src/providers/groq.rs
+++ b/tensorzero-core/src/providers/groq.rs
@@ -1092,7 +1092,7 @@ fn apply_inference_params(
     } = inference_params;
 
     if reasoning_effort.is_some() {
-        request.reasoning_effort = reasoning_effort.clone();
+        request.reasoning_effort.clone_from(reasoning_effort);
     }
 
     // Groq supports auto and flex, but not priority and default

--- a/tensorzero-core/src/providers/helpers.rs
+++ b/tensorzero-core/src/providers/helpers.rs
@@ -950,7 +950,7 @@ pub(crate) fn check_new_tool_call_name(
                 // If the previous tool name was the same as the old name, we can just return None as it will have already been sent
                 return None;
             }
-            *last_tool_name = new_name.clone();
+            last_tool_name.clone_from(&new_name);
             Some(new_name)
         }
     }

--- a/tensorzero-core/src/providers/hyperbolic.rs
+++ b/tensorzero-core/src/providers/hyperbolic.rs
@@ -350,7 +350,7 @@ fn apply_inference_params(
     } = inference_params;
 
     if reasoning_effort.is_some() {
-        request.reasoning_effort = reasoning_effort.clone();
+        request.reasoning_effort.clone_from(reasoning_effort);
     }
 
     if service_tier.is_some() {

--- a/tensorzero-core/src/providers/openai/mod.rs
+++ b/tensorzero-core/src/providers/openai/mod.rs
@@ -875,11 +875,11 @@ fn apply_inference_params(
     } = inference_params;
 
     if reasoning_effort.is_some() {
-        request.reasoning_effort = reasoning_effort.clone();
+        request.reasoning_effort.clone_from(reasoning_effort);
     }
 
     if service_tier.is_some() {
-        request.service_tier = service_tier.clone();
+        request.service_tier.clone_from(service_tier);
     }
 
     if thinking_budget_tokens.is_some() {
@@ -891,7 +891,7 @@ fn apply_inference_params(
     }
 
     if verbosity.is_some() {
-        request.verbosity = verbosity.clone();
+        request.verbosity.clone_from(verbosity);
     }
 }
 

--- a/tensorzero-core/src/providers/openai/responses.rs
+++ b/tensorzero-core/src/providers/openai/responses.rs
@@ -566,7 +566,7 @@ fn apply_inference_params(
     }
 
     if service_tier.is_some() {
-        request.service_tier = service_tier.clone();
+        request.service_tier.clone_from(service_tier);
     }
 
     if thinking_budget_tokens.is_some() {
@@ -578,7 +578,7 @@ fn apply_inference_params(
     }
 
     if verbosity.is_some() {
-        request.text.verbosity = verbosity.clone();
+        request.text.verbosity.clone_from(verbosity);
     }
 }
 

--- a/tensorzero-core/src/providers/openrouter.rs
+++ b/tensorzero-core/src/providers/openrouter.rs
@@ -1434,7 +1434,7 @@ fn apply_inference_params(
     } = inference_params;
 
     if reasoning_effort.is_some() {
-        request.reasoning_effort = reasoning_effort.clone();
+        request.reasoning_effort.clone_from(reasoning_effort);
     }
 
     if service_tier.is_some() {
@@ -1450,7 +1450,7 @@ fn apply_inference_params(
     }
 
     if verbosity.is_some() {
-        request.verbosity = verbosity.clone();
+        request.verbosity.clone_from(verbosity);
     }
 }
 

--- a/tensorzero-core/src/providers/sglang.rs
+++ b/tensorzero-core/src/providers/sglang.rs
@@ -612,7 +612,7 @@ fn apply_inference_params(
     } = inference_params;
 
     if reasoning_effort.is_some() {
-        request.reasoning_effort = reasoning_effort.clone();
+        request.reasoning_effort.clone_from(reasoning_effort);
     }
 
     if service_tier.is_some() {

--- a/tensorzero-core/src/providers/together.rs
+++ b/tensorzero-core/src/providers/together.rs
@@ -393,7 +393,7 @@ fn apply_inference_params(
     } = inference_params;
 
     if reasoning_effort.is_some() {
-        request.reasoning_effort = reasoning_effort.clone();
+        request.reasoning_effort.clone_from(reasoning_effort);
     }
 
     if service_tier.is_some() {

--- a/tensorzero-core/src/providers/xai.rs
+++ b/tensorzero-core/src/providers/xai.rs
@@ -367,7 +367,7 @@ fn apply_inference_params(
     } = inference_params;
 
     if reasoning_effort.is_some() {
-        request.reasoning_effort = reasoning_effort.clone();
+        request.reasoning_effort.clone_from(reasoning_effort);
     }
 
     if service_tier.is_some() {


### PR DESCRIPTION
Feeds clippy, part of #1961 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `clone()` with `clone_from()` in `apply_inference_params()` across multiple provider modules to comply with Clippy's `assigning_clones` lint.
> 
>   - **Behavior**:
>     - Replaces `clone()` with `clone_from()` in `apply_inference_params()` in `azure.rs`, `fireworks/mod.rs`, `groq.rs`, `hyperbolic.rs`, `openai/mod.rs`, `openai/responses.rs`, `openrouter.rs`, `sglang.rs`, `together.rs`, and `xai.rs`.
>     - Updates `Cargo.toml` to enforce `assigning_clones` lint rule.
>   - **Misc**:
>     - Part of issue #1961.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 091cd61e1939845d47c7d72ce33998df01dc7c6f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->