### PR TITLE
Disable autopilot dispatch success check

### DIFF
--- a/.github/workflows/dispatch-autopilot-e2e.yml
+++ b/.github/workflows/dispatch-autopilot-e2e.yml
@@ -78,7 +78,7 @@ jobs:
                 exit 0
               else
                 echo "Autopilot E2E tests failed with conclusion: $CONCLUSION"
-                exit 1
+                exit 0
               fi
             fi
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **CI workflow behavior change**
> 
> - In `\.github/workflows/dispatch-autopilot-e2e.yml`, the polling step now exits with `0` on non-`success` conclusions, preventing the main workflow from failing when the Autopilot E2E run fails.
> - Logging remains, but failure no longer propagates to this repository's workflow status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dedc052a8ada4f8eaca8f055151bb073ba9b1f19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->