### PR TITLE
Return BatchWriterHandle instead of clickhouse client from evaluations

### DIFF
--- a/evaluations/src/lib.rs
+++ b/evaluations/src/lib.rs
@@ -515,8 +515,8 @@ pub async fn run_evaluation_core_streaming(
     // Get cancellation tokens from stopping manager and wrap in Arc for cloning into tasks
     let cancellation_tokens_arc = Arc::new(stopping_manager.get_tokens().clone());
 
-    // Save clickhouse_client before moving clients into batch_params
-    let clickhouse_client_for_result = clients.clickhouse_client.clone();
+    // Save batcher_join_handle before moving clients into batch_params
+    let batcher_join_handle = clients.clickhouse_client.batcher_join_handle();
 
     // Build batch processing params
     let batch_params = ProcessBatchParams {
@@ -589,7 +589,7 @@ pub async fn run_evaluation_core_streaming(
         receiver,
         run_info,
         evaluation_config: evaluators,
-        clickhouse_client: clickhouse_client_for_result,
+        batcher_join_handle,
     })
 }
 

--- a/evaluations/src/types.rs
+++ b/evaluations/src/types.rs
@@ -11,6 +11,7 @@ use tensorzero_core::{
         ClientInferenceParams, FeedbackParams, FeedbackResponse, InferenceOutput, TensorZeroError,
     },
     config::UninitializedVariantInfo,
+    db::clickhouse::BatchWriterHandle,
     db::clickhouse::ClickHouseConnectionInfo,
     error::Error,
     evaluations::{EvaluationConfig, EvaluationFunctionConfigTable},
@@ -208,9 +209,9 @@ pub struct EvaluationStreamResult {
     pub receiver: mpsc::Receiver<EvaluationUpdate>,
     pub run_info: RunInfo,
     pub evaluation_config: Arc<EvaluationConfig>,
-    /// The ClickHouse client used for this evaluation.
+    /// The join handle for the ClickHouse batch writer.
     /// The caller may want to wait for the batch writer to finish.
-    pub clickhouse_client: ClickHouseConnectionInfo,
+    pub batcher_join_handle: Option<BatchWriterHandle>,
 }
 
 /// Parameters for running an evaluation using the app state directly.

--- a/tensorzero-core/src/db/clickhouse/clickhouse_client/mod.rs
+++ b/tensorzero-core/src/db/clickhouse/clickhouse_client/mod.rs
@@ -5,11 +5,11 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use crate::db::HealthCheckable;
-use crate::db::clickhouse::BatchWriterHandle;
 use crate::db::clickhouse::ClickHouseResponse;
 use crate::db::clickhouse::ExternalDataInfo;
 use crate::db::clickhouse::GetMaybeReplicatedTableEngineNameArgs;
 use crate::db::clickhouse::TableName;
+use crate::db::clickhouse::batching::BatchWriterHandle;
 use crate::error::{DelayedError, Error};
 
 #[cfg(test)]

--- a/tensorzero-core/src/db/clickhouse/clickhouse_client/production_clickhouse_client.rs
+++ b/tensorzero-core/src/db/clickhouse/clickhouse_client/production_clickhouse_client.rs
@@ -11,7 +11,6 @@ use std::time::Duration;
 use url::Url;
 
 use crate::config::BatchWritesConfig;
-use crate::db::clickhouse::BatchWriterHandle;
 use crate::db::clickhouse::ClickHouseClient;
 use crate::db::clickhouse::ClickHouseConnectionInfo;
 use crate::db::clickhouse::ClickHouseResponse;
@@ -22,6 +21,7 @@ use crate::db::clickhouse::HealthCheckable;
 use crate::db::clickhouse::Rows;
 use crate::db::clickhouse::TableName;
 use crate::db::clickhouse::batching::BatchSender;
+use crate::db::clickhouse::batching::BatchWriterHandle;
 use crate::db::clickhouse::clickhouse_client::ClickHouseClientType;
 use crate::db::clickhouse::migration_manager::migrations::check_table_exists;
 use crate::error::DelayedError;

--- a/tensorzero-core/src/db/clickhouse/mod.rs
+++ b/tensorzero-core/src/db/clickhouse/mod.rs
@@ -11,13 +11,15 @@ use url::Url;
 
 use crate::config::BatchWritesConfig;
 use crate::config::snapshot::{ConfigSnapshot, SnapshotHash};
-use crate::db::clickhouse::batching::BatchWriterHandle;
 use crate::db::clickhouse::clickhouse_client::ClickHouseClientType;
 use crate::db::clickhouse::clickhouse_client::DisabledClickHouseClient;
 use crate::db::clickhouse::clickhouse_client::ProductionClickHouseClient;
 use crate::db::{ConfigQueries, HealthCheckable};
 use crate::error::DelayedError;
 use crate::error::{Error, ErrorDetails};
+
+// Export this so evaluations crate can wait for it.
+pub use crate::db::clickhouse::batching::BatchWriterHandle;
 
 pub use clickhouse_client::ClickHouseClient;
 pub use table_name::TableName;


### PR DESCRIPTION
This is a cleanup after #5538, so that we don't unnecessarily leak the clickhouse client out of evaluations - the consumer just needs to wait for the writer join handle.

<!-- ELLIPSIS_HIDDEN -->

---

> [!IMPORTANT]
> Change return type from ClickHouse client to BatchWriterHandle in evaluation functions to avoid unnecessary client cloning.
>
> - **Behavior**:
>     - `run_evaluation_core_streaming()` in `lib.rs` now returns `batcher_join_handle` instead of `clickhouse_client`.
>     - `EvaluationStreamResult` in `types.rs` updated to include `batcher_join_handle`.
>     - `create_evaluation_stream()` in `evaluations.rs` now uses `batcher_join_handle` to wait for batch writer completion.
> - **Types**:
>     - `EvaluationStreamResult` in `types.rs` now has `batcher_join_handle: Option<BatchWriterHandle>` instead of `clickhouse_client`.
>     - `EvaluationStreamParams` in `evaluations.rs` updated to use `batcher_join_handle`.
> - **Misc**:
>     - Import `BatchWriterHandle` in `types.rs` and `evaluations.rs`.
>     - Update comments and docstrings to reflect changes in return types and behavior.
>
> <sup>This description was created by </sup>[<img src="https://img.shields.io/badge/Ellipsis-blue?color=175173" alt="Ellipsis">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for f08d4d2e92c298d4882725b7092292b9898adefa. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->