### PR TITLE
Add orange menu highlight styling

### DIFF
--- a/ui/app/components/dataset/use-dataset-options.tsx
+++ b/ui/app/components/dataset/use-dataset-options.tsx
@@ -70,7 +70,10 @@ export function useDatasetOptions({
         return allowCreation ? (
           <TablePlus size={16} className="text-blue-600" />
         ) : (
-          <Table size={16} className="text-fg-muted" />
+          <Table
+            size={16}
+            className="text-fg-muted group-data-[selected=true]:text-menu-highlight-icon"
+          />
         );
       }
       const exists = datasetsByName.has(item);
@@ -80,7 +83,12 @@ export function useDatasetOptions({
       if (isSelected && !exists) {
         return <TablePlus size={16} className="text-blue-600" />;
       }
-      return <Table size={16} className="text-fg-muted" />;
+      return (
+        <Table
+          size={16}
+          className="text-fg-muted group-data-[selected=true]:text-menu-highlight-icon"
+        />
+      );
     },
     [allowCreation, datasetsByName],
   );
@@ -91,7 +99,7 @@ export function useDatasetOptions({
       const dataset = datasetsByName.get(item);
       if (!dataset) return null;
       return (
-        <span className="bg-bg-tertiary text-fg-tertiary shrink-0 rounded px-1.5 py-0.5 font-mono text-xs">
+        <span className="bg-bg-tertiary text-fg-tertiary group-data-[selected=true]:bg-menu-highlight-badge group-data-[selected=true]:text-menu-highlight-badge-foreground shrink-0 rounded px-1.5 py-0.5 font-mono text-xs">
           {formatCompactNumber(dataset.count)}
         </span>
       );

--- a/ui/app/components/function/variant/variant-filter.tsx
+++ b/ui/app/components/function/variant/variant-filter.tsx
@@ -157,7 +157,7 @@ function VariantFilterItem({
   return (
     <ComboboxItem
       focusOnHover
-      className="data-[active-item]:bg-accent data-[active-item]:text-accent-foreground relative flex h-8 cursor-default items-center justify-between gap-2 rounded-sm px-2 py-1.5 select-none data-[active-item]:outline-none"
+      className="data-[active-item]:bg-menu-highlight data-[active-item]:text-menu-highlight-foreground relative flex h-8 cursor-default items-center justify-between gap-2 rounded-sm px-2 py-1.5 select-none data-[active-item]:outline-none"
       value={value}
       onClick={() => onClick?.(value)}
     >

--- a/ui/app/components/ui/command.tsx
+++ b/ui/app/components/ui/command.tsx
@@ -113,7 +113,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "group data-[selected=true]:bg-menu-highlight data-[selected=true]:text-menu-highlight-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       className,
     )}
     {...props}

--- a/ui/app/components/ui/dropdown-menu.tsx
+++ b/ui/app/components/ui/dropdown-menu.tsx
@@ -25,7 +25,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "focus:bg-accent data-[state=open]:bg-accent flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "focus:bg-menu-highlight focus:text-menu-highlight-foreground data-[state=open]:bg-menu-highlight data-[state=open]:text-menu-highlight-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className,
     )}
@@ -80,7 +80,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+      "group focus:bg-menu-highlight focus:text-menu-highlight-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
       inset && "pl-8",
       className,
     )}
@@ -96,7 +96,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50",
+      "focus:bg-menu-highlight focus:text-menu-highlight-foreground relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50",
       className,
     )}
     checked={checked}
@@ -120,7 +120,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50",
+      "focus:bg-menu-highlight focus:text-menu-highlight-foreground relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50",
       className,
     )}
     {...props}

--- a/ui/app/components/ui/select.tsx
+++ b/ui/app/components/ui/select.tsx
@@ -116,7 +116,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default items-center rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50",
+      "group focus:bg-menu-highlight focus:text-menu-highlight-foreground relative flex w-full cursor-default items-center rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50",
       className,
     )}
     {...props}

--- a/ui/app/tailwind.css
+++ b/ui/app/tailwind.css
@@ -138,6 +138,26 @@
   --color-purple-800: hsl(var(--purple-800));
   --color-purple-900: hsl(var(--purple-900));
 
+  --color-orange-50: hsl(var(--orange-50));
+  --color-orange-100: hsl(var(--orange-100));
+  --color-orange-200: hsl(var(--orange-200));
+  --color-orange-300: hsl(var(--orange-300));
+  --color-orange-400: hsl(var(--orange-400));
+  --color-orange-500: hsl(var(--orange-500));
+  --color-orange-600: hsl(var(--orange-600));
+  --color-orange-700: hsl(var(--orange-700));
+  --color-orange-800: hsl(var(--orange-800));
+  --color-orange-900: hsl(var(--orange-900));
+  --color-orange-950: hsl(var(--orange-950));
+
+  --color-menu-highlight: hsl(var(--menu-highlight));
+  --color-menu-highlight-foreground: hsl(var(--menu-highlight-foreground));
+  --color-menu-highlight-icon: hsl(var(--menu-highlight-icon));
+  --color-menu-highlight-badge: hsl(var(--menu-highlight-badge));
+  --color-menu-highlight-badge-foreground: hsl(
+    var(--menu-highlight-badge-foreground)
+  );
+
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
 
@@ -298,6 +318,25 @@
     --purple-700: 260 72% 36%;
     --purple-800: 260 80% 24%;
     --purple-900: 260 88% 16%;
+
+    --orange-50: 32 100% 96%;
+    --orange-100: 34 100% 91%;
+    --orange-200: 31 100% 82%;
+    --orange-300: 30 100% 71%;
+    --orange-400: 26 100% 60%;
+    --orange-500: 23 100% 52%;
+    --orange-600: 19 100% 50%;
+    --orange-700: 15 98% 40%;
+    --orange-800: 13 87% 34%;
+    --orange-900: 13 83% 28%;
+    --orange-950: 11 89% 15%;
+
+    /* Menu highlight colors */
+    --menu-highlight: var(--orange-50);
+    --menu-highlight-foreground: var(--orange-900);
+    --menu-highlight-icon: var(--orange-800);
+    --menu-highlight-badge: var(--orange-100);
+    --menu-highlight-badge-foreground: var(--orange-800);
   }
 
   .dark {
@@ -339,6 +378,13 @@
     --sidebar-accent-foreground: 240 4.8% 95.9%;
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 217.2 91.2% 59.8%;
+
+    /* Menu highlight colors (dark mode) */
+    --menu-highlight: var(--orange-900);
+    --menu-highlight-foreground: var(--orange-100);
+    --menu-highlight-icon: var(--orange-200);
+    --menu-highlight-badge: var(--orange-800);
+    --menu-highlight-badge-foreground: var(--orange-200);
   }
 }
 


### PR DESCRIPTION
## Summary
- Add orange color scale CSS variables (`--orange-50` through `--orange-950`)
- Add semantic menu highlight variables for systematic theming:
  - `--menu-highlight` - item background
  - `--menu-highlight-foreground` - item text
  - `--menu-highlight-icon` - icon color when selected
  - `--menu-highlight-badge` - badge background when selected
  - `--menu-highlight-badge-foreground` - badge text when selected
- Update menu components to use new menu-highlight colors:
  - `CommandItem`, `DropdownMenuItem`, `DropdownMenuSubTrigger`, `DropdownMenuCheckboxItem`, `DropdownMenuRadioItem`, `SelectItem`
  - `VariantFilterItem` (ariakit combobox in playground)
- Add `group` class to menu items for child element styling via `group-data-[selected=true]:` variants
- Update DatasetCombobox prefix icons and suffix badges to use semantic vars

<img width="633" height="459" alt="Screenshot 2026-01-15 at 3 58 41 PM" src="https://github.com/user-attachments/assets/799c5f66-d452-4666-8e3f-fa18cdab7a97" />

### Color values (consistent 100-unit step pattern)
| Variable | Light | Dark |
|----------|-------|------|
| `menu-highlight` | orange-50 | orange-900 |
| `menu-highlight-foreground` | orange-900 | orange-100 |
| `menu-highlight-icon` | orange-800 | orange-200 |
| `menu-highlight-badge` | orange-100 | orange-800 |
| `menu-highlight-badge-foreground` | orange-800 | orange-200 |

## Test plan
- [ ] Visual inspection of menu highlight in light mode
- [ ] Visual inspection of menu highlight in dark mode
- [ ] Test CommandItem selection styling (Combobox)
- [ ] Test DropdownMenu item focus styling
- [ ] Test Select item focus styling
- [ ] Test VariantFilter in playground page
- [ ] Verify prefix icons change color when selected
- [ ] Verify suffix count badges change color when selected

**Status: WIP** - awaiting visual review and feedback