### PR TITLE
[WIP] Remove redundant route-level error boundaries

### DIFF
--- a/ui/app/routes/api-keys/route.tsx
+++ b/ui/app/routes/api-keys/route.tsx
@@ -1,10 +1,5 @@
 import type { Route } from "./+types/route";
-import {
-  data,
-  isRouteErrorResponse,
-  useNavigate,
-  type RouteHandle,
-} from "react-router";
+import { data, useNavigate, type RouteHandle } from "react-router";
 import PageButtons from "~/components/utils/PageButtons";
 import {
   PageHeader,
@@ -13,6 +8,7 @@ import {
 } from "~/components/layout/PageLayout";
 import { useState } from "react";
 import { logger } from "~/utils/logger";
+import { RouteErrorContent } from "~/components/ui/error";
 import {
   getPostgresClient,
   isPostgresAvailable,
@@ -204,28 +200,5 @@ export default function AuthPage({ loaderData }: Route.ComponentProps) {
 
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
   logger.error(error);
-
-  if (isRouteErrorResponse(error)) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">
-          {error.status} {error.statusText}
-        </h1>
-        <p>{error.data}</p>
-      </div>
-    );
-  } else if (error instanceof Error) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">Error</h1>
-        <p>{error.message}</p>
-      </div>
-    );
-  } else {
-    return (
-      <div className="flex h-screen items-center justify-center text-red-500">
-        <h1 className="text-2xl font-bold">Unknown Error</h1>
-      </div>
-    );
-  }
+  return <RouteErrorContent error={error} />;
 }

--- a/ui/app/routes/autopilot/sessions/$session_id/route.tsx
+++ b/ui/app/routes/autopilot/sessions/$session_id/route.tsx
@@ -8,13 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
-import {
-  data,
-  isRouteErrorResponse,
-  Link,
-  useNavigate,
-  type RouteHandle,
-} from "react-router";
+import { data, Link, useNavigate, type RouteHandle } from "react-router";
 import { Loader2, Plus } from "lucide-react";
 import { PageHeader } from "~/components/layout/PageLayout";
 import EventStream, {
@@ -651,32 +645,4 @@ function EventStreamContentWrapper({
       />
     </div>
   );
-}
-
-export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  logger.error(error);
-
-  if (isRouteErrorResponse(error)) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">
-          {error.status} {error.statusText}
-        </h1>
-        <p>{error.data}</p>
-      </div>
-    );
-  } else if (error instanceof Error) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">Error</h1>
-        <p>{error.message}</p>
-      </div>
-    );
-  } else {
-    return (
-      <div className="flex h-screen items-center justify-center text-red-500">
-        <h1 className="text-2xl font-bold">Unknown Error</h1>
-      </div>
-    );
-  }
 }

--- a/ui/app/routes/autopilot/sessions/route.tsx
+++ b/ui/app/routes/autopilot/sessions/route.tsx
@@ -1,12 +1,7 @@
 import { Plus } from "lucide-react";
 import { Suspense, use } from "react";
 import type { Route } from "./+types/route";
-import {
-  data,
-  isRouteErrorResponse,
-  useLocation,
-  useNavigate,
-} from "react-router";
+import { data, useLocation, useNavigate } from "react-router";
 import { useTensorZeroStatusFetcher } from "~/routes/api/tensorzero/status";
 import {
   PageHeader,
@@ -16,7 +11,6 @@ import {
 import { ActionBar } from "~/components/layout/ActionBar";
 import { Button } from "~/components/ui/button";
 import PageButtons from "~/components/utils/PageButtons";
-import { logger } from "~/utils/logger";
 import { SessionsTableRows } from "../AutopilotSessionsTable";
 import { getAutopilotClient } from "~/utils/tensorzero.server";
 import type { Session } from "~/types/tensorzero";
@@ -221,32 +215,4 @@ export default function AutopilotSessionsPage({
       </SectionLayout>
     </PageLayout>
   );
-}
-
-export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  logger.error(error);
-
-  if (isRouteErrorResponse(error)) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">
-          {error.status} {error.statusText}
-        </h1>
-        <p>{error.data}</p>
-      </div>
-    );
-  } else if (error instanceof Error) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">Error</h1>
-        <p>{error.message}</p>
-      </div>
-    );
-  } else {
-    return (
-      <div className="flex h-screen items-center justify-center text-red-500">
-        <h1 className="text-2xl font-bold">Unknown Error</h1>
-      </div>
-    );
-  }
 }

--- a/ui/app/routes/datasets/$dataset_name/datapoint/$id/route.tsx
+++ b/ui/app/routes/datasets/$dataset_name/datapoint/$id/route.tsx
@@ -1,15 +1,7 @@
-import type { ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import type { ActionFunctionArgs, RouteHandle } from "react-router";
-import {
-  data,
-  isRouteErrorResponse,
-  Link,
-  redirect,
-  useFetcher,
-  useParams,
-} from "react-router";
-import { toDatapointUrl, toDatasetUrl } from "~/utils/urls";
+import { data, redirect, useFetcher } from "react-router";
+import { toDatapointUrl } from "~/utils/urls";
 import { InputElement } from "~/components/input_output/InputElement";
 import { ChatOutputElement } from "~/components/input_output/ChatOutputElement";
 import { JsonOutputElement } from "~/components/input_output/JsonOutputElement";
@@ -781,73 +773,5 @@ export default function DatapointPage({ loaderData }: Route.ComponentProps) {
         />
       )}
     </PageLayout>
-  );
-}
-
-function getUserFacingError(error: unknown): {
-  heading: string;
-  message: ReactNode;
-} {
-  if (isRouteErrorResponse(error)) {
-    switch (error.status) {
-      case 400:
-        return {
-          heading: `${error.status}: Bad Request`,
-          message: "Please try again later.",
-        };
-      case 401:
-        return {
-          heading: `${error.status}: Unauthorized`,
-          message: "You do not have permission to access this resource.",
-        };
-      case 403:
-        return {
-          heading: `${error.status}: Forbidden`,
-          message: "You do not have permission to access this resource.",
-        };
-      case 404:
-        return {
-          heading: `${error.status}: Not Found`,
-          message:
-            "The requested resource was not found. Please check the URL and try again.",
-        };
-      case 500:
-      default:
-        return {
-          heading: "An unknown error occurred",
-          message: "Please try again later.",
-        };
-    }
-  }
-  return {
-    heading: "An unknown error occurred",
-    message: "Please try again later.",
-  };
-}
-
-export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  useEffect(() => {
-    logger.error(error);
-  }, [error]);
-  const { heading, message } = getUserFacingError(error);
-  const { dataset_name: datasetName } = useParams<{
-    dataset_name: string;
-    id: string;
-  }>();
-  return (
-    <div className="flex flex-col items-center justify-center md:h-full">
-      <div className="mt-8 flex flex-col items-center justify-center gap-2 rounded-xl bg-red-50 p-6 md:mt-0">
-        <h1 className="text-2xl font-bold">{heading}</h1>
-        {typeof message === "string" ? <p>{message}</p> : message}
-        {datasetName && (
-          <Link
-            to={toDatasetUrl(datasetName)}
-            className="font-bold text-red-800 hover:text-red-600"
-          >
-            Go back &rarr;
-          </Link>
-        )}
-      </div>
-    </div>
   );
 }

--- a/ui/app/routes/datasets/route.tsx
+++ b/ui/app/routes/datasets/route.tsx
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/route";
 import DatasetTable from "./DatasetTable";
-import { data, isRouteErrorResponse } from "react-router";
+import { data } from "react-router";
 import { useNavigate } from "react-router";
 import {
   PageHeader,
@@ -8,7 +8,6 @@ import {
   SectionLayout,
 } from "~/components/layout/PageLayout";
 import { DatasetsActions } from "./DatasetsActions";
-import { logger } from "~/utils/logger";
 import { getTensorZeroClient } from "~/utils/tensorzero.server";
 
 export async function loader() {
@@ -54,32 +53,4 @@ export default function DatasetListPage({ loaderData }: Route.ComponentProps) {
       </SectionLayout>
     </PageLayout>
   );
-}
-
-export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  logger.error(error);
-
-  if (isRouteErrorResponse(error)) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">
-          {error.status} {error.statusText}
-        </h1>
-        <p>{error.data}</p>
-      </div>
-    );
-  } else if (error instanceof Error) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">Error</h1>
-        <p>{error.message}</p>
-      </div>
-    );
-  } else {
-    return (
-      <div className="flex h-screen items-center justify-center text-red-500">
-        <h1 className="text-2xl font-bold">Unknown Error</h1>
-      </div>
-    );
-  }
 }

--- a/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/route.tsx
+++ b/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/route.tsx
@@ -16,7 +16,6 @@ import { getTensorZeroClient } from "~/utils/tensorzero.server";
 
 import {
   data,
-  isRouteErrorResponse,
   Link,
   redirect,
   useFetcher,
@@ -465,34 +464,6 @@ const MetricRow = ({
     </div>
   );
 };
-
-export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  logger.error(error);
-
-  if (isRouteErrorResponse(error)) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">
-          {error.status} {error.statusText}
-        </h1>
-        <p>{error.data}</p>
-      </div>
-    );
-  } else if (error instanceof Error) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">Error</h1>
-        <p>{error.message}</p>
-      </div>
-    );
-  } else {
-    return (
-      <div className="flex h-screen items-center justify-center text-red-500">
-        <h1 className="text-2xl font-bold">Unknown Error</h1>
-      </div>
-    );
-  }
-}
 
 type OutputsSectionProps = {
   outputsToDisplay: Array<{

--- a/ui/app/routes/evaluations/route.tsx
+++ b/ui/app/routes/evaluations/route.tsx
@@ -1,5 +1,5 @@
 import type { Route } from "./+types/route";
-import { isRouteErrorResponse, redirect, useNavigate } from "react-router";
+import { redirect, useNavigate } from "react-router";
 import PageButtons from "~/components/utils/PageButtons";
 import {
   PageHeader,
@@ -128,32 +128,4 @@ export default function EvaluationSummaryPage({
       />
     </PageLayout>
   );
-}
-
-export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  logger.error(error);
-
-  if (isRouteErrorResponse(error)) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">
-          {error.status} {error.statusText}
-        </h1>
-        <p>{error.data}</p>
-      </div>
-    );
-  } else if (error instanceof Error) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">Error</h1>
-        <p>{error.message}</p>
-      </div>
-    );
-  } else {
-    return (
-      <div className="flex h-screen items-center justify-center text-red-500">
-        <h1 className="text-2xl font-bold">Unknown Error</h1>
-      </div>
-    );
-  }
 }

--- a/ui/app/routes/index.tsx
+++ b/ui/app/routes/index.tsx
@@ -1,4 +1,6 @@
 import { Link, type RouteHandle, Await, useAsyncError } from "react-router";
+import { RouteErrorContent } from "~/components/ui/error";
+import { logger } from "~/utils/logger";
 import * as React from "react";
 import { Card } from "~/components/ui/card";
 import { PageLayout } from "~/components/layout/PageLayout";
@@ -363,4 +365,9 @@ export default function Home({ loaderData }: Route.ComponentProps) {
       </div>
     </PageLayout>
   );
+}
+
+export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  logger.error(error);
+  return <RouteErrorContent error={error} />;
 }

--- a/ui/app/routes/observability/episodes/route.tsx
+++ b/ui/app/routes/observability/episodes/route.tsx
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/route";
 import EpisodesTable from "./EpisodesTable";
-import { data, isRouteErrorResponse, useNavigate } from "react-router";
+import { data, useNavigate } from "react-router";
 import PageButtons from "~/components/utils/PageButtons";
 import EpisodeSearchBar from "./EpisodeSearchBar";
 import {
@@ -8,7 +8,6 @@ import {
   PageLayout,
   SectionLayout,
 } from "~/components/layout/PageLayout";
-import { logger } from "~/utils/logger";
 import { getTensorZeroClient } from "~/utils/tensorzero.server";
 import type { EpisodeByIdRow, TableBoundsWithCount } from "~/types/tensorzero";
 import { Suspense, use } from "react";
@@ -120,32 +119,4 @@ export default function EpisodesPage({ loaderData }: Route.ComponentProps) {
       </SectionLayout>
     </PageLayout>
   );
-}
-
-export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  logger.error(error);
-
-  if (isRouteErrorResponse(error)) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">
-          {error.status} {error.statusText}
-        </h1>
-        <p>{error.data}</p>
-      </div>
-    );
-  } else if (error instanceof Error) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">Error</h1>
-        <p>{error.message}</p>
-      </div>
-    );
-  } else {
-    return (
-      <div className="flex h-screen items-center justify-center text-red-500">
-        <h1 className="text-2xl font-bold">Unknown Error</h1>
-      </div>
-    );
-  }
 }

--- a/ui/app/routes/observability/functions/$function_name/route.tsx
+++ b/ui/app/routes/observability/functions/$function_name/route.tsx
@@ -1,11 +1,6 @@
 import { countInferencesForFunction } from "~/utils/clickhouse/inference.server";
 import type { Route } from "./+types/route";
-import {
-  data,
-  isRouteErrorResponse,
-  useNavigate,
-  useSearchParams,
-} from "react-router";
+import { data, useNavigate, useSearchParams } from "react-router";
 import PageButtons from "~/components/utils/PageButtons";
 import { getConfig, getFunctionConfig } from "~/utils/config/index.server";
 import FunctionInferenceTable from "./FunctionInferenceTable";
@@ -26,7 +21,6 @@ import {
   SectionHeader,
 } from "~/components/layout/PageLayout";
 import { getFunctionTypeIcon } from "~/utils/icon";
-import { logger } from "~/utils/logger";
 import { DEFAULT_FUNCTION } from "~/utils/constants";
 import type { TimeWindow } from "~/types/tensorzero";
 import { getTensorZeroClient } from "~/utils/tensorzero.server";
@@ -336,31 +330,4 @@ export default function InferencesPage({ loaderData }: Route.ComponentProps) {
       </SectionsGroup>
     </PageLayout>
   );
-}
-export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  logger.error(error);
-
-  if (isRouteErrorResponse(error)) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">
-          {error.status} {error.statusText}
-        </h1>
-        <p>{error.data}</p>
-      </div>
-    );
-  } else if (error instanceof Error) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">Error</h1>
-        <p>{error.message}</p>
-      </div>
-    );
-  } else {
-    return (
-      <div className="flex h-screen items-center justify-center text-red-500">
-        <h1 className="text-2xl font-bold">Unknown Error</h1>
-      </div>
-    );
-  }
 }

--- a/ui/app/routes/observability/functions/$function_name/variants/route.tsx
+++ b/ui/app/routes/observability/functions/$function_name/variants/route.tsx
@@ -1,10 +1,4 @@
-import {
-  data,
-  isRouteErrorResponse,
-  redirect,
-  useNavigate,
-  useSearchParams,
-} from "react-router";
+import { data, redirect, useNavigate, useSearchParams } from "react-router";
 import type { LoaderFunctionArgs, RouteHandle } from "react-router";
 import BasicInfo from "./VariantBasicInfo";
 import VariantTemplate from "./VariantTemplate";
@@ -26,7 +20,6 @@ import {
   SectionsGroup,
   SectionHeader,
 } from "~/components/layout/PageLayout";
-import { logger } from "~/utils/logger";
 import { applyPaginationLogic } from "~/utils/pagination";
 import { DEFAULT_FUNCTION } from "~/utils/constants";
 
@@ -283,32 +276,4 @@ export default function VariantDetails({ loaderData }: Route.ComponentProps) {
       </SectionsGroup>
     </PageLayout>
   );
-}
-
-export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  logger.error(error);
-
-  if (isRouteErrorResponse(error)) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">
-          {error.status} {error.statusText}
-        </h1>
-        <p>{error.data}</p>
-      </div>
-    );
-  } else if (error instanceof Error) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">Error</h1>
-        <p>{error.message}</p>
-      </div>
-    );
-  } else {
-    return (
-      <div className="flex h-screen items-center justify-center text-red-500">
-        <h1 className="text-2xl font-bold">Unknown Error</h1>
-      </div>
-    );
-  }
 }

--- a/ui/app/routes/observability/functions/route.tsx
+++ b/ui/app/routes/observability/functions/route.tsx
@@ -1,5 +1,4 @@
 import type { Route } from "./+types/route";
-import { isRouteErrorResponse } from "react-router";
 import FunctionsTable from "./FunctionsTable";
 import { useConfig } from "~/context/config";
 import {
@@ -7,7 +6,6 @@ import {
   PageLayout,
   SectionLayout,
 } from "~/components/layout/PageLayout";
-import { logger } from "~/utils/logger";
 import { useMemo, useState } from "react";
 import { getTensorZeroClient } from "~/utils/tensorzero.server";
 
@@ -63,32 +61,4 @@ export default function FunctionsPage({ loaderData }: Route.ComponentProps) {
       </SectionLayout>
     </PageLayout>
   );
-}
-
-export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  logger.error(error);
-
-  if (isRouteErrorResponse(error)) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">
-          {error.status} {error.statusText}
-        </h1>
-        <p>{error.data}</p>
-      </div>
-    );
-  } else if (error instanceof Error) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">Error</h1>
-        <p>{error.message}</p>
-      </div>
-    );
-  } else {
-    return (
-      <div className="flex h-screen items-center justify-center text-red-500">
-        <h1 className="text-2xl font-bold">Unknown Error</h1>
-      </div>
-    );
-  }
 }

--- a/ui/app/routes/observability/inferences/$inference_id/route.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/route.tsx
@@ -5,19 +5,11 @@ import {
   loadFileDataForStoredInput,
 } from "~/utils/resolve.server";
 import type { Route } from "./+types/route";
-import {
-  data,
-  isRouteErrorResponse,
-  Link,
-  useNavigate,
-  type RouteHandle,
-} from "react-router";
+import { data, useNavigate, type RouteHandle } from "react-router";
 import PageButtons from "~/components/utils/PageButtons";
 import { useEffect } from "react";
-import type { ReactNode } from "react";
 import { PageHeader, PageLayout } from "~/components/layout/PageLayout";
 import { useToast } from "~/hooks/use-toast";
-import { logger } from "~/utils/logger";
 import { DEFAULT_FUNCTION } from "~/utils/constants";
 import {
   InferenceDetailContent,
@@ -249,67 +241,5 @@ export default function InferencePage({ loaderData }: Route.ComponentProps) {
         )}
       />
     </PageLayout>
-  );
-}
-
-function getUserFacingError(error: unknown): {
-  heading: string;
-  message: ReactNode;
-} {
-  if (isRouteErrorResponse(error)) {
-    switch (error.status) {
-      case 400:
-        return {
-          heading: `${error.status}: Bad Request`,
-          message: "Please try again later.",
-        };
-      case 401:
-        return {
-          heading: `${error.status}: Unauthorized`,
-          message: "You do not have permission to access this resource.",
-        };
-      case 403:
-        return {
-          heading: `${error.status}: Forbidden`,
-          message: "You do not have permission to access this resource.",
-        };
-      case 404:
-        return {
-          heading: `${error.status}: Not Found`,
-          message:
-            "The requested resource was not found. Please check the URL and try again.",
-        };
-      case 500:
-      default:
-        return {
-          heading: "An unknown error occurred",
-          message: "Please try again later.",
-        };
-    }
-  }
-  return {
-    heading: "An unknown error occurred",
-    message: "Please try again later.",
-  };
-}
-
-export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  useEffect(() => {
-    logger.error(error);
-  }, [error]);
-  const { heading, message } = getUserFacingError(error);
-  return (
-    <div className="flex flex-col items-center justify-center md:h-full">
-      <div className="mt-8 flex flex-col items-center justify-center gap-2 rounded-xl bg-red-50 p-6 md:mt-0">
-        <h1 className="text-2xl font-bold">{heading}</h1>
-        {typeof message === "string" ? <p>{message}</p> : message}
-        <Link
-          to={`/observability/inferences`}
-          className="font-bold text-red-800 hover:text-red-600"
-        >
-          Go back &rarr;
-        </Link>
-      </div>
-    </div>
   );
 }

--- a/ui/app/routes/observability/inferences/route.tsx
+++ b/ui/app/routes/observability/inferences/route.tsx
@@ -1,14 +1,13 @@
 import { listInferencesWithPagination } from "~/utils/clickhouse/inference.server";
 import type { Route } from "./+types/route";
 import InferencesTable, { type InferencesData } from "./InferencesTable";
-import { data, isRouteErrorResponse } from "react-router";
+import { data } from "react-router";
 import InferenceSearchBar from "./InferenceSearchBar";
 import {
   PageHeader,
   PageLayout,
   SectionLayout,
 } from "~/components/layout/PageLayout";
-import { logger } from "~/utils/logger";
 import type { InferenceFilter, InferenceMetadata } from "~/types/tensorzero";
 import { getTensorZeroClient } from "~/utils/tensorzero.server";
 import { applyPaginationLogic } from "~/utils/pagination";
@@ -148,32 +147,4 @@ export default function InferencesPage({ loaderData }: Route.ComponentProps) {
       </SectionLayout>
     </PageLayout>
   );
-}
-
-export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  logger.error(error);
-
-  if (isRouteErrorResponse(error)) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">
-          {error.status} {error.statusText}
-        </h1>
-        <p>{error.data}</p>
-      </div>
-    );
-  } else if (error instanceof Error) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">Error</h1>
-        <p>{error.message}</p>
-      </div>
-    );
-  } else {
-    return (
-      <div className="flex h-screen items-center justify-center text-red-500">
-        <h1 className="text-2xl font-bold">Unknown Error</h1>
-      </div>
-    );
-  }
 }

--- a/ui/app/routes/observability/models/route.tsx
+++ b/ui/app/routes/observability/models/route.tsx
@@ -1,6 +1,7 @@
-import { data } from "react-router";
+import { data, type RouteHandle } from "react-router";
 import type { Route } from "./+types/route";
-import type { RouteHandle } from "react-router";
+import { RouteErrorContent } from "~/components/ui/error";
+import { logger } from "~/utils/logger";
 
 export const handle: RouteHandle = {
   crumb: () => ["Models"],
@@ -92,4 +93,9 @@ export default function ModelsPage({ loaderData }: Route.ComponentProps) {
       </SectionsGroup>
     </PageLayout>
   );
+}
+
+export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  logger.error(error);
+  return <RouteErrorContent error={error} />;
 }

--- a/ui/app/routes/optimization/supervised-fine-tuning/route.tsx
+++ b/ui/app/routes/optimization/supervised-fine-tuning/route.tsx
@@ -1,7 +1,7 @@
-import { data, type RouteHandle } from "react-router";
+import { data, type RouteHandle, redirect, useRevalidator } from "react-router";
 import { useEffect, useState } from "react";
-import { useRevalidator } from "react-router";
-import { redirect } from "react-router";
+import { RouteErrorContent } from "~/components/ui/error";
+import { logger } from "~/utils/logger";
 import { useConfig } from "~/context/config";
 import { dump_optimizer_output } from "~/utils/config/models";
 import type { Route } from "./+types/route";
@@ -195,4 +195,9 @@ export default function SupervisedFineTuning(props: Route.ComponentProps) {
     );
   }
   return <SupervisedFineTuningImpl {...loaderData} />;
+}
+
+export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  logger.error(error);
+  return <RouteErrorContent error={error} />;
 }

--- a/ui/app/routes/playground/route.tsx
+++ b/ui/app/routes/playground/route.tsx
@@ -4,9 +4,10 @@ import {
   Link,
   type RouteHandle,
   type ShouldRevalidateFunctionArgs,
-  isRouteErrorResponse,
   useNavigation,
 } from "react-router";
+import { RouteErrorContent } from "~/components/ui/error";
+import { logger } from "~/utils/logger";
 import { DatasetSelector } from "~/components/dataset/DatasetSelector";
 import { FunctionSelector } from "~/components/function/FunctionSelector";
 import { PageHeader, PageLayout } from "~/components/layout/PageLayout";
@@ -577,70 +578,8 @@ export default function PlaygroundPage({ loaderData }: Route.ComponentProps) {
 }
 
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  if (isRouteErrorResponse(error)) {
-    return (
-      <PageLayout>
-        <div className="flex min-h-[50vh] flex-col items-center justify-center">
-          <div className="text-center">
-            <h1 className="text-4xl font-bold text-gray-900">
-              {error.status} {error.statusText}
-            </h1>
-            <p className="mt-4 text-lg text-gray-600">{error.data}</p>
-            <Link
-              to="/playground"
-              className="mt-6 inline-block rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
-            >
-              Go to Playground
-            </Link>
-          </div>
-        </div>
-      </PageLayout>
-    );
-  } else if (error instanceof Error) {
-    return (
-      <PageLayout>
-        <div className="flex min-h-[50vh] flex-col items-center justify-center">
-          <div className="text-center">
-            <h1 className="text-4xl font-bold text-gray-900">Error</h1>
-            <p className="mt-4 text-lg text-gray-600">{error.message}</p>
-            <details className="mt-4 max-w-2xl text-left">
-              <summary className="cursor-pointer text-sm text-gray-500">
-                Stack trace
-              </summary>
-              <pre className="mt-2 overflow-auto rounded bg-gray-100 p-4 text-xs">
-                {error.stack}
-              </pre>
-            </details>
-            <Link
-              to="/playground"
-              className="mt-6 inline-block rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
-            >
-              Go to Playground
-            </Link>
-          </div>
-        </div>
-      </PageLayout>
-    );
-  } else {
-    return (
-      <PageLayout>
-        <div className="flex min-h-[50vh] flex-col items-center justify-center">
-          <div className="text-center">
-            <h1 className="text-4xl font-bold text-gray-900">Unknown Error</h1>
-            <p className="mt-4 text-lg text-gray-600">
-              An unexpected error occurred. Please try again.
-            </p>
-            <Link
-              to="/playground"
-              className="mt-6 inline-block rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
-            >
-              Go to Playground
-            </Link>
-          </div>
-        </div>
-      </PageLayout>
-    );
-  }
+  logger.error(error);
+  return <RouteErrorContent error={error} />;
 }
 
 function GridRow({

--- a/ui/app/routes/workflow_evaluations/route.tsx
+++ b/ui/app/routes/workflow_evaluations/route.tsx
@@ -1,5 +1,5 @@
 import type { Route } from "./+types/route";
-import { isRouteErrorResponse, useNavigate } from "react-router";
+import { useNavigate } from "react-router";
 import PageButtons from "~/components/utils/PageButtons";
 import {
   PageHeader,
@@ -9,7 +9,6 @@ import {
 } from "~/components/layout/PageLayout";
 import WorkflowEvaluationRunsTable from "./WorkflowEvaluationRunsTable";
 import WorkflowEvaluationProjectsTable from "./WorkflowEvaluationProjectsTable";
-import { logger } from "~/utils/logger";
 import { getTensorZeroClient } from "~/utils/tensorzero.server";
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -113,32 +112,4 @@ export default function EvaluationSummaryPage({
       </SectionLayout>
     </PageLayout>
   );
-}
-
-export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  logger.error(error);
-
-  if (isRouteErrorResponse(error)) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">
-          {error.status} {error.statusText}
-        </h1>
-        <p>{error.data}</p>
-      </div>
-    );
-  } else if (error instanceof Error) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">Error</h1>
-        <p>{error.message}</p>
-      </div>
-    );
-  } else {
-    return (
-      <div className="flex h-screen items-center justify-center text-red-500">
-        <h1 className="text-2xl font-bold">Unknown Error</h1>
-      </div>
-    );
-  }
 }

--- a/ui/app/routes/workflow_evaluations/runs/$run_id/route.tsx
+++ b/ui/app/routes/workflow_evaluations/runs/$run_id/route.tsx
@@ -1,9 +1,5 @@
 import type { Route } from "./+types/route";
-import {
-  isRouteErrorResponse,
-  useNavigate,
-  type RouteHandle,
-} from "react-router";
+import { data, useNavigate, type RouteHandle } from "react-router";
 import PageButtons from "~/components/utils/PageButtons";
 import {
   PageHeader,
@@ -12,7 +8,6 @@ import {
 } from "~/components/layout/PageLayout";
 import BasicInfo from "./WorkflowEvaluationRunBasicInfo";
 import WorkflowEvaluationRunEpisodesTable from "./WorkflowEvaluationRunEpisodesTable";
-import { logger } from "~/utils/logger";
 import { getTensorZeroClient } from "~/utils/tensorzero.server";
 
 export const handle: RouteHandle = {
@@ -47,9 +42,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const statistics = statisticsResponse.statistics;
   const workflowEvaluationRuns = workflowEvaluationRunsResponse.runs;
   if (workflowEvaluationRuns.length != 1) {
-    throw new Error(
-      `Expected exactly one workflow evaluation run, got ${workflowEvaluationRuns.length}`,
-    );
+    throw data(`Workflow evaluation run "${run_id}" not found`, {
+      status: 404,
+    });
   }
   const workflowEvaluationRun = workflowEvaluationRuns[0];
   return {
@@ -108,32 +103,4 @@ export default function WorkflowEvaluationRunSummaryPage({
       </SectionLayout>
     </PageLayout>
   );
-}
-
-export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  logger.error(error);
-
-  if (isRouteErrorResponse(error)) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">
-          {error.status} {error.statusText}
-        </h1>
-        <p>{error.data}</p>
-      </div>
-    );
-  } else if (error instanceof Error) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 text-red-500">
-        <h1 className="text-2xl font-bold">Error</h1>
-        <p>{error.message}</p>
-      </div>
-    );
-  } else {
-    return (
-      <div className="flex h-screen items-center justify-center text-red-500">
-        <h1 className="text-2xl font-bold">Unknown Error</h1>
-      </div>
-    );
-  }
 }


### PR DESCRIPTION
## Summary
- Removes custom error handling from individual routes
- Errors now bubble up to layout-level ErrorBoundary
- Deletes ~700 lines of duplicated code

**Part of error boundary PR stack:**
1. #5549 - Global error boundary
2. #5568 - Layout-level error boundaries (base)
3. **This PR** - Remove redundant route error handling
4. (Planned) Form/input validation errors

## Status
🚧 **Work in progress** - not ready for review

## Test plan
- [ ] Verify errors still display correctly after removing route-level handlers
- [ ] Confirm layout ErrorBoundary catches child route errors