### PR TITLE
Use jlumbroso/free-disk-space instead of our custom script

### DIFF
--- a/.github/workflows/caching-hack.yml
+++ b/.github/workflows/caching-hack.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Cleanup disk space
         if: runner.os == 'Linux'
-        run: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
       - name: Install Rust toolchain
         run: |
           for attempt in 1 2 3; do

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -744,7 +744,7 @@ jobs:
       # ClickHouse intermittently runs out of disk space on the `ubuntu-latest` runner
       # Use extreme disk cleanup script that frees up ~26GB of space (11-phase cleanup)
       - name: "Free up disk space"
-        run: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
       - name: Install cargo-nextest
         uses: taiki-e/install-action@60581cd7025e0e855cebd745379013e286d9c787
         with:
@@ -1002,7 +1002,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Cleanup disk space
-        run: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
 
       - name: Install Rust toolchain
         run: |
@@ -1155,7 +1155,7 @@ jobs:
           uv run ./ui/fixtures/download-small-fixtures.py
 
       - name: Cleanup disk space
-        run: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
 
       - name: Set up TENSORZERO_CLICKHOUSE_URL for E2E tests
         run: |

--- a/.github/workflows/live-batch-test.yml
+++ b/.github/workflows/live-batch-test.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Cleanup disk space
-        run: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
 
       - name: Install Rust toolchain
         run: |

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -127,7 +127,7 @@ jobs:
           wait-for-builder: true
 
       - name: Cleanup disk space
-        run: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
 
       - name: Restore provider-proxy cache
         if: github.event_name != 'schedule'
@@ -235,7 +235,7 @@ jobs:
           # curl -H "Modal-Key: $MODAL_KEY" -H "Modal-Secret: $MODAL_SECRET" https://tensorzero--vllm-gpt-oss-20b-serve.modal.run/ > vllm_gpt_oss_modal_logs.txt &
 
       - name: Cleanup disk space
-        run: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
 
       - name: Restore client-tests provider-proxy cache
         if: github.event_name != 'schedule'

--- a/.github/workflows/mocked-batch-test.yml
+++ b/.github/workflows/mocked-batch-test.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Cleanup disk space
-        run: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
 
       - name: Install Rust toolchain
         run: |

--- a/.github/workflows/optimization-test-cron.yml
+++ b/.github/workflows/optimization-test-cron.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Cleanup disk space
-        run: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
 
       - name: Write GCP JWT key to file
         env:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Cleanup disk space
-        run: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
 
       - name: Install Rust toolchain
         run: |


### PR DESCRIPTION
We saw another weird 'pnpm' missing in
https://github.com/tensorzero/tensorzero/actions/runs/21488452649/job/61904504902?pr=5966

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple GitHub Actions workflows and changes how runner disk space is reclaimed, which can affect availability of preinstalled toolchains/caches and overall CI stability. No production code paths are impacted.
> 
> **Overview**
> Switches CI disk cleanup from running the repo’s `./ci/free-disk-space.sh` script to using `jlumbroso/free-disk-space@54081f...` across several workflows (`general.yml`, `merge-queue.yml`, `ui-tests.yml`, and scheduled/batch workflows).
> 
> Updates related workflow commentary to reflect the new cleanup mechanism (notably around `setup-uv` cache behavior after toolcache removal).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db5ac6d6d0cf7bb4e7244a64095a928bb0e2a34d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->