### PR TITLE
Track in-flight requests by route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,6 +1680,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2580,7 +2594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
 dependencies = [
  "cfg-if",
- "dashmap",
+ "dashmap 5.5.3",
  "futures",
  "futures-timer",
  "no-std-compat",
@@ -6166,6 +6180,7 @@ dependencies = [
  "chrono",
  "clap",
  "clarabel",
+ "dashmap 6.1.0",
  "derive_builder 0.20.2",
  "durable",
  "enum-map",

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -8,9 +8,9 @@ use std::io::ErrorKind;
 use std::net::SocketAddr;
 use std::process::ExitCode;
 use std::time::Duration;
+use tensorzero_core::observability::request_logging::InFlightRequestsData;
 use tokio::signal;
 use tokio_stream::wrappers::IntervalStream;
-use tower_http::metrics::in_flight_requests::InFlightRequestsCounter;
 
 use autopilot_worker::{AutopilotWorkerConfig, AutopilotWorkerHandle, spawn_autopilot_worker};
 use durable_tools::EmbeddedClient;
@@ -261,7 +261,7 @@ async fn run() -> Result<(), ExitCode> {
         return Ok(());
     }
 
-    let (router, in_flight_requests_counter) = router::build_axum_router(
+    let (router, in_flight_requests_data) = router::build_axum_router(
         base_path,
         delayed_log_config.otel_tracer.clone(),
         gateway_handle.app_state.clone(),
@@ -376,7 +376,7 @@ async fn run() -> Result<(), ExitCode> {
     tokio::spawn(monitor_server_shutdown(
         shutdown_signal,
         server_fut.clone(),
-        in_flight_requests_counter,
+        in_flight_requests_data,
     ));
 
     // Wait for the server to finish - this happens once the shutdown signal is received,
@@ -414,7 +414,7 @@ async fn run() -> Result<(), ExitCode> {
 async fn monitor_server_shutdown(
     shutdown_signal: impl Future<Output = ()>,
     server_fut: impl Future<Output = ()>,
-    in_flight_requests_counter: InFlightRequestsCounter,
+    in_flight_requests_data: InFlightRequestsData,
 ) {
     // First, wait for the shutdown signal
     shutdown_signal.await;
@@ -422,10 +422,23 @@ async fn monitor_server_shutdown(
     IntervalStream::new(tokio::time::interval(Duration::from_secs(5)))
         .take_until(server_fut)
         .for_each(|_| async {
+            let counts = in_flight_requests_data
+                .current_counts_by_route()
+                .collect::<Vec<_>>();
+
+            let total = counts.iter().map(|(_, count)| *count).sum::<u32>();
             tracing::info!(
                 "Server shutdown in progress: {} in-flight requests remaining",
-                in_flight_requests_counter.get()
+                total
             );
+            if total > 0 {
+                tracing::info!("In-flight requests by route:");
+                for (route, count) in counts {
+                    if count > 0 {
+                        tracing::info!("├ `{route}` -> {count} requests in flight");
+                    }
+                }
+            }
         })
         .await;
     tracing::info!("Server shutdown complete");

--- a/tensorzero-core/Cargo.toml
+++ b/tensorzero-core/Cargo.toml
@@ -133,6 +133,7 @@ schemars = { workspace = true, features = ["uuid1"] }
 opentelemetry-http = "0.31.0"
 # durable.workspace = true
 regex = { workspace = true }
+dashmap = "6.1.0"
 
 [dev-dependencies]
 tempfile = "3.21.0"

--- a/tensorzero-core/src/observability/request_logging.rs
+++ b/tensorzero-core/src/observability/request_logging.rs
@@ -1,11 +1,21 @@
 use std::{
     cell::Cell,
     pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering},
+    },
     task::{Context, Poll},
     time::{Duration, Instant},
 };
 
-use axum::{body::Body, extract::Request, middleware::Next, response::Response};
+use axum::{
+    body::Body,
+    extract::{MatchedPath, Request, State},
+    middleware::Next,
+    response::Response,
+};
+use dashmap::DashMap;
 use http::{Method, StatusCode};
 use http_body::{Frame, SizeHint};
 use metrics::Label;
@@ -19,6 +29,8 @@ use crate::observability::overhead_timing::{
 
 /// A drop guard that logs a message on drop if `start_time` is set.
 struct ConnectionDropGuard {
+    // The counter to decrement when the request is finished
+    count_per_route: Arc<AtomicU32>,
     latency_span: Option<Span>,
     request_logging_data: Option<HttpMetricData>,
     span: Span,
@@ -44,6 +56,7 @@ impl ConnectionDropGuard {
 impl Drop for ConnectionDropGuard {
     fn drop(&mut self) {
         let _guard = self.span.enter();
+        self.count_per_route.fetch_sub(1, Ordering::Relaxed);
         let latency_duration = if let Some(finished_with_latency) = self.finished_with_latency.get()
         {
             if let Some(latency_span) = &self.latency_span {
@@ -152,6 +165,29 @@ pub struct HttpMetricData {
     pub extra_overhead_labels: Vec<Label>,
 }
 
+/// A clonable handle that tracks the number of in-flight requests for each route.
+#[derive(Clone)]
+pub struct InFlightRequestsData {
+    count_per_route: Arc<DashMap<String, Arc<AtomicU32>>>,
+}
+
+impl InFlightRequestsData {
+    #[expect(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            count_per_route: Arc::new(Default::default()),
+        }
+    }
+
+    /// Gets the current in-flight requests counts for each route
+    /// Note that routes that have never been requested will not be included in the iterator.
+    pub fn current_counts_by_route(&self) -> impl Iterator<Item = (String, u32)> {
+        self.count_per_route
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().load(Ordering::Relaxed)))
+    }
+}
+
 // An Axum middleware that logs request processing events
 // * 'started processing request' when we begin processing a request
 // * 'finished processing request' when we we *completely* finish a request.
@@ -159,10 +195,25 @@ pub struct HttpMetricData {
 //    not when the response status code is initially sent
 // * 'Client closed the connection before the response was sent' if the connection is closed early.
 pub async fn request_logging_middleware(
+    state: State<InFlightRequestsData>,
     request: Request,
     next: Next,
 ) -> Response<GuardBodyWrapper> {
     let start_time = Instant::now();
+
+    let route = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|p| format!("{} {}", request.method(), p.as_str()).to_string())
+        .unwrap_or_else(|| "<unknown_route>".to_string());
+    let count_per_route = state
+        .count_per_route
+        .entry(route)
+        .or_insert_with(|| Arc::new(Default::default()))
+        .clone();
+
+    count_per_route.fetch_add(1, Ordering::Relaxed);
+
     // Create a separate span for latency tracing, using a custom 'target' that will
     // get filtered out when we log to console/otel
     // This prevents the `tensorzero.overhead.*` span attributes from being visible to users
@@ -214,6 +265,7 @@ pub async fn request_logging_middleware(
         span: span.clone(),
         start_time,
         finished_with_latency: Cell::new(None),
+        count_per_route,
         status: None,
     };
     let mut response = next.run(request).instrument(span).await;

--- a/tensorzero-core/src/utils/gateway.rs
+++ b/tensorzero-core/src/utils/gateway.rs
@@ -629,7 +629,8 @@ pub async fn start_openai_compatible_gateway(
         .register_openai_compatible_routes()
         .fallback(endpoints::fallback::handle_404)
         .layer(DefaultBodyLimit::max(100 * 1024 * 1024)) // increase the default body limit from 2MB to 100MB
-        .layer(axum::middleware::from_fn(
+        .layer(axum::middleware::from_fn_with_state(
+            crate::observability::request_logging::InFlightRequestsData::new(),
             crate::observability::request_logging::request_logging_middleware,
         ))
         .with_state(gateway_handle.app_state.clone());


### PR DESCRIPTION
We now print the total count, as well as the per-route counts, during shutdown while waiting for all in-flight requests to complete
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Track and log in-flight requests by route during server shutdown using `InFlightRequestsData`.
> 
>   - **Behavior**:
>     - During shutdown, logs total and per-route in-flight request counts in `monitor_server_shutdown()` in `main.rs`.
>     - Replaces `InFlightRequestsCounter` with `InFlightRequestsData` in `main.rs` and `router.rs`.
>   - **Middleware**:
>     - Updates `request_logging_middleware()` in `request_logging.rs` to track requests per route using `InFlightRequestsData`.
>   - **Dependencies**:
>     - Adds `dashmap` crate to `Cargo.toml` for concurrent data access.
>   - **Misc**:
>     - Removes `InFlightRequestsLayer` from `router.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 09c6325f6c4ba7fff0b515cb83f7daef76256f78. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->