### PR TITLE
Fix autopilot stuck on 'Thinking...' after error event

### DIFF
--- a/ui/app/hooks/useAutopilotEventStream.ts
+++ b/ui/app/hooks/useAutopilotEventStream.ts
@@ -169,7 +169,13 @@ export function useAutopilotEventStream({
                   });
 
                   // Update autopilot status
-                  setStatus(streamUpdate.status);
+                  // Force status to "failed" when an error event arrives,
+                  // in case the backend didn't send the correct status
+                  if (event.payload.type === "error") {
+                    setStatus({ status: "failed" });
+                  } else {
+                    setStatus(streamUpdate.status);
+                  }
                 } catch {
                   // Skip invalid JSON
                 }


### PR DESCRIPTION
## Summary
- Force autopilot status to `failed` when an error event arrives via SSE
- Ensures UI shows "Something went wrong. Please try again." instead of staying stuck on "Thinking..."

## Problem
When an error event (`type: "error"`) arrives via SSE, the `streamUpdate.status` may still be `server_side_processing`, causing the UI to show "Thinking..." instead of the error state.

## Solution
In `useAutopilotEventStream`, when an error event is detected, force the status to `{ status: "failed" }` regardless of what the backend sent.

## Recovery
When status is `failed`, `submitDisabled` is false, so users can send a new message to retry.

## Edge cases considered
- Error followed by successful message: subsequent events update status normally
- Multiple error events: each sets status to failed (correct)
- Already in failed state: no change needed

Fixes #5944

## Test plan
- Trigger an autopilot error event
- Verify UI shows "Something went wrong. Please try again." instead of "Thinking..."
- Verify user can send a new message to retry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state tweak confined to the SSE event-stream hook; main risk is masking a non-failed backend status if an event is misclassified as `error`.
> 
> **Overview**
> Prevents autopilot from staying stuck in a processing state when an SSE `error` event arrives.
> 
> `useAutopilotEventStream` now **forces `status` to `{ status: "failed" }`** for `event.payload.type === "error"`, instead of trusting `streamUpdate.status`, while leaving all other event types to update status normally.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e1253b091c3a5fec810a71b91ed4cbb11ddae0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->