### PR TITLE
Add clone_datapoints to DatasetQueries trait

### DIFF
--- a/tensorzero-core/src/db/clickhouse/dataset_queries.rs
+++ b/tensorzero-core/src/db/clickhouse/dataset_queries.rs
@@ -502,6 +502,139 @@ impl DatasetQueries for ClickHouseConnectionInfo {
         written_rows += json_written_rows?;
         Ok(written_rows)
     }
+
+    async fn clone_datapoints(
+        &self,
+        target_dataset_name: &str,
+        source_datapoint_ids: &[Uuid],
+    ) -> Result<Vec<Option<Uuid>>, Error> {
+        if source_datapoint_ids.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Generate all mappings from source to target IDs
+        let mappings: Vec<(Uuid, Uuid)> = source_datapoint_ids
+            .iter()
+            .map(|id| (*id, Uuid::now_v7()))
+            .collect();
+
+        // Build the mappings array string for ClickHouse
+        let mappings_str = format!(
+            "[{}]",
+            mappings
+                .iter()
+                .map(|(old, new)| format!("('{old}', '{new}')"))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+
+        // Clone queries using CTE + EXCEPT pattern
+        let chat_clone_query = r"
+            INSERT INTO ChatInferenceDatapoint
+            WITH source AS (
+                SELECT ChatInferenceDatapoint.*, mapping.new_id
+                FROM ChatInferenceDatapoint FINAL
+                INNER JOIN (
+                    SELECT
+                        tupleElement(pair, 1) as old_id,
+                        tupleElement(pair, 2) as new_id
+                    FROM (
+                        SELECT arrayJoin({mappings: Array(Tuple(UUID, UUID))}) as pair
+                    )
+                ) AS mapping ON ChatInferenceDatapoint.id = mapping.old_id
+                WHERE ChatInferenceDatapoint.staled_at IS NULL
+            )
+            SELECT * EXCEPT(new_id) REPLACE(
+                new_id AS id,
+                {target_dataset_name: String} AS dataset_name,
+                now64() AS updated_at
+            )
+            FROM source
+        ";
+
+        let json_clone_query = r"
+            INSERT INTO JsonInferenceDatapoint
+            WITH source AS (
+                SELECT JsonInferenceDatapoint.*, mapping.new_id
+                FROM JsonInferenceDatapoint FINAL
+                INNER JOIN (
+                    SELECT
+                        tupleElement(pair, 1) as old_id,
+                        tupleElement(pair, 2) as new_id
+                    FROM (
+                        SELECT arrayJoin({mappings: Array(Tuple(UUID, UUID))}) as pair
+                    )
+                ) AS mapping ON JsonInferenceDatapoint.id = mapping.old_id
+                WHERE JsonInferenceDatapoint.staled_at IS NULL
+            )
+            SELECT * EXCEPT(new_id) REPLACE(
+                new_id AS id,
+                {target_dataset_name: String} AS dataset_name,
+                now64() AS updated_at
+            )
+            FROM source
+        ";
+
+        let insert_params = HashMap::from([
+            ("target_dataset_name", target_dataset_name),
+            ("mappings", mappings_str.as_str()),
+        ]);
+
+        // Execute both inserts in parallel
+        let (chat_result, json_result) = try_join!(
+            self.run_query_synchronous(chat_clone_query.to_string(), &insert_params),
+            self.run_query_synchronous(json_clone_query.to_string(), &insert_params)
+        )?;
+        drop(chat_result);
+        drop(json_result);
+
+        // Verify which new_ids were actually created
+        let new_ids_str = format!(
+            "[{}]",
+            mappings
+                .iter()
+                .map(|(_, new)| format!("'{new}'"))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+
+        let verify_query = r"
+            SELECT id FROM (
+                SELECT id FROM ChatInferenceDatapoint FINAL
+                WHERE id IN ({new_ids: Array(UUID)}) AND staled_at IS NULL
+                UNION ALL
+                SELECT id FROM JsonInferenceDatapoint FINAL
+                WHERE id IN ({new_ids: Array(UUID)}) AND staled_at IS NULL
+            )
+        ";
+        let verify_params = HashMap::from([("new_ids", new_ids_str.as_str())]);
+        let verify_result = self
+            .run_query_synchronous(verify_query.to_string(), &verify_params)
+            .await?;
+
+        let created_ids: std::collections::HashSet<Uuid> = verify_result
+            .response
+            .lines()
+            .filter_map(|line| Uuid::parse_str(line.trim()).ok())
+            .collect();
+
+        // Map results based on which new_ids were created
+        let results: Vec<Option<Uuid>> = mappings
+            .iter()
+            .map(|(source_id, new_id)| {
+                if created_ids.contains(new_id) {
+                    Some(*new_id)
+                } else {
+                    tracing::warn!(
+                        "Failed to clone datapoint (likely does not exist): {source_id}"
+                    );
+                    None
+                }
+            })
+            .collect();
+
+        Ok(results)
+    }
 }
 
 /// Converts a vec of OrderBy terms to the correct ClickHouse ORDER BY clauses.

--- a/tensorzero-core/src/db/clickhouse/mock_clickhouse_connection_info.rs
+++ b/tensorzero-core/src/db/clickhouse/mock_clickhouse_connection_info.rs
@@ -159,6 +159,16 @@ impl DatasetQueries for MockClickHouseConnectionInfo {
             .delete_datapoints(dataset_name, datapoint_ids)
             .await
     }
+
+    async fn clone_datapoints(
+        &self,
+        target_dataset_name: &str,
+        source_datapoint_ids: &[Uuid],
+    ) -> Result<Vec<Option<Uuid>>, Error> {
+        self.dataset_queries
+            .clone_datapoints(target_dataset_name, source_datapoint_ids)
+            .await
+    }
 }
 
 impl ConfigQueries for MockClickHouseConnectionInfo {

--- a/tensorzero-core/src/db/datasets.rs
+++ b/tensorzero-core/src/db/datasets.rs
@@ -149,4 +149,18 @@ pub trait DatasetQueries {
         dataset_name: &str,
         datapoint_ids: Option<&[Uuid]>,
     ) -> Result<u64, Error>;
+
+    /// Clones datapoints to a target dataset, preserving all fields except id and dataset_name.
+    ///
+    /// For each source datapoint ID, generates a new UUID and attempts to clone the datapoint
+    /// to the target dataset. The operation handles both Chat and Json datapoints.
+    ///
+    /// Returns a Vec with the same length as `source_datapoint_ids`, where each element is:
+    /// - `Some(new_id)` if the source datapoint was found and cloned successfully
+    /// - `None` if the source datapoint doesn't exist
+    async fn clone_datapoints(
+        &self,
+        target_dataset_name: &str,
+        source_datapoint_ids: &[Uuid],
+    ) -> Result<Vec<Option<Uuid>>, Error>;
 }

--- a/tensorzero-core/src/endpoints/datasets/internal/clone_datapoints.rs
+++ b/tensorzero-core/src/endpoints/datasets/internal/clone_datapoints.rs
@@ -1,10 +1,9 @@
 use axum::Json;
 use axum::extract::{Path, State};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use uuid::Uuid;
 
-use crate::db::clickhouse::ClickHouseConnectionInfo;
+use crate::db::datasets::DatasetQueries;
 use crate::error::Error;
 use crate::utils::gateway::{AppState, StructuredJson};
 
@@ -37,144 +36,12 @@ pub async fn clone_datapoints_handler(
 ) -> Result<Json<CloneDatapointsResponse>, Error> {
     validate_dataset_name(&path_params.dataset_name)?;
 
-    let new_ids = clone_datapoints(
-        &path_params.dataset_name,
-        &request.datapoint_ids,
-        &app_state.clickhouse_connection_info,
-    )
-    .await?;
+    let new_ids = app_state
+        .clickhouse_connection_info
+        .clone_datapoints(&path_params.dataset_name, &request.datapoint_ids)
+        .await?;
 
     Ok(Json(CloneDatapointsResponse {
         datapoint_ids: new_ids,
     }))
-}
-
-pub async fn clone_datapoints(
-    target_dataset_name: &str,
-    datapoint_ids: &[Uuid],
-    clickhouse: &ClickHouseConnectionInfo,
-) -> Result<Vec<Option<Uuid>>, Error> {
-    if datapoint_ids.is_empty() {
-        return Ok(vec![]);
-    }
-
-    // Generate all mappings from source to target IDs
-    let mappings: Vec<(Uuid, Uuid)> = datapoint_ids
-        .iter()
-        .map(|id| (*id, Uuid::now_v7()))
-        .collect();
-
-    // Round trip 1: Parallel INSERTs with CTE + EXCEPT pattern
-    let chat_clone_query = r"
-        INSERT INTO ChatInferenceDatapoint
-        WITH source AS (
-            SELECT ChatInferenceDatapoint.*, mapping.new_id
-            FROM ChatInferenceDatapoint FINAL
-            INNER JOIN (
-                SELECT
-                    tupleElement(pair, 1) as old_id,
-                    tupleElement(pair, 2) as new_id
-                FROM (
-                    SELECT arrayJoin({mappings: Array(Tuple(UUID, UUID))}) as pair
-                )
-            ) AS mapping ON ChatInferenceDatapoint.id = mapping.old_id
-            WHERE ChatInferenceDatapoint.staled_at IS NULL
-        )
-        SELECT * EXCEPT(new_id) REPLACE(
-            new_id AS id,
-            {target_dataset_name: String} AS dataset_name,
-            now64() AS updated_at
-        )
-        FROM source
-    ";
-
-    let json_clone_query = r"
-        INSERT INTO JsonInferenceDatapoint
-        WITH source AS (
-            SELECT JsonInferenceDatapoint.*, mapping.new_id
-            FROM JsonInferenceDatapoint FINAL
-            INNER JOIN (
-                SELECT
-                    tupleElement(pair, 1) as old_id,
-                    tupleElement(pair, 2) as new_id
-                FROM (
-                    SELECT arrayJoin({mappings: Array(Tuple(UUID, UUID))}) as pair
-                )
-            ) AS mapping ON JsonInferenceDatapoint.id = mapping.old_id
-            WHERE JsonInferenceDatapoint.staled_at IS NULL
-        )
-        SELECT * EXCEPT(new_id) REPLACE(
-            new_id AS id,
-            {target_dataset_name: String} AS dataset_name,
-            now64() AS updated_at
-        )
-        FROM source
-    ";
-
-    let mappings_str = format!(
-        "[{}]",
-        mappings
-            .iter()
-            .map(|(old, new)| format!("('{old}', '{new}')"))
-            .collect::<Vec<_>>()
-            .join(",")
-    );
-    let insert_params = HashMap::from([
-        ("target_dataset_name", target_dataset_name),
-        ("mappings", mappings_str.as_str()),
-    ]);
-
-    let chat_future =
-        clickhouse.run_query_synchronous(chat_clone_query.to_string(), &insert_params);
-    let json_future =
-        clickhouse.run_query_synchronous(json_clone_query.to_string(), &insert_params);
-
-    let (chat_result, json_result) = tokio::join!(chat_future, json_future);
-    chat_result?;
-    json_result?;
-
-    // Round trip 2: Verify which `new_ids` were actually created (in case some source datapoints don't exist)
-    let new_ids_str = format!(
-        "[{}]",
-        mappings
-            .iter()
-            .map(|(_, new)| format!("'{new}'"))
-            .collect::<Vec<_>>()
-            .join(",")
-    );
-
-    let verify_query = r"
-        SELECT id FROM (
-            SELECT id FROM ChatInferenceDatapoint FINAL
-            WHERE id IN ({new_ids: Array(UUID)}) AND staled_at IS NULL
-            UNION ALL
-            SELECT id FROM JsonInferenceDatapoint FINAL
-            WHERE id IN ({new_ids: Array(UUID)}) AND staled_at IS NULL
-        )
-    ";
-    let verify_params = HashMap::from([("new_ids", new_ids_str.as_str())]);
-    let verify_result = clickhouse
-        .run_query_synchronous(verify_query.to_string(), &verify_params)
-        .await?;
-
-    let created_ids: std::collections::HashSet<Uuid> = verify_result
-        .response
-        .lines()
-        .filter_map(|line| Uuid::parse_str(line.trim()).ok())
-        .collect();
-
-    // Map results based on which `new_ids` were created
-    let results: Vec<Option<Uuid>> = mappings
-        .iter()
-        .map(|(source_id, new_id)| {
-            if created_ids.contains(new_id) {
-                Some(*new_id)
-            } else {
-                tracing::warn!("Failed to clone datapoint (likely does not exist): {source_id}");
-                None
-            }
-        })
-        .collect();
-
-    Ok(results)
 }


### PR DESCRIPTION
Move the clone datapoints SQL queries from the endpoint handler to the DatasetQueries trait. This centralizes the database logic and enables future Postgres support.

The clone operation:
1. Generates new UUIDs for each source datapoint
2. Inserts cloned rows into Chat and Json datapoint tables in parallel
3. Verifies which clones succeeded (source might not exist)
4. Returns mapping of source IDs to new IDs (None if source missing)