### PR TITLE
Fix chat input state bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,7 +334,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot-client"
-version = "2026.1.7"
+version = "2026.1.8"
 dependencies = [
  "chrono",
  "durable-tools-spawn",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-tools"
-version = "2026.1.7"
+version = "2026.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-worker"
-version = "2026.1.7"
+version = "2026.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools"
-version = "2026.1.7"
+version = "2026.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1946,7 +1946,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools-spawn"
-version = "2026.1.7"
+version = "2026.1.8"
 dependencies = [
  "async-trait",
  "durable",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2026.1.7"
+version = "2026.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2180,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2026.1.7"
+version = "2026.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2026.1.7"
+version = "2026.1.8"
 dependencies = [
  "async-stream",
  "autopilot-tools",
@@ -3671,7 +3671,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-utils"
-version = "2026.1.7"
+version = "2026.1.8"
 dependencies = [
  "minijinja",
  "serde",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2026.1.7"
+version = "2026.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "reqwest-sse-stream"
-version = "2026.1.7"
+version = "2026.1.8"
 dependencies = [
  "async-stream",
  "futures",
@@ -6334,7 +6334,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2026.1.7"
+version = "2026.1.8"
 dependencies = [
  "axum",
  "chrono",
@@ -6354,7 +6354,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2026.1.7"
+version = "2026.1.8"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -6474,7 +6474,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2026.1.7"
+version = "2026.1.8"
 dependencies = [
  "napi",
  "napi-build",
@@ -6487,7 +6487,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-optimizers"
-version = "2026.1.7"
+version = "2026.1.8"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -6521,7 +6521,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2026.1.7"
+version = "2026.1.8"
 dependencies = [
  "evaluations",
  "futures",
@@ -6539,7 +6539,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types"
-version = "2026.1.7"
+version = "2026.1.8"
 dependencies = [
  "aws-smithy-types",
  "infer",
@@ -6559,7 +6559,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types-providers"
-version = "2026.1.7"
+version = "2026.1.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -6567,7 +6567,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-unsafe-helpers"
-version = "2026.1.7"
+version = "2026.1.8"
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2026.1.7"
+version = "2026.1.8"
 rust-version = "1.88.0"
 license = "Apache-2.0"
 edition = "2024"

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2026.1.7"
+appVersion: "2026.1.8"

--- a/ui/app/routes/autopilot/sessions/$session_id/route.tsx
+++ b/ui/app/routes/autopilot/sessions/$session_id/route.tsx
@@ -442,11 +442,12 @@ export default function AutopilotSessionEventsPage({
   const userActionRef = useRef(false);
   const [isInCooldown, setIsInCooldown] = useState(false);
 
-  // Reset loading/error state when navigating to a different session
-  // Note: key={sessionId} on Suspense remounts EventStreamContent, which will call onLoaded
+  // Reset state when navigating to a different session
+  // Note: key={sessionId} on EventStreamContent ensures a fresh mount that will call onLoaded
+  // We don't set isEventsLoading here because the effect ordering with Suspense is unpredictable -
+  // EventStreamContent's onLoaded may run before this effect, causing isEventsLoading to get stuck
   useEffect(() => {
     setOptimisticMessages([]);
-    setIsEventsLoading(!isNewSession);
     setHasLoadError(false);
     setHasReachedStart(false);
     setAutopilotStatus({ status: "idle" });

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2026.1.7",
+  "version": "2026.1.8",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small UI state-reset tweak around Suspense ordering plus a routine version bump across packages.
> 
> **Overview**
> Fixes a session-navigation edge case in the Autopilot UI where `isEventsLoading` could become stuck due to unpredictable `Suspense` effect ordering, by no longer resetting that flag in the session-change effect and relying on `EventStreamContent` remount/`onLoaded`.
> 
> Bumps workspace/app versions from `2026.1.7` to `2026.1.8` across Rust crates (`Cargo.toml`/`Cargo.lock`), the UI package, and the Helm chart `appVersion`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff1957c3bfdfce6f15377b2f1adf57894ccfa760. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->