### PR TITLE
use mocks properly for testing durable-tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,7 @@ dependencies = [
  "autopilot-client",
  "chrono",
  "durable",
+ "durable-tools",
  "durable-tools-spawn",
  "evaluations",
  "mockall",

--- a/internal/durable-tools/Cargo.toml
+++ b/internal/durable-tools/Cargo.toml
@@ -7,7 +7,11 @@ license.workspace = true
 [lints]
 workspace = true
 
+[features]
+test-support = ["dep:mockall"]
+
 [dependencies]
+mockall = { version = "0.14", optional = true }
 durable-tools-spawn.workspace = true
 durable.workspace = true
 tokio.workspace = true
@@ -31,3 +35,4 @@ tensorzero-optimizers = { path = "../../tensorzero-optimizers" }
 
 [dev-dependencies]
 mockall = "0.14"
+durable-tools = { path = ".", features = ["test-support"] }

--- a/internal/durable-tools/src/lib.rs
+++ b/internal/durable-tools/src/lib.rs
@@ -199,6 +199,10 @@ pub use tensorzero_client::{
     http_gateway_client,
 };
 
+// Re-export mock for testing
+#[cfg(any(test, feature = "test-support"))]
+pub use tensorzero_client::MockTensorZeroClient;
+
 // Re-export autopilot types for use by tools
 pub use tensorzero_client::{
     CreateEventGatewayRequest, CreateEventResponse, EventPayload, ListEventsParams,

--- a/internal/durable-tools/src/tensorzero_client/mod.rs
+++ b/internal/durable-tools/src/tensorzero_client/mod.rs
@@ -42,7 +42,7 @@ pub use autopilot_client::{
 };
 pub use tensorzero_core::endpoints::internal::autopilot::CreateEventGatewayRequest;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 use mockall::automock;
 
 /// Error type for TensorZero client operations.
@@ -139,7 +139,7 @@ pub struct RunEvaluationResponse {
 /// call inference and autopilot operations without directly depending on
 /// the concrete client type.
 #[async_trait]
-#[cfg_attr(test, automock)]
+#[cfg_attr(any(test, feature = "test-support"), automock)]
 pub trait TensorZeroClient: Send + Sync + 'static {
     /// Run inference with the given parameters.
     ///


### PR DESCRIPTION
Rip the manual implementation of mocking in `durable-tools` for a more ergonomic `automock` client downstream users can import with feature `test-support` for testing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a first-class, feature-gated mock for the TensorZero client and updates tests accordingly.
> 
> - Introduces `test-support` feature in `durable-tools` with optional `mockall`; enables via dev-dependency
> - Applies `#[cfg_attr(any(test, feature = "test-support"), automock)]` to `TensorZeroClient` and re-exports `MockTensorZeroClient`
> - Refactors integration tests to use the generated mock with expectation helpers (`mock_client_error_on_call`, `mock_client_with_response`), removing the previous manual mock implementation
> - Minor import/CFG adjustments to support mocking in both test and feature-enabled builds
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf8d4909e93acd8310b9a33a56a7d1d3671016c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->