### PR TITLE
Making betting confidence sequences take running intersection of intervals

### DIFF
--- a/evaluations/src/betting_confidence_sequences.rs
+++ b/evaluations/src/betting_confidence_sequences.rs
@@ -393,8 +393,9 @@ pub fn update_betting_cs(
         (m_values[n_grid - 1], n_grid - 1)
     };
 
-    // Intersect with previous bounds to ensure nested confidence sequences.
-    // If the intersection would be empty, ensure the interval still contains mean_est.
+    // Intersect with previous bounds to ensure nested confidence sequences,
+    // unless that would result in an empty set, in which case just return
+    // [mean_est, mean_est].
     let cs_lower = cs_lower_new.max(prev_results.cs_lower).min(mean_est);
     let cs_upper = cs_upper_new.min(prev_results.cs_upper).max(mean_est);
 


### PR DESCRIPTION
Closes #5572.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Modify `update_betting_cs` to ensure nested confidence intervals by taking running intersections, with a new test to verify this behavior.
> 
>   - **Behavior**:
>     - Modify `update_betting_cs` in `betting_confidence_sequences.rs` to ensure confidence intervals are nested by taking the running intersection of intervals.
>     - If intersection results in an empty set, return `[mean_est, mean_est]`.
>   - **Tests**:
>     - Add `test_intervals_are_nested_over_updates` to verify that each update produces an interval contained within or equal to the previous interval.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7327cf82e9f76715c82721ac59d7a83cfa221757. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->