### PR TITLE
Use import_exception! for Python error types

### DIFF
--- a/tensorzero-core/src/inference/types/pyo3_helpers.rs
+++ b/tensorzero-core/src/inference/types/pyo3_helpers.rs
@@ -27,11 +27,14 @@ use crate::stored_inference::{
 };
 use pyo3::types::PyNone;
 
+pub mod tensorzero_error {
+    pyo3::import_exception!(tensorzero.types, TensorZeroError);
+    pyo3::import_exception!(tensorzero.types, TensorZeroInternalError);
+}
+
 pub static JSON_LOADS: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
 pub static JSON_DUMPS: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
 pub static UUID_UUID: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
-static TENSORZERO_INTERNAL_ERROR: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
-static TENSORZERO_ERROR: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
 
 pub fn uuid_to_python(py: Python<'_>, uuid: Uuid) -> PyResult<Bound<'_, PyAny>> {
     let uuid_class = UUID_UUID.get_or_try_init::<_, PyErr>(py, || {
@@ -383,7 +386,11 @@ pub fn deserialize_from_stored_sample<'a>(
         let wire = deserialize_from_pyobj::<StoredInference>(py, obj)?;
         let storage = match wire.to_storage(config) {
             Ok(s) => s,
-            Err(e) => return Err(tensorzero_core_error(py, &e.to_string())?),
+            Err(e) => {
+                return Err(tensorzero_error::TensorZeroInternalError::new_err(
+                    e.to_string(),
+                ));
+            }
         };
         return Ok(StoredSampleItem::StoredInference(storage));
     }
@@ -395,7 +402,11 @@ pub fn deserialize_from_stored_sample<'a>(
             Datapoint::Chat(chat_wire) => {
                 let function_config = match config.get_function(&chat_wire.function_name) {
                     Ok(f) => f,
-                    Err(e) => return Err(tensorzero_core_error(py, &e.to_string())?),
+                    Err(e) => {
+                        return Err(tensorzero_error::TensorZeroInternalError::new_err(
+                            e.to_string(),
+                        ));
+                    }
                 };
                 let datapoint = match chat_wire.into_storage_without_file_handling(
                     &function_config,
@@ -403,7 +414,11 @@ pub fn deserialize_from_stored_sample<'a>(
                     &config.hash,
                 ) {
                     Ok(d) => d,
-                    Err(e) => return Err(tensorzero_core_error(py, &e.to_string())?),
+                    Err(e) => {
+                        return Err(tensorzero_error::TensorZeroInternalError::new_err(
+                            e.to_string(),
+                        ));
+                    }
                 };
                 Ok(StoredSampleItem::Datapoint(StoredDatapoint::Chat(
                     datapoint,
@@ -413,7 +428,11 @@ pub fn deserialize_from_stored_sample<'a>(
                 let datapoint =
                     match json_wire.into_storage_without_file_handling(config.hash.clone()) {
                         Ok(d) => d,
-                        Err(e) => return Err(tensorzero_core_error(py, &e.to_string())?),
+                        Err(e) => {
+                            return Err(tensorzero_error::TensorZeroInternalError::new_err(
+                                e.to_string(),
+                            ));
+                        }
                     };
                 Ok(StoredSampleItem::Datapoint(StoredDatapoint::Json(
                     datapoint,
@@ -541,35 +560,10 @@ pub fn deserialize_from_pyobj<'a, T: serde::de::DeserializeOwned>(
     let val: Result<T, _> = serde_path_to_error::deserialize(&mut deserializer);
     match val {
         Ok(val) => Ok(val),
-        Err(e) => Err(tensorzero_core_error(
-            py,
-            &format!(
-                "Failed to deserialize JSON to {}: {}",
-                std::any::type_name::<T>(),
-                e
-            ),
-        )?),
+        Err(e) => Err(tensorzero_error::TensorZeroInternalError::new_err(format!(
+            "Failed to deserialize JSON to {}: {}",
+            std::any::type_name::<T>(),
+            e
+        ))),
     }
-}
-
-pub fn tensorzero_error_class(py: Python<'_>) -> PyResult<&Py<PyAny>> {
-    TENSORZERO_ERROR.get_or_try_init::<_, PyErr>(py, || {
-        let self_module = PyModule::import(py, "tensorzero.types")?;
-        let err: Bound<'_, PyAny> = self_module.getattr("TensorZeroError")?;
-        Ok(err.unbind())
-    })
-}
-
-pub fn tensorzero_core_error_class(py: Python<'_>) -> PyResult<&Py<PyAny>> {
-    TENSORZERO_INTERNAL_ERROR.get_or_try_init::<_, PyErr>(py, || {
-        let self_module = PyModule::import(py, "tensorzero.types")?;
-        let err: Bound<'_, PyAny> = self_module.getattr("TensorZeroInternalError")?;
-        Ok(err.unbind())
-    })
-}
-
-pub fn tensorzero_core_error(py: Python<'_>, msg: &str) -> PyResult<PyErr> {
-    Ok(PyErr::from_value(
-        tensorzero_core_error_class(py)?.bind(py).call1((msg,))?,
-    ))
 }


### PR DESCRIPTION
This change is a first step to refactoring Python error types per #3168. It replaces the manual initialization with PyO3's `import_exception!`.
https://pyo3.rs/v0.27.2/exception.html#using-exceptions-defined-in-python-code
https://docs.rs/pyo3/0.27.2/pyo3/macro.import_exception.html

Next steps:
- Add an error enum and From traits
- Remove `convert_error`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor error handling by using PyO3's `import_exception!` for Python error types in `clients/python/src/lib.rs` and `tensorzero-core/src/inference/types/pyo3_helpers.rs`.
> 
>   - **Error Handling**:
>     - Replace manual exception initialization with `import_exception!` in `tensorzero-core/src/inference/types/pyo3_helpers.rs`.
>     - Update `convert_error` function in `clients/python/src/lib.rs` to use `tensorzero_error::TensorZeroError` and `tensorzero_error::TensorZeroInternalError`.
>     - Refactor error handling in `deserialize_from_stored_sample` and `deserialize_from_pyobj` in `pyo3_helpers.rs` to use new exception types.
>   - **Misc**:
>     - Remove unused static variables `TENSORZERO_INTERNAL_ERROR` and `TENSORZERO_ERROR` in `pyo3_helpers.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for fe7766df8bedb492ff37e0b7040c33e870993b7d. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->