### PR TITLE
Add ErrorBoundary to episode detail page

### DIFF
--- a/ui/app/routes/observability/episodes/$episode_id/route.tsx
+++ b/ui/app/routes/observability/episodes/$episode_id/route.tsx
@@ -6,6 +6,7 @@ import {
   Await,
   data,
   useAsyncError,
+  useLocation,
   useNavigate,
   useParams,
   type RouteHandle,
@@ -45,6 +46,7 @@ import {
 } from "~/components/ui/table";
 import {
   PageErrorNotice,
+  SectionAsyncErrorState,
   TableErrorNotice,
 } from "~/components/ui/error/ErrorContentPrimitives";
 import { AlertCircle, AlertTriangle } from "lucide-react";
@@ -345,6 +347,7 @@ export default function EpisodeDetailPage({
     num_feedbacks,
     newFeedbackId,
   } = loaderData;
+  const location = useLocation();
   const navigate = useNavigate();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [openSheetInferenceId, setOpenSheetInferenceId] = useState<
@@ -430,10 +433,10 @@ export default function EpisodeDetailPage({
             onCloseSheet={handleCloseSheet}
             openSheetInferenceId={openSheetInferenceId}
           />
-          <Suspense fallback={<PageButtons disabled />}>
+          <Suspense key={location.key} fallback={<PageButtons disabled />}>
             <Await
               resolve={inferencesData}
-              errorElement={<PageButtons disabled />}
+              errorElement={<SectionAsyncErrorState />}
             >
               {(resolvedData) => (
                 <InferencePaginationContent data={resolvedData} />
@@ -453,6 +456,7 @@ export default function EpisodeDetailPage({
             }}
           />
           <Suspense
+            key={location.key}
             fallback={
               <>
                 <FeedbackTableSkeleton />


### PR DESCRIPTION
## Summary

Adds route-level ErrorBoundary to episode detail page that preserves page context (episode_id in header, breadcrumbs) when sync loader errors occur.

## Error Handling Pattern

This PR follows the established error handling pattern for detail pages:

| Layer | When it triggers | Component |
|-------|------------------|-----------|
| **Route-level ErrorBoundary** | Sync loader errors (validation, 404) | `PageLayout` + `PageHeader` + `PageErrorNotice` |
| **Section-level `<Await errorElement>`** | Async/deferred data errors | `TableAsyncErrorState` / custom error components |

The route-level ErrorBoundary catches errors thrown synchronously in the loader (e.g., `throw data("Episode not found", { status: 404 })`) before any promises are returned. Section-level error handling (via `<Await errorElement>`) handles failures in deferred promises after the page shell renders.

## Changes
- Add route-level ErrorBoundary that preserves PageHeader with episode_id and breadcrumbs
- Use `getPageErrorInfo()` for consistent error message extraction (reuses existing utility)
- Use `useEffect` for logging to prevent re-logging on re-renders
- Minor: Update FeedbackSectionError title from generic "Error loading data" to "Error loading feedback"

## Dependencies
- #5797 (streaming primitives)

## Test Plan
- [ ] Loader sync error (e.g., invalid limit, episode not found) shows episode_id in header
- [ ] Breadcrumbs navigation works in error state
- [ ] Error message properly extracted from various error types
- [ ] Section-level errors (inferences/feedback) still handled by their respective error elements

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces robust error handling on the episode detail page while preserving page context.
> 
> - Adds route-level `ErrorBoundary` that renders `PageLayout` + `PageHeader` (with `episode_id` + breadcrumbs) and `PageErrorNotice` using `getPageErrorInfo`; logs via `logger` in `useEffect`
> - Swaps `<Await errorElement>` for inferences to `SectionAsyncErrorState`; updates feedback error title to "Error loading feedback"
> - Keys `Suspense` blocks by `location.key` to correctly reset section fallbacks/pagination on URL changes
> - No data fetching logic changes beyond error/UI handling; minor imports cleanup/additions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f2467fde4f2be473ace809955813dbf31c89368. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->