### PR TITLE
Bump batch test sleep and flush clickhouse writes

### DIFF
--- a/tensorzero-core/tests/e2e/providers/batch.rs
+++ b/tensorzero-core/tests/e2e/providers/batch.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use reqwest::{Client, StatusCode};
 use serde_json::{Value, json};
 use std::collections::HashSet;
+use tensorzero_core::db::test_helpers::TestDatabaseHelpers;
 use tensorzero_core::inference::types::{StoredContentBlock, StoredRequestMessage};
 use tensorzero_core::tool::Tool;
 use tensorzero_core::{
@@ -444,6 +445,7 @@ pub async fn check_clickhouse_batch_request_status(
     provider: &E2ETestProvider,
     expected_status: &str,
 ) {
+    clickhouse.flush_pending_writes().await;
     // Check if ClickHouse is ok - BatchRequest Table
     let result = select_latest_batch_request_clickhouse(clickhouse, batch_id)
         .await

--- a/tensorzero-core/tests/e2e/providers/mock_batch.rs
+++ b/tensorzero-core/tests/e2e/providers/mock_batch.rs
@@ -355,7 +355,7 @@ pub async fn test_simple_image_unified_mock_batch_with_provider(
     // Step 4: Verify ClickHouse storage
     let clickhouse = get_clickhouse().await;
     // Sleep to allow ClickHouse async_insert to become visible
-    sleep(Duration::from_millis(200)).await;
+    sleep(Duration::from_millis(1000)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(
@@ -423,7 +423,7 @@ pub async fn test_json_mode_unified_mock_batch_with_provider(
 
     let clickhouse = get_clickhouse().await;
     // Sleep to allow ClickHouse async_insert to become visible
-    sleep(Duration::from_millis(200)).await;
+    sleep(Duration::from_millis(1000)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(
@@ -594,7 +594,7 @@ pub async fn test_tool_use_unified_mock_batch_with_provider(
 
     let clickhouse = get_clickhouse().await;
     // Sleep to allow ClickHouse async_insert to become visible
-    sleep(Duration::from_millis(200)).await;
+    sleep(Duration::from_millis(1000)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(
@@ -678,7 +678,7 @@ pub async fn test_parallel_tool_use_unified_mock_batch_with_provider(
 
     let clickhouse = get_clickhouse().await;
     // Sleep to allow ClickHouse async_insert to become visible
-    sleep(Duration::from_millis(200)).await;
+    sleep(Duration::from_millis(1000)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(
@@ -758,7 +758,7 @@ pub async fn test_inference_params_unified_mock_batch_with_provider(
     // Step 4: Verify ClickHouse storage
     let clickhouse = get_clickhouse().await;
     // Sleep to allow ClickHouse async_insert to become visible
-    sleep(Duration::from_millis(200)).await;
+    sleep(Duration::from_millis(1000)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(
@@ -953,7 +953,7 @@ pub async fn test_multi_turn_parallel_tool_use_unified_mock_batch_with_provider(
     // Step 4: Verify ClickHouse storage
     let clickhouse = get_clickhouse().await;
     // Sleep to allow ClickHouse async_insert to become visible
-    sleep(Duration::from_millis(200)).await;
+    sleep(Duration::from_millis(1000)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(
@@ -1041,7 +1041,7 @@ pub async fn test_dynamic_tool_use_unified_mock_batch_with_provider(
     // Step 4: Verify ClickHouse storage
     let clickhouse = get_clickhouse().await;
     // Sleep to allow ClickHouse async_insert to become visible
-    sleep(Duration::from_millis(200)).await;
+    sleep(Duration::from_millis(1000)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(
@@ -1134,7 +1134,7 @@ pub async fn test_dynamic_json_mode_unified_mock_batch_with_provider(
     // Step 4: Verify ClickHouse storage
     let clickhouse = get_clickhouse().await;
     // Sleep to allow ClickHouse async_insert to become visible
-    sleep(Duration::from_millis(200)).await;
+    sleep(Duration::from_millis(1000)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(
@@ -1206,7 +1206,7 @@ pub async fn test_allowed_tools_unified_mock_batch_with_provider(
     // Step 4: Verify ClickHouse storage
     let clickhouse = get_clickhouse().await;
     // Sleep to allow ClickHouse async_insert to become visible
-    sleep(Duration::from_millis(200)).await;
+    sleep(Duration::from_millis(1000)).await;
     check_clickhouse_batch_request_status(&clickhouse, batch_id, provider, "completed").await;
 
     println!(


### PR DESCRIPTION
This should fix the flake we saw in
https://github.com/tensorzero/tensorzero/actions/runs/21528361007/job/62037864972

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to E2E test timing/DB visibility helpers and do not affect production code paths.
> 
> **Overview**
> Improves reliability of batch provider E2E tests by explicitly calling `flush_pending_writes()` before asserting `BatchRequest` status in ClickHouse.
> 
> Also increases the post-batch wait in unified mock batch tests (from `200ms` to `1000ms`) to reduce flakiness from ClickHouse `async_insert` visibility lag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65cf981a3d40c448be9275a856c8358d937beb41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->