### PR TITLE
WIP: [3] Inference detail page streaming

### DIFF
--- a/ui/app/components/inference/InferenceDetailContent.tsx
+++ b/ui/app/components/inference/InferenceDetailContent.tsx
@@ -257,21 +257,18 @@ export function InferenceDetailContent({
 
   const isDefault = inference.function_name === DEFAULT_FUNCTION;
 
-  const modelsSet = new Set<string>([...usedVariants, ...config.model_names]);
+  const modelsSet = new Set<string>([
+    ...usedVariants,
+    ...(config?.model_names ?? []),
+  ]);
   const models = [...modelsSet].sort();
 
   const options = isDefault ? models : variants;
   const onSelect = isDefault ? onModelSelect : onVariantSelect;
 
-  const inferenceUsage = getTotalInferenceUsage(model_inferences);
-
   // Build the header components
   const basicInfoElement = (
-    <BasicInfo
-      inference={inference}
-      inferenceUsage={inferenceUsage}
-      modelInferences={model_inferences}
-    />
+    <BasicInfo inference={inference} modelInferences={model_inferences} />
   );
 
   const actionBarElement = (
@@ -422,7 +419,7 @@ export function InferenceDetailContent({
             setLastRequestArgs(null);
           }}
           item={inference}
-          inferenceUsage={inferenceUsage}
+          inferenceUsage={getTotalInferenceUsage(model_inferences)}
           selectedVariant={selectedVariant}
           source={variantSource}
           onRefresh={lastRequestArgs ? handleRefresh : null}


### PR DESCRIPTION
## Status: WIP - NOT READY FOR REVIEW

This is part of the error boundaries work, split into separate PRs for review.

**Stacked on:** #5588

**Note:** `InferenceDetailContent.tsx` has overlapping changes with PR 2a (#5597). These PRs need to be coordinated when merging.

## Summary

Transforms inference detail page to use streaming data patterns:
- Primary data (inference) is awaited for immediate render
- Secondary data (model inferences, feedback) is deferred for streaming
- Uses `Await`/`Suspense` for progressive loading
- Adds skeleton loading states for deferred sections
- Includes TryWithButton variant response functionality

This improves perceived performance by showing the main inference data immediately while loading secondary data in the background.

## Test plan
- [ ] Typecheck passes
- [ ] Lint passes
- [ ] Unit tests pass
- [ ] Manual verification: Page loads instantly with skeletons, secondary data streams in