### PR TITLE
Fix Start bar display

### DIFF
--- a/ui/app/components/autopilot/EventStream.tsx
+++ b/ui/app/components/autopilot/EventStream.tsx
@@ -585,10 +585,12 @@ export default function EventStream({
   status,
 }: EventStreamProps) {
   // Determine what to show at the top: sentinel, error, or session start
+  // Only show session start when there's content to display (events or optimistic messages)
   const showSessionStart =
     (hasReachedStart || optimisticMessages.length > 0) &&
     !isLoadingOlder &&
-    !loadError;
+    !loadError &&
+    (events.length > 0 || optimisticMessages.length > 0);
 
   return (
     <div className={cn("flex flex-col gap-3", className)}>
@@ -604,9 +606,11 @@ export default function EventStream({
       {/* Session start indicator */}
       {showSessionStart && <SessionStartDivider />}
 
-      {/* Always show 3 skeletons when more content exists above */}
+      {/* Show skeletons when more content exists above (not yet loaded) */}
       {/* This prevents layout jump when loading starts */}
-      {!showSessionStart && !loadError && <EventSkeletons count={3} />}
+      {!showSessionStart && !hasReachedStart && !loadError && (
+        <EventSkeletons count={3} />
+      )}
 
       {events.map((event) => (
         <EventErrorBoundary key={event.id} eventId={event.id}>


### PR DESCRIPTION
Before:

<img width="3506" height="2382" alt="Image" src="https://github.com/user-attachments/assets/4b82da72-78df-447b-b694-909970251f7f" />

After:

<img width="4064" height="2334" alt="CleanShot 2026-01-30 at 11 27 26@2x" src="https://github.com/user-attachments/assets/1839dd25-9ce4-4e35-972b-5f6909f5754f" />

Previously, we only showed "Started" when a session had started (i.e. user had sent a message). Now it shows up in the new session page, which is a bit misleading. We should hide it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only conditional rendering changes affecting when the "Start" divider and loading skeletons appear; no data or auth logic is touched.
> 
> **Overview**
> Prevents the `Start` (session start) divider in `EventStream` from showing on a brand-new/empty session by requiring actual content (`events` or `optimisticMessages`) before rendering it.
> 
> Adjusts the top-of-stream loading skeleton behavior to only render when older content is expected (`!hasReachedStart`), avoiding misleading placeholders once the start has been reached.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdb1f02ba81b684dd12a0f2ed71cab2e0019c88f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->