### PR TITLE
Bump url crate to 2.5.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7050,14 +7050,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ minijinja = { version = "2.14.0", features = [
     "builtins",
     "unstable_machinery",
 ] }
-url = "2.5.4"
+url = { version = "2.5.8", features = ["serde"] }
 google-cloud-auth = "1.3.0"
 serde-untagged = "0.1.8"
 object_store = { version = "0.13.0", features = ["serde", "aws", "gcp"] }


### PR DESCRIPTION
Dependabot was unable to do this automatically
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `url` crate to version 2.5.8 with updated checksum and added `serde_derive` dependency.
> 
>   - **Dependencies**:
>     - Bump `url` crate from version `2.5.7` to `2.5.8` in `Cargo.lock` and `Cargo.toml`.
>     - Update checksum for `url` crate in `Cargo.lock`.
>     - Add `serde_derive` dependency for `url` crate in `Cargo.lock`.
>     - Add `serde` feature for `url` crate in `Cargo.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for c0b8957ee58c048e283b12a62965f6d43dc78118. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->