### PR TITLE
WIP: Error boundaries PR 2/3 - Layout error boundaries

### DIFF
--- a/ui/app/components/ui/error/LayoutErrorBoundary.tsx
+++ b/ui/app/components/ui/error/LayoutErrorBoundary.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+import { isRouteErrorResponse } from "react-router";
+import { ErrorDialog } from "./ErrorDialog";
+import { ErrorContent } from "./ErrorContent";
+import {
+  ErrorScope,
+  NotFoundDisplay,
+  PageErrorContainer,
+  PageErrorStack,
+} from "./ErrorContentPrimitives";
+import { AlertTriangle } from "lucide-react";
+import {
+  isInfraError,
+  classifyError,
+  getErrorLabel,
+  getPageErrorInfo,
+} from "~/utils/tensorzero/errors";
+
+interface LayoutErrorBoundaryProps {
+  error: unknown;
+}
+
+/**
+ * Unified error display for layout ErrorBoundaries.
+ * - Infra errors (gateway, auth, DB): Shows dismissible dialog
+ * - Page errors (404, resource not found): Shows inline content
+ */
+export function LayoutErrorBoundary({ error }: LayoutErrorBoundaryProps) {
+  const [dialogOpen, setDialogOpen] = React.useState(true);
+
+  // Infra errors -> dismissible dialog
+  if (isInfraError(error)) {
+    const classified = classifyError(error);
+    return (
+      <ErrorDialog
+        open={dialogOpen}
+        onDismiss={() => setDialogOpen(false)}
+        onReopen={() => setDialogOpen(true)}
+        label={getErrorLabel(classified.type)}
+      >
+        <ErrorContent error={classified} />
+      </ErrorDialog>
+    );
+  }
+
+  // Page-scope: 404s get special muted treatment
+  if (isRouteErrorResponse(error) && error.status === 404) {
+    return <NotFoundDisplay />;
+  }
+
+  // Page-scope: other errors
+  const { title, message, status } = getPageErrorInfo(error);
+  return (
+    <PageErrorContainer>
+      <PageErrorStack
+        icon={AlertTriangle}
+        title={status ? `Error ${status}` : title}
+        description={message}
+        scope={ErrorScope.Page}
+      />
+    </PageErrorContainer>
+  );
+}

--- a/ui/app/components/ui/error/index.ts
+++ b/ui/app/components/ui/error/index.ts
@@ -14,6 +14,7 @@
  *    - Sidebar stays fully functional
  *
  * Components:
+ *    - LayoutErrorBoundary: Handles both infra (dialog) and page (inline) errors
  *    - PageErrorContent: Page errors only (for routes without layout boundaries)
  *    - RootErrorBoundaryLayout: Shell with sidebar for root-level errors
  */
@@ -22,3 +23,4 @@ export { RootErrorBoundaryLayout } from "./RootErrorBoundaryLayout";
 export { ErrorDialog } from "./ErrorDialog";
 export { ErrorContent } from "./ErrorContent";
 export { PageErrorContent } from "./PageErrorContent";
+export { LayoutErrorBoundary } from "./LayoutErrorBoundary";

--- a/ui/app/routes/autopilot/layout.tsx
+++ b/ui/app/routes/autopilot/layout.tsx
@@ -6,6 +6,7 @@ import {
 } from "react-router";
 import type { Route } from "./+types/layout";
 import { AutopilotUnavailableState } from "~/components/ui/error/AutopilotUnavailableState";
+import { LayoutErrorBoundary } from "~/components/ui/error";
 import { isAutopilotUnavailableError } from "~/utils/tensorzero/errors";
 import { getAutopilotClient } from "~/utils/tensorzero.server";
 
@@ -35,7 +36,7 @@ export default function AutopilotLayout() {
 }
 
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  // Check if this is an autopilot unavailable error
+  // Autopilot unavailable gets special treatment
   if (
     isRouteErrorResponse(error) &&
     error.data?.errorType === AUTOPILOT_UNAVAILABLE_ERROR
@@ -46,6 +47,6 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
     return <AutopilotUnavailableState />;
   }
 
-  // Re-throw other errors to be handled by parent error boundary
-  throw error;
+  // All other errors (including infra) handled by LayoutErrorBoundary
+  return <LayoutErrorBoundary error={error} />;
 }

--- a/ui/app/routes/datapoints/layout.tsx
+++ b/ui/app/routes/datapoints/layout.tsx
@@ -1,4 +1,6 @@
 import { Outlet, type RouteHandle } from "react-router";
+import type { Route } from "./+types/layout";
+import { LayoutErrorBoundary } from "~/components/ui/error";
 
 export const handle: RouteHandle = {
   crumb: () => [{ label: "Datapoints", noLink: true }],
@@ -6,4 +8,8 @@ export const handle: RouteHandle = {
 
 export default function DatapointsLayout() {
   return <Outlet />;
+}
+
+export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  return <LayoutErrorBoundary error={error} />;
 }

--- a/ui/app/routes/datasets/layout.tsx
+++ b/ui/app/routes/datasets/layout.tsx
@@ -1,4 +1,6 @@
 import { Outlet, type RouteHandle } from "react-router";
+import type { Route } from "./+types/layout";
+import { LayoutErrorBoundary } from "~/components/ui/error";
 
 export const handle: RouteHandle = {
   crumb: () => ["Datasets"],
@@ -6,4 +8,8 @@ export const handle: RouteHandle = {
 
 export default function DatasetsLayout() {
   return <Outlet />;
+}
+
+export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  return <LayoutErrorBoundary error={error} />;
 }

--- a/ui/app/routes/evaluations/layout.tsx
+++ b/ui/app/routes/evaluations/layout.tsx
@@ -1,4 +1,6 @@
 import { Outlet, type RouteHandle } from "react-router";
+import type { Route } from "./+types/layout";
+import { LayoutErrorBoundary } from "~/components/ui/error";
 
 export const handle: RouteHandle = {
   crumb: () => ["Evaluations"],
@@ -6,4 +8,8 @@ export const handle: RouteHandle = {
 
 export default function EvaluationsLayout() {
   return <Outlet />;
+}
+
+export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  return <LayoutErrorBoundary error={error} />;
 }

--- a/ui/app/routes/observability/episodes/layout.tsx
+++ b/ui/app/routes/observability/episodes/layout.tsx
@@ -1,4 +1,6 @@
 import { Outlet, type RouteHandle } from "react-router";
+import type { Route } from "./+types/layout";
+import { LayoutErrorBoundary } from "~/components/ui/error";
 
 export const handle: RouteHandle = {
   crumb: () => ["Episodes"],
@@ -6,4 +8,8 @@ export const handle: RouteHandle = {
 
 export default function EpisodesLayout() {
   return <Outlet />;
+}
+
+export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  return <LayoutErrorBoundary error={error} />;
 }

--- a/ui/app/routes/observability/functions/layout.tsx
+++ b/ui/app/routes/observability/functions/layout.tsx
@@ -1,4 +1,6 @@
 import { Outlet, type RouteHandle } from "react-router";
+import type { Route } from "./+types/layout";
+import { LayoutErrorBoundary } from "~/components/ui/error";
 
 export const handle: RouteHandle = {
   crumb: () => ["Functions"],
@@ -6,4 +8,8 @@ export const handle: RouteHandle = {
 
 export default function FunctionsLayout() {
   return <Outlet />;
+}
+
+export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  return <LayoutErrorBoundary error={error} />;
 }

--- a/ui/app/routes/observability/inferences/layout.tsx
+++ b/ui/app/routes/observability/inferences/layout.tsx
@@ -1,4 +1,6 @@
 import { Outlet, type RouteHandle } from "react-router";
+import type { Route } from "./+types/layout";
+import { LayoutErrorBoundary } from "~/components/ui/error";
 
 export const handle: RouteHandle = {
   crumb: () => ["Inferences"],
@@ -6,4 +8,8 @@ export const handle: RouteHandle = {
 
 export default function InferencesLayout() {
   return <Outlet />;
+}
+
+export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  return <LayoutErrorBoundary error={error} />;
 }

--- a/ui/app/routes/workflow_evaluations/layout.tsx
+++ b/ui/app/routes/workflow_evaluations/layout.tsx
@@ -1,4 +1,6 @@
 import { Outlet, type RouteHandle } from "react-router";
+import type { Route } from "./+types/layout";
+import { LayoutErrorBoundary } from "~/components/ui/error";
 
 export const handle: RouteHandle = {
   crumb: () => ["Workflow Evaluations"],
@@ -6,4 +8,8 @@ export const handle: RouteHandle = {
 
 export default function DynamicEvaluationsLayout() {
   return <Outlet />;
+}
+
+export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  return <LayoutErrorBoundary error={error} />;
 }

--- a/ui/e2e_tests/error-boundaries.spec.ts
+++ b/ui/e2e_tests/error-boundaries.spec.ts
@@ -33,6 +33,77 @@ test.describe("Error Boundaries", () => {
     });
   });
 
+  test.describe("Resource Not Found (Layout Boundaries)", () => {
+    test("should show error for non-existent inference", async ({ page }) => {
+      // Navigate to an inference ID that doesn't exist
+      await page.goto(
+        "/observability/inferences/00000000-0000-0000-0000-000000000000",
+      );
+
+      // Should show an error (caught by layout boundary)
+      const errorVisible = await page
+        .getByText(/error|not found/i)
+        .first()
+        .isVisible()
+        .catch(() => false);
+
+      expect(errorVisible).toBe(true);
+
+      // Sidebar should remain functional
+      await expect(page.getByText("Inferences")).toBeVisible();
+    });
+
+    test("should show error for non-existent episode", async ({ page }) => {
+      await page.goto(
+        "/observability/episodes/00000000-0000-0000-0000-000000000000",
+      );
+
+      // Should show an error
+      const errorVisible = await page
+        .getByText(/error|not found/i)
+        .first()
+        .isVisible()
+        .catch(() => false);
+
+      expect(errorVisible).toBe(true);
+
+      // Sidebar should remain functional
+      await expect(page.getByText("Episodes")).toBeVisible();
+    });
+
+    test("should show error for non-existent dataset", async ({ page }) => {
+      await page.goto("/datasets/this-dataset-does-not-exist-xyz");
+
+      // Should show an error
+      const errorVisible = await page
+        .getByText(/error|not found/i)
+        .first()
+        .isVisible()
+        .catch(() => false);
+
+      expect(errorVisible).toBe(true);
+
+      // Sidebar should remain functional
+      await expect(page.getByText("Datasets")).toBeVisible();
+    });
+
+    test("should show error for non-existent function", async ({ page }) => {
+      await page.goto("/observability/functions/this_function_does_not_exist");
+
+      // Should show an error
+      const errorVisible = await page
+        .getByText(/error|not found/i)
+        .first()
+        .isVisible()
+        .catch(() => false);
+
+      expect(errorVisible).toBe(true);
+
+      // Sidebar should remain functional
+      await expect(page.getByText("Functions")).toBeVisible();
+    });
+  });
+
   test.describe("Navigation Recovery", () => {
     test("should recover from error state when navigating to valid page", async ({
       page,


### PR DESCRIPTION
## Status: WIP - Do not review yet

This is PR 2 of 3 in the error boundaries stack. Stacked on #5588.

## Summary

Add `LayoutErrorBoundary` to all top-level layout routes:
- autopilot, datapoints, datasets, evaluations
- observability/episodes, observability/functions, observability/inferences
- workflow_evaluations

`LayoutErrorBoundary` handles both error types:
- **Infra errors**: Shows dismissible dialog (gateway, auth, ClickHouse)
- **Page errors**: Shows inline error content (404s, resource not found)

## Test plan
- [ ] e2e tests for resource not found pass
- [ ] Nested errors caught at layout level, not root

## PR Stack
- PR 1: Root error handling (#5588)
- **PR 2 (this)**: Layout error boundaries
- PR 3: Graceful degradation (config optional)