### PR TITLE
Retry ClickHouse Cloud API lookup on buildkite

### DIFF
--- a/ci/buildkite/test-clickhouse-cloud.sh
+++ b/ci/buildkite/test-clickhouse-cloud.sh
@@ -13,7 +13,7 @@ export CLICKHOUSE_PASSWORD=$(buildkite-agent secret get clickhouse_password)
 # We concatenate our clickhouse instance prefix, along with our chosen clickhouse id (e.g. 'dev-tensorzero-e2e-tests-instance-' and '0'), to form the instance name
 # Then, we look up the instance url for this name, and add basic-auth credentials to the url to get our full TENSORZERO_CLICKHOUSE_URL
 # The 'export' statements go on separate lines to prevent the return code from the $() command from being ignored
-CURL_OUTPUT=$(curl --user "$CLICKHOUSE_API_KEY:$CLICKHOUSE_KEY_SECRET" https://api.clickhouse.cloud/v1/organizations/b55f1935-803f-4931-90b3-4d26089004d4/services)
+CURL_OUTPUT=$(curl --retry 3 --user "$CLICKHOUSE_API_KEY:$CLICKHOUSE_KEY_SECRET" https://api.clickhouse.cloud/v1/organizations/b55f1935-803f-4931-90b3-4d26089004d4/services)
 echo "ClickHouse API response: $CURL_OUTPUT"
 TENSORZERO_CLICKHOUSE_URL=$(echo "$CURL_OUTPUT" | jq -r ".result[] | select(.name == \"${CLICKHOUSE_PREFIX}${CLICKHOUSE_ID}\") | .endpoints[] | select(.protocol == \"https\") | \"https://$CLICKHOUSE_USERNAME:$CLICKHOUSE_PASSWORD@\" + .host + \":\" + (.port | tostring)")
 export TENSORZERO_CLICKHOUSE_URL


### PR DESCRIPTION
This sometimes fails with 502 Bad Gateway, which immediately fails the entire buildkite job
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add retry mechanism to `curl` command in `test-clickhouse-cloud.sh` to handle 502 errors.
> 
>   - **Behavior**:
>     - Adds `--retry 3` to `curl` command in `test-clickhouse-cloud.sh` to retry on 502 Bad Gateway errors.
>   - **Misc**:
>     - No other changes or additions in the script.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c89dc6770fe02b60d20ae72e653672e71bb27384. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->