### PR TITLE
Ban `Uuid::new_v4` via clippy and replace usages with `Uuid::now_v7`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -9,4 +9,5 @@ disallowed-methods = [
     { path = "tracing_subscriber::layer::Layer::with_filter", reason = "Call `apply_filter_fixing_tracing_bug` instead" },
     { path = "tokio::task::spawn", reason = "Verify that it's okay for the gateway to shut down without waiting for this task" },
     { path = "std::process::exit", reason = "Verify that it's okay to shut down the entire process without our normal shutdown logic" },
+    { path = "uuid::Uuid::new_v4", reason = "Use `Uuid::now_v7` for new UUIDs instead" },
 ]

--- a/internal/autopilot-client/src/lib.rs
+++ b/internal/autopilot-client/src/lib.rs
@@ -23,7 +23,7 @@
 //! let response = client.create_event(
 //!     Uuid::nil(),
 //!     CreateEventRequest {
-//!         deployment_id: Uuid::new_v4(),
+//!         deployment_id: Uuid::now_v7(),
 //!         tensorzero_version: "2025.1.0".to_string(),
 //!         payload: EventPayload::Message(InputMessage {
 //!             role: Role::User,

--- a/tensorzero-core/src/providers/openai/responses.rs
+++ b/tensorzero-core/src/providers/openai/responses.rs
@@ -2579,7 +2579,7 @@ mod tests {
 
         let response: OpenAIResponsesResponse = serde_json::from_str(json).unwrap();
         let generic_request = ModelInferenceRequest {
-            inference_id: uuid::Uuid::new_v4(),
+            inference_id: uuid::Uuid::now_v7(),
             messages: vec![],
             system: None,
             temperature: None,
@@ -2678,7 +2678,7 @@ mod tests {
 
         let response: OpenAIResponsesResponse = serde_json::from_str(json).unwrap();
         let generic_request = ModelInferenceRequest {
-            inference_id: uuid::Uuid::new_v4(),
+            inference_id: uuid::Uuid::now_v7(),
             messages: vec![],
             system: None,
             temperature: None,

--- a/tensorzero-core/tests/e2e/db/experimentation_queries.rs
+++ b/tensorzero-core/tests/e2e/db/experimentation_queries.rs
@@ -10,11 +10,11 @@ use uuid::Uuid;
 // ===== HELPER FUNCTIONS =====
 
 fn generate_function_name(prefix: &str) -> String {
-    format!("{}_func_{}", prefix, Uuid::new_v4())
+    format!("{}_func_{}", prefix, Uuid::now_v7())
 }
 
 fn generate_variant_name(prefix: &str) -> String {
-    format!("{}_variant_{}", prefix, Uuid::new_v4())
+    format!("{}_variant_{}", prefix, Uuid::now_v7())
 }
 
 async fn verify_variant_stored(

--- a/tensorzero-core/tests/e2e/db/workflow_evaluation_queries.rs
+++ b/tensorzero-core/tests/e2e/db/workflow_evaluation_queries.rs
@@ -386,7 +386,7 @@ async fn test_get_workflow_evaluation_run_statistics_nonexistent_run() {
     let clickhouse = get_clickhouse().await;
 
     // Use a random UUID that doesn't exist
-    let run_id = uuid::Uuid::new_v4();
+    let run_id = uuid::Uuid::now_v7();
 
     let result = clickhouse
         .get_workflow_evaluation_run_statistics(run_id, None)


### PR DESCRIPTION
### Motivation
- Enforce a project-wide rule to avoid `uuid::Uuid::new_v4` and prefer time-ordered UUIDs using `Uuid::now_v7`.
- Prevent new code from introducing non-time-ordered UUID generation and make linting catch regressions early.
- Update existing example, tests, and provider parsing tests to conform to the new guidance.

### Description
- Added a clippy disallow rule for `uuid::Uuid::new_v4` in `clippy.toml` with the reason to use `Uuid::now_v7` instead.
- Replaced `Uuid::new_v4()` with `Uuid::now_v7()` in the Autopilot client example doc in `internal/autopilot-client/src/lib.rs`.
- Replaced `Uuid::new_v4()` with `Uuid::now_v7()` in E2E DB tests in `tensorzero-core/tests/e2e/db/experimentation_queries.rs` and `tensorzero-core/tests/e2e/db/workflow_evaluation_queries.rs`.
- Replaced `uuid::Uuid::new_v4()` with `uuid::Uuid::now_v7()` in OpenAI response unit tests in `tensorzero-core/src/providers/openai/responses.rs`.

### Testing
- Ran `cargo fmt` successfully to format changes.
- Ran `cargo clippy --all-targets --all-features -- -D warnings` and completed without remaining clippy warnings.
- Attempted `cargo test-unit-fast` but it failed because `nextest` is not installed in the environment (test runner not available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6970399e8804832dbd097009bd552f2d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces time-ordered UUIDs project-wide and updates examples/tests accordingly.
> 
> - **Lint:** Add `uuid::Uuid::new_v4` to `disallowed-methods` in `clippy.toml` with guidance to use `Uuid::now_v7`
> - **Docs/Examples:** Switch `deployment_id` to `Uuid::now_v7()` in `internal/autopilot-client/src/lib.rs`
> - **Unit tests:** Use `Uuid::now_v7()` for `inference_id` and `model_inference_id` in OpenAI Responses tests (`tensorzero-core/src/providers/openai/responses.rs`)
> - **E2E tests:** Generate IDs/names with `Uuid::now_v7()` in DB tests (`experimentation_queries.rs`, `workflow_evaluation_queries.rs`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1eba2f74cc533bfa7a3d0d4a6fe0a5eb50ae1d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->