### PR TITLE
Minor docs update

### DIFF
--- a/docs/deployment/valkey-redis.mdx
+++ b/docs/deployment/valkey-redis.mdx
@@ -85,6 +85,5 @@ If both `TENSORZERO_VALKEY_URL` and `TENSORZERO_POSTGRES_URL` are set, the gatew
 
 ### Durability
 
-A critical failure of Valkey (e.g. crash or power outage) could mean losing rate limiting data since the last backup.
-When the rate limiting window is granular (e.g. minutes), this can be tolerated.
-If your rate limiting config includes larger windows, we recommend setting up [recurrent RDB backups](https://valkey.io/topics/persistence/) (point-in-time snapshots) for better durability guarantees.
+A critical failure of Valkey (e.g. server crash) may result in loss of rate limiting data since the last backup.
+This is generally tolerable if your rate limiting windows are short (e.g. minutes), but if you require precise limits or longer time windows, we recommend configuring [recurring RDB (point-in-time) snapshots](https://valkey.io/topics/persistence/) for improved durability.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates documentation for Valkey/Redis deployment durability.
> 
> - Rewrites the "Durability" section to clarify potential data loss on server crash and when it’s tolerable
> - Explicitly recommends recurring RDB (point‑in‑time) snapshots for longer/precise rate-limiting windows
> - No code or behavior changes; docs-only edit in `docs/deployment/valkey-redis.mdx`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd205dd9a1d8d3b2d2e15bfff2d594abf4526725. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->