### PR TITLE
Show all configured variants in Variants panel even without inferences

### DIFF
--- a/ui/app/routes/observability/functions/$function_name/FunctionVariantTable.tsx
+++ b/ui/app/routes/observability/functions/$function_name/FunctionVariantTable.tsx
@@ -21,10 +21,15 @@ import {
 } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 import { ChevronUp, ChevronDown, Search } from "lucide-react";
-import type { InferenceCountByVariant } from "~/types/tensorzero";
 import { Input } from "~/components/ui/input";
 
-type VariantCountsWithMetadata = InferenceCountByVariant & {
+// Using explicit type instead of InferenceCountByVariant because:
+// 1. last_used_at needs to be nullable for variants without inferences
+// 2. inference_count is number at runtime (JSON.parse), not bigint as the binding suggests
+type VariantCountsWithMetadata = {
+  variant_name: string;
+  inference_count: number;
+  last_used_at: string | null;
   type: string;
 };
 
@@ -65,7 +70,14 @@ export default function FunctionVariantTable({
       }),
       columnHelper.accessor("last_used_at", {
         header: "Last Used",
-        cell: (info) => <TableItemTime timestamp={info.getValue()} />,
+        cell: (info) => {
+          const value = info.getValue();
+          return value ? (
+            <TableItemTime timestamp={value} />
+          ) : (
+            <span className="text-fg-muted">—</span>
+          );
+        },
       }),
     ],
     [function_name],

--- a/ui/app/routes/observability/functions/$function_name/route.tsx
+++ b/ui/app/routes/observability/functions/$function_name/route.tsx
@@ -176,6 +176,23 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     };
   });
 
+  // Add config variants that have no inferences yet (not applicable to DEFAULT_FUNCTION)
+  if (function_name !== DEFAULT_FUNCTION) {
+    const existingVariants = new Set(
+      variant_counts_with_metadata.map((v) => v.variant_name),
+    );
+    const missingVariants = Object.entries(function_config.variants)
+      .filter(([name]) => !existingVariants.has(name))
+      .map(([name, config]) => ({
+        variant_name: name,
+        inference_count: 0,
+        last_used_at: null,
+        type: config.inner.type,
+        weight: config.inner.weight,
+      }));
+    variant_counts_with_metadata.push(...missingVariants);
+  }
+
   // Handle pagination from listInferenceMetadata response
   const {
     items: inferences,


### PR DESCRIPTION
## Summary
- Fixes the inconsistency where variants only appeared in the Variants panel if they had associated inferences
- Now iterates over all variants from the function config and merges in inference count data where available
- Variants without inferences display with count of 0 and "—" for last used timestamp

Fixes #5894

## Test plan
- [ ] Navigate to a function with variants that have no inferences yet
- [ ] Verify they appear in the Variants panel with count 0 and "—" for last used
- [ ] Verify the Experimentation -> Variant Weights panel still works correctly
- [ ] Verify functions with existing inferences still display correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the Variants panel lists all configured variants, even if they have no inferences yet.
> 
> - Loader (`route.tsx`) augments `variant_counts` with variants from `function_config` that lack inferences (skips `DEFAULT_FUNCTION`), setting `inference_count: 0` and `last_used_at: null` while preserving `type`/`weight`.
> - `FunctionVariantTable.tsx` switches to an explicit `VariantCountsWithMetadata` type (`inference_count: number`, `last_used_at: string | null`) and renders "—" when `last_used_at` is null.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fcfc53b70f7e19eb9c3dd05a2c7d13de262dd86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->