### PR TITLE
Change backend connection errors from 500 to 503 (#5736)

### DIFF
--- a/tensorzero-core/src/error/mod.rs
+++ b/tensorzero-core/src/error/mod.rs
@@ -793,7 +793,7 @@ impl ErrorDetails {
             ErrorDetails::Cache { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::ChannelWrite { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::ClickHouseConfiguration { .. } => StatusCode::INTERNAL_SERVER_ERROR,
-            ErrorDetails::ClickHouseConnection { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorDetails::ClickHouseConnection { .. } => StatusCode::SERVICE_UNAVAILABLE,
             ErrorDetails::ClickHouseDeserialization { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::ClickHouseMigration { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::ClickHouseMigrationsDisabled => StatusCode::INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
Fixes #5736

Change ClickhouseConnection, PostgresConnection and ValkeyConnection errors to return HTTP 503 (Service Unavailable) instead of 500 (Internal Server Error).

This is more semantically correct for transient backend failures, signals to clients that retrying might succeed, and distinguishes infrastructure issues from application bugs.