### PR TITLE
Revert "Add Google Tag Manager (#5621)"

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -12,11 +12,6 @@
   "contextual": {
     "options": ["copy", "view", "chatgpt", "claude"]
   },
-  "integrations": {
-    "gtm": {
-      "tagId": "GTM-M57LVZ4N"
-    }
-  },
   "navigation": {
     "tabs": [
       {


### PR DESCRIPTION
This reverts commit 8f39bbf38850457d67519dc542fa0be58f43b14f.

We're not going to use it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes Google Tag Manager integration from the docs configuration.
> 
> - Deletes the `integrations.gtm.tagId` block from `docs/docs.json`
> - No other documentation structure or settings changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07a19725d86e95b80ebd0c504fdd91f1f3b3c970. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->