### PR TITLE
durable-tools-spawn should not check tools are registered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,7 +1807,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 [[package]]
 name = "durable"
 version = "0.1.0"
-source = "git+https://github.com/tensorzero/durable?rev=d564532eb8e46d74db028013e8d3e4dcb0d41d6d#d564532eb8e46d74db028013e8d3e4dcb0d41d6d"
+source = "git+https://github.com/tensorzero/durable?branch=viraj%2Fspawn-unchecked#9860f359d05c4a15e52dc33dbbf5aa96639c2295"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ metrics-exporter-prometheus = { version = "0.18.1", features = [
 schemars = "1.1.0"
 blake3 = "1.8.2"
 moka = { version = "0.12.10", features = ["sync"] }
-durable = { git = "https://github.com/tensorzero/durable", rev = "d564532eb8e46d74db028013e8d3e4dcb0d41d6d" }
+durable = { git = "https://github.com/tensorzero/durable", branch = "viraj/spawn-unchecked" }
 durable-tools-spawn = { path = "internal/durable-tools-spawn" }
 tensorzero = { path = "clients/rust" }
 tensorzero-core = { path = "tensorzero-core" }

--- a/internal/durable-tools-spawn/src/client.rs
+++ b/internal/durable-tools-spawn/src/client.rs
@@ -109,7 +109,7 @@ impl SpawnClient {
         };
 
         self.durable
-            .spawn_by_name(tool_name, serde_json::to_value(wrapped_params)?, options)
+            .spawn_by_name_unchecked(tool_name, serde_json::to_value(wrapped_params)?, options)
             .await
             .map_err(Into::into)
     }


### PR DESCRIPTION
Blocked on upstream here: https://github.com/tensorzero/durable/pull/43
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update `durable` dependency and modify `SpawnClient` to use `spawn_by_name_unchecked` for task spawning.
> 
>   - **Dependency Update**:
>     - Update `durable` dependency in `Cargo.toml` to use branch `viraj/spawn-unchecked` instead of a specific revision.
>   - **Functionality Change**:
>     - In `internal/durable-tools-spawn/src/client.rs`, change `spawn_by_name` to `spawn_by_name_unchecked` in `SpawnClient::spawn_tool_by_name_with_options()` to bypass tool registration checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for adee2ae537bc37e85b9b99e0f6151a960d136f65. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->