### PR TITLE
bumped timeout for trybuild tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -129,10 +129,11 @@ filter = 'package(gateway)'
 slow-timeout = { period = "20s", terminate-after = 2 }
 
 # The proc-macro tests use `trybuild`, which runs compilation
-# for various crates as part of the test
+# for various crates as part of the test. This can be slow on CI runners
+# without a warm cache, so we give it a longer timeout.
 [[profile.default.overrides]]
 filter = 'package(tensorzero-derive)'
-slow-timeout = { period = "20s", terminate-after = 2 }
+slow-timeout = { period = "30s", terminate-after = 3 }
 
 [[profile.default.overrides]]
 # Web search is very slow


### PR DESCRIPTION
these run compilation as part of the test and so can be slowed down by CI runners under heavy load. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts test runtime settings to reduce CI flakiness for proc-macro/trybuild tests.
> 
> - Bumps `slow-timeout` for `package(tensorzero-derive)` from `20s/2` to `30s/3` in `.config/nextest.toml`
> - Adds comments explaining that trybuild compiles multiple crates and can be slow on cold CI caches
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0386eae8a0eb1746c2b247f103fb3457ffef9c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->