### PR TITLE
Address CI flakiness in `test_rate_limiting_time_intervals`

### DIFF
--- a/tensorzero-core/tests/e2e/rate_limiting.rs
+++ b/tensorzero-core/tests/e2e/rate_limiting.rs
@@ -948,12 +948,12 @@ make_rate_limit_tests!(test_rate_limiting_time_intervals);
 
 async fn test_rate_limiting_time_intervals(backend: &str, stream: bool) {
     // Test different time intervals work correctly
-    // We use concurrent requests to avoid flakiness from token refill if the requests are not cached
+    // We use `refill_rate = 0` to avoid flakiness from tokens refilling if requests serialize due to database locking delays
     let id = Uuid::now_v7();
     let config = generate_rate_limit_config(
         &[&format!(
             r#"[[rate_limiting.rules]]
-model_inferences_per_second = {{ capacity = 2, refill_rate = 2 }}
+model_inferences_per_second = {{ capacity = 2, refill_rate = 0 }}
 always = true
 scope = [
     {{ tag_key = "test12_user_id_{id}", tag_value = "123" }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Stabilizes flakey e2e rate limiting test**
> 
> - In `test_rate_limiting_time_intervals`, set `model_inferences_per_second` to `capacity = 2, refill_rate = 0` to avoid token refills when requests serialize due to DB locks
> - Update test comment to reflect the new approach to reduce flakiness
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b675d25badd18c2521078185172efb9c37ff42fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->