### PR TITLE
Improve error & guidance when Postgres fails during initialization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 - Use `cargo check` for quick verification, restrict further (e.g. `cargo check --package tensorzero-core`) if appropriate. For complex changes, you might want to run `cargo check --all-targets --all-features`. Test suite compilation is slow.
 - If you update Rust types or functions used in TypeScript, regenerate bindings with `pnpm build-bindings` from `internal/tensorzero-node` (not root). Run `cargo check` first to catch compilation errors.
-- If you change a signature of a struct, function, and so on, use `rg` to find all instances in the codebase. For example, search for `StructName {` when updating struct fields.
+- If you change a signature of a struct, function, and so on, use `grep` to find all instances in the codebase. For example, search for `StructName {` when updating struct fields.
 - Place crate imports at the top of the file or module using `use crate::...`. Avoid imports inside functions or tests. Avoid long inline crate paths.
 - Once you're done with your work, make sure to:
   - Run `cargo fmt`.
@@ -55,4 +55,4 @@ We use `ts-rs` and `n-api` for TypeScript-Rust interoperability.
 # Misc
 
 - `CONTRIBUTING.md` has additional context on working on this codebase.
-- `rg` should be available by default. Install it if it's missing.
+- Prefer backticks (`) instead of ticks (') to wrap technical terms in comments, error messages, READMEs, etc.

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -69,7 +69,14 @@ async fn handle_disable_api_key(public_id: &str) -> Result<(), Box<dyn std::erro
 }
 
 #[tokio::main]
-async fn main() -> Result<(), ExitCode> {
+async fn main() -> ExitCode {
+    match run().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(code) => code,
+    }
+}
+
+async fn run() -> Result<(), ExitCode> {
     let args = GatewayArgs::parse();
     // Set up logs and metrics immediately, so that we can use `tracing`.
     // OTLP will be enabled based on the config file
@@ -117,11 +124,11 @@ async fn main() -> Result<(), ExitCode> {
     let (unwritten_config, glob) = match (args.default_config, args.config_file) {
         (true, Some(_)) => {
             tracing::error!("You must not specify both `--config-file` and `--default-config`.");
-            return Err(ExitCode::from(1));
+            return Err(ExitCode::FAILURE);
         }
         (false, None) => {
             tracing::error!("You must specify either `--config-file` or `--default-config`.");
-            return Err(ExitCode::from(1));
+            return Err(ExitCode::FAILURE);
         }
         (true, None) => {
             tracing::warn!(
@@ -181,7 +188,7 @@ async fn main() -> Result<(), ExitCode> {
                 tracing::error!(
                     "The `gateway.export.otlp.traces.enabled` configuration option is `true`, but environment variable `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is not set. Please set it to the OTLP endpoint (e.g. `http://localhost:4317`)."
                 );
-                return Err(ExitCode::from(1));
+                return Err(ExitCode::FAILURE);
             }
         }
 
@@ -212,7 +219,7 @@ async fn main() -> Result<(), ExitCode> {
                 tracing::error!(
                     "Could not enable OpenTelemetry export due to previous error: `{e}`. Exiting."
                 );
-                return Err(ExitCode::from(1));
+                return Err(ExitCode::FAILURE);
             }
         }
     } else if let Err(e) = delayed_log_config.delayed_otel {
@@ -243,7 +250,7 @@ async fn main() -> Result<(), ExitCode> {
     let base_path = config.gateway.base_path.as_deref().unwrap_or("/");
     if !base_path.starts_with("/") {
         tracing::error!("[gateway.base_path] must start with a `/` : `{base_path}`");
-        return Err(ExitCode::from(1));
+        return Err(ExitCode::FAILURE);
     }
     let base_path = base_path.trim_end_matches("/");
 
@@ -272,11 +279,11 @@ async fn main() -> Result<(), ExitCode> {
                 "Failed to bind to socket address {bind_address}: {e}. Tip: Ensure no other process is using port {} or try a different port.",
                 bind_address.port()
             );
-            return Err(ExitCode::from(1));
+            return Err(ExitCode::FAILURE);
         }
         Err(e) => {
             tracing::error!("Failed to bind to socket address {bind_address}: {e}");
-            return Err(ExitCode::from(1));
+            return Err(ExitCode::FAILURE);
         }
     };
 
@@ -492,7 +499,7 @@ async fn spawn_autopilot_worker_if_configured(
             tracing::error!(
                 "TENSORZERO_AUTOPILOT_API_KEY env var set, but Postgres is not enabled."
             );
-            return Err(ExitCode::from(1));
+            return Err(ExitCode::FAILURE);
         }
         #[cfg(test)]
         #[expect(unreachable_patterns)]
@@ -545,7 +552,7 @@ impl<T, E: Display> LogErrPretty<T> for Result<T, E> {
             Ok(value) => Ok(value),
             Err(err) => {
                 tracing::error!("{msg}: {err}");
-                Err(ExitCode::from(1))
+                Err(ExitCode::FAILURE)
             }
         }
     }
@@ -557,7 +564,7 @@ impl<T> LogErrPretty<T> for Option<T> {
             Some(value) => Ok(value),
             None => {
                 tracing::error!("{msg}");
-                Err(ExitCode::from(1))
+                Err(ExitCode::FAILURE)
             }
         }
     }

--- a/tensorzero-core/src/error/mod.rs
+++ b/tensorzero-core/src/error/mod.rs
@@ -17,7 +17,7 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::config::snapshot::SnapshotHash;
-use crate::db::clickhouse::migration_manager::get_run_migrations_command;
+use crate::db::clickhouse::migration_manager::RUN_MIGRATIONS_COMMAND;
 use crate::inference::types::Thought;
 use crate::inference::types::storage::StoragePath;
 use crate::rate_limiting::{FailedRateLimit, RateLimitingConfigScopes};
@@ -1082,10 +1082,9 @@ impl std::fmt::Display for ErrorDetails {
                 write!(f, "Error running ClickHouse migration {id}: {message}")
             }
             ErrorDetails::ClickHouseMigrationsDisabled => {
-                let run_migrations_command: String = get_run_migrations_command();
                 write!(
                     f,
-                    "Automatic ClickHouse migrations were disabled, but not all migrations were run. Please run `{run_migrations_command}`"
+                    "Automatic ClickHouse migrations were disabled, but not all migrations were run. {RUN_MIGRATIONS_COMMAND}"
                 )
             }
             ErrorDetails::ClickHouseQuery { message } => {


### PR DESCRIPTION
Fix #5432. The guidance was incorrect and didn't work in many scenarios (e.g. the ad-hoc container could not talk to the PG network)...


<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve error handling and guidance for Postgres and ClickHouse migrations by using static documentation links and consistent logging.
> 
>   - **Behavior**:
>     - Replace dynamic migration command generation with static documentation links in error messages for Postgres and ClickHouse in `mod.rs` files.
>     - Update error handling in `main.rs` files to return `ExitCode::FAILURE` on errors.
>   - **Logging**:
>     - Use `tracing::info` and `tracing::error` consistently in `main.rs` files for logging.
>   - **Documentation**:
>     - Update `AGENTS.md` to prefer backticks for technical terms and replace `rg` with `grep` for codebase searches.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 242313521bea38043da6455ce82c7cdc8f0ab8d4. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->