### PR TITLE
bumped version to 2025.12.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot-client"
-version = "2025.12.4"
+version = "2025.12.5"
 dependencies = [
  "chrono",
  "futures",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-tools"
-version = "2025.12.4"
+version = "2025.12.5"
 dependencies = [
  "durable-tools",
 ]
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools"
-version = "2025.12.4"
+version = "2025.12.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools-spawn"
-version = "2025.12.4"
+version = "2025.12.5"
 dependencies = [
  "async-trait",
  "durable",
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2025.12.4"
+version = "2025.12.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2025.12.4"
+version = "2025.12.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2313,7 +2313,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2025.12.4"
+version = "2025.12.5"
 dependencies = [
  "axum",
  "brotli",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-utils"
-version = "2025.12.4"
+version = "2025.12.5"
 dependencies = [
  "minijinja",
  "serde",
@@ -4718,7 +4718,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2025.12.4"
+version = "2025.12.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6056,7 +6056,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2025.12.4"
+version = "2025.12.5"
 dependencies = [
  "axum",
  "chrono",
@@ -6076,7 +6076,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2025.12.4"
+version = "2025.12.5"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -6191,7 +6191,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2025.12.4"
+version = "2025.12.5"
 dependencies = [
  "evaluations",
  "napi",
@@ -6210,7 +6210,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-optimizers"
-version = "2025.12.4"
+version = "2025.12.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -6243,7 +6243,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.12.4"
+version = "2025.12.5"
 dependencies = [
  "evaluations",
  "futures",
@@ -6261,7 +6261,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types"
-version = "2025.12.4"
+version = "2025.12.5"
 dependencies = [
  "aws-smithy-types",
  "chrono",
@@ -6282,7 +6282,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-unsafe-helpers"
-version = "2025.12.4"
+version = "2025.12.5"
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2025.12.4"
+version = "2025.12.5"
 rust-version = "1.88.0"
 license = "Apache-2.0"
 edition = "2024"

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2025.12.4"
+appVersion: "2025.12.5"

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2025.12.4",
+  "version": "2025.12.5",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump version from 2025.12.4 to 2025.12.5 across multiple project files.
> 
>   - **Version Bump**:
>     - Update version from `2025.12.4` to `2025.12.5` in `Cargo.lock`, `Cargo.toml`, `Chart.yaml`, and `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7ef3ef97ef16d343f997bec7262a74812ab2eb56. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->