### PR TITLE
bumped version to 2026.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot-client"
-version = "2026.1.3"
+version = "2026.1.4"
 dependencies = [
  "chrono",
  "durable-tools-spawn",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-tools"
-version = "2026.1.3"
+version = "2026.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-worker"
-version = "2026.1.3"
+version = "2026.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools"
-version = "2026.1.3"
+version = "2026.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools-spawn"
-version = "2026.1.3"
+version = "2026.1.4"
 dependencies = [
  "async-trait",
  "durable",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2026.1.3"
+version = "2026.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2026.1.3"
+version = "2026.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2337,7 +2337,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2026.1.3"
+version = "2026.1.4"
 dependencies = [
  "async-stream",
  "autopilot-worker",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-utils"
-version = "2026.1.3"
+version = "2026.1.4"
 dependencies = [
  "minijinja",
  "serde",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2026.1.3"
+version = "2026.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6206,7 +6206,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2026.1.3"
+version = "2026.1.4"
 dependencies = [
  "axum",
  "chrono",
@@ -6226,7 +6226,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2026.1.3"
+version = "2026.1.4"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -6346,7 +6346,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2026.1.3"
+version = "2026.1.4"
 dependencies = [
  "napi",
  "napi-build",
@@ -6359,7 +6359,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-optimizers"
-version = "2026.1.3"
+version = "2026.1.4"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -6393,7 +6393,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2026.1.3"
+version = "2026.1.4"
 dependencies = [
  "evaluations",
  "futures",
@@ -6411,7 +6411,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types"
-version = "2026.1.3"
+version = "2026.1.4"
 dependencies = [
  "aws-smithy-types",
  "infer",
@@ -6431,7 +6431,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types-providers"
-version = "2026.1.3"
+version = "2026.1.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -6439,7 +6439,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-unsafe-helpers"
-version = "2026.1.3"
+version = "2026.1.4"
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2026.1.3"
+version = "2026.1.4"
 rust-version = "1.88.0"
 license = "Apache-2.0"
 edition = "2024"

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2026.1.3"
+appVersion: "2026.1.4"

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2026.1.3",
+  "version": "2026.1.4",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prepares the repo for the 2026.1.4 release with coordinated version bumps across workspace, packages, and deployment metadata.
> 
> - Updates workspace `version` in `Cargo.toml` to `2026.1.4`
> - Bumps many internal crate versions in `Cargo.lock` from `2026.1.3` → `2026.1.4`
> - Updates Helm chart `appVersion` in `examples/production-deployment-k8s-helm/Chart.yaml` to `2026.1.4`
> - Updates UI `version` in `ui/package.json` to `2026.1.4`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ee57bf70f0333bf5f24cf7b9123cc2d935e8224. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->