### PR TITLE
made parameters schema return a result again

### DIFF
--- a/internal/autopilot-worker/src/wrapper.rs
+++ b/internal/autopilot-worker/src/wrapper.rs
@@ -64,7 +64,7 @@ impl<T: TaskTool> ToolMetadata for ClientTaskToolWrapper<T> {
         T::description()
     }
 
-    fn parameters_schema() -> Schema {
+    fn parameters_schema() -> DurableToolResult<Schema> {
         T::parameters_schema()
     }
 

--- a/internal/durable-tools/src/registry.rs
+++ b/internal/durable-tools/src/registry.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tensorzero::{FunctionTool, Tool};
 
+use crate::ToolResult;
 use crate::context::SimpleToolContext;
 use crate::error::ToolError;
 use crate::simple_tool::SimpleTool;
@@ -21,7 +22,7 @@ impl TryFrom<&dyn ErasedTool> for Tool {
         Ok(Tool::Function(FunctionTool {
             name: tool.name().to_string(),
             description: tool.description().to_string(),
-            parameters: serde_json::to_value(tool.parameters_schema())?,
+            parameters: serde_json::to_value(tool.parameters_schema()?)?,
             strict: false,
         }))
     }
@@ -38,7 +39,7 @@ pub trait ErasedTool: Send + Sync {
     fn description(&self) -> Cow<'static, str>;
 
     /// Get the JSON Schema for the tool's parameters.
-    fn parameters_schema(&self) -> Schema;
+    fn parameters_schema(&self) -> ToolResult<Schema>;
 
     /// Get the tool's execution timeout.
     fn timeout(&self) -> Duration;
@@ -94,7 +95,7 @@ impl<T: TaskTool> ErasedTool for ErasedTaskToolWrapper<T> {
         <T as ToolMetadata>::description()
     }
 
-    fn parameters_schema(&self) -> Schema {
+    fn parameters_schema(&self) -> ToolResult<Schema> {
         <T as ToolMetadata>::parameters_schema()
     }
 
@@ -117,7 +118,7 @@ impl<T: SimpleTool> ErasedTool for T {
         <T as ToolMetadata>::description()
     }
 
-    fn parameters_schema(&self) -> Schema {
+    fn parameters_schema(&self) -> ToolResult<Schema> {
         <T as ToolMetadata>::parameters_schema()
     }
 

--- a/internal/durable-tools/src/tests.rs
+++ b/internal/durable-tools/src/tests.rs
@@ -486,7 +486,7 @@ mod erasure_tests {
     #[test]
     fn erased_task_tool_wrapper_parameters_schema_has_message_field() {
         let wrapper = ErasedTaskToolWrapper::<EchoTaskTool>::new();
-        let schema = wrapper.parameters_schema();
+        let schema = wrapper.parameters_schema().unwrap();
 
         // The schema should be an object with a "message" property
         let schema_json = serde_json::to_value(&schema).unwrap();

--- a/internal/durable-tools/src/tool_metadata.rs
+++ b/internal/durable-tools/src/tool_metadata.rs
@@ -3,6 +3,8 @@ use serde::{Serialize, de::DeserializeOwned};
 use std::borrow::Cow;
 use std::time::Duration;
 
+use crate::ToolResult;
+
 /// Marker trait for side information types.
 ///
 /// Types implementing this can be used as side information for tools.
@@ -85,8 +87,8 @@ pub trait ToolMetadata: Send + Sync + 'static {
     ///
     /// By default, this is derived from the `LlmParams` type using `schemars`.
     /// Override this if you need custom schema generation.
-    fn parameters_schema() -> Schema {
-        SchemaGenerator::default().into_root_schema_for::<Self::LlmParams>()
+    fn parameters_schema() -> ToolResult<Schema> {
+        Ok(SchemaGenerator::default().into_root_schema_for::<Self::LlmParams>())
     }
 
     /// Execution timeout for this tool.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `parameters_schema()` return type to `ToolResult<Schema>` for error handling in `ToolMetadata` and update related implementations and tests.
> 
>   - **Behavior**:
>     - Change return type of `parameters_schema()` from `Schema` to `ToolResult<Schema>` in `ToolMetadata` trait.
>     - Update `parameters_schema()` in `wrapper.rs`, `registry.rs`, and `tool_metadata.rs` to return `ToolResult<Schema>`.
>     - Modify test `erased_task_tool_wrapper_parameters_schema_has_message_field` in `tests.rs` to unwrap `ToolResult`.
>   - **Misc**:
>     - Add `use crate::ToolResult` in `registry.rs` and `tool_metadata.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for bad4e9b2c7a0e11a5e168b3f0075fa593f0d6f62. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->