### PR TITLE
Fix Start bar display on empty sessions

### DIFF
--- a/ui/app/components/autopilot/EventStream.tsx
+++ b/ui/app/components/autopilot/EventStream.tsx
@@ -585,10 +585,13 @@ export default function EventStream({
   status,
 }: EventStreamProps) {
   // Determine what to show at the top: sentinel, error, or session start
+  // Only show "Session started" when there's actual content to display
+  const hasContent = events.length > 0 || optimisticMessages.length > 0;
   const showSessionStart =
     (hasReachedStart || optimisticMessages.length > 0) &&
     !isLoadingOlder &&
-    !loadError;
+    !loadError &&
+    hasContent;
 
   return (
     <div className={cn("flex flex-col gap-3", className)}>
@@ -604,9 +607,11 @@ export default function EventStream({
       {/* Session start indicator */}
       {showSessionStart && <SessionStartDivider />}
 
-      {/* Always show 3 skeletons when more content exists above */}
-      {/* This prevents layout jump when loading starts */}
-      {!showSessionStart && !loadError && <EventSkeletons count={3} />}
+      {/* Show skeletons when more content might exist above */}
+      {/* Don't show if we've reached the start (nothing more to load) */}
+      {!showSessionStart && !hasReachedStart && !loadError && (
+        <EventSkeletons count={3} />
+      )}
 
       {events.map((event) => (
         <EventErrorBoundary key={event.id} eventId={event.id}>


### PR DESCRIPTION
## Summary
- Only show 'Session started' divider when there's actual content (events or optimistic messages)
- Don't show loading skeletons when we've reached the start of the conversation
- Prevents confusing UI on empty or newly created sessions

## Test plan
- [ ] Create new empty session - should not show "Session started" divider
- [ ] Session with messages - should show "Session started" divider at top
- [ ] Loading state - skeletons should not appear after reaching conversation start

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that tightens render conditions for the top-of-stream divider and loading skeletons; main risk is minor regressions in edge-case loading states.
> 
> **Overview**
> Prevents confusing top-of-stream UI in `EventStream` by only rendering the "Start"/session divider when there is actual content (`events` or `optimisticMessages`).
> 
> Also stops rendering the "load older" skeleton placeholders once `hasReachedStart` is true, avoiding misleading loading UI at the beginning of a conversation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18488a76c2ba90f931c0ee4b4ed59a1cec51110b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->