### PR TITLE
Enable default OpenTelemetry resource detectors

### DIFF
--- a/tensorzero-core/src/observability/mod.rs
+++ b/tensorzero-core/src/observability/mod.rs
@@ -283,7 +283,7 @@ fn build_tracer<T: SpanExporter + 'static>(
         })?;
 
     let mut builder = SdkTracerProvider::builder().with_resource(
-        Resource::builder_empty()
+        Resource::builder()
             .with_attribute(KeyValue::new(
                 opentelemetry_semantic_conventions::resource::SERVICE_NAME,
                 "tensorzero-gateway",


### PR DESCRIPTION
See https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/struct.Resource.html#method.builder In particular, this allows setting the OTEL_RESOURCE_ATTRIBUTES env var, which is useful in autopilot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to OpenTelemetry resource initialization that may alter emitted resource attributes but doesn’t affect request handling or data flow.
> 
> **Overview**
> Updates OTLP tracer initialization in `observability/mod.rs` to use `Resource::builder()` instead of `Resource::builder_empty()`, enabling default OpenTelemetry resource detectors and allowing env-driven resource attributes (e.g. `OTEL_RESOURCE_ATTRIBUTES`) to be applied alongside the existing `service.name` and extra resources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9f9ff041bb7bdecd92ccb6e48e7542de2c1518b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->