### PR TITLE
Fix `create_datapoints_from_inferences` tool schema for tagged enum

### DIFF
--- a/internal/autopilot-tools/src/tools/prod/create_datapoints_from_inferences.rs
+++ b/internal/autopilot-tools/src/tools/prod/create_datapoints_from_inferences.rs
@@ -55,26 +55,67 @@ impl ToolMetadata for CreateDatapointsFromInferencesTool {
                     "description": "The name of the dataset to create datapoints in."
                 },
                 "params": {
-                    "type": "object",
-                    "description": "Parameters specifying which inferences to use.",
-                    "properties": {
-                        "inference_ids": {
-                            "type": "array",
-                            "items": { "type": "string", "format": "uuid" },
-                            "description": "Specific inference IDs to create datapoints from (use this OR query parameters)."
+                    "description": "Parameters specifying which inferences to use. Use 'inference_ids' mode to specify exact IDs, or 'inference_query' mode to query by function name.",
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "description": "Create datapoints from specific inference IDs.",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "enum": ["inference_ids"],
+                                    "description": "Mode selector - must be 'inference_ids' for this variant."
+                                },
+                                "inference_ids": {
+                                    "type": "array",
+                                    "items": { "type": "string", "format": "uuid" },
+                                    "description": "The inference IDs to create datapoints from."
+                                },
+                                "output_source": {
+                                    "type": "string",
+                                    "enum": ["none", "inference", "demonstration"],
+                                    "description": "Source for datapoint output: 'none' (input-only), 'inference' (original output, default), or 'demonstration' (use demonstration feedback)."
+                                }
+                            },
+                            "required": ["type", "inference_ids"],
+                            "additionalProperties": false
                         },
-                        "function_name": {
-                            "type": "string",
-                            "description": "Filter inferences by function name (for query mode)."
-                        },
-                        "limit": {
-                            "type": "integer",
-                            "description": "Maximum number of inferences to use (for query mode)."
+                        {
+                            "type": "object",
+                            "description": "Create datapoints from inferences matching a query.",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "enum": ["inference_query"],
+                                    "description": "Mode selector - must be 'inference_query' for this variant."
+                                },
+                                "function_name": {
+                                    "type": "string",
+                                    "description": "Filter inferences by function name."
+                                },
+                                "variant_name": {
+                                    "type": "string",
+                                    "description": "Filter inferences by variant name."
+                                },
+                                "limit": {
+                                    "type": "integer",
+                                    "description": "Maximum number of inferences to use.",
+                                    "minimum": 1
+                                },
+                                "output_source": {
+                                    "type": "string",
+                                    "enum": ["none", "inference", "demonstration"],
+                                    "description": "Source for datapoint output: 'none' (input-only), 'inference' (original output, default), or 'demonstration' (use demonstration feedback)."
+                                }
+                            },
+                            "required": ["type"],
+                            "additionalProperties": false
                         }
-                    }
+                    ]
                 }
             },
-            "required": ["dataset_name", "params"]
+            "required": ["dataset_name", "params"],
+            "additionalProperties": false
         });
 
         serde_json::from_value(schema).map_err(|e| {


### PR DESCRIPTION
## Summary

- Fixed the `parameters_schema()` to include the `type` discriminator field required by the `#[serde(tag = "type")]` tagged enum
- Used `anyOf` to properly represent the two variants (`inference_ids` and `inference_query`)
- Added missing `output_source` and `variant_name` fields to the schema

## Problem

The schema was missing the `type` field, causing LLMs to generate invalid JSON like:
```json
{ "inference_ids": [...], "function_name": "..." }
```

Instead of:
```json
{ "type": "inference_ids", "inference_ids": [...] }
```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes schema in `create_datapoints_from_inferences.rs` by adding `type` discriminator and using `anyOf` for parameter variants.
> 
>   - **Schema Fixes**:
>     - Added `type` discriminator field to `parameters_schema()` for tagged enum in `create_datapoints_from_inferences.rs`.
>     - Used `anyOf` to represent `inference_ids` and `inference_query` variants.
>     - Added `output_source` and `variant_name` fields to the schema.
>   - **Problem Addressed**:
>     - Fixed missing `type` field causing invalid JSON generation by LLMs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 7f60fd8355590e2ec615d5a94d140801e207117f. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->