### PR TITLE
Hide internal 'tensorzero.overhead' attributes from console logs

### DIFF
--- a/gateway/tests/logging.rs
+++ b/gateway/tests/logging.rs
@@ -193,6 +193,10 @@ async fn test_log_early_drop_non_streaming() {
         "Log line missing request information: {next_line}"
     );
     assert!(
+        !next_line.contains("overhead"),
+        "Tensorzero overhead attributes should not be logged to console: {next_line}"
+    );
+    assert!(
         next_line.contains("WARN"),
         "Log line missing WARN: {next_line}"
     );


### PR DESCRIPTION
We now create a separate span for overhead tracking - it will be seen by our custom layer, but will get filtered out when logging to the console
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces a separate span for overhead tracking in `request_logging.rs`, filtering out `tensorzero.overhead` attributes from console logs, and updates tests in `logging.rs` to ensure this behavior.
> 
>   - **Behavior**:
>     - Introduces a separate span for overhead tracking in `request_logging_middleware()` in `request_logging.rs`, filtering out `tensorzero.overhead` attributes from console logs.
>     - Ensures `tensorzero.overhead` attributes are not logged to console in `test_log_early_drop_non_streaming()` in `logging.rs`.
>   - **Implementation**:
>     - Adds `latency_span` to `ConnectionDropGuard` in `request_logging.rs` for tracking request latency.
>     - Modifies `Drop` implementation in `ConnectionDropGuard` to use `latency_span` for recording latency.
>   - **Testing**:
>     - Updates `test_log_early_drop_non_streaming()` in `logging.rs` to assert absence of `overhead` in console logs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5a883147080ebe849db52cf660de8e089a7e4d50. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->