### PR TITLE
Remove spurious inference request in check_test_streaming_cache_with_err

### DIFF
--- a/tensorzero-core/tests/e2e/cache.rs
+++ b/tensorzero-core/tests/e2e/cache.rs
@@ -3,7 +3,6 @@
 use futures::StreamExt;
 use rand::Rng;
 use reqwest::Client;
-use reqwest::StatusCode;
 use reqwest_eventsource::Event;
 use reqwest_eventsource::RequestBuilderExt;
 use serde_json::Value;


### PR DESCRIPTION
We were performing two streaming requests, and ignoring the first one. The first one could have populated the cache in the background, causing an unexpected cache hit for the real request

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies `check_test_streaming_cache_with_err` by eliminating an unused initial HTTP request and status check that could populate the cache and affect the subsequent streaming request.
> 
> - Remove `reqwest::StatusCode` import and the first non-streaming POST/OK assertion
> - Stream directly via `eventsource()` for the single intended request to ensure accurate cache behavior in the test
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2be611215011a83ff893f4cc5886edd9402afb37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->