### PR TITLE
Fix `launch_optimization_workflow` tool schema optimizer types

### DIFF
--- a/internal/autopilot-tools/src/tools/prod/launch_optimization_workflow.rs
+++ b/internal/autopilot-tools/src/tools/prod/launch_optimization_workflow.rs
@@ -101,8 +101,9 @@ impl ToolMetadata for LaunchOptimizationWorkflowTool {
                 },
                 "output_source": {
                     "type": "string",
-                    "enum": ["inference_output", "demonstration"],
-                    "description": "Source of output data: 'inference_output' (model outputs) or 'demonstration' (human demonstrations)."
+                    "enum": ["none", "inference", "demonstration"],
+                    "default": "inference",
+                    "description": "Source of the inference output. 'inference' returns the original output, 'demonstration' returns manually-curated output if available, 'none' returns no output."
                 },
                 "limit": {
                     "type": "integer",


### PR DESCRIPTION
The `launch_optimization_workflow` tool's custom JSON Schema had outdated `optimizer_config.type` enum values that don't match the actual supported optimizer types.

## Changes

Updated the `optimizer_config.type` enum in `internal/autopilot-tools/src/tools/prod/launch_optimization_workflow.rs`:

**Before:** `["sft", "dpo", "mipro_v2"]`

**After:** `["dicl", "openai_sft", "fireworks_sft", "gcp_vertex_gemini_sft", "gepa", "together_sft"]`

## Optimizer Types

- `dicl` - Dynamic in-context learning
- `openai_sft` - OpenAI supervised fine-tuning
- `fireworks_sft` - Fireworks supervised fine-tuning
- `gcp_vertex_gemini_sft` - GCP Vertex Gemini supervised fine-tuning
- `together_sft` - Together supervised fine-tuning
- `gepa` - Genetic prompt algorithm
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update `optimizer_config.type` enum in `launch_optimization_workflow.rs` to reflect current optimizer types.
> 
>   - **Schema Update**:
>     - Updated `optimizer_config.type` enum in `launch_optimization_workflow.rs` from `["sft", "dpo", "mipro_v2"]` to `["dicl", "openai_sft", "fireworks_sft", "gcp_vertex_gemini_sft", "gepa", "together_sft"]`.
>     - Updated `output_source` enum to `["none", "inference", "demonstration"]` with default `"inference"`.
>   - **Optimizer Types**:
>     - `dicl`: Dynamic in-context learning.
>     - `openai_sft`, `fireworks_sft`, `gcp_vertex_gemini_sft`, `together_sft`: Supervised fine-tuning on various providers.
>     - `gepa`: Genetic prompt algorithm.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 63ceccf09555d670ebb78195b156e390a314811a. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->