### PR TITLE
Add script instruction

### DIFF
--- a/ui/fixtures/regenerate-model-inference-cache.sh
+++ b/ui/fixtures/regenerate-model-inference-cache.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# IMPORTANT: You likely should not run this script manually. Instead, comment `/regen-fixtures` in the PR on GitHub. (TensorZero team only)
+
 set -euxo pipefail
 
 cd "$(dirname "$0")"/../


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a clear usage note to `ui/fixtures/regenerate-model-inference-cache.sh` advising contributors to trigger regeneration via the `/regen-fixtures` PR comment instead of running the script manually.
> 
> - Prepends an instructional comment to the regeneration script without changing its behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed90e1133167dd7497574496675295e9220fefc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->