### PR TITLE
Make AWS an optional, default features

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -556,6 +556,29 @@ jobs:
           unset TENSORZERO_CLICKHOUSE_URL
           cargo run-e2e --validate-and-exit
 
+  rust-build-no-default:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      # We deliberately install our MSRV here (rather than 'stable') to ensure that everything compiles with that version
+      - name: Install Rust ${{ env.RUST_MSRV }}
+        run: |
+          for attempt in 1 2 3; do
+            if rustup install ${{ env.RUST_MSRV }} --component rustfmt && rustup default ${{ env.RUST_MSRV }}; then
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "Failed to install Rust ${{ env.RUST_MSRV }} after 3 attempts"
+              exit 1
+            fi
+            sleep $((10 * attempt))
+          done
+        shell: bash
+      - name: Build (Rust) without default features
+        run: cargo build --workspace --no-default-features --verbose
+
   rust-test:
     permissions:
       contents: read
@@ -1207,6 +1230,7 @@ jobs:
         mocked-batch-tests,
         minikube,
         rust-build,
+        rust-build-no-default,
         rust-test,
         validate,
         validate-node,

--- a/tensorzero-core/Cargo.toml
+++ b/tensorzero-core/Cargo.toml
@@ -8,12 +8,22 @@ exclude = ["tests/", "fixtures/"]
 
 
 [features]
+default = ["aws"]
 # Forward this feature to the Rust client, so that the embedded gateway
 # has the `e2e_tests` feature enabled when we run our e2e tests
 e2e_tests = ["tensorzero/e2e_tests", "tensorzero-types/e2e_tests"]
 optimization_tests = ["e2e_tests"]
 pyo3 = ["dep:pyo3", "tensorzero-types/pyo3"]
 git = ["dep:git2"]
+aws = [
+    "dep:aws-config",
+    "dep:aws-sdk-bedrockruntime",
+    "dep:aws-smithy-types",
+    "dep:aws-types",
+    "dep:aws-sdk-sagemakerruntime",
+    "dep:aws-smithy-runtime-api",
+    "object_store/aws",
+]
 
 [[test]]
 name = "e2e"
@@ -27,17 +37,17 @@ workspace = true
 [dependencies]
 async-stream = { workspace = true }
 async-trait = { workspace = true }
-aws-config = { version = "1.8", features = ["behavior-version-latest"] }
+aws-config = { version = "1.8", features = ["behavior-version-latest"], optional = true }
 aws-sdk-bedrockruntime = { version = "1.120.0", default-features = false, features = [
     "behavior-version-latest",
     "rt-tokio",
     "default-https-client",
-] }
+], optional = true }
 aws-smithy-types = { version = "1.3.3", features = [
     "serde-deserialize",
     "serde-serialize",
-] }
-aws-types = "1.3.6"
+], optional = true }
+aws-types = { version = "1.3.6", optional = true }
 axum = { workspace = true }
 backon = { version = "1.6.0", features = ["tokio-sleep"] }
 blake3 = { workspace = true }
@@ -55,7 +65,7 @@ metrics = "0.24.3"
 metrics-exporter-prometheus = { workspace = true }
 minijinja = { workspace = true }
 num-bigint = "0.4"
-object_store = { workspace = true }
+object_store = { workspace = true, features = ["serde", "gcp"] }
 rand = { workspace = true }
 reqwest = { workspace = true }
 reqwest-eventsource = { workspace = true }
@@ -86,8 +96,8 @@ aws-sdk-sagemakerruntime = { version = "1.93.0", features = [
     "behavior-version-latest",
     "rt-tokio",
     "default-https-client",
-], default-features = false }
-aws-smithy-runtime-api = "1.9.1"
+], default-features = false, optional = true }
+aws-smithy-runtime-api = { version = "1.9.1", optional = true }
 eventsource-stream = "0.2.3"
 opentelemetry_sdk = "0.31.0"
 opentelemetry = "0.31.0"

--- a/tensorzero-core/src/endpoints/object_storage.rs
+++ b/tensorzero-core/src/endpoints/object_storage.rs
@@ -12,7 +12,7 @@ use crate::{
     inference::types::storage::StoragePath,
     utils::gateway::{AppState, AppStateData},
 };
-use aws_smithy_types::base64;
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 
 #[derive(Debug, Deserialize, Serialize)]
 #[cfg_attr(feature = "e2e_tests", derive(PartialEq))]
@@ -93,7 +93,7 @@ pub async fn get_object(
         })
     })?;
     Ok(ObjectResponse {
-        data: base64::encode(&bytes),
+        data: BASE64_STANDARD.encode(&bytes),
         reused_object_store: matches!(store, Cow::Borrowed(_)),
     })
 }

--- a/tensorzero-core/src/inference/types/resolved_input.rs
+++ b/tensorzero-core/src/inference/types/resolved_input.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::future::Future;
 use std::pin::Pin;
 
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use futures::FutureExt;
 use futures::future::Shared;
 use mime::MediaType;
@@ -163,7 +164,7 @@ pub async fn write_file(
     // The store might be explicitly disabled
     if let Some(store) = object_store.object_store.as_ref() {
         let data = raw.data();
-        let bytes = aws_smithy_types::base64::decode(data).map_err(|e| {
+        let bytes = BASE64_STANDARD.decode(data).map_err(|e| {
             Error::new(ErrorDetails::ObjectStoreWrite {
                 message: format!("Failed to decode file as base64: {e:?}"),
                 path: storage_path.clone(),

--- a/tensorzero-core/src/providers/mod.rs
+++ b/tensorzero-core/src/providers/mod.rs
@@ -1,7 +1,11 @@
 pub mod anthropic;
+#[cfg(feature = "aws")]
 pub mod aws_bedrock;
+#[cfg(feature = "aws")]
 pub mod aws_common;
+#[cfg(feature = "aws")]
 mod aws_http_client;
+#[cfg(feature = "aws")]
 pub mod aws_sagemaker;
 pub mod azure;
 pub mod chat_completions;


### PR DESCRIPTION
This allows more lightweight binary where we know some providers won't be used.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make AWS features optional by adding a feature flag and updating the build process to exclude AWS dependencies when not needed.
> 
>   - **Build Process**:
>     - Adds `rust-build-no-default` job in `.github/workflows/general.yml` to build without default features.
>     - Updates `rust-build` job dependencies to include `rust-build-no-default`.
>   - **Features**:
>     - Makes AWS dependencies optional in `Cargo.toml` by adding `optional = true` to AWS-related dependencies.
>     - Adds `aws` feature in `Cargo.toml` to group AWS dependencies.
>     - Sets `default = ["aws"]` in `Cargo.toml` to include AWS by default.
>   - **Code Changes**:
>     - Replaces `aws_smithy_types::base64` with `base64` crate in `object_storage.rs` and `resolved_input.rs`.
>     - Wraps AWS provider imports and usage in `model.rs` and `providers/mod.rs` with `#[cfg(feature = "aws")]` to conditionally compile AWS-related code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ae866191b5ae00c3009ed4ec64d9708a583aa71c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->