### PR TITLE
Improve error details in UI

### DIFF
--- a/ui/app/components/autopilot/EventStream.tsx
+++ b/ui/app/components/autopilot/EventStream.tsx
@@ -165,8 +165,9 @@ function summarizeEvent(event: GatewayEvent): EventSummary {
       }
       return {};
     case "error":
-      // TODO: handle errors
-      return {};
+      return {
+        description: payload.message,
+      };
     case "unknown":
       return {};
     default:
@@ -329,6 +330,7 @@ function EventItem({
   const eventIsToolEvent = isToolEvent(event);
   const isExpandable =
     event.payload.type === "tool_call" ||
+    event.payload.type === "error" ||
     (event.payload.type === "tool_call_authorization" &&
       event.payload.status.type === "rejected") ||
     (event.payload.type === "tool_result" &&
@@ -384,7 +386,8 @@ function EventItem({
           className={cn(
             "text-fg-secondary whitespace-pre-wrap",
             event.payload.type === "tool_call" ||
-              event.payload.type === "tool_result"
+              event.payload.type === "tool_result" ||
+              event.payload.type === "error"
               ? "font-mono text-sm"
               : "text-sm",
           )}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds visible, expandable error details in the Autopilot event stream.
> 
> - `summarizeEvent` now returns `payload.message` for `error` events
> - `EventItem` treats `error` as expandable and renders details in monospace
> - Styling logic updated to apply monospace `text-sm` for `error` descriptions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aef6d4fd000cadf83916309c3763df6e881507c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->