### PR TITLE
Bump image tests timeout

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -155,9 +155,9 @@ slow-timeout = { period = "30s", terminate-after = 3 }
 filter = 'test(websearch)'
 slow-timeout = { period = "120s", terminate-after = 2 }
 
-# Image inference seems to be slow on GCP Vertex Gemini, so we give it a longer timeout
+# Image inference seems to be slow on many providers, so we give it a longer timeout
 [[profile.default.overrides]]
-filter = 'test(providers::gcp_vertex_gemini::test_image_inference)'
+filter = 'test(test_image_inference)'
 slow-timeout = { period = "60s", terminate-after = 2 }
 
 [[profile.default.overrides]]


### PR DESCRIPTION
This should fix some of the flakes we're seeing on CI (as some of these tests can take over 30 seconds, even when running locally)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Broadens the nextest slow-timeout override for image inference tests.
> 
> - Changes override filter from `test(providers::gcp_vertex_gemini::test_image_inference)` to `test(test_image_inference)` while retaining `60s` slow-timeout
> - Updates comment to reflect applicability across providers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31fb184c2c83e4107796aa736b5609f47a46b667. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->