### PR TITLE
Bump durable to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,7 +1840,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 [[package]]
 name = "durable"
 version = "0.1.0"
-source = "git+https://github.com/tensorzero/durable?rev=ca986b6042829d924d413fc0f42d3bbd87b2df70#ca986b6042829d924d413fc0f42d3bbd87b2df70"
+source = "git+https://github.com/tensorzero/durable?rev=8ceb3c447ea8c77b7f6faef4e717602ad149a0f4#8ceb3c447ea8c77b7f6faef4e717602ad149a0f4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ metrics-exporter-prometheus = { version = "0.18.1", features = [
 schemars = "1.1.0"
 blake3 = "1.8.2"
 moka = { version = "0.12.10", features = ["sync"] }
-durable = { git = "https://github.com/tensorzero/durable", rev = "ca986b6042829d924d413fc0f42d3bbd87b2df70" }
+durable = { git = "https://github.com/tensorzero/durable", rev = "8ceb3c447ea8c77b7f6faef4e717602ad149a0f4" }
 durable-tools-spawn = { path = "internal/durable-tools-spawn" }
 tensorzero = { path = "clients/rust" }
 tensorzero-core = { path = "tensorzero-core" }

--- a/internal/durable-tools/src/error.rs
+++ b/internal/durable-tools/src/error.rs
@@ -66,6 +66,12 @@ impl From<TaskError> for ToolError {
             TaskError::ChildFailed { step_name, message } => ToolError::ExecutionFailed(
                 anyhow::anyhow!("child task failed at '{step_name}': {message}"),
             ),
+            TaskError::User {
+                message,
+                error_data,
+            } => {
+                ToolError::ExecutionFailed(anyhow::anyhow!("user error: {message} {error_data:?}"))
+            }
             TaskError::ChildCancelled { step_name } => ToolError::ExecutionFailed(anyhow::anyhow!(
                 "child task was cancelled at '{step_name}'"
             )),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `durable` to latest version and add error handling for `TaskError::User` in `internal/durable-tools/src/error.rs`.
> 
>   - **Dependencies**:
>     - Bump `durable` to latest version in `Cargo.toml` and `Cargo.lock`.
>   - **Error Handling**:
>     - Add handling for `TaskError::User` in `From<TaskError> for ToolError` in `internal/durable-tools/src/error.rs` to convert it to `ToolError::ExecutionFailed`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 4f8debdbbe505ceb8113cdce2abe5d87e6d087f1. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->