### PR TITLE
bumped sqlx to alpha version globally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,17 +1928,6 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
-dependencies = [
- "cfg-if",
- "home",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "etcetera"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
@@ -2312,7 +2301,7 @@ dependencies = [
  "reqwest-eventsource",
  "secrecy",
  "serde_json",
- "sqlx 0.9.0-alpha.1",
+ "sqlx",
  "tempfile",
  "tensorzero",
  "tensorzero-auth",
@@ -4699,7 +4688,7 @@ dependencies = [
  "async-trait",
  "clap",
  "rlt",
- "sqlx 0.8.6",
+ "sqlx",
  "tensorzero-core",
  "tokio",
  "tracing",
@@ -5603,66 +5592,15 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
-dependencies = [
- "sqlx-core 0.8.6",
- "sqlx-macros 0.8.6",
- "sqlx-mysql 0.8.6",
- "sqlx-postgres 0.8.6",
- "sqlx-sqlite 0.8.6",
-]
-
-[[package]]
-name = "sqlx"
 version = "0.9.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "decccfa5f2f3eac95eb68085cfe69a0172fa9711666c3a634cfc806d4fb74a47"
 dependencies = [
- "sqlx-core 0.9.0-alpha.1",
- "sqlx-macros 0.9.0-alpha.1",
- "sqlx-mysql 0.9.0-alpha.1",
- "sqlx-postgres 0.9.0-alpha.1",
- "sqlx-sqlite 0.9.0-alpha.1",
-]
-
-[[package]]
-name = "sqlx-core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "chrono",
- "crc",
- "crossbeam-queue",
- "either",
- "event-listener",
- "futures-core",
- "futures-intrusive",
- "futures-io",
- "futures-util",
- "hashbrown 0.15.5",
- "hashlink",
- "indexmap 2.12.1",
- "log",
- "memchr",
- "once_cell",
- "percent-encoding",
- "rustls",
- "serde",
- "serde_json",
- "sha2",
- "smallvec",
- "thiserror 2.0.17",
- "tokio",
- "tokio-stream",
- "tracing",
- "url",
- "uuid",
- "webpki-roots 0.26.11",
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
 ]
 
 [[package]]
@@ -5700,20 +5638,8 @@ dependencies = [
  "toml 0.8.23",
  "tracing",
  "url",
+ "uuid",
  "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "sqlx-macros"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
-dependencies = [
- "proc-macro2",
- "quote",
- "sqlx-core 0.8.6",
- "sqlx-macros-core 0.8.6",
- "syn 2.0.111",
 ]
 
 [[package]]
@@ -5724,34 +5650,9 @@ checksum = "d7aab9442ed1568e3aed6c368737226ee4e0e8d1deb0e0887fa6bf15282ace44"
 dependencies = [
  "proc-macro2",
  "quote",
- "sqlx-core 0.9.0-alpha.1",
- "sqlx-macros-core 0.9.0-alpha.1",
+ "sqlx-core",
+ "sqlx-macros-core",
  "syn 2.0.111",
-]
-
-[[package]]
-name = "sqlx-macros-core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
-dependencies = [
- "dotenvy",
- "either",
- "heck 0.5.0",
- "hex",
- "once_cell",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "sha2",
- "sqlx-core 0.8.6",
- "sqlx-mysql 0.8.6",
- "sqlx-postgres 0.8.6",
- "sqlx-sqlite 0.8.6",
- "syn 2.0.111",
- "tokio",
- "url",
 ]
 
 [[package]]
@@ -5770,58 +5671,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "sqlx-core 0.9.0-alpha.1",
- "sqlx-mysql 0.9.0-alpha.1",
- "sqlx-postgres 0.9.0-alpha.1",
- "sqlx-sqlite 0.9.0-alpha.1",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
  "syn 2.0.111",
  "thiserror 2.0.17",
  "tokio",
  "url",
-]
-
-[[package]]
-name = "sqlx-mysql"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
-dependencies = [
- "atoi",
- "base64 0.22.1",
- "bitflags",
- "byteorder",
- "bytes",
- "chrono",
- "crc",
- "digest",
- "dotenvy",
- "either",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-util",
- "generic-array",
- "hex",
- "hkdf",
- "hmac",
- "itoa",
- "log",
- "md-5",
- "memchr",
- "once_cell",
- "percent-encoding",
- "rand 0.8.5",
- "rsa",
- "serde",
- "sha1",
- "sha2",
- "smallvec",
- "sqlx-core 0.8.6",
- "stringprep",
- "thiserror 2.0.17",
- "tracing",
- "uuid",
- "whoami",
 ]
 
 [[package]]
@@ -5859,45 +5716,7 @@ dependencies = [
  "sha1",
  "sha2",
  "smallvec",
- "sqlx-core 0.9.0-alpha.1",
- "stringprep",
- "thiserror 2.0.17",
- "tracing",
- "whoami",
-]
-
-[[package]]
-name = "sqlx-postgres"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
-dependencies = [
- "atoi",
- "base64 0.22.1",
- "bitflags",
- "byteorder",
- "chrono",
- "crc",
- "dotenvy",
- "etcetera 0.8.0",
- "futures-channel",
- "futures-core",
- "futures-util",
- "hex",
- "hkdf",
- "hmac",
- "home",
- "itoa",
- "log",
- "md-5",
- "memchr",
- "once_cell",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "sha2",
- "smallvec",
- "sqlx-core 0.8.6",
+ "sqlx-core",
  "stringprep",
  "thiserror 2.0.17",
  "tracing",
@@ -5918,7 +5737,7 @@ dependencies = [
  "chrono",
  "crc",
  "dotenvy",
- "etcetera 0.10.0",
+ "etcetera",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -5935,37 +5754,12 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "sqlx-core 0.9.0-alpha.1",
+ "sqlx-core",
  "stringprep",
  "thiserror 2.0.17",
  "tracing",
- "whoami",
-]
-
-[[package]]
-name = "sqlx-sqlite"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
-dependencies = [
- "atoi",
- "chrono",
- "flume",
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-intrusive",
- "futures-util",
- "libsqlite3-sys",
- "log",
- "percent-encoding",
- "serde",
- "serde_urlencoded",
- "sqlx-core 0.8.6",
- "thiserror 2.0.17",
- "tracing",
- "url",
  "uuid",
+ "whoami",
 ]
 
 [[package]]
@@ -5987,10 +5781,11 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_urlencoded",
- "sqlx-core 0.9.0-alpha.1",
+ "sqlx-core",
  "thiserror 2.0.17",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -6228,7 +6023,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "sqlx 0.9.0-alpha.1",
+ "sqlx",
  "thiserror 2.0.17",
  "tracing",
  "ts-rs",
@@ -6309,8 +6104,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "sha2",
- "sqlx 0.8.6",
- "sqlx 0.9.0-alpha.1",
+ "sqlx",
  "strum 0.27.2",
  "tempfile",
  "tensorzero",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,13 +84,14 @@ tower-http = { version = "0.6.7", features = ["trace"] }
 mime = { git = "https://github.com/hyperium/mime", rev = "1ef137c7358fc64e07c8a640e4e9ba2a784b7f7d", features = [
     "serde1",
 ] }
-sqlx = { version = "0.8.6", features = [
+sqlx = { version = "0.9.0-alpha.1", features = [
     "runtime-tokio",
     "tls-rustls",
     "postgres",
     "migrate",
     "chrono",
     "uuid",
+    "sqlx-toml",
 ] }
 rlt = "0.2.1"
 metrics-exporter-prometheus = { version = "0.18.1", features = [

--- a/gateway/src/router.rs
+++ b/gateway/src/router.rs
@@ -45,7 +45,7 @@ pub fn build_axum_router(
         let state = TensorzeroAuthMiddlewareState::new(TensorzeroAuthMiddlewareStateInner {
             unauthenticated_routes: UNAUTHENTICATED_ROUTES,
             auth_cache: app_state.auth_cache.clone(),
-            pool: app_state.postgres_connection_info.get_alpha_pool().cloned(),
+            pool: app_state.postgres_connection_info.get_pool().cloned(),
             error_json: app_state.config.gateway.unstable_error_json,
         });
         router = router.layer(middleware::from_fn_with_state(

--- a/internal/tensorzero-auth/Cargo.toml
+++ b/internal/tensorzero-auth/Cargo.toml
@@ -11,9 +11,7 @@ hex = "0.4.3"
 secrecy.workspace = true
 serde.workspace = true
 sha2 = "0.10.9"
-# Unfortunately, this cannot be a workspace dependency, since renaming the 'sqlx' package breaks all of the macros
-# (which emit '::sqlx' tokens)
-sqlx = { version = "0.9.0-alpha.1", features = ["sqlx-toml", "postgres", "runtime-tokio", "chrono", "tls-rustls"] }
+sqlx = { workspace = true }
 thiserror = { workspace = true }
 rand = { workspace = true }
 chrono.workspace = true

--- a/internal/tensorzero-auth/src/postgres/mod.rs
+++ b/internal/tensorzero-auth/src/postgres/mod.rs
@@ -21,9 +21,7 @@ pub struct MigrationsData {
 
 /// Helper function to retrieve the set of applied migrations from the database.
 /// We pull this out so that the error can be mapped in one place.
-/// This is almost the same as the corresponding `get_applied_migrations` function in 'tensorzero_core', but with a different table name,
-/// and using sqlx_alpha
-/// TODO - consolidate these functions into a single `get_applied_migrations`function  once we're using a single sqlx version.
+/// This is almost the same as the corresponding `get_applied_migrations` function in 'tensorzero_core', but with a different table name.
 async fn get_applied_migrations(pool: &PgPool) -> Result<HashSet<i64>, sqlx::Error> {
     let mut applied_migrations: HashSet<i64> = HashSet::new();
     let mut rows =

--- a/internal/tensorzero-node/src/postgres.rs
+++ b/internal/tensorzero-node/src/postgres.rs
@@ -31,7 +31,7 @@ impl PostgresClient {
     pub async fn create_api_key(&self, description: Option<String>) -> Result<String, napi::Error> {
         let pool = self
             .connection_info
-            .get_alpha_pool()
+            .get_pool()
             .ok_or_else(|| napi::Error::from_reason("Postgres connection not available"))?;
 
         let key = tensorzero_auth::postgres::create_key(
@@ -54,7 +54,7 @@ impl PostgresClient {
     ) -> Result<String, napi::Error> {
         let pool = self
             .connection_info
-            .get_alpha_pool()
+            .get_pool()
             .ok_or_else(|| napi::Error::from_reason("Postgres connection not available"))?;
 
         let keys = tensorzero_auth::postgres::list_key_info(None, limit, offset, pool)
@@ -70,7 +70,7 @@ impl PostgresClient {
     pub async fn disable_api_key(&self, public_id: String) -> Result<String, napi::Error> {
         let pool = self
             .connection_info
-            .get_alpha_pool()
+            .get_pool()
             .ok_or_else(|| napi::Error::from_reason("Postgres connection not available"))?;
 
         let disabled_at = tensorzero_auth::postgres::disable_key(&public_id, pool)
@@ -90,7 +90,7 @@ impl PostgresClient {
     ) -> Result<String, napi::Error> {
         let pool = self
             .connection_info
-            .get_alpha_pool()
+            .get_pool()
             .ok_or_else(|| napi::Error::from_reason("Postgres connection not available"))?;
 
         let key = tensorzero_auth::postgres::update_key_description(

--- a/tensorzero-core/Cargo.toml
+++ b/tensorzero-core/Cargo.toml
@@ -117,12 +117,6 @@ ts-rs = { workspace = true }
 moka = { workspace = true }
 tonic = { version = "0.14.2", default-features = false }
 sqlx = { workspace = true }
-sqlx_alpha = { package = "sqlx", version = "0.9.0-alpha.1", features = [
-    "sqlx-toml",
-    "postgres",
-    "runtime-tokio",
-    "chrono",
-] }
 pin-project = { workspace = true }
 once_cell = "1.21.3"
 clarabel = { version = "0", default-features = false, features = ["serde"] }

--- a/tensorzero-core/src/db/postgres/mod.rs
+++ b/tensorzero-core/src/db/postgres/mod.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use futures::TryStreamExt;
-use futures::future::try_join;
 use std::{collections::HashSet, time::Duration};
 use tokio::time::timeout;
 
@@ -24,9 +23,6 @@ fn get_run_migrations_command() -> String {
 pub enum PostgresConnectionInfo {
     Enabled {
         pool: PgPool,
-        /// The `tensorzero-auth` crate currently uses an alpha release of `sqlx`, so the `PgPool` type is different.
-        /// As a result, we need to create a separate pool for it.
-        alpha_pool: Option<sqlx_alpha::PgPool>,
     },
     #[cfg(test)]
     Mock {
@@ -36,8 +32,8 @@ pub enum PostgresConnectionInfo {
 }
 
 impl PostgresConnectionInfo {
-    pub fn new_with_pool(pool: PgPool, alpha_pool: Option<sqlx_alpha::PgPool>) -> Self {
-        Self::Enabled { pool, alpha_pool }
+    pub fn new_with_pool(pool: PgPool) -> Self {
+        Self::Enabled { pool }
     }
 
     #[cfg(test)]
@@ -51,22 +47,7 @@ impl PostgresConnectionInfo {
 
     pub fn get_pool(&self) -> Option<&PgPool> {
         match self {
-            Self::Enabled {
-                pool,
-                alpha_pool: _,
-            } => Some(pool),
-            #[cfg(test)]
-            Self::Mock { .. } => None,
-            Self::Disabled => None,
-        }
-    }
-
-    pub fn get_alpha_pool(&self) -> Option<&sqlx_alpha::PgPool> {
-        match self {
-            Self::Enabled {
-                pool: _,
-                alpha_pool,
-            } => alpha_pool.as_ref(),
+            Self::Enabled { pool } => Some(pool),
             #[cfg(test)]
             Self::Mock { .. } => None,
             Self::Disabled => None,
@@ -75,10 +56,7 @@ impl PostgresConnectionInfo {
 
     pub fn get_pool_result(&self) -> Result<&PgPool, Error> {
         match self {
-            Self::Enabled {
-                pool,
-                alpha_pool: _,
-            } => Ok(pool),
+            Self::Enabled { pool } => Ok(pool),
             #[cfg(test)]
             Self::Mock { .. } => Err(Error::new(ErrorDetails::PostgresConnectionInitialization {
                 message: "Mock database is not supported".to_string(),
@@ -97,21 +75,19 @@ impl PostgresConnectionInfo {
             let expected_migrations: HashSet<i64> = migrator.iter().map(|m| m.version).collect();
             // Query the database for all successfully applied migration versions.
             let applied_migrations = get_applied_migrations(pool).await.map_err(|e| {
-            Error::new(ErrorDetails::PostgresConnectionInitialization {
-                message: format!("Failed to retrieve applied `tensorzero-core` migrations: {e}. You may need to run the migrations with `{}`", get_run_migrations_command()),
-            })
-        })?;
+                Error::new(ErrorDetails::PostgresConnectionInitialization {
+                    message: format!("Failed to retrieve applied `tensorzero-core` migrations: {e}. You may need to run the migrations with `{}`", get_run_migrations_command()),
+                })
+            })?;
 
             Self::check_applied_expected(
                 "tensorzero-core",
                 &applied_migrations,
                 &expected_migrations,
             )?;
-        }
 
-        if let Some(alpha_pool) = self.get_alpha_pool() {
             let tensorzero_auth_migrations_data =
-                tensorzero_auth::postgres::get_migrations_data(alpha_pool).await.map_err(|e| {
+                tensorzero_auth::postgres::get_migrations_data(pool).await.map_err(|e| {
                     Error::new(ErrorDetails::PostgresConnectionInitialization {
                         message: format!("Failed to retrieve applied `tensorzero-auth` migrations: {e}. You may need to run the migrations with `{}`", get_run_migrations_command()),
                     })
@@ -160,38 +136,20 @@ impl HealthCheckable for PostgresConnectionInfo {
                     }))
                 }
             }
-            Self::Enabled { pool, alpha_pool } => {
+            Self::Enabled { pool } => {
                 let check = async {
-                    let _result = sqlx::query("SELECT 1")
-                        .fetch_one(pool)
-                        .await
-                        .map_err(|_e| {
-                            Error::new(ErrorDetails::PostgresConnection {
-                                message: _e.to_string(),
-                            })
-                        })?;
+                    let _result = sqlx::query("SELECT 1").fetch_one(pool).await.map_err(|e| {
+                        Error::new(ErrorDetails::PostgresConnection {
+                            message: e.to_string(),
+                        })
+                    })?;
 
                     Ok(())
                 };
-                let alpha_check = async {
-                    if let Some(alpha_pool) = alpha_pool {
-                        let _result = sqlx_alpha::query("SELECT 1")
-                            .fetch_one(alpha_pool)
-                            .await
-                            .map_err(|_e| {
-                                Error::new(ErrorDetails::PostgresConnection {
-                                    message: _e.to_string(),
-                                })
-                            })?;
-                        Ok(())
-                    } else {
-                        Ok(())
-                    }
-                };
 
                 // TODO(shuyang): customize postgres timeout
-                match timeout(Duration::from_millis(1000), try_join(check, alpha_check)).await {
-                    Ok(Ok(((), ()))) => Ok(()),
+                match timeout(Duration::from_millis(1000), check).await {
+                    Ok(Ok(())) => Ok(()),
                     Ok(Err(e)) => Err(e),
                     Err(_) => Err(Error::new(ErrorDetails::PostgresConnection {
                         message: "Postgres healthcheck query timed out.".to_string(),
@@ -230,16 +188,8 @@ pub async fn manual_run_postgres_migrations_with_url(postgres_url: &str) -> Resu
         })
     })?;
 
-    // Our 'tensorzero-auth' crate currently uses an alpha release of 'sqlx', so the `PgPool` type is different.
-    let sqlx_alpha_pool = sqlx_alpha::PgPool::connect(postgres_url)
-        .await
-        .map_err(|err| {
-            Error::new(ErrorDetails::PostgresConnectionInitialization {
-                message: err.to_string(),
-            })
-        })?;
     tensorzero_auth::postgres::make_migrator()
-        .run(&sqlx_alpha_pool)
+        .run(&pool)
         .await
         .map_err(|e| {
             Error::new(ErrorDetails::PostgresMigration {

--- a/tensorzero-core/src/utils/gateway.rs
+++ b/tensorzero-core/src/utils/gateway.rs
@@ -393,8 +393,6 @@ async fn create_postgres_connection(
     postgres_url: &str,
     connection_pool_size: u32,
 ) -> Result<PostgresConnectionInfo, Error> {
-    // TODO - decide how we should handle apply `connection_pool_size` to two pools
-    // Hopefully, sqlx does a stable release before we actually start using `alpha_pool`
     let pool = PgPoolOptions::new()
         .max_connections(connection_pool_size)
         .connect(postgres_url)
@@ -405,17 +403,7 @@ async fn create_postgres_connection(
             })
         })?;
 
-    let alpha_pool = sqlx_alpha::postgres::PgPoolOptions::new()
-        .max_connections(connection_pool_size)
-        .connect(postgres_url)
-        .await
-        .map_err(|err| {
-            Error::new(ErrorDetails::PostgresConnectionInitialization {
-                message: err.to_string(),
-            })
-        })?;
-
-    let connection_info = PostgresConnectionInfo::new_with_pool(pool, Some(alpha_pool));
+    let connection_info = PostgresConnectionInfo::new_with_pool(pool);
     connection_info.check_migrations().await?;
     Ok(connection_info)
 }

--- a/tensorzero-core/tests/e2e/db/experimentation_queries.rs
+++ b/tensorzero-core/tests/e2e/db/experimentation_queries.rs
@@ -48,7 +48,7 @@ async fn test_cas_basic_functionality(pool_opts: PgPoolOptions, conn_opts: PgCon
         .await
         .unwrap();
     let pool = pool_opts.connect_with(conn_opts).await.unwrap();
-    let conn = PostgresConnectionInfo::new_with_pool(pool, None);
+    let conn = PostgresConnectionInfo::new_with_pool(pool);
 
     let episode_id = Uuid::now_v7();
     let function_name = generate_function_name("basic");
@@ -89,7 +89,7 @@ async fn test_cas_isolation(pool_opts: PgPoolOptions, conn_opts: PgConnectOption
         .await
         .unwrap();
     let pool = pool_opts.connect_with(conn_opts).await.unwrap();
-    let conn = PostgresConnectionInfo::new_with_pool(pool, None);
+    let conn = PostgresConnectionInfo::new_with_pool(pool);
 
     // Create comprehensive test matrix: 3 episodes × 3 functions = 9 combinations
     let episodes: Vec<Uuid> = (0..3).map(|_| Uuid::now_v7()).collect();
@@ -151,7 +151,7 @@ async fn test_cas_concurrency_and_atomicity(pool_opts: PgPoolOptions, conn_opts:
         .await
         .unwrap();
     let pool = pool_opts.connect_with(conn_opts).await.unwrap();
-    let conn = PostgresConnectionInfo::new_with_pool(pool, None);
+    let conn = PostgresConnectionInfo::new_with_pool(pool);
 
     let episode_id = Uuid::now_v7();
     let function_name = generate_function_name("concurrency");
@@ -210,7 +210,7 @@ async fn test_cas_edge_case_values(pool_opts: PgPoolOptions, conn_opts: PgConnec
         .await
         .unwrap();
     let pool = pool_opts.connect_with(conn_opts).await.unwrap();
-    let conn = PostgresConnectionInfo::new_with_pool(pool, None);
+    let conn = PostgresConnectionInfo::new_with_pool(pool);
 
     let episode_id = Uuid::now_v7();
 
@@ -324,7 +324,7 @@ async fn test_cas_stress_test(pool_opts: PgPoolOptions, conn_opts: PgConnectOpti
         .await
         .unwrap();
     let pool = pool_opts.connect_with(conn_opts).await.unwrap();
-    let conn = PostgresConnectionInfo::new_with_pool(pool, None);
+    let conn = PostgresConnectionInfo::new_with_pool(pool);
 
     let num_episodes = 5;
     let num_functions = 4;
@@ -416,7 +416,7 @@ async fn test_cas_failure_recovery(pool_opts: PgPoolOptions, conn_opts: PgConnec
         .await
         .unwrap();
     let pool = pool_opts.connect_with(conn_opts).await.unwrap();
-    let conn = PostgresConnectionInfo::new_with_pool(pool, None);
+    let conn = PostgresConnectionInfo::new_with_pool(pool);
 
     let episode_id = Uuid::now_v7();
     let function_name = generate_function_name("failure_recovery");

--- a/tensorzero-core/tests/e2e/db/rate_limit_queries.rs
+++ b/tensorzero-core/tests/e2e/db/rate_limit_queries.rs
@@ -56,7 +56,7 @@ async fn test_atomic_multi_key_all_or_nothing(
         .await
         .unwrap();
     let pool = pool_opts.connect_with(conn_opts).await.unwrap();
-    let conn = PostgresConnectionInfo::new_with_pool(pool, None);
+    let conn = PostgresConnectionInfo::new_with_pool(pool);
 
     // First, consume some tokens from key1 to set up a scenario where key1 can succeed but key2 fails
     let setup_request = create_consume_request("key1", 50, 100, 10, Duration::seconds(60));
@@ -101,7 +101,7 @@ async fn test_atomic_consistency_under_load(pool_opts: PgPoolOptions, conn_opts:
         .await
         .unwrap();
     let pool = pool_opts.connect_with(conn_opts).await.unwrap();
-    let conn = PostgresConnectionInfo::new_with_pool(pool, None);
+    let conn = PostgresConnectionInfo::new_with_pool(pool);
 
     // Launch many concurrent multi-key requests where some will fail
     let handles: Vec<_> = (0..20)
@@ -157,7 +157,7 @@ async fn test_race_condition_no_over_consumption(
         .await
         .unwrap();
     let pool = pool_opts.connect_with(conn_opts).await.unwrap();
-    let conn = PostgresConnectionInfo::new_with_pool(pool, None);
+    let conn = PostgresConnectionInfo::new_with_pool(pool);
     let key = "race_test";
 
     // Launch 50 concurrent requests for 5 tokens each on a bucket with 100 capacity
@@ -219,7 +219,7 @@ async fn test_race_condition_interleaved_consume_return(
         .await
         .unwrap();
     let pool = pool_opts.connect_with(conn_opts).await.unwrap();
-    let conn = PostgresConnectionInfo::new_with_pool(pool, None);
+    let conn = PostgresConnectionInfo::new_with_pool(pool);
     let key = "interleaved_test";
 
     // Set up initial state
@@ -286,7 +286,7 @@ async fn test_rate_limit_lifecycle(pool_opts: PgPoolOptions, conn_opts: PgConnec
         .await
         .unwrap();
     let pool = pool_opts.connect_with(conn_opts).await.unwrap();
-    let conn = PostgresConnectionInfo::new_with_pool(pool, None);
+    let conn = PostgresConnectionInfo::new_with_pool(pool);
     let key = "lifecycle_test";
 
     // Phase 1: Initial consumption
@@ -334,7 +334,7 @@ async fn test_capacity_boundaries(pool_opts: PgPoolOptions, conn_opts: PgConnect
         .await
         .unwrap();
     let pool = pool_opts.connect_with(conn_opts).await.unwrap();
-    let conn = PostgresConnectionInfo::new_with_pool(pool, None);
+    let conn = PostgresConnectionInfo::new_with_pool(pool);
 
     // Test 1: Zero request (should always succeed)
     let zero_req = create_consume_request("zero_test", 0, 50, 5, Duration::seconds(60));
@@ -368,7 +368,7 @@ async fn test_refill_mechanics(pool_opts: PgPoolOptions, conn_opts: PgConnectOpt
         .await
         .unwrap();
     let pool = pool_opts.connect_with(conn_opts).await.unwrap();
-    let conn = PostgresConnectionInfo::new_with_pool(pool, None);
+    let conn = PostgresConnectionInfo::new_with_pool(pool);
     let key = "refill_test";
 
     // Phase 1: Consume most tokens
@@ -435,7 +435,7 @@ async fn test_empty_operations(pool_opts: PgPoolOptions, conn_opts: PgConnectOpt
         .await
         .unwrap();
     let pool = pool_opts.connect_with(conn_opts).await.unwrap();
-    let conn = PostgresConnectionInfo::new_with_pool(pool, None);
+    let conn = PostgresConnectionInfo::new_with_pool(pool);
 
     // Empty consume requests
     let results = conn.consume_tickets(&[]).await.unwrap();
@@ -452,7 +452,7 @@ async fn test_new_bucket_behavior(pool_opts: PgPoolOptions, conn_opts: PgConnect
         .await
         .unwrap();
     let pool = pool_opts.connect_with(conn_opts).await.unwrap();
-    let conn = PostgresConnectionInfo::new_with_pool(pool, None);
+    let conn = PostgresConnectionInfo::new_with_pool(pool);
 
     // New bucket starts at capacity
     let balance = conn
@@ -482,7 +482,7 @@ async fn test_concurrent_stress(pool_opts: PgPoolOptions, conn_opts: PgConnectOp
         .await
         .unwrap();
     let pool = pool_opts.connect_with(conn_opts).await.unwrap();
-    let conn = PostgresConnectionInfo::new_with_pool(pool, None);
+    let conn = PostgresConnectionInfo::new_with_pool(pool);
 
     // High concurrency test with multiple keys
     let handles: Vec<_> = (0..100)
@@ -528,7 +528,7 @@ async fn test_zero_refill_interval_exception(
         .await
         .unwrap();
     let pool = pool_opts.connect_with(conn_opts).await.unwrap();
-    let conn = PostgresConnectionInfo::new_with_pool(pool, None);
+    let conn = PostgresConnectionInfo::new_with_pool(pool);
 
     // Test zero interval throws exception
     let zero_interval_request =

--- a/tensorzero-core/tests/load/rate-limit-load-test/src/main.rs
+++ b/tensorzero-core/tests/load/rate-limit-load-test/src/main.rs
@@ -62,7 +62,7 @@ async fn main() -> Result<()> {
     // Create connection pool
     let pool_size = args.pool_size.unwrap_or(50);
     let pool = create_postgres_pool(pool_size).await?;
-    let client = PostgresConnectionInfo::new_with_pool(pool, None);
+    let client = PostgresConnectionInfo::new_with_pool(pool);
 
     // Create bucket settings
     let bucket_settings = Arc::new(create_bucket_settings(args.capacity, args.refill_amount));


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `sqlx` to `0.9.0-alpha.1` globally, removing `sqlx_alpha` and simplifying `PostgresConnectionInfo` logic.
> 
>   - **Dependencies**:
>     - Bump `sqlx` to `0.9.0-alpha.1` in `Cargo.toml` files.
>     - Remove `sqlx_alpha` dependency and related logic.
>   - **Code Simplification**:
>     - Remove `get_alpha_pool()` method from `PostgresConnectionInfo` in `postgres/mod.rs`.
>     - Update `build_axum_router()` in `router.rs` to use `get_pool()` instead of `get_alpha_pool()`.
>   - **Tests**:
>     - Update tests in `experimentation_queries.rs` and `rate_limit_queries.rs` to use the updated `PostgresConnectionInfo`.
>     - Remove references to `sqlx_alpha` in test setup.
>   - **Misc**:
>     - Update comments and documentation to reflect the removal of `sqlx_alpha`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 5e02b3cd2e52f697c2e6b75054b07dded9f53afe. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->