### PR TITLE
Clear hasLoadError when events successfully load

### DIFF
--- a/ui/app/routes/autopilot/sessions/$session_id/route.tsx
+++ b/ui/app/routes/autopilot/sessions/$session_id/route.tsx
@@ -638,6 +638,7 @@ export default function AutopilotSessionEventsPage({
 
   const handleEventsLoaded = useCallback(() => {
     setIsEventsLoading(false);
+    setHasLoadError(false);
   }, []);
 
   const handleLoadError = useCallback(() => {


### PR DESCRIPTION
## Summary
- Clear `hasLoadError` in `handleEventsLoaded` callback

## Problem
If a revalidation fails (setting `hasLoadError = true`) and then succeeds:
1. `EventStreamContent` remounts (Await renders children again)
2. `handleEventsLoaded` fires, setting `isEventsLoading = false`
3. But `hasLoadError` stays `true`
4. ChatInput stays disabled because `disabled={isEventsLoading || hasLoadError}`

## Solution
Add `setHasLoadError(false)` to `handleEventsLoaded`. When EventStreamContent mounts/remounts successfully, it clears both loading and error states.

## Test plan
- Simulate transient backend failure during revalidation
- Verify ChatInput re-enables after successful retry

Follow-up to #5948

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI state fix limited to resetting `hasLoadError` after a successful load; no data, auth, or API behavior changes.
> 
> **Overview**
> Fixes a UI state bug in `autopilot/sessions/$session_id/route.tsx` where `ChatInput` could remain disabled after a transient event-stream load/revalidation failure.
> 
> `handleEventsLoaded` now clears both `isEventsLoading` and `hasLoadError` when events resolve successfully.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit affe520dd4947faf6af22ca74e0e8fd2fb2170f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->