### PR TITLE
Bump to 2026.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot-client"
-version = "2026.1.1"
+version = "2026.1.2"
 dependencies = [
  "chrono",
  "durable-tools-spawn",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-tools"
-version = "2026.1.1"
+version = "2026.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-worker"
-version = "2026.1.1"
+version = "2026.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools"
-version = "2026.1.1"
+version = "2026.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools-spawn"
-version = "2026.1.1"
+version = "2026.1.2"
 dependencies = [
  "async-trait",
  "durable",
@@ -2035,7 +2035,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2026.1.1"
+version = "2026.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2026.1.1"
+version = "2026.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2026.1.1"
+version = "2026.1.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3618,7 +3618,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-utils"
-version = "2026.1.1"
+version = "2026.1.2"
 dependencies = [
  "minijinja",
  "serde",
@@ -4813,7 +4813,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2026.1.1"
+version = "2026.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6152,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2026.1.1"
+version = "2026.1.2"
 dependencies = [
  "axum",
  "chrono",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2026.1.1"
+version = "2026.1.2"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -6289,7 +6289,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2026.1.1"
+version = "2026.1.2"
 dependencies = [
  "evaluations",
  "napi",
@@ -6308,7 +6308,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-optimizers"
-version = "2026.1.1"
+version = "2026.1.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -6341,7 +6341,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2026.1.1"
+version = "2026.1.2"
 dependencies = [
  "evaluations",
  "futures",
@@ -6359,7 +6359,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types"
-version = "2026.1.1"
+version = "2026.1.2"
 dependencies = [
  "aws-smithy-types",
  "chrono",
@@ -6380,7 +6380,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-unsafe-helpers"
-version = "2026.1.1"
+version = "2026.1.2"
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2026.1.1"
+version = "2026.1.2"
 rust-version = "1.88.0"
 license = "Apache-2.0"
 edition = "2024"

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2026.1.1"
+appVersion: "2026.1.2"

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2026.1.1",
+  "version": "2026.1.2",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump version from `2026.1.1` to `2026.1.2` across multiple components including `Cargo.lock`, `Cargo.toml`, `Chart.yaml`, and `package.json`.
> 
>   - **Version Bumps**:
>     - Update version from `2026.1.1` to `2026.1.2` in `Cargo.lock` for packages: `autopilot-client`, `autopilot-tools`, `autopilot-worker`, `durable-tools`, `durable-tools-spawn`, `evaluations`, `feedback-load-test`, `gateway`, `minijinja-utils`, `rate-limit-load-test`, `tensorzero-auth`, `tensorzero-core`, `tensorzero-node`, `tensorzero-optimizers`, `tensorzero-python`, `tensorzero-types`, `tensorzero-unsafe-helpers`.
>     - Update version from `2026.1.1` to `2026.1.2` in `Cargo.toml`.
>     - Update `appVersion` from `2026.1.1` to `2026.1.2` in `Chart.yaml`.
>     - Update version from `2026.1.1` to `2026.1.2` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for 459ab1629455ad6face3c03e3326c4974172de62. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->