### PR TITLE
removed crypto.randomUUID(), banned, bumped version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,7 +334,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot-client"
-version = "2026.1.6"
+version = "2026.1.7"
 dependencies = [
  "chrono",
  "durable-tools-spawn",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-tools"
-version = "2026.1.6"
+version = "2026.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-worker"
-version = "2026.1.6"
+version = "2026.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools"
-version = "2026.1.6"
+version = "2026.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1946,7 +1946,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools-spawn"
-version = "2026.1.6"
+version = "2026.1.7"
 dependencies = [
  "async-trait",
  "durable",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2026.1.6"
+version = "2026.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2180,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2026.1.6"
+version = "2026.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2026.1.6"
+version = "2026.1.7"
 dependencies = [
  "async-stream",
  "autopilot-tools",
@@ -3671,7 +3671,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-utils"
-version = "2026.1.6"
+version = "2026.1.7"
 dependencies = [
  "minijinja",
  "serde",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2026.1.6"
+version = "2026.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "reqwest-sse-stream"
-version = "2026.1.6"
+version = "2026.1.7"
 dependencies = [
  "async-stream",
  "futures",
@@ -6334,7 +6334,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2026.1.6"
+version = "2026.1.7"
 dependencies = [
  "axum",
  "chrono",
@@ -6354,7 +6354,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2026.1.6"
+version = "2026.1.7"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -6474,7 +6474,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2026.1.6"
+version = "2026.1.7"
 dependencies = [
  "napi",
  "napi-build",
@@ -6487,7 +6487,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-optimizers"
-version = "2026.1.6"
+version = "2026.1.7"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -6521,7 +6521,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2026.1.6"
+version = "2026.1.7"
 dependencies = [
  "evaluations",
  "futures",
@@ -6539,7 +6539,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types"
-version = "2026.1.6"
+version = "2026.1.7"
 dependencies = [
  "aws-smithy-types",
  "infer",
@@ -6559,7 +6559,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types-providers"
-version = "2026.1.6"
+version = "2026.1.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -6567,7 +6567,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-unsafe-helpers"
-version = "2026.1.6"
+version = "2026.1.7"
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2026.1.6"
+version = "2026.1.7"
 rust-version = "1.88.0"
 license = "Apache-2.0"
 edition = "2024"

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2026.1.6"
+appVersion: "2026.1.7"

--- a/ui/app/routes/autopilot/sessions/$session_id/route.tsx
+++ b/ui/app/routes/autopilot/sessions/$session_id/route.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { v7 as uuid } from "uuid";
 import {
   Await,
   data,
@@ -659,7 +660,7 @@ export default function AutopilotSessionEventsPage({
       setOptimisticMessages((prev) => [
         ...prev,
         {
-          tempId: crypto.randomUUID(),
+          tempId: uuid(),
           eventId: response.event_id,
           text,
           status: "sending",

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -86,6 +86,12 @@ export default [
           message:
             "Do not import types directly from 'tensorzero-node'. Use 'import type { ... } from \"~/types/tensorzero\"' instead to avoid bundling the native client in browser code.",
         },
+        {
+          selector:
+            "CallExpression[callee.object.name='crypto'][callee.property.name='randomUUID']",
+          message:
+            "Do not use crypto.randomUUID(). Use `import { v7 as uuid } from 'uuid'` and call `uuid()` instead for UUIDv7.",
+        },
       ],
     },
   },

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2026.1.6",
+  "version": "2026.1.7",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is primarily a version bump plus a small UI-only change to generate temporary IDs differently, with a new lint rule to prevent regressions.
> 
> **Overview**
> Bumps the workspace/UI/Helm chart version from `2026.1.6` to `2026.1.7` (including `Cargo.lock`, `Cargo.toml`, `ui/package.json`, and Helm `appVersion`).
> 
> In the UI Autopilot session route, replaces `crypto.randomUUID()` with `uuid()` (UUIDv7) for optimistic message `tempId`s, and adds an ESLint restriction to forbid future `crypto.randomUUID()` usage in favor of UUIDv7.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a33575c13d67e36fb85b3dde01fc050d6b2d6806. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->