### PR TITLE
Allow reading flags without init

### DIFF
--- a/tensorzero-core/src/feature_flags/mod.rs
+++ b/tensorzero-core/src/feature_flags/mod.rs
@@ -97,8 +97,7 @@ impl<T: FlagValue> FlagDefinition<T> {
     pub fn get(&self) -> T {
         self.value
             .get_or_init(|| {
-                let flag_value = self
-                    .read_from_env()
+                self.read_from_env()
                     .inspect_err(|e| {
                         tracing::error!(
                             "Failed to parse flag value: {:?}. Using default value: {:?}",
@@ -106,9 +105,7 @@ impl<T: FlagValue> FlagDefinition<T> {
                             self.default,
                         );
                     })
-                    .unwrap_or(self.default.clone());
-
-                flag_value
+                    .unwrap_or_else(|_| self.default.clone())
             })
             .clone()
     }


### PR DESCRIPTION
We have many ways of bringing up a gateway (start_openai_compatible_gateway, for example)
and last time we thought we initialized flags but we didn't catch this. It seems more
dangerous to force flags to be initialized than to fall back to default value (and log error)
at runtime if flags are not properly set, and we mostly expect people to not use feature
flags anyways.