### PR TITLE
Wait for ui container build before dispatching autopilot

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1169,7 +1169,7 @@ jobs:
     permissions:
       contents: read
     if: github.repository == 'tensorzero/tensorzero' && github.event_name == 'merge_group'
-    needs: [build-gateway-e2e-container]
+    needs: [build-gateway-e2e-container, build-ui-container]
     uses: ./.github/workflows/dispatch-autopilot-e2e.yml
     secrets:
       AUTOPILOT_DISPATCH_APP_ID: ${{ secrets.AUTOPILOT_DISPATCH_APP_ID }}


### PR DESCRIPTION
There was a race condition where the autopilot dispatch would run before the ui container was pushed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **CI workflow update**
> 
> - Adds `build-ui-container` to `autopilot-e2e` job `needs`, ensuring `dispatch-autopilot-e2e.yml` runs only after both `gateway-e2e` and `ui` images are built
> - Prevents a race where Autopilot E2E dispatch could start before the `ui` container is pushed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56f245c52e0ffb737724b7512a298797a4841018. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->