### PR TITLE
made dev images use debug builds

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -97,6 +97,10 @@ jobs:
           tags: ${{ env.DOCKERHUB_USER }}/${{ matrix.container.name }}
           labels: ${{ steps.meta.outputs.labels }}
           sbom: true
+          # Use debug builds for dev images
+          build-args: |
+            PROFILE=${{ inputs.is_dev && 'dev' || 'performance' }}
+            DEBUG_BUILD=${{ inputs.is_dev && '1' || '0' }}
 
       - name: Export digest
         run: |

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -956,11 +956,11 @@ jobs:
 
       - name: Install Namespace CLI
         uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
-        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}  
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Login to Namespace registry
         run: nsc docker login
-        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}  
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Download gateway container image
         run: |

--- a/evaluations/Dockerfile
+++ b/evaluations/Dockerfile
@@ -1,6 +1,12 @@
+# Global build args
+ARG CARGO_BUILD_FLAGS=""
+ARG PROFILE="release"
+
 # ========== builder ==========
 
 FROM rust:1.88.0 AS builder
+ARG CARGO_BUILD_FLAGS
+ARG PROFILE
 
 WORKDIR /src
 
@@ -8,10 +14,8 @@ RUN apt-get update && apt-get install -y clang libc++-dev && rm -rf /var/lib/apt
 
 COPY . .
 
-ARG CARGO_BUILD_FLAGS=""
-
-RUN cargo build --release -p evaluations $CARGO_BUILD_FLAGS && \
-    cp -r /src/target/release /release
+RUN cargo build --profile ${PROFILE} -p evaluations $CARGO_BUILD_FLAGS
+RUN if [ "${PROFILE}" = "dev" ]; then cp -r /src/target/debug /release; else cp -r /src/target/${PROFILE} /release; fi
 
 # ========== base ==========
 

--- a/tensorzero-core/tests/e2e/docker-compose.live.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.live.yml
@@ -6,7 +6,6 @@ volumes:
   # We need this for e2e tests that write to a tmpdir from a test, and then read it from the gateway
   shared-tmpdir:
 
-
 services:
   provider-proxy:
     image: tensorzero/provider-proxy:${TENSORZERO_COMMIT_TAG}
@@ -23,9 +22,16 @@ services:
     # Cache mode can be overridden via PROVIDER_PROXY_CACHE_MODE environment variable.
     # Options: read-old-write-new (default), read-only, read-write
     # See: https://github.com/tensorzero/tensorzero/issues/5380
-    command: [ "--cache-path", "/app/ci/provider-proxy-cache", "--mode", "${PROVIDER_PROXY_CACHE_MODE:-read-old-write-new}" ]
+    command:
+      [
+        "--cache-path",
+        "/app/ci/provider-proxy-cache",
+        "--mode",
+        "${PROVIDER_PROXY_CACHE_MODE:-read-old-write-new}",
+      ]
     healthcheck:
-      test: [ "CMD", "wget", "--spider", "--tries=1", "http://localhost:3004/health" ]
+      test:
+        ["CMD", "wget", "--spider", "--tries=1", "http://localhost:3004/health"]
       start_period: 10s
       start_interval: 1s
       timeout: 1s
@@ -83,7 +89,7 @@ services:
       VLLM_API_KEY: ${VLLM_API_KEY:-}
       VOYAGE_API_KEY: ${VOYAGE_API_KEY:-}
       XAI_API_KEY: ${XAI_API_KEY:-}
-    command: [ --config-file, tensorzero-core/tests/e2e/config/tensorzero.*.toml ]
+    command: [--config-file, tensorzero-core/tests/e2e/config/tensorzero.*.toml]
     volumes:
       # Mount the e2e directory so the config path exists inside the container
       - ./:/app/tensorzero-core/tests/e2e:ro
@@ -111,7 +117,15 @@ services:
     extra_hosts:
       - "howdy.tensorzero.com:127.0.0.1"
     healthcheck:
-      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/health" ]
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:3000/health",
+        ]
       start_period: 1s
       start_interval: 1s
       timeout: 1s
@@ -135,9 +149,10 @@ services:
       gateway:
         condition: service_healthy
     # Keep this running to make `check-docker-compose.sh` detect that all containers are healthy
-    command: [ "bash", "-c", "cd /fixtures && ./load_fixtures.sh tensorzero_e2e_tests" ]
+    command:
+      ["bash", "-c", "cd /fixtures && ./load_fixtures.sh tensorzero_e2e_tests"]
     healthcheck:
-      test: [ "CMD", "test", "-f", "/load_complete.marker" ]
+      test: ["CMD", "test", "-f", "/load_complete.marker"]
       interval: 5s
       timeout: 1s
       retries: 72 # Retry for up to 6 minutes
@@ -161,9 +176,14 @@ services:
         condition: service_healthy
       gateway-postgres-migrations:
         condition: service_healthy
-    command: [ "bash", "-c", "cd /fixtures && ./load_fixtures_postgres.sh && touch /load_complete_postgres.marker" ]
+    command:
+      [
+        "bash",
+        "-c",
+        "cd /fixtures && ./load_fixtures_postgres.sh && touch /load_complete_postgres.marker",
+      ]
     healthcheck:
-      test: [ "CMD", "test", "-f", "/load_complete_postgres.marker" ]
+      test: ["CMD", "test", "-f", "/load_complete_postgres.marker"]
       interval: 5s
       timeout: 1s
       retries: 72 # Retry for up to 6 minutes

--- a/tensorzero-core/tests/e2e/docker-compose.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.yml
@@ -38,9 +38,14 @@ services:
       gateway-clickhouse-migrations:
         condition: service_healthy
     # Keep this running to make `check-docker-compose.sh` detect that all containers are healthy
-    command: [ "bash", "-c", "cd /fixtures && ./load_fixtures.sh ${TENSORZERO_E2E_TESTS_DATABASE:-tensorzero_e2e_tests} && sleep infinity" ]
+    command:
+      [
+        "bash",
+        "-c",
+        "cd /fixtures && ./load_fixtures.sh ${TENSORZERO_E2E_TESTS_DATABASE:-tensorzero_e2e_tests} && sleep infinity",
+      ]
     healthcheck:
-      test: [ "CMD", "test", "-f", "/load_complete.marker" ]
+      test: ["CMD", "test", "-f", "/load_complete.marker"]
       interval: 5s
       timeout: 1s
       retries: 72 # Retry for up to 6 minutes
@@ -64,9 +69,14 @@ services:
         condition: service_healthy
       gateway-postgres-migrations:
         condition: service_healthy
-    command: [ "bash", "-c", "cd /fixtures && ./load_fixtures_postgres.sh && touch /load_complete_postgres.marker && sleep infinity" ]
+    command:
+      [
+        "bash",
+        "-c",
+        "cd /fixtures && ./load_fixtures_postgres.sh && touch /load_complete_postgres.marker && sleep infinity",
+      ]
     healthcheck:
-      test: [ "CMD", "test", "-f", "/load_complete_postgres.marker" ]
+      test: ["CMD", "test", "-f", "/load_complete_postgres.marker"]
       interval: 5s
       timeout: 1s
       retries: 72 # Retry for up to 6 minutes


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Makes dev-tagged Docker images use debug builds and adds profile configurability.
> 
> - In `docker-hub-publish.yml`, passes `PROFILE` (`dev` vs `performance`) and `DEBUG_BUILD` as build args to Buildx for `ui`, `gateway`, and `evaluations` images
> - Updates `evaluations/Dockerfile` to accept `CARGO_BUILD_FLAGS` and `PROFILE`, build with `cargo build --profile ${PROFILE}`, and copy the correct target dir (`debug` for dev, `${PROFILE}` otherwise)
> - Reformat-only changes in e2e `docker-compose` files (command/healthcheck arrays) and minor whitespace fixes in `general.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a78008bd69ef40f8a122e5190980fd3b3310183c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->