### PR TITLE
Minimal Fix to `UpdateDatapointTool`parameter schema

### DIFF
--- a/internal/autopilot-tools/src/tools/prod/update_datapoints.rs
+++ b/internal/autopilot-tools/src/tools/prod/update_datapoints.rs
@@ -57,7 +57,13 @@ impl ToolMetadata for UpdateDatapointsTool {
                     "description": "The datapoints to update.",
                     "items": {
                         "type": "object",
+                        "description": "A datapoint update. Use 'chat' type for chat datapoints, or 'json' type for JSON datapoints.",
                         "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["chat", "json"],
+                                "description": "The datapoint type. Must match the type of the existing datapoint."
+                            },
                             "id": {
                                 "type": "string",
                                 "format": "uuid",
@@ -68,7 +74,11 @@ impl ToolMetadata for UpdateDatapointsTool {
                                 "description": "New input data (optional)."
                             },
                             "output": {
-                                "description": "New output data (optional)."
+                                "description": "New output data (optional). For chat: array of content blocks. For json: object with 'raw' string field."
+                            },
+                            "output_schema": {
+                                "type": "object",
+                                "description": "Output schema for validation (optional, only for 'json' type datapoints)."
                             },
                             "tags": {
                                 "type": "object",
@@ -76,7 +86,7 @@ impl ToolMetadata for UpdateDatapointsTool {
                                 "description": "New tags (optional)."
                             }
                         },
-                        "required": ["id"]
+                        "required": ["type", "id"]
                     }
                 }
             },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `UpdateDatapointsTool` schema to include `type` property and enhance `output` and `output_schema` descriptions in `update_datapoints.rs`.
> 
>   - **Schema Updates**:
>     - Add `type` property to datapoint schema with `enum` values `chat` and `json` in `update_datapoints.rs`.
>     - Update `output` description to specify format for `chat` and `json` types.
>     - Add `output_schema` property for `json` type validation.
>     - Add `type` to required fields in datapoint schema.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1fcdc305ca26100be2dd32a19015070e2020a7c4. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->