### PR TITLE
updated timeouts for inference and evaluation

### DIFF
--- a/internal/autopilot-tools/src/tools/prod/inference.rs
+++ b/internal/autopilot-tools/src/tools/prod/inference.rs
@@ -1,6 +1,6 @@
 //! Inference tool for calling TensorZero inference endpoint.
 
-use std::borrow::Cow;
+use std::{borrow::Cow, time::Duration};
 
 use async_trait::async_trait;
 use durable_tools::{NonControlToolError, SimpleTool, SimpleToolContext, ToolMetadata, ToolResult};
@@ -141,6 +141,10 @@ impl ToolMetadata for InferenceTool {
             }
             .into()
         })
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(5 * 60)
     }
 }
 

--- a/internal/autopilot-tools/src/tools/prod/run_evaluation.rs
+++ b/internal/autopilot-tools/src/tools/prod/run_evaluation.rs
@@ -1,7 +1,7 @@
 //! Tool for running evaluations on datasets.
 
-use std::borrow::Cow;
 use std::collections::HashMap;
+use std::{borrow::Cow, time::Duration};
 
 use async_trait::async_trait;
 use durable_tools::{
@@ -142,6 +142,10 @@ impl ToolMetadata for RunEvaluationTool {
             }
             .into()
         })
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(30 * 60)
     }
 }
 


### PR DESCRIPTION
Default is 1 minute.
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only changes tool-level timeout configuration, affecting when long-running inference/evaluation calls are aborted but not request/response semantics.
> 
> **Overview**
> Adds explicit per-tool timeouts to autopilot’s prod tools by implementing `ToolMetadata::timeout()`.
> 
> `InferenceTool` now times out after 5 minutes and `RunEvaluationTool` after 30 minutes, and both files import `std::time::Duration` to support the new defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fff2935d2b26c43e72cec241614c7efd20f867e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->