### PR TITLE
Add docs on provider prompt caching: Anthropic, AWS Bedrock

### DIFF
--- a/docs/gateway/api-reference/inference-openai-compatible.mdx
+++ b/docs/gateway/api-reference/inference-openai-compatible.mdx
@@ -157,6 +157,7 @@ If you use `tensorzero::extra_body`, it will override the request from the gatew
 Each object in the array must have two or three fields:
 
 - `pointer`: A [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) string specifying where to modify the request body
+  - Use `-` as the final path element to append to an array (e.g., `/messages/-` appends to `messages`)
 - One of the following:
   - `value`: The value to insert at that location; it can be of any type including nested types
   - `delete = true`: Deletes the field at the specified location, if present.

--- a/docs/gateway/api-reference/inference.mdx
+++ b/docs/gateway/api-reference/inference.mdx
@@ -237,6 +237,7 @@ This advanced feature is an "escape hatch" that lets you use provider-specific f
 Each object in the array must have two or three fields:
 
 - `pointer`: A [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) string specifying where to modify the request body
+  - Use `-` as the final path element to append to an array (e.g., `/messages/-` appends to `messages`)
 - One of the following:
   - `value`: The value to insert at that location; it can be of any type including nested types
   - `delete = true`: Deletes the field at the specified location, if present.

--- a/docs/gateway/configuration-reference.mdx
+++ b/docs/gateway/configuration-reference.mdx
@@ -444,6 +444,7 @@ This advanced feature is an "escape hatch" that lets you use provider-specific f
 Each object in the array must have two fields:
 
 - `pointer`: A [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) string specifying where to modify the request body
+  - Use `-` as the final path element to append to an array (e.g., `/messages/-` appends to `messages`)
 - One of the following:
   - `value`: The value to insert at that location; it can be of any type including nested types
   - `delete = true`: Deletes the field at the specified location, if present.
@@ -1774,6 +1775,7 @@ This advanced feature is an "escape hatch" that lets you use provider-specific f
 Each object in the array must have two fields:
 
 - `pointer`: A [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) string specifying where to modify the request body
+  - Use `-` as the final path element to append to an array (e.g., `/messages/-` appends to `messages`)
 - One of the following:
   - `value`: The value to insert at that location; it can be of any type including nested types
   - `delete = true`: Deletes the field at the specified location, if present.
@@ -2685,6 +2687,7 @@ This advanced feature is an "escape hatch" that lets you use provider-specific f
 Each object in the array must have two fields:
 
 - `pointer`: A [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) string specifying where to modify the request body
+  - Use `-` as the final path element to append to an array (e.g., `/messages/-` appends to `messages`)
 - One of the following:
   - `value`: The value to insert at that location; it can be of any type including nested types
   - `delete = true`: Deletes the field at the specified location, if present.
@@ -3390,6 +3393,7 @@ For `experimental_dynamic_in_context_learning` variants, `extra_body` only appli
 Each object in the array must have two fields:
 
 - `pointer`: A [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) string specifying where to modify the request body
+  - Use `-` as the final path element to append to an array (e.g., `/messages/-` appends to `messages`)
 - One of the following:
   - `value`: The value to insert at that location; it can be of any type including nested types
   - `delete = true`: Deletes the field at the specified location, if present.

--- a/docs/gateway/guides/inference-caching.mdx
+++ b/docs/gateway/guides/inference-caching.mdx
@@ -61,3 +61,12 @@ print(response)
 - Inference caching also works for embeddings, using the same cache modes and options as chat completion inference.
   Caching works for single embeddings.
   Batch embedding requests (multiple inputs) will write to the cache but won't serve cached responses.
+
+## Enable prompt caching by model providers
+
+This guide focuses on caching by TensorZero.
+
+Separately, many model providers support some form of caching.
+Some of those are enabled automatically (e.g. OpenAI), whereas others require manual configuration (e.g. Anthropic).
+
+See the guides for [Anthropic](/integrations/model-providers/anthropic) and [AWS Bedrock](/integrations/model-providers/aws-bedrock) to learn more about enabling prompt caching at the model provider level.

--- a/docs/integrations/model-providers/anthropic.mdx
+++ b/docs/integrations/model-providers/anthropic.mdx
@@ -130,6 +130,74 @@ curl -X POST http://localhost:3000/inference \
   }'
 ```
 
+## Enable Anthropic's prompt caching capability
+
+You can enable [Anthropic's prompt caching capability](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) with TensorZero's `extra_body`.
+
+For example, to enable caching on your system prompt:
+
+```bash {14-19}
+curl -X POST "http://localhost:3000/inference" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_name": "anthropic::claude-haiku-4-5",
+    "input": {
+      "system": "... very long prompt ...",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Write a haiku about TensorZero."
+        }
+      ]
+    },
+    "extra_body": [
+        {
+            "pointer": "/system/0/cache_control",
+            "value": {"type": "ephemeral"}
+        }
+    ]
+  }'
+```
+
+Similarly, to enable caching on a message:
+
+```bash {16}
+curl -X POST "http://localhost:3000/inference" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_name": "anthropic::claude-haiku-4-5",
+    "input": {
+      "system": "... very long prompt ...",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Write a haiku about TensorZero."
+        }
+      ]
+    },
+    "extra_body": [
+        {
+            "pointer": "/messages/0/content/0/cache_control",
+            "value": {"type": "ephemeral"}
+        }
+    ]
+  }'
+```
+
+<Tip>
+
+You can specify `extra_body` in the [configuration](/gateway/configuration-reference) or at [inference time](/gateway/api-reference/inference).
+If you're using the OpenAI-Compatible Inference API, use `tensorzero::extra_body` instead.
+
+</Tip>
+
+<Tip>
+
+You can retrieve prompt caching usage information with `include_raw_usage`.
+See the [API Reference](/gateway/api-reference/inference) for more information.
+
+</Tip>
+
 ## Other Features
 
-See [Extending TensorZero](/operations/extend-tensorzero) for information about Anthropic Computer Use and other beta features.
+See [Extend TensorZero](/operations/extend-tensorzero) for information about Anthropic Computer Use and other beta features.

--- a/docs/integrations/model-providers/aws-bedrock.mdx
+++ b/docs/integrations/model-providers/aws-bedrock.mdx
@@ -116,3 +116,92 @@ curl -X POST http://localhost:3000/inference \
     }
   }'
 ```
+
+## Enable AWS Bedrock's prompt caching capability
+
+You can enable [AWS Bedrock's prompt caching capability](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) for supported models with TensorZero's `extra_body`.
+
+For example, to enable caching on your system prompt:
+
+```bash {14-21}
+curl -X POST "http://localhost:3000/inference" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_name": "...",
+    "input": {
+      "system": "... very long prompt ...",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Write a haiku about TensorZero."
+        }
+      ]
+    },
+    "extra_body": [
+        {
+            "pointer": "/system/-",
+            "value": {
+                "cachePoint": {"type": "default"}
+            }
+        }
+    ]
+  }'
+```
+
+<Tip>
+
+The `/abc/-` notation appends a value to the `abc` array.
+
+</Tip>
+
+Similarly, to enable caching on a message:
+
+```bash {16}
+curl -X POST "http://localhost:3000/inference" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_name": "...",
+    "input": {
+      "system": "... very long prompt ...",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Write a haiku about TensorZero."
+        }
+      ]
+    },
+    "extra_body": [
+        {
+            "pointer": "/messages/0/content/-",
+            "value": {
+                "cachePoint": {"type": "default"}
+            }
+        }
+    ]
+  }'
+```
+
+<Tip>
+
+You can specify `extra_body` in the [configuration](/gateway/configuration-reference) or at [inference time](/gateway/api-reference/inference).
+If you're using the OpenAI-Compatible Inference API, use `tensorzero::extra_body` instead.
+
+</Tip>
+
+<Tip>
+
+You can retrieve prompt caching usage information with `include_raw_usage`.
+See the [API Reference](/gateway/api-reference/inference) for more information.
+
+</Tip>
+
+## Other Features
+
+See [Extend TensorZero](/operations/extend-tensorzero) for information about Anthropic Computer Use and other beta features.
+
+<Note>
+
+TensorZero integrates with AWS Bedrock's Converse API.
+To use `extra_body` with AWS Bedrock, the JSON Pointer should match the Converse API specification.
+
+</Note>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add documentation for enabling prompt caching for Anthropic and AWS Bedrock using TensorZero's `extra_body` feature.
> 
>   - **Documentation**:
>     - Adds instructions for enabling prompt caching for Anthropic in `anthropic.mdx` using `extra_body` with examples for system prompts and messages.
>     - Adds instructions for enabling prompt caching for AWS Bedrock in `aws-bedrock.mdx` using `extra_body` with examples for system prompts and messages.
>   - **Guides**:
>     - Updates `inference-caching.mdx` to reference new guides for Anthropic and AWS Bedrock prompt caching.
>   - **API Reference**:
>     - Adds note in `inference-openai-compatible.mdx`, `inference.mdx`, and `configuration-reference.mdx` about using `-` in JSON Pointers to append to arrays.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tensorzero%2Ftensorzero&utm_source=github&utm_medium=referral)<sup> for d4ff53d85f862ad382f5099d727a8b5c4112a1e5. You can [customize](https://app.ellipsis.dev/tensorzero/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

Fix #4525