### PR TITLE
Fix chat input staying disabled after tool approval

### DIFF
--- a/ui/app/hooks/useAutopilotEventStream.test.ts
+++ b/ui/app/hooks/useAutopilotEventStream.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import type { AutopilotStatus } from "~/types/tensorzero";
+
+/**
+ * Tests for useAutopilotEventStream hook behavior.
+ *
+ * These tests document and verify the expected state management logic,
+ * particularly around error handling and status reset behavior.
+ *
+ * Note: These tests verify the logic patterns rather than the hook directly
+ * (which would require @testing-library/react). They serve as documentation
+ * and regression prevention for the expected behavior.
+ */
+describe("useAutopilotEventStream", () => {
+  describe("SSE error handling", () => {
+    it("should reset status to idle when connection fails", () => {
+      // When SSE connection fails, status resets to "idle" so users can
+      // still send messages. This happens in the hook's catch block:
+      //   setStatus({ status: "idle" });
+
+      let status: AutopilotStatus = { status: "server_side_processing" };
+
+      const handleConnectionError = () => {
+        status = { status: "idle" };
+      };
+
+      expect(status.status).toBe("server_side_processing");
+      handleConnectionError();
+      expect(status.status).toBe("idle");
+    });
+
+    it("should allow submit when status is idle or failed", () => {
+      // From route.tsx:
+      //   const submitDisabled =
+      //     autopilotStatus.status !== "idle" && autopilotStatus.status !== "failed";
+
+      const isSubmitDisabled = (status: AutopilotStatus["status"]): boolean => {
+        return status !== "idle" && status !== "failed";
+      };
+
+      // Submit ENABLED for idle and failed
+      expect(isSubmitDisabled("idle")).toBe(false);
+      expect(isSubmitDisabled("failed")).toBe(false);
+
+      // Submit DISABLED for all other statuses
+      expect(isSubmitDisabled("server_side_processing")).toBe(true);
+      expect(isSubmitDisabled("waiting_for_tool_call_authorization")).toBe(
+        true,
+      );
+      expect(isSubmitDisabled("waiting_for_tool_execution")).toBe(true);
+      expect(isSubmitDisabled("waiting_for_retry")).toBe(true);
+    });
+
+    it("should clear error state when reconnecting", () => {
+      // The hook clears error state at the start of connect():
+      //   setError(null);
+      //   setIsRetrying(false);
+
+      let error: string | null = "Connection failed";
+      let isRetrying = true;
+
+      const attemptReconnect = () => {
+        error = null;
+        isRetrying = false;
+      };
+
+      expect(error).toBe("Connection failed");
+      expect(isRetrying).toBe(true);
+
+      attemptReconnect();
+
+      expect(error).toBe(null);
+      expect(isRetrying).toBe(false);
+    });
+  });
+});

--- a/ui/app/hooks/useAutopilotEventStream.ts
+++ b/ui/app/hooks/useAutopilotEventStream.ts
@@ -205,6 +205,9 @@ export function useAutopilotEventStream({
       setIsConnected(false);
       setError(errorMessage);
       setIsRetrying(true);
+      // Reset status to idle so the user can still send messages while disconnected.
+      // The correct status will be restored when the connection is re-established.
+      setStatus({ status: "idle" });
 
       // Schedule retry
       retryTimeoutRef.current = setTimeout(() => {


### PR DESCRIPTION
## Summary

Fix bug where chat input would stay disabled after approving a tool call.

## Problem

The `isEventsLoading` state was being reset to `true` mid-session when `eventsData` reference changed (e.g., React Router revalidation after tool approval). Since `EventStreamContent` was already mounted, its `onLoaded` callback wouldn't fire again, leaving the input disabled permanently.

**Repro steps:**
1. Start autopilot session, type "hi", get response
2. Type "what functions do i have"
3. Approve tool call when prompted
4. Tool executes and response loads
5. **Bug:** Input stays disabled

## Solution

Track which session we've successfully loaded via a ref (`loadedSessionRef`). Only reset the loading state when navigating to a **different** session, not when `eventsData` changes within the same session.

## Test plan

- [ ] Verify input stays enabled after tool approval flow
- [ ] Verify input is properly disabled during initial page load
- [ ] Verify navigating between sessions resets loading state correctly