### PR TITLE
changed the name of the overhead metric to tensorzero_inference_laten…

### DIFF
--- a/gateway/tests/prometheus.rs
+++ b/gateway/tests/prometheus.rs
@@ -81,22 +81,22 @@ async fn test_prometheus_metrics_inference_helper(stream: bool) {
     println!("Metrics: {metrics:#?}");
 
     assert_eq!(
-        metrics[r#"tensorzero_overhead_count{kind="POST /inference"}"#],
+        metrics[r#"tensorzero_inference_latency_overhead_seconds_count{kind="POST /inference"}"#],
         count.to_string()
     );
 
-    let pct_50 = metrics[r#"tensorzero_overhead{kind="POST /inference",quantile="0.5"}"#]
+    let pct_50 = metrics[r#"tensorzero_inference_latency_overhead_seconds{kind="POST /inference",quantile="0.5"}"#]
         .parse::<f64>()
         .unwrap();
     assert!(
-        pct_50 > 1.0,
+        pct_50 > 0.001,
         "50th percentile overhead should be greater than 1ms"
     );
     // We have observability disabled, so we expect the overhead to be low (even though this is a debug build)
     // Notably, it does *not* include the 5-second sleep in the 'dummy::slow' model
     // This test can be slow on CI, so we give a generous 200ms margin
     assert!(
-        pct_50 < 200.0,
-        "Unexpectedly high 50th percentile overhead: {pct_50}ms"
+        pct_50 < 0.2,
+        "Unexpectedly high 50th percentile overhead: {pct_50}s"
     );
 }

--- a/tensorzero-core/src/observability/mod.rs
+++ b/tensorzero-core/src/observability/mod.rs
@@ -1241,8 +1241,8 @@ pub fn setup_metrics() -> Result<PrometheusHandle, Error> {
     );
 
     describe_histogram!(
-        "tensorzero_overhead",
-        Unit::Milliseconds,
+        "tensorzero_inference_latency_overhead_seconds",
+        Unit::Seconds,
         "Overhead of TensorZero on HTTP requests"
     );
 

--- a/tensorzero-core/src/observability/overhead_timing.rs
+++ b/tensorzero-core/src/observability/overhead_timing.rs
@@ -203,8 +203,11 @@ where
                 Duration::ZERO
             });
 
-            metrics::histogram!("tensorzero_overhead", &[("kind", overhead_data.kind)])
-                .record(overhead.as_millis() as f64);
+            metrics::histogram!(
+                "tensorzero_inference_latency_overhead_seconds",
+                &[("kind", overhead_data.kind)]
+            )
+            .record(overhead.as_secs_f64());
         }
     }
 

--- a/tensorzero-core/src/observability/request_logging.rs
+++ b/tensorzero-core/src/observability/request_logging.rs
@@ -32,7 +32,7 @@ impl ConnectionDropGuard {
     fn mark_finished(&self) {
         // Calculate the elapsed time when we've finished sending the response to
         // the client - this is the latency that we want to log to users,
-        // and use for computing the `tensorzero_overhead` metric
+        // and use for computing the `tensorzero_inference_latency_overhead_seconds` metric
         self.finished_with_latency
             .set(Some(self.start_time.elapsed()));
     }

--- a/tensorzero-core/src/providers/dummy.rs
+++ b/tensorzero-core/src/providers/dummy.rs
@@ -261,7 +261,7 @@ pub static DUMMY_STREAMING_JSON_RESPONSE: [&str; 5] =
 pub static DUMMY_RAW_REQUEST: &str = "raw request";
 
 /// Like `tokio::time::sleep`, but attaches a span that excludes
-/// this time for our `tensorzero_overhead` metric
+/// this time for our `tensorzero_inference_latency_overhead_seconds` metric
 /// We use this to simulate slow HTTP requests (which also have
 /// their latency excluded via `TensorzeroHttpClient`)
 async fn sleep_excluding_latency(duration: Duration) {


### PR DESCRIPTION
…cy_overhead_seconds
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rename `tensorzero_overhead` metric to `tensorzero_inference_latency_overhead_seconds` and update its unit from milliseconds to seconds.
> 
>   - **Metric Renaming**:
>     - Rename `tensorzero_overhead` to `tensorzero_inference_latency_overhead_seconds` in `prometheus.rs`, `mod.rs`, `overhead_timing.rs`, and `request_logging.rs`.
>     - Update metric unit from milliseconds to seconds in `mod.rs` and `overhead_timing.rs`.
>   - **Tests**:
>     - Update assertions in `test_prometheus_metrics_inference_helper()` in `prometheus.rs` to reflect new metric name and unit.
>   - **Documentation**:
>     - Update comments in `request_logging.rs` and `dummy.rs` to use new metric name.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 510a685d37bee1b5da61e6d97b76aee3f310801c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->