### PR TITLE
Use R2 sync in CI

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -956,11 +956,11 @@ jobs:
 
       - name: Install Namespace CLI
         uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
-        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}  
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Login to Namespace registry
         run: nsc docker login
-        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}  
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Download gateway container image
         run: |
@@ -1114,6 +1114,9 @@ jobs:
     uses: ./.github/workflows/ui-tests.yml
     with:
       is_merge_group: ${{ github.event_name == 'merge_group' }}
+    secrets:
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
     needs: [build-gateway-container, build-mock-provider-api-container]
 
   ui-tests-e2e:

--- a/.github/workflows/ui-tests-e2e-model-inference-cache.yml
+++ b/.github/workflows/ui-tests-e2e-model-inference-cache.yml
@@ -256,6 +256,9 @@ jobs:
 
       - name: Start dependency Docker containers and apply fixtures
         working-directory: ui
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: |
           # Environment variables only used by the gateway container
           # We deliberately leave these unset when starting the UI container, to ensure

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -2,6 +2,11 @@ name: UI Tests
 
 on:
   workflow_call:
+    secrets:
+      R2_ACCESS_KEY_ID:
+        required: true
+      R2_SECRET_ACCESS_KEY:
+        required: true
     inputs:
       is_merge_group:
         required: true
@@ -82,6 +87,9 @@ jobs:
 
       - name: Start Docker containers and apply fixtures
         working-directory: ui
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: |
           echo "FIREWORKS_ACCOUNT_ID=not_used" >> fixtures/.env
           echo "TENSORZERO_GATEWAY_TAG=sha-${{ github.sha }}" >> fixtures/.env

--- a/tensorzero-core/tests/e2e/docker-compose.live.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.live.yml
@@ -6,7 +6,6 @@ volumes:
   # We need this for e2e tests that write to a tmpdir from a test, and then read it from the gateway
   shared-tmpdir:
 
-
 services:
   provider-proxy:
     image: tensorzero/provider-proxy:${TENSORZERO_COMMIT_TAG}
@@ -23,9 +22,16 @@ services:
     # Cache mode can be overridden via PROVIDER_PROXY_CACHE_MODE environment variable.
     # Options: read-old-write-new (default), read-only, read-write
     # See: https://github.com/tensorzero/tensorzero/issues/5380
-    command: [ "--cache-path", "/app/ci/provider-proxy-cache", "--mode", "${PROVIDER_PROXY_CACHE_MODE:-read-old-write-new}" ]
+    command:
+      [
+        "--cache-path",
+        "/app/ci/provider-proxy-cache",
+        "--mode",
+        "${PROVIDER_PROXY_CACHE_MODE:-read-old-write-new}",
+      ]
     healthcheck:
-      test: [ "CMD", "wget", "--spider", "--tries=1", "http://localhost:3004/health" ]
+      test:
+        ["CMD", "wget", "--spider", "--tries=1", "http://localhost:3004/health"]
       start_period: 10s
       start_interval: 1s
       timeout: 1s
@@ -83,7 +89,7 @@ services:
       VLLM_API_KEY: ${VLLM_API_KEY:-}
       VOYAGE_API_KEY: ${VOYAGE_API_KEY:-}
       XAI_API_KEY: ${XAI_API_KEY:-}
-    command: [ --config-file, tensorzero-core/tests/e2e/config/tensorzero.*.toml ]
+    command: [--config-file, tensorzero-core/tests/e2e/config/tensorzero.*.toml]
     volumes:
       # Mount the e2e directory so the config path exists inside the container
       - ./:/app/tensorzero-core/tests/e2e:ro
@@ -111,7 +117,15 @@ services:
     extra_hosts:
       - "howdy.tensorzero.com:127.0.0.1"
     healthcheck:
-      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/health" ]
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:3000/health",
+        ]
       start_period: 1s
       start_interval: 1s
       timeout: 1s
@@ -135,9 +149,10 @@ services:
       gateway:
         condition: service_healthy
     # Keep this running to make `check-docker-compose.sh` detect that all containers are healthy
-    command: [ "bash", "-c", "cd /fixtures && ./load_fixtures.sh tensorzero_e2e_tests" ]
+    command:
+      ["bash", "-c", "cd /fixtures && ./load_fixtures.sh tensorzero_e2e_tests"]
     healthcheck:
-      test: [ "CMD", "test", "-f", "/load_complete.marker" ]
+      test: ["CMD", "test", "-f", "/load_complete.marker"]
       interval: 5s
       timeout: 1s
       retries: 72 # Retry for up to 6 minutes
@@ -161,9 +176,14 @@ services:
         condition: service_healthy
       gateway-postgres-migrations:
         condition: service_healthy
-    command: [ "bash", "-c", "cd /fixtures && ./load_fixtures_postgres.sh && touch /load_complete_postgres.marker" ]
+    command:
+      [
+        "bash",
+        "-c",
+        "cd /fixtures && ./load_fixtures_postgres.sh && touch /load_complete_postgres.marker",
+      ]
     healthcheck:
-      test: [ "CMD", "test", "-f", "/load_complete_postgres.marker" ]
+      test: ["CMD", "test", "-f", "/load_complete_postgres.marker"]
       interval: 5s
       timeout: 1s
       retries: 72 # Retry for up to 6 minutes

--- a/tensorzero-core/tests/e2e/docker-compose.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.yml
@@ -38,9 +38,14 @@ services:
       gateway-clickhouse-migrations:
         condition: service_healthy
     # Keep this running to make `check-docker-compose.sh` detect that all containers are healthy
-    command: [ "bash", "-c", "cd /fixtures && ./load_fixtures.sh ${TENSORZERO_E2E_TESTS_DATABASE:-tensorzero_e2e_tests} && sleep infinity" ]
+    command:
+      [
+        "bash",
+        "-c",
+        "cd /fixtures && ./load_fixtures.sh ${TENSORZERO_E2E_TESTS_DATABASE:-tensorzero_e2e_tests} && sleep infinity",
+      ]
     healthcheck:
-      test: [ "CMD", "test", "-f", "/load_complete.marker" ]
+      test: ["CMD", "test", "-f", "/load_complete.marker"]
       interval: 5s
       timeout: 1s
       retries: 72 # Retry for up to 6 minutes
@@ -64,9 +69,14 @@ services:
         condition: service_healthy
       gateway-postgres-migrations:
         condition: service_healthy
-    command: [ "bash", "-c", "cd /fixtures && ./load_fixtures_postgres.sh && touch /load_complete_postgres.marker && sleep infinity" ]
+    command:
+      [
+        "bash",
+        "-c",
+        "cd /fixtures && ./load_fixtures_postgres.sh && touch /load_complete_postgres.marker && sleep infinity",
+      ]
     healthcheck:
-      test: [ "CMD", "test", "-f", "/load_complete_postgres.marker" ]
+      test: ["CMD", "test", "-f", "/load_complete_postgres.marker"]
       interval: 5s
       timeout: 1s
       retries: 72 # Retry for up to 6 minutes


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables R2-backed fixture downloads/sync in CI UI tests and cache regeneration.
> 
> - Passes `R2_ACCESS_KEY_ID` and `R2_SECRET_ACCESS_KEY` as required `workflow_call` secrets in `ui-tests.yml` and forwards them from `general.yml`
> - Sets R2 env vars for fixture steps in `ui-tests.yml` and `ui-tests-e2e-model-inference-cache.yml`
> - Minor CI cleanup: trims trailing spaces and keeps `continue-on-error` unchanged logically
> - docker-compose (e2e/live) YAML: reformat `command` and `healthcheck` to explicit list style; no functional change
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 678ffc5992121dc63e90722a800f62d4d62957bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->