### PR TITLE
Fix SSE error handling for HTTP status codes

### DIFF
--- a/internal/autopilot-client/src/client.rs
+++ b/internal/autopilot-client/src/client.rs
@@ -742,6 +742,15 @@ impl AutopilotClient {
     /// HTTP errors are converted to AutopilotError::Http for consistency.
     fn convert_sse_error(e: reqwest_sse_stream::ReqwestSseStreamError) -> AutopilotError {
         match e {
+            reqwest_sse_stream::ReqwestSseStreamError::InvalidStatusCode(status, _response) => {
+                AutopilotError::Http {
+                    status_code: status.as_u16(),
+                    message: status
+                        .canonical_reason()
+                        .unwrap_or("Unknown error")
+                        .to_string(),
+                }
+            }
             reqwest_sse_stream::ReqwestSseStreamError::ReqwestError(e) if e.is_status() => {
                 AutopilotError::Http {
                     status_code: e.status().map(|s| s.as_u16()).unwrap_or(0),


### PR DESCRIPTION
## Summary
- Fixes a bug introduced in #5998 where HTTP error status codes (403/404) were not being converted to `AutopilotError::Http`
- The `convert_sse_error` function was missing a case for `InvalidStatusCode` variant

The switch from `eventsource-stream` to `sse-stream` changed how HTTP errors are reported. The new `reqwest_sse_stream` library returns `InvalidStatusCode(status, response)` for non-success HTTP responses, but `convert_sse_error` was only handling the `ReqwestError` variant with `is_status()`.

This caused autopilot's `test_stream_events_isolated_same_org_different_workspace` test to fail because it expected `AutopilotError::Http` but received `AutopilotError::Sse` instead.

## Test plan
- [ ] Verify autopilot e2e tests pass with this fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrow change to error mapping for SSE connection setup, affecting only how non-2xx HTTP responses are surfaced (e.g., 403/404) without altering streaming logic.
> 
> **Overview**
> Fixes SSE connection error handling so non-success HTTP responses returned by `reqwest_sse_stream` as `InvalidStatusCode` are converted into `AutopilotError::Http` (status code + canonical reason) instead of falling back to `AutopilotError::Sse`.
> 
> This makes HTTP failures during `stream_events` establishment consistent with existing handling of `ReqwestError` status errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f36dce691623ae1faa9d9c674a762715f5e727e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->