### PR TITLE
Prioritize buildkite merge queue based on pr queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,10 @@
 agents:
   queue: "t0-merge-queue"
 
+# Priority based on merge queue position (negative so earlier positions have higher priority)
+# Set via MERGE_QUEUE_PRIORITY env var from GitHub Actions
+priority: ${MERGE_QUEUE_PRIORITY:-0}
+
 # We need to use individual steps instead of a build matrix, as we can't use matrix keys
 # inside concurrency_group
 steps:

--- a/.github/workflows/buildkite-merge-queue.yml
+++ b/.github/workflows/buildkite-merge-queue.yml
@@ -5,15 +5,50 @@ on:
   # merge_group:
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   merge-queue-tests:
     runs-on: ubuntu-latest
     if: github.repository == 'tensorzero/tensorzero'
     steps:
+      - name: Get merge queue position
+        id: get-position
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Extract PR number from merge queue branch name (format: gh-readonly-queue/main/pr-<NUMBER>-<SHA>)
+          PR_NUMBER=$(echo "${{ github.ref_name }}" | sed -n 's/.*\/pr-\([0-9]*\)-.*/\1/p')
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "Could not extract PR number from ref: ${{ github.ref_name }}"
+            echo "priority=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Query GitHub GraphQL API for merge queue position
+          POSITION=$(gh api graphql -f query='
+            query($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) {
+                  mergeQueueEntry {
+                    position
+                  }
+                }
+              }
+            }
+          ' -f owner="${{ github.repository_owner }}" -f name="${{ github.event.repository.name }}" -F number="$PR_NUMBER" \
+            --jq '.data.repository.pullRequest.mergeQueueEntry.position // 0')
+
+          # Set priority to negative of position (so lower positions have higher priority)
+          PRIORITY=$((-POSITION))
+          echo "PR #$PR_NUMBER is at merge queue position $POSITION, setting priority to $PRIORITY"
+          echo "priority=$PRIORITY" >> "$GITHUB_OUTPUT"
+
       - name: Trigger a Buildkite Build on Push using v2.0.0
         uses: buildkite/trigger-pipeline-action@v2.0.0
         with:
           buildkite_api_access_token: ${{ secrets.TRIGGER_BK_BUILD_TOKEN }}
           pipeline: "tensorzero/merge-queue-tests"
+          build_env_vars: '{"MERGE_QUEUE_PRIORITY": "${{ steps.get-position.outputs.priority }}"}'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change that affects Buildkite job scheduling/ordering but not application runtime behavior. Main risk is miscomputed priority (e.g., failing PR number extraction/GraphQL query) leading to default priority 0 and unexpected build ordering.
> 
> **Overview**
> Adds merge-queue-aware scheduling for Buildkite runs by introducing a pipeline `priority` derived from `MERGE_QUEUE_PRIORITY`.
> 
> The GitHub workflow now extracts the PR number from the merge-queue ref, queries GitHub’s GraphQL API for the PR’s merge queue `position`, converts it to a negative priority (earlier in queue = higher priority), and passes it to Buildkite via `build_env_vars`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 518d074a1b5d9c87a0882998f40c8481a8a5c7f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->