### PR TITLE
Auto-approve PR workflow runs with 'trusted-external-pr' label

### DIFF
--- a/.github/workflows/auto-approve-trusted-pr-workflows.yml
+++ b/.github/workflows/auto-approve-trusted-pr-workflows.yml
@@ -40,11 +40,11 @@ jobs:
 
             # Get workflow runs for this PR that are awaiting approval
             # We look for workflow runs on the head ref that have the 'action_required' status
-            runs=$(gh api \
+            runs=$(HEAD_REF="$head_ref" gh api \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "/repos/${{ github.repository }}/actions/runs?event=pull_request&status=action_required&per_page=100" \
-              --jq ".workflow_runs[] | select(.head_branch == \"$head_ref\") | .id")
+              --jq '.workflow_runs[] | select(.head_branch == env.HEAD_REF) | .id')
 
             if [ -z "$runs" ]; then
               echo "  No workflow runs awaiting approval for PR #$pr_number"


### PR DESCRIPTION
This will effectively auto-click the 'Approve workflow runs' button for all pushes to PRs that have the 'trusted-external-pr' label applied. We can use this to let trusted contributors get faster feedback on their PRs by allowing CI to auto-run every time that they push.

External PRs never have secrets available (including with this change), so the stakes are pretty low here - the worst thing that could happen with 'trusted-external-pr' would be a user making lots of jobs run on Namespace and wasting some of our Namespace budget/quota
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a GitHub Actions workflow to auto-approve workflow runs for PRs with 'trusted-external-pr' label in `tensorzero/tensorzero`.
> 
>   - **Behavior**:
>     - New workflow `auto-approve-trusted-pr-workflows.yml` auto-approves workflow runs for PRs with 'trusted-external-pr' label.
>     - Runs every 5 minutes and can be manually triggered.
>     - Only affects `tensorzero/tensorzero` repository.
>   - **Implementation**:
>     - Uses `gh` CLI to list PRs and approve workflow runs.
>     - Checks for workflow runs with 'action_required' status and approves them.
>     - Handles cases where runs are already approved or don't need approval.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 864c64f052ddb2cb0d12e9f3035f02dbcdb6d951. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->