### PR TITLE
Bump fixtures health check timeout to 6 minutes

### DIFF
--- a/tensorzero-core/tests/e2e/docker-compose-common.yml
+++ b/tensorzero-core/tests/e2e/docker-compose-common.yml
@@ -119,7 +119,7 @@ services:
       test: ["CMD", "test", "-f", "/tmp/migrations_complete.marker"]
       interval: 5s
       timeout: 1s
-      retries: 48 # Retry for up to 4 minutes
+      retries: 72 # Retry for up to 6 minutes
       start_period: 5s
 
   # This is not a gateway to use but rather one that just sets up migrations for the Postgres db
@@ -149,5 +149,5 @@ services:
       test: ["CMD", "test", "-f", "/tmp/migrations_complete.marker"]
       interval: 5s
       timeout: 1s
-      retries: 48 # Retry for up to 4 minutes
+      retries: 72 # Retry for up to 6 minutes
       start_period: 5s

--- a/tensorzero-core/tests/e2e/docker-compose.clickhouse.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.clickhouse.yml
@@ -84,7 +84,7 @@ services:
       test: ["CMD", "test", "-f", "/load_complete.marker"]
       interval: 5s
       timeout: 1s
-      retries: 48 # Retry for up to 4 minutes
+      retries: 72 # Retry for up to 6 minutes
       start_interval: 1s
       start_period: 300s # Give the script time to start
 

--- a/tensorzero-core/tests/e2e/docker-compose.live.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.live.yml
@@ -155,7 +155,7 @@ services:
       test: ["CMD", "test", "-f", "/load_complete.marker"]
       interval: 5s
       timeout: 1s
-      retries: 48 # Retry for up to 4 minutes
+      retries: 72 # Retry for up to 6 minutes
       start_period: 5s # Give the script time to start
 
   live-tests:

--- a/tensorzero-core/tests/e2e/docker-compose.replicated.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.replicated.yml
@@ -149,7 +149,7 @@ services:
       test: ["CMD", "test", "-f", "/tmp/migrations_complete.marker"]
       interval: 5s
       timeout: 1s
-      retries: 48 # Retry for up to 4 minutes
+      retries: 72 # Retry for up to 6 minutes
       start_period: 5s
 
   # This is not a gateway to use but rather one that just sets up migrations for the ClickHouse db
@@ -209,5 +209,5 @@ services:
       test: ["CMD", "test", "-f", "/load_complete.marker"]
       interval: 5s
       timeout: 1s
-      retries: 48 # Retry for up to 4 minutes
+      retries: 72 # Retry for up to 6 minutes
       start_period: 5s # Give the script time to start

--- a/tensorzero-core/tests/e2e/docker-compose.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.yml
@@ -52,5 +52,5 @@ services:
       test: ["CMD", "test", "-f", "/load_complete.marker"]
       interval: 5s
       timeout: 1s
-      retries: 48 # Retry for up to 4 minutes
+      retries: 72 # Retry for up to 6 minutes
       start_period: 5s # Give the script time to start

--- a/ui/fixtures/docker-compose-common.yml
+++ b/ui/fixtures/docker-compose-common.yml
@@ -37,7 +37,7 @@ services:
       test: ["CMD", "test", "-f", "/tmp/migrations_complete.marker"]
       interval: 5s
       timeout: 1s
-      retries: 48 # Retry for up to 4 minutes
+      retries: 72 # Retry for up to 6 minutes
       start_period: 5s
 
   mock-provider-api:

--- a/ui/fixtures/docker-compose.e2e.ci.yml
+++ b/ui/fixtures/docker-compose.e2e.ci.yml
@@ -98,7 +98,7 @@ services:
       test: ["CMD", "test", "-f", "/load_complete.marker"]
       interval: 5s
       timeout: 1s
-      retries: 48 # Retry for up to 4 minutes
+      retries: 72 # Retry for up to 6 minutes
       start_interval: 1s
       start_period: 300s # Give the script time to start
 

--- a/ui/fixtures/docker-compose.e2e.yml
+++ b/ui/fixtures/docker-compose.e2e.yml
@@ -99,6 +99,6 @@ services:
       test: ["CMD", "test", "-f", "/load_complete.marker"]
       interval: 5s
       timeout: 1s
-      retries: 48 # Retry for up to 4 minutes
+      retries: 72 # Retry for up to 6 minutes
       start_interval: 1s
       start_period: 300s # Give the script time to start

--- a/ui/fixtures/docker-compose.unit.yml
+++ b/ui/fixtures/docker-compose.unit.yml
@@ -96,7 +96,7 @@ services:
       test: ["CMD", "test", "-f", "/load_complete.marker"]
       interval: 5s
       timeout: 1s
-      retries: 48 # Retry for up to 4 minutes
+      retries: 72 # Retry for up to 6 minutes
       start_interval: 1s
       start_period: 300s # Give the script time to start
 

--- a/ui/fixtures/docker-compose.yml
+++ b/ui/fixtures/docker-compose.yml
@@ -93,6 +93,6 @@ services:
       test: ["CMD", "test", "-f", "/load_complete.marker"]
       interval: 5s
       timeout: 1s
-      retries: 48 # Retry for up to 4 minutes
+      retries: 72 # Retry for up to 6 minutes
       start_interval: 1s
       start_period: 300s # Give the script time to start


### PR DESCRIPTION
We've seen several flakes in CI due to slow network connections, so let's give it longer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends healthcheck retry windows from 4 to 6 minutes across e2e and UI Docker Compose stacks to mitigate CI flakes waiting on data fixtures and DB migrations.
> 
> - Bumps `healthcheck.retries` 48→72 for `fixtures` loaders and `gateway-*-migrations` services in `tensorzero-core/tests/e2e` (`docker-compose*.yml`) and `ui/fixtures` (`docker-compose*.yml`)
> - Applies to ClickHouse/Postgres migration helpers and fixture loaders in clickhouse, live, replicated, unit, e2e, and CI variants
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4176c80c828d099700df6a8b59758ce9f458a03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->