### PR TITLE
Try again to prioritize Buildkite builds based on merge queue order

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -9,3 +9,30 @@
 # be good enough to let us run many concurrent jobs most of the time.
 export CLICKHOUSE_CLOUD_COUNT=4
 export CLICKHOUSE_ID=$(($BUILDKITE_BUILD_NUMBER%$CLICKHOUSE_CLOUD_COUNT))
+
+# Get merge queue position and set priority for merge queue builds
+# Merge queue branches have the format: gh-readonly-queue/<base>/pr-<number>-<sha>
+# Position 1 is the first in the queue (highest priority), so we negate it for Buildkite priority
+if [[ "$BUILDKITE_BRANCH" =~ ^gh-readonly-queue/.*/pr-([0-9]+)- ]]; then
+    PR_NUMBER="${BASH_REMATCH[1]}"
+
+    # Query GitHub GraphQL API for the merge queue position
+    POSITION=$(gh api graphql -f query='
+        query($owner: String!, $name: String!, $number: Int!) {
+            repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) {
+                    mergeQueueEntry {
+                        position
+                    }
+                }
+            }
+        }
+    ' -f owner="tensorzero" -f name="tensorzero" -F number="$PR_NUMBER" \
+        --jq '.data.repository.pullRequest.mergeQueueEntry.position' 2>/dev/null)
+
+    if [[ -n "$POSITION" && "$POSITION" != "null" ]]; then
+        export MERGE_QUEUE_POSITION="$POSITION"
+        # Negate position so earlier queue entries get higher priority
+        export MERGE_QUEUE_PRIORITY=$((-POSITION))
+    fi
+fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,12 @@ steps:
     concurrency: 1
     concurrency_group: "clickhouse-cloud-normal-${CLICKHOUSE_ID}"
     command: CLICKHOUSE_PREFIX="dev-tensorzero-e2e-tests-instance-" ./ci/buildkite/test-clickhouse-cloud.sh
+    # Priority for merge queue builds - earlier queue positions get higher priority
+    # MERGE_QUEUE_PRIORITY is set in post-checkout hook as the negative of queue position
+    # See https://buildkite.com/docs/pipelines/configure/workflows/controlling-concurrency#concurrency-and-parallelism-concurrency-and-prioritization
+    priority: ${MERGE_QUEUE_PRIORITY:-0}
+    concurrency_method: eager
+
   # Temporarily disabled - see https://github.com/tensorzero/tensorzero/issues/5887
   # - label: "Clickhouse Cloud tests - fast release channel"
   #   plugins:


### PR DESCRIPTION
This should hopefully ensure that jobs earlier in the merge queue get to run on ClickHouse first (compared to jobs later in the merge queue)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI scheduling by querying GitHub GraphQL and setting Buildkite step priority/concurrency behavior; misconfiguration or `gh`/API failures could lead to unexpected job ordering or no prioritization, but it doesn’t affect production code paths.
> 
> **Overview**
> **Merge-queue builds are now prioritized in Buildkite.** The `post-checkout` hook detects `gh-readonly-queue/...` branches, extracts the PR number, queries GitHub GraphQL for the merge-queue `position`, and exports `MERGE_QUEUE_PRIORITY` as the negative of that position.
> 
> The ClickHouse Cloud test step now uses `priority: ${MERGE_QUEUE_PRIORITY:-0}` and sets `concurrency_method: eager`, so earlier merge-queue entries should win access to limited ClickHouse Cloud concurrency slots.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 703b4081a43d3ed19b2c2532b495b6b625232ccb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->