### PR TITLE
Update the Hyperbolic model

### DIFF
--- a/docs/gateway/configuration-reference.mdx
+++ b/docs/gateway/configuration-reference.mdx
@@ -1409,7 +1409,7 @@ This field can be either a string for a single credential location, or an object
 The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
-[models."meta-llama/Meta-Llama-3-70B-Instruct".providers.hyperbolic]
+[models."openai/gpt-oss-20b".providers.hyperbolic]
 # ...
 type = "hyperbolic"
 api_key_location = "dynamic::hyperbolic_api_key"
@@ -1428,10 +1428,10 @@ Defines the model name to use with the Hyperbolic API.
 See [Hyperbolic's documentation](https://app.hyperbolic.xyz/models) for the list of available model names.
 
 ```toml title="tensorzero.toml"
-[models."meta-llama/Meta-Llama-3-70B-Instruct".providers.hyperbolic]
+[models."openai/gpt-oss-20b".providers.hyperbolic]
 # ...
 type = "hyperbolic"
-model_name = "meta-llama/Meta-Llama-3-70B-Instruct"
+model_name = "openai/gpt-oss-20b"
 # ...
 ```
 

--- a/docs/integrations/model-providers/hyperbolic.mdx
+++ b/docs/integrations/model-providers/hyperbolic.mdx
@@ -16,7 +16,7 @@ For example:
 ```toml {3}
 [functions.my_function_name.variants.my_variant_name]
 type = "chat_completion"
-model = "hyperbolic::meta-llama/Meta-Llama-3-70B-Instruct"
+model = "hyperbolic::openai/gpt-oss-20b"
 ```
 
 Additionally, you can set `model_name` in the inference request to use a specific Hyperbolic model, without having to configure a function and variant in TensorZero.
@@ -25,7 +25,7 @@ Additionally, you can set `model_name` in the inference request to use a specifi
 curl -X POST http://localhost:3000/inference \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "hyperbolic::meta-llama/Meta-Llama-3-70B-Instruct",
+    "model_name": "hyperbolic::openai/gpt-oss-20b",
     "input": {
       "messages": [
         {
@@ -61,19 +61,19 @@ For production deployments, see our [Deployment Guide](/deployment/tensorzero-ga
 Create a minimal configuration file that defines a model and a simple chat function:
 
 ```toml title="config/tensorzero.toml"
-[models."meta-llama/Meta-Llama-3-70B-Instruct"]
+[models."openai/gpt-oss-20b"]
 routing = ["hyperbolic"]
 
-[models."meta-llama/Meta-Llama-3-70B-Instruct".providers.hyperbolic]
+[models."openai/gpt-oss-20b".providers.hyperbolic]
 type = "hyperbolic"
-model_name = "meta-llama/Meta-Llama-3-70B-Instruct"
+model_name = "openai/gpt-oss-20b"
 
 [functions.my_function_name]
 type = "chat"
 
 [functions.my_function_name.variants.my_variant_name]
 type = "chat_completion"
-model = "meta-llama/Meta-Llama-3-70B-Instruct"
+model = "openai/gpt-oss-20b"
 ```
 
 See the [list of models available on Hyperbolic](https://app.hyperbolic.xyz/models).

--- a/examples/guides/providers/hyperbolic/config/tensorzero.toml
+++ b/examples/guides/providers/hyperbolic/config/tensorzero.toml
@@ -1,13 +1,13 @@
-[models."meta-llama/Meta-Llama-3-70B-Instruct"]
+[models."openai/gpt-oss-20b"]
 routing = ["hyperbolic"]
 
-[models."meta-llama/Meta-Llama-3-70B-Instruct".providers.hyperbolic]
+[models."openai/gpt-oss-20b".providers.hyperbolic]
 type = "hyperbolic"
-model_name = "meta-llama/Meta-Llama-3-70B-Instruct"
+model_name = "openai/gpt-oss-20b"
 
 [functions.my_function_name]
 type = "chat"
 
 [functions.my_function_name.variants.my_variant_name]
 type = "chat_completion"
-model = "meta-llama/Meta-Llama-3-70B-Instruct"
+model = "openai/gpt-oss-20b"

--- a/tensorzero-core/src/providers/hyperbolic.rs
+++ b/tensorzero-core/src/providers/hyperbolic.rs
@@ -560,10 +560,9 @@ mod tests {
             ..Default::default()
         };
 
-        let hyperbolic_request =
-            HyperbolicRequest::new("meta-llama/Meta-Llama-3-70B-Instruct", &request_with_tools)
-                .await
-                .expect("failed to create Hyperbolic Request during test");
+        let hyperbolic_request = HyperbolicRequest::new("openai/gpt-oss-20b", &request_with_tools)
+            .await
+            .expect("failed to create Hyperbolic Request during test");
 
         assert_eq!(hyperbolic_request.messages.len(), 1);
         assert_eq!(hyperbolic_request.temperature, Some(0.5));

--- a/tensorzero-core/tests/e2e/config/tensorzero.functions.basic_test.toml
+++ b/tensorzero-core/tests/e2e/config/tensorzero.functions.basic_test.toml
@@ -693,20 +693,20 @@ max_tokens = 800
 
 [functions.basic_test.variants.hyperbolic]
 type = "chat_completion"
-model = "meta-llama/Meta-Llama-3-70B-Instruct"
+model = "openai/gpt-oss-20b"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 
 [functions.basic_test.variants.hyperbolic-extra-body]
 type = "chat_completion"
-model = "meta-llama/Meta-Llama-3-70B-Instruct"
+model = "openai/gpt-oss-20b"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 extra_body = [{ pointer = "/temperature", value = 0.123 }]
 
 [functions.basic_test.variants.hyperbolic-extra-headers]
 type = "chat_completion"
-model = "meta-llama/Meta-Llama-3-70B-Instruct"
+model = "openai/gpt-oss-20b"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 extra_headers = [
@@ -715,13 +715,13 @@ extra_headers = [
 
 [functions.basic_test.variants.hyperbolic-dynamic]
 type = "chat_completion"
-model = "meta-llama/Meta-Llama-3-70B-Instruct-dynamic"
+model = "openai/gpt-oss-20b-dynamic"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 
 [functions.basic_test.variants.hyperbolic-shorthand]
 type = "chat_completion"
-model = "hyperbolic::meta-llama/Meta-Llama-3-70B-Instruct"
+model = "hyperbolic::openai/gpt-oss-20b"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 

--- a/tensorzero-core/tests/e2e/config/tensorzero.models.toml
+++ b/tensorzero-core/tests/e2e/config/tensorzero.models.toml
@@ -499,19 +499,19 @@ routing = ["xai"]
 type = "xai"
 model_name = "grok-4-fast-reasoning"
 
-[models."meta-llama/Meta-Llama-3-70B-Instruct"]
+[models."openai/gpt-oss-20b"]
 routing = ["hyperbolic"]
 
-[models."meta-llama/Meta-Llama-3-70B-Instruct".providers.hyperbolic]
+[models."openai/gpt-oss-20b".providers.hyperbolic]
 type = "hyperbolic"
-model_name = "meta-llama/Meta-Llama-3-70B-Instruct"
+model_name = "openai/gpt-oss-20b"
 
-[models."meta-llama/Meta-Llama-3-70B-Instruct-dynamic"]
+[models."openai/gpt-oss-20b-dynamic"]
 routing = ["hyperbolic"]
 
-[models."meta-llama/Meta-Llama-3-70B-Instruct-dynamic".providers.hyperbolic]
+[models."openai/gpt-oss-20b-dynamic".providers.hyperbolic]
 type = "hyperbolic"
-model_name = "meta-llama/Meta-Llama-3-70B-Instruct"
+model_name = "openai/gpt-oss-20b"
 api_key_location = "dynamic::hyperbolic_api_key"
 
 [models."deepseek-chat"]

--- a/tensorzero-core/tests/e2e/providers/hyperbolic.rs
+++ b/tensorzero-core/tests/e2e/providers/hyperbolic.rs
@@ -14,7 +14,7 @@ async fn get_providers() -> E2ETestProviders {
     let standard_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "hyperbolic".to_string(),
-        model_name: "meta-llama/Meta-Llama-3-70B-Instruct".into(),
+        model_name: "openai/gpt-oss-20b".into(),
         model_provider_name: "hyperbolic".into(),
         credentials: HashMap::new(),
     }];
@@ -22,7 +22,7 @@ async fn get_providers() -> E2ETestProviders {
     let extra_body_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "hyperbolic-extra-body".to_string(),
-        model_name: "meta-llama/Meta-Llama-3-70B-Instruct".into(),
+        model_name: "openai/gpt-oss-20b".into(),
         model_provider_name: "hyperbolic".into(),
         credentials: HashMap::new(),
     }];
@@ -30,7 +30,7 @@ async fn get_providers() -> E2ETestProviders {
     let bad_auth_extra_headers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "hyperbolic-extra-headers".to_string(),
-        model_name: "meta-llama/Meta-Llama-3-70B-Instruct".into(),
+        model_name: "openai/gpt-oss-20b".into(),
         model_provider_name: "hyperbolic".into(),
         credentials: HashMap::new(),
     }];
@@ -38,7 +38,7 @@ async fn get_providers() -> E2ETestProviders {
     let inference_params_dynamic_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "hyperbolic-dynamic".to_string(),
-        model_name: "meta-llama/Meta-Llama-3-70B-Instruct-dynamic".into(),
+        model_name: "openai/gpt-oss-20b-dynamic".into(),
         model_provider_name: "hyperbolic".into(),
         credentials,
     }];
@@ -46,7 +46,7 @@ async fn get_providers() -> E2ETestProviders {
     let shorthand_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "hyperbolic-shorthand".to_string(),
-        model_name: "hyperbolic::meta-llama/Meta-Llama-3-70B-Instruct".into(),
+        model_name: "hyperbolic::openai/gpt-oss-20b".into(),
         model_provider_name: "hyperbolic".into(),
         credentials: HashMap::new(),
     }];
@@ -54,7 +54,7 @@ async fn get_providers() -> E2ETestProviders {
     let provider_type_default_credentials_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "hyperbolic".to_string(),
-        model_name: "meta-llama/Meta-Llama-3-70B-Instruct".into(),
+        model_name: "openai/gpt-oss-20b".into(),
         model_provider_name: "hyperbolic".into(),
         credentials: HashMap::new(),
     }];
@@ -62,17 +62,14 @@ async fn get_providers() -> E2ETestProviders {
     let provider_type_default_credentials_shorthand_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "hyperbolic-shorthand".to_string(),
-        model_name: "hyperbolic::meta-llama/Meta-Llama-3-70B-Instruct".into(),
+        model_name: "hyperbolic::openai/gpt-oss-20b".into(),
         model_provider_name: "hyperbolic".into(),
         credentials: HashMap::new(),
     }];
 
     let credential_fallbacks = vec![ModelTestProvider {
         provider_type: "hyperbolic".to_string(),
-        model_info: HashMap::from([(
-            "model_name".to_string(),
-            "meta-llama/Meta-Llama-3-70B-Instruct".to_string(),
-        )]),
+        model_info: HashMap::from([("model_name".to_string(), "openai/gpt-oss-20b".to_string())]),
         use_modal_headers: false,
     }];
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates Hyperbolic integration to use `openai/gpt-oss-20b` as the example/default model throughout.
> 
> - Replace `meta-llama/Meta-Llama-3-70B-Instruct` with `openai/gpt-oss-20b` in docs, example config, and e2e TOML configs (including dynamic/shorthand forms)
> - Update provider/unit tests to use the new model name and tweak assertions to filter non-text (reasoning) blocks
> - E2E: skip assistant-prefill and invalid-streaming tests for `hyperbolic` due to ignored params
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ce0da7ca9e296efe74625b58b2c0ca1ca7ca92e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->