### PR TITLE
Support both `thinkingLevel` and `thinkingBudget` for Gemini

### DIFF
--- a/docs/gateway/configuration-reference.mdx
+++ b/docs/gateway/configuration-reference.mdx
@@ -3125,6 +3125,8 @@ presence_penalty = 0.5
 
 Controls the reasoning effort level for reasoning models.
 
+For Gemini, this value corresponds to `generationConfig.thinkingConfig.thinkingLevel`.
+
 <Warning>
 
 Only some model providers support this parameter. TensorZero will warn and ignore it if unsupported.
@@ -3133,7 +3135,7 @@ Only some model providers support this parameter. TensorZero will warn and ignor
 
 <Tip>
 
-Some providers (e.g. Anthropic, Gemini) support `thinking_budget_tokens` instead.
+Some providers (e.g. Anthropic) support `thinking_budget_tokens` instead.
 
 </Tip>
 

--- a/docs/integrations/model-providers/gcp-vertex-ai-gemini.mdx
+++ b/docs/integrations/model-providers/gcp-vertex-ai-gemini.mdx
@@ -113,3 +113,10 @@ curl -X POST http://localhost:3000/inference \
     }
   }'
 ```
+
+## Thinking Parameters
+
+Gemini supports two thinking parameters:
+
+- `reasoning_effort` maps to `thinkingConfig.thinkingLevel`
+- `thinking_budget_tokens` maps to `thinkingConfig.thinkingBudget` (legacy)

--- a/docs/integrations/model-providers/google-ai-studio-gemini.mdx
+++ b/docs/integrations/model-providers/google-ai-studio-gemini.mdx
@@ -129,3 +129,10 @@ curl -X POST http://localhost:3000/inference \
     }
   }'
 ```
+
+## Thinking Parameters
+
+Gemini supports two thinking parameters:
+
+- `reasoning_effort` maps to `thinkingConfig.thinkingLevel`
+- `thinking_budget_tokens` maps to `thinkingConfig.thinkingBudget` (legacy)

--- a/tensorzero-core/src/providers/gcp_vertex_gemini/mod.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_gemini/mod.rs
@@ -1906,7 +1906,10 @@ enum GCPVertexGeminiResponseMimeType {
 #[derive(Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct GCPVertexGeminiThinkingConfig {
-    thinking_budget: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking_budget: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking_level: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Serialize)]
@@ -1962,26 +1965,18 @@ fn apply_inference_params(
         verbosity,
     } = inference_params;
 
-    if reasoning_effort.is_some() {
-        warn_inference_parameter_not_supported(
-            PROVIDER_NAME,
-            "reasoning_effort",
-            Some("Tip: You might want to use `thinking_budget_tokens` for this provider."),
-        );
-    }
-
-    if let Some(budget_tokens) = thinking_budget_tokens {
+    if reasoning_effort.is_some() || thinking_budget_tokens.is_some() {
+        let thinking_config = GCPVertexGeminiThinkingConfig {
+            thinking_budget: *thinking_budget_tokens,
+            thinking_level: reasoning_effort.clone(),
+        };
         if let Some(gen_config) = &mut request.generation_config {
-            gen_config.thinking_config = Some(GCPVertexGeminiThinkingConfig {
-                thinking_budget: *budget_tokens,
-            });
+            gen_config.thinking_config = Some(thinking_config);
         } else {
             request.generation_config = Some(GCPVertexGeminiGenerationConfig {
                 stop_sequences: None,
                 temperature: None,
-                thinking_config: Some(GCPVertexGeminiThinkingConfig {
-                    thinking_budget: *budget_tokens,
-                }),
+                thinking_config: Some(thinking_config),
                 max_output_tokens: None,
                 top_p: None,
                 presence_penalty: None,
@@ -5491,19 +5486,19 @@ mod tests {
 
         apply_inference_params(&mut request, &inference_params);
 
-        // Test that reasoning_effort warns with tip about thinking_budget_tokens
-        assert!(logs_contain(
-            "GCP Vertex Gemini does not support the inference parameter `reasoning_effort`, so it will be ignored. Tip: You might want to use `thinking_budget_tokens` for this provider."
-        ));
-
-        // Test that thinking_budget_tokens is applied correctly in generation_config
-        assert!(request.generation_config.is_some());
+        // Test that thinking_budget_tokens and reasoning_effort are applied correctly in generation_config
+        assert!(
+            request.generation_config.is_some(),
+            "generation_config should be set when thinking params are provided"
+        );
         let gen_config = request.generation_config.unwrap();
         assert_eq!(
             gen_config.thinking_config,
             Some(GCPVertexGeminiThinkingConfig {
-                thinking_budget: 1024,
-            })
+                thinking_budget: Some(1024),
+                thinking_level: Some("high".to_string()),
+            }),
+            "thinking_config should contain both thinking_budget and thinking_level"
         );
 
         // Test that verbosity warns

--- a/tensorzero-core/src/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-core/src/providers/google_ai_studio_gemini.rs
@@ -801,7 +801,10 @@ enum GeminiResponseMimeType {
 #[derive(Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct GeminiThinkingConfig {
-    thinking_budget: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking_budget: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking_level: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Serialize)]
@@ -853,26 +856,18 @@ fn apply_inference_params(
         verbosity,
     } = inference_params;
 
-    if reasoning_effort.is_some() {
-        warn_inference_parameter_not_supported(
-            PROVIDER_NAME,
-            "reasoning_effort",
-            Some("Tip: You might want to use `thinking_budget_tokens` for this provider."),
-        );
-    }
-
-    if let Some(budget_tokens) = thinking_budget_tokens {
+    if reasoning_effort.is_some() || thinking_budget_tokens.is_some() {
+        let thinking_config = GeminiThinkingConfig {
+            thinking_budget: *thinking_budget_tokens,
+            thinking_level: reasoning_effort.clone(),
+        };
         if let Some(gen_config) = &mut request.generation_config {
-            gen_config.thinking_config = Some(GeminiThinkingConfig {
-                thinking_budget: *budget_tokens,
-            });
+            gen_config.thinking_config = Some(thinking_config);
         } else {
             request.generation_config = Some(GeminiGenerationConfig {
                 stop_sequences: None,
                 temperature: None,
-                thinking_config: Some(GeminiThinkingConfig {
-                    thinking_budget: *budget_tokens,
-                }),
+                thinking_config: Some(thinking_config),
                 top_p: None,
                 presence_penalty: None,
                 frequency_penalty: None,
@@ -3093,19 +3088,19 @@ mod tests {
 
         apply_inference_params(&mut request, &inference_params);
 
-        // Test that reasoning_effort warns with tip about thinking_budget_tokens
-        assert!(logs_contain(
-            "Google AI Studio Gemini does not support the inference parameter `reasoning_effort`, so it will be ignored. Tip: You might want to use `thinking_budget_tokens` for this provider."
-        ));
-
-        // Test that thinking_budget_tokens is applied correctly in generation_config
-        assert!(request.generation_config.is_some());
+        // Test that thinking_budget_tokens and reasoning_effort are applied correctly in generation_config
+        assert!(
+            request.generation_config.is_some(),
+            "generation_config should be set when thinking params are provided"
+        );
         let gen_config = request.generation_config.unwrap();
         assert_eq!(
             gen_config.thinking_config,
             Some(GeminiThinkingConfig {
-                thinking_budget: 1024,
-            })
+                thinking_budget: Some(1024),
+                thinking_level: Some("high".to_string()),
+            }),
+            "thinking_config should contain both thinking_budget and thinking_level"
         );
 
         // Test that verbosity warns


### PR DESCRIPTION
Fix #5700 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables Gemini thinking parameters across both Vertex AI and Google AI Studio.
> 
> - Map `reasoning_effort` to `generationConfig.thinkingConfig.thinkingLevel` and include `thinking_budget_tokens` as `thinkingBudget` (now optional) in request payloads
> - Update Gemini thinking config structs to use optional fields (`thinking_level`, `thinking_budget`) and apply when either param is provided
> - Adjust tests to assert both fields are forwarded (as `Some(...)`) and remove prior unsupported warnings
> - Update docs: configuration reference clarifies Gemini mapping; provider guides add a "Thinking Parameters" section for both Vertex AI and AI Studio
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec0eae60a14e01687cb817f6b4903add4f4aa4e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->