### PR TITLE
Fix an erroneous image for postgres fixture

### DIFF
--- a/tensorzero-core/tests/e2e/docker-compose.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.yml
@@ -48,7 +48,6 @@ services:
 
   # fixtures-postgres and fixtures have exactly the same build context, so the fixture is downloaded only once and shared.
   fixtures-postgres:
-    image: tensorzero/fixtures:${TENSORZERO_COMMIT_TAG:-latest}
     build:
       dockerfile: ui/fixtures/Dockerfile
       context: ../../..


### PR DESCRIPTION
The tensorzero/fixtures image is only available in CI, not locally, so this fixes `docker compose up`