### PR TITLE
Reset autopilot status to idle on SSE connection error

### DIFF
--- a/ui/app/hooks/useAutopilotEventStream.ts
+++ b/ui/app/hooks/useAutopilotEventStream.ts
@@ -205,6 +205,9 @@ export function useAutopilotEventStream({
       setIsConnected(false);
       setError(errorMessage);
       setIsRetrying(true);
+      // Reset status to idle so the user can still send messages while disconnected.
+      // The correct status will be restored when the connection is re-established.
+      setStatus({ status: "idle" });
 
       // Schedule retry
       retryTimeoutRef.current = setTimeout(() => {


### PR DESCRIPTION
## Summary

Reset autopilot status to idle when SSE connection fails, so users can still send messages while disconnected.

## Problem

When the SSE connection fails mid-session, the `status` state was not being reset. If the autopilot was in a non-idle state (like `server_side_processing`) when the connection dropped, the submit button would remain disabled with no way to recover.

## Solution

Reset status to `{ status: "idle" }` on SSE connection error. This allows users to continue sending messages while the connection is being re-established. The correct status will be restored once the connection recovers and new events arrive.

## Test plan

- [ ] Verify chat input stays enabled when SSE connection fails
- [ ] Verify status is restored when SSE reconnects