### PR TITLE
Fix create_datapoints tool schema to match API types

### DIFF
--- a/internal/autopilot-tools/src/tools/prod/create_datapoints.rs
+++ b/internal/autopilot-tools/src/tools/prod/create_datapoints.rs
@@ -57,11 +57,11 @@ impl ToolMetadata for CreateDatapointsTool {
                     "description": "The datapoints to create. Each can be Chat or Json type.",
                     "items": {
                         "type": "object",
-                        "description": "A datapoint. Use 'Chat' type with 'input' containing messages, or 'Json' type with 'input'/'output' as JSON objects.",
+                        "description": "A datapoint. Use 'chat' type with 'input' containing messages, or 'json' type with structured input/output.",
                         "properties": {
                             "type": {
                                 "type": "string",
-                                "enum": ["Chat", "Json"],
+                                "enum": ["chat", "json"],
                                 "description": "The datapoint type."
                             },
                             "function_name": {
@@ -73,7 +73,11 @@ impl ToolMetadata for CreateDatapointsTool {
                                 "description": "The input data. For Chat: {system?, messages}. For Json: any JSON object."
                             },
                             "output": {
-                                "description": "Expected output. For Chat: string or content blocks. For Json: any JSON."
+                                "description": "Expected output. For 'chat': array of content blocks like [{\"type\": \"text\", \"text\": \"...\"}]. For 'json': object with 'raw' field containing JSON string, e.g. {\"raw\": \"{\\\"key\\\": \\\"value\\\"}\"}"
+                            },
+                            "output_schema": {
+                                "type": "object",
+                                "description": "JSON Schema for validating the output. Only used for 'json' type datapoints."
                             },
                             "tags": {
                                 "type": "object",


### PR DESCRIPTION
  1. Fixed type enum case (line 64): ["Chat", "Json"] → ["chat", "json"]
  2. Updated description (line 60): Simplified to match the snake_case types
  3. Added output_schema property (lines 78-81): New field for JSON Schema validation on json-type datapoints
  4. Fixed output description (lines 75-76): Now accurately describes the expected format:
    - For chat: array of content blocks like [{"type": "text", "text": "..."}]
    - For json: object with raw field containing JSON string
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `create_datapoints` tool schema and descriptions to match API types and formats in `create_datapoints.rs`.
> 
>   - **Schema Updates**:
>     - Changed enum cases from `"Chat", "Json"` to `"chat", "json"` in `create_datapoints.rs`.
>     - Added `output_schema` property for JSON Schema validation on `json` type datapoints.
>   - **Description Updates**:
>     - Simplified description to match snake_case types.
>     - Updated `output` description to specify format for `chat` and `json` types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2e1dc70c5a1f14b5552ee5ba8bf55d4a51abbcba. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->