### PR TITLE
Increase overhead margin to 300ms for prometheus test

### DIFF
--- a/gateway/tests/prometheus.rs
+++ b/gateway/tests/prometheus.rs
@@ -117,8 +117,8 @@ async fn test_prometheus_metrics_inference_helper(stream: bool) {
     );
     // We have observability disabled, so we expect the overhead to be low (even though this is a debug build)
     // Notably, it does *not* include the 5-second sleep in the 'dummy::slow' model
-    // This test can be slow on CI, so we give a generous 200ms margin
-    assert!(sum < 0.2, "Unexpectedly high histogram sum: {sum}s");
+    // This test can be slow on CI, so we give a generous 300ms margin
+    assert!(sum < 0.3, "Unexpectedly high histogram sum: {sum}s");
 
     // Verify default buckets are present
     let expected_buckets = ["0.001", "0.01", "0.1", "+Inf"];
@@ -304,6 +304,6 @@ model = "dummy::slow"
     );
     // We have observability disabled, so we expect the overhead to be low (even though this is a debug build)
     // Notably, it does *not* include the 5-second sleep in the 'dummy::slow' model
-    // This test can be slow on CI, so we give a generous 200ms margin
-    assert!(sum < 0.2, "Unexpectedly high histogram sum: {sum}s");
+    // This test can be slow on CI, so we give a generous 300ms margin
+    assert!(sum < 0.3, "Unexpectedly high histogram sum: {sum}s");
 }


### PR DESCRIPTION
This test has been flaking on CI with ~210ms of latency, so let's bump it again (since we don't control the github runners)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase overhead margin from 200ms to 300ms in `prometheus.rs` test to address CI flakiness.
> 
>   - **Tests**:
>     - Increase overhead margin from 200ms to 300ms in `test_prometheus_metrics_inference_helper()` in `prometheus.rs` to address CI flakiness.
>     - Update margin in two assertions within the same function to reflect the new 300ms threshold.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 91ad4c6ae3d239268906ee04bc2c6785c9ff6c43. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->