### PR TITLE
Include 'x-amzn-trace-id' header in request span fields (if set)

### DIFF
--- a/tensorzero-core/src/observability/request_logging.rs
+++ b/tensorzero-core/src/observability/request_logging.rs
@@ -190,6 +190,7 @@ pub async fn request_logging_middleware(
             uri = %request.uri(),
             version = ?request.version(),
             request_id = %request_id,
+            x_amzn_trace_id = tracing::field::Empty,
         )
     } else {
         tracing::info_span!(
@@ -199,8 +200,16 @@ pub async fn request_logging_middleware(
             uri = %request.uri(),
             version = ?request.version(),
             request_id = %request_id,
+            x_amzn_trace_id = tracing::field::Empty,
         )
     };
+    if let Some(x_amzn_trace_id) = request
+        .headers()
+        .get("x-amzn-trace-id")
+        .and_then(|h| h.to_str().ok())
+    {
+        span.record("x_amzn_trace_id", x_amzn_trace_id);
+    }
     span.in_scope(|| {
         tracing::debug!("started processing request");
     });


### PR DESCRIPTION
This allows correlating individual log lines with an incoming request when deploying TensorZero on AWS
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add 'x-amzn-trace-id' header to request span fields in `request_logging_middleware` for AWS traceability.
> 
>   - **Behavior**:
>     - Include 'x-amzn-trace-id' header in request span fields in `request_logging_middleware` in `request_logging.rs`.
>     - If 'x-amzn-trace-id' is present in request headers, it is recorded in the span.
>   - **Misc**:
>     - No changes to existing functionality, only additional logging for AWS traceability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for b351c24026972635cdfe0c3622172f85145c4ad9. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->