### PR TITLE
Bump to 2026.1.3

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
     inputs:
       is_dev:
-        description: 'Whether to use -dev suffix for container names'
+        description: "Whether to use -dev suffix for container names"
         type: boolean
         required: false
         default: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot-client"
-version = "2026.1.2"
+version = "2026.1.3"
 dependencies = [
  "chrono",
  "durable-tools-spawn",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-tools"
-version = "2026.1.2"
+version = "2026.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-worker"
-version = "2026.1.2"
+version = "2026.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools"
-version = "2026.1.2"
+version = "2026.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools-spawn"
-version = "2026.1.2"
+version = "2026.1.3"
 dependencies = [
  "async-trait",
  "durable",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2026.1.2"
+version = "2026.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2026.1.2"
+version = "2026.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2026.1.2"
+version = "2026.1.3"
 dependencies = [
  "async-stream",
  "autopilot-worker",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-utils"
-version = "2026.1.2"
+version = "2026.1.3"
 dependencies = [
  "minijinja",
  "serde",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2026.1.2"
+version = "2026.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6205,7 +6205,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2026.1.2"
+version = "2026.1.3"
 dependencies = [
  "axum",
  "chrono",
@@ -6225,7 +6225,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2026.1.2"
+version = "2026.1.3"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -6345,7 +6345,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2026.1.2"
+version = "2026.1.3"
 dependencies = [
  "napi",
  "napi-build",
@@ -6358,7 +6358,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-optimizers"
-version = "2026.1.2"
+version = "2026.1.3"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -6392,7 +6392,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2026.1.2"
+version = "2026.1.3"
 dependencies = [
  "evaluations",
  "futures",
@@ -6410,7 +6410,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types"
-version = "2026.1.2"
+version = "2026.1.3"
 dependencies = [
  "aws-smithy-types",
  "infer",
@@ -6430,7 +6430,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types-providers"
-version = "2026.1.2"
+version = "2026.1.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -6438,7 +6438,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-unsafe-helpers"
-version = "2026.1.2"
+version = "2026.1.3"
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2026.1.2"
+version = "2026.1.3"
 rust-version = "1.88.0"
 license = "Apache-2.0"
 edition = "2024"

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2026.1.2"
+appVersion: "2026.1.3"

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2026.1.2",
+  "version": "2026.1.3",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Releases version 2026.1.3 across the project.
> 
> - Bumps Rust workspace and internal crates to `2026.1.3` (`Cargo.toml`, `Cargo.lock`)
> - Updates `ui/package.json` and Helm chart `appVersion` to `2026.1.3`
> - Minor quote normalization in `.github/workflows/docker-hub-publish.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f058b7c01befb023170461cc81ae62a662ada832. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->