### PR TITLE
Fix Python input tool call types to retain tool call data

### DIFF
--- a/clients/python/tensorzero/generated_types.py
+++ b/clients/python/tensorzero/generated_types.py
@@ -520,6 +520,17 @@ class InputMessageContentTemplate:
 
 
 @dataclass(kw_only=True)
+class InputMessageContentInferenceResponseToolCall(InferenceResponseToolCall):
+    """
+    `ToolCallWrapper` helps us disambiguate between `ToolCall` (no `raw_*`) and `InferenceResponseToolCall` (has `raw_*`).
+    Typically tool calls come from previous inferences and are therefore outputs of TensorZero (`InferenceResponseToolCall`)
+    but they may also be constructed client side or through the OpenAI endpoint `ToolCall` so we support both via this wrapper.
+    """
+
+    type: Literal["tool_call"] = "tool_call"
+
+
+@dataclass(kw_only=True)
 class InputMessageContentToolResult:
     """
     A ToolResult is the outcome of a ToolCall, which we may want to present back to the model
@@ -1119,7 +1130,13 @@ class InferenceParams:
 
 
 @dataclass(kw_only=True)
-class InputMessageContentToolCall:
+class InputMessageContentToolCall(ToolCall):
+    """
+    `ToolCallWrapper` helps us disambiguate between `ToolCall` (no `raw_*`) and `InferenceResponseToolCall` (has `raw_*`).
+    Typically tool calls come from previous inferences and are therefore outputs of TensorZero (`InferenceResponseToolCall`)
+    but they may also be constructed client side or through the OpenAI endpoint `ToolCall` so we support both via this wrapper.
+    """
+
     type: Literal["tool_call"] = "tool_call"
 
 
@@ -1339,6 +1356,7 @@ InputMessageContent = (
     InputMessageContentText
     | InputMessageContentTemplate
     | InputMessageContentToolCall
+    | InputMessageContentInferenceResponseToolCall
     | InputMessageContentToolResult
     | InputMessageContentRawText
     | InputMessageContentThought

--- a/internal/tensorzero-types/src/message.rs
+++ b/internal/tensorzero-types/src/message.rs
@@ -5,7 +5,7 @@
 use crate::content::{Arguments, RawText, System, Template, Text, Thought, Unknown};
 use crate::file::File;
 use crate::role::Role;
-use crate::tool::{ToolCallWrapper, ToolResult};
+use crate::tool::{ToolCallWrapper, ToolCallWrapperJsonSchema, ToolResult};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -37,7 +37,8 @@ pub enum InputMessageContent {
     Text(Text),
     #[schemars(title = "InputMessageContentTemplate")]
     Template(Template),
-    #[schemars(title = "InputMessageContentToolCall")]
+    // `ToolCallWrapper` is `serde(untagged)` so no need to name it.
+    #[schemars(with = "ToolCallWrapperJsonSchema")]
     ToolCall(ToolCallWrapper),
     #[schemars(title = "InputMessageContentToolResult")]
     ToolResult(ToolResult),

--- a/internal/tensorzero-types/src/tool.rs
+++ b/internal/tensorzero-types/src/tool.rs
@@ -107,8 +107,18 @@ impl InferenceResponseToolCall {
 #[serde(untagged)]
 #[export_schema]
 pub enum ToolCallWrapper {
-    ToolCall(ToolCall), // the format we store in the database
-    InferenceResponseToolCall(InferenceResponseToolCall), // the format we send on an inference response
+    // The format we store in the database
+    #[schemars(title = "InputMessageContentToolCall")]
+    ToolCall(ToolCall),
+    // The format we send on an inference response, with parsed name and arguments
+    #[schemars(title = "InputMessageContentInferenceResponseToolCall")]
+    InferenceResponseToolCall(InferenceResponseToolCall),
+}
+
+#[derive(JsonSchema)]
+pub(crate) struct ToolCallWrapperJsonSchema {
+    #[serde(flatten)]
+    _tool_call_wrapper: ToolCallWrapper,
 }
 
 impl ToolCallWrapper {


### PR DESCRIPTION
# Description
- Update schema metadata so `ToolCallWrapper` produces distinct input message tool call variants.
- Ensure Python generated types include `id`, `name`, and `arguments` for input tool calls, preventing data loss in serialized message histories.

## Problem

When querying datapoints from TensorZero via the Python SDK, tool call content blocks in assistant messages lose their data. The `InputMessageContentToolCall` class only serializes to `{"type": "tool_call"}` instead of including the full tool call information (`id`, `name`, `arguments`).

This causes issues when trying to pass message histories to other TensorZero functions, as the incomplete tool call data fails JSON schema validation.

## Example

**Expected serialization:**
```json
{
  "type": "tool_call",
  "id": "call_69WJUP56NUyztAJo9NvBqAoP",
  "name": "find_user_id_by_name_zip",
  "arguments": "{\"first_name\": \"Ethan\", \"last_name\": \"Lopez\", \"zip\": \"43275\"}"
}
```

**Actual serialization:**
```json
{
  "type": "tool_call"
}
```

## Root Cause

The Python SDK's `InputMessageContentToolCall` class in `generated_types.py` only has the type discriminator field:

```python
@dataclass(kw_only=True)
class InputMessageContentToolCall:
    type: Literal["tool_call"] = "tool_call"
```

Notably, `StoredInputMessageContentToolCall` correctly inherits from `ToolCall`:

```python
class StoredInputMessageContentToolCall(ToolCall):
    type: Literal["tool_call"] = "tool_call"
```

This inconsistency suggests `InputMessageContentToolCall` should also inherit from `ToolCall` but doesn't.

In the Rust types, both properly wrap the tool call data:

```rust
// In tensorzero-types/src/message.rs
pub enum InputMessageContent {
    // ...
    ToolCall(ToolCallWrapper),
}

// In tensorzero-types/src/tool.rs
pub type ToolCallWrapper = ToolCall | InferenceResponseToolCall;

pub struct ToolCall {
    pub id: String,
    pub name: String,
    pub arguments: String,
}
```

The Python type generation is not preserving the inner `ToolCallWrapper` fields.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves tool-call schema fidelity and Python type generation.
> 
> - Rust: Annotates `ToolCallWrapper` variants with distinct schema titles and introduces `ToolCallWrapperJsonSchema`; `InputMessageContent::ToolCall` now references this schema wrapper.
> - Python: `InputMessageContentToolCall` now extends `ToolCall` (with `id`, `name`, `arguments`), and a new `InputMessageContentInferenceResponseToolCall` variant extends `InferenceResponseToolCall`; both included in `InputMessageContent` union.
> 
> These changes ensure serialized message histories preserve full tool call data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 289184d13052d288fd46532d7449efdff241da3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->