### PR TITLE
Speed up download provider proxy cache

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -956,11 +956,11 @@ jobs:
 
       - name: Install Namespace CLI
         uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
-        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}  
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Login to Namespace registry
         run: nsc docker login
-        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}  
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Download gateway container image
         run: |

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -89,6 +89,14 @@ jobs:
       - name: Cleanup disk space
         run: ./ci/free-disk-space.sh
 
+      - name: Restore provider-proxy cache
+        if: github.event_name != 'schedule'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: ./ci/provider-proxy-cache/
+          key: provider-proxy-cache-${{ github.run_id }}
+          restore-keys: provider-proxy-cache-
+
       - name: Download provider-proxy cache
         # When running as a cron job, don't use the provider-proxy cache.
         # The cron job is used to gather information about provider flakiness.
@@ -180,6 +188,14 @@ jobs:
 
       - name: Cleanup disk space
         run: ./ci/free-disk-space.sh
+
+      - name: Restore client-tests provider-proxy cache
+        if: github.event_name != 'schedule'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: ./ci/provider-proxy-cache/
+          key: provider-proxy-cache-client-tests-${{ github.run_id }}
+          restore-keys: provider-proxy-cache-client-tests-
 
       - name: Download client-tests provider-proxy cache
         # When running as a cron job, don't use the provider-proxy cache.

--- a/ci/download-provider-proxy-cache.sh
+++ b/ci/download-provider-proxy-cache.sh
@@ -2,7 +2,7 @@
 set -euxo pipefail
 cd $(dirname $0)/provider-proxy-cache
 for i in {1..5}; do
-  if aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync s3://${PROVIDER_PROXY_CACHE_BUCKET} .; then
+  if aws s3 --endpoint-url https://19918a216783f0ac9e052233569aef60.r2.cloudflarestorage.com/ sync --only-show-errors s3://${PROVIDER_PROXY_CACHE_BUCKET} .; then
     break
   else
     echo "Attempt $i failed. Retrying..."

--- a/tensorzero-core/tests/e2e/docker-compose.live.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.live.yml
@@ -6,7 +6,6 @@ volumes:
   # We need this for e2e tests that write to a tmpdir from a test, and then read it from the gateway
   shared-tmpdir:
 
-
 services:
   provider-proxy:
     image: tensorzero/provider-proxy:${TENSORZERO_COMMIT_TAG}
@@ -23,9 +22,16 @@ services:
     # Cache mode can be overridden via PROVIDER_PROXY_CACHE_MODE environment variable.
     # Options: read-old-write-new (default), read-only, read-write
     # See: https://github.com/tensorzero/tensorzero/issues/5380
-    command: [ "--cache-path", "/app/ci/provider-proxy-cache", "--mode", "${PROVIDER_PROXY_CACHE_MODE:-read-old-write-new}" ]
+    command:
+      [
+        "--cache-path",
+        "/app/ci/provider-proxy-cache",
+        "--mode",
+        "${PROVIDER_PROXY_CACHE_MODE:-read-old-write-new}",
+      ]
     healthcheck:
-      test: [ "CMD", "wget", "--spider", "--tries=1", "http://localhost:3004/health" ]
+      test:
+        ["CMD", "wget", "--spider", "--tries=1", "http://localhost:3004/health"]
       start_period: 10s
       start_interval: 1s
       timeout: 1s
@@ -83,7 +89,7 @@ services:
       VLLM_API_KEY: ${VLLM_API_KEY:-}
       VOYAGE_API_KEY: ${VOYAGE_API_KEY:-}
       XAI_API_KEY: ${XAI_API_KEY:-}
-    command: [ --config-file, tensorzero-core/tests/e2e/config/tensorzero.*.toml ]
+    command: [--config-file, tensorzero-core/tests/e2e/config/tensorzero.*.toml]
     volumes:
       # Mount the e2e directory so the config path exists inside the container
       - ./:/app/tensorzero-core/tests/e2e:ro
@@ -111,7 +117,15 @@ services:
     extra_hosts:
       - "howdy.tensorzero.com:127.0.0.1"
     healthcheck:
-      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/health" ]
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:3000/health",
+        ]
       start_period: 1s
       start_interval: 1s
       timeout: 1s
@@ -135,9 +149,10 @@ services:
       gateway:
         condition: service_healthy
     # Keep this running to make `check-docker-compose.sh` detect that all containers are healthy
-    command: [ "bash", "-c", "cd /fixtures && ./load_fixtures.sh tensorzero_e2e_tests" ]
+    command:
+      ["bash", "-c", "cd /fixtures && ./load_fixtures.sh tensorzero_e2e_tests"]
     healthcheck:
-      test: [ "CMD", "test", "-f", "/load_complete.marker" ]
+      test: ["CMD", "test", "-f", "/load_complete.marker"]
       interval: 5s
       timeout: 1s
       retries: 72 # Retry for up to 6 minutes
@@ -161,9 +176,14 @@ services:
         condition: service_healthy
       gateway-postgres-migrations:
         condition: service_healthy
-    command: [ "bash", "-c", "cd /fixtures && ./load_fixtures_postgres.sh && touch /load_complete_postgres.marker" ]
+    command:
+      [
+        "bash",
+        "-c",
+        "cd /fixtures && ./load_fixtures_postgres.sh && touch /load_complete_postgres.marker",
+      ]
     healthcheck:
-      test: [ "CMD", "test", "-f", "/load_complete_postgres.marker" ]
+      test: ["CMD", "test", "-f", "/load_complete_postgres.marker"]
       interval: 5s
       timeout: 1s
       retries: 72 # Retry for up to 6 minutes

--- a/tensorzero-core/tests/e2e/docker-compose.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.yml
@@ -38,9 +38,14 @@ services:
       gateway-clickhouse-migrations:
         condition: service_healthy
     # Keep this running to make `check-docker-compose.sh` detect that all containers are healthy
-    command: [ "bash", "-c", "cd /fixtures && ./load_fixtures.sh ${TENSORZERO_E2E_TESTS_DATABASE:-tensorzero_e2e_tests} && sleep infinity" ]
+    command:
+      [
+        "bash",
+        "-c",
+        "cd /fixtures && ./load_fixtures.sh ${TENSORZERO_E2E_TESTS_DATABASE:-tensorzero_e2e_tests} && sleep infinity",
+      ]
     healthcheck:
-      test: [ "CMD", "test", "-f", "/load_complete.marker" ]
+      test: ["CMD", "test", "-f", "/load_complete.marker"]
       interval: 5s
       timeout: 1s
       retries: 72 # Retry for up to 6 minutes
@@ -64,9 +69,14 @@ services:
         condition: service_healthy
       gateway-postgres-migrations:
         condition: service_healthy
-    command: [ "bash", "-c", "cd /fixtures && ./load_fixtures_postgres.sh && touch /load_complete_postgres.marker && sleep infinity" ]
+    command:
+      [
+        "bash",
+        "-c",
+        "cd /fixtures && ./load_fixtures_postgres.sh && touch /load_complete_postgres.marker && sleep infinity",
+      ]
     healthcheck:
-      test: [ "CMD", "test", "-f", "/load_complete_postgres.marker" ]
+      test: ["CMD", "test", "-f", "/load_complete_postgres.marker"]
       interval: 5s
       timeout: 1s
       retries: 72 # Retry for up to 6 minutes


### PR DESCRIPTION
- Use GHA/NS cache

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves CI performance and noise for merge-queue runs.
> 
> - Add `actions/cache` restore steps for `provider-proxy` and `client-tests` caches in `merge-queue.yml` (uses `${{ github.run_id }}` keys with fallbacks) to speed cache availability before R2 download
> - Quiet cache download logs by adding `--only-show-errors` to `ci/download-provider-proxy-cache.sh`
> - Minor whitespace cleanup in `general.yml`; reformat array/healthcheck `command` entries in docker-compose files without changing behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8b84dd84e5fe91336260b31782e25a14b13379b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->