### PR TITLE
Add randomly-generated request_id to HTTP logging

### DIFF
--- a/tensorzero-core/src/observability/request_logging.rs
+++ b/tensorzero-core/src/observability/request_logging.rs
@@ -11,6 +11,7 @@ use http_body::{Frame, SizeHint};
 use metrics::Label;
 use tracing::{Level, Span};
 use tracing_futures::Instrument;
+use uuid::Uuid;
 
 use crate::observability::overhead_timing::{
     OverheadSpanExt, TENSORZERO_TRACK_OVERHEAD_ATTRIBUTE_NAME,
@@ -177,6 +178,9 @@ pub async fn request_logging_middleware(
         None
     };
 
+    // Generate a random ID so that we can associate log lines with this request
+    let request_id = Uuid::now_v7();
+
     let span = if let Some(latency_span) = &latency_span {
         tracing::info_span!(
             target: "gateway",
@@ -185,6 +189,7 @@ pub async fn request_logging_middleware(
             method = %request.method(),
             uri = %request.uri(),
             version = ?request.version(),
+            request_id = %request_id,
         )
     } else {
         tracing::info_span!(
@@ -193,6 +198,7 @@ pub async fn request_logging_middleware(
             method = %request.method(),
             uri = %request.uri(),
             version = ?request.version(),
+            request_id = %request_id,
         )
     };
     span.in_scope(|| {


### PR DESCRIPTION
This will allow users to determine which log lines are associated with a particular HTTP request
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a randomly-generated `request_id` to HTTP logging in `request_logging_middleware` to associate log lines with specific requests.
> 
>   - **Behavior**:
>     - Adds a randomly-generated `request_id` to HTTP logging in `request_logging_middleware` in `request_logging.rs`.
>     - Uses `Uuid::now_v7()` to generate the `request_id`.
>     - Includes `request_id` in the logging span for both latency-tracked and non-latency-tracked requests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4e275146ae3fb3231c08a88f1d418a88bcda4d7b. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->