### PR TITLE
Clear hasLoadError on successful event load

### DIFF
--- a/ui/app/routes/autopilot/sessions/$session_id/route.tsx
+++ b/ui/app/routes/autopilot/sessions/$session_id/route.tsx
@@ -638,6 +638,7 @@ export default function AutopilotSessionEventsPage({
 
   const handleEventsLoaded = useCallback(() => {
     setIsEventsLoading(false);
+    setHasLoadError(false);
   }, []);
 
   const handleLoadError = useCallback(() => {


### PR DESCRIPTION
## Summary
- Reset `hasLoadError` in `handleEventsLoaded` so successful loads clear previous errors

## Problem
If a revalidation fails (setting `hasLoadError = true`) and then a subsequent revalidation succeeds, `handleEventsLoaded` only set `isEventsLoading = false` but didn't clear `hasLoadError`. The ChatInput stayed disabled because `disabled={isEventsLoading || hasLoadError}`.

## Solution
Add `setHasLoadError(false)` to `handleEventsLoaded`.

## Test plan
- Simulate a temporary backend failure during revalidation
- Verify input re-enables after successful retry

Follow-up to #5948

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state fix limited to the Autopilot session page; it only resets an error flag on successful event load and shouldn’t affect data flow beyond re-enabling the input.
> 
> **Overview**
> Fixes a sticky error state on the Autopilot session page by clearing `hasLoadError` when events successfully load (`handleEventsLoaded`).
> 
> This ensures `ChatInput` re-enables after a transient event-stream load/revalidation failure once a subsequent load succeeds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f5fe1bf4080acd213c2502abbfbf2990bddaaaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->