### PR TITLE
Normalize test function names

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -109,7 +109,7 @@ slow-timeout = { period = "60s", terminate-after = 4 }
 retries = 0
 
 [[profile.default.overrides]]
-filter = 'test(e2e_test_variant_failover)'
+filter = 'test(test_variant_failover)'
 # This test makes lots of requests, so give it extra time for the slower Github runners.
 slow-timeout = { period = "60s", terminate-after = 2 }
 

--- a/clients/rust/src/test_helpers.rs
+++ b/clients/rust/src/test_helpers.rs
@@ -215,7 +215,7 @@ pub async fn make_embedded_gateway_e2e_with_unique_db(db_prefix: &str) -> Client
 /// Starts an HTTP gateway with a unique ClickHouse database.
 /// Returns the base URL (e.g., "http://127.0.0.1:12345") and a shutdown handle.
 /// The gateway shuts down when the handle is dropped.
-pub async fn start_http_gateway_with_unique_db(
+pub async fn make_http_gateway_with_unique_db(
     db_prefix: &str,
 ) -> (String, tensorzero_core::utils::gateway::ShutdownHandle) {
     let clickhouse_url = create_unique_clickhouse_url(db_prefix);

--- a/tensorzero-core/tests/e2e/best_of_n.rs
+++ b/tensorzero-core/tests/e2e/best_of_n.rs
@@ -15,22 +15,22 @@ use tensorzero_core::db::clickhouse::test_helpers::{
 };
 
 #[tokio::test]
-async fn e2e_test_best_of_n_dummy_candidates_dummy_judge_non_stream() {
+async fn test_best_of_n_dummy_candidates_dummy_judge_non_stream() {
     // Include randomness in put to make sure that the first request is a cache miss
     let random_input = Uuid::now_v7();
-    e2e_test_best_of_n_dummy_candidates_dummy_judge_inner(random_input, false, false).await;
-    e2e_test_best_of_n_dummy_candidates_dummy_judge_inner(random_input, true, false).await;
+    test_best_of_n_dummy_candidates_dummy_judge_inner(random_input, false, false).await;
+    test_best_of_n_dummy_candidates_dummy_judge_inner(random_input, true, false).await;
 }
 
 #[tokio::test]
-async fn e2e_test_best_of_n_dummy_candidates_dummy_judge_streaming() {
+async fn test_best_of_n_dummy_candidates_dummy_judge_streaming() {
     // Include randomness in put to make sure that the first request is a cache miss
     let random_input = Uuid::now_v7();
-    e2e_test_best_of_n_dummy_candidates_dummy_judge_inner(random_input, false, true).await;
-    e2e_test_best_of_n_dummy_candidates_dummy_judge_inner(random_input, true, true).await;
+    test_best_of_n_dummy_candidates_dummy_judge_inner(random_input, false, true).await;
+    test_best_of_n_dummy_candidates_dummy_judge_inner(random_input, true, true).await;
 }
 
-async fn e2e_test_best_of_n_dummy_candidates_dummy_judge_inner(
+async fn test_best_of_n_dummy_candidates_dummy_judge_inner(
     random_input: Uuid,
     should_be_cached: bool,
     stream: bool,
@@ -191,7 +191,7 @@ async fn e2e_test_best_of_n_dummy_candidates_dummy_judge_inner(
 /// We check that the good response is selected and that the other responses are not
 /// but they get stored to the ModelInference table.
 #[tokio::test]
-async fn e2e_test_best_of_n_dummy_candidates_real_judge() {
+async fn test_best_of_n_dummy_candidates_real_judge() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -511,7 +511,7 @@ async fn e2e_test_best_of_n_dummy_candidates_real_judge() {
 /// We check that the good response is selected and that the other responses are not
 /// but they get stored to the ModelInference table.
 #[tokio::test]
-async fn e2e_test_best_of_n_json_real_judge() {
+async fn test_best_of_n_json_real_judge() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -785,7 +785,7 @@ async fn e2e_test_best_of_n_json_real_judge() {
 /// but they get stored to the ModelInference table.
 /// This test uses `json_mode="tool"` in the evaluator, so we also check that there was actually a tool call made under the hood.
 #[tokio::test]
-async fn e2e_test_best_of_n_json_real_judge_implicit_tool() {
+async fn test_best_of_n_json_real_judge_implicit_tool() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -1061,7 +1061,7 @@ async fn e2e_test_best_of_n_json_real_judge_implicit_tool() {
 }
 
 #[tokio::test]
-async fn e2e_test_best_of_n_judge_extra_body() {
+async fn test_best_of_n_judge_extra_body() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({

--- a/tensorzero-core/tests/e2e/built_in.rs
+++ b/tensorzero-core/tests/e2e/built_in.rs
@@ -23,7 +23,7 @@ use tensorzero_core::db::clickhouse::test_helpers::{
 use uuid::Uuid;
 
 #[tokio::test]
-async fn e2e_test_built_in_hello_chat_with_system_variables() {
+async fn test_built_in_hello_chat_with_system_variables() {
     // Test calling the built-in tensorzero::hello_chat function with system template variables
     // using a dynamic variant config
     let mut payload = json!({
@@ -97,7 +97,7 @@ async fn e2e_test_built_in_hello_chat_with_system_variables() {
 }
 
 #[tokio::test]
-async fn e2e_test_built_in_hello_json() {
+async fn test_built_in_hello_json() {
     // Test calling the built-in tensorzero::hello_json function
     let mut payload = json!({
         "function_name": "tensorzero::hello_json",
@@ -162,7 +162,7 @@ async fn e2e_test_built_in_hello_json() {
 }
 
 #[tokio::test]
-async fn e2e_test_built_in_error_no_variant() {
+async fn test_built_in_error_no_variant() {
     // Test that built-in functions fail gracefully without dynamic variant config
     let payload = json!({
         "function_name": "tensorzero::hello_chat",

--- a/tensorzero-core/tests/e2e/cache.rs
+++ b/tensorzero-core/tests/e2e/cache.rs
@@ -48,7 +48,7 @@ use tensorzero_core::inference::types::{RequestMessage, StoredContentBlock, Stor
 
 use crate::common::get_gateway_endpoint;
 use tensorzero::test_helpers::{
-    make_embedded_gateway_e2e_with_unique_db, start_http_gateway_with_unique_db,
+    make_embedded_gateway_e2e_with_unique_db, make_http_gateway_with_unique_db,
 };
 use tensorzero_core::db::clickhouse::test_helpers::{
     get_clickhouse, select_chat_inference_clickhouse, select_model_inference_clickhouse,
@@ -877,7 +877,7 @@ async fn test_streaming_cache_usage_only_in_final_chunk_native() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_streaming_cache_usage_only_in_final_chunk_openai() {
     let (base_url, _shutdown_handle) =
-        start_http_gateway_with_unique_db("cache_usage_final_chunk_openai").await;
+        make_http_gateway_with_unique_db("cache_usage_final_chunk_openai").await;
 
     let input = "cache_usage_openai_test: Tell me a story";
 

--- a/tensorzero-core/tests/e2e/dynamic_variants.rs
+++ b/tensorzero-core/tests/e2e/dynamic_variants.rs
@@ -7,7 +7,7 @@ use tensorzero_core::db::clickhouse::test_helpers::select_chat_inference_clickho
 use uuid::Uuid;
 
 #[tokio::test]
-async fn e2e_test_dynamic_chat_variant() {
+async fn test_dynamic_chat_variant() {
     let mut payload = json!({
         "function_name": "basic_test",
         "episode_id": Uuid::now_v7(),
@@ -67,7 +67,7 @@ async fn e2e_test_dynamic_chat_variant() {
 }
 
 #[tokio::test]
-async fn e2e_test_dynamic_mixture_of_n() {
+async fn test_dynamic_mixture_of_n() {
     let mut payload = json!({
         "function_name": "basic_test",
         "episode_id": Uuid::now_v7(),
@@ -130,7 +130,7 @@ async fn e2e_test_dynamic_mixture_of_n() {
 }
 
 #[tokio::test]
-async fn e2e_test_dynamic_best_of_n() {
+async fn test_dynamic_best_of_n() {
     let mut payload = json!({
         "function_name": "basic_test",
         "episode_id": Uuid::now_v7(),

--- a/tensorzero-core/tests/e2e/feedback.rs
+++ b/tensorzero-core/tests/e2e/feedback.rs
@@ -28,8 +28,8 @@ use crate::common::get_gateway_endpoint;
 use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
 
 #[tokio::test]
-async fn e2e_test_comment_feedback_normal_function() {
-    e2e_test_comment_feedback_with_payload(serde_json::json!({
+async fn test_comment_feedback_normal_function() {
+    test_comment_feedback_with_payload(serde_json::json!({
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
@@ -40,8 +40,8 @@ async fn e2e_test_comment_feedback_normal_function() {
 }
 
 #[tokio::test]
-async fn e2e_test_comment_feedback_default_function() {
-    e2e_test_comment_feedback_with_payload(serde_json::json!({
+async fn test_comment_feedback_default_function() {
+    test_comment_feedback_with_payload(serde_json::json!({
         "model_name": "dummy::good",
         "input": {
             "messages": [{"role": "user", "content": "Hello, world!"}]
@@ -51,7 +51,7 @@ async fn e2e_test_comment_feedback_default_function() {
     .await;
 }
 
-async fn e2e_test_comment_feedback_with_payload(inference_payload: serde_json::Value) {
+async fn test_comment_feedback_with_payload(inference_payload: serde_json::Value) {
     let client = Client::new();
     // // Running without valid episode_id. Should fail.
     let episode_id = Uuid::now_v7();
@@ -245,7 +245,7 @@ async fn e2e_test_comment_feedback_with_payload(inference_payload: serde_json::V
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn e2e_test_comment_feedback_validation_disabled() {
+async fn test_comment_feedback_validation_disabled() {
     let mut config = Config::new_empty()
         .await
         .unwrap()
@@ -289,8 +289,8 @@ async fn e2e_test_comment_feedback_validation_disabled() {
 }
 
 #[tokio::test]
-async fn e2e_test_demonstration_feedback_normal_function() {
-    e2e_test_demonstration_feedback_with_payload(serde_json::json!({
+async fn test_demonstration_feedback_normal_function() {
+    test_demonstration_feedback_with_payload(serde_json::json!({
         "function_name": "basic_test",
         "input": {
             "system": {"assistant_name": "AskJeeves"},
@@ -302,8 +302,8 @@ async fn e2e_test_demonstration_feedback_normal_function() {
 }
 
 #[tokio::test]
-async fn e2e_test_demonstration_feedback_default_function() {
-    e2e_test_demonstration_feedback_with_payload(serde_json::json!({
+async fn test_demonstration_feedback_default_function() {
+    test_demonstration_feedback_with_payload(serde_json::json!({
         "model_name": "dummy::good",
         "input": {
             "messages": [{"role": "user", "content": "Hello, world!"}]
@@ -313,7 +313,7 @@ async fn e2e_test_demonstration_feedback_default_function() {
     .await;
 }
 
-async fn e2e_test_demonstration_feedback_with_payload(inference_payload: serde_json::Value) {
+async fn test_demonstration_feedback_with_payload(inference_payload: serde_json::Value) {
     let client = Client::new();
     // Running without valid inference_id. Should fail.
     let tag_value = Uuid::now_v7().to_string();
@@ -481,7 +481,7 @@ async fn e2e_test_demonstration_feedback_with_payload(inference_payload: serde_j
 }
 
 #[tokio::test]
-async fn e2e_test_demonstration_feedback_json() {
+async fn test_demonstration_feedback_json() {
     let client = Client::new();
     // Running without valid inference_id. Should fail.
     let inference_id = Uuid::now_v7();
@@ -616,7 +616,7 @@ async fn e2e_test_demonstration_feedback_json() {
 }
 
 #[tokio::test]
-async fn e2e_test_demonstration_feedback_llm_judge() {
+async fn test_demonstration_feedback_llm_judge() {
     let client = Client::new();
     // Run inference (standard, no dryrun) to get an inference_id
     let old_output_schema = json!({
@@ -702,7 +702,7 @@ async fn e2e_test_demonstration_feedback_llm_judge() {
 }
 
 #[tokio::test]
-async fn e2e_test_demonstration_feedback_dynamic_json() {
+async fn test_demonstration_feedback_dynamic_json() {
     let client = Client::new();
     // Running without valid inference_id. Should fail.
     let inference_id = Uuid::now_v7();
@@ -872,7 +872,7 @@ async fn e2e_test_demonstration_feedback_dynamic_json() {
 }
 
 #[tokio::test]
-async fn e2e_test_demonstration_feedback_tool() {
+async fn test_demonstration_feedback_tool() {
     // Running without valid inference_id. Should fail.
     let client = Client::new();
     let inference_id = Uuid::now_v7();
@@ -1068,7 +1068,7 @@ async fn e2e_test_demonstration_feedback_tool() {
 }
 
 #[tokio::test]
-async fn e2e_test_demonstration_feedback_dynamic_tool() {
+async fn test_demonstration_feedback_dynamic_tool() {
     let client = Client::new();
 
     // Run inference (standard, no dryrun) to get an inference_id
@@ -1262,8 +1262,8 @@ async fn e2e_test_demonstration_feedback_dynamic_tool() {
 }
 
 #[tokio::test]
-async fn e2e_test_float_feedback_normal_function() {
-    e2e_test_float_feedback_with_payload(serde_json::json!({
+async fn test_float_feedback_normal_function() {
+    test_float_feedback_with_payload(serde_json::json!({
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
@@ -1274,8 +1274,8 @@ async fn e2e_test_float_feedback_normal_function() {
 }
 
 #[tokio::test]
-async fn e2e_test_float_feedback_default_function() {
-    e2e_test_float_feedback_with_payload(serde_json::json!({
+async fn test_float_feedback_default_function() {
+    test_float_feedback_with_payload(serde_json::json!({
         "model_name": "dummy::good",
         "input": {
             "messages": [{"role": "user", "content": "Hello, world!"}]
@@ -1285,7 +1285,7 @@ async fn e2e_test_float_feedback_default_function() {
     .await;
 }
 
-async fn e2e_test_float_feedback_with_payload(inference_payload: serde_json::Value) {
+async fn test_float_feedback_with_payload(inference_payload: serde_json::Value) {
     let client = Client::new();
     let tag_value = Uuid::now_v7().to_string();
     // Running without valid episode_id. Should fail.
@@ -1543,7 +1543,7 @@ async fn e2e_test_float_feedback_with_payload(inference_payload: serde_json::Val
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn e2e_test_float_feedback_validation_disabled() {
+async fn test_float_feedback_validation_disabled() {
     let mut config = Config::new_empty()
         .await
         .unwrap()
@@ -1596,8 +1596,8 @@ async fn e2e_test_float_feedback_validation_disabled() {
 }
 
 #[tokio::test]
-async fn e2e_test_boolean_feedback_normal_function() {
-    e2e_test_boolean_feedback_with_payload(serde_json::json!({
+async fn test_boolean_feedback_normal_function() {
+    test_boolean_feedback_with_payload(serde_json::json!({
         "function_name": "json_success",
         "input": {
             "system": {"assistant_name": "Alfred Pennyworth"},
@@ -1608,8 +1608,8 @@ async fn e2e_test_boolean_feedback_normal_function() {
 }
 
 #[tokio::test]
-async fn e2e_test_boolean_feedback_default_function() {
-    e2e_test_boolean_feedback_with_payload(serde_json::json!({
+async fn test_boolean_feedback_default_function() {
+    test_boolean_feedback_with_payload(serde_json::json!({
         "model_name": "dummy::good",
         "input": {
             "messages": [{"role": "user", "content": "Hello, world!"}]
@@ -1619,7 +1619,7 @@ async fn e2e_test_boolean_feedback_default_function() {
     .await;
 }
 
-async fn e2e_test_boolean_feedback_with_payload(inference_payload: serde_json::Value) {
+async fn test_boolean_feedback_with_payload(inference_payload: serde_json::Value) {
     let client = Client::new();
     let inference_id = Uuid::now_v7();
     let tag_value = Uuid::now_v7().to_string();
@@ -1885,7 +1885,7 @@ async fn e2e_test_boolean_feedback_with_payload(inference_payload: serde_json::V
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn e2e_test_boolean_feedback_validation_disabled() {
+async fn test_boolean_feedback_validation_disabled() {
     let mut config = Config::new_empty()
         .await
         .unwrap()

--- a/tensorzero-core/tests/e2e/human_feedback.rs
+++ b/tensorzero-core/tests/e2e/human_feedback.rs
@@ -20,7 +20,7 @@ use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
 // TODO: make these write human feedback and make sure this is writing correctly.
 
 #[tokio::test]
-async fn e2e_test_comment_human_feedback() {
+async fn test_comment_human_feedback() {
     let client = Client::new();
     // Run inference (standard, no dryrun) to get an episode_id.
     let inference_payload = serde_json::json!({
@@ -175,7 +175,7 @@ async fn e2e_test_comment_human_feedback() {
 }
 
 #[tokio::test]
-async fn e2e_test_demonstration_feedback() {
+async fn test_demonstration_feedback() {
     let client = Client::new();
     // Running without valid inference_id. Should fail.
     let tag_value = Uuid::now_v7().to_string();
@@ -328,7 +328,7 @@ async fn e2e_test_demonstration_feedback() {
 }
 
 #[tokio::test]
-async fn e2e_test_demonstration_feedback_json() {
+async fn test_demonstration_feedback_json() {
     let client = Client::new();
     // Running without valid inference_id. Should fail.
     let inference_id = Uuid::now_v7();
@@ -463,7 +463,7 @@ async fn e2e_test_demonstration_feedback_json() {
 }
 
 #[tokio::test]
-async fn e2e_test_demonstration_feedback_dynamic_json() {
+async fn test_demonstration_feedback_dynamic_json() {
     let client = Client::new();
     // Running without valid inference_id. Should fail.
     let inference_id = Uuid::now_v7();
@@ -633,7 +633,7 @@ async fn e2e_test_demonstration_feedback_dynamic_json() {
 }
 
 #[tokio::test]
-async fn e2e_test_demonstration_feedback_tool() {
+async fn test_demonstration_feedback_tool() {
     // Running without valid inference_id. Should fail.
     let client = Client::new();
     let inference_id = Uuid::now_v7();
@@ -829,7 +829,7 @@ async fn e2e_test_demonstration_feedback_tool() {
 }
 
 #[tokio::test]
-async fn e2e_test_demonstration_feedback_dynamic_tool() {
+async fn test_demonstration_feedback_dynamic_tool() {
     let client = Client::new();
 
     // Run inference (standard, no dryrun) to get an inference_id
@@ -1023,7 +1023,7 @@ async fn e2e_test_demonstration_feedback_dynamic_tool() {
 }
 
 #[tokio::test]
-async fn e2e_test_float_feedback() {
+async fn test_float_feedback() {
     let client = Client::new();
     let tag_value = Uuid::now_v7().to_string();
     // Running without valid episode_id. Should fail.
@@ -1247,7 +1247,7 @@ async fn e2e_test_float_feedback() {
 }
 
 #[tokio::test]
-async fn e2e_test_boolean_feedback() {
+async fn test_boolean_feedback() {
     let client = Client::new();
     let inference_id = Uuid::now_v7();
     let tag_value = Uuid::now_v7().to_string();

--- a/tensorzero-core/tests/e2e/inference/mod.rs
+++ b/tensorzero-core/tests/e2e/inference/mod.rs
@@ -53,7 +53,7 @@ pub mod json_mode_tool;
 pub mod tool_params;
 
 #[tokio::test]
-async fn e2e_test_inference_dryrun() {
+async fn test_inference_dryrun() {
     let payload = json!({
         "function_name": "basic_test",
         "episode_id": Uuid::now_v7(),
@@ -95,7 +95,7 @@ async fn e2e_test_inference_dryrun() {
 }
 
 #[tokio::test]
-async fn e2e_test_inference_chat_strip_unknown_block_non_stream() {
+async fn test_inference_chat_strip_unknown_block_non_stream() {
     let payload = json!({
         "function_name": "basic_test",
         "episode_id": Uuid::now_v7(),
@@ -457,7 +457,7 @@ async fn test_dummy_only_inference_chat_strip_unknown_block_stream() {
 /// then the second provider works fine. We expect this request to work despite the first provider
 /// being broken.
 #[tokio::test]
-async fn e2e_test_inference_model_fallback() {
+async fn test_inference_model_fallback() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -599,7 +599,7 @@ async fn e2e_test_inference_model_fallback() {
 }
 
 #[tokio::test]
-async fn e2e_test_tool_call() {
+async fn test_tool_call() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -798,7 +798,7 @@ async fn e2e_test_tool_call() {
 }
 
 #[tokio::test]
-async fn e2e_test_tool_call_malformed() {
+async fn test_tool_call_malformed() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -996,7 +996,7 @@ async fn e2e_test_tool_call_malformed() {
 /// a response which does not satisfy the schema.
 /// We expect to see a null `parsed_content` field in the response and a null `parsed_content` field in the table.
 #[tokio::test]
-async fn e2e_test_inference_json_fail() {
+async fn test_inference_json_fail() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -1129,7 +1129,7 @@ async fn e2e_test_inference_json_fail() {
 /// a response which satisfies the schema.
 /// We expect to see a filled-out `content` field in the response and a filled-out `output` field in the table.
 #[tokio::test]
-async fn e2e_test_inference_json_success() {
+async fn test_inference_json_success() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -1281,7 +1281,7 @@ async fn e2e_test_inference_json_success() {
 /// We do this by making several requests and checking that the response is 200 in each, then checking that
 /// the response is correct for the last one.
 #[tokio::test]
-async fn e2e_test_variant_failover() {
+async fn test_variant_failover() {
     let mut last_response = None;
     let mut last_episode_id = None;
     for _ in 0..50 {
@@ -1446,7 +1446,7 @@ async fn e2e_test_variant_failover() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn e2e_test_variant_zero_weight_skip_zero() {
+async fn test_variant_zero_weight_skip_zero() {
     let client = tensorzero::test_helpers::make_embedded_gateway().await;
     let error = client
         .inference(ClientInferenceParams {
@@ -1492,7 +1492,7 @@ async fn e2e_test_variant_zero_weight_skip_zero() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn e2e_test_variant_zero_weight_pin_zero() {
+async fn test_variant_zero_weight_pin_zero() {
     let client = tensorzero::test_helpers::make_embedded_gateway().await;
     let error = client
         .inference(ClientInferenceParams {
@@ -1535,7 +1535,7 @@ async fn e2e_test_variant_zero_weight_pin_zero() {
 
 /// This test checks that streaming inference works as expected.
 #[tokio::test]
-async fn e2e_test_streaming() {
+async fn test_streaming() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -1719,7 +1719,7 @@ async fn e2e_test_streaming() {
 
 /// This test checks that streaming inference works as expected when dryrun is true.
 #[tokio::test]
-async fn e2e_test_streaming_dryrun() {
+async fn test_streaming_dryrun() {
     let payload = json!({
         "function_name": "basic_test",
         "episode_id": Uuid::now_v7(),
@@ -1794,7 +1794,7 @@ async fn e2e_test_streaming_dryrun() {
 }
 
 #[tokio::test]
-async fn e2e_test_inference_original_response_non_stream() {
+async fn test_inference_original_response_non_stream() {
     let payload = json!({
         "function_name": "basic_test",
         "episode_id": Uuid::now_v7(),
@@ -2225,7 +2225,7 @@ fn check_dummy_model_span(
 }
 
 #[tokio::test]
-async fn e2e_test_tool_call_streaming() {
+async fn test_tool_call_streaming() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -2451,7 +2451,7 @@ async fn e2e_test_tool_call_streaming() {
 }
 
 #[tokio::test]
-async fn e2e_test_tool_call_streaming_split_tool_name() {
+async fn test_tool_call_streaming_split_tool_name() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -2772,7 +2772,7 @@ pub async fn test_raw_text(client: tensorzero::Client) {
 }
 
 #[tokio::test]
-pub async fn e2e_test_dynamic_api_key() {
+pub async fn test_dynamic_api_key() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({

--- a/tensorzero-core/tests/e2e/inference_evaluation_human_feedback.rs
+++ b/tensorzero-core/tests/e2e/inference_evaluation_human_feedback.rs
@@ -14,7 +14,7 @@ use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
 // or for demonstrations or comments as we don't have inference evaluations that do this yet.
 
 #[tokio::test]
-async fn e2e_test_float_human_feedback() {
+async fn test_float_human_feedback() {
     let client = Client::new();
 
     // Run inference (standard, no dryrun) to get an episode_id.
@@ -129,7 +129,7 @@ async fn e2e_test_float_human_feedback() {
 }
 
 #[tokio::test]
-async fn e2e_test_boolean_human_feedback() {
+async fn test_boolean_human_feedback() {
     let client = Client::new();
 
     // Run inference (standard, no dryrun) to get an inference_id.

--- a/tensorzero-core/tests/e2e/mixture_of_n.rs
+++ b/tensorzero-core/tests/e2e/mixture_of_n.rs
@@ -14,22 +14,22 @@ use tensorzero_core::db::clickhouse::test_helpers::{
 };
 
 #[tokio::test]
-async fn e2e_test_mixture_of_n_dummy_candidates_dummy_judge_non_stream() {
+async fn test_mixture_of_n_dummy_candidates_dummy_judge_non_stream() {
     // Include randomness in put to make sure that the first request is a cache miss
     let random_input = Uuid::now_v7();
-    e2e_test_mixture_of_n_dummy_candidates_dummy_judge_inner(random_input, false, false).await;
-    e2e_test_mixture_of_n_dummy_candidates_dummy_judge_inner(random_input, true, false).await;
+    test_mixture_of_n_dummy_candidates_dummy_judge_inner(random_input, false, false).await;
+    test_mixture_of_n_dummy_candidates_dummy_judge_inner(random_input, true, false).await;
 }
 
 #[tokio::test]
-async fn e2e_test_mixture_of_n_dummy_candidates_dummy_judge_streaming() {
+async fn test_mixture_of_n_dummy_candidates_dummy_judge_streaming() {
     // Include randomness in put to make sure that the first request is a cache miss
     let random_input = Uuid::now_v7();
-    e2e_test_mixture_of_n_dummy_candidates_dummy_judge_inner(random_input, false, true).await;
-    e2e_test_mixture_of_n_dummy_candidates_dummy_judge_inner(random_input, true, true).await;
+    test_mixture_of_n_dummy_candidates_dummy_judge_inner(random_input, false, true).await;
+    test_mixture_of_n_dummy_candidates_dummy_judge_inner(random_input, true, true).await;
 }
 
-async fn e2e_test_mixture_of_n_dummy_candidates_dummy_judge_inner(
+async fn test_mixture_of_n_dummy_candidates_dummy_judge_inner(
     random_input: Uuid,
     should_be_cached: bool,
     stream: bool,
@@ -249,20 +249,20 @@ async fn e2e_test_mixture_of_n_dummy_candidates_dummy_judge_inner(
 }
 
 #[tokio::test]
-async fn e2e_test_mixture_of_n_dummy_candidates_real_judge_non_stream() {
-    e2e_test_mixture_of_n_dummy_candidates_real_judge_inner(false).await;
+async fn test_mixture_of_n_dummy_candidates_real_judge_non_stream() {
+    test_mixture_of_n_dummy_candidates_real_judge_inner(false).await;
 }
 
 #[tokio::test]
-async fn e2e_test_mixture_of_n_dummy_candidates_real_judge_streaming() {
-    e2e_test_mixture_of_n_dummy_candidates_real_judge_inner(true).await;
+async fn test_mixture_of_n_dummy_candidates_real_judge_streaming() {
+    test_mixture_of_n_dummy_candidates_real_judge_inner(true).await;
 }
 
 /// This test calls a function which currently uses mixture of n.
 /// We call 2 models that each give a different response, and then use GPT4o-mini to fuse them.
 /// Besides checking that the response is well-formed and everything is stored correctly,
 /// we also check that the input to GPT4o-mini is correct (as this is the most critical part).
-async fn e2e_test_mixture_of_n_dummy_candidates_real_judge_inner(stream: bool) {
+async fn test_mixture_of_n_dummy_candidates_real_judge_inner(stream: bool) {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -562,7 +562,7 @@ async fn e2e_test_mixture_of_n_dummy_candidates_real_judge_inner(stream: bool) {
 /// We check that the good response is selected and that the other responses are not
 /// but they get stored to the ModelInference table.
 #[tokio::test]
-async fn e2e_test_mixture_of_n_json_real_judge() {
+async fn test_mixture_of_n_json_real_judge() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -782,7 +782,7 @@ async fn e2e_test_mixture_of_n_json_real_judge() {
 }
 
 #[tokio::test]
-async fn e2e_test_mixture_of_n_extra_body() {
+async fn test_mixture_of_n_extra_body() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -917,7 +917,7 @@ async fn e2e_test_mixture_of_n_extra_body() {
 }
 
 #[tokio::test]
-async fn e2e_test_mixture_of_n_bad_fuser_streaming() {
+async fn test_mixture_of_n_bad_fuser_streaming() {
     let episode_id = Uuid::now_v7();
     let payload = json!({
         "function_name": "mixture_of_n",
@@ -1089,9 +1089,9 @@ async fn e2e_test_mixture_of_n_bad_fuser_streaming() {
 }
 
 #[tokio::test]
-async fn e2e_test_mixture_of_n_single_candidate_streaming() {
+async fn test_mixture_of_n_single_candidate_streaming() {
     let episode_id = Uuid::now_v7();
-    e2e_test_mixture_of_n_single_candidate_inner(true, episode_id, json!({
+    test_mixture_of_n_single_candidate_inner(true, episode_id, json!({
         "function_name": "mixture_of_n_single_candidate",
         "variant_name": "mixture_of_n_variant",
         "episode_id": episode_id,
@@ -1109,11 +1109,7 @@ async fn e2e_test_mixture_of_n_single_candidate_streaming() {
     })).await;
 }
 
-async fn e2e_test_mixture_of_n_single_candidate_inner(
-    stream: bool,
-    episode_id: Uuid,
-    payload: Value,
-) {
+async fn test_mixture_of_n_single_candidate_inner(stream: bool, episode_id: Uuid, payload: Value) {
     let builder = Client::new()
         .post(get_gateway_endpoint("/inference"))
         .json(&payload);

--- a/tensorzero-core/tests/e2e/raw_response/cache.rs
+++ b/tensorzero-core/tests/e2e/raw_response/cache.rs
@@ -10,7 +10,7 @@ use reqwest::{Client, StatusCode};
 use reqwest_eventsource::{Event, RequestBuilderExt};
 use serde_json::{Map, Value, json};
 use tensorzero::test_helpers::{
-    make_embedded_gateway_e2e_with_unique_db, start_http_gateway_with_unique_db,
+    make_embedded_gateway_e2e_with_unique_db, make_http_gateway_with_unique_db,
 };
 use tensorzero::{
     CacheParamsOptions, ClientInferenceParams, InferenceOutput, Input, InputMessage,
@@ -473,7 +473,7 @@ async fn make_openai_request_to_gateway(
 async fn test_raw_response_cache_openai_compatible_non_streaming() {
     // Start HTTP gateway with unique database
     let (base_url, _shutdown_handle) =
-        start_http_gateway_with_unique_db("raw_response_openai_cache_non_streaming").await;
+        make_http_gateway_with_unique_db("raw_response_openai_cache_non_streaming").await;
 
     let input = "raw_response_openai_non_streaming: What is 5+5?";
 
@@ -504,7 +504,7 @@ async fn test_raw_response_cache_openai_compatible_non_streaming() {
 async fn test_raw_response_cache_openai_compatible_streaming() {
     // Start HTTP gateway with unique database
     let (base_url, _shutdown_handle) =
-        start_http_gateway_with_unique_db("raw_response_openai_cache_streaming").await;
+        make_http_gateway_with_unique_db("raw_response_openai_cache_streaming").await;
 
     let input = "raw_response_openai_streaming: What is 6+6?";
 

--- a/tensorzero-core/tests/e2e/raw_response/embeddings.rs
+++ b/tensorzero-core/tests/e2e/raw_response/embeddings.rs
@@ -46,7 +46,7 @@ fn assert_raw_response_entry(entry: &Value) {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_embeddings_raw_response_requested() {
+async fn test_embeddings_raw_response_requested() {
     let payload = json!({
         "input": "Hello, world!",
         "model": "tensorzero::embedding_model_name::text-embedding-3-small",
@@ -115,7 +115,7 @@ async fn e2e_test_embeddings_raw_response_requested() {
 }
 
 #[tokio::test]
-async fn e2e_test_embeddings_raw_response_not_requested() {
+async fn test_embeddings_raw_response_not_requested() {
     let payload = json!({
         "input": "Hello, world!",
         "model": "tensorzero::embedding_model_name::text-embedding-3-small"
@@ -145,7 +145,7 @@ async fn e2e_test_embeddings_raw_response_not_requested() {
 }
 
 #[tokio::test]
-async fn e2e_test_embeddings_raw_response_explicitly_false() {
+async fn test_embeddings_raw_response_explicitly_false() {
     let payload = json!({
         "input": "Hello, world!",
         "model": "tensorzero::embedding_model_name::text-embedding-3-small",
@@ -175,7 +175,7 @@ async fn e2e_test_embeddings_raw_response_explicitly_false() {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_embeddings_raw_response_batch() {
+async fn test_embeddings_raw_response_batch() {
     let inputs = vec![
         "Hello, world!",
         "How are you today?",
@@ -233,7 +233,7 @@ async fn e2e_test_embeddings_raw_response_batch() {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_embeddings_raw_response_with_cache() {
+async fn test_embeddings_raw_response_with_cache() {
     let input_text = format!(
         "This is a cache test for embeddings raw_response - {}",
         rand::random::<u32>()
@@ -316,7 +316,7 @@ async fn e2e_test_embeddings_raw_response_with_cache() {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_embeddings_raw_response_entry_structure() {
+async fn test_embeddings_raw_response_entry_structure() {
     let payload = json!({
         "input": "Test entry structure",
         "model": "tensorzero::embedding_model_name::text-embedding-3-small",
@@ -373,7 +373,7 @@ async fn e2e_test_embeddings_raw_response_entry_structure() {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_embeddings_raw_response_with_dimensions() {
+async fn test_embeddings_raw_response_with_dimensions() {
     let payload = json!({
         "input": "Test with specific dimensions",
         "model": "tensorzero::embedding_model_name::text-embedding-3-small",

--- a/tensorzero-core/tests/e2e/raw_response/mod.rs
+++ b/tensorzero-core/tests/e2e/raw_response/mod.rs
@@ -52,7 +52,7 @@ fn assert_raw_response_entry(entry: &Value) {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_raw_response_chat_completions_non_streaming() {
+async fn test_raw_response_chat_completions_non_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -121,7 +121,7 @@ async fn e2e_test_raw_response_chat_completions_non_streaming() {
 }
 
 #[tokio::test]
-async fn e2e_test_raw_response_chat_completions_streaming() {
+async fn test_raw_response_chat_completions_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -206,7 +206,7 @@ async fn e2e_test_raw_response_chat_completions_streaming() {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_raw_response_responses_api_non_streaming() {
+async fn test_raw_response_responses_api_non_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -266,7 +266,7 @@ async fn e2e_test_raw_response_responses_api_non_streaming() {
 }
 
 #[tokio::test]
-async fn e2e_test_raw_response_responses_api_streaming() {
+async fn test_raw_response_responses_api_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -331,7 +331,7 @@ async fn e2e_test_raw_response_responses_api_streaming() {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_raw_response_not_requested_non_streaming() {
+async fn test_raw_response_not_requested_non_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -371,7 +371,7 @@ async fn e2e_test_raw_response_not_requested_non_streaming() {
 }
 
 #[tokio::test]
-async fn e2e_test_raw_response_not_requested_streaming() {
+async fn test_raw_response_not_requested_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -427,7 +427,7 @@ async fn e2e_test_raw_response_not_requested_streaming() {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_raw_response_best_of_n_non_streaming() {
+async fn test_raw_response_best_of_n_non_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -497,7 +497,7 @@ async fn e2e_test_raw_response_best_of_n_non_streaming() {
 }
 
 #[tokio::test]
-async fn e2e_test_raw_response_best_of_n_streaming() {
+async fn test_raw_response_best_of_n_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -583,7 +583,7 @@ async fn e2e_test_raw_response_best_of_n_streaming() {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_raw_response_mixture_of_n_non_streaming() {
+async fn test_raw_response_mixture_of_n_non_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -644,7 +644,7 @@ async fn e2e_test_raw_response_mixture_of_n_non_streaming() {
 }
 
 #[tokio::test]
-async fn e2e_test_raw_response_mixture_of_n_streaming() {
+async fn test_raw_response_mixture_of_n_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -731,7 +731,7 @@ async fn e2e_test_raw_response_mixture_of_n_streaming() {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_raw_response_dicl_non_streaming() {
+async fn test_raw_response_dicl_non_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -812,7 +812,7 @@ async fn e2e_test_raw_response_dicl_non_streaming() {
 }
 
 #[tokio::test]
-async fn e2e_test_raw_response_dicl_streaming() {
+async fn test_raw_response_dicl_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -896,7 +896,7 @@ async fn e2e_test_raw_response_dicl_streaming() {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_raw_response_json_function_non_streaming() {
+async fn test_raw_response_json_function_non_streaming() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -950,7 +950,7 @@ async fn e2e_test_raw_response_json_function_non_streaming() {
 }
 
 #[tokio::test]
-async fn e2e_test_raw_response_json_function_streaming() {
+async fn test_raw_response_json_function_streaming() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({

--- a/tensorzero-core/tests/e2e/raw_usage/cache.rs
+++ b/tensorzero-core/tests/e2e/raw_usage/cache.rs
@@ -10,7 +10,7 @@ use reqwest::{Client, StatusCode};
 use reqwest_eventsource::{Event, RequestBuilderExt};
 use serde_json::{Map, Value, json};
 use tensorzero::test_helpers::{
-    make_embedded_gateway_e2e_with_unique_db, start_http_gateway_with_unique_db,
+    make_embedded_gateway_e2e_with_unique_db, make_http_gateway_with_unique_db,
 };
 use tensorzero::{
     CacheParamsOptions, ClientInferenceParams, InferenceOutput, Input, InputMessage,
@@ -468,7 +468,7 @@ async fn make_openai_request_to_gateway(
 async fn test_raw_usage_cache_openai_compatible_non_streaming() {
     // Start HTTP gateway with unique database
     let (base_url, _shutdown_handle) =
-        start_http_gateway_with_unique_db("openai_cache_non_streaming").await;
+        make_http_gateway_with_unique_db("openai_cache_non_streaming").await;
 
     let input = "raw_usage_openai_non_streaming: What is 5+5?";
 
@@ -499,7 +499,7 @@ async fn test_raw_usage_cache_openai_compatible_non_streaming() {
 async fn test_raw_usage_cache_openai_compatible_streaming() {
     // Start HTTP gateway with unique database
     let (base_url, _shutdown_handle) =
-        start_http_gateway_with_unique_db("openai_cache_streaming").await;
+        make_http_gateway_with_unique_db("openai_cache_streaming").await;
 
     let input = "raw_usage_openai_streaming: What is 6+6?";
 

--- a/tensorzero-core/tests/e2e/raw_usage/mod.rs
+++ b/tensorzero-core/tests/e2e/raw_usage/mod.rs
@@ -117,7 +117,7 @@ fn assert_openai_embeddings_usage_details(entry: &Value) {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_raw_usage_chat_completions_non_streaming() {
+async fn test_raw_usage_chat_completions_non_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -205,7 +205,7 @@ async fn e2e_test_raw_usage_chat_completions_non_streaming() {
 }
 
 #[tokio::test]
-async fn e2e_test_raw_usage_chat_completions_streaming() {
+async fn test_raw_usage_chat_completions_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -286,7 +286,7 @@ async fn e2e_test_raw_usage_chat_completions_streaming() {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_raw_usage_responses_api_non_streaming() {
+async fn test_raw_usage_responses_api_non_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -352,7 +352,7 @@ async fn e2e_test_raw_usage_responses_api_non_streaming() {
 }
 
 #[tokio::test]
-async fn e2e_test_raw_usage_responses_api_streaming() {
+async fn test_raw_usage_responses_api_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -432,7 +432,7 @@ async fn e2e_test_raw_usage_responses_api_streaming() {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_raw_usage_not_requested_non_streaming() {
+async fn test_raw_usage_not_requested_non_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -472,7 +472,7 @@ async fn e2e_test_raw_usage_not_requested_non_streaming() {
 }
 
 #[tokio::test]
-async fn e2e_test_raw_usage_not_requested_streaming() {
+async fn test_raw_usage_not_requested_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -523,7 +523,7 @@ async fn e2e_test_raw_usage_not_requested_streaming() {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_raw_usage_best_of_n_non_streaming() {
+async fn test_raw_usage_best_of_n_non_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -594,7 +594,7 @@ async fn e2e_test_raw_usage_best_of_n_non_streaming() {
 }
 
 #[tokio::test]
-async fn e2e_test_raw_usage_best_of_n_streaming() {
+async fn test_raw_usage_best_of_n_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -671,7 +671,7 @@ async fn e2e_test_raw_usage_best_of_n_streaming() {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_raw_usage_mixture_of_n_non_streaming() {
+async fn test_raw_usage_mixture_of_n_non_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -747,7 +747,7 @@ async fn e2e_test_raw_usage_mixture_of_n_non_streaming() {
 }
 
 #[tokio::test]
-async fn e2e_test_raw_usage_mixture_of_n_streaming() {
+async fn test_raw_usage_mixture_of_n_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -830,7 +830,7 @@ async fn e2e_test_raw_usage_mixture_of_n_streaming() {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_raw_usage_dicl_non_streaming() {
+async fn test_raw_usage_dicl_non_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -916,7 +916,7 @@ async fn e2e_test_raw_usage_dicl_non_streaming() {
 }
 
 #[tokio::test]
-async fn e2e_test_raw_usage_dicl_streaming() {
+async fn test_raw_usage_dicl_streaming() {
     let episode_id = Uuid::now_v7();
     let random_suffix = Uuid::now_v7();
 
@@ -998,7 +998,7 @@ async fn e2e_test_raw_usage_dicl_streaming() {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_raw_usage_streaming_requires_include_usage() {
+async fn test_raw_usage_streaming_requires_include_usage() {
     let episode_id = Uuid::now_v7();
 
     // OpenAI-compatible API: include_raw_usage without include_usage should error
@@ -1038,7 +1038,7 @@ async fn e2e_test_raw_usage_streaming_requires_include_usage() {
 // =============================================================================
 
 #[tokio::test]
-async fn e2e_test_raw_usage_json_function_non_streaming() {
+async fn test_raw_usage_json_function_non_streaming() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -1099,7 +1099,7 @@ async fn e2e_test_raw_usage_json_function_non_streaming() {
 }
 
 #[tokio::test]
-async fn e2e_test_raw_usage_json_function_streaming() {
+async fn test_raw_usage_json_function_streaming() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({

--- a/tensorzero-core/tests/e2e/retries.rs
+++ b/tensorzero-core/tests/e2e/retries.rs
@@ -19,7 +19,7 @@ use tensorzero_core::db::clickhouse::test_helpers::{
 
 /// This test calls a function which calls a model where the provider is flaky but with retries.
 #[tokio::test]
-async fn e2e_test_inference_flaky() {
+async fn test_inference_flaky() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -162,7 +162,7 @@ async fn e2e_test_inference_flaky() {
 
 /// This test checks that streaming inference works as expected with a flaky provider and retries.
 #[tokio::test]
-async fn e2e_test_streaming_flaky() {
+async fn test_streaming_flaky() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -355,7 +355,7 @@ async fn e2e_test_streaming_flaky() {
 /// We check that the good response is selected and that the other responses are not
 /// but they get stored to the ModelInference table.
 #[tokio::test]
-async fn e2e_test_best_of_n_dummy_candidates_flaky_judge() {
+async fn test_best_of_n_dummy_candidates_flaky_judge() {
     let episode_id = Uuid::now_v7();
 
     let payload = json!({

--- a/tensorzero-core/tests/e2e/template.rs
+++ b/tensorzero-core/tests/e2e/template.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::common::get_gateway_endpoint;
 
 #[tokio::test]
-async fn e2e_test_template_no_schema() {
+async fn test_template_no_schema() {
     let payload = json!({
         "function_name": "basic_test_template_no_schema",
         "variant_name": "test",
@@ -123,7 +123,7 @@ async fn e2e_test_template_no_schema() {
 }
 
 #[tokio::test]
-async fn e2e_test_mixture_of_n_template_no_schema() {
+async fn test_mixture_of_n_template_no_schema() {
     let payload = json!({
         "function_name": "basic_test_template_no_schema",
         "variant_name": "mixture_of_n",
@@ -205,7 +205,7 @@ async fn e2e_test_mixture_of_n_template_no_schema() {
 }
 
 #[tokio::test]
-async fn e2e_test_best_of_n_template_no_schema() {
+async fn test_best_of_n_template_no_schema() {
     let payload = json!({
         "function_name": "basic_test_template_no_schema",
         "variant_name": "best_of_n",
@@ -348,7 +348,7 @@ async fn e2e_test_best_of_n_template_no_schema() {
 }
 
 #[tokio::test]
-async fn e2e_test_invalid_system_input_template_no_schema() {
+async fn test_invalid_system_input_template_no_schema() {
     let payload = json!({
         "function_name": "basic_test_template_no_schema",
         "input":{
@@ -391,7 +391,7 @@ async fn e2e_test_invalid_system_input_template_no_schema() {
 }
 
 #[tokio::test]
-async fn e2e_test_invalid_json_user_input_template_no_schema() {
+async fn test_invalid_json_user_input_template_no_schema() {
     let payload = json!({
         "function_name": "null_json",
         "input":{
@@ -426,7 +426,7 @@ async fn e2e_test_invalid_json_user_input_template_no_schema() {
 }
 
 #[tokio::test]
-async fn e2e_test_invalid_user_input_template_no_schema() {
+async fn test_invalid_user_input_template_no_schema() {
     let payload = json!({
         "function_name": "basic_test_template_no_schema",
         "input":{
@@ -461,7 +461,7 @@ async fn e2e_test_invalid_user_input_template_no_schema() {
 }
 
 #[tokio::test]
-async fn e2e_test_invalid_assistant_input_template_no_schema() {
+async fn test_invalid_assistant_input_template_no_schema() {
     let payload = json!({
         "function_name": "basic_test_template_no_schema",
         "variant_name": "test",
@@ -496,7 +496,7 @@ async fn e2e_test_invalid_assistant_input_template_no_schema() {
 }
 
 #[tokio::test]
-async fn e2e_test_invalid_json_assistant_input_template_no_schema() {
+async fn test_invalid_json_assistant_input_template_no_schema() {
     let payload = json!({
         "function_name": "null_json",
         "input":{
@@ -530,7 +530,7 @@ async fn e2e_test_invalid_json_assistant_input_template_no_schema() {
 }
 
 #[tokio::test]
-async fn e2e_test_named_system_template_no_schema() {
+async fn test_named_system_template_no_schema() {
     let config_dir = tempfile::tempdir().unwrap();
     let config_path = config_dir.path().join("tensorzero.toml");
     let config = r#"
@@ -590,7 +590,7 @@ async fn e2e_test_named_system_template_no_schema() {
 }
 
 #[tokio::test]
-async fn e2e_test_named_system_template_with_schema() {
+async fn test_named_system_template_with_schema() {
     let config_dir = tempfile::tempdir().unwrap();
     let config_path = config_dir.path().join("tensorzero.toml");
     let config = r#"


### PR DESCRIPTION
- Every test starts with `test_*`
- Creating a test gateway starts with `make_[http/embedded]_gateway*`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only rename/refactor: updates many test function names and a test helper API, with minimal risk outside of CI/test filtering.
> 
> **Overview**
> **Normalizes test naming across the e2e suite.** Many `tensorzero-core` e2e tests are renamed from `e2e_test_*` to `test_*`, including corresponding internal helper functions.
> 
> **Standardizes gateway test helper APIs.** The Rust client test helper `start_http_gateway_with_unique_db` is renamed to `make_http_gateway_with_unique_db`, and call sites are updated.
> 
> **Keeps CI/test selection working.** `.config/nextest.toml` filters are updated to match the renamed tests (notably `test_variant_failover`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d668e772f720c4fd2512437de6aad5b2bf8fa2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->