### PR TITLE
Adjust nextest filter for 'evaluations' timeout

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,7 +12,7 @@ slow-timeout = { period = "10s", terminate-after = 3 }
 default-filter = "not (test(no_aws_credentials) | test(export_bindings_) | test(export_schema_))"
 
 [[profile.default.overrides]]
-filter = 'test(evaluations)'
+filter = 'test(evaluations) | package(evaluations)'
 slow-timeout = { period = "20s", terminate-after = 5 }
 
 # Profiles config


### PR DESCRIPTION
This wasn't including tests in the 'evaluations' package unless they also had 'evaluations' in the test name itself

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts `cargo nextest` filtering for a timeout override, affecting which tests get the longer `evaluations` timeout but not production behavior.
> 
> **Overview**
> Updates `.config/nextest.toml` so the longer `slow-timeout` override for *evaluations* applies to all tests in the `evaluations` crate via `package(evaluations)`, not just tests whose names match `test(evaluations)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c106740e804f13b08f17dcde20434f662134e2ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->