### PR TITLE
Add redis crate and fix conflicts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,7 +1281,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
+ "futures-core",
  "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4744,6 +4754,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "redis",
  "rlt",
  "sqlx",
  "tensorzero-core",
@@ -4843,6 +4854,46 @@ dependencies = [
  "time",
  "x509-parser",
  "yasna",
+]
+
+[[package]]
+name = "redis"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfe20977fe93830c0e9817a16fbf1ed1cfd8d4bba366087a1841d2c6033c251"
+dependencies = [
+ "arc-swap",
+ "arcstr",
+ "backon",
+ "bytes",
+ "cfg-if",
+ "combine",
+ "futures-channel",
+ "futures-util",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "url",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "redis-test"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5143ae9e73f2ff0f3509af5e3a056b48bac2d1e1caa093257f20a9e68ef7534f"
+dependencies = [
+ "futures",
+ "rand 0.9.2",
+ "redis",
+ "socket2",
+ "tempfile",
 ]
 
 [[package]]
@@ -5547,6 +5598,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6234,6 +6291,8 @@ dependencies = [
  "pyo3",
  "rand 0.9.2",
  "rand_distr",
+ "redis",
+ "redis-test",
  "regex",
  "reqwest 0.12.28",
  "reqwest-eventsource",
@@ -7771,6 +7830,12 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "y4m"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,8 @@ durable-tools-spawn = { path = "internal/durable-tools-spawn" }
 tensorzero = { path = "clients/rust" }
 tensorzero-core = { path = "tensorzero-core" }
 regex = "1.12.2"
+redis = { version = "1.0.2", features = ["tokio-comp", "connection-manager"] }
+redis-test = { version = "1.0.1", features = ["aio"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,10 @@
 # cargo-deny
 
 [sources]
-allow-git = ["https://github.com/hyperium/mime", "https://github.com/tensorzero/durable"]
+allow-git = [
+    "https://github.com/hyperium/mime",
+    "https://github.com/tensorzero/durable",
+]
 unknown-git = "deny"
 
 [bans]
@@ -24,6 +27,7 @@ allow = [
     "Unicode-3.0",
     "Apache-2.0",
     "MIT",
+    "BSL-1.0",
     "CDLA-Permissive-2.0",
     "ISC",
     "CC0-1.0",

--- a/tensorzero-core/Cargo.toml
+++ b/tensorzero-core/Cargo.toml
@@ -32,7 +32,9 @@ aws-smithy-types = { version = "1.3.6", features = [
     "serde-serialize",
 ] }
 aws-types = "1.3.6"
-aws-credential-types = { version = "1.2.2", features = ["hardcoded-credentials"] }
+aws-credential-types = { version = "1.2.2", features = [
+    "hardcoded-credentials",
+] }
 aws-sigv4 = "1.3"
 aws-smithy-eventstream = "0.60"
 aws-smithy-runtime-api = "1.10.0"
@@ -126,6 +128,7 @@ opentelemetry-http = "0.31.0"
 # durable.workspace = true
 regex = { workspace = true }
 dashmap = "6.1.0"
+redis = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.21.0"
@@ -140,6 +143,7 @@ gag = "1.0.0"
 log = "0.4.29"
 mockall = "0.14"
 tensorzero-unsafe-helpers = { path = "../internal/tensorzero-unsafe-helpers" }
+redis-test = { workspace = true }
 
 [build-dependencies]
 built = { version = "0.8.0", features = ["git2"] }

--- a/tensorzero-core/src/config/tests.rs
+++ b/tensorzero-core/src/config/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::sync::Arc;
 use std::{io::Write, path::PathBuf};
 use tempfile::NamedTempFile;
 use toml::de::DeTable;
@@ -116,7 +117,7 @@ async fn test_config_from_toml_table_valid() {
         .await
         .expect("Error getting embedding model")
         .unwrap();
-    assert_eq!(embedding_model.routing, vec!["openai".into()]);
+    assert_eq!(embedding_model.routing, vec![Arc::<str>::from("openai")]);
     assert_eq!(embedding_model.providers.len(), 1);
     let provider = embedding_model.providers.get("openai").unwrap();
     assert!(matches!(provider.inner, EmbeddingProviderConfig::OpenAI(_)));
@@ -131,7 +132,10 @@ async fn test_config_from_toml_table_valid() {
             assert_eq!(json_config.variants.len(), 7);
             match &json_config.variants["anthropic_promptA"].inner {
                 VariantConfig::ChatCompletion(chat_config) => {
-                    assert_eq!(chat_config.model(), &"anthropic::claude-3.5-sonnet".into());
+                    assert_eq!(
+                        chat_config.model(),
+                        &Arc::<str>::from("anthropic::claude-3.5-sonnet")
+                    );
                     assert_eq!(chat_config.weight(), Some(1.0));
                     assert_eq!(
                         chat_config

--- a/tensorzero-core/src/model.rs
+++ b/tensorzero-core/src/model.rs
@@ -2735,6 +2735,7 @@ impl ShorthandModelConfig for ModelConfig {
 #[cfg(test)]
 mod tests {
     use std::borrow::Cow;
+    use std::sync::Arc;
 
     use crate::cache::CacheEnabledMode;
     use crate::config::with_skip_credential_validation;
@@ -3674,7 +3675,7 @@ mod tests {
             .await
             .unwrap()
             .expect("Missing dummy model");
-        assert_eq!(model_config.routing, vec!["dummy".into()]);
+        assert_eq!(model_config.routing, vec![Arc::<str>::from("dummy")]);
         let provider_config = &model_config.providers.get("dummy").unwrap().config;
         match provider_config {
             ProviderConfig::Dummy(provider) => assert_eq!(&*provider.model_name, "gpt-4o"),

--- a/tensorzero-core/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-core/src/variant/best_of_n_sampling.rs
@@ -835,6 +835,7 @@ fn map_evaluator_to_actual_index(evaluator_idx: usize, skipped_indices: &[usize]
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::Arc;
     use uuid::Uuid;
 
     use crate::rate_limiting::ScopeInfo;
@@ -1737,7 +1738,7 @@ mod tests {
             exported.candidates,
             vec!["variant1".to_string(), "variant2".to_string()]
         );
-        assert_eq!(exported.evaluator.inner.model, "gpt-4".into());
+        assert_eq!(exported.evaluator.inner.model, Arc::<str>::from("gpt-4"));
         assert_eq!(exported.evaluator.inner.temperature, Some(0.3));
     }
 
@@ -1765,7 +1766,10 @@ mod tests {
 
         let exported = config.as_uninitialized();
 
-        assert_eq!(exported.evaluator.inner.model, "judge-model".into());
+        assert_eq!(
+            exported.evaluator.inner.model,
+            Arc::<str>::from("judge-model")
+        );
         assert_eq!(exported.evaluator.inner.temperature, Some(0.1));
         assert_eq!(exported.evaluator.inner.max_tokens, Some(50));
         assert_eq!(exported.evaluator.inner.seed, Some(99));

--- a/tensorzero-core/src/variant/chain_of_thought.rs
+++ b/tensorzero-core/src/variant/chain_of_thought.rs
@@ -293,6 +293,7 @@ fn parse_thinking_output(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_prepare_thinking_output_schema() {
@@ -455,7 +456,7 @@ mod tests {
 
         let exported = config.as_uninitialized();
 
-        assert_eq!(exported.inner.model, "gpt-4".into());
+        assert_eq!(exported.inner.model, Arc::<str>::from("gpt-4"));
         assert_eq!(exported.inner.weight, Some(0.8));
         assert_eq!(exported.inner.temperature, Some(0.7));
         assert_eq!(exported.inner.max_tokens, Some(150));

--- a/tensorzero-core/src/variant/chat_completion/mod.rs
+++ b/tensorzero-core/src/variant/chat_completion/mod.rs
@@ -877,6 +877,7 @@ mod tests {
     use indexmap::IndexMap;
     use std::collections::HashMap;
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     use super::*;
 
@@ -2015,11 +2016,11 @@ mod tests {
                 assert_eq!(json_result.model_inference_results.len(), 1);
                 assert_eq!(
                     json_result.model_inference_results[0].model_provider_name,
-                    "json_provider".into()
+                    Arc::<str>::from("json_provider")
                 );
                 assert_eq!(
                     json_result.model_inference_results[0].model_name,
-                    "json".into()
+                    Arc::<str>::from("json")
                 );
                 assert_eq!(json_result.inference_params, inference_params);
             }
@@ -2147,11 +2148,11 @@ mod tests {
                 assert_eq!(json_result.model_inference_results.len(), 1);
                 assert_eq!(
                     json_result.model_inference_results[0].model_provider_name,
-                    "json_provider".into()
+                    Arc::<str>::from("json_provider")
                 );
                 assert_eq!(
                     json_result.model_inference_results[0].model_name,
-                    "json".into()
+                    Arc::<str>::from("json")
                 );
                 assert_eq!(json_result.inference_params, inference_params);
             }
@@ -2272,11 +2273,11 @@ mod tests {
                 assert_eq!(json_result.model_inference_results.len(), 1);
                 assert_eq!(
                     json_result.model_inference_results[0].model_provider_name,
-                    "json_provider".into()
+                    Arc::<str>::from("json_provider")
                 );
                 assert_eq!(
                     json_result.model_inference_results[0].model_name,
-                    "json".into()
+                    Arc::<str>::from("json")
                 );
                 let expected_inference_params = InferenceParams {
                     chat_completion: ChatCompletionInferenceParams {
@@ -3000,7 +3001,7 @@ mod tests {
 
         let exported = config.as_uninitialized();
 
-        assert_eq!(exported.model, "gpt-4".into());
+        assert_eq!(exported.model, Arc::<str>::from("gpt-4"));
         assert_eq!(exported.weight, Some(0.8));
         assert_eq!(exported.temperature, Some(0.7));
         assert_eq!(exported.top_p, Some(0.9));

--- a/tensorzero-core/src/variant/mixture_of_n.rs
+++ b/tensorzero-core/src/variant/mixture_of_n.rs
@@ -944,6 +944,7 @@ impl FuserConfig {
 mod tests {
     use crate::rate_limiting::ScopeInfo;
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     use tokio_stream::StreamExt;
     use uuid::Uuid;
@@ -1884,7 +1885,7 @@ mod tests {
             exported.candidates,
             vec!["variant1".to_string(), "variant2".to_string()]
         );
-        assert_eq!(exported.fuser.inner.model, "gpt-4".into());
+        assert_eq!(exported.fuser.inner.model, Arc::<str>::from("gpt-4"));
         assert_eq!(exported.fuser.inner.temperature, Some(0.3));
     }
 
@@ -1912,7 +1913,7 @@ mod tests {
 
         let exported = config.as_uninitialized();
 
-        assert_eq!(exported.fuser.inner.model, "fuser-model".into());
+        assert_eq!(exported.fuser.inner.model, Arc::<str>::from("fuser-model"));
         assert_eq!(exported.fuser.inner.temperature, Some(0.1));
         assert_eq!(exported.fuser.inner.max_tokens, Some(50));
         assert_eq!(exported.fuser.inner.seed, Some(99));

--- a/tensorzero-core/tests/load/rate-limit-load-test/Cargo.toml
+++ b/tensorzero-core/tests/load/rate-limit-load-test/Cargo.toml
@@ -10,6 +10,7 @@ tensorzero-core = { path = "../../../" }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 clap = { workspace = true }
+redis = { workspace = true }
 rlt = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
We're using the redis crate because Valkey doesn't publish a Rust client, and they are compatible with each other. When Valkey publishes its Rust client, we can swap over.

redis-rs pulls in xxhash which is licensed under BSL-1.0 (Boost Software License) https://github.com/DoumanAsh/xxhash-rust/blob/master/LICENSE. This looks fine to me but would like a second opinion.

Also it pulls in arcstr which required some changes to Arc<str>.