### PR TITLE
Update GEPA Thought Block Validation to Include Signature Field

### DIFF
--- a/tensorzero-optimizers/src/gepa/validate.rs
+++ b/tensorzero-optimizers/src/gepa/validate.rs
@@ -192,11 +192,15 @@ fn validate_stored_output(stored_output: Option<&StoredOutput>) -> Result<(), St
                     }
                 }
                 // Check Thought block
+                // Destructure to cause compile error if new fields are added to Thought
                 ContentBlockChatOutput::Thought(thought) => {
-                    if thought.text.is_none()
-                        && thought.signature.is_none()
-                        && thought.summary.is_none()
-                    {
+                    let tensorzero_core::inference::types::Thought {
+                        text,
+                        signature,
+                        summary,
+                        provider_type: _,
+                    } = thought;
+                    if text.is_none() && signature.is_none() && summary.is_none() {
                         return Err(format!(
                             "stored_output[{content_idx}] Thought block has text, signature, and summary all as None"
                         ));
@@ -251,11 +255,15 @@ fn validate_stored_input_messages(
                     }
                 }
                 // Check Thought block
+                // Destructure to cause compile error if new fields are added to Thought
                 StoredInputMessageContent::Thought(thought) => {
-                    if thought.text.is_none()
-                        && thought.signature.is_none()
-                        && thought.summary.is_none()
-                    {
+                    let tensorzero_core::inference::types::Thought {
+                        text,
+                        signature,
+                        summary,
+                        provider_type: _,
+                    } = thought;
+                    if text.is_none() && signature.is_none() && summary.is_none() {
                         return Err(format!(
                             "stored_input.messages[{msg_idx}].content[{content_idx}] Thought block has text, signature, and summary all as None"
                         ));


### PR DESCRIPTION
Updates the GEPA example validation logic to check all three fields (`text`, `signature`, `summary`) of `Thought` blocks instead of just `text` and `summary`. Examples are now only dropped if ALL THREE fields are `None`.

This allows GEPA to work with encrypted thinking responses that only contain a `signature` field.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts GEPA example validation to consider `Thought.signature`, enabling encrypted-thinking responses where only `signature` is present.
> 
> - Update validation in `validate.rs` for both `stored_output` and `stored_input.messages` to reject `Thought` only when `text`, `signature`, and `summary` are all `None`
> - Destructure `Thought` fields to trigger compile errors if the struct changes
> - Refresh doc comments and error messages accordingly
> - Add/rename unit tests: cases for all-none invalid and signature-only valid for both stored output and input
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de43359cb3d499daa06d0d5ca210bc8ba33e63c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->