### PR TITLE
Improve episode detail page error handling

### DIFF
--- a/ui/app/routes/observability/episodes/$episode_id/route.tsx
+++ b/ui/app/routes/observability/episodes/$episode_id/route.tsx
@@ -4,6 +4,7 @@ import { getTensorZeroClient } from "~/utils/tensorzero.server";
 import type { Route } from "./+types/route";
 import {
   data,
+  isRouteErrorResponse,
   useNavigate,
   useParams,
   type RouteHandle,
@@ -434,8 +435,14 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
   const params = useParams<{ episode_id: string }>();
   logger.error(error);
 
-  const message =
-    error instanceof Error ? error.message : "Failed to load episode";
+  let message: string;
+  if (isRouteErrorResponse(error)) {
+    message = error.data ?? `${error.status} ${error.statusText}`;
+  } else if (error instanceof Error) {
+    message = error.message;
+  } else {
+    message = "Failed to load episode";
+  }
 
   return (
     <PageLayout>


### PR DESCRIPTION
## Summary

Improves error handling for the episode detail page by preserving page context (episode_id in header) when errors occur.

## Status: Needs Rebase

This PR's branch is stale and needs to be rebased onto the primitives PR.

## Changes
- ErrorBoundary shows PageHeader with episode_id from route params
- Consistent error UI with PageErrorStack component

## Dependencies
- #5797 (streaming primitives)

## Test Plan
- [ ] Error boundary shows PageHeader with episode_id
- [ ] Visual consistency with other detail page error states