### PR TITLE
Document disabling API keys programmatically

### DIFF
--- a/docs/operations/set-up-auth-for-tensorzero.mdx
+++ b/docs/operations/set-up-auth-for-tensorzero.mdx
@@ -10,7 +10,7 @@ This page shows how to:
 
 - Create API keys for the TensorZero Gateway
 - Require clients to use these API keys for requests
-- Manage API keys in the TensorZero UI
+- Manage and disable API keys
 
 <Note>
 
@@ -301,10 +301,18 @@ curl -X POST http://localhost:3000/openai/v1/chat/completions \
 
 </Step>
 
-<Step title="Manage API keys in the TensorZero UI">
+<Step title="Manage API keys">
 
-You can manage and delete API keys in the TensorZero UI.
+You can manage and disable API keys in the TensorZero UI.
 If you're running a standard local deployment, visit `http://localhost:4000/api-keys` to manage your keys.
+
+Alternatively, you can disable API keys programmatically in the CLI using the gateway binary with the `--disable-api-key` flag.
+Pass the public ID of the key you want to disable (the 12-character portion after `sk-t0-`).
+For example:
+
+```bash
+docker compose run --rm gateway --disable-api-key xxxxxxxxxxxx
+```
 
 </Step>
 


### PR DESCRIPTION
Fix #5398

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands API key management guidance to cover disabling keys.
> 
> - Updates "Manage API keys" section to note disabling in the UI
> - Adds instructions to disable API keys programmatically via the gateway CLI using `--disable-api-key` with the public ID, plus a `docker compose` example
> - Minor copy/title tweaks in the management step and bullet list
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83754322323575f2dde2771581341ee501ee4dc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update documentation to include instructions for disabling API keys programmatically using the CLI.
> 
>   - **Documentation**:
>     - Update `set-up-auth-for-tensorzero.mdx` to include instructions for disabling API keys programmatically using the CLI with the `--disable-api-key` flag.
>     - Modify section title from "Manage API keys in the TensorZero UI" to "Manage and disable API keys".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 83754322323575f2dde2771581341ee501ee4dc6. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->