### PR TITLE
Unify FeedbackBadges colors to orange/amber/yellow spectrum

### DIFF
--- a/ui/app/components/feedback/FeedbackBadges.stories.tsx
+++ b/ui/app/components/feedback/FeedbackBadges.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import FeedbackBadges from "./FeedbackBadges";
+import FeedbackBadges, { getBadgeStyle } from "./FeedbackBadges";
 import { Badge } from "~/components/ui/badge";
 import type { FeedbackConfig } from "~/utils/config/feedback";
 
@@ -60,121 +60,102 @@ const floatMinEpisode: FeedbackConfig = {
   level: "episode",
 };
 
-// Badge color classes - same as in FeedbackBadges.tsx
-const badgeColors = {
-  boolean: "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-300",
-  float:
-    "bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300",
-  demonstration:
-    "bg-yellow-100 text-yellow-700 dark:bg-yellow-800 dark:text-yellow-300",
-  max: "bg-orange-200 text-orange-800 dark:bg-orange-800 dark:text-orange-200",
-  min: "bg-amber-200 text-amber-700 dark:bg-amber-800 dark:text-amber-200",
-  episode:
-    "bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300",
-  inference:
-    "bg-yellow-200 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-200",
-};
-
 export const AllVariants: Story = {
   render: () => (
-    <div className="flex flex-col gap-6 p-4">
-      <h2 className="text-lg font-semibold">All Badge Variants</h2>
-
-      <div className="flex flex-col gap-4">
-        <div>
-          <h3 className="text-fg-muted mb-2 text-sm font-medium">
-            Boolean + Max + Inference
-          </h3>
-          <FeedbackBadges metric={booleanMaxInference} />
-        </div>
-
-        <div>
-          <h3 className="text-fg-muted mb-2 text-sm font-medium">
-            Boolean + Max + Episode
-          </h3>
-          <FeedbackBadges metric={booleanMaxEpisode} />
-        </div>
-
-        <div>
-          <h3 className="text-fg-muted mb-2 text-sm font-medium">
-            Boolean + Min + Inference
-          </h3>
-          <FeedbackBadges metric={booleanMinInference} />
-        </div>
-
-        <div>
-          <h3 className="text-fg-muted mb-2 text-sm font-medium">
-            Boolean + Min + Episode
-          </h3>
-          <FeedbackBadges metric={booleanMinEpisode} />
-        </div>
-
-        <div>
-          <h3 className="text-fg-muted mb-2 text-sm font-medium">
-            Float + Max + Inference
-          </h3>
-          <FeedbackBadges metric={floatMaxInference} />
-        </div>
-
-        <div>
-          <h3 className="text-fg-muted mb-2 text-sm font-medium">
-            Float + Max + Episode
-          </h3>
-          <FeedbackBadges metric={floatMaxEpisode} />
-        </div>
-
-        <div>
-          <h3 className="text-fg-muted mb-2 text-sm font-medium">
-            Float + Min + Inference
-          </h3>
-          <FeedbackBadges metric={floatMinInference} />
-        </div>
-
-        <div>
-          <h3 className="text-fg-muted mb-2 text-sm font-medium">
-            Float + Min + Episode
-          </h3>
-          <FeedbackBadges metric={floatMinEpisode} />
-        </div>
-      </div>
-
-      <h2 className="mt-4 text-lg font-semibold">Individual Badge Colors</h2>
-      <p className="text-fg-muted text-sm">
-        All badges use orange/amber/yellow spectrum for visual cohesion
-      </p>
-
-      <div className="flex flex-col gap-4">
-        <div>
-          <h3 className="text-fg-muted mb-2 text-sm font-medium">
-            Type Badges
-          </h3>
-          <div className="flex gap-2">
-            <Badge className={badgeColors.boolean}>boolean</Badge>
-            <Badge className={badgeColors.float}>float</Badge>
-            <Badge className={badgeColors.demonstration}>demonstration</Badge>
+    <div className="flex flex-col gap-8 p-6">
+      {/* Color Palette */}
+      <section>
+        <h2 className="mb-4 text-lg font-semibold">Badge Color Palette</h2>
+        <div className="flex gap-12">
+          <div className="flex flex-col items-start gap-2">
+            <span className="text-fg-muted text-xs font-medium tracking-wide uppercase">
+              Type
+            </span>
+            <div className="flex flex-col items-start gap-1.5">
+              <Badge className={getBadgeStyle("type", "boolean")}>
+                boolean
+              </Badge>
+              <Badge className={getBadgeStyle("type", "float")}>float</Badge>
+              <Badge className={getBadgeStyle("type", "demonstration")}>
+                demonstration
+              </Badge>
+            </div>
+          </div>
+          <div className="flex flex-col items-start gap-2">
+            <span className="text-fg-muted text-xs font-medium tracking-wide uppercase">
+              Optimize
+            </span>
+            <div className="flex flex-col items-start gap-1.5">
+              <Badge className={getBadgeStyle("optimize", "max")}>max</Badge>
+              <Badge className={getBadgeStyle("optimize", "min")}>min</Badge>
+            </div>
+          </div>
+          <div className="flex flex-col items-start gap-2">
+            <span className="text-fg-muted text-xs font-medium tracking-wide uppercase">
+              Level
+            </span>
+            <div className="flex flex-col items-start gap-1.5">
+              <Badge className={getBadgeStyle("level", "episode")}>
+                episode
+              </Badge>
+              <Badge className={getBadgeStyle("level", "inference")}>
+                inference
+              </Badge>
+            </div>
           </div>
         </div>
+      </section>
 
-        <div>
-          <h3 className="text-fg-muted mb-2 text-sm font-medium">
-            Optimize Badges
-          </h3>
-          <div className="flex gap-2">
-            <Badge className={badgeColors.max}>max</Badge>
-            <Badge className={badgeColors.min}>min</Badge>
+      {/* Combinations Grid */}
+      <section>
+        <h2 className="mb-4 text-lg font-semibold">Metric Combinations</h2>
+        <div className="grid grid-cols-2 gap-x-8 gap-y-4">
+          <div className="flex items-center justify-between gap-4 rounded border p-3">
+            <span className="text-fg-muted text-sm">
+              boolean / max / inference
+            </span>
+            <FeedbackBadges metric={booleanMaxInference} />
+          </div>
+          <div className="flex items-center justify-between gap-4 rounded border p-3">
+            <span className="text-fg-muted text-sm">
+              boolean / max / episode
+            </span>
+            <FeedbackBadges metric={booleanMaxEpisode} />
+          </div>
+          <div className="flex items-center justify-between gap-4 rounded border p-3">
+            <span className="text-fg-muted text-sm">
+              boolean / min / inference
+            </span>
+            <FeedbackBadges metric={booleanMinInference} />
+          </div>
+          <div className="flex items-center justify-between gap-4 rounded border p-3">
+            <span className="text-fg-muted text-sm">
+              boolean / min / episode
+            </span>
+            <FeedbackBadges metric={booleanMinEpisode} />
+          </div>
+          <div className="flex items-center justify-between gap-4 rounded border p-3">
+            <span className="text-fg-muted text-sm">
+              float / max / inference
+            </span>
+            <FeedbackBadges metric={floatMaxInference} />
+          </div>
+          <div className="flex items-center justify-between gap-4 rounded border p-3">
+            <span className="text-fg-muted text-sm">float / max / episode</span>
+            <FeedbackBadges metric={floatMaxEpisode} />
+          </div>
+          <div className="flex items-center justify-between gap-4 rounded border p-3">
+            <span className="text-fg-muted text-sm">
+              float / min / inference
+            </span>
+            <FeedbackBadges metric={floatMinInference} />
+          </div>
+          <div className="flex items-center justify-between gap-4 rounded border p-3">
+            <span className="text-fg-muted text-sm">float / min / episode</span>
+            <FeedbackBadges metric={floatMinEpisode} />
           </div>
         </div>
-
-        <div>
-          <h3 className="text-fg-muted mb-2 text-sm font-medium">
-            Level Badges
-          </h3>
-          <div className="flex gap-2">
-            <Badge className={badgeColors.episode}>episode</Badge>
-            <Badge className={badgeColors.inference}>inference</Badge>
-          </div>
-        </div>
-      </div>
+      </section>
     </div>
   ),
 };

--- a/ui/app/components/feedback/FeedbackBadges.tsx
+++ b/ui/app/components/feedback/FeedbackBadges.tsx
@@ -3,7 +3,7 @@ import type { FeedbackRow } from "~/types/tensorzero";
 import type { FeedbackConfig } from "~/utils/config/feedback";
 
 // Badge styles using orange/amber/yellow spectrum for visual cohesion
-const getBadgeStyle = (
+export const getBadgeStyle = (
   property: "type" | "optimize" | "level",
   value: string | undefined,
 ) => {


### PR DESCRIPTION
## Summary
- Updated badge colors to use cohesive orange/amber/yellow spectrum instead of mixed cyan/purple/fuchsia/sky/indigo/teal
- Added `FeedbackBadges.stories.tsx` to showcase all badge color variants

### Color mapping:
| Badge | Before | After |
|-------|--------|-------|
| boolean | amber | amber (unchanged) |
| float | cyan | orange |
| demonstration | purple | yellow |
| max | fuchsia | orange-200 |
| min | sky | amber-200 |
| episode | indigo | yellow-100 |
| inference | teal | yellow-200 |

## Test plan
- [ ] Review in Storybook at `/?path=/story/feedbackbadges--all-variants`
- [ ] Check FeedbackTable stories for badge appearance in context
- [ ] Verify dark mode colors look good