### PR TITLE
Converted anonymous enum variants to named structs

### DIFF
--- a/internal/autopilot-client/src/lib.rs
+++ b/internal/autopilot-client/src/lib.rs
@@ -54,6 +54,6 @@ pub use types::{
     InputMessageContent, ListEventsParams, ListEventsResponse, ListSessionsParams,
     ListSessionsResponse, ObjectStoragePointer, OptimizationWorkflowSideInfo, RawText, Role,
     Session, StatusUpdate, StreamEventsParams, Template, Text, Thought, ToolCallAuthorization,
-    ToolCallAuthorizationStatus, ToolCallDecisionSource, ToolCallWrapper, ToolOutcome, Unknown,
+    ToolCallAuthorizationStatus, ToolCallDecisionSource, ToolCallWrapper, ToolOutcome, ToolResult, Unknown,
     UrlFile,
 };

--- a/internal/autopilot-client/src/types.rs
+++ b/internal/autopilot-client/src/types.rs
@@ -51,10 +51,7 @@ pub enum EventPayload {
     },
     ToolCall(AutopilotToolCall),
     ToolCallAuthorization(ToolCallAuthorization),
-    ToolResult {
-        tool_call_event_id: Uuid,
-        outcome: ToolOutcome,
-    },
+    ToolResult(ToolResult),
     #[serde(other)]
     Other,
 }
@@ -64,19 +61,15 @@ impl EventPayload {
     /// System-generated types (StatusUpdate, ToolCall) return false.
     pub fn is_client_writable(&self) -> bool {
         matches!(self, EventPayload::Message(msg) if msg.role == Role::User)
-            || matches!(
-                self,
-                EventPayload::ToolCallAuthorization(_) | EventPayload::ToolResult { .. }
-            )
+            || matches!(self, EventPayload::ToolCallAuthorization(_) | EventPayload::ToolResult(_))
     }
 }
 
 /// A status update within a session.
 #[derive(Debug, Clone, Serialize, Deserialize, ts_rs::TS)]
-#[serde(tag = "type", rename_all = "snake_case")]
-#[ts(export, tag = "type", rename_all = "snake_case")]
-pub enum StatusUpdate {
-    Text { text: String },
+#[ts(export)]
+pub struct StatusUpdate {
+    pub text: String,
 }
 
 // =============================================================================
@@ -186,6 +179,12 @@ impl From<AutopilotSideInfo> for () {
 #[derive(Debug, Clone, Serialize, Deserialize, ts_rs::TS)]
 pub struct AutopilotToolResult {
     pub result: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ts_rs::TS)]
+pub struct ToolResult {
+    pub tool_call_event_id: Uuid,
+    pub outcome: ToolOutcome,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ts_rs::TS)]


### PR DESCRIPTION
PR addressing issue: tensorzero/tensorzero#5467
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Convert anonymous `ToolResult` and `StatusUpdate` enum variants to named structs in `types.rs` and update related logic in `wrapper.rs`.
> 
>   - **Behavior**:
>     - Convert `ToolResult` from anonymous struct to named struct in `types.rs`.
>     - Convert `StatusUpdate` from enum variant to named struct in `types.rs`.
>   - **Code Adjustments**:
>     - Update `EventPayload` enum in `types.rs` to use `ToolResult` struct.
>     - Modify `is_client_writable()` in `types.rs` to match new `ToolResult` struct.
>     - Adjust `publish_result()` in `wrapper.rs` to use `ToolResult` struct.
>   - **Tests**:
>     - Update tests in `wrapper.rs` to reflect `ToolResult` struct changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f57b7179608c4cbf6d88589b37be8bd06ad1bd84. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->