### PR TITLE
Add autopilot session status to the UI

### DIFF
--- a/ui/app/components/autopilot/ChatInput.tsx
+++ b/ui/app/components/autopilot/ChatInput.tsx
@@ -31,6 +31,7 @@ type ChatInputProps = {
   ) => void;
   onMessageFailed?: (error: Error) => void;
   disabled?: boolean;
+  submitDisabled?: boolean;
   className?: string;
   isNewSession?: boolean;
 };
@@ -40,6 +41,7 @@ export function ChatInput({
   onMessageSent,
   onMessageFailed,
   disabled = false,
+  submitDisabled = false,
   className,
   isNewSession = false,
 }: ChatInputProps) {
@@ -104,9 +106,12 @@ export function ChatInput({
     }
   }, [fetcher.state, fetcher.data]);
 
+  const canSend =
+    text.trim().length > 0 && !isSubmitting && !disabled && !submitDisabled;
+
   const handleSend = useCallback(() => {
     const trimmedText = text.trim();
-    if (!trimmedText || isSubmitting) return;
+    if (!trimmedText || isSubmitting || submitDisabled) return;
 
     pendingTextRef.current = trimmedText;
 
@@ -123,19 +128,19 @@ export function ChatInput({
         encType: "application/json",
       },
     );
-  }, [text, isSubmitting, sessionId, fetcher]);
+  }, [text, isSubmitting, submitDisabled, sessionId, fetcher]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
-        handleSend();
+        if (canSend) {
+          handleSend();
+        }
       }
     },
-    [handleSend],
+    [canSend, handleSend],
   );
-
-  const canSend = text.trim().length > 0 && !isSubmitting && !disabled;
 
   return (
     <div className={cn("flex items-end gap-2", className)}>

--- a/ui/app/components/autopilot/EventStream.tsx
+++ b/ui/app/components/autopilot/EventStream.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, ChevronRight } from "lucide-react";
+import { AlertTriangle, ChevronRight, Loader2 } from "lucide-react";
 import { type RefObject, useState } from "react";
 import { Skeleton } from "~/components/ui/skeleton";
 import { TableItemTime } from "~/components/ui/TableItems";
@@ -8,6 +8,7 @@ import {
   TooltipTrigger,
 } from "~/components/ui/tooltip";
 import type {
+  AutopilotStatus,
   Event,
   EventPayload,
   InputMessageContent,
@@ -47,6 +48,7 @@ type EventStreamProps = {
   authLoadingStates?: Map<string, "approving" | "rejecting">;
   onAuthorize?: (eventId: string, approved: boolean) => Promise<void>;
   optimisticMessages?: OptimisticMessage[];
+  status?: AutopilotStatus;
 };
 
 export function ToolEventId({ id }: { id: string }) {
@@ -411,7 +413,7 @@ function SessionStartedDivider() {
   return (
     <div className="flex items-center gap-4 py-2">
       <div className="border-border flex-1 border-t" />
-      <span className="text-fg-muted text-xs">Session Started</span>
+      <span className="text-fg-muted text-xs">Started</span>
       <div className="border-border flex-1 border-t" />
     </div>
   );
@@ -433,6 +435,45 @@ function OptimisticMessageItem({ message }: { message: OptimisticMessage }) {
   );
 }
 
+function getStatusLabel(status: AutopilotStatus): string {
+  switch (status.status) {
+    case "idle":
+      return "Ready";
+    case "server_side_processing":
+      return "Thinking...";
+    case "waiting_for_tool_call_authorization":
+      return "Waiting";
+    case "waiting_for_tool_execution":
+      return "Executing tool...";
+    case "waiting_for_retry":
+      return "Something went wrong. Retrying...";
+    case "failed":
+      return "Something went wrong. Please try again.";
+  }
+}
+
+function isLoadingStatus(status: AutopilotStatus): boolean {
+  return (
+    status.status === "server_side_processing" ||
+    status.status === "waiting_for_tool_execution" ||
+    status.status === "waiting_for_retry"
+  );
+}
+
+function StatusIndicator({ status }: { status: AutopilotStatus }) {
+  const showSpinner = isLoadingStatus(status);
+  return (
+    <div className="flex items-center gap-4 py-2">
+      <div className="border-border flex-1 border-t" />
+      <span className="text-fg-muted flex items-center gap-1.5 text-xs">
+        {getStatusLabel(status)}
+        {showSpinner && <Loader2 className="h-3 w-3 animate-spin" />}
+      </span>
+      <div className="border-border flex-1 border-t" />
+    </div>
+  );
+}
+
 export default function EventStream({
   events,
   className,
@@ -441,6 +482,7 @@ export default function EventStream({
   topSentinelRef,
   pendingToolCallIds,
   optimisticMessages = [],
+  status,
 }: EventStreamProps) {
   return (
     <div className={cn("flex flex-col gap-3", className)}>
@@ -467,6 +509,9 @@ export default function EventStream({
       {optimisticMessages.map((message) => (
         <OptimisticMessageItem key={message.tempId} message={message} />
       ))}
+
+      {/* Status indicator at the bottom */}
+      {status && <StatusIndicator status={status} />}
     </div>
   );
 }

--- a/ui/app/routes/autopilot/sessions/$session_id/route.tsx
+++ b/ui/app/routes/autopilot/sessions/$session_id/route.tsx
@@ -25,7 +25,7 @@ import { ChatInput } from "~/components/autopilot/ChatInput";
 import { logger } from "~/utils/logger";
 import { getAutopilotClient } from "~/utils/tensorzero.server";
 import { useAutopilotEventStream } from "~/hooks/useAutopilotEventStream";
-import type { Event } from "~/types/tensorzero";
+import type { AutopilotStatus, Event } from "~/types/tensorzero";
 import { useToast } from "~/hooks/use-toast";
 
 // Nil UUID for creating new sessions
@@ -45,6 +45,7 @@ export type EventsData = {
   events: Event[];
   hasMoreEvents: boolean;
   pendingToolCalls: Event[];
+  status: AutopilotStatus;
 };
 
 export async function loader({ params }: Route.LoaderArgs) {
@@ -61,6 +62,7 @@ export async function loader({ params }: Route.LoaderArgs) {
         events: [] as Event[],
         hasMoreEvents: false,
         pendingToolCalls: [] as Event[],
+        status: { status: "idle" } as AutopilotStatus,
       },
       isNewSession: true,
     };
@@ -86,7 +88,12 @@ export async function loader({ params }: Route.LoaderArgs) {
         (a, b) =>
           new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
       );
-      return { events, hasMoreEvents, pendingToolCalls };
+      return {
+        events,
+        hasMoreEvents,
+        pendingToolCalls,
+        status: response.status,
+      };
     });
 
   return {
@@ -131,6 +138,7 @@ function EventStreamContent({
   onOptimisticMessagesChange,
   scrollContainerRef,
   onLoaded,
+  onStatusChange,
 }: {
   sessionId: string;
   eventsData: EventsData | Promise<EventsData>;
@@ -139,12 +147,14 @@ function EventStreamContent({
   onOptimisticMessagesChange: (messages: OptimisticMessage[]) => void;
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
   onLoaded: () => void;
+  onStatusChange: (status: AutopilotStatus) => void;
 }) {
   // Resolve promise (or use direct data for new session)
   const {
     events: initialEvents,
     hasMoreEvents: initialHasMore,
     pendingToolCalls: initialPendingToolCalls,
+    status: initialStatus,
   } = eventsData instanceof Promise ? use(eventsData) : eventsData;
 
   // Signal that loading is complete (this runs after promise resolves)
@@ -153,13 +163,19 @@ function EventStreamContent({
   }, [onLoaded]);
 
   // Now that we have resolved events, start SSE with the correct lastEventId
-  const { events, pendingToolCalls, error, isRetrying, prependEvents } =
+  const { events, pendingToolCalls, status, error, isRetrying, prependEvents } =
     useAutopilotEventStream({
       sessionId: isNewSession ? NIL_UUID : sessionId,
       initialEvents,
       initialPendingToolCalls,
+      initialStatus,
       enabled: !isNewSession,
     });
+
+  // Notify parent of status changes
+  useEffect(() => {
+    onStatusChange(status);
+  }, [status, onStatusChange]);
 
   // State for pagination
   const [isLoadingOlder, setIsLoadingOlder] = useState(false);
@@ -474,6 +490,7 @@ function EventStreamContent({
           topSentinelRef={topSentinelRef}
           pendingToolCallIds={pendingToolCallIds}
           optimisticMessages={visibleOptimisticMessages}
+          status={isNewSession ? undefined : status}
         />
       </div>
 
@@ -524,6 +541,24 @@ export default function AutopilotSessionEventsPage({
   useEffect(() => {
     setIsEventsLoading(!isNewSession && eventsData instanceof Promise);
   }, [sessionId, isNewSession, eventsData]);
+
+  // Track autopilot status for disabling submit
+  const [autopilotStatus, setAutopilotStatus] = useState<AutopilotStatus>({
+    status: "idle",
+  });
+
+  // Reset status when session changes
+  useEffect(() => {
+    setAutopilotStatus({ status: "idle" });
+  }, [sessionId]);
+
+  const handleStatusChange = useCallback((status: AutopilotStatus) => {
+    setAutopilotStatus(status);
+  }, []);
+
+  // Disable submit unless status is idle or failed
+  const submitDisabled =
+    autopilotStatus.status !== "idle" && autopilotStatus.status !== "failed";
 
   // Ref for scroll container - shared between parent and EventStreamContent
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
@@ -610,6 +645,7 @@ export default function AutopilotSessionEventsPage({
           onOptimisticMessagesChange={setOptimisticMessages}
           scrollContainerRef={scrollContainerRef}
           onLoaded={() => setIsEventsLoading(false)}
+          onStatusChange={handleStatusChange}
         />
       </Suspense>
 
@@ -621,6 +657,7 @@ export default function AutopilotSessionEventsPage({
         className="mt-4"
         isNewSession={isNewSession}
         disabled={isEventsLoading}
+        submitDisabled={submitDisabled}
       />
     </div>
   );
@@ -635,6 +672,7 @@ function EventStreamContentWrapper({
   onOptimisticMessagesChange,
   scrollContainerRef,
   onLoaded,
+  onStatusChange,
 }: {
   sessionId: string;
   eventsData: EventsData | Promise<EventsData>;
@@ -643,6 +681,7 @@ function EventStreamContentWrapper({
   onOptimisticMessagesChange: (messages: OptimisticMessage[]) => void;
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
   onLoaded: () => void;
+  onStatusChange: (status: AutopilotStatus) => void;
 }) {
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -654,6 +693,7 @@ function EventStreamContentWrapper({
         onOptimisticMessagesChange={onOptimisticMessagesChange}
         scrollContainerRef={scrollContainerRef}
         onLoaded={onLoaded}
+        onStatusChange={onStatusChange}
       />
     </div>
   );


### PR DESCRIPTION
https://github.com/user-attachments/assets/1355aa81-440c-47ad-9599-9683fbe4f9bb




<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a live session status indicator and wires status through loader → SSE hook → UI, with input guarded while busy.
> 
> - **UI**: `EventStream` shows a bottom status indicator (with spinner) based on `AutopilotStatus`; minor copy tweak to "Started"
> - **SSE Hook**: `useAutopilotEventStream` now accepts/returns `status` and updates it from `StreamUpdate`
> - **Data Loading**: `loader` returns initial `status`; status propagated via `EventStreamContent` and wrapper
> - **Input Control**: `ChatInput` gains `submitDisabled`; send (button/Enter) blocked unless idle/failed; route computes and passes `submitDisabled`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8832182edad3f86f5c2c4914a1def730bd564b5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->