### PR TITLE
Give test_concurrent_requests even more time to run

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -192,7 +192,7 @@ slow-timeout = { period = "900s", terminate-after = 1 }
 [[profile.default.overrides]]
 filter = 'test(test_concurrent_requests)'
 # This test creates and uses lots of `reqwest::Client`s, which can be slow
-slow-timeout = { period = "60s", terminate-after = 2 }
+slow-timeout = { period = "60s", terminate-after = 3 }
 
 [[profile.default.overrides]]
 # Settings for running mock optimization tests


### PR DESCRIPTION
This recently timed out on ci

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that just gives `test(test_concurrent_requests)` more chances to complete on slower CI runners.
> 
> **Overview**
> Extends the `nextest` `slow-timeout` tolerance for `test(test_concurrent_requests)` by increasing `terminate-after` from 2 to 3, reducing CI timeouts for this slow/flaky concurrency test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 259980a55b4a593d1f7c2a7f372588d10f159b82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->