### PR TITLE
Factor out logic from `run_evaluation_handler()`

### DIFF
--- a/evaluations/src/types.rs
+++ b/evaluations/src/types.rs
@@ -15,6 +15,7 @@ use tensorzero_core::{
     error::Error,
     evaluations::{EvaluationConfig, EvaluationFunctionConfigTable},
     inference::types::storage::StoragePath,
+    utils::gateway::AppStateData,
 };
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -69,6 +70,65 @@ impl EvaluationsInferenceExecutor for ClientInferenceExecutor {
     async fn resolve_storage_path(&self, storage_path: StoragePath) -> Result<String, Error> {
         use tensorzero_core::inference::types::stored_input::StoragePathResolver;
         self.client.resolve(storage_path).await
+    }
+}
+
+/// Executor that calls gateway handlers directly without HTTP overhead.
+/// This is used when running evaluations from within the gateway or embedded mode.
+pub struct AppStateInferenceExecutor {
+    app_state: AppStateData,
+}
+
+impl AppStateInferenceExecutor {
+    pub fn new(app_state: AppStateData) -> Self {
+        Self { app_state }
+    }
+}
+
+#[async_trait]
+impl EvaluationsInferenceExecutor for AppStateInferenceExecutor {
+    async fn inference(
+        &self,
+        params: ClientInferenceParams,
+    ) -> Result<InferenceOutput, TensorZeroError> {
+        use tensorzero_core::endpoints::inference::Params as InferenceParams;
+
+        // Convert ClientInferenceParams to endpoint Params
+        let endpoint_params: InferenceParams = params
+            .try_into()
+            .map_err(|e: Error| TensorZeroError::Other { source: e.into() })?;
+
+        // Call the inference endpoint directly
+        let result = Box::pin(tensorzero_core::endpoints::inference::inference(
+            self.app_state.config.clone(),
+            &self.app_state.http_client,
+            self.app_state.clickhouse_connection_info.clone(),
+            self.app_state.postgres_connection_info.clone(),
+            self.app_state.deferred_tasks.clone(),
+            endpoint_params,
+            None, // No API key for internal calls
+        ))
+        .await
+        .map_err(|e| TensorZeroError::Other { source: e.into() })?;
+
+        Ok(result.output)
+    }
+
+    async fn feedback(&self, params: FeedbackParams) -> Result<FeedbackResponse, TensorZeroError> {
+        // Call the feedback endpoint directly
+        tensorzero_core::endpoints::feedback::feedback(self.app_state.clone(), params, None)
+            .await
+            .map_err(|e| TensorZeroError::Other { source: e.into() })
+    }
+
+    async fn resolve_storage_path(&self, storage_path: StoragePath) -> Result<String, Error> {
+        // Use the object storage endpoint directly
+        let response = tensorzero_core::endpoints::object_storage::get_object(
+            self.app_state.config.object_store_info.as_ref(),
+            storage_path,
+        )
+        .await?;
+        Ok(response.data)
     }
 }
 
@@ -148,4 +208,44 @@ pub struct EvaluationStreamResult {
     pub receiver: mpsc::Receiver<EvaluationUpdate>,
     pub run_info: RunInfo,
     pub evaluation_config: Arc<EvaluationConfig>,
+    /// The ClickHouse client used for this evaluation.
+    /// The caller may want to wait for the batch writer to finish.
+    pub clickhouse_client: ClickHouseConnectionInfo,
+}
+
+/// Parameters for running an evaluation using the app state directly.
+/// This is used by the gateway handler and embedded mode in durable-tools.
+pub struct RunEvaluationWithAppStateParams {
+    /// The evaluation configuration
+    pub evaluation_config: EvaluationConfig,
+
+    /// Function configuration for output schema validation
+    pub function_config: tensorzero_core::evaluations::EvaluationFunctionConfig,
+
+    /// Name of the evaluation (for tagging/logging purposes)
+    pub evaluation_name: String,
+
+    /// Name of the dataset to run on.
+    /// Either dataset_name or datapoint_ids must be provided, but not both.
+    pub dataset_name: Option<String>,
+
+    /// Specific datapoint IDs to evaluate.
+    /// Either dataset_name or datapoint_ids must be provided, but not both.
+    pub datapoint_ids: Option<Vec<Uuid>>,
+
+    /// Variant to use for evaluation.
+    pub variant: EvaluationVariant,
+
+    /// Number of concurrent requests to make.
+    pub concurrency: usize,
+
+    /// Cache configuration for inference requests
+    pub cache_mode: CacheEnabledMode,
+
+    /// Maximum number of datapoints to evaluate
+    pub max_datapoints: Option<u32>,
+
+    /// Precision targets for adaptive stopping.
+    /// Maps evaluator names to target confidence interval half-widths.
+    pub precision_targets: std::collections::HashMap<String, f32>,
 }


### PR DESCRIPTION
- Moves some of the logic from `run_evaluation_handler()` in the `gateway` crate into a new function `run_evaluation_with_app_state()` in the `evaluations` crate.
- This will enable the `run_evaluation` autopilot tool to call `run_evaluation_with_app_state()` and avoid calling `run_evaluation_core_streaming()` directly (which requires manually setting up the executor, ClickHouse client, function configs, etc.).
- This split mirrors other endpoints like `inference()` and `feedback()`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor evaluation logic by moving it to `run_evaluation_with_app_state()` in `evaluations`, enabling easier use by the `run_evaluation` autopilot tool.
> 
>   - **Behavior**:
>     - Refactor `run_evaluation_handler()` in `gateway` to use `run_evaluation_with_app_state()` from `evaluations`.
>     - `run_evaluation_with_app_state()` sets up evaluation infrastructure and calls `run_evaluation_core_streaming()`.
>     - Enables `run_evaluation` autopilot tool to use `run_evaluation_with_app_state()`.
>   - **Functions**:
>     - Add `run_evaluation_with_app_state()` in `evaluations/src/lib.rs`.
>     - Remove redundant logic from `run_evaluation_handler()` in `gateway/src/routes/evaluations.rs`.
>   - **Types**:
>     - Add `AppStateInferenceExecutor` in `evaluations/src/types.rs` for direct handler calls.
>     - Add `RunEvaluationWithAppStateParams` in `evaluations/src/types.rs` for parameter encapsulation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ec455d6eae23a9bf0a0e30c2ab3934a62bfb5d76. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->