### PR TITLE
Add round-trip tests for Python SDK content block types

### DIFF
--- a/clients/python/tests/test_roundtrip_template_types.py
+++ b/clients/python/tests/test_roundtrip_template_types.py
@@ -221,22 +221,21 @@ async def test_async_template_content_roundtrip_complete_flow(
 
     dataset_name = f"test_template_roundtrip_{uuid7()}"
 
-    datapoint_response = await async_client.create_datapoints_from_inferences(
-        dataset_name=dataset_name,
-        params=CreateDatapointsFromInferenceRequestParamsInferenceIds(inference_ids=[follow_up_id]),
-        output_source="inference",
-    )
-
-    assert datapoint_response.ids is not None, "create_datapoints_from_inferences must return IDs"
-    assert len(datapoint_response.ids) == 1, "Should create exactly 1 datapoint"
-
-    datapoint_id = datapoint_response.ids[0]
-
-    # ============================================================================
-    # Step 8: Retrieve datapoint and verify InputMessageContentTemplate
-    # ============================================================================
-
     try:
+        datapoint_response = await async_client.create_datapoints_from_inferences(
+            dataset_name=dataset_name,
+            params=CreateDatapointsFromInferenceRequestParamsInferenceIds(inference_ids=[follow_up_id]),
+            output_source="inference",
+        )
+
+        assert datapoint_response.ids is not None, "create_datapoints_from_inferences must return IDs"
+        assert len(datapoint_response.ids) == 1, "Should create exactly 1 datapoint"
+
+        datapoint_id = datapoint_response.ids[0]
+
+        # ============================================================================
+        # Step 8: Retrieve datapoint and verify InputMessageContentTemplate
+        # ============================================================================
         datapoint_get_response = await async_client.get_datapoints(dataset_name=dataset_name, ids=[datapoint_id])
 
         assert datapoint_get_response.datapoints is not None, "get_datapoints must return datapoints"
@@ -389,19 +388,18 @@ def test_sync_template_content_roundtrip_complete_flow(sync_client: TensorZeroGa
 
     dataset_name = f"test_template_roundtrip_{uuid7()}"
 
-    datapoint_response = sync_client.create_datapoints_from_inferences(
-        dataset_name=dataset_name,
-        params=CreateDatapointsFromInferenceRequestParamsInferenceIds(inference_ids=[follow_up_id]),
-        output_source="inference",
-    )
-
-    datapoint_id = datapoint_response.ids[0]
-
-    # ============================================================================
-    # Step 5: Verify InputMessageContentTemplate in datapoint
-    # ============================================================================
-
     try:
+        datapoint_response = sync_client.create_datapoints_from_inferences(
+            dataset_name=dataset_name,
+            params=CreateDatapointsFromInferenceRequestParamsInferenceIds(inference_ids=[follow_up_id]),
+            output_source="inference",
+        )
+
+        datapoint_id = datapoint_response.ids[0]
+
+        # ============================================================================
+        # Step 5: Verify InputMessageContentTemplate in datapoint
+        # ============================================================================
         datapoint_get_response = sync_client.get_datapoints(dataset_name=dataset_name, ids=[datapoint_id])
 
         datapoint = datapoint_get_response.datapoints[0]

--- a/clients/python/tests/test_roundtrip_text_types.py
+++ b/clients/python/tests/test_roundtrip_text_types.py
@@ -245,22 +245,21 @@ async def test_async_text_content_roundtrip_complete_flow(
 
     dataset_name = f"test_text_roundtrip_{uuid7()}"
 
-    datapoint_response = await async_client.create_datapoints_from_inferences(
-        dataset_name=dataset_name,
-        params=CreateDatapointsFromInferenceRequestParamsInferenceIds(inference_ids=[follow_up_id]),
-        output_source="inference",
-    )
-
-    assert datapoint_response.ids is not None, "create_datapoints_from_inferences must return IDs"
-    assert len(datapoint_response.ids) == 1, "Should create exactly 1 datapoint"
-
-    datapoint_id = datapoint_response.ids[0]
-
-    # ============================================================================
-    # Step 10: Retrieve datapoint via get_datapoints
-    # ============================================================================
-
     try:
+        datapoint_response = await async_client.create_datapoints_from_inferences(
+            dataset_name=dataset_name,
+            params=CreateDatapointsFromInferenceRequestParamsInferenceIds(inference_ids=[follow_up_id]),
+            output_source="inference",
+        )
+
+        assert datapoint_response.ids is not None, "create_datapoints_from_inferences must return IDs"
+        assert len(datapoint_response.ids) == 1, "Should create exactly 1 datapoint"
+
+        datapoint_id = datapoint_response.ids[0]
+
+        # ============================================================================
+        # Step 10: Retrieve datapoint via get_datapoints
+        # ============================================================================
         datapoint_get_response = await async_client.get_datapoints(dataset_name=dataset_name, ids=[datapoint_id])
 
         assert datapoint_get_response.datapoints is not None, "get_datapoints must return datapoints"
@@ -488,15 +487,14 @@ def test_sync_text_content_roundtrip_complete_flow(sync_client: TensorZeroGatewa
 
     dataset_name = f"test_text_roundtrip_{uuid7()}"
 
-    datapoint_response = sync_client.create_datapoints_from_inferences(
-        dataset_name=dataset_name,
-        params=CreateDatapointsFromInferenceRequestParamsInferenceIds(inference_ids=[follow_up_id]),
-        output_source="inference",
-    )
-
-    datapoint_id = datapoint_response.ids[0]
-
     try:
+        datapoint_response = sync_client.create_datapoints_from_inferences(
+            dataset_name=dataset_name,
+            params=CreateDatapointsFromInferenceRequestParamsInferenceIds(inference_ids=[follow_up_id]),
+            output_source="inference",
+        )
+
+        datapoint_id = datapoint_response.ids[0]
         datapoint_get_response = sync_client.get_datapoints(dataset_name=dataset_name, ids=[datapoint_id])
 
         datapoint = datapoint_get_response.datapoints[0]

--- a/clients/python/tests/test_roundtrip_thought_types.py
+++ b/clients/python/tests/test_roundtrip_thought_types.py
@@ -234,22 +234,21 @@ async def test_async_thought_content_roundtrip_complete_flow(
 
     dataset_name = f"test_thought_roundtrip_{uuid7()}"
 
-    datapoint_response = await async_client.create_datapoints_from_inferences(
-        dataset_name=dataset_name,
-        params=CreateDatapointsFromInferenceRequestParamsInferenceIds(inference_ids=[follow_up_id]),
-        output_source="inference",
-    )
-
-    assert datapoint_response.ids is not None, "create_datapoints_from_inferences must return IDs"
-    assert len(datapoint_response.ids) == 1, "Should create exactly 1 datapoint"
-
-    datapoint_id = datapoint_response.ids[0]
-
-    # ============================================================================
-    # Step 9: Retrieve datapoint via get_datapoints
-    # ============================================================================
-
     try:
+        datapoint_response = await async_client.create_datapoints_from_inferences(
+            dataset_name=dataset_name,
+            params=CreateDatapointsFromInferenceRequestParamsInferenceIds(inference_ids=[follow_up_id]),
+            output_source="inference",
+        )
+
+        assert datapoint_response.ids is not None, "create_datapoints_from_inferences must return IDs"
+        assert len(datapoint_response.ids) == 1, "Should create exactly 1 datapoint"
+
+        datapoint_id = datapoint_response.ids[0]
+
+        # ============================================================================
+        # Step 9: Retrieve datapoint via get_datapoints
+        # ============================================================================
         datapoint_get_response = await async_client.get_datapoints(dataset_name=dataset_name, ids=[datapoint_id])
 
         assert datapoint_get_response.datapoints is not None, "get_datapoints must return datapoints"
@@ -448,15 +447,14 @@ def test_sync_thought_content_roundtrip_complete_flow(sync_client: TensorZeroGat
 
     dataset_name = f"test_thought_roundtrip_{uuid7()}"
 
-    datapoint_response = sync_client.create_datapoints_from_inferences(
-        dataset_name=dataset_name,
-        params=CreateDatapointsFromInferenceRequestParamsInferenceIds(inference_ids=[follow_up_id]),
-        output_source="inference",
-    )
-
-    datapoint_id = datapoint_response.ids[0]
-
     try:
+        datapoint_response = sync_client.create_datapoints_from_inferences(
+            dataset_name=dataset_name,
+            params=CreateDatapointsFromInferenceRequestParamsInferenceIds(inference_ids=[follow_up_id]),
+            output_source="inference",
+        )
+
+        datapoint_id = datapoint_response.ids[0]
         datapoint_get_response = sync_client.get_datapoints(dataset_name=dataset_name, ids=[datapoint_id])
 
         datapoint = datapoint_get_response.datapoints[0]

--- a/clients/python/tests/test_roundtrip_tool_types.py
+++ b/clients/python/tests/test_roundtrip_tool_types.py
@@ -336,25 +336,24 @@ async def test_async_tool_call_roundtrip_complete_flow(
 
     dataset_name = f"test_tool_call_roundtrip_{uuid7()}"
 
-    # Use follow_up_id instead of inference_id to get the complete conversation
-    datapoint_response = await async_client.create_datapoints_from_inferences(
-        dataset_name=dataset_name,
-        params=CreateDatapointsFromInferenceRequestParamsInferenceIds(
-            inference_ids=[follow_up_id]  # Use follow-up inference with full conversation
-        ),
-        output_source="inference",
-    )
-
-    assert datapoint_response.ids is not None, "create_datapoints_from_inferences must return IDs"
-    assert len(datapoint_response.ids) == 1, "Should create exactly 1 datapoint"
-
-    datapoint_id = datapoint_response.ids[0]
-
-    # ============================================================================
-    # Step 10: Retrieve datapoint via get_datapoints
-    # ============================================================================
-
     try:
+        # Use follow_up_id instead of inference_id to get the complete conversation
+        datapoint_response = await async_client.create_datapoints_from_inferences(
+            dataset_name=dataset_name,
+            params=CreateDatapointsFromInferenceRequestParamsInferenceIds(
+                inference_ids=[follow_up_id]  # Use follow-up inference with full conversation
+            ),
+            output_source="inference",
+        )
+
+        assert datapoint_response.ids is not None, "create_datapoints_from_inferences must return IDs"
+        assert len(datapoint_response.ids) == 1, "Should create exactly 1 datapoint"
+
+        datapoint_id = datapoint_response.ids[0]
+
+        # ============================================================================
+        # Step 10: Retrieve datapoint via get_datapoints
+        # ============================================================================
         datapoint_get_response = await async_client.get_datapoints(dataset_name=dataset_name, ids=[datapoint_id])
 
         assert datapoint_get_response.datapoints is not None, "get_datapoints must return datapoints"
@@ -765,25 +764,24 @@ def test_sync_tool_call_roundtrip_complete_flow(sync_client: TensorZeroGateway):
 
     dataset_name = f"test_tool_call_roundtrip_{uuid7()}"
 
-    # Use follow_up_id instead of inference_id to get the complete conversation
-    datapoint_response = sync_client.create_datapoints_from_inferences(
-        dataset_name=dataset_name,
-        params=CreateDatapointsFromInferenceRequestParamsInferenceIds(
-            inference_ids=[follow_up_id]  # Use follow-up inference with full conversation
-        ),
-        output_source="inference",
-    )
-
-    assert datapoint_response.ids is not None, "create_datapoints_from_inferences must return IDs"
-    assert len(datapoint_response.ids) == 1, "Should create exactly 1 datapoint"
-
-    datapoint_id = datapoint_response.ids[0]
-
-    # ============================================================================
-    # Step 10: Retrieve datapoint via get_datapoints
-    # ============================================================================
-
     try:
+        # Use follow_up_id instead of inference_id to get the complete conversation
+        datapoint_response = sync_client.create_datapoints_from_inferences(
+            dataset_name=dataset_name,
+            params=CreateDatapointsFromInferenceRequestParamsInferenceIds(
+                inference_ids=[follow_up_id]  # Use follow-up inference with full conversation
+            ),
+            output_source="inference",
+        )
+
+        assert datapoint_response.ids is not None, "create_datapoints_from_inferences must return IDs"
+        assert len(datapoint_response.ids) == 1, "Should create exactly 1 datapoint"
+
+        datapoint_id = datapoint_response.ids[0]
+
+        # ============================================================================
+        # Step 10: Retrieve datapoint via get_datapoints
+        # ============================================================================
         datapoint_get_response = sync_client.get_datapoints(dataset_name=dataset_name, ids=[datapoint_id])
 
         assert datapoint_get_response.datapoints is not None, "get_datapoints must return datapoints"


### PR DESCRIPTION
## Summary

Adds type validation for **20 content block types** covering tool calls, text, templates, and thought content. Tests validate type preservation through the complete lifecycle: inference → storage → serialization → datapoint creation.

## Tests Added

Created 4 focused test files (8 test functions, 16 test runs):

| Test File                           | Content Type      | Types Covered                                                                                                                                                                             | Count |
| ----------------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
| `test_roundtrip_tool_types.py`      | Tool Calls        | ToolCall, ContentBlockChatOutputToolCall, StoredInputMessageContentToolCall, StoredInputMessageContentToolResult, InputMessageContentToolCall, InputMessageContentToolResult, DatapointChat | 7     |
| `test_roundtrip_text_types.py`      | Text              | Text, RawText, ContentBlockChatOutputText, StoredInputMessageContentText, StoredInputMessageContentRawText, InputMessageContentText, InputMessageContentRawText                           | 7     |
| `test_roundtrip_template_types.py`  | Templates         | StoredInputMessageContentTemplate, InputMessageContentTemplate                                                                                                                            | 2     |
| `test_roundtrip_thought_types.py`   | Thought/Reasoning | Thought, ContentBlockChatOutputThought, StoredInputMessageContentThought, InputMessageContentThought                                                                                      | 4     |
| **Total**                           |                   |                                                                                                                                                                                           | **20** |

### Not Covered (Deferred)

| Content Type    | Types Not Covered                                                                                   | Reason                                                           |
| --------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| File Content    | InputMessageContentFile, StoredInputMessageContentFile                                              | Requires S3 storage configuration                                |
| Unknown Content | ContentBlockChatOutputUnknown, InputMessageContentUnknown, StoredInputMessageContentUnknown        | Requires real provider features (e.g., OpenAI web_search_call)  |

## Test Pattern

All tests follow the same 12-step pattern:

**Inference round-trip (steps 1-8):**
- Create inference → verify response type (Text, ToolCall, Thought)
- Query via `get_inferences()` → verify stored output/input types (ContentBlockChatOutput*, StoredInputMessageContent*)
- Serialize with `asdict()` + JSON round-trip
- Reuse serialized content in follow-up inference

**Datapoint round-trip (steps 9-12):**
- Create datapoint via `create_datapoints_from_inferences()`
- Query via `get_datapoints()` → verify datapoint types (InputMessageContent*, ContentBlockChatOutput*)

## Key Features

- **No external dependencies**: Uses dummy provider (no API keys or reasoning models needed)
- **Fast & deterministic**: ~0.7s per test, consistent results
- **Comprehensive validation**: Type discriminators, isinstance checks, field preservation, serialization, reusability
- **Catches type generation issues**: Like PR #5803 where fields were dropped during code generation

## What This Catches

- Missing fields in generated types
- Incorrect type discriminators
- Serialization/deserialization errors
- Type mismatches between response/storage/datapoint layers
- Data loss through storage/retrieval cycles

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds comprehensive round-trip tests for Python SDK content blocks to ensure type/field preservation across inference → storage → serialization → reuse → datapoints.
> 
> - New tests: `test_roundtrip_tool_types.py`, `test_roundtrip_text_types.py`, `test_roundtrip_template_types.py`, `test_roundtrip_thought_types.py`
> - Validate `tool_call`, `text`/`raw_text`, `template`, and `thought` types across response (`ContentBlock*`/runtime types), stored input (`StoredInputMessageContent*`), and datapoints (`InputMessageContent*`/`Datapoint*`)
> - Cover both async and sync clients; include JSON asdict round-trips and creation/retrieval of datapoints
> - No production code changes; focuses on catching missing fields/type discriminator/serialization regressions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0f6d45db6f7fe6fc6fab2bc364266a72e2ca75c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->