### PR TITLE
Bump to 2025.12.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot-client"
-version = "2025.12.5"
+version = "2025.12.6"
 dependencies = [
  "chrono",
  "durable-tools-spawn",
@@ -332,14 +332,14 @@ dependencies = [
 
 [[package]]
 name = "autopilot-tools"
-version = "2025.12.5"
+version = "2025.12.6"
 dependencies = [
  "durable-tools",
 ]
 
 [[package]]
 name = "autopilot-worker"
-version = "2025.12.5"
+version = "2025.12.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools"
-version = "2025.12.5"
+version = "2025.12.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools-spawn"
-version = "2025.12.5"
+version = "2025.12.6"
 dependencies = [
  "async-trait",
  "durable",
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2025.12.5"
+version = "2025.12.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2025.12.5"
+version = "2025.12.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2344,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2025.12.5"
+version = "2025.12.6"
 dependencies = [
  "autopilot-worker",
  "axum",
@@ -3566,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-utils"
-version = "2025.12.5"
+version = "2025.12.6"
 dependencies = [
  "minijinja",
  "serde",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2025.12.5"
+version = "2025.12.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6089,7 +6089,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2025.12.5"
+version = "2025.12.6"
 dependencies = [
  "axum",
  "chrono",
@@ -6109,7 +6109,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2025.12.5"
+version = "2025.12.6"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -6224,7 +6224,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2025.12.5"
+version = "2025.12.6"
 dependencies = [
  "evaluations",
  "napi",
@@ -6243,7 +6243,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-optimizers"
-version = "2025.12.5"
+version = "2025.12.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -6276,7 +6276,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2025.12.5"
+version = "2025.12.6"
 dependencies = [
  "evaluations",
  "futures",
@@ -6294,7 +6294,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types"
-version = "2025.12.5"
+version = "2025.12.6"
 dependencies = [
  "aws-smithy-types",
  "chrono",
@@ -6315,7 +6315,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-unsafe-helpers"
-version = "2025.12.5"
+version = "2025.12.6"
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2025.12.5"
+version = "2025.12.6"
 rust-version = "1.88.0"
 license = "Apache-2.0"
 edition = "2024"

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2025.12.5"
+appVersion: "2025.12.6"

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2025.12.5",
+  "version": "2025.12.6",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump version to 2025.12.6 across multiple files for a new release.
> 
>   - **Version Bump**:
>     - Update version to `2025.12.6` in `Cargo.lock`, `Cargo.toml`, `Chart.yaml`, and `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for bdc5104c5130701e7fde7460ed6cdf3d6ad749da. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->