### PR TITLE
added better defaults for durable worker on client side gateway

### DIFF
--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -15,7 +15,7 @@ use tokio::signal;
 use tokio_stream::wrappers::IntervalStream;
 
 use autopilot_worker::{AutopilotWorkerConfig, AutopilotWorkerHandle, spawn_autopilot_worker};
-use durable_tools::EmbeddedClient;
+use durable_tools::{EmbeddedClient, WorkerOptions};
 use tensorzero_auth::constants::{DEFAULT_ORGANIZATION, DEFAULT_WORKSPACE};
 use tensorzero_core::config::{Config, ConfigFileGlob};
 use tensorzero_core::db::clickhouse::migration_manager::manual_run_clickhouse_migrations;
@@ -564,7 +564,12 @@ async fn spawn_autopilot_worker_if_configured(
 
     // TODO: decide how we want to do autopilot config.
     let default_max_attempts = 5;
-    let config = AutopilotWorkerConfig::new(pool, t0_client, default_max_attempts);
+    let worker_options = WorkerOptions {
+        poll_interval: Duration::from_secs(1),
+        concurrency: 8,
+        ..Default::default()
+    };
+    let config = AutopilotWorkerConfig::new(pool, t0_client, default_max_attempts, worker_options);
 
     Ok(Some(
         spawn_autopilot_worker(


### PR DESCRIPTION
Concurrency: 8
Poll interval: 1s

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets explicit durable worker defaults and wires them through the autopilot worker.
> 
> - Adds `worker_options: WorkerOptions` to `AutopilotWorkerConfig` and stores it in `AutopilotWorker`
> - `start()` now uses provided `worker_options` instead of `WorkerOptions::default()`
> - Gateway configures the worker with `poll_interval = 1s` and `concurrency = 8` when spawning
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5941d06de0ac22ff170ba16b718c58b48a89083. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->