### PR TITLE
Abstract away clickhouse_flush_async_insert

### DIFF
--- a/evaluations/tests/tests.rs
+++ b/evaluations/tests/tests.rs
@@ -17,6 +17,7 @@ use tensorzero_core::db::clickhouse::test_helpers::{
 use tensorzero_core::db::stored_datapoint::{
     StoredChatInferenceDatapoint, StoredJsonInferenceDatapoint,
 };
+use tensorzero_core::db::test_helpers::TestDatabaseHelpers;
 use tensorzero_core::endpoints::datasets::{
     ChatInferenceDatapoint, Datapoint, JsonInferenceDatapoint,
     v1::{list_datapoints, types::ListDatapointsRequest},
@@ -45,8 +46,8 @@ use tensorzero_core::config::{
 use tensorzero_core::variant::chat_completion::UninitializedChatCompletionConfig;
 use tensorzero_core::{
     db::clickhouse::test_helpers::{
-        clickhouse_flush_async_insert, get_clickhouse, select_chat_inference_clickhouse,
-        select_feedback_by_target_id_clickhouse, select_json_inference_clickhouse,
+        get_clickhouse, select_chat_inference_clickhouse, select_feedback_by_target_id_clickhouse,
+        select_json_inference_clickhouse,
     },
     inference::types::{ContentBlockChatOutput, JsonInferenceOutput, Usage},
 };
@@ -145,7 +146,7 @@ async fn run_evaluations_json() {
     Box::pin(run_evaluation(args(), evaluation_run_id, &mut output))
         .await
         .unwrap();
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     sleep(Duration::from_secs(5)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
@@ -345,7 +346,7 @@ async fn run_evaluations_json() {
     Box::pin(run_evaluation(args(), evaluation_run_id, &mut output))
         .await
         .unwrap();
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     sleep(Duration::from_secs(5)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
@@ -612,7 +613,7 @@ async fn run_evaluation_with_specific_datapoint_ids() {
     Box::pin(run_evaluation(args, evaluation_run_id, &mut output))
         .await
         .unwrap();
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     sleep(Duration::from_secs(5)).await;
 
     let output_str = String::from_utf8(output).unwrap();
@@ -706,7 +707,7 @@ async fn run_exact_match_evaluation_chat() {
     Box::pin(run_evaluation(args, evaluation_run_id, &mut output))
         .await
         .unwrap();
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     sleep(Duration::from_secs(5)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
@@ -847,7 +848,7 @@ async fn run_llm_judge_evaluation_chat() {
     Box::pin(run_evaluation(args(), evaluation_run_id, &mut output))
         .await
         .unwrap();
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     sleep(Duration::from_secs(5)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
@@ -997,7 +998,7 @@ async fn run_llm_judge_evaluation_chat() {
     Box::pin(run_evaluation(args(), evaluation_run_id, &mut output))
         .await
         .unwrap();
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     sleep(Duration::from_secs(5)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
@@ -1075,7 +1076,7 @@ async fn run_image_evaluation() {
     Box::pin(run_evaluation(args, evaluation_run_id, &mut output))
         .await
         .unwrap();
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     sleep(Duration::from_secs(5)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
@@ -1297,7 +1298,7 @@ async fn check_invalid_image_evaluation() {
     Box::pin(run_evaluation(args, evaluation_run_id, &mut output))
         .await
         .unwrap();
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     sleep(Duration::from_secs(5)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
@@ -1659,7 +1660,7 @@ async fn run_evaluations_errors() {
     Box::pin(run_evaluation(args, evaluation_run_id, &mut output))
         .await
         .unwrap();
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     sleep(Duration::from_secs(5)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
@@ -2104,7 +2105,7 @@ async fn run_evaluations_best_of_3() {
     Box::pin(run_evaluation(args, evaluation_run_id, &mut output))
         .await
         .unwrap();
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     sleep(Duration::from_secs(5)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
@@ -2297,7 +2298,7 @@ async fn run_evaluations_mixture_of_3() {
     Box::pin(run_evaluation(args, evaluation_run_id, &mut output))
         .await
         .unwrap();
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     sleep(Duration::from_secs(5)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
@@ -2493,7 +2494,7 @@ async fn run_evaluations_dicl() {
     Box::pin(run_evaluation(args, evaluation_run_id, &mut output))
         .await
         .unwrap();
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     sleep(Duration::from_secs(5)).await;
     let output_str = String::from_utf8(output).unwrap();
     let output_lines: Vec<&str> = output_str.lines().skip(1).collect();
@@ -3026,7 +3027,7 @@ async fn test_precision_targets_parameter() {
             .await
             .expect("ClickHouse batch writer should complete before tag assertions");
     }
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     sleep(Duration::from_secs(5)).await;
 
     let inference_id =

--- a/tensorzero-core/src/db/mod.rs
+++ b/tensorzero-core/src/db/mod.rs
@@ -25,6 +25,7 @@ pub mod model_inferences;
 pub mod postgres;
 pub mod rate_limiting;
 pub mod stored_datapoint;
+pub mod test_helpers;
 pub mod valkey;
 pub mod workflow_evaluation_queries;
 
@@ -36,9 +37,6 @@ pub trait ClickHouseConnection:
     SelectQueries + DatasetQueries + FeedbackQueries + HealthCheckable + Send + Sync
 {
 }
-
-#[async_trait]
-pub trait PostgresConnection: RateLimitQueries + HealthCheckable + Send + Sync {}
 
 #[async_trait]
 pub trait HealthCheckable {
@@ -173,11 +171,6 @@ pub struct TableBounds {
     pub first_id: Option<Uuid>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_id: Option<Uuid>,
-}
-
-impl<T: RateLimitQueries + ExperimentationQueries + HealthCheckable + Send + Sync>
-    PostgresConnection for T
-{
 }
 
 pub trait ExperimentationQueries {

--- a/tensorzero-core/src/db/test_helpers.rs
+++ b/tensorzero-core/src/db/test_helpers.rs
@@ -1,0 +1,45 @@
+#![cfg(feature = "e2e_tests")]
+
+use std::time::Duration;
+
+use tonic::async_trait;
+
+use crate::db::{clickhouse::ClickHouseConnectionInfo, postgres::PostgresConnectionInfo};
+
+/// Trait for database operations needed in tests.
+/// Provides a database-agnostic way to ensure writes are visible before reads.
+#[async_trait]
+pub trait TestDatabaseHelpers: Send + Sync {
+    /// Ensures all pending writes are visible for subsequent reads.
+    async fn flush_pending_writes(&self);
+
+    /// (In ClickHouse only) sleeps for a given duration to ensure writes are visible.
+    async fn sleep_for_writes_to_be_visible(&self);
+}
+
+#[async_trait]
+impl TestDatabaseHelpers for ClickHouseConnectionInfo {
+    /// For ClickHouse, this flushes the async insert queue.
+    async fn flush_pending_writes(&self) {
+        if let Err(e) = self
+            .run_query_synchronous_no_params("SYSTEM FLUSH ASYNC INSERT QUEUE".to_string())
+            .await
+        {
+            tracing::warn!("Failed to run `SYSTEM FLUSH ASYNC INSERT QUEUE`: {}", e);
+        }
+    }
+
+    /// For ClickHouse, this sleeps for a given duration to ensure writes are visible.
+    async fn sleep_for_writes_to_be_visible(&self) {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+#[async_trait]
+impl TestDatabaseHelpers for PostgresConnectionInfo {
+    /// For Postgres, this is a no-op since writes are immediately visible.
+    async fn flush_pending_writes(&self) {}
+
+    /// For Postgres, this is a no-op since writes are immediately visible.
+    async fn sleep_for_writes_to_be_visible(&self) {}
+}

--- a/tensorzero-core/tests/e2e/datasets/tool_params.rs
+++ b/tensorzero-core/tests/e2e/datasets/tool_params.rs
@@ -10,11 +10,10 @@
 use reqwest::{Client, StatusCode};
 use serde_json::{Value, json};
 use std::time::Duration;
-use tensorzero_core::db::clickhouse::test_helpers::{
-    clickhouse_flush_async_insert, get_clickhouse,
-};
+use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
 use tensorzero_core::db::datasets::DatasetQueries;
 use tensorzero_core::db::stored_datapoint::{StoredChatInferenceDatapoint, StoredDatapoint};
+use tensorzero_core::db::test_helpers::TestDatabaseHelpers;
 use tensorzero_core::inference::types::{
     Arguments, ContentBlockChatOutput, Role, StoredInput, StoredInputMessage,
     StoredInputMessageContent, System, Text,
@@ -299,7 +298,7 @@ async fn test_datapoint_update_tool_params() {
     assert_ne!(new_id, original_id, "Should create a new datapoint ID");
 
     // Wait for writes
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
     // Verify old datapoint is staled
@@ -860,7 +859,7 @@ async fn test_datapoint_tool_params_three_states() {
         .parse()
         .unwrap();
 
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     let resp1 = http_client
@@ -905,7 +904,7 @@ async fn test_datapoint_tool_params_three_states() {
         .parse()
         .unwrap();
 
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     let resp2 = http_client
@@ -981,7 +980,7 @@ async fn test_datapoint_tool_params_three_states() {
         .parse()
         .unwrap();
 
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     let resp3 = http_client

--- a/tensorzero-core/tests/e2e/db/feedback_queries.rs
+++ b/tensorzero-core/tests/e2e/db/feedback_queries.rs
@@ -17,6 +17,7 @@ use tensorzero_core::db::feedback::{
     DemonstrationFeedbackInsert, FeedbackQueries, FeedbackRow, FloatMetricFeedbackInsert,
     GetVariantPerformanceParams, StaticEvaluationHumanFeedbackInsert,
 };
+use tensorzero_core::db::test_helpers::TestDatabaseHelpers;
 use tensorzero_core::function::FunctionConfigType;
 use uuid::Uuid;
 
@@ -941,7 +942,7 @@ async fn test_get_variant_performances_ask_question_num_questions_with_variant(
 }
 make_db_test!(test_get_variant_performances_ask_question_num_questions_with_variant);
 
-async fn test_insert_boolean_feedback(conn: impl FeedbackQueries) {
+async fn test_insert_boolean_feedback(conn: impl FeedbackQueries + TestDatabaseHelpers) {
     let feedback_id = Uuid::now_v7();
     // Use a known inference ID from the test database
     let target_id = Uuid::parse_str("0192e14c-09b8-738c-970e-c0bb29429e3e").unwrap();
@@ -965,8 +966,7 @@ async fn test_insert_boolean_feedback(conn: impl FeedbackQueries) {
         .await
         .expect("Boolean feedback insert should succeed");
 
-    // Wait for ClickHouse to process the insert
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    conn.sleep_for_writes_to_be_visible().await;
 
     // Read back the feedback
     let feedback = conn
@@ -983,7 +983,7 @@ async fn test_insert_boolean_feedback(conn: impl FeedbackQueries) {
 }
 make_db_test!(test_insert_boolean_feedback);
 
-async fn test_insert_float_feedback(conn: impl FeedbackQueries) {
+async fn test_insert_float_feedback(conn: impl FeedbackQueries + TestDatabaseHelpers) {
     let feedback_id = Uuid::now_v7();
     // Use a known inference ID from the test database
     let target_id = Uuid::parse_str("0192e14c-09b8-738c-970e-c0bb29429e3e").unwrap();
@@ -1003,8 +1003,7 @@ async fn test_insert_float_feedback(conn: impl FeedbackQueries) {
         .await
         .expect("Float feedback insert should succeed");
 
-    // Wait for ClickHouse to process the insert
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    conn.sleep_for_writes_to_be_visible().await;
 
     // Read back the feedback
     let feedback = conn
@@ -1021,7 +1020,9 @@ async fn test_insert_float_feedback(conn: impl FeedbackQueries) {
 }
 make_db_test!(test_insert_float_feedback);
 
-async fn test_insert_comment_feedback_inference_level(conn: impl FeedbackQueries) {
+async fn test_insert_comment_feedback_inference_level(
+    conn: impl FeedbackQueries + TestDatabaseHelpers,
+) {
     let feedback_id = Uuid::now_v7();
     // Use a known inference ID from the test database
     let target_id = Uuid::parse_str("0192e14c-09b8-738c-970e-c0bb29429e3e").unwrap();
@@ -1041,8 +1042,7 @@ async fn test_insert_comment_feedback_inference_level(conn: impl FeedbackQueries
         .await
         .expect("Comment feedback insert should succeed");
 
-    // Wait for ClickHouse to process the insert
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    conn.sleep_for_writes_to_be_visible().await;
 
     // Read back the feedback
     let feedback = conn
@@ -1059,7 +1059,9 @@ async fn test_insert_comment_feedback_inference_level(conn: impl FeedbackQueries
 }
 make_db_test!(test_insert_comment_feedback_inference_level);
 
-async fn test_insert_comment_feedback_episode_level(conn: impl FeedbackQueries) {
+async fn test_insert_comment_feedback_episode_level(
+    conn: impl FeedbackQueries + TestDatabaseHelpers,
+) {
     let feedback_id = Uuid::now_v7();
     // Use a known episode ID from the test database
     let target_id = Uuid::parse_str("0192e14c-09b8-7d3e-8618-46aed8c213dc").unwrap();
@@ -1083,8 +1085,7 @@ async fn test_insert_comment_feedback_episode_level(conn: impl FeedbackQueries) 
         .await
         .expect("Comment feedback insert should succeed");
 
-    // Wait for ClickHouse to process the insert
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    conn.sleep_for_writes_to_be_visible().await;
 
     // Read back the feedback
     let feedback = conn
@@ -1101,7 +1102,7 @@ async fn test_insert_comment_feedback_episode_level(conn: impl FeedbackQueries) 
 }
 make_db_test!(test_insert_comment_feedback_episode_level);
 
-async fn test_insert_demonstration_feedback(conn: impl FeedbackQueries) {
+async fn test_insert_demonstration_feedback(conn: impl FeedbackQueries + TestDatabaseHelpers) {
     let feedback_id = Uuid::now_v7();
     // Use a known inference ID from the test database
     let inference_id = Uuid::parse_str("0192e14c-09b8-738c-970e-c0bb29429e3e").unwrap();
@@ -1120,8 +1121,7 @@ async fn test_insert_demonstration_feedback(conn: impl FeedbackQueries) {
         .await
         .expect("Demonstration feedback insert should succeed");
 
-    // Wait for ClickHouse to process the insert
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    conn.sleep_for_writes_to_be_visible().await;
 
     // Read back the feedback using demonstration-specific query
     let feedback = conn
@@ -1137,7 +1137,9 @@ async fn test_insert_demonstration_feedback(conn: impl FeedbackQueries) {
 }
 make_db_test!(test_insert_demonstration_feedback);
 
-async fn test_insert_static_eval_feedback(conn: impl FeedbackQueries + EvaluationQueries) {
+async fn test_insert_static_eval_feedback(
+    conn: impl FeedbackQueries + EvaluationQueries + TestDatabaseHelpers,
+) {
     let feedback_id = Uuid::now_v7();
     let datapoint_id = Uuid::now_v7();
     let evaluator_inference_id = Uuid::now_v7();
@@ -1158,8 +1160,7 @@ async fn test_insert_static_eval_feedback(conn: impl FeedbackQueries + Evaluatio
         .await
         .expect("Static eval feedback insert should succeed");
 
-    // Wait for ClickHouse to process the insert
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    conn.sleep_for_writes_to_be_visible().await;
 
     // Read back the feedback using evaluation queries
     let feedback = conn
@@ -1186,7 +1187,7 @@ async fn test_insert_static_eval_feedback(conn: impl FeedbackQueries + Evaluatio
 make_clickhouse_only_test!(test_insert_static_eval_feedback);
 
 async fn test_insert_static_eval_feedback_without_evaluator_inference_id(
-    conn: impl FeedbackQueries + EvaluationQueries,
+    conn: impl FeedbackQueries + EvaluationQueries + TestDatabaseHelpers,
 ) {
     let feedback_id = Uuid::now_v7();
     let datapoint_id = Uuid::now_v7();
@@ -1207,8 +1208,7 @@ async fn test_insert_static_eval_feedback_without_evaluator_inference_id(
         .await
         .expect("Static eval feedback insert without evaluator_inference_id should succeed");
 
-    // Wait for ClickHouse to process the insert
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    conn.sleep_for_writes_to_be_visible().await;
 
     // Read back the feedback using evaluation queries
     let feedback = conn
@@ -1242,7 +1242,9 @@ make_clickhouse_only_test!(test_insert_static_eval_feedback_without_evaluator_in
 /// This verifies the SQL semantics of:
 /// `SELECT DISTINCT ON (target_id) ... ORDER BY target_id, created_at DESC`
 /// which should keep only the latest feedback per target_id.
-async fn test_get_variant_performances_distinct_on_semantics(conn: impl FeedbackQueries) {
+async fn test_get_variant_performances_distinct_on_semantics(
+    conn: impl FeedbackQueries + TestDatabaseHelpers,
+) {
     // Use the inference ID from fixture data for write_haiku function
     let target_id = Uuid::parse_str("0196c682-72e0-7c83-a92b-9d1a3c7630f2").unwrap();
     let unique_metric_name = format!("e2e_distinct_on_test_{}", Uuid::now_v7());
@@ -1279,7 +1281,7 @@ async fn test_get_variant_performances_distinct_on_semantics(conn: impl Feedback
         .expect("Second feedback insert should succeed");
 
     // Wait for database to process (especially for ClickHouse)
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    conn.sleep_for_writes_to_be_visible().await;
 
     // Query variant performances
     let metric_config = MetricConfig {
@@ -1326,7 +1328,7 @@ async fn test_get_variant_performances_distinct_on_semantics(conn: impl Feedback
 }
 make_db_test!(test_get_variant_performances_distinct_on_semantics);
 
-async fn test_insert_feedback_with_multiple_tags(conn: impl FeedbackQueries) {
+async fn test_insert_feedback_with_multiple_tags(conn: impl FeedbackQueries + TestDatabaseHelpers) {
     let feedback_id = Uuid::now_v7();
     let target_id = Uuid::parse_str("0192e14c-09b8-738c-970e-c0bb29429e3e").unwrap();
     let metric_name = format!("e2e_test_with_tags_{feedback_id}");
@@ -1351,8 +1353,7 @@ async fn test_insert_feedback_with_multiple_tags(conn: impl FeedbackQueries) {
         .await
         .expect("Feedback insert with multiple tags should succeed");
 
-    // Wait for ClickHouse to process the insert
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    conn.sleep_for_writes_to_be_visible().await;
 
     // Read back the feedback
     let feedback = conn

--- a/tensorzero-core/tests/e2e/endpoints/datasets/update_datapoints.rs
+++ b/tensorzero-core/tests/e2e/endpoints/datasets/update_datapoints.rs
@@ -8,13 +8,12 @@ use std::time::Duration;
 use tensorzero::{FunctionTool, GetDatapointParams};
 use uuid::Uuid;
 
-use tensorzero_core::db::clickhouse::test_helpers::{
-    clickhouse_flush_async_insert, get_clickhouse,
-};
+use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
 use tensorzero_core::db::datasets::DatasetQueries;
 use tensorzero_core::db::stored_datapoint::{
     StoredChatInferenceDatapoint, StoredDatapoint, StoredJsonInferenceDatapoint,
 };
+use tensorzero_core::db::test_helpers::TestDatabaseHelpers;
 use tensorzero_core::endpoints::datasets::v1::types::{
     DatapointMetadataUpdate, UpdateDatapointMetadataRequest, UpdateDatapointsMetadataRequest,
 };
@@ -114,7 +113,7 @@ async fn test_update_chat_datapoint_output() {
 
     // Wait for async inserts and give ClickHouse time to merge the staled version
 
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
     // Verify the old datapoint is staled
@@ -394,7 +393,7 @@ async fn test_update_multiple_datapoints() {
 
     // Wait for async inserts and give ClickHouse time to merge the staled versions
     tokio::time::sleep(Duration::from_millis(1000)).await;
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
     // Verify both old datapoints are staled
@@ -1340,7 +1339,7 @@ async fn test_update_metadata_chat_datapoint() {
 
     // Wait for async inserts
     tokio::time::sleep(Duration::from_millis(1000)).await;
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
     // Verify the datapoint has updated name
@@ -1439,7 +1438,7 @@ async fn test_update_metadata_json_datapoint() {
 
     // Wait for async inserts
     tokio::time::sleep(Duration::from_millis(1000)).await;
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
     // Verify the datapoint has updated name
@@ -1522,7 +1521,7 @@ async fn test_update_metadata_set_name_to_null() {
     assert!(resp.status().is_success());
 
     // Wait for async inserts
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
     // Verify name is now null
@@ -1649,7 +1648,7 @@ async fn test_update_metadata_multiple_datapoints() {
     assert_eq!(returned_ids.len(), 2);
 
     // Wait for async inserts
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
     // Verify both datapoints have updated names
@@ -1838,7 +1837,7 @@ async fn test_get_chat_datapoint_modify_and_update_roundtrip() {
     assert_ne!(new_id, datapoint_id, "Should create a new datapoint ID");
 
     // Wait for async inserts
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
     // Verify the new datapoint has the modified output
@@ -1994,7 +1993,7 @@ async fn test_get_json_datapoint_modify_and_update_roundtrip() {
     assert_ne!(new_id, datapoint_id, "Should create a new datapoint ID");
 
     // Wait for async inserts
-    clickhouse_flush_async_insert(&clickhouse).await;
+    clickhouse.flush_pending_writes().await;
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
     // Verify the new datapoint has the modified output and name


### PR DESCRIPTION
Change `clickhouse_flush_async_insert` to be a Trait, so the Postgres interface can implement it and provide a no-op, so it's easy to change the db e2e tests to use both databases.

Step towards #5691