### PR TITLE
fixed docs to use config-file not config-path

### DIFF
--- a/docs/deployment/tensorzero-gateway.mdx
+++ b/docs/deployment/tensorzero-gateway.mdx
@@ -54,7 +54,7 @@ docker run \
   --env-file .env \
   -p 3000:3000 \
   tensorzero/gateway \
-  --config-path config/tensorzero.toml
+  --config-file config/tensorzero.toml
 ```
 
 </Accordion>

--- a/docs/operations/organize-your-configuration.mdx
+++ b/docs/operations/organize-your-configuration.mdx
@@ -21,7 +21,7 @@ This makes it easier to manage and maintain your configuration.
 For example, you can create separate TOML files for different projects, environments, and so on.
 You can also move deprecated entries like functions to a separate file.
 
-You can instruct TensorZero Gateway to load multiple configuration files by specifying a glob pattern that matches all the relevant TOML files by setting the CLI flag `--config-path path/to/**/*.toml`.
+You can instruct TensorZero Gateway to load multiple configuration files by specifying a glob pattern that matches all the relevant TOML files by setting the CLI flag `--config-file path/to/**/*.toml`.
 
 Under the hood, TensorZero will concatenate the configuration files, with special handling for paths.
 For example, you can declare a model in one file and use it in a variant declared in another file.


### PR DESCRIPTION
https://github.com/tensorzero/tensorzero/discussions/5566
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix documentation to use `--config-file` instead of `--config-path` in CLI examples.
> 
>   - **Docs**:
>     - Change `--config-path` to `--config-file` in `tensorzero-gateway.mdx` and `organize-your-configuration.mdx` to correct CLI flag usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for fd2cd513ab1cb93dae4c1a19f301687ccb29dc95. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->