### PR TITLE
Bump tensorzero_auth span from 'trace' to 'info'

### DIFF
--- a/internal/tensorzero-auth/src/middleware.rs
+++ b/internal/tensorzero-auth/src/middleware.rs
@@ -116,7 +116,7 @@ pub async fn tensorzero_auth_middleware(
             }),
         }
     }
-    .instrument(tracing::trace_span!(
+    .instrument(tracing::info_span!(
         "tensorzero_auth",
         otel.name = "tensorzero_auth"
     ));


### PR DESCRIPTION
This ensures that it's compiled in for release builds, and will be reported on the autopilot server
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change logging level from `trace` to `info` for `tensorzero_auth` span in `middleware.rs`.
> 
>   - **Behavior**:
>     - Change logging level from `trace` to `info` for `tensorzero_auth` span in `tensorzero_auth_middleware()` in `middleware.rs`.
>     - Ensures span is compiled in release builds and reported on the autopilot server.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 856c6c9f1ec2deb0225cbf34e3690e5a4173701d. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->