### PR TITLE
Add 'workflow_call' trigger to force-merge-queue.yml

### DIFF
--- a/.github/workflows/force-merge-queue.yml
+++ b/.github/workflows/force-merge-queue.yml
@@ -18,6 +18,7 @@ on:
   # even when the PR is from a fork.
   pull_request_target:
     types: [labeled, unlabeled]
+  workflow_call:
 
 jobs:
   attach-successful-status:


### PR DESCRIPTION
This will let us call this workflow from the autopilot repo
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `workflow_call` trigger to `force-merge-queue.yml` to enable external workflow triggering.
> 
>   - **Trigger Addition**:
>     - Adds `workflow_call` trigger to `.github/workflows/force-merge-queue.yml` to enable triggering from other workflows, such as from the autopilot repo.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f06b8869cc7419b9867a157a99363f9c563ff916. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->