### PR TITLE
Fix `GetConfigToolParams` deserialization from empty JSON object

### DIFF
--- a/internal/autopilot-tools/src/tools/prod/get_config.rs
+++ b/internal/autopilot-tools/src/tools/prod/get_config.rs
@@ -12,7 +12,7 @@ use autopilot_client::AutopilotSideInfo;
 
 /// Parameters for the get_config tool (visible to LLM).
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
-pub struct GetConfigToolParams;
+pub struct GetConfigToolParams {}
 
 /// Tool for retrieving config snapshots.
 #[derive(Default)]


### PR DESCRIPTION
## Problem

The `get_config` tool fails with the error:

```
invalid type: map, expected unit struct GetConfigToolParams
```

This happens when the LLM generates a tool call with `"arguments": {}`, which is standard behavior for OpenAI-style function calling when a tool has no parameters.

## Root Cause

Commit `5697f87b0` ("Simplify SideInfo & add JSON schemas for tools") changed `GetConfigToolParams` from a struct with an optional field to a unit struct:

```rust
// Before (worked):
pub struct GetConfigToolParams {
    #[serde(default)]
    pub hash: Option<String>,
}

// After (broken):
pub struct GetConfigToolParams;
```

Serde handles these differently:

| Type | Definition | Deserializes from | Serializes to |
|------|------------|-------------------|---------------|
| Unit struct | `struct Foo;` | `null` | `null` |
| Empty struct | `struct Foo {}` | `{}` | `{}` |

Since LLMs always return `{}` for tools with no parameters, the unit struct causes deserialization to fail.

## Fix

Change the unit struct to an empty struct in `internal/autopilot-tools/src/tools/prod/get_config.rs`:

```diff
- pub struct GetConfigToolParams;
+ pub struct GetConfigToolParams {}
```

## Verification

```rust
use serde::{Deserialize, Serialize};

#[derive(Debug, Serialize, Deserialize)]
struct UnitStruct;

#[derive(Debug, Serialize, Deserialize)]
struct EmptyStruct {}

fn main() {
    // Unit struct - FAILS
    let result: Result<UnitStruct, _> = serde_json::from_str("{}");
    // Err("invalid type: map, expected unit struct")

    // Empty struct - WORKS
    let result: Result<EmptyStruct, _> = serde_json::from_str("{}");
    // Ok(EmptyStruct)
}
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes deserialization of `GetConfigToolParams` from empty JSON objects by changing to an empty struct in `get_config.rs`.
> 
>   - **Behavior**:
>     - Fixes deserialization error in `GetConfigToolParams` in `get_config.rs` by changing from a unit struct to an empty struct.
>     - Handles empty JSON objects correctly, aligning with LLM-generated tool calls using `{}` for no parameters.
>   - **Verification**:
>     - Demonstrated deserialization success with empty struct using test code in the PR description.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for bc9923456eacc1f77587d1433264cd3276054115. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->