### PR TITLE
Wait on publish-dev-docker-hub-images and re-enable autopilot e2e

### DIFF
--- a/.github/workflows/dispatch-autopilot-e2e.yml
+++ b/.github/workflows/dispatch-autopilot-e2e.yml
@@ -78,7 +78,7 @@ jobs:
                 exit 0
               else
                 echo "Autopilot E2E tests failed with conclusion: $CONCLUSION"
-                exit 0
+                exit 1
               fi
             fi
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1175,7 +1175,7 @@ jobs:
     permissions:
       contents: read
     if: github.repository == 'tensorzero/tensorzero' && github.event_name == 'merge_group'
-    needs: [build-gateway-e2e-container]
+    needs: [build-gateway-e2e-container, publish-dev-docker-hub-images]
     uses: ./.github/workflows/dispatch-autopilot-e2e.yml
     secrets:
       AUTOPILOT_DISPATCH_APP_ID: ${{ secrets.AUTOPILOT_DISPATCH_APP_ID }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens merge-group CI around Autopilot E2E.
> 
> - `dispatch-autopilot-e2e.yml`: change non-success E2E conclusion to `exit 1` so the job fails on Autopilot failure
> - `general.yml`: add `publish-dev-docker-hub-images` to `autopilot-e2e` `needs` to ensure images are published before dispatching tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d8f976a169576e8f4ae86de44e95b6b35e1d09a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->