### PR TITLE
Add session search bar to autopilot sessions page

### DIFF
--- a/ui/app/routes/autopilot/sessions/SessionSearchBar.tsx
+++ b/ui/app/routes/autopilot/sessions/SessionSearchBar.tsx
@@ -1,0 +1,63 @@
+import { useNavigate } from "react-router";
+import { z } from "zod";
+import { toAutopilotSessionUrl } from "~/utils/urls";
+import { Button } from "~/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "~/components/ui/form";
+import { Input } from "~/components/ui/input";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+const formSchema = z.object({
+  sessionId: z.string().uuid("Please enter a valid UUID"),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+export default function SessionSearchBar() {
+  const navigate = useNavigate();
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      sessionId: "",
+    },
+    mode: "onChange",
+  });
+
+  const onSubmit = (data: FormValues) => {
+    navigate(toAutopilotSessionUrl(data.sessionId));
+    form.reset();
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="mb-4">
+        <div className="flex gap-2">
+          <FormField
+            control={form.control}
+            name="sessionId"
+            render={({ field }) => (
+              <FormItem className="grow">
+                <FormControl>
+                  <Input
+                    placeholder="00000000-0000-0000-0000-000000000000"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button type="submit" disabled={!form.formState.isValid}>
+            Go to Session
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/ui/app/routes/autopilot/sessions/route.tsx
+++ b/ui/app/routes/autopilot/sessions/route.tsx
@@ -29,6 +29,7 @@ import {
   TableHeader,
   TableRow,
 } from "~/components/ui/table";
+import SessionSearchBar from "./SessionSearchBar";
 
 const MAX_PAGE_SIZE = 50;
 const DEFAULT_PAGE_SIZE = 20;
@@ -171,6 +172,7 @@ export default function AutopilotSessionsPage({
     <PageLayout>
       <PageHeader heading="Autopilot Sessions" />
       <SectionLayout>
+        <SessionSearchBar />
         <ActionBar>
           <Button
             variant="outline"

--- a/ui/app/utils/urls.ts
+++ b/ui/app/utils/urls.ts
@@ -95,3 +95,11 @@ export function toWorkflowEvaluationProjectUrl(projectName: string): string {
 export function toSupervisedFineTuningJobUrl(jobId: string): string {
   return `/optimization/supervised-fine-tuning/${encodeURIComponent(jobId)}`;
 }
+
+// ============================================================================
+// Autopilot
+// ============================================================================
+
+export function toAutopilotSessionUrl(sessionId: string): string {
+  return `/autopilot/sessions/${encodeURIComponent(sessionId)}`;
+}


### PR DESCRIPTION
## Summary
- Add search bar to quickly navigate to a specific autopilot session by UUID
- Follows existing `EpisodeSearchBar` pattern

## Test plan
- [ ] Navigate to /autopilot/sessions
- [ ] Enter a valid session UUID and click "Go to Session"
- [ ] Verify navigation to the session detail page
- [ ] Enter an invalid UUID and verify validation error appears

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds client-side UUID validation and navigation; no backend or data-fetching logic is modified.
> 
> **Overview**
> Adds a `SessionSearchBar` to the Autopilot Sessions list page so users can paste a session UUID and navigate directly to that session.
> 
> Introduces `toAutopilotSessionUrl` in `ui/app/utils/urls.ts` and uses a `react-hook-form` + `zod` UUID validator to disable submit and show an error until the input is valid.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c206c7473f41ccbb7f45a11b8c82b6f124dc3c39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->