### PR TITLE
Fix chat input staying disabled after tool approval

### DIFF
--- a/ui/app/routes/autopilot/sessions/$session_id/route.tsx
+++ b/ui/app/routes/autopilot/sessions/$session_id/route.tsx
@@ -625,15 +625,16 @@ export default function AutopilotSessionEventsPage({
     autopilotStatus.status !== "idle" && autopilotStatus.status !== "failed";
 
   // Track loading/error state for ChatInput - disabled until events resolve
-  const [isEventsLoading, setIsEventsLoading] = useState(
-    !isNewSession && eventsData instanceof Promise,
-  );
+  // For existing sessions, start loading until EventStreamContent calls onLoaded
+  const [isEventsLoading, setIsEventsLoading] = useState(!isNewSession);
   const [hasLoadError, setHasLoadError] = useState(false);
 
+  // Reset loading/error state when navigating to a different session
+  // Note: key={sessionId} on Suspense remounts EventStreamContent, which will call onLoaded
   useEffect(() => {
-    setIsEventsLoading(!isNewSession && eventsData instanceof Promise);
+    setIsEventsLoading(!isNewSession);
     setHasLoadError(false);
-  }, [sessionId, isNewSession, eventsData]);
+  }, [sessionId, isNewSession]);
 
   const handleEventsLoaded = useCallback(() => {
     setIsEventsLoading(false);


### PR DESCRIPTION
## Summary
- Fix `isEventsLoading` state being incorrectly reset to true mid-session when `eventsData` reference changes (e.g., React Router revalidation after tool approval)
- Track which session has been loaded via a ref to only reset loading state on actual session navigation, not on revalidation

## Problem
After approving a tool call in autopilot, the chat input would stay disabled. This happened because:
1. React Router revalidation after tool approval causes `eventsData` reference to change
2. The useEffect with `eventsData` dependency would reset `isEventsLoading` to true
3. Since `EventStreamContent` was already mounted, its `onLoaded` callback wouldn't fire again
4. Input stayed disabled indefinitely

## Solution
Track which session we've successfully loaded via `loadedSessionRef`. Only reset the loading state when navigating to a different session, not when `eventsData` changes within the same session.

## Test plan
- Start new autopilot session
- Send a message that triggers a tool call
- Approve the tool call
- Verify input is enabled after tool execution completes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI state change confined to the autopilot session route; main risk is incorrectly toggling the loading flag during session navigation vs. revalidation.
> 
> **Overview**
> Fixes `ChatInput` being stuck disabled after tool approval by changing `isEventsLoading` to be driven only by *session navigation* (start `true` for existing sessions, cleared by `EventStreamContent.onLoaded`) rather than by `eventsData` promise/reference changes during React Router revalidation.
> 
> The effect that resets loading/error state now depends only on `sessionId`/`isNewSession`, avoiding mid-session resets that previously prevented `onLoaded` from firing again.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbee708e8c10469ef240fa18d588404f339a3c8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->