### PR TITLE
Check org member status when deciding to skip slack notifications

### DIFF
--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -27,8 +27,9 @@ jobs:
     steps:
       - name: Check if user should be skipped
         id: check-skip
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          SKIP_USERS="${{ vars.SLACK_NOTIFICATION_SKIP_USERS }}"
           ACTOR="${{ github.actor }}"
 
           # Check if user is a bot (ends with [bot], case insensitive)
@@ -39,24 +40,15 @@ jobs:
             exit 0
           fi
 
-          if [ -z "$SKIP_USERS" ]; then
+          # Check if user is a member of the organization
+          MEMBER=$((gh api "orgs/tensorzero/members/$ACTOR" && echo 1) || echo 0)
+          if [ "$MEMBER" = "0" ]; then
             echo "should_skip=false" >> $GITHUB_OUTPUT
-            exit 0
+            echo "Sending notification for non-member: $ACTOR"
+          else
+            echo "should_skip=true" >> $GITHUB_OUTPUT
+            echo "Skipping notification for organization member: $ACTOR"
           fi
-
-          # Convert comma-separated list to array and check if actor is in the list (case insensitive)
-          IFS=',' read -ra SKIP_ARRAY <<< "$SKIP_USERS"
-          for skip_user in "${SKIP_ARRAY[@]}"; do
-            # Trim whitespace and convert to lowercase
-            skip_user=$(echo "$skip_user" | xargs | tr '[:upper:]' '[:lower:]')
-            if [ "$skip_user" = "$ACTOR_LOWER" ]; then
-              echo "should_skip=true" >> $GITHUB_OUTPUT
-              echo "Skipping notification for user: $ACTOR"
-              exit 0
-            fi
-          done
-
-          echo "should_skip=false" >> $GITHUB_OUTPUT
 
       - name: Build payload for new issue notification
         if: steps.check-skip.outputs.should_skip == 'false' && github.event_name == 'issues' && github.event.action == 'opened'


### PR DESCRIPTION
This removes the need to update a hardcoded list
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> The PR updates the Slack notification workflow to dynamically check organization membership, removing the need for a hardcoded skip list.
> 
>   - **Behavior**:
>     - Removes hardcoded `SLACK_NOTIFICATION_SKIP_USERS` list in `.github/workflows/slack-notifications.yml`.
>     - Checks if `github.actor` is a bot or an organization member to decide on skipping notifications.
>     - Sends notifications only for non-members and non-bot users.
>   - **Environment**:
>     - Uses `GH_TOKEN` from `secrets.GITHUB_TOKEN` to authenticate GitHub API requests.
>   - **Logging**:
>     - Logs actions for skipping or sending notifications based on membership status.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1624260629d470ca0aadd69ad1f241f6094e5771. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->