### PR TITLE
Fix streaming usage counting in Azure

### DIFF
--- a/tensorzero-core/src/providers/azure.rs
+++ b/tensorzero-core/src/providers/azure.rs
@@ -42,7 +42,7 @@ use super::chat_completions::{
 };
 use super::openai::{
     OpenAIEmbeddingUsage, OpenAIRequestMessage, OpenAIResponse, OpenAIResponseChoice,
-    SystemOrDeveloper, handle_openai_error, prepare_openai_messages, stream_openai,
+    StreamOptions, SystemOrDeveloper, handle_openai_error, prepare_openai_messages, stream_openai,
 };
 use crate::inference::{InferenceProvider, TensorZeroEventError};
 
@@ -639,6 +639,8 @@ struct AzureRequest<'a> {
     seed: Option<u32>,
     stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
+    stream_options: Option<StreamOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     response_format: Option<AzureResponseFormat>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<ChatCompletionTool<'a>>>,
@@ -714,6 +716,13 @@ impl<'a> AzureRequest<'a> {
         )
         .await?;
         let (tools, tool_choice, _) = prepare_chat_completion_tools(request, true)?;
+        let stream_options = if request.stream {
+            Some(StreamOptions {
+                include_usage: true,
+            })
+        } else {
+            None
+        };
         let mut azure_request = AzureRequest {
             messages,
             temperature: request.temperature,
@@ -723,6 +732,7 @@ impl<'a> AzureRequest<'a> {
             frequency_penalty: request.frequency_penalty,
             max_completion_tokens: request.max_tokens,
             stream: request.stream,
+            stream_options,
             response_format,
             seed: request.seed,
             tools,
@@ -1246,6 +1256,7 @@ mod tests {
             max_completion_tokens: None,
             seed: None,
             stream: false,
+            stream_options: None,
             response_format: None,
             tools: None,
             // allowed_tools is now part of tool_choice (AllowedToolsChoice variant)

--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -3886,22 +3886,8 @@ pub async fn test_simple_streaming_inference_request_with_provider_cache(
         }
 
         if let Some(usage) = chunk_json.get("usage") {
-            // Azure OpenAI Service doesn't return usage in streaming, so tokens may be null
-            let is_azure_without_usage = provider.variant_name.contains("azure")
-                && !provider.variant_name.contains("azure-ai-foundry");
-            if is_azure_without_usage {
-                input_tokens += usage
-                    .get("input_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-                output_tokens += usage
-                    .get("output_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-            } else {
-                input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
-                output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
-            }
+            input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
+            output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
         }
 
         if let Some(chunk_finish_reason) = chunk_json.get("finish_reason") {
@@ -3915,15 +3901,9 @@ pub async fn test_simple_streaming_inference_request_with_provider_cache(
 
     // This is flaky on Fireworks - it seems like they sometimes don't send us usage information,
     // so TensorZero reports 0 for input/output token usage.
-    if provider.model_provider_name != "fireworks" {
-        // NB: Azure OpenAI Service doesn't support input/output tokens during streaming, but Azure AI Foundry does
-        if (provider.variant_name.contains("azure")
-            && !provider.variant_name.contains("azure-ai-foundry"))
-            || assert_response_is_cached
-        {
-            assert_eq!(input_tokens, 0);
-            assert_eq!(output_tokens, 0);
-        }
+    if provider.model_provider_name != "fireworks" && assert_response_is_cached {
+        assert_eq!(input_tokens, 0);
+        assert_eq!(output_tokens, 0);
     }
 
     assert!(finish_reason.is_some());
@@ -4023,19 +4003,13 @@ pub async fn test_simple_streaming_inference_request_with_provider_cache(
         assert!(serde_json::from_str::<Value>(line).is_ok());
     }
 
-    let input_tokens = result.get("input_tokens").unwrap();
-    let output_tokens = result.get("output_tokens").unwrap();
-
     // This is flaky on Fireworks - it seems like they sometimes don't send us usage information,
     // so TensorZero reports 0 for input/output token usage.
-    if provider.model_provider_name != "fireworks" {
-        // NB: Azure OpenAI Service doesn't support input/output tokens during streaming, but Azure AI Foundry does
-        if provider.variant_name.contains("azure")
-            && !provider.variant_name.contains("azure-ai-foundry")
-        {
-            assert!(input_tokens.is_null());
-            assert!(output_tokens.is_null());
-        }
+    if provider.model_provider_name != "fireworks" && !assert_response_is_cached {
+        let input_tokens = result.get("input_tokens").unwrap();
+        let output_tokens = result.get("output_tokens").unwrap();
+        assert!(input_tokens.as_u64().unwrap() > 0);
+        assert!(output_tokens.as_u64().unwrap() > 0);
     }
 
     let response_time_ms = result.get("response_time_ms").unwrap().as_u64().unwrap();
@@ -4421,38 +4395,16 @@ pub async fn test_inference_params_streaming_inference_request_with_provider(
         }
 
         if let Some(usage) = chunk_json.get("usage") {
-            // Azure OpenAI Service doesn't return usage in streaming, so tokens may be null
-            let is_azure_without_usage = provider.variant_name.contains("azure")
-                && !provider.variant_name.contains("azure-ai-foundry");
-            if is_azure_without_usage {
-                input_tokens += usage
-                    .get("input_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-                output_tokens += usage
-                    .get("output_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-            } else {
-                input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
-                output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
-            }
+            input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
+            output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
         }
     }
 
     let inference_id = inference_id.unwrap();
     assert!(full_content.to_lowercase().contains("tokyo"));
 
-    // NB: Azure OpenAI Service doesn't support input/output tokens during streaming, but Azure AI Foundry does
-    if provider.variant_name.contains("azure")
-        && !provider.variant_name.contains("azure-ai-foundry")
-    {
-        assert_eq!(input_tokens, 0);
-        assert_eq!(output_tokens, 0);
-    } else {
-        assert!(input_tokens > 0);
-        assert!(output_tokens > 0);
-    }
+    assert!(input_tokens > 0);
+    assert!(output_tokens > 0);
 
     // Sleep to allow time for data to be inserted into ClickHouse (trailing writes from API)
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
@@ -4574,17 +4526,8 @@ pub async fn test_inference_params_streaming_inference_request_with_provider(
 
     let input_tokens = result.get("input_tokens").unwrap();
     let output_tokens = result.get("output_tokens").unwrap();
-
-    // NB: Azure OpenAI Service doesn't support input/output tokens during streaming, but Azure AI Foundry does
-    if provider.variant_name.contains("azure")
-        && !provider.variant_name.contains("azure-ai-foundry")
-    {
-        assert!(input_tokens.is_null());
-        assert!(output_tokens.is_null());
-    } else {
-        assert!(input_tokens.as_u64().unwrap() > 0);
-        assert!(output_tokens.as_u64().unwrap() > 0);
-    }
+    assert!(input_tokens.as_u64().unwrap() > 0);
+    assert!(output_tokens.as_u64().unwrap() > 0);
 
     let response_time_ms = result.get("response_time_ms").unwrap().as_u64().unwrap();
     assert!(response_time_ms > 0);
@@ -5116,33 +5059,15 @@ pub async fn test_tool_use_tool_choice_auto_used_streaming_inference_request_wit
         }
 
         if let Some(usage) = chunk_json.get("usage").and_then(|u| u.as_object()) {
-            // Azure OpenAI Service doesn't return usage in streaming, so tokens may be null
-            let is_azure_without_usage = provider.variant_name.contains("azure")
-                && !provider.variant_name.contains("azure-ai-foundry");
-            if is_azure_without_usage {
-                input_tokens += usage
-                    .get("input_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-                output_tokens += usage
-                    .get("output_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-            } else {
-                input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
-                output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
-            }
+            input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
+            output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
         }
     }
 
     assert!(tool_name.is_some());
     assert_eq!(tool_name.as_ref().unwrap(), "get_temperature");
 
-    // NB: Azure doesn't return usage during streaming
-    if provider.variant_name.contains("azure") {
-        assert_eq!(input_tokens, 0);
-        assert_eq!(output_tokens, 0);
-    } else if provider.variant_name.contains("together") {
+    if provider.variant_name.contains("together") {
         // Do nothing: Together is flaky. Sometimes it returns non-zero usage, sometimes it returns zero usage...
     } else {
         assert!(input_tokens > 0);
@@ -5310,13 +5235,7 @@ pub async fn test_tool_use_tool_choice_auto_used_streaming_inference_request_wit
     let input_tokens = result.get("input_tokens").unwrap();
     let output_tokens = result.get("output_tokens").unwrap();
 
-    // NB: Azure OpenAI Service doesn't support input/output tokens during streaming, but Azure AI Foundry does
-    if provider.variant_name.contains("azure")
-        && !provider.variant_name.contains("azure-ai-foundry")
-    {
-        assert!(input_tokens.is_null());
-        assert!(output_tokens.is_null());
-    } else if provider.variant_name.contains("together") {
+    if provider.variant_name.contains("together") {
         // Do nothing: Together is flaky. Sometimes it returns non-zero usage, sometimes it returns zero usage...
     } else {
         assert!(input_tokens.as_u64().unwrap() > 0);
@@ -5731,33 +5650,13 @@ pub async fn test_tool_use_tool_choice_auto_unused_streaming_inference_request_w
         }
 
         if let Some(usage) = chunk_json.get("usage").and_then(|u| u.as_object()) {
-            // Azure OpenAI Service doesn't return usage in streaming, so tokens may be null
-            let is_azure_without_usage = provider.variant_name.contains("azure")
-                && !provider.variant_name.contains("azure-ai-foundry");
-            if is_azure_without_usage {
-                input_tokens += usage
-                    .get("input_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-                output_tokens += usage
-                    .get("output_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-            } else {
-                input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
-                output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
-            }
+            input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
+            output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
         }
     }
 
-    // NB: Azure doesn't return usage during streaming
-    if provider.variant_name.contains("azure") {
-        assert_eq!(input_tokens, 0);
-        assert_eq!(output_tokens, 0);
-    } else {
-        assert!(input_tokens > 0);
-        assert!(output_tokens > 0);
-    }
+    assert!(input_tokens > 0);
+    assert!(output_tokens > 0);
 
     let inference_id = inference_id.unwrap();
 
@@ -5911,16 +5810,8 @@ pub async fn test_tool_use_tool_choice_auto_unused_streaming_inference_request_w
     let input_tokens = result.get("input_tokens").unwrap();
     let output_tokens = result.get("output_tokens").unwrap();
 
-    // NB: Azure OpenAI Service doesn't support input/output tokens during streaming, but Azure AI Foundry does
-    if provider.variant_name.contains("azure")
-        && !provider.variant_name.contains("azure-ai-foundry")
-    {
-        assert!(input_tokens.is_null());
-        assert!(output_tokens.is_null());
-    } else {
-        assert!(input_tokens.as_u64().unwrap() > 0);
-        assert!(output_tokens.as_u64().unwrap() > 0);
-    }
+    assert!(input_tokens.as_u64().unwrap() > 0);
+    assert!(output_tokens.as_u64().unwrap() > 0);
 
     let response_time_ms = result.get("response_time_ms").unwrap().as_u64().unwrap();
     assert!(response_time_ms > 0);
@@ -6387,36 +6278,16 @@ pub async fn test_tool_use_tool_choice_required_streaming_inference_request_with
         }
 
         if let Some(usage) = chunk_json.get("usage").and_then(|u| u.as_object()) {
-            // Azure OpenAI Service doesn't return usage in streaming, so tokens may be null
-            let is_azure_without_usage = provider.variant_name.contains("azure")
-                && !provider.variant_name.contains("azure-ai-foundry");
-            if is_azure_without_usage {
-                input_tokens += usage
-                    .get("input_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-                output_tokens += usage
-                    .get("output_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-            } else {
-                input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
-                output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
-            }
+            input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
+            output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
         }
     }
 
     assert!(tool_name.is_some());
     assert_eq!(tool_name.as_ref().unwrap(), "get_temperature");
 
-    // NB: Azure doesn't return usage during streaming
-    if provider.variant_name.contains("azure") {
-        assert_eq!(input_tokens, 0);
-        assert_eq!(output_tokens, 0);
-    } else {
-        assert!(input_tokens > 0);
-        assert!(output_tokens > 0);
-    }
+    assert!(input_tokens > 0);
+    assert!(output_tokens > 0);
 
     let inference_id = inference_id.unwrap();
     let tool_id = tool_id.unwrap();
@@ -6578,16 +6449,8 @@ pub async fn test_tool_use_tool_choice_required_streaming_inference_request_with
     let input_tokens = result.get("input_tokens").unwrap().as_u64().unwrap();
     let output_tokens = result.get("output_tokens").unwrap().as_u64().unwrap();
 
-    // NB: Azure OpenAI Service doesn't support input/output tokens during streaming, but Azure AI Foundry does
-    if provider.variant_name.contains("azure")
-        && !provider.variant_name.contains("azure-ai-foundry")
-    {
-        assert_eq!(input_tokens, 0);
-        assert_eq!(output_tokens, 0);
-    } else {
-        assert!(input_tokens > 0);
-        assert!(output_tokens > 0);
-    }
+    assert!(input_tokens > 0);
+    assert!(output_tokens > 0);
 
     let response_time_ms = result.get("response_time_ms").unwrap().as_u64().unwrap();
     assert!(response_time_ms > 0);
@@ -7003,33 +6866,13 @@ pub async fn test_tool_use_tool_choice_none_streaming_inference_request_with_pro
         }
 
         if let Some(usage) = chunk_json.get("usage").and_then(|u| u.as_object()) {
-            // Azure OpenAI Service doesn't return usage in streaming, so tokens may be null
-            let is_azure_without_usage = provider.variant_name.contains("azure")
-                && !provider.variant_name.contains("azure-ai-foundry");
-            if is_azure_without_usage {
-                input_tokens += usage
-                    .get("input_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-                output_tokens += usage
-                    .get("output_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-            } else {
-                input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
-                output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
-            }
+            input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
+            output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
         }
     }
 
-    // NB: Azure doesn't return usage during streaming
-    if provider.variant_name.contains("azure") {
-        assert_eq!(input_tokens, 0);
-        assert_eq!(output_tokens, 0);
-    } else {
-        assert!(input_tokens > 0);
-        assert!(output_tokens > 0);
-    }
+    assert!(input_tokens > 0);
+    assert!(output_tokens > 0);
 
     let inference_id = inference_id.unwrap();
 
@@ -7177,16 +7020,8 @@ pub async fn test_tool_use_tool_choice_none_streaming_inference_request_with_pro
     let input_tokens = result.get("input_tokens").unwrap();
     let output_tokens = result.get("output_tokens").unwrap();
 
-    // NB: Azure OpenAI Service doesn't support input/output tokens during streaming, but Azure AI Foundry does
-    if provider.variant_name.contains("azure")
-        && !provider.variant_name.contains("azure-ai-foundry")
-    {
-        assert!(input_tokens.is_null());
-        assert!(output_tokens.is_null());
-    } else {
-        assert!(input_tokens.as_u64().unwrap() > 0);
-        assert!(output_tokens.as_u64().unwrap() > 0);
-    }
+    assert!(input_tokens.as_u64().unwrap() > 0);
+    assert!(output_tokens.as_u64().unwrap() > 0);
 
     let response_time_ms = result.get("response_time_ms").unwrap().as_u64().unwrap();
     assert!(response_time_ms > 0);
@@ -7719,33 +7554,13 @@ pub async fn test_tool_use_tool_choice_specific_streaming_inference_request_with
         }
 
         if let Some(usage) = chunk_json.get("usage").and_then(|u| u.as_object()) {
-            // Azure OpenAI Service doesn't return usage in streaming, so tokens may be null
-            let is_azure_without_usage = provider.variant_name.contains("azure")
-                && !provider.variant_name.contains("azure-ai-foundry");
-            if is_azure_without_usage {
-                input_tokens += usage
-                    .get("input_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-                output_tokens += usage
-                    .get("output_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-            } else {
-                input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
-                output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
-            }
+            input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
+            output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
         }
     }
 
-    // NB: Azure doesn't return usage during streaming
-    if provider.variant_name.contains("azure") {
-        assert_eq!(input_tokens, 0);
-        assert_eq!(output_tokens, 0);
-    } else {
-        assert!(input_tokens > 0);
-        assert!(output_tokens > 0);
-    }
+    assert!(input_tokens > 0);
+    assert!(output_tokens > 0);
 
     let inference_id = inference_id.unwrap();
     let tool_id = tool_id.unwrap();
@@ -7947,16 +7762,8 @@ pub async fn test_tool_use_tool_choice_specific_streaming_inference_request_with
     let input_tokens = result.get("input_tokens").unwrap();
     let output_tokens = result.get("output_tokens").unwrap();
 
-    // NB: Azure OpenAI Service doesn't support input/output tokens during streaming, but Azure AI Foundry does
-    if provider.variant_name.contains("azure")
-        && !provider.variant_name.contains("azure-ai-foundry")
-    {
-        assert!(input_tokens.is_null());
-        assert!(output_tokens.is_null());
-    } else {
-        assert!(input_tokens.as_u64().unwrap() > 0);
-        assert!(output_tokens.as_u64().unwrap() > 0);
-    }
+    assert!(input_tokens.as_u64().unwrap() > 0);
+    assert!(output_tokens.as_u64().unwrap() > 0);
 
     let response_time_ms = result.get("response_time_ms").unwrap().as_u64().unwrap();
     assert!(response_time_ms > 0);
@@ -8426,32 +8233,14 @@ pub async fn test_tool_use_allowed_tools_streaming_inference_request_with_provid
         }
 
         if let Some(usage) = chunk_json.get("usage").and_then(|u| u.as_object()) {
-            // Azure OpenAI Service doesn't return usage in streaming, so tokens may be null
-            let is_azure_without_usage = provider.variant_name.contains("azure")
-                && !provider.variant_name.contains("azure-ai-foundry");
-            if is_azure_without_usage {
-                input_tokens += usage
-                    .get("input_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-                output_tokens += usage
-                    .get("output_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-            } else {
-                input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
-                output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
-            }
+            input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
+            output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
         }
     }
     assert!(tool_name.is_some());
     assert_eq!(tool_name.as_ref().unwrap(), "get_humidity");
 
-    // NB: Azure doesn't return usage during streaming
-    if provider.variant_name.contains("azure") {
-        assert_eq!(input_tokens, 0);
-        assert_eq!(output_tokens, 0);
-    } else if provider.variant_name.contains("together") {
+    if provider.variant_name.contains("together") {
         // Do nothing: Together is flaky. Sometimes it returns non-zero usage, sometimes it returns zero usage...
     } else {
         assert!(input_tokens > 0);
@@ -8608,13 +8397,7 @@ pub async fn test_tool_use_allowed_tools_streaming_inference_request_with_provid
     let input_tokens = result.get("input_tokens").unwrap();
     let output_tokens = result.get("output_tokens").unwrap();
 
-    // NB: Azure OpenAI Service doesn't support input/output tokens during streaming, but Azure AI Foundry does
-    if provider.variant_name.contains("azure")
-        && !provider.variant_name.contains("azure-ai-foundry")
-    {
-        assert!(input_tokens.is_null());
-        assert!(output_tokens.is_null());
-    } else if provider.variant_name.contains("together") {
+    if provider.variant_name.contains("together") {
         // Do nothing: Together is flaky. Sometimes it returns non-zero usage, sometimes it returns zero usage...
     } else {
         assert!(input_tokens.as_u64().unwrap() > 0);
@@ -9053,38 +8836,16 @@ pub async fn test_tool_multi_turn_streaming_inference_request_with_provider(
         }
 
         if let Some(usage) = chunk_json.get("usage") {
-            // Azure OpenAI Service doesn't return usage in streaming, so tokens may be null
-            let is_azure_without_usage = provider.variant_name.contains("azure")
-                && !provider.variant_name.contains("azure-ai-foundry");
-            if is_azure_without_usage {
-                input_tokens += usage
-                    .get("input_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-                output_tokens += usage
-                    .get("output_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-            } else {
-                input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
-                output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
-            }
+            input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
+            output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
         }
     }
 
     let inference_id = inference_id.unwrap();
     assert!(full_content.to_lowercase().contains("tokyo"));
 
-    // NB: Azure OpenAI Service doesn't support input/output tokens during streaming, but Azure AI Foundry does
-    if provider.variant_name.contains("azure")
-        && !provider.variant_name.contains("azure-ai-foundry")
-    {
-        assert_eq!(input_tokens, 0);
-        assert_eq!(output_tokens, 0);
-    } else {
-        assert!(input_tokens > 0);
-        assert!(output_tokens > 0);
-    }
+    assert!(input_tokens > 0);
+    assert!(output_tokens > 0);
 
     // Sleep to allow time for data to be inserted into ClickHouse (trailing writes from API)
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
@@ -9206,16 +8967,8 @@ pub async fn test_tool_multi_turn_streaming_inference_request_with_provider(
     let input_tokens = result.get("input_tokens").unwrap();
     let output_tokens = result.get("output_tokens").unwrap();
 
-    // NB: Azure OpenAI Service doesn't support input/output tokens during streaming, but Azure AI Foundry does
-    if provider.variant_name.contains("azure")
-        && !provider.variant_name.contains("azure-ai-foundry")
-    {
-        assert!(input_tokens.is_null());
-        assert!(output_tokens.is_null());
-    } else {
-        assert!(input_tokens.as_u64().unwrap() > 0);
-        assert!(output_tokens.as_u64().unwrap() > 0);
-    }
+    assert!(input_tokens.as_u64().unwrap() > 0);
+    assert!(output_tokens.as_u64().unwrap() > 0);
 
     let response_time_ms = result.get("response_time_ms").unwrap().as_u64().unwrap();
     assert!(response_time_ms > 0);
@@ -9864,33 +9617,15 @@ pub async fn test_dynamic_tool_use_streaming_inference_request_with_provider(
         }
 
         if let Some(usage) = chunk_json.get("usage").and_then(|u| u.as_object()) {
-            // Azure OpenAI Service doesn't return usage in streaming, so tokens may be null
-            let is_azure_without_usage = provider.variant_name.contains("azure")
-                && !provider.variant_name.contains("azure-ai-foundry");
-            if is_azure_without_usage {
-                input_tokens += usage
-                    .get("input_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-                output_tokens += usage
-                    .get("output_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-            } else {
-                input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
-                output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
-            }
+            input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
+            output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
         }
     }
 
     assert!(tool_name.is_some());
     assert_eq!(tool_name.as_ref().unwrap(), "get_temperature");
 
-    // NB: Azure doesn't return usage during streaming
-    if provider.variant_name.contains("azure") {
-        assert_eq!(input_tokens, 0);
-        assert_eq!(output_tokens, 0);
-    } else if provider.variant_name.contains("together") {
+    if provider.variant_name.contains("together") {
         // Do nothing: Together is flaky. Sometimes it returns non-zero usage, sometimes it returns zero usage...
     } else {
         assert!(input_tokens > 0);
@@ -10059,13 +9794,7 @@ pub async fn test_dynamic_tool_use_streaming_inference_request_with_provider(
     let input_tokens = result.get("input_tokens").unwrap();
     let output_tokens = result.get("output_tokens").unwrap();
 
-    // NB: Azure OpenAI Service doesn't support input/output tokens during streaming, but Azure AI Foundry does
-    if provider.variant_name.contains("azure")
-        && !provider.variant_name.contains("azure-ai-foundry")
-    {
-        assert!(input_tokens.is_null());
-        assert!(output_tokens.is_null());
-    } else if provider.variant_name.contains("together") {
+    if provider.variant_name.contains("together") {
         // Do nothing: Together is flaky. Sometimes it returns non-zero usage, sometimes it returns zero usage...
     } else {
         assert!(input_tokens.as_u64().unwrap() > 0);
@@ -10613,32 +10342,14 @@ pub async fn test_parallel_tool_use_streaming_inference_request_with_provider(
         }
 
         if let Some(usage) = chunk_json.get("usage").and_then(|u| u.as_object()) {
-            // Azure OpenAI Service doesn't return usage in streaming, so tokens may be null
-            let is_azure_without_usage = provider.variant_name.contains("azure")
-                && !provider.variant_name.contains("azure-ai-foundry");
-            if is_azure_without_usage {
-                input_tokens += usage
-                    .get("input_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-                output_tokens += usage
-                    .get("output_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-            } else {
-                input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
-                output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
-            }
+            input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
+            output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
         }
     }
     assert!(get_temperature_tool_id.is_some());
     assert!(get_humidity_tool_id.is_some());
 
-    // NB: Azure doesn't return usage during streaming
-    if provider.variant_name.contains("azure") {
-        assert_eq!(input_tokens, 0);
-        assert_eq!(output_tokens, 0);
-    } else if provider.variant_name.contains("together") {
+    if provider.variant_name.contains("together") {
         // Do nothing: Together is flaky. Sometimes it returns non-zero usage, sometimes it returns zero usage...
     } else {
         assert!(input_tokens > 0);
@@ -10871,13 +10582,7 @@ pub async fn test_parallel_tool_use_streaming_inference_request_with_provider(
     let input_tokens = result.get("input_tokens").unwrap();
     let output_tokens = result.get("output_tokens").unwrap();
 
-    // NB: Azure OpenAI Service doesn't support input/output tokens during streaming, but Azure AI Foundry does
-    if provider.variant_name.contains("azure")
-        && !provider.variant_name.contains("azure-ai-foundry")
-    {
-        assert!(input_tokens.is_null());
-        assert!(output_tokens.is_null());
-    } else if provider.variant_name.contains("together") {
+    if provider.variant_name.contains("together") {
         // Do nothing: Together is flaky. Sometimes it returns non-zero usage, sometimes it returns zero usage...
     } else {
         assert!(input_tokens.as_u64().unwrap() > 0);
@@ -11534,38 +11239,16 @@ pub async fn test_json_mode_streaming_inference_request_with_provider(provider: 
         }
 
         if let Some(usage) = chunk_json.get("usage") {
-            // Azure OpenAI Service doesn't return usage in streaming, so tokens may be null
-            let is_azure_without_usage = provider.variant_name.contains("azure")
-                && !provider.variant_name.contains("azure-ai-foundry");
-            if is_azure_without_usage {
-                input_tokens += usage
-                    .get("input_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-                output_tokens += usage
-                    .get("output_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-            } else {
-                input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
-                output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
-            }
+            input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
+            output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
         }
     }
 
     let inference_id = inference_id.unwrap();
     assert!(full_content.to_lowercase().contains("tokyo"));
 
-    // NB: Azure OpenAI Service doesn't support input/output tokens during streaming, but Azure AI Foundry does
-    if provider.variant_name.contains("azure")
-        && !provider.variant_name.contains("azure-ai-foundry")
-    {
-        assert_eq!(input_tokens, 0);
-        assert_eq!(output_tokens, 0);
-    } else {
-        assert!(input_tokens > 0);
-        assert!(output_tokens > 0);
-    }
+    assert!(input_tokens > 0);
+    assert!(output_tokens > 0);
 
     // Sleep to allow time for data to be inserted into ClickHouse (trailing writes from API)
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
@@ -11691,16 +11374,8 @@ pub async fn test_json_mode_streaming_inference_request_with_provider(provider: 
     let input_tokens = result.get("input_tokens").unwrap();
     let output_tokens = result.get("output_tokens").unwrap();
 
-    // NB: Azure OpenAI Service doesn't support input/output tokens during streaming, but Azure AI Foundry does
-    if provider.variant_name.contains("azure")
-        && !provider.variant_name.contains("azure-ai-foundry")
-    {
-        assert!(input_tokens.is_null());
-        assert!(output_tokens.is_null());
-    } else {
-        assert!(input_tokens.as_u64().unwrap() > 0);
-        assert!(output_tokens.as_u64().unwrap() > 0);
-    }
+    assert!(input_tokens.as_u64().unwrap() > 0);
+    assert!(output_tokens.as_u64().unwrap() > 0);
 
     let response_time_ms = result.get("response_time_ms").unwrap().as_u64().unwrap();
     assert!(response_time_ms > 0);
@@ -12596,30 +12271,12 @@ pub async fn test_multi_turn_parallel_tool_use_streaming_inference_request_with_
         }
 
         if let Some(usage) = chunk_json.get("usage").and_then(|u| u.as_object()) {
-            // Azure OpenAI Service doesn't return usage in streaming, so tokens may be null
-            let is_azure_without_usage = provider.variant_name.contains("azure")
-                && !provider.variant_name.contains("azure-ai-foundry");
-            if is_azure_without_usage {
-                input_tokens += usage
-                    .get("input_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-                output_tokens += usage
-                    .get("output_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-            } else {
-                input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
-                output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
-            }
+            input_tokens += usage.get("input_tokens").unwrap().as_u64().unwrap();
+            output_tokens += usage.get("output_tokens").unwrap().as_u64().unwrap();
         }
     }
 
-    // NB: Azure doesn't return usage during streaming
-    if provider.variant_name.contains("azure") {
-        assert_eq!(input_tokens, 0);
-        assert_eq!(output_tokens, 0);
-    } else if provider.variant_name.contains("together") {
+    if provider.variant_name.contains("together") {
         // Do nothing: Together is flaky. Sometimes it returns non-zero usage, sometimes it returns zero usage...
     } else {
         assert!(input_tokens > 0);
@@ -12714,13 +12371,7 @@ pub async fn test_multi_turn_parallel_tool_use_streaming_inference_request_with_
     let input_tokens = result.get("input_tokens").unwrap();
     let output_tokens = result.get("output_tokens").unwrap();
 
-    // NB: Azure OpenAI Service doesn't support input/output tokens during streaming, but Azure AI Foundry does
-    if provider.variant_name.contains("azure")
-        && !provider.variant_name.contains("azure-ai-foundry")
-    {
-        assert!(input_tokens.is_null());
-        assert!(output_tokens.is_null());
-    } else if provider.variant_name.contains("together") {
+    if provider.variant_name.contains("together") {
         // Do nothing: Together is flaky. Sometimes it returns non-zero usage, sometimes it returns zero usage...
     } else {
         assert!(input_tokens.as_u64().unwrap() > 0);


### PR DESCRIPTION
In the past, Azure didn't support `stream_options`, so we stripped it. This is no longer true.

This behavior broke `include_raw_usage` for Azure.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `stream_options` to `AzureRequest` to support streaming usage counting in Azure, updating tests accordingly.
> 
>   - **Behavior**:
>     - Adds `stream_options` to `AzureRequest` in `azure.rs` to support streaming usage counting.
>     - Sets `stream_options` to `Some(StreamOptions { include_usage: true })` if `request.stream` is true.
>   - **Tests**:
>     - Updates multiple test functions in `common.rs` to remove Azure-specific conditions that assumed no usage data during streaming.
>     - Ensures `input_tokens` and `output_tokens` are asserted to be greater than 0 for Azure, reflecting the new support for streaming usage counting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for ebc1d394955fe0a59ce0ee77e42d48a1b698445c. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->