### PR TITLE
Use Cloudflare R2 credentials when download fixtures on Buildkite

### DIFF
--- a/ci/buildkite/test-clickhouse-cloud.sh
+++ b/ci/buildkite/test-clickhouse-cloud.sh
@@ -10,6 +10,8 @@ export CLICKHOUSE_API_KEY=$(buildkite-agent secret get clickhouse_api_key)
 export CLICKHOUSE_KEY_SECRET=$(buildkite-agent secret get clickhouse_key_secret)
 export CLICKHOUSE_USERNAME=$(buildkite-agent secret get clickhouse_username)
 export CLICKHOUSE_PASSWORD=$(buildkite-agent secret get clickhouse_password)
+export R2_ACCESS_KEY_ID=$(buildkite-agent secret get R2_ACCESS_KEY_ID)
+export R2_SECRET_ACCESS_KEY=$(buildkite-agent secret get R2_SECRET_ACCESS_KEY)
 # We concatenate our clickhouse instance prefix, along with our chosen clickhouse id (e.g. 'dev-tensorzero-e2e-tests-instance-' and '0'), to form the instance name
 # Then, we look up the instance url for this name, and add basic-auth credentials to the url to get our full TENSORZERO_CLICKHOUSE_URL
 # The 'export' statements go on separate lines to prevent the return code from the $() command from being ignored


### PR DESCRIPTION
We were falling back to the slow public-endpoint download
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Cloudflare R2 credentials to `test-clickhouse-cloud.sh` for faster fixture downloads on Buildkite.
> 
>   - **Environment Variables**:
>     - Add `R2_ACCESS_KEY_ID` and `R2_SECRET_ACCESS_KEY` to `test-clickhouse-cloud.sh` for Cloudflare R2 credentials.
>   - **Behavior**:
>     - Use Cloudflare R2 credentials for downloading fixtures, avoiding fallback to slower public endpoint.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for e9cb54f16005d07c41cf2f576a8980aa7796d654. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->