### PR TITLE
Extract get_inference_output to InferenceQueries

### DIFF
--- a/tensorzero-core/src/db/clickhouse/mock_clickhouse_connection_info.rs
+++ b/tensorzero-core/src/db/clickhouse/mock_clickhouse_connection_info.rs
@@ -114,6 +114,16 @@ impl InferenceQueries for MockClickHouseConnectionInfo {
             .get_json_inference_output_schema(function_name, inference_id)
             .await
     }
+
+    async fn get_inference_output(
+        &self,
+        function_info: &FunctionInfo,
+        inference_id: Uuid,
+    ) -> Result<Option<String>, Error> {
+        self.inference_queries
+            .get_inference_output(function_info, inference_id)
+            .await
+    }
 }
 
 #[async_trait]

--- a/tensorzero-core/src/db/inferences.rs
+++ b/tensorzero-core/src/db/inferences.rs
@@ -381,4 +381,16 @@ pub trait InferenceQueries {
         function_name: &str,
         inference_id: Uuid,
     ) -> Result<Option<Value>, Error>;
+
+    /// Get the output string from an inference for human feedback context.
+    ///
+    /// Returns the serialized output of the inference, which is needed when
+    /// writing static evaluation human feedback records.
+    ///
+    /// Returns `None` if the inference doesn't exist.
+    async fn get_inference_output(
+        &self,
+        function_info: &FunctionInfo,
+        inference_id: Uuid,
+    ) -> Result<Option<String>, Error>;
 }

--- a/tensorzero-core/tests/e2e/db/inference_queries.rs
+++ b/tensorzero-core/tests/e2e/db/inference_queries.rs
@@ -1,14 +1,16 @@
 use std::path::Path;
 
 use tensorzero_core::{
-    config::{Config, ConfigFileGlob},
+    config::{Config, ConfigFileGlob, MetricConfigLevel},
     db::{
         clickhouse::{query_builder::InferenceFilter, test_helpers::get_clickhouse},
         feedback::{FeedbackQueries, FeedbackRow},
-        inferences::{InferenceOutputSource, InferenceQueries, ListInferencesParams},
+        inferences::{FunctionInfo, InferenceOutputSource, InferenceQueries, ListInferencesParams},
     },
     endpoints::stored_inferences::v1::types::DemonstrationFeedbackFilter,
+    inference::types::FunctionType,
 };
+use uuid::Uuid;
 
 async fn get_e2e_config() -> Config {
     Config::load_from_path_optional_verify_credentials(
@@ -114,4 +116,143 @@ async fn test_list_inferences_filtered_to_no_demonstrations() {
             "Expected no demonstration feedback for inference {inference_id}"
         );
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_inference_output_chat_inference() {
+    let config = get_e2e_config().await;
+    let clickhouse = get_clickhouse().await;
+
+    // First, list some chat inferences to get a valid inference_id
+    let inferences = clickhouse
+        .list_inferences(
+            &config,
+            &ListInferencesParams {
+                function_name: Some("write_haiku"),
+                output_source: InferenceOutputSource::Inference,
+                limit: 1,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        !inferences.is_empty(),
+        "Should have at least one chat inference"
+    );
+
+    let inference = &inferences[0];
+    let inference_id = inference.id();
+
+    // Get function info for this inference
+    let function_info = clickhouse
+        .get_function_info(&inference_id, MetricConfigLevel::Inference)
+        .await
+        .unwrap()
+        .expect("Should find function info for existing inference");
+
+    assert_eq!(
+        function_info.function_type,
+        FunctionType::Chat,
+        "write_haiku should be a Chat function"
+    );
+
+    // Now test get_inference_output
+    let output = clickhouse
+        .get_inference_output(&function_info, inference_id)
+        .await
+        .unwrap();
+
+    assert!(
+        output.is_some(),
+        "Should return output for existing inference"
+    );
+    let output_str = output.unwrap();
+    assert!(
+        !output_str.is_empty(),
+        "Output should not be empty for existing inference"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_inference_output_json_inference() {
+    let config = get_e2e_config().await;
+    let clickhouse = get_clickhouse().await;
+
+    // First, list some json inferences to get a valid inference_id
+    let inferences = clickhouse
+        .list_inferences(
+            &config,
+            &ListInferencesParams {
+                function_name: Some("extract_entities"),
+                output_source: InferenceOutputSource::Inference,
+                limit: 1,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        !inferences.is_empty(),
+        "Should have at least one json inference"
+    );
+
+    let inference = &inferences[0];
+    let inference_id = inference.id();
+
+    // Get function info for this inference
+    let function_info = clickhouse
+        .get_function_info(&inference_id, MetricConfigLevel::Inference)
+        .await
+        .unwrap()
+        .expect("Should find function info for existing inference");
+
+    assert_eq!(
+        function_info.function_type,
+        FunctionType::Json,
+        "extract_entities should be a Json function"
+    );
+
+    // Now test get_inference_output
+    let output = clickhouse
+        .get_inference_output(&function_info, inference_id)
+        .await
+        .unwrap();
+
+    assert!(
+        output.is_some(),
+        "Should return output for existing json inference"
+    );
+    let output_str = output.unwrap();
+    assert!(
+        !output_str.is_empty(),
+        "Output should not be empty for existing json inference"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_inference_output_not_found() {
+    let clickhouse = get_clickhouse().await;
+
+    // Create a fake function_info with a non-existent inference_id
+    let fake_function_info = FunctionInfo {
+        function_name: "write_haiku".to_string(),
+        function_type: FunctionType::Chat,
+        variant_name: "test_variant".to_string(),
+        episode_id: Uuid::now_v7(),
+    };
+
+    let non_existent_inference_id = Uuid::now_v7();
+
+    let output = clickhouse
+        .get_inference_output(&fake_function_info, non_existent_inference_id)
+        .await
+        .unwrap();
+
+    assert!(
+        output.is_none(),
+        "Should return None for non-existent inference"
+    );
 }


### PR DESCRIPTION
A step towards #5691.

The get_output() function in human_feedback.rs used format!() with direct string interpolation for inference_id, episode_id, function_name, variant_name, and table_name. This is a potential SQL injection vulnerability.

Added InferenceQueries::get_inference_output() trait method with a proper parameterized query implementation in ClickHouse.