### PR TITLE
Remove a use of FromComponents in durable-tools

### DIFF
--- a/internal/durable-tools/src/tensorzero_client/client_ext.rs
+++ b/internal/durable-tools/src/tensorzero_client/client_ext.rs
@@ -15,12 +15,12 @@ use evaluations::{
     ClientInferenceExecutor, EvaluationUpdate, OutputFormat, run_evaluation_core_streaming,
 };
 use tensorzero::{
-    Client, ClientBuilder, ClientBuilderMode, ClientExt, ClientInferenceParams, ClientMode,
-    CreateDatapointRequest, CreateDatapointsFromInferenceRequestParams, CreateDatapointsResponse,
-    DeleteDatapointsResponse, FeedbackParams, FeedbackResponse, GetConfigResponse,
-    GetDatapointsResponse, GetInferencesResponse, InferenceOutput, InferenceResponse,
-    ListDatapointsRequest, ListInferencesRequest, TensorZeroError, UpdateDatapointRequest,
-    UpdateDatapointsResponse, WriteConfigRequest, WriteConfigResponse,
+    Client, ClientExt, ClientInferenceParams, ClientMode, CreateDatapointRequest,
+    CreateDatapointsFromInferenceRequestParams, CreateDatapointsResponse, DeleteDatapointsResponse,
+    FeedbackParams, FeedbackResponse, GetConfigResponse, GetDatapointsResponse,
+    GetInferencesResponse, InferenceOutput, InferenceResponse, ListDatapointsRequest,
+    ListInferencesRequest, TensorZeroError, UpdateDatapointRequest, UpdateDatapointsResponse,
+    WriteConfigRequest, WriteConfigResponse,
 };
 use tensorzero_core::config::snapshot::SnapshotHash;
 use tensorzero_core::db::feedback::FeedbackByVariant;
@@ -598,7 +598,10 @@ impl TensorZeroClient for Client {
             ClientMode::HTTPGateway(_) => Err(TensorZeroClientError::NotSupported(
                 "run_evaluation is only supported in embedded gateway mode".to_string(),
             )),
-            ClientMode::EmbeddedGateway { gateway, timeout } => {
+            ClientMode::EmbeddedGateway {
+                gateway,
+                timeout: _,
+            } => {
                 let app_state = &gateway.handle.app_state;
 
                 // Look up the evaluation config
@@ -625,24 +628,8 @@ impl TensorZeroClient for Client {
                     .collect();
                 let function_configs = Arc::new(function_configs);
 
-                // Build a Client from our existing components
-                let tensorzero_client = ClientBuilder::new(ClientBuilderMode::FromComponents {
-                    config: app_state.config.clone(),
-                    clickhouse_connection_info: app_state.clickhouse_connection_info.clone(),
-                    postgres_connection_info: app_state.postgres_connection_info.clone(),
-                    http_client: app_state.http_client.clone(),
-                    timeout: *timeout,
-                })
-                .build()
-                .await
-                .map_err(|e| {
-                    TensorZeroClientError::Evaluation(format!("Failed to build client: {e}"))
-                })?;
-
+                let inference_executor = Arc::new(ClientInferenceExecutor::new(self.clone()));
                 let evaluation_run_id = Uuid::now_v7();
-
-                // Wrap the client in ClientInferenceExecutor for use with evaluations
-                let inference_executor = Arc::new(ClientInferenceExecutor::new(tensorzero_client));
 
                 let core_args = EvaluationCoreArgs {
                     inference_executor,


### PR DESCRIPTION
We can just re-use our existing client
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `ClientBuilder::new(ClientBuilderMode::FromComponents)` and reuse existing `Client` in `client_ext.rs`.
> 
>   - **Behavior**:
>     - Removes `ClientBuilder::new(ClientBuilderMode::FromComponents)` in `client_ext.rs`.
>     - Directly uses existing `Client` instance for `ClientInferenceExecutor` creation in `run_evaluation()`.
>   - **Imports**:
>     - Removes unused imports: `ClientBuilder`, `ClientBuilderMode` from `client_ext.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 2484a500b024c5c02093282df938e7f0f7370c0f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->