### PR TITLE
Migrate Postgres rate limiting

### DIFF
--- a/.sqlx/query-2ec7fee182456e6d7be7134ac1ee9da0099534c9b249429d98802460618a8a50.json
+++ b/.sqlx/query-2ec7fee182456e6d7be7134ac1ee9da0099534c9b249429d98802460618a8a50.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT bucket_key as key, is_successful as success, tickets_remaining, tickets_consumed\n             FROM consume_multiple_resource_tickets($1, $2, $3, $4, $5)",
+  "query": "SELECT bucket_key as key, is_successful as success, tickets_remaining, tickets_consumed\n             FROM tensorzero.consume_multiple_resource_tickets($1, $2, $3, $4, $5)",
   "describe": {
     "columns": [
       {
@@ -44,5 +44,5 @@
       null
     ]
   },
-  "hash": "a4d2aa2e85389d921b4c1581321838689d73b9496a26b3116bafd0584e500016"
+  "hash": "2ec7fee182456e6d7be7134ac1ee9da0099534c9b249429d98802460618a8a50"
 }

--- a/.sqlx/query-4329264f512454a32ff24a6393a80083ccd85a9f7e427b54fdbe8af0e9751a42.json
+++ b/.sqlx/query-4329264f512454a32ff24a6393a80083ccd85a9f7e427b54fdbe8af0e9751a42.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT get_resource_bucket_balance($1, $2, $3, $4)",
+  "query": "SELECT tensorzero.get_resource_bucket_balance($1, $2, $3, $4)",
   "describe": {
     "columns": [
       {
@@ -22,5 +22,5 @@
       null
     ]
   },
-  "hash": "517ba464982dbb0568a648e49c9d0f8736955599e16b1c1b75430877dbd73c65"
+  "hash": "4329264f512454a32ff24a6393a80083ccd85a9f7e427b54fdbe8af0e9751a42"
 }

--- a/.sqlx/query-bd28103da7e4ca7a9db0c78dc9692bf6e89d5ecea5ef594f83676971b1845c6c.json
+++ b/.sqlx/query-bd28103da7e4ca7a9db0c78dc9692bf6e89d5ecea5ef594f83676971b1845c6c.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT bucket_key_returned as key_returned, final_balance\n             FROM return_multiple_resource_tickets($1, $2, $3, $4, $5)",
+  "query": "SELECT bucket_key_returned as key_returned, final_balance\n             FROM tensorzero.return_multiple_resource_tickets($1, $2, $3, $4, $5)",
   "describe": {
     "columns": [
       {
@@ -30,5 +30,5 @@
       null
     ]
   },
-  "hash": "1975ecaf2913207959a4951af399535d3c8846a3cfa39f7d16724a9bd81f0f0e"
+  "hash": "bd28103da7e4ca7a9db0c78dc9692bf6e89d5ecea5ef594f83676971b1845c6c"
 }

--- a/tensorzero-core/src/db/postgres/migrations/20260126200850_rate_limiting_tensorzero_schema.sql
+++ b/tensorzero-core/src/db/postgres/migrations/20260126200850_rate_limiting_tensorzero_schema.sql
@@ -1,0 +1,320 @@
+-- Migration to move rate limiting objects to tensorzero schema
+-- This provides namespace isolation and allows for backwards-compatible upgrades.
+
+-- Create the tensorzero schema if it doesn't exist
+CREATE SCHEMA IF NOT EXISTS tensorzero;
+
+-- Create the new table in tensorzero schema
+CREATE TABLE tensorzero.resource_bucket (
+    key TEXT PRIMARY KEY,
+    tickets BIGINT NOT NULL CHECK (tickets >= 0),
+    balance_as_of TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Migrate existing data from old table to new table
+INSERT INTO tensorzero.resource_bucket (key, tickets, balance_as_of)
+SELECT key, tickets, balance_as_of
+FROM resource_bucket
+ON CONFLICT (key) DO NOTHING;
+
+-- Create the type in tensorzero schema
+CREATE TYPE tensorzero.calculated_bucket_state AS (
+    available_tickets BIGINT,
+    new_balance_as_of TIMESTAMPTZ,
+    intervals_passed  BIGINT
+);
+
+-- Internal helper function that calculates the up-to-date state of a bucket
+CREATE OR REPLACE FUNCTION tensorzero._calculate_refilled_state(
+    p_current_tickets BIGINT,
+    p_balance_as_of TIMESTAMPTZ,
+    p_capacity BIGINT,
+    p_refill_amount BIGINT,
+    p_refill_interval INTERVAL
+)
+RETURNS tensorzero.calculated_bucket_state
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_intervals_passed BIGINT;
+    v_available_tickets BIGINT;
+    v_result tensorzero.calculated_bucket_state;
+BEGIN
+    -- Calculate how many whole refill intervals have passed.
+    IF p_refill_interval <= '0 seconds'::interval THEN
+        RAISE EXCEPTION 'Refill interval must be positive, got: %', p_refill_interval;
+    ELSE
+        -- EPOCH FROM converts to a number of seconds
+        -- Allows us to do integer division rather than interval division
+        v_intervals_passed := floor(
+            EXTRACT(EPOCH FROM (now() - p_balance_as_of)) / EXTRACT(EPOCH FROM p_refill_interval)
+        );
+    END IF;
+
+    -- Ensure we don't go backwards in time
+    -- (e.g., due to transaction time < p_balance_as_of after a race)
+    v_intervals_passed := GREATEST(v_intervals_passed, 0);
+
+    -- Calculate available tickets: current + refilled, capped at capacity.
+    v_available_tickets := least(
+        p_current_tickets + (v_intervals_passed * p_refill_amount),
+        p_capacity
+    );
+
+    -- Build the result using our custom type
+    v_result.available_tickets := v_available_tickets;
+    v_result.intervals_passed := v_intervals_passed;
+    v_result.new_balance_as_of := p_balance_as_of + (v_intervals_passed * p_refill_interval);
+
+    RETURN v_result;
+END;
+$$;
+
+-- Function to get the current balance without modification.
+CREATE OR REPLACE FUNCTION tensorzero.get_resource_bucket_balance(
+    p_key TEXT,
+    p_capacity BIGINT,
+    p_refill_amount BIGINT,
+    p_refill_interval INTERVAL
+)
+RETURNS BIGINT
+LANGUAGE plpgsql AS $$
+DECLARE
+    bucket_state record;
+    refilled_state tensorzero.calculated_bucket_state;
+BEGIN
+    -- Step 1: Find the bucket.
+    SELECT * INTO bucket_state FROM tensorzero.resource_bucket WHERE tensorzero.resource_bucket.key = p_key;
+
+    -- Step 2: If the bucket doesn't exist, the balance is the capacity.
+    IF NOT FOUND THEN
+        RETURN p_capacity;
+    END IF;
+
+    -- Step 3: If the bucket exists, calculate its current refilled state.
+    SELECT * INTO refilled_state
+    FROM tensorzero._calculate_refilled_state(
+        bucket_state.tickets,
+        bucket_state.balance_as_of,
+        p_capacity,
+        p_refill_amount,
+        p_refill_interval
+    );
+
+    -- Step 4: Return the available tickets from the calculated state.
+    RETURN refilled_state.available_tickets;
+END;
+$$;
+
+-- Function to atomically consume tickets from multiple resource buckets.
+CREATE OR REPLACE FUNCTION tensorzero.consume_multiple_resource_tickets(
+    p_keys TEXT[],
+    p_requested_amounts BIGINT[],
+    p_capacities BIGINT[],
+    p_refill_amounts BIGINT[],
+    p_refill_intervals INTERVAL[]
+)
+RETURNS TABLE (bucket_key TEXT, is_successful BOOLEAN, tickets_remaining BIGINT, tickets_consumed BIGINT)
+LANGUAGE plpgsql AS $$
+DECLARE
+    i INT;
+    bucket_state RECORD;
+    refilled_state tensorzero.calculated_bucket_state;
+    failure_detected BOOLEAN := false;
+    temp_row RECORD;
+BEGIN
+    -- Input validation: check for consistent array lengths
+    IF array_length(p_keys, 1) IS NULL OR
+       array_length(p_keys, 1) != array_length(p_requested_amounts, 1) OR
+       array_length(p_keys, 1) != array_length(p_capacities, 1) OR
+       array_length(p_keys, 1) != array_length(p_refill_amounts, 1) OR
+       array_length(p_keys, 1) != array_length(p_refill_intervals, 1) THEN
+        RAISE EXCEPTION 'Input arrays must have the same length';
+    END IF;
+
+    -- Input validation: check for duplicate keys
+    IF array_length(p_keys, 1) > 0 AND array_length(p_keys, 1) != (
+        SELECT COUNT(DISTINCT key_column)
+        FROM unnest(p_keys) AS keys(key_column)
+    ) THEN
+        RAISE EXCEPTION 'Duplicate keys are not allowed in the input array';
+    END IF;
+
+    -- Create a temporary table to store intermediate results
+    CREATE TEMP TABLE temp_bucket_states (
+        key TEXT PRIMARY KEY,
+        requested BIGINT,
+        capacity BIGINT,
+        refill_amount BIGINT,
+        refill_interval INTERVAL,
+        refilled_tickets BIGINT,
+        new_balance_as_of TIMESTAMPTZ
+    ) ON COMMIT DROP;
+
+    -- Populate temp table from input arrays
+    FOR i IN 1..array_length(p_keys, 1) LOOP
+        INSERT INTO temp_bucket_states (key, requested, capacity, refill_amount, refill_interval)
+        VALUES (p_keys[i], p_requested_amounts[i], p_capacities[i], p_refill_amounts[i], p_refill_intervals[i]);
+    END LOOP;
+
+    -- Pass 1: Lock rows in a consistent order, calculate new states, and check for sufficiency.
+    FOR temp_row IN SELECT * FROM temp_bucket_states ORDER BY temp_bucket_states.key LOOP
+        -- Atomically get-or-create the bucket, locking the row.
+        INSERT INTO tensorzero.resource_bucket (key, tickets, balance_as_of)
+        VALUES (temp_row.key, temp_row.capacity, now())
+        ON CONFLICT (key) DO UPDATE SET key = EXCLUDED.key
+        RETURNING * INTO bucket_state;
+
+        -- Calculate the refilled state.
+        SELECT * INTO refilled_state
+        FROM tensorzero._calculate_refilled_state(
+            bucket_state.tickets,
+            bucket_state.balance_as_of,
+            temp_row.capacity,
+            temp_row.refill_amount,
+            temp_row.refill_interval
+        );
+
+        -- Store calculated values back into the temp table
+        UPDATE temp_bucket_states
+        SET refilled_tickets = refilled_state.available_tickets,
+            new_balance_as_of = refilled_state.new_balance_as_of
+        WHERE temp_bucket_states.key = temp_row.key;
+
+        -- Check for failure.
+        IF NOT failure_detected AND refilled_state.available_tickets < temp_row.requested THEN
+            failure_detected := true;
+        END IF;
+    END LOOP;
+
+    -- Pass 2: Commit changes based on whether a failure was detected.
+    IF failure_detected THEN
+        -- Failure: Update buckets to their refilled state without consuming tickets.
+        FOR temp_row IN SELECT * FROM temp_bucket_states LOOP
+            UPDATE tensorzero.resource_bucket
+            SET tickets = temp_row.refilled_tickets,
+                balance_as_of = temp_row.new_balance_as_of
+            WHERE tensorzero.resource_bucket.key = temp_row.key;
+        END LOOP;
+    ELSE
+        -- Success: Update all buckets with consumed amounts.
+        FOR temp_row IN SELECT * FROM temp_bucket_states LOOP
+            UPDATE tensorzero.resource_bucket
+            SET tickets = temp_row.refilled_tickets - temp_row.requested,
+                balance_as_of = temp_row.new_balance_as_of
+            WHERE tensorzero.resource_bucket.key = temp_row.key;
+        END LOOP;
+    END IF;
+
+    -- Pass 3: Return the final state for each key.
+    RETURN QUERY
+        SELECT
+            t.key AS bucket_key,
+            NOT failure_detected,
+            CASE
+                WHEN failure_detected THEN t.refilled_tickets
+                ELSE t.refilled_tickets - t.requested
+            END::BIGINT,
+            CASE
+                WHEN failure_detected THEN 0::BIGINT
+                ELSE t.requested
+            END::BIGINT
+        FROM temp_bucket_states t;
+END;
+$$;
+
+-- Function to atomically return tickets to multiple resource buckets.
+CREATE OR REPLACE FUNCTION tensorzero.return_multiple_resource_tickets(
+    p_keys TEXT[],
+    p_amounts BIGINT[],
+    p_capacities BIGINT[],
+    p_refill_amounts BIGINT[],
+    p_refill_intervals INTERVAL[]
+)
+RETURNS TABLE (bucket_key_returned TEXT, final_balance BIGINT)
+LANGUAGE plpgsql AS $$
+DECLARE
+    i INT;
+    bucket_state RECORD;
+    refilled_state tensorzero.calculated_bucket_state;
+    temp_row RECORD;
+    new_balance BIGINT;
+BEGIN
+    -- Input validation: check for consistent array lengths
+    IF array_length(p_keys, 1) IS NULL OR
+       array_length(p_keys, 1) != array_length(p_amounts, 1) OR
+       array_length(p_keys, 1) != array_length(p_capacities, 1) OR
+       array_length(p_keys, 1) != array_length(p_refill_amounts, 1) OR
+       array_length(p_keys, 1) != array_length(p_refill_intervals, 1) THEN
+        RAISE EXCEPTION 'Input arrays must have the same length';
+    END IF;
+
+    -- Input validation: check for duplicate keys
+    IF array_length(p_keys, 1) > 0 AND array_length(p_keys, 1) != (
+        SELECT COUNT(DISTINCT key_column)
+        FROM unnest(p_keys) AS keys(key_column)
+    ) THEN
+        RAISE EXCEPTION 'Duplicate keys are not allowed in the input array';
+    END IF;
+
+    -- Create a temporary table to store inputs
+    CREATE TEMP TABLE temp_return_states (
+        key TEXT PRIMARY KEY,
+        amount BIGINT,
+        capacity BIGINT,
+        refill_amount BIGINT,
+        refill_interval INTERVAL
+    ) ON COMMIT DROP;
+
+    -- Populate temp table from input arrays
+    FOR i IN 1..array_length(p_keys, 1) LOOP
+        INSERT INTO temp_return_states (key, amount, capacity, refill_amount, refill_interval)
+        VALUES (p_keys[i], p_amounts[i], p_capacities[i], p_refill_amounts[i], p_refill_intervals[i]);
+    END LOOP;
+
+    -- Lock rows in a consistent order, calculate new state, and update.
+    FOR temp_row IN SELECT * FROM temp_return_states ORDER BY temp_return_states.key LOOP
+        -- Atomically get-or-create the bucket, locking the row.
+        INSERT INTO tensorzero.resource_bucket (key, tickets, balance_as_of)
+        VALUES (temp_row.key, temp_row.capacity, now())
+        ON CONFLICT (key) DO UPDATE SET key = EXCLUDED.key
+        RETURNING * INTO bucket_state;
+
+        -- Calculate the refilled state.
+        SELECT * INTO refilled_state
+        FROM tensorzero._calculate_refilled_state(
+            bucket_state.tickets,
+            bucket_state.balance_as_of,
+            temp_row.capacity,
+            temp_row.refill_amount,
+            temp_row.refill_interval
+        );
+
+        -- Calculate the new balance, capped at capacity.
+        new_balance := least(
+            refilled_state.available_tickets + temp_row.amount,
+            temp_row.capacity
+        );
+
+        -- Update the bucket with the new balance and timestamp.
+        UPDATE tensorzero.resource_bucket
+        SET
+            tickets = new_balance,
+            balance_as_of = refilled_state.new_balance_as_of
+        WHERE tensorzero.resource_bucket.key = temp_row.key;
+
+        -- Prepare the row for the return query.
+        bucket_key_returned := temp_row.key;
+        final_balance := new_balance;
+        RETURN NEXT;
+    END LOOP;
+END;
+$$;
+
+-- TODO: Drop the old objects (table, type, functions) from public schema in a future migration.
+
+-- DROP FUNCTION IF EXISTS consume_multiple_resource_tickets(TEXT[], BIGINT[], BIGINT[], BIGINT[], INTERVAL[]);
+-- DROP FUNCTION IF EXISTS return_multiple_resource_tickets(TEXT[], BIGINT[], BIGINT[], BIGINT[], INTERVAL[]);
+-- DROP FUNCTION IF EXISTS get_resource_bucket_balance(TEXT, BIGINT, BIGINT, INTERVAL);
+-- DROP FUNCTION IF EXISTS _calculate_refilled_state(BIGINT, TIMESTAMPTZ, BIGINT, BIGINT, INTERVAL);
+-- DROP TYPE IF EXISTS calculated_bucket_state;
+-- DROP TABLE IF EXISTS resource_bucket;

--- a/tensorzero-core/src/db/postgres/rate_limiting.rs
+++ b/tensorzero-core/src/db/postgres/rate_limiting.rs
@@ -50,7 +50,7 @@ impl RateLimitQueries for PostgresConnectionInfo {
         let responses = sqlx::query_as!(
             ConsumeTicketsResponse,
             "SELECT bucket_key as key, is_successful as success, tickets_remaining, tickets_consumed
-             FROM consume_multiple_resource_tickets($1, $2, $3, $4, $5)",
+             FROM tensorzero.consume_multiple_resource_tickets($1, $2, $3, $4, $5)",
             &keys,
             &requested_amounts,
             &capacities,
@@ -95,7 +95,7 @@ impl RateLimitQueries for PostgresConnectionInfo {
         let responses = sqlx::query_as!(
             ReturnTicketsResponse,
             "SELECT bucket_key_returned as key_returned, final_balance
-             FROM return_multiple_resource_tickets($1, $2, $3, $4, $5)",
+             FROM tensorzero.return_multiple_resource_tickets($1, $2, $3, $4, $5)",
             &keys,
             &amounts,
             &capacities,
@@ -134,7 +134,7 @@ impl RateLimitQueries for PostgresConnectionInfo {
         })?;
 
         let balance: Option<i64> = sqlx::query_scalar!(
-            "SELECT get_resource_bucket_balance($1, $2, $3, $4)",
+            "SELECT tensorzero.get_resource_bucket_balance($1, $2, $3, $4)",
             key,
             capacity as i64,
             refill_amount as i64,


### PR DESCRIPTION
The old functions reference old types in the public schema so we need to recreate the function with reference to the new type.

Dropping the old table is a breaking change (old gateways will not function after a new gateway is deployed); we may want to be more careful and dual read/write.