### PR TITLE
Retry CH checks

### DIFF
--- a/ci/buildkite/test-clickhouse-cloud.sh
+++ b/ci/buildkite/test-clickhouse-cloud.sh
@@ -74,7 +74,10 @@ echo "deb https://packages.clickhouse.com/deb stable main" | sudo tee /etc/apt/s
 sudo apt-get update
 sudo apt-get install -y clickhouse-client
 
-curl "$TENSORZERO_CLICKHOUSE_URL" --data-binary 'SHOW DATABASES'
+curl \
+    --retry 10 --retry-delay 5 --retry-max-time 300 --retry-all-errors --max-time 30 \
+    "$TENSORZERO_CLICKHOUSE_URL" --data-binary 'SHOW DATABASES'
+
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh  -s -- -y
 . "$HOME/.cargo/env"
 curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves robustness of ClickHouse cloud validation in CI.
> 
> - Replaces single `curl` against `TENSORZERO_CLICKHOUSE_URL` with a retriable/timeout-configured call (`--retry 10`, delays, max time, and retry on all errors) before running fixtures and tests in `ci/buildkite/test-clickhouse-cloud.sh`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8eee15e38e124150bba605b1addec85b66ae979a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->