### PR TITLE
Run CI on prs to all branches, not just 'main'

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -6,7 +6,6 @@ on:
     paths-ignore:
       - "docs/**"
   pull_request:
-    branches: ["main"]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This will let us run CI checks for stacked prs
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes branch restriction for CI on pull requests, allowing CI to run on all branches, not just 'main'.
> 
>   - **CI Configuration**:
>     - Removes branch restriction for `pull_request` in `.github/workflows/general.yml`, allowing CI to run on all branches, not just `main`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d13ad7d4ce8d57965ad9c16f912afe34404eb525. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->