### PR TITLE
bumped dependency on durable to use better indices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,7 +1805,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 [[package]]
 name = "durable"
 version = "0.1.0"
-source = "git+https://github.com/tensorzero/durable?rev=75bde52f2a40d1fabd72443ddcf26e1342e28b56#75bde52f2a40d1fabd72443ddcf26e1342e28b56"
+source = "git+https://github.com/tensorzero/durable?rev=3a06598377de257ba27dc1e5be2aa44f92b1dd49#3a06598377de257ba27dc1e5be2aa44f92b1dd49"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ metrics-exporter-prometheus = { version = "0.18.1", features = [
 schemars = "1.1.0"
 blake3 = "1.8.3"
 moka = { version = "0.12.10", features = ["sync"] }
-durable = { git = "https://github.com/tensorzero/durable", rev = "75bde52f2a40d1fabd72443ddcf26e1342e28b56" }
+durable = { git = "https://github.com/tensorzero/durable", rev = "3a06598377de257ba27dc1e5be2aa44f92b1dd49" }
 durable-tools-spawn = { path = "internal/durable-tools-spawn" }
 tensorzero = { path = "clients/rust" }
 tensorzero-core = { path = "tensorzero-core" }


### PR DESCRIPTION
Blocked on #5768 

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **Dependency update:** Bumps `durable` git dependency to `3a06598377de257ba27dc1e5be2aa44f92b1dd49` in `Cargo.toml`.
> - **Lockfile:** Updates `Cargo.lock` to reflect the new `durable` revision.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c11e2b8b35fc6dbfb2c85be29a3c6668cf11e129. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->