### PR TITLE
Bound Estimated Performance chart for booleans to [0, 1]

### DIFF
--- a/ui/app/components/function/variant/FeedbackMeansTimeseries.tsx
+++ b/ui/app/components/function/variant/FeedbackMeansTimeseries.tsx
@@ -1,4 +1,5 @@
-import type { MetricConfig, TimeWindow } from "~/types/tensorzero";
+import type { TimeWindow } from "~/types/tensorzero";
+import { useConfig } from "~/context/config";
 import {
   Area,
   CartesianGrid,
@@ -39,7 +40,6 @@ export function FeedbackMeansTimeseries({
   variantNames,
   timeGranularity,
   metricName,
-  metric,
   time_granularity,
   onTimeGranularityChange,
   chartConfig,
@@ -49,11 +49,12 @@ export function FeedbackMeansTimeseries({
   variantNames: string[];
   timeGranularity: TimeWindow;
   metricName: string;
-  metric?: MetricConfig;
   time_granularity: TimeWindow;
   onTimeGranularityChange: (value: TimeWindow) => void;
   chartConfig: Record<string, { label: string; color: string }>;
 }) {
+  const config = useConfig();
+  const metric = metricName ? config.metrics[metricName] : undefined;
   // Add numeric timestamps for x-axis (Recharts requires numbers for linear scale)
   const meanDataWithTimestamps: Array<
     FeedbackMeansTimeseriesData & { timestamp: number }

--- a/ui/app/routes/observability/functions/$function_name/FunctionExperimentation.tsx
+++ b/ui/app/routes/observability/functions/$function_name/FunctionExperimentation.tsx
@@ -8,7 +8,6 @@ import {
 } from "~/components/experimentation/PieChart";
 import { DEFAULT_FUNCTION } from "~/utils/constants";
 import { memo } from "react";
-import { useConfig } from "~/context/config";
 import { FeedbackCountsTimeseries } from "~/components/function/variant/FeedbackCountsTimeseries";
 import { FeedbackMeansTimeseries } from "~/components/function/variant/FeedbackMeansTimeseries";
 import { useTimeGranularityParam } from "~/hooks/use-time-granularity-param";
@@ -33,7 +32,6 @@ export const FunctionExperimentation = memo(function FunctionExperimentation({
     "cumulative_feedback_time_granularity",
     "week",
   );
-  const config = useConfig();
 
   // Don't render experimentation section for the default function
   if (functionName === DEFAULT_FUNCTION) {
@@ -65,12 +63,11 @@ export const FunctionExperimentation = memo(function FunctionExperimentation({
     ? transformFeedbackTimeseries(feedbackTimeseries!, timeGranularity)
     : { countsData: [], meansData: [], variantNames: [] };
 
-  // Extract metric name and config for track_and_stop experimentation
+  // Extract metric name for track_and_stop experimentation
   const metricName =
     functionConfig.experimentation.type === "track_and_stop"
       ? functionConfig.experimentation.metric
       : "";
-  const metric = metricName ? config.metrics[metricName] : undefined;
 
   // Create a centralized chart config to ensure consistent colors across all panels
   // Use union of variant names from current weights and historical feedback data
@@ -119,7 +116,6 @@ export const FunctionExperimentation = memo(function FunctionExperimentation({
               variantNames={variantNames}
               timeGranularity={timeGranularity}
               metricName={metricName}
-              metric={metric}
               time_granularity={timeGranularity}
               onTimeGranularityChange={onTimeGranularityChange}
               chartConfig={chartConfig}


### PR DESCRIPTION
#4384 is a more native solution we can do later if relevant. This PR only adjusts the plot in the UI.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Bounds Y-axis domain to [0, 1] for boolean metrics in `FeedbackMeansTimeseries` component.
> 
>   - **Behavior**:
>     - Bounds Y-axis domain to [0, 1] for boolean metrics in `FeedbackMeansTimeseries` component.
>     - Uses `metric?.type` to determine if the metric is boolean.
>   - **Files**:
>     - Modifies `FeedbackMeansTimeseries.tsx` to include Y-axis domain logic for boolean metrics.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7c566b72a5e117588dc03050f3d06de79b9d9986. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->