### PR TITLE
Only run build-gateway-e2e-container job in merge queue

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1047,7 +1047,7 @@ jobs:
 
   build-gateway-e2e-container:
     uses: ./.github/workflows/build-gateway-e2e-container.yml
-    if: github.repository == 'tensorzero/tensorzero'
+    if: (github.repository == 'tensorzero/tensorzero' && github.event_name == 'merge_group')
     permissions:
       # Permission to checkout the repository
       contents: read


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Restrict `build-gateway-e2e-container` job in `general.yml` to run only on `merge_group` events.
> 
>   - **Workflow Execution**:
>     - Modify `build-gateway-e2e-container` job in `general.yml` to only run when `github.event_name` is `merge_group`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 03ea4f8906ae6aaa7e3e104abaf4831bb1ba28c2. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->