### PR TITLE
Use Namespace builders for building '-dev' containers

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -68,6 +68,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Install Namespace CLI
+        uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
+
+      - name: Configure Namespace-powered Buildx
+        uses: namespacelabs/nscloud-setup-buildx-action@91c2e6537780e3b092cb8476406be99a8f91bd5e
+        with:
+          wait-for-builder: true
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
Now that this runs as part of the merge queue, doing a local build on the Github runner causes a large delay in launching the autopilot-e2e dispatch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves Docker image builds to a Namespace-powered remote builder to speed up CI builds and avoid local runner bottlenecks.
> 
> - Adds `namespacelabs/nscloud-setup` and `namespacelabs/nscloud-setup-buildx-action` steps in `docker-hub-publish.yml` to install Namespace CLI and configure Buildx (with `wait-for-builder: true`)
> - Keeps existing Docker metadata extraction and build-push steps; no changes to images, tags, or matrix configuration
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9835a6a5333725ef6c272b1e68ee20c69adf6f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->