### PR TITLE
Switch back to released version of init-tracing-opentelemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,8 +3166,9 @@ dependencies = [
 
 [[package]]
 name = "init-tracing-opentelemetry"
-version = "0.34.0"
-source = "git+https://github.com/Aaron1011/tracing-opentelemetry-instrumentation-sdk?rev=c240499e464c2c787dedda2b870ae50747a95e6f#c240499e464c2c787dedda2b870ae50747a95e6f"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edab8336260bdd46dc17926fe475a7a3d735fd5708fb937c885cd9caf5b9c51"
 dependencies = [
  "opentelemetry",
  "opentelemetry-aws",

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,7 @@
 # cargo-deny
 
 [sources]
-allow-git = ["https://github.com/hyperium/mime", "https://github.com/tensorzero/durable", "https://github.com/Aaron1011/tracing-opentelemetry-instrumentation-sdk"]
+allow-git = ["https://github.com/hyperium/mime", "https://github.com/tensorzero/durable"]
 unknown-git = "deny"
 
 [bans]

--- a/tensorzero-core/Cargo.toml
+++ b/tensorzero-core/Cargo.toml
@@ -99,8 +99,7 @@ opentelemetry-otlp = { version = "0.31.0", features = [
     "tls-roots",
 ] }
 opentelemetry-semantic-conventions = "0.31.0"
-# TODO - switch back to a released version once https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/pull/309 is merged
-init-tracing-opentelemetry = { git = "https://github.com/Aaron1011/tracing-opentelemetry-instrumentation-sdk", rev = "c240499e464c2c787dedda2b870ae50747a95e6f", features = ["xray"] }
+init-tracing-opentelemetry = { version = "0.35.0", features = ["xray"] }
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 tracing-opentelemetry-instrumentation-sdk = { workspace = true, features = [
     "http",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Switch `init-tracing-opentelemetry` from a git commit to version `0.35.0` on crates.io, updating `Cargo.lock`, `tensorzero-core/Cargo.toml`, and `deny.toml`.
> 
>   - **Dependencies**:
>     - Update `init-tracing-opentelemetry` from git commit `c240499` to version `0.35.0` in `Cargo.lock` and `tensorzero-core/Cargo.toml`.
>     - Change source from git to crates.io registry in `Cargo.lock`.
>   - **Configuration**:
>     - Remove `https://github.com/Aaron1011/tracing-opentelemetry-instrumentation-sdk` from `allow-git` in `deny.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 8f8f594ae2a30914dfe1e84c1c51caf259cb9072. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->