### PR TITLE
Try installing pnpm via curl in model inference cache job

### DIFF
--- a/.github/workflows/ui-tests-e2e-model-inference-cache.yml
+++ b/.github/workflows/ui-tests-e2e-model-inference-cache.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup `pnpm`
         run: |
           for attempt in 1 2 3; do
-            if npm install -g pnpm@latest; then
+            if curl -fsSL https://get.pnpm.io/install.sh | sh - ; then
               break
             fi
             if [ $attempt -eq 3 ]; then


### PR DESCRIPTION
The installation is inexplicably failing to create the 'pnpm' binary in the path in several runs, so let's try a new way of installing it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `pnpm` installation method in `ui-tests-e2e-model-inference-cache.yml`.
> 
> - Replaces `npm install -g pnpm@latest` with `curl -fsSL https://get.pnpm.io/install.sh | sh -` inside the existing 3-attempt retry loop
> - No other workflow or application logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 451d43605ba3c107ae572385c09efd8a5112af15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->