### PR TITLE
Bump taiki-e/install-action to latest version

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -354,7 +354,7 @@ jobs:
         shell: bash
 
       - name: Install cargo-hack
-        uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb
+        uses: taiki-e/install-action@60581cd7025e0e855cebd745379013e286d9c787
         with:
           tool: cargo-hack
 
@@ -544,7 +544,7 @@ jobs:
         shell: bash
 
       - name: Install cargo-nextest, cargo-deny, and cargo-hack
-        uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb
+        uses: taiki-e/install-action@60581cd7025e0e855cebd745379013e286d9c787
         with:
           tool: cargo-nextest,cargo-deny,cargo-hack
 
@@ -579,7 +579,7 @@ jobs:
         shell: bash
 
       - name: Install cargo-nextest, cargo-deny, and cargo-hack
-        uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb
+        uses: taiki-e/install-action@60581cd7025e0e855cebd745379013e286d9c787
         with:
           tool: cargo-nextest,cargo-deny,cargo-hack
 
@@ -706,7 +706,7 @@ jobs:
       #   run: uv run --with nb-clean nb-clean check --remove-empty-cells
 
       - name: Install cargo-nextest, cargo-deny, and cargo-hack
-        uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb
+        uses: taiki-e/install-action@60581cd7025e0e855cebd745379013e286d9c787
         with:
           tool: cargo-nextest,cargo-deny,cargo-hack
 
@@ -782,7 +782,7 @@ jobs:
       - name: "Free up disk space"
         run: ./ci/free-disk-space.sh
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb
+        uses: taiki-e/install-action@60581cd7025e0e855cebd745379013e286d9c787
         with:
           tool: cargo-nextest
 
@@ -985,7 +985,7 @@ jobs:
           shared-key: "build-gateway-cache"
           save-if: false
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb
+        uses: taiki-e/install-action@60581cd7025e0e855cebd745379013e286d9c787
         with:
           tool: cargo-nextest
 

--- a/.github/workflows/live-batch-test.yml
+++ b/.github/workflows/live-batch-test.yml
@@ -77,7 +77,7 @@ jobs:
           curl "${{ secrets.CLICKHOUSE_CLOUD_URL }}" --retry 4 --retry-all-errors --data-binary 'SHOW DATABASES'
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb
+        uses: taiki-e/install-action@60581cd7025e0e855cebd745379013e286d9c787
         with:
           tool: cargo-nextest
 

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -260,7 +260,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb
+        uses: taiki-e/install-action@60581cd7025e0e855cebd745379013e286d9c787
         with:
           tool: cargo-nextest
 

--- a/.github/workflows/mocked-batch-test.yml
+++ b/.github/workflows/mocked-batch-test.yml
@@ -72,7 +72,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb
+        uses: taiki-e/install-action@60581cd7025e0e855cebd745379013e286d9c787
         with:
           tool: cargo-nextest
 

--- a/.github/workflows/optimization-test-cron.yml
+++ b/.github/workflows/optimization-test-cron.yml
@@ -62,7 +62,7 @@ jobs:
           shared-key: "optimization-test-cache"
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb
+        uses: taiki-e/install-action@60581cd7025e0e855cebd745379013e286d9c787
         with:
           tool: cargo-nextest
 


### PR DESCRIPTION
This allows us to install the latest versions of all the crates we install with this action
In particular, it should bump `cargo-deny` to fix the CVV 4.0 issue
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `taiki-e/install-action` to latest version in multiple workflows to ensure latest crate versions, addressing CVV 4.0 issue with `cargo-deny`.
> 
>   - **Workflows**:
>     - Update `taiki-e/install-action` to `60581cd7025e0e855cebd745379013e286d9c787` in `general.yml`, `live-batch-test.yml`, and `merge-queue.yml`.
>     - Ensure latest versions of crates, including `cargo-deny`, are installed to address CVV 4.0 issue.
>   - **Consistency**:
>     - Consistent update across all workflows using `taiki-e/install-action`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2aef33515a3a75a6c5acb84a358c5fb9aaf06dfb. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->