### PR TITLE
Refactor RateLimitQueries to replace Pg-specific type

### DIFF
--- a/tensorzero-core/src/db/rate_limiting.rs
+++ b/tensorzero-core/src/db/rate_limiting.rs
@@ -4,8 +4,7 @@ use async_trait::async_trait;
 use mockall::automock;
 
 use crate::error::Error;
-use crate::rate_limiting::ActiveRateLimitKey;
-use sqlx::postgres::types::PgInterval;
+use crate::rate_limiting::{ActiveRateLimitKey, RateLimitInterval};
 
 #[async_trait]
 #[cfg_attr(test, automock)]
@@ -27,7 +26,7 @@ pub trait RateLimitQueries: Send + Sync {
         key: &str,
         capacity: u64,
         refill_amount: u64,
-        refill_interval: PgInterval,
+        refill_interval: RateLimitInterval,
     ) -> Result<u64, Error>;
 }
 
@@ -37,7 +36,7 @@ pub struct ConsumeTicketsRequest {
     pub requested: u64,
     pub capacity: u64,
     pub refill_amount: u64,
-    pub refill_interval: PgInterval,
+    pub refill_interval: RateLimitInterval,
 }
 
 #[derive(Debug)]
@@ -53,7 +52,7 @@ pub struct ReturnTicketsRequest {
     pub returned: u64,
     pub capacity: u64,
     pub refill_amount: u64,
-    pub refill_interval: PgInterval,
+    pub refill_interval: RateLimitInterval,
 }
 
 pub struct ReturnTicketsReceipt {

--- a/tensorzero-core/tests/load/rate-limit-load-test/src/benchmark.rs
+++ b/tensorzero-core/tests/load/rate-limit-load-test/src/benchmark.rs
@@ -4,10 +4,9 @@ use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use rlt::{BenchSuite, IterInfo, IterReport, Status};
 use sqlx::PgPool;
-use sqlx::postgres::types::PgInterval;
 use tensorzero_core::{
     db::{ConsumeTicketsRequest, RateLimitQueries, postgres::PostgresConnectionInfo},
-    rate_limiting::ActiveRateLimitKey,
+    rate_limiting::{ActiveRateLimitKey, RateLimitInterval},
 };
 use tokio::time::Instant;
 
@@ -50,7 +49,7 @@ impl Contention {
 pub struct BucketSettings {
     pub capacity: i64,
     pub refill_amount: i64,
-    pub interval: PgInterval,
+    pub interval: RateLimitInterval,
 }
 
 #[derive(Clone)]
@@ -164,10 +163,6 @@ pub fn create_bucket_settings(capacity: i64, refill_amount: i64) -> BucketSettin
     BucketSettings {
         capacity,
         refill_amount,
-        interval: PgInterval {
-            months: 0,
-            days: 0,
-            microseconds: 1_000_000, // 1 second
-        },
+        interval: RateLimitInterval::Second,
     }
 }


### PR DESCRIPTION
A step towards #5623. We are allowing Valkey-backed rate limiting so we should remove Postgres-specific mentions from rate limiting implementation.

Should be a clean refactor.

https://github.com/tensorzero/agentic-design-docs/blob/main/redis-rate-limiting/plan.md for design.