### PR TITLE
Bump migration timeout

### DIFF
--- a/ci/buildkite/test-clickhouse-cloud.sh
+++ b/ci/buildkite/test-clickhouse-cloud.sh
@@ -95,7 +95,7 @@ cargo run --bin gateway --features e2e_tests -- --run-postgres-migrations
 
 cargo run-e2e > e2e_logs.txt 2>&1 &
     count=0
-    max_attempts=90
+    max_attempts=180
     while ! curl -s -f http://localhost:3000/health >/dev/null 2>&1; do
         echo "Waiting for gateway to be healthy..."
         sleep 1


### PR DESCRIPTION
Addressing flake: https://buildkite.com/tensorzero/merge-checks/builds/5353/steps/canvas?sid=019bf875-d0ab-4264-8e2f-1af32d7a8a14

Migration took 93s but timeout is 90s.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends CI tolerance for slow startup/migrations in ClickHouse e2e pipeline.
> 
> - In `ci/buildkite/test-clickhouse-cloud.sh`, increases `max_attempts` for the gateway `/health` check from `90` to `180`, effectively doubling the timeout before failing the job
> - No application code changes; CI-only timing adjustment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42a2104d39fae07c565dc2d4795b601be021a759. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->