### PR TITLE
add an eventPayload type for turn completed

### DIFF
--- a/internal/autopilot-client/src/types.rs
+++ b/internal/autopilot-client/src/types.rs
@@ -55,6 +55,7 @@ pub enum EventPayload {
         tool_call_event_id: Uuid,
         outcome: ToolOutcome,
     },
+    TurnComplete,
     #[serde(other)]
     Other,
 }

--- a/internal/tensorzero-node/lib/bindings/EventPayload.ts
+++ b/internal/tensorzero-node/lib/bindings/EventPayload.ts
@@ -14,4 +14,5 @@ export type EventPayload =
   | ({ type: "tool_call" } & AutopilotToolCall)
   | ({ type: "tool_call_authorization" } & ToolCallAuthorization)
   | { type: "tool_result"; tool_call_event_id: string; outcome: ToolOutcome }
+  | { type: "turn_complete" }
   | { type: "other" };

--- a/ui/app/components/autopilot/EventStream.tsx
+++ b/ui/app/components/autopilot/EventStream.tsx
@@ -162,6 +162,9 @@ function summarizeEvent(event: Event): EventSummary {
       return {};
     case "other":
       return {};
+    case "turn_complete":
+      // TODO: handle appropriately in UI
+      return {};
     default:
       return {};
   }
@@ -262,6 +265,8 @@ function renderEventTitle(event: Event) {
             "Unknown tool call authorization status. This should never happen. Please open a bug report: https://github.com/tensorzero/tensorzero/discussions/new?category=bug-reports",
           );
       }
+    case "turn_complete":
+      return "Turn Complete";
 
     case "other":
       return (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `TurnComplete` event type to `EventPayload` in Rust and TypeScript, with initial handling in `EventStream.tsx`.
> 
>   - **EventPayload**:
>     - Add `TurnComplete` to `EventPayload` enum in `types.rs` and `EventPayload.ts`.
>   - **UI Handling**:
>     - Update `summarizeEvent()` and `renderEventTitle()` in `EventStream.tsx` to handle `turn_complete` event type, with TODO comments for UI handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for fbea034349eb81bd9efde22d282261934bfe4a00. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->