### PR TITLE
Convert Anthropic streaming cumulative output tokens to incremental

### DIFF
--- a/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
@@ -386,6 +386,7 @@ fn stream_anthropic(
     Box::pin(async_stream::stream! {
         let mut current_tool_id : Option<String> = None;
         let mut current_tool_name: Option<String> = None;
+        let mut previous_output_tokens: u32 = 0;
         while let Some(ev) = event_source.next().await {
             match ev {
                 Err(e) => {
@@ -416,6 +417,7 @@ fn stream_anthropic(
                                 start_time.elapsed(),
                                 &mut current_tool_id,
                                 &mut current_tool_name,
+                                &mut previous_output_tokens,
                                 discard_unknown_chunks,
                                 &model_name,
                                 &provider_name,


### PR DESCRIPTION
Taking a crack at #5481 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Convert cumulative output tokens to incremental in Anthropic streaming API for `anthropic.rs` and `gcp_vertex_anthropic.rs`.
> 
>   - **Behavior**:
>     - Convert cumulative output tokens to incremental in `stream_anthropic()` in `anthropic.rs` and `gcp_vertex_anthropic.rs`.
>     - Introduce `previous_output_tokens` to track cumulative tokens and calculate incremental tokens.
>   - **Functions**:
>     - Update `parse_usage_info()` in `anthropic.rs` to use `previous_output_tokens` for incremental calculation.
>     - Update `anthropic_to_tensorzero_stream_message()` in `anthropic.rs` and `gcp_vertex_anthropic.rs` to pass `previous_output_tokens`.
>   - **Tests**:
>     - Add tests for cumulative to incremental conversion in `tests` module in `anthropic.rs` and `gcp_vertex_anthropic.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 48b01e7951b546326339041912ca1a932ce7a4e9. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->