### PR TITLE
ensure roundtrip serde for rate limiting

### DIFF
--- a/tensorzero-core/src/rate_limiting/mod.rs
+++ b/tensorzero-core/src/rate_limiting/mod.rs
@@ -410,7 +410,7 @@ impl RateLimitingConfigRule {
 }
 
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "ts-bindings", ts(export))]
 pub struct RateLimit {
     pub resource: RateLimitResource,


### PR DESCRIPTION
Because we have a custom deserializer for rate limiting rules but do not serialize stored configs in the same format, we had a non-roundtrip Ser/de impl for rate limiting config. This PR makes the deserialization logic more liberal so we can accept either format and roundtrip.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rate-limiting config deserialization to accept multiple on-disk formats; mistakes here could cause configs to fail to load or apply different limits. Added tests reduce risk but this still touches enforcement-critical parsing.
> 
> **Overview**
> Enables **roundtrip serialization/deserialization** of rate limiting configs by making `RateLimitingConfigRule` accept both the TOML shorthand (e.g. `tokens_per_minute`) and the database-stored serialized format (explicit `limits` array).
> 
> Extends `RateLimitingConfigPriority` deserialization to also accept the stored enum representations (e.g. `priority = { Priority = 0 }` and `priority = "Always"`), derives `Deserialize` for `RateLimit`, and adds tests covering roundtrip behavior and direct parsing of stored formats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79fe2388532f009e15dd5fbeef11b4bc001c952a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->