### PR TITLE
Reduce default tooltip delay to 250ms

### DIFF
--- a/ui/app/providers/app-providers.tsx
+++ b/ui/app/providers/app-providers.tsx
@@ -33,7 +33,9 @@ export function AppProviders({ children, loaderData }: AppProvidersProps) {
           >
             <ConfigProvider value={loaderData?.config ?? EMPTY_CONFIG}>
               <SidebarProvider>
-                <TooltipProvider>{children}</TooltipProvider>
+                <TooltipProvider delayDuration={250}>
+                  {children}
+                </TooltipProvider>
               </SidebarProvider>
             </ConfigProvider>
           </AutopilotAvailableProvider>


### PR DESCRIPTION
## Summary
- Reduces the default tooltip delay from 700ms (Radix default) to 250ms for faster tooltip display

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts tooltip timing globally; primary risk is minor UX/behavior differences across the app.
> 
> **Overview**
> Reduces the app-wide tooltip hover delay by passing `delayDuration={250}` to the root `TooltipProvider` in `app-providers.tsx`, making tooltips appear faster everywhere.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a09dea7cf6b36c90ff7e8496680f11eaaa451a81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->