### PR TITLE
Fix nightly clippy

### DIFF
--- a/tensorzero-core/tests/e2e/db/bandit_queries.rs
+++ b/tensorzero-core/tests/e2e/db/bandit_queries.rs
@@ -52,7 +52,7 @@ async fn test_clickhouse_metrics_by_variant_many_results() {
     assert_eq!(metrics_by_variant.len(), 3);
     // Sort by count in descending order for deterministic results
     let mut metrics_by_variant = metrics_by_variant;
-    metrics_by_variant.sort_by(|a, b| b.count.cmp(&a.count));
+    metrics_by_variant.sort_by_key(|b| std::cmp::Reverse(b.count));
     let metric = metrics_by_variant.first().unwrap();
     assert_eq!(metric.variant_name, "dicl");
     assert_eq!(metric.count, 39);
@@ -81,7 +81,7 @@ async fn test_clickhouse_metrics_by_variant_episode_boolean() {
         .unwrap();
     // Sort by count in descending order for deterministic results
     let mut metrics_by_variant = metrics_by_variant;
-    metrics_by_variant.sort_by(|a, b| b.count.cmp(&a.count));
+    metrics_by_variant.sort_by_key(|b| std::cmp::Reverse(b.count));
     println!("metrics_by_variant: {metrics_by_variant:?}");
     assert_eq!(metrics_by_variant.len(), 3);
     let metric = metrics_by_variant.first().unwrap();
@@ -112,7 +112,7 @@ async fn test_clickhouse_metrics_by_variant_episode_float() {
         .unwrap();
     // Sort by count in descending order for deterministic results
     let mut metrics_by_variant = metrics_by_variant;
-    metrics_by_variant.sort_by(|a, b| b.count.cmp(&a.count));
+    metrics_by_variant.sort_by_key(|b| std::cmp::Reverse(b.count));
     println!("metrics_by_variant: {metrics_by_variant:?}");
     assert_eq!(metrics_by_variant.len(), 3);
     let metric = metrics_by_variant.first().unwrap();
@@ -893,7 +893,7 @@ async fn test_clickhouse_get_cumulative_feedback_timeseries_baseline_continuity(
             .collect();
 
         // Sort by period
-        variant_points.sort_by(|a, b| a.period_end.cmp(&b.period_end));
+        variant_points.sort_by_key(|a| a.period_end);
 
         if variant_points.len() > 1 {
             // Verify counts are non-decreasing (cumulative)


### PR DESCRIPTION
```
warning: consider using `sort_by_key`
  --> tensorzero-core/tests/e2e/db/bandit_queries.rs:55:5
   |
55 |     metrics_by_variant.sort_by(|a, b| b.count.cmp(&a.count));
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_sort_by
   = note: `#[warn(clippy::unnecessary_sort_by)]` on by default
help: try
   |
55 -     metrics_by_variant.sort_by(|a, b| b.count.cmp(&a.count));
55 +     metrics_by_variant.sort_by_key(|b| std::cmp::Reverse(b.count));
   |

warning: consider using `sort_by_key`
  --> tensorzero-core/tests/e2e/db/bandit_queries.rs:84:5
   |
84 |     metrics_by_variant.sort_by(|a, b| b.count.cmp(&a.count));
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_sort_by
help: try                                                                                                                |
84 -     metrics_by_variant.sort_by(|a, b| b.count.cmp(&a.count));
84 +     metrics_by_variant.sort_by_key(|b| std::cmp::Reverse(b.count));
   |

warning: consider using `sort_by_key`
   --> tensorzero-core/tests/e2e/db/bandit_queries.rs:115:5
    |
115 |     metrics_by_variant.sort_by(|a, b| b.count.cmp(&a.count));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_sort_by
help: try
    |
115 -     metrics_by_variant.sort_by(|a, b| b.count.cmp(&a.count));
115 +     metrics_by_variant.sort_by_key(|b| std::cmp::Reverse(b.count));
    |

warning: consider using `sort_by_key`
   --> tensorzero-core/tests/e2e/db/bandit_queries.rs:896:9
    |
896 |         variant_points.sort_by(|a, b| a.period_end.cmp(&b.period_end));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_sort_by
help: try
    |
896 -         variant_points.sort_by(|a, b| a.period_end.cmp(&b.period_end));
896 +         variant_points.sort_by_key(|a| a.period_end);
    |
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes sorting in `tensorzero-core/tests/e2e/db/bandit_queries.rs` to address nightly clippy.
> 
> - Replace `sort_by` closures with `sort_by_key`, using `std::cmp::Reverse(count)` for descending variant counts
> - Sort cumulative timeseries by `period_end` via `sort_by_key`
> - No functional changes; keeps deterministic ordering and resolves clippy lints
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d71625091f3f53cf32ebd4e24c73cb9dac7f3268. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->