### PR TITLE
Remove a bunch of unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,6 @@ dependencies = [
  "sqlx",
  "tensorzero-types",
  "thiserror 2.0.17",
- "tracing",
  "ts-rs",
  "url",
  "uuid",
@@ -370,11 +369,9 @@ dependencies = [
  "tensorzero",
  "tensorzero-core",
  "tensorzero-optimizers",
- "thiserror 2.0.17",
  "tokio",
  "tokio-util",
  "tracing",
- "url",
  "uuid",
 ]
 
@@ -1873,7 +1870,6 @@ dependencies = [
  "durable-tools-spawn",
  "evaluations",
  "mockall",
- "moka",
  "schemars 1.2.0",
  "secrecy",
  "serde",
@@ -1884,7 +1880,6 @@ dependencies = [
  "tensorzero-optimizers",
  "thiserror 2.0.17",
  "tokio",
- "tokio-util",
  "url",
  "uuid",
 ]
@@ -1900,7 +1895,6 @@ dependencies = [
  "serde_json",
  "sqlx",
  "thiserror 2.0.17",
- "tokio",
  "uuid",
 ]
 
@@ -2002,17 +1996,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "erased-serde"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e8918065695684b2b0702da20382d5ae6065cf3327bc2d6436bd49a71ce9f3"
-dependencies = [
- "serde",
- "serde_core",
- "typeid",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,13 +2023,10 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
- "durable",
  "futures",
  "indicatif",
- "rand 0.9.2",
  "serde",
  "serde_json",
- "sqlx",
  "tensorzero-core",
  "tokio",
  "tokio-util",
@@ -2389,13 +2369,10 @@ dependencies = [
 name = "gateway"
 version = "2026.1.2"
 dependencies = [
- "anyhow",
  "async-stream",
- "async-trait",
  "autopilot-worker",
  "axum",
  "brotli",
- "chrono",
  "clap",
  "durable-tools",
  "evaluations",
@@ -2421,7 +2398,6 @@ dependencies = [
  "tower-http",
  "tracing",
  "ts-rs",
- "url",
  "uuid",
  "zstd",
 ]
@@ -5433,18 +5409,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-untagged"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
-dependencies = [
- "erased-serde",
- "serde",
- "serde_core",
- "typeid",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6245,7 +6209,6 @@ dependencies = [
  "schemars 1.2.0",
  "secrecy",
  "serde",
- "serde-untagged",
  "serde_json",
  "serde_path_to_error",
  "sha2",
@@ -6292,19 +6255,13 @@ dependencies = [
 name = "tensorzero-node"
 version = "2026.1.2"
 dependencies = [
- "evaluations",
  "napi",
  "napi-build",
  "napi-derive",
  "secrecy",
- "serde",
  "serde_json",
- "tensorzero",
  "tensorzero-auth",
  "tensorzero-core",
- "ts-rs",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -6363,7 +6320,6 @@ name = "tensorzero-types"
 version = "2026.1.2"
 dependencies = [
  "aws-smithy-types",
- "chrono",
  "infer",
  "mime 0.4.0-a.0",
  "object_store",
@@ -6376,7 +6332,6 @@ dependencies = [
  "tracing",
  "ts-rs",
  "url",
- "uuid",
 ]
 
 [[package]]
@@ -6947,12 +6902,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
-
-[[package]]
-name = "typeid"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ minijinja = { version = "2.14.0", features = [
 ] }
 url = { version = "2.5.8", features = ["serde"] }
 google-cloud-auth = "1.3.0"
-serde-untagged = "0.1.8"
 object_store = { version = "0.13.0", features = ["serde", "aws", "gcp"] }
 rand = "0.9.1"
 ts-rs = { version = "11.1.0", features = [

--- a/evaluations/Cargo.toml
+++ b/evaluations/Cargo.toml
@@ -25,9 +25,6 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 futures = { workspace = true }
 indicatif = "0.18.2"
-durable = { workspace = true }
-rand = { workspace = true }
-sqlx.workspace = true
 
 [dev-dependencies]
 tensorzero-core = { path = "../tensorzero-core", features = ["e2e_tests"] }

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -9,7 +9,6 @@ license.workspace = true
 tensorzero-core = { path = "../tensorzero-core" }
 tensorzero-optimizers = { path = "../tensorzero-optimizers" }
 evaluations = { path = "../evaluations" }
-async-trait = { workspace = true }
 axum = { workspace = true }
 tracing = { version = "0.1.43", features = ["log", "release_max_level_debug"] }
 tokio = { workspace = true }
@@ -28,10 +27,7 @@ secrecy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
-anyhow = { workspace = true }
-chrono = { workspace = true }
 ts-rs = { workspace = true }
-url = { workspace = true }
 async-stream = { workspace = true }
 
 [lints]

--- a/internal/autopilot-client/Cargo.toml
+++ b/internal/autopilot-client/Cargo.toml
@@ -18,7 +18,6 @@ serde_json.workspace = true
 sqlx.workspace = true
 schemars.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
 ts-rs.workspace = true
 url.workspace = true
 uuid.workspace = true

--- a/internal/autopilot-worker/Cargo.toml
+++ b/internal/autopilot-worker/Cargo.toml
@@ -29,10 +29,8 @@ sqlx = { workspace = true }
 
 # Utilities
 anyhow.workspace = true
-thiserror.workspace = true
 uuid.workspace = true
 tracing.workspace = true
-url.workspace = true
 schemars.workspace = true
 
 [dev-dependencies]

--- a/internal/durable-tools-spawn/Cargo.toml
+++ b/internal/durable-tools-spawn/Cargo.toml
@@ -9,7 +9,6 @@ workspace = true
 
 [dependencies]
 durable.workspace = true
-tokio.workspace = true
 async-trait = "0.1"
 serde.workspace = true
 serde_json.workspace = true

--- a/internal/durable-tools/Cargo.toml
+++ b/internal/durable-tools/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 durable-tools-spawn.workspace = true
 durable.workspace = true
 tokio.workspace = true
-tokio-util = "0.7"
 async-trait = "0.1"
 serde.workspace = true
 serde_json.workspace = true
@@ -25,7 +24,6 @@ chrono.workspace = true
 tensorzero.workspace = true
 url = "2"
 secrecy.workspace = true
-moka.workspace = true
 
 tensorzero-core.workspace = true
 evaluations = { path = "../../evaluations" }

--- a/internal/tensorzero-node/Cargo.toml
+++ b/internal/tensorzero-node/Cargo.toml
@@ -15,16 +15,10 @@ napi = { version = "2.12.2", default-features = false, features = [
     "tokio_rt",
 ] }
 napi-derive = "2.12.2"
-serde.workspace = true
 serde_json.workspace = true
-url.workspace = true
-uuid.workspace = true
 secrecy.workspace = true
-tensorzero = { path = "../../clients/rust" }
 tensorzero-core = { path = "../../tensorzero-core" }
 tensorzero-auth = { path = "../../internal/tensorzero-auth" }
-evaluations = { path = "../../evaluations" }
-ts-rs = { workspace = true }
 
 [build-dependencies]
 napi-build = "2.3.0"

--- a/internal/tensorzero-types/Cargo.toml
+++ b/internal/tensorzero-types/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 
 [dependencies]
 aws-smithy-types = { version = "1.3.3", features = ["byte-stream-poll-next"] }
-chrono.workspace = true
 infer.workspace = true
 mime.workspace = true
 object_store.workspace = true
@@ -19,7 +18,6 @@ thiserror.workspace = true
 tracing.workspace = true
 ts-rs.workspace = true
 url = { workspace = true, features = ["serde"] }
-uuid.workspace = true
 
 [features]
 default = []

--- a/tensorzero-core/Cargo.toml
+++ b/tensorzero-core/Cargo.toml
@@ -63,7 +63,6 @@ reqwest = { workspace = true }
 reqwest-eventsource = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true }
-serde-untagged = { workspace = true }
 serde_json = { workspace = true }
 http = { workspace = true }
 serde_path_to_error = { workspace = true }


### PR DESCRIPTION
This should slightly speed up a clean build, since more crates can now be compiled in parallel

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes unused dependencies across the workspace to shrink the build graph and speed up clean builds.
> 
> - Drops unused crates from multiple packages (`gateway`, `evaluations`, `durable-tools*`, `autopilot-*`, `tensorzero-node`, `tensorzero-types`, `tensorzero-core`), including `serde-untagged`, `moka`, `tokio-util`, `anyhow`, `tracing`, `chrono`, `url`, `uuid`, `thiserror` where not needed
> - Eliminates workspace `serde-untagged` and transitive `erased-serde`/`typeid`; prunes related entries from `Cargo.lock`
> - No functional code changes; only `Cargo.toml` and lockfile updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41328c15f8e9882fffb0806cf7b8af046b8e5498. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->