### PR TITLE
Run auto-approve-trusted-pr-workflows on pull_request_target

### DIFF
--- a/.github/workflows/auto-approve-trusted-pr-workflows.yml
+++ b/.github/workflows/auto-approve-trusted-pr-workflows.yml
@@ -5,6 +5,8 @@ on:
     # Runs every 5 minutes
     - cron: "*/5 * * * *"
   workflow_dispatch: # Allow manual triggering
+  pull_request_target:
+    types: [synchronize, opened, labeled, reopened]
 
 permissions:
   actions: write


### PR DESCRIPTION
I'm not 100% certain that this will work (the event might be fired before the workflow approval shows up), but it should hopefully help speed up the auto-approve time when trusted contributors push to their PRs. We still run this on a cron job, so this PR will at worst do nothing
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `pull_request_target` event trigger to auto-approve trusted PR workflows for faster processing.
> 
>   - **Behavior**:
>     - Adds `pull_request_target` event trigger to `auto-approve-trusted-pr-workflows.yml` for `synchronize`, `opened`, `labeled`, and `reopened` events.
>     - Aims to speed up auto-approval for trusted contributors' PRs.
>   - **Misc**:
>     - Retains existing cron schedule for redundancy.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 967daed7ae9d4e2e0eb80e70223ba92ffab89a78. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->