### PR TITLE
Close autopilot stream when gateway shuts down

### DIFF
--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -598,12 +598,14 @@ impl ClientExt for Client {
             }),
             ClientMode::EmbeddedGateway { gateway, timeout } => {
                 Ok(with_embedded_timeout(*timeout, async {
-                    tensorzero_core::endpoints::batch_inference::start_batch_inference(
-                        gateway.handle.app_state.clone(),
-                        params,
-                        // We currently ban auth-enabled configs in embedded gateway mode,
-                        // so we don't have an API key here
-                        None,
+                    Box::pin(
+                        tensorzero_core::endpoints::batch_inference::start_batch_inference(
+                            gateway.handle.app_state.clone(),
+                            params,
+                            // We currently ban auth-enabled configs in embedded gateway mode,
+                            // so we don't have an API key here
+                            None,
+                        ),
                     )
                     .await
                     .map_err(err_to_http)

--- a/internal/durable-tools/src/action.rs
+++ b/internal/durable-tools/src/action.rs
@@ -154,6 +154,7 @@ pub async fn action(
                 app_state.postgres_connection_info.clone(),
                 app_state.valkey_connection_info.clone(),
                 app_state.deferred_tasks.clone(),
+                app_state.shutdown_token.clone(),
             )?;
 
             let response = feedback(snapshot_app_state, *feedback_params, None).await?;
@@ -168,6 +169,7 @@ pub async fn action(
                 app_state.postgres_connection_info.clone(),
                 app_state.valkey_connection_info.clone(),
                 app_state.deferred_tasks.clone(),
+                app_state.shutdown_token.clone(),
             )?;
 
             // Run the evaluation using the shared helper


### PR DESCRIPTION
The ui will automatically reconnect. This stops the gateway shutdown from hanging indefinitely when browser tabs are open

Fixes https://github.com/tensorzero/tensorzero/issues/5905

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies gateway shutdown handling and ensures long-lived streams don’t block shutdown.
> 
> - Adds `shutdown_token` to `AppStateData`; removes `GatewayHandle.cancel_token` and switches all shutdown paths to `app_state.shutdown_token` (server graceful shutdown, deferred tasks, ClickHouse batcher, rate limiting shutdown)
> - `gateway/main.rs`: trigger shutdown by cancelling the token; use it for `with_graceful_shutdown` and `monitor_server_shutdown`; pass to `spawn_autopilot_worker`
> - `internal/autopilot.rs`: Autopilot SSE stream now `take_until(app_state.shutdown_token.cancelled_owned())` to close on shutdown
> - `AppStateData::new_for_snapshot` updated to accept `shutdown_token`; tests adjusted accordingly
> - Minor: wrap embedded `start_batch_inference` future in `Box::pin` in Rust client
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18b389b81b8cd17f9a81aa85f30b975886fae473. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->