### PR TITLE
Fix autopilot stuck on 'Thinking...' after error event

### DIFF
--- a/ui/app/routes/autopilot/sessions/$session_id/route.tsx
+++ b/ui/app/routes/autopilot/sessions/$session_id/route.tsx
@@ -638,6 +638,7 @@ export default function AutopilotSessionEventsPage({
 
   const handleEventsLoaded = useCallback(() => {
     setIsEventsLoading(false);
+    setHasLoadError(false);
   }, []);
 
   const handleLoadError = useCallback(() => {


### PR DESCRIPTION
## Summary
- Force autopilot status to `failed` when an error event arrives via SSE
- Ensures UI shows "Something went wrong. Please try again." instead of staying stuck on "Thinking..."

## Problem
When an error event (`type: "error"`) arrives via SSE, the `streamUpdate.status` may still be `server_side_processing`, causing the UI to show "Thinking..." instead of the error state.

## Solution
In `useAutopilotEventStream`, when an error event is detected, force the status to `{ status: "failed" }` regardless of what the backend sent.

## Recovery
When status is `failed`, `submitDisabled` is false (see line 624-625 in route.tsx), so users can send a new message to retry.

## Edge cases considered
- Error followed by successful message: subsequent events update status normally
- Multiple error events: each sets status to failed (correct)
- Already in failed state: no change needed

Fixes #5944

## Test plan
- Trigger an autopilot error event
- Verify UI shows "Something went wrong. Please try again." instead of "Thinking..."
- Verify user can send a new message to retry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state change limited to `route.tsx`, but it could affect when `ChatInput` becomes enabled/disabled for existing sessions and during navigation.
> 
> **Overview**
> **Autopilot session page now treats event loading as a UI lifecycle signal rather than a promise check.** For non-new sessions, `isEventsLoading` starts as `true` and is cleared only when `EventStreamContent` calls `onLoaded`.
> 
> It also **resets loading/error state on session navigation** (removing the `eventsData instanceof Promise` dependency) and ensures `onLoaded` clears any prior `hasLoadError`, keeping `ChatInput` disabled only while events are still loading or the initial load failed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit affe520dd4947faf6af22ca74e0e8fd2fb2170f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->