### PR TITLE
Stop making git optional

### DIFF
--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -22,7 +22,7 @@ url = { workspace = true }
 pyo3 = { workspace = true, optional = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
-git2 = { workspace = true, optional = true }
+git2 = { workspace = true }
 mime = { workspace = true }
 tempfile = { version = "3.21.0" }
 paste = { version = "1.0.15", optional = true }
@@ -42,11 +42,9 @@ tracing-subscriber = "0.3.22"
 # Forward this feature to 'tensorzero-core', so that our types will generate
 # the appropriate pyo3 attributes.
 pyo3 = ["dep:pyo3", "tensorzero-core/pyo3"]
-default = ["git"]
 # Forward this feature to 'tensorzero-core', so that our embedded
 # client can recognize things like the `dummy` provider
 e2e_tests = ["tensorzero-core/e2e_tests", "dep:paste"]
-git = ["dep:git2", "tensorzero-core/git"]
 
 # Ignore the `pyo3` crate (used by our own `pyo3` feature above)
 [package.metadata.cargo-machete]

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -110,7 +110,6 @@ pub use tensorzero_optimizers::endpoints::{
 };
 
 // Keep git module for Git-related extension traits
-#[cfg(feature = "git")]
 mod git;
 
 #[cfg(feature = "e2e_tests")]
@@ -120,7 +119,6 @@ pub mod test_helpers;
 #[cfg(feature = "pyo3")]
 pub use tensorzero_core::observability;
 
-#[cfg(feature = "git")]
 use crate::git::GitInfo;
 
 // NOTE(shuyangli): For methods that delegate to APIs in the gateway, the arguments generally are flattened from the request type for
@@ -677,7 +675,6 @@ impl ClientExt for Client {
             .map_err(|e| TensorZeroError::Other { source: e.into() })?;
 
         // Apply the git information to the tags so it gets stored for our workflow evaluation run
-        #[cfg(feature = "git")]
         if let Ok(git_info) = GitInfo::new() {
             params.tags.extend(git_info.into_tags());
         }

--- a/tensorzero-core/Cargo.toml
+++ b/tensorzero-core/Cargo.toml
@@ -13,7 +13,6 @@ exclude = ["tests/", "fixtures/"]
 e2e_tests = ["tensorzero/e2e_tests", "tensorzero-types/e2e_tests"]
 optimization_tests = ["e2e_tests"]
 pyo3 = ["dep:pyo3", "tensorzero-types/pyo3"]
-git = ["dep:git2"]
 
 [[test]]
 name = "e2e"
@@ -128,8 +127,8 @@ urlencoding = "2.1.3"
 http-body = "1.0.1"
 tensorzero-auth = { path = "../internal/tensorzero-auth" }
 autopilot-client = { path = "../internal/autopilot-client" }
-git2 = { workspace = true, optional = true }
 schemars = { workspace = true, features = ["uuid1"] }
+git2 = { workspace = true }
 opentelemetry-http = "0.31.0"
 # durable.workspace = true
 regex = { workspace = true }

--- a/tensorzero-core/src/client/mod.rs
+++ b/tensorzero-core/src/client/mod.rs
@@ -332,7 +332,6 @@ pub enum TensorZeroError {
         source: TensorZeroInternalError,
     },
     RequestTimeout,
-    #[cfg(feature = "git")]
     Git {
         #[source]
         source: git2::Error,
@@ -355,7 +354,6 @@ impl Display for TensorZeroError {
             }
             TensorZeroError::Other { source } => write!(f, "{source}"),
             TensorZeroError::RequestTimeout => write!(f, "HTTP Error: request timed out"),
-            #[cfg(feature = "git")]
             TensorZeroError::Git { source } => write!(f, "Failed to get git info: {source}"),
         }
     }


### PR DESCRIPTION
We don't have an internal need for this to be optional. Making it mandatory streamlines CI (`cargo hack`, etc.).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `git2` dependency mandatory by removing optional status and related feature flags in `Cargo.toml` and source files.
> 
>   - **Dependencies**:
>     - Make `git2` mandatory in `clients/rust/Cargo.toml` and `tensorzero-core/Cargo.toml` by removing `optional = true`.
>     - Remove `git` feature from `features` section in `clients/rust/Cargo.toml` and `tensorzero-core/Cargo.toml`.
>   - **Code Changes**:
>     - Remove `#[cfg(feature = "git")]` conditionals in `src/lib.rs` and `tensorzero-core/src/client/mod.rs`.
>     - Always include `GitInfo` in `workflow_evaluation_run()` in `src/lib.rs`.
>     - Remove `TensorZeroError::Git` variant conditional compilation in `tensorzero-core/src/client/mod.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d5293ac230729b5a56c3776ed918cbf9d1eeaff4. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->