### PR TITLE
expect clippy option_option lint for serde

### DIFF
--- a/tensorzero-core/src/endpoints/datasets/v1/types.rs
+++ b/tensorzero-core/src/endpoints/datasets/v1/types.rs
@@ -143,6 +143,8 @@ impl<'de> Deserialize<'de> for UpdateChatDatapointRequest {
             #[serde(default)]
             input: Option<Input>,
             #[serde(default, deserialize_with = "deserialize_double_option")]
+            // Expect to distinguish between an omitted field, JSON null, and a concrete value.
+            #[expect(clippy::option_option)]
             output: Option<Option<Vec<ContentBlockChatOutput>>>,
             #[serde(flatten)]
             tool_params_new: UpdateDynamicToolParamsRequest,
@@ -329,6 +331,8 @@ impl<'de> Deserialize<'de> for UpdateJsonDatapointRequest {
             #[serde(default)]
             input: Option<Input>,
             #[serde(default, deserialize_with = "deserialize_double_option")]
+            // Expect to distinguish between an omitted field, JSON null, and a concrete value.
+            #[expect(clippy::option_option)]
             output: Option<Option<JsonDatapointOutputUpdate>>,
             #[serde(default)]
             output_schema: Option<Value>,

--- a/tensorzero-core/src/serde_util.rs
+++ b/tensorzero-core/src/serde_util.rs
@@ -259,6 +259,7 @@ where
 /// #[derive(Deserialize)]
 /// struct ParamsStruct {
 ///     #[serde(default, deserialize_with = "deserialize_double_option")]
+///     #[expect(clippy::option_option)]
 ///     maybe_null_field: Option<Option<String>>,
 /// }
 /// ```
@@ -797,6 +798,8 @@ mod tests {
     #[derive(Debug, Deserialize, PartialEq)]
     struct TestDoubleOptionStruct<T: for<'a> Deserialize<'a>> {
         #[serde(default, deserialize_with = "deserialize_double_option")]
+        // Expect to distinguish between an omitted field, JSON null, and a concrete value.
+        #[expect(clippy::option_option)]
         maybe_null_field: Option<Option<T>>,
     }
 


### PR DESCRIPTION
Feeds clippy, part of #1961 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `#[expect(clippy::option_option)]` to handle `Option<Option<T>>` lint in deserialization for specific fields in `types.rs` and `serde_util.rs`.
> 
>   - **Lint Handling**:
>     - Add `#[expect(clippy::option_option)]` to `output` field in `UpdateChatDatapointRequest` and `UpdateJsonDatapointRequest` in `types.rs`.
>     - Add `#[expect(clippy::option_option)]` to `maybe_null_field` in `TestDoubleOptionStruct` in `serde_util.rs`.
>   - **Purpose**:
>     - Distinguish between omitted fields, JSON null, and concrete values during deserialization.
>   - **Tests**:
>     - Update test cases in `serde_util.rs` to reflect changes in handling `Option<Option<T>>`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d1659d02021470f3be6bf68a365400ad24ff905a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->