### PR TITLE
Force install cargo-deny@0.18.9 on ci

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -546,7 +546,7 @@ jobs:
       - name: Install cargo-nextest, cargo-deny, and cargo-hack
         uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb
         with:
-          tool: cargo-nextest,cargo-deny,cargo-hack
+          tool: cargo-nextest,cargo-deny@0.18.9,cargo-hack
 
       - name: Build (Rust)
         run: cargo build --workspace --verbose
@@ -581,7 +581,7 @@ jobs:
       - name: Install cargo-nextest, cargo-deny, and cargo-hack
         uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb
         with:
-          tool: cargo-nextest,cargo-deny,cargo-hack
+          tool: cargo-nextest,cargo-deny0.18.9,cargo-hack
 
       - name: Test (Rust)
         env:
@@ -708,7 +708,7 @@ jobs:
       - name: Install cargo-nextest, cargo-deny, and cargo-hack
         uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb
         with:
-          tool: cargo-nextest,cargo-deny,cargo-hack
+          tool: cargo-nextest,cargo-deny0.18.9,cargo-hack
 
       - name: Run cargo-deny
         run: cargo deny check


### PR DESCRIPTION
For some reason, we're not install the latest version, which is now causing a failure with the error 'unsupported CVSS version: 4.0'
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Force install `cargo-deny@0.18.9` in CI to fix installation issue causing 'unsupported CVSS version: 4.0' error.
> 
>   - **CI Configuration**:
>     - Force install `cargo-deny@0.18.9` in `.github/workflows/general.yml` to fix installation issue causing 'unsupported CVSS version: 4.0' error.
>     - Updated in `rust-build`, `rust-test`, and `validate` jobs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 6b4065daedd2da4bd3ea20f7da7be6df7d8c961f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->