### PR TITLE
Increase default page size in autopilot

### DIFF
--- a/ui/app/routes/autopilot/sessions/$session_id/route.tsx
+++ b/ui/app/routes/autopilot/sessions/$session_id/route.tsx
@@ -45,7 +45,7 @@ export const handle: RouteHandle = {
   ],
 };
 
-const EVENTS_PER_PAGE = 20;
+const EVENTS_PER_PAGE = 25;
 
 export type EventsData = {
   events: GatewayEvent[];


### PR DESCRIPTION
20 doesn't always fill screen

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX tweak that only changes the pagination limit, with a minor potential impact on payload size and render performance.
> 
> **Overview**
> Increases the autopilot session event pagination size by changing `EVENTS_PER_PAGE` from 20 to 25, affecting both the initial `listAutopilotEvents` fetch and the "load older" requests so more events are shown per page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03ec07841560ff208452204bab43062d6bdd33c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->