### PR TITLE
Bump test_prometheus_metrics_multi_variant threshold again

### DIFF
--- a/gateway/tests/prometheus.rs
+++ b/gateway/tests/prometheus.rs
@@ -305,5 +305,5 @@ model = "dummy::slow"
     // We have observability disabled, so we expect the overhead to be low (even though this is a debug build)
     // Notably, it does *not* include the 5-second sleep in the 'dummy::slow' model
     // This test can be slow on CI, so we give a generous 300ms margin
-    assert!(sum < 0.3, "Unexpectedly high histogram sum: {sum}s");
+    assert!(sum < 0.5, "Unexpectedly high histogram sum: {sum}s");
 }


### PR DESCRIPTION
We saw '0.375932924s' in a /merge-queue run, so let's bump it again. It's unfortunate that we need to make this value higher, but we don't control the performance/noisy-neighbors of Github runners
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase histogram sum threshold in `test_prometheus_metrics_multi_variant` in `prometheus.rs` to 0.5 seconds.
> 
>   - **Tests**:
>     - In `prometheus.rs`, increase threshold for histogram sum in `test_prometheus_metrics_multi_variant` from 0.3 to 0.5 seconds to handle CI variability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 1dee00abfd3e6c1bdb2f5aa7a3e5a2be47148fff. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->