### PR TITLE
Use an IndexMap for durable tool registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,6 +1835,7 @@ dependencies = [
  "durable",
  "durable-tools-spawn",
  "evaluations",
+ "indexmap 2.13.0",
  "mockall",
  "schemars 1.2.0",
  "secrecy",

--- a/internal/durable-tools/Cargo.toml
+++ b/internal/durable-tools/Cargo.toml
@@ -30,6 +30,7 @@ secrecy.workspace = true
 tensorzero-core.workspace = true
 evaluations = { path = "../../evaluations" }
 tensorzero-optimizers = { path = "../../tensorzero-optimizers" }
+indexmap = "2.13.0"
 
 [dev-dependencies]
 mockall = "0.14"

--- a/internal/durable-tools/src/registry.rs
+++ b/internal/durable-tools/src/registry.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
+use indexmap::IndexMap;
 use schemars::Schema;
 use serde_json::Value as JsonValue;
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tensorzero::{FunctionTool, Tool};
@@ -190,19 +190,22 @@ impl<T: SimpleTool> ErasedSimpleTool for T {
 /// - Looking up tool metadata
 /// - Generating LLM function definitions
 /// - Dynamically invoking tools by name
+/// We use an IndexMap to get consistent iteration order across runs,
+/// which is important for LLM request/prompt caching
+/// (the tools get passed to the LLM input)
 pub struct ToolRegistry {
     /// All tools (for metadata queries).
-    tools: HashMap<String, Arc<dyn ErasedTool>>,
+    tools: IndexMap<String, Arc<dyn ErasedTool>>,
     /// `SimpleTools` specifically (for step execution).
-    simple_tools: HashMap<String, Arc<dyn ErasedSimpleTool>>,
+    simple_tools: IndexMap<String, Arc<dyn ErasedSimpleTool>>,
 }
 
 impl ToolRegistry {
     /// Create a new empty registry.
     pub fn new() -> Self {
         Self {
-            tools: HashMap::new(),
-            simple_tools: HashMap::new(),
+            tools: IndexMap::new(),
+            simple_tools: IndexMap::new(),
         }
     }
 


### PR DESCRIPTION
This gives us a consistent iteration order across runs, which ensures that the LLM input is deterministic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures deterministic tool ordering for LLM inputs by stabilizing iteration order.
> 
> - Replace `HashMap` with `IndexMap` for `ToolRegistry`'s `tools` and `simple_tools`, including constructor and imports
> - Add `indexmap` dependency to `durable-tools` crate
> - Keeps public API and behavior the same aside from iteration order stability
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 974aa8148643199dba87db02fc2584f9c3a3bf01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->