### PR TITLE
Make Playwright downloads more resilient in CI

### DIFF
--- a/.github/workflows/slash-command-regen-fixtures.yml
+++ b/.github/workflows/slash-command-regen-fixtures.yml
@@ -47,7 +47,18 @@ jobs:
       - name: Install `pnpm` dependencies
         run: pnpm install --frozen-lockfile
       - name: Setup Playwright
-        run: pnpm --filter=tensorzero-ui exec playwright install --with-deps chromium
+        run: |
+          for attempt in 1 2 3; do
+            if pnpm --filter=tensorzero-ui exec playwright install --with-deps chromium; then
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "Failed to install Playwright after 3 attempts"
+              exit 1
+            fi
+            sleep $((10 * attempt))
+          done
+        shell: bash
       - name: Regenerate fixtures
         id: e2e_tests
         run: |

--- a/.github/workflows/ui-tests-e2e-model-inference-cache.yml
+++ b/.github/workflows/ui-tests-e2e-model-inference-cache.yml
@@ -83,7 +83,18 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Setup Playwright
-        run: pnpm --filter=tensorzero-ui exec playwright install --with-deps chromium
+        run: |
+          for attempt in 1 2 3; do
+            if pnpm --filter=tensorzero-ui exec playwright install --with-deps chromium; then
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "Failed to install Playwright after 3 attempts"
+              exit 1
+            fi
+            sleep $((10 * attempt))
+          done
+        shell: bash
 
       - name: Download container images
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53

--- a/.github/workflows/ui-tests-e2e.yml
+++ b/.github/workflows/ui-tests-e2e.yml
@@ -111,7 +111,18 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Setup Playwright
-        run: pnpm --filter=tensorzero-ui exec playwright install --with-deps chromium
+        run: |
+          for attempt in 1 2 3; do
+            if pnpm --filter=tensorzero-ui exec playwright install --with-deps chromium; then
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "Failed to install Playwright after 3 attempts"
+              exit 1
+            fi
+            sleep $((10 * attempt))
+          done
+        shell: bash
 
       - name: Download container images
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
@@ -226,7 +237,18 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Setup Playwright
-        run: pnpm --filter=tensorzero-ui exec playwright install --with-deps chromium
+        run: |
+          for attempt in 1 2 3; do
+            if pnpm --filter=tensorzero-ui exec playwright install --with-deps chromium; then
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "Failed to install Playwright after 3 attempts"
+              exit 1
+            fi
+            sleep $((10 * attempt))
+          done
+        shell: bash
 
       - name: Download container images
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
@@ -314,7 +336,18 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Setup Playwright
-        run: pnpm --filter=tensorzero-ui exec playwright install --with-deps chromium
+        run: |
+          for attempt in 1 2 3; do
+            if pnpm --filter=tensorzero-ui exec playwright install --with-deps chromium; then
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "Failed to install Playwright after 3 attempts"
+              exit 1
+            fi
+            sleep $((10 * attempt))
+          done
+        shell: bash
 
       - name: Download container images
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves reliability of Playwright setup across CI workflows by adding a retry loop (up to 3 attempts with backoff) to `pnpm --filter=tensorzero-ui exec playwright install --with-deps chromium`.
> 
> - Updates `slash-command-regen-fixtures.yml`, `ui-tests-e2e-model-inference-cache.yml`, and `ui-tests-e2e.yml` to wrap Playwright install in a bash retry loop and explicitly set `shell: bash` for that step
> - No application code changes; affects CI stability for UI E2E and fixture regeneration jobs only
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8a76d7189019f0d1755405eff1a1e649021317e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->