### PR TITLE
temporarily disabling CI bot

### DIFF
--- a/.github/workflows/tensorzero-ci-bot-failure-diagnosis.yml
+++ b/.github/workflows/tensorzero-ci-bot-failure-diagnosis.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.workflow_run.head_sha }tcle}
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
           fetch-tags: false
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Temporarily disables the CI bot by commenting out the trigger in `tensorzero-ci-bot-failure-diagnosis.yml`, stopping automatic runs after "General Checks".
> 
>   - **Behavior**:
>     - Temporarily disables the CI bot by commenting out the `on` trigger in `tensorzero-ci-bot-failure-diagnosis.yml`.
>     - Workflow no longer runs automatically after "General Checks" completion.
>   - **Misc**:
>     - No changes to job definitions or steps within the workflow.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2794713175adf1536b003dcbfaae0f63d3a185c2. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->