### PR TITLE
Fix docker hub publish action when run from release

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -143,7 +143,7 @@ jobs:
             latest=false
           tags: |
             type=ref,event=tag,
-            type=sha,format=long,enable=${{ inputs.is_dev }}
+            type=sha,format=long,enable=${{ inputs.is_dev && 'true' || 'false' }}
             type=raw,value=latest,enable=${{ github.event_name == 'release' && github.event.prerelease == false }}
 
       - name: Create manifest list and push


### PR DESCRIPTION
The 'is_dev' input will not exist, so we need to explicitly provide a default value of 'false'

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes Docker Hub publish workflow tag generation to avoid failures during release runs.
> 
> - In `docker-hub-publish.yml`, updates `docker/metadata-action` `tags` config to use `enable=${{ inputs.is_dev && 'true' || 'false' }}` for SHA tags, ensuring a valid boolean-like string when `is_dev` may be unset during releases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9719ff5db02b32008bdfdab31a1f76ed802e5d6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->