### PR TITLE
Enable 'xray' feature for 'init-tracing-opentelemetry'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3154,6 +3154,7 @@ version = "0.34.0"
 source = "git+https://github.com/Aaron1011/tracing-opentelemetry-instrumentation-sdk?rev=c240499e464c2c787dedda2b870ae50747a95e6f#c240499e464c2c787dedda2b870ae50747a95e6f"
 dependencies = [
  "opentelemetry",
+ "opentelemetry-aws",
  "opentelemetry_sdk",
  "thiserror 2.0.17",
  "tracing",
@@ -4042,6 +4043,16 @@ dependencies = [
  "pin-project-lite",
  "thiserror 2.0.17",
  "tracing",
+]
+
+[[package]]
+name = "opentelemetry-aws"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fbe9af6b9403e7fe43c11cc341d320d7cf5e779c6708b41415228af1921045"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
 ]
 
 [[package]]

--- a/tensorzero-core/Cargo.toml
+++ b/tensorzero-core/Cargo.toml
@@ -100,7 +100,7 @@ opentelemetry-otlp = { version = "0.31.0", features = [
 ] }
 opentelemetry-semantic-conventions = "0.31.0"
 # TODO - switch back to a released version once https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/pull/309 is merged
-init-tracing-opentelemetry = { git = "https://github.com/Aaron1011/tracing-opentelemetry-instrumentation-sdk", rev = "c240499e464c2c787dedda2b870ae50747a95e6f" }
+init-tracing-opentelemetry = { git = "https://github.com/Aaron1011/tracing-opentelemetry-instrumentation-sdk", rev = "c240499e464c2c787dedda2b870ae50747a95e6f", features = ["xray"] }
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 tracing-opentelemetry-instrumentation-sdk = { workspace = true, features = [
     "http",


### PR DESCRIPTION
This lets users add 'xray' to the 'OTEL_PROPAGATORS' env var
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable 'xray' feature for `init-tracing-opentelemetry` and add `opentelemetry-aws` dependency for AWS telemetry support.
> 
>   - **Features**:
>     - Enable 'xray' feature for `init-tracing-opentelemetry` in `Cargo.toml`.
>     - Allows 'xray' to be added to 'OTEL_PROPAGATORS' environment variable.
>   - **Dependencies**:
>     - Add `opentelemetry-aws` package to `Cargo.lock` for AWS-related telemetry features.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1deea58ecd714a68cb7b12624c5227ba07346a8c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->