### PR TITLE
Retry clickhouse wakeup on buildkite

### DIFF
--- a/ci/buildkite/test-clickhouse-cloud.sh
+++ b/ci/buildkite/test-clickhouse-cloud.sh
@@ -74,7 +74,7 @@ echo "deb https://packages.clickhouse.com/deb stable main" | sudo tee /etc/apt/s
 sudo apt-get update
 sudo apt-get install -y clickhouse-client
 
-curl "$TENSORZERO_CLICKHOUSE_URL" --data-binary 'SHOW DATABASES'
+curl "$TENSORZERO_CLICKHOUSE_URL" --retry 4 --retry-all-errors --data-binary 'SHOW DATABASES'
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh  -s -- -y
 . "$HOME/.cargo/env"
 curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **CI reliability:** Add retries to ClickHouse readiness check in `ci/buildkite/test-clickhouse-cloud.sh`.
> 
> - Update the `curl` probing `TENSORZERO_CLICKHOUSE_URL` to include `--retry 4 --retry-all-errors` when running `SHOW DATABASES`, reducing transient startup/network flakes during Buildkite runs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0f9c61e80b7bae406219b0e1559e0cd91df5ad9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->