### PR TITLE
Use DisplayOrDebugGateway for autopilot errors

### DIFF
--- a/tensorzero-core/src/endpoints/internal/autopilot.rs
+++ b/tensorzero-core/src/endpoints/internal/autopilot.rs
@@ -264,7 +264,10 @@ pub async fn stream_events_handler(
             Ok(event) => match serde_json::to_string(&event) {
                 Ok(data) => Ok(SseEvent::default().event("event").data(data)),
                 Err(e) => {
-                    tracing::error!("Failed to serialize autopilot event: {}", DisplayOrDebugGateway::new(&e));
+                    tracing::error!(
+                        "Failed to serialize autopilot event: {}",
+                        DisplayOrDebugGateway::new(&e)
+                    );
                     Err(Error::new(ErrorDetails::Serialization {
                         message: e.to_string(),
                     }))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves error logging in the Autopilot SSE stream handler.
> 
> - Use `DisplayOrDebugGateway` when logging serialization failures and stream errors in `stream_events_handler` of `autopilot.rs`
> - Update imports to include `DisplayOrDebugGateway`; no API or logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8272884dad394035ac7dd931683fe05f08d4a5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->