### PR TITLE
Add last_event_at field to Session type

### DIFF
--- a/internal/autopilot-client/src/types.rs
+++ b/internal/autopilot-client/src/types.rs
@@ -90,6 +90,9 @@ pub struct Session {
     pub created_at: DateTime<Utc>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "ts-bindings", ts(optional))]
+    pub last_event_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts-bindings", ts(optional))]
     pub short_summary: Option<String>,
 }
 

--- a/internal/tensorzero-node/lib/bindings/Session.ts
+++ b/internal/tensorzero-node/lib/bindings/Session.ts
@@ -10,5 +10,6 @@ export type Session = {
   deployment_id: string;
   tensorzero_version: string;
   created_at: string;
+  last_event_at?: string;
   short_summary?: string;
 };


### PR DESCRIPTION
## Summary
Add `last_event_at` field to the Session type to enable sorting by most recent activity.

This is a minimal type-only change that allows the Autopilot API to return the timestamp of the most recent event in each session.

## Files
- `internal/autopilot-client/src/types.rs` - Add optional `last_event_at: DateTime<Utc>` field
- `internal/tensorzero-node/lib/bindings/Session.ts` - Generated TypeScript binding

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-only change that adds a new optional field; main impact is downstream consumers relying on exact `Session` shape or needing to populate the field server-side.
> 
> **Overview**
> Exposes a new optional `last_event_at` field on `Session` to represent the timestamp of the most recent event, enabling clients to sort sessions by latest activity.
> 
> Updates both the Rust wire type (`internal/autopilot-client/src/types.rs`) and the generated TypeScript binding (`internal/tensorzero-node/lib/bindings/Session.ts`) to include the new optional timestamp.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1cc356cde70fc116eb29dd768a72e9098e89b58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->