### PR TITLE
Disable fail-fast for live-tests on scheduled CI runs

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -74,6 +74,8 @@ jobs:
     strategy:
       matrix:
         batch_writes: [true, false]
+      # Don't fail-fast for manual/cron runs, so that we get the full picture of what broke
+      fail-fast: ${{ github.event_name == 'merge_group' }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
The live-tests job was missing the fail-fast configuration, causing it
to terminate early when one matrix job fails during scheduled runs. This
matches the existing behavior of the client-tests job, which already had
this setting to ensure scheduled runs complete all jobs for better
visibility into provider flakiness.

Next up we will make them produce JUnit and we can analyze those.