### PR TITLE
Remove random suffix from raw usage test

### DIFF
--- a/tensorzero-core/tests/e2e/providers/commonv2/raw_usage.rs
+++ b/tensorzero-core/tests/e2e/providers/commonv2/raw_usage.rs
@@ -41,7 +41,6 @@ fn assert_raw_usage_entry(entry: &Value, provider: &E2ETestProvider) {
 /// Test that include_raw_usage works correctly for non-streaming inference
 pub async fn test_raw_usage_inference_with_provider_non_streaming(provider: E2ETestProvider) {
     let episode_id = Uuid::now_v7();
-    let random_suffix = Uuid::now_v7();
     let extra_headers = if provider.is_modal_provider() {
         get_modal_extra_headers()
     } else {
@@ -57,7 +56,7 @@ pub async fn test_raw_usage_inference_with_provider_non_streaming(provider: E2ET
             "messages": [
                 {
                     "role": "user",
-                    "content": format!("What is the capital of Japan? {random_suffix}")
+                    "content": "What is the capital of Japan?"
                 }
             ]
         },
@@ -135,7 +134,6 @@ pub async fn test_raw_usage_inference_with_provider_streaming(provider: E2ETestP
     }
 
     let episode_id = Uuid::now_v7();
-    let random_suffix = Uuid::now_v7();
     let extra_headers = if provider.is_modal_provider() {
         get_modal_extra_headers()
     } else {
@@ -151,7 +149,7 @@ pub async fn test_raw_usage_inference_with_provider_streaming(provider: E2ETestP
             "messages": [
                 {
                     "role": "user",
-                    "content": format!("What is the capital of France? {random_suffix}")
+                    "content": "What is the capital of France?"
                 }
             ]
         },


### PR DESCRIPTION
We're trying to use provider-proxy cache more

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes randomness from raw usage E2E tests to improve cacheability and stability.
> 
> - In `tests/e2e/providers/commonv2/raw_usage.rs`, replace formatted prompts with fixed strings in both non-streaming and streaming tests
> - Remove unused `random_suffix` variable
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c94ec6e866f0537d579afa620f51e6c6606ddf3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->