### PR TITLE
Add sortable columns and Last Activity to autopilot sessions table

### DIFF
--- a/ui/app/routes/autopilot/AutopilotSessionsTable.tsx
+++ b/ui/app/routes/autopilot/AutopilotSessionsTable.tsx
@@ -148,6 +148,13 @@ export function SessionsTableRows({
           <TableCell className="w-0 text-right whitespace-nowrap">
             <TableItemTime timestamp={session.created_at} />
           </TableCell>
+          <TableCell className="w-0 text-right whitespace-nowrap">
+            {session.last_event_at ? (
+              <TableItemTime timestamp={session.last_event_at} />
+            ) : (
+              <span className="text-fg-muted">—</span>
+            )}
+          </TableCell>
         </TableRow>
       ))}
     </>
@@ -166,6 +173,9 @@ export default function AutopilotSessionsTable({
           <TableHead>Session ID</TableHead>
           <TableHead className="w-0 text-right whitespace-nowrap">
             Created
+          </TableHead>
+          <TableHead className="w-0 text-right whitespace-nowrap">
+            Last Activity
           </TableHead>
         </TableRow>
       </TableHeader>

--- a/ui/app/routes/autopilot/sessions/route.tsx
+++ b/ui/app/routes/autopilot/sessions/route.tsx
@@ -1,4 +1,4 @@
-import { Plus } from "lucide-react";
+import { ChevronDown, ChevronUp, Plus } from "lucide-react";
 import { Suspense, use } from "react";
 import type { Route } from "./+types/route";
 import {
@@ -19,7 +19,7 @@ import PageButtons from "~/components/utils/PageButtons";
 import { logger } from "~/utils/logger";
 import { SessionsTableRows } from "../AutopilotSessionsTable";
 import { getAutopilotClient } from "~/utils/tensorzero.server";
-import type { Session } from "~/types/tensorzero";
+import type { Session, SessionSortField, SortOrder } from "~/types/tensorzero";
 import { Skeleton } from "~/components/ui/skeleton";
 import {
   Table,
@@ -29,9 +29,10 @@ import {
   TableHeader,
   TableRow,
 } from "~/components/ui/table";
-
 const MAX_PAGE_SIZE = 50;
 const DEFAULT_PAGE_SIZE = 20;
+const DEFAULT_SORT_BY: SessionSortField = "last_event_at";
+const DEFAULT_SORT_ORDER: SortOrder = "desc";
 
 export type SessionsData = {
   sessions: Session[];
@@ -44,6 +45,20 @@ function parseInteger(value: string | null, fallback: number) {
   return Number.isNaN(parsed) ? fallback : parsed;
 }
 
+function parseSortBy(value: string | null): SessionSortField {
+  if (value === "created_at" || value === "last_event_at") {
+    return value;
+  }
+  return DEFAULT_SORT_BY;
+}
+
+function parseSortOrder(value: string | null): SortOrder {
+  if (value === "asc" || value === "desc") {
+    return value;
+  }
+  return DEFAULT_SORT_ORDER;
+}
+
 export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url);
   const limitParam = parseInteger(
@@ -53,6 +68,8 @@ export async function loader({ request }: Route.LoaderArgs) {
   const offsetParam = parseInteger(url.searchParams.get("offset"), 0);
   const limit = Math.max(1, limitParam);
   const offset = Math.max(0, offsetParam);
+  const sortBy = parseSortBy(url.searchParams.get("sort_by"));
+  const sortOrder = parseSortOrder(url.searchParams.get("sort_order"));
 
   if (limit > MAX_PAGE_SIZE) {
     throw data(`Limit cannot exceed ${MAX_PAGE_SIZE}`, { status: 400 });
@@ -65,6 +82,8 @@ export async function loader({ request }: Route.LoaderArgs) {
     .listAutopilotSessions({
       limit: limit + 1,
       offset,
+      sort_by: sortBy,
+      sort_order: sortOrder,
     })
     .then((response) => {
       const hasMore = response.sessions.length > limit;
@@ -76,10 +95,12 @@ export async function loader({ request }: Route.LoaderArgs) {
     sessionsData: sessionsDataPromise,
     offset,
     limit,
+    sortBy,
+    sortOrder,
   };
 }
 
-// Skeleton rows for loading state - matches table columns (Session ID, Created)
+// Skeleton rows for loading state - matches table columns (Session ID, Created, Last Activity)
 function SkeletonRows() {
   return (
     <>
@@ -87,6 +108,9 @@ function SkeletonRows() {
         <TableRow key={i}>
           <TableCell>
             <Skeleton className="h-5 w-24" />
+          </TableCell>
+          <TableCell className="w-0 text-right whitespace-nowrap">
+            <Skeleton className="ml-auto h-5 w-36" />
           </TableCell>
           <TableCell className="w-0 text-right whitespace-nowrap">
             <Skeleton className="ml-auto h-5 w-36" />
@@ -142,29 +166,89 @@ function PaginationContent({
   );
 }
 
+// Sortable column header component
+function SortableHeader({
+  label,
+  field,
+  currentSortBy,
+  currentSortOrder,
+  onSort,
+  className,
+}: {
+  label: string;
+  field: SessionSortField;
+  currentSortBy: SessionSortField;
+  currentSortOrder: SortOrder;
+  onSort: (field: SessionSortField) => void;
+  className?: string;
+}) {
+  const isActive = currentSortBy === field;
+
+  return (
+    <TableHead
+      className={`cursor-pointer select-none ${className ?? ""}`}
+      onClick={() => onSort(field)}
+    >
+      <div className="flex items-center justify-end gap-1">
+        {label}
+        {isActive ? (
+          currentSortOrder === "asc" ? (
+            <ChevronUp className="h-3 w-3" />
+          ) : (
+            <ChevronDown className="h-3 w-3" />
+          )
+        ) : (
+          <div className="flex flex-col">
+            <ChevronUp className="h-2 w-2 opacity-40" />
+            <ChevronDown className="h-2 w-2 opacity-40" />
+          </div>
+        )}
+      </div>
+    </TableHead>
+  );
+}
+
 export default function AutopilotSessionsPage({
   loaderData,
 }: Route.ComponentProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const { status } = useTensorZeroStatusFetcher();
-  const { sessionsData, offset, limit } = loaderData;
+  const { sessionsData, offset, limit, sortBy, sortOrder } = loaderData;
   const gatewayVersion = status?.version;
   const uiVersion = __APP_VERSION__;
 
-  const updateOffset = (nextOffset: number) => {
+  const updateSearchParams = (updates: Record<string, string>) => {
     const searchParams = new URLSearchParams(window.location.search);
-    searchParams.set("offset", String(nextOffset));
-    searchParams.set("limit", String(limit));
+    for (const [key, value] of Object.entries(updates)) {
+      searchParams.set(key, value);
+    }
     navigate(`?${searchParams.toString()}`, { preventScrollReset: true });
   };
 
+  const handleSort = (field: SessionSortField) => {
+    // If clicking the same field, toggle order. Otherwise, sort desc by the new field.
+    const newOrder =
+      sortBy === field ? (sortOrder === "desc" ? "asc" : "desc") : "desc";
+    updateSearchParams({
+      sort_by: field,
+      sort_order: newOrder,
+      offset: "0", // Reset to first page when changing sort
+    });
+  };
+
   const handleNextPage = () => {
-    updateOffset(offset + limit);
+    updateSearchParams({
+      offset: String(offset + limit),
+      limit: String(limit),
+    });
   };
 
   const handlePreviousPage = () => {
-    updateOffset(Math.max(0, offset - limit));
+    updateSearchParams({
+      offset: String(Math.max(0, offset - limit)),
+      limit: String(limit),
+    });
   };
 
   return (
@@ -185,9 +269,22 @@ export default function AutopilotSessionsPage({
           <TableHeader>
             <TableRow>
               <TableHead>Session ID</TableHead>
-              <TableHead className="w-0 text-right whitespace-nowrap">
-                Created
-              </TableHead>
+              <SortableHeader
+                label="Created"
+                field="created_at"
+                currentSortBy={sortBy}
+                currentSortOrder={sortOrder}
+                onSort={handleSort}
+                className="w-0 text-right whitespace-nowrap"
+              />
+              <SortableHeader
+                label="Last Activity"
+                field="last_event_at"
+                currentSortBy={sortBy}
+                currentSortOrder={sortOrder}
+                onSort={handleSort}
+                className="w-0 text-right whitespace-nowrap"
+              />
             </TableRow>
           </TableHeader>
           <TableBody>

--- a/ui/app/utils/tensorzero/autopilot-client.ts
+++ b/ui/app/utils/tensorzero/autopilot-client.ts
@@ -17,7 +17,7 @@ import type {
  */
 export class AutopilotClient extends BaseTensorZeroClient {
   /**
-   * Lists autopilot sessions with optional pagination.
+   * Lists autopilot sessions with optional pagination and sorting.
    */
   async listAutopilotSessions(
     params?: ListSessionsParams,
@@ -25,6 +25,8 @@ export class AutopilotClient extends BaseTensorZeroClient {
     const searchParams = new URLSearchParams();
     if (params?.limit) searchParams.set("limit", params.limit.toString());
     if (params?.offset) searchParams.set("offset", params.offset.toString());
+    if (params?.sort_by) searchParams.set("sort_by", params.sort_by);
+    if (params?.sort_order) searchParams.set("sort_order", params.sort_order);
     const queryString = searchParams.toString();
     const endpoint = `/internal/autopilot/v1/sessions${queryString ? `?${queryString}` : ""}`;
 


### PR DESCRIPTION
## Summary
- Add Last Activity column showing `last_event_at` timestamp
- Add sortable column headers for Created and Last Activity with chevron indicators
- Pass `sort_by` and `sort_order` params to API client
- Default sort is by `last_event_at` descending (most recent activity first)
- Persist sort state in URL query params for shareable links

## Stack
Depends on #6016 (sorting types)

## Test plan
- [ ] Visit /autopilot/sessions
- [ ] Verify Last Activity column shows timestamps
- [ ] Click Created header to sort by created_at (desc, then asc)
- [ ] Click Last Activity header to sort by last_event_at
- [ ] Verify URL updates with sort_by and sort_order params
- [ ] Refresh page and verify sort state persists

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds client-driven sorting and a new timestamp column to the Autopilot sessions list, and now always sends `sort_by`/`sort_order` to the API; issues would mainly surface as incorrect ordering/pagination or backend incompatibility with the new query params.
> 
> **Overview**
> **Autopilot sessions list now shows and sorts by activity.** The sessions table adds a *Last Activity* column displaying `session.last_event_at` (with an em dash when missing), and the loading skeleton is updated to match the new column.
> 
> The `/autopilot/sessions` route adds sortable headers for *Created* and *Last Activity* (with chevron indicators), persists `sort_by`/`sort_order` in URL query params (resetting pagination on sort change), and defaults to sorting by `last_event_at` descending.
> 
> `AutopilotClient.listAutopilotSessions` now forwards optional `sort_by` and `sort_order` as query parameters when calling `/internal/autopilot/v1/sessions`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4beaa413c4087e34d03b8d58bc8448b140da10a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->