### PR TITLE
Fix error message

### DIFF
--- a/tensorzero-core/src/utils/gateway.rs
+++ b/tensorzero-core/src/utils/gateway.rs
@@ -514,11 +514,11 @@ async fn setup_autopilot_client(
                 })
             })?;
 
-            // Require deployment_id (from ClickHouse) for autopilot
+            // Require `deployment_id` (from ClickHouse) for autopilot
             if deployment_id.is_none() {
                 return Err(Error::new(ErrorDetails::AppState {
                     message:
-                        "Autopilot client requires ClickHouse; set `TENSORZERO_CLICKHOUSE_URL`."
+                        "Failed to fetch the deployment ID from ClickHouse. Please make sure that ClickHouse is running and accessible."
                             .to_string(),
                 }));
             }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Improve Autopilot client initialization messaging**
> 
> - Updates `setup_autopilot_client` to return a clearer error when `deployment_id` cannot be fetched from ClickHouse, guiding users to ensure ClickHouse is running and accessible
> - Minor comment tweak to reference `deployment_id` with backticks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12d4d7cc44d02996fe885fabd32deefe01be5b73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->