### PR TITLE
Chart design refinements

### DIFF
--- a/ui/app/components/model/ModelLatency.tsx
+++ b/ui/app/components/model/ModelLatency.tsx
@@ -8,7 +8,12 @@ import {
   Tooltip,
 } from "recharts";
 import { useMemo } from "react";
-import { CHART_COLORS } from "~/utils/chart";
+import {
+  CHART_COLORS,
+  CHART_MARGIN,
+  CHART_AXIS_STROKE,
+  formatLatency,
+} from "~/utils/chart";
 import {
   Select,
   SelectItem,
@@ -16,11 +21,7 @@ import {
   SelectValue,
   SelectTrigger,
 } from "~/components/ui/select";
-import {
-  ChartContainer,
-  ChartLegend,
-  ChartLegendContent,
-} from "~/components/ui/chart";
+import { ChartContainer, BasicChartLegend } from "~/components/ui/chart";
 
 export type LatencyMetric = "response_time_ms" | "ttft_ms";
 
@@ -79,7 +80,7 @@ function CustomTooltipContent({ active, payload, label }: TooltipProps) {
                 </span>
               </div>
               <span className="text-foreground font-mono font-medium tabular-nums">
-                {Math.round(entry.value)}ms
+                {formatLatency(entry.value)}
               </span>
             </div>
           );
@@ -88,8 +89,6 @@ function CustomTooltipContent({ active, payload, label }: TooltipProps) {
     </div>
   );
 }
-
-const MARGIN = { top: 12, right: 16, bottom: 28, left: 56 };
 
 export function LatencyTimeWindowSelector({
   value,
@@ -169,57 +168,56 @@ export function LatencyQuantileChart({
   );
 
   return (
-    <ChartContainer config={chartConfig} className="h-80 w-full">
-      <LineChart accessibilityLayer data={data} margin={MARGIN}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis
-          dataKey="percentile"
-          domain={[0, 1]}
-          tickLine={false}
-          tickMargin={10}
-          axisLine={true}
-          ticks={[
-            0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1.0,
-          ]}
-          tickFormatter={(v) => `${(v * 100).toFixed(0)}%`}
-        />
-        <YAxis
-          scale="log"
-          domain={["dataMin", "dataMax"]}
-          tickLine={false}
-          tickMargin={10}
-          axisLine={true}
-          tickFormatter={(v) => `${v}ms`}
-        />
-
-        <Tooltip
-          content={<CustomTooltipContent />}
-          cursor={{
-            stroke: "#666666",
-            strokeDasharray: "3 3",
-            strokeWidth: 2,
-          }}
-        />
-
-        <ChartLegend
-          content={<ChartLegendContent className="font-mono text-xs" />}
-        />
-
-        {modelNames.map((name, index) => (
-          <Line
-            key={name}
-            type="monotone"
-            dataKey={name}
-            name={name}
-            stroke={CHART_COLORS[index % CHART_COLORS.length]}
-            strokeWidth={2}
-            dot={false}
-            connectNulls={false}
-            isAnimationActive={false}
+    <div>
+      <ChartContainer config={chartConfig} className="h-72 w-full">
+        <LineChart accessibilityLayer data={data} margin={CHART_MARGIN}>
+          <CartesianGrid />
+          <XAxis
+            dataKey="percentile"
+            domain={[0, 1]}
+            tickLine={false}
+            tickMargin={10}
+            axisLine={{ stroke: CHART_AXIS_STROKE }}
+            ticks={[
+              0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1.0,
+            ]}
+            tickFormatter={(v) => `${(v * 100).toFixed(0)}%`}
           />
-        ))}
-      </LineChart>
-    </ChartContainer>
+          <YAxis
+            scale="log"
+            domain={["dataMin", "dataMax"]}
+            tickLine={false}
+            tickMargin={10}
+            axisLine={{ stroke: CHART_AXIS_STROKE }}
+            tickFormatter={formatLatency}
+          />
+
+          <Tooltip
+            content={<CustomTooltipContent />}
+            cursor={{
+              stroke: "hsl(var(--chart-4))",
+              strokeDasharray: "3 3",
+              strokeWidth: 2,
+            }}
+          />
+
+          {modelNames.map((name, index) => (
+            <Line
+              key={name}
+              type="monotone"
+              dataKey={name}
+              name={name}
+              stroke={CHART_COLORS[index % CHART_COLORS.length]}
+              strokeWidth={2}
+              dot={false}
+              connectNulls={false}
+              isAnimationActive={false}
+            />
+          ))}
+        </LineChart>
+      </ChartContainer>
+      <BasicChartLegend items={modelNames} colors={CHART_COLORS} />
+    </div>
   );
 }
 

--- a/ui/app/components/model/ModelUsage.tsx
+++ b/ui/app/components/model/ModelUsage.tsx
@@ -6,12 +6,13 @@ import {
   formatXAxisTimestamp,
   formatTooltipTimestamp,
   CHART_COLORS,
+  CHART_MARGIN,
+  CHART_AXIS_STROKE,
 } from "~/utils/chart";
 
 import {
   ChartContainer,
-  ChartLegend,
-  ChartLegendContent,
+  BasicChartLegend,
   ChartTooltip,
   ChartTooltipContent,
 } from "~/components/ui/chart";
@@ -116,83 +117,83 @@ export function ModelUsageChart({
     );
 
   return (
-    <ChartContainer config={chartConfig} className="h-80 w-full">
-      <BarChart accessibilityLayer data={data}>
-        <CartesianGrid vertical={false} />
-        {timeGranularity !== "cumulative" && (
-          <XAxis
-            dataKey="date"
+    <div>
+      <ChartContainer config={chartConfig} className="h-72 w-full">
+        <BarChart accessibilityLayer data={data} margin={CHART_MARGIN}>
+          <CartesianGrid vertical={false} />
+          {timeGranularity !== "cumulative" && (
+            <XAxis
+              dataKey="date"
+              tickLine={false}
+              tickMargin={10}
+              axisLine={{ stroke: CHART_AXIS_STROKE }}
+              tickFormatter={(value) =>
+                formatXAxisTimestamp(new Date(value), timeGranularity)
+              }
+            />
+          )}
+          <YAxis
             tickLine={false}
             tickMargin={10}
-            axisLine={true}
-            tickFormatter={(value) =>
-              formatXAxisTimestamp(new Date(value), timeGranularity)
+            axisLine={false}
+            tickFormatter={formatChartNumber}
+          />
+          <ChartTooltip
+            content={
+              <ChartTooltipContent
+                labelFormatter={(label) =>
+                  timeGranularity === "cumulative"
+                    ? "Total"
+                    : formatTooltipTimestamp(new Date(label), timeGranularity)
+                }
+                formatter={(value, name, entry) => {
+                  const count = entry.payload[`${name}_count`];
+                  const inputTokens = entry.payload[`${name}_input_tokens`];
+                  const outputTokens = entry.payload[`${name}_output_tokens`];
+                  const totalTokens = inputTokens + outputTokens;
+
+                  return (
+                    <div className="flex flex-1 items-center justify-between leading-none">
+                      <span className="text-muted-foreground mr-2 font-mono text-xs">
+                        {name}
+                      </span>
+                      <div className="grid text-right">
+                        <span className="text-foreground font-mono font-medium tabular-nums">
+                          {USAGE_METRIC_CONFIG[selectedMetric].formatter(
+                            value as number,
+                          )}
+                        </span>
+                        {selectedMetric === "inferences" && (
+                          <span className="text-muted-foreground text-[10px]">
+                            {formatDetailedNumber(totalTokens)} tokens
+                          </span>
+                        )}
+                        {selectedMetric !== "inferences" && (
+                          <span className="text-muted-foreground text-[10px]">
+                            {formatDetailedNumber(count)} requests
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  );
+                }}
+              />
             }
           />
-        )}
-        <YAxis
-          tickLine={false}
-          tickMargin={10}
-          axisLine={true}
-          tickFormatter={formatChartNumber}
-        />
-        <ChartTooltip
-          content={
-            <ChartTooltipContent
-              labelFormatter={(label) =>
-                timeGranularity === "cumulative"
-                  ? "Total"
-                  : formatTooltipTimestamp(new Date(label), timeGranularity)
-              }
-              formatter={(value, name, entry) => {
-                const count = entry.payload[`${name}_count`];
-                const inputTokens = entry.payload[`${name}_input_tokens`];
-                const outputTokens = entry.payload[`${name}_output_tokens`];
-                const totalTokens = inputTokens + outputTokens;
-
-                return (
-                  <div className="flex flex-1 items-center justify-between leading-none">
-                    <span className="text-muted-foreground mr-2 font-mono text-xs">
-                      {name}
-                    </span>
-                    <div className="grid text-right">
-                      <span className="text-foreground font-mono font-medium tabular-nums">
-                        {USAGE_METRIC_CONFIG[selectedMetric].formatter(
-                          value as number,
-                        )}
-                      </span>
-                      {selectedMetric === "inferences" && (
-                        <span className="text-muted-foreground text-[10px]">
-                          {formatDetailedNumber(totalTokens)} tokens
-                        </span>
-                      )}
-                      {selectedMetric !== "inferences" && (
-                        <span className="text-muted-foreground text-[10px]">
-                          {formatDetailedNumber(count)} requests
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                );
-              }}
+          {modelNames.map((modelName, index) => (
+            <Bar
+              key={modelName}
+              dataKey={modelName}
+              name={modelName}
+              fill={CHART_COLORS[index % CHART_COLORS.length]}
+              radius={4}
+              maxBarSize={100}
             />
-          }
-        />
-        <ChartLegend
-          content={<ChartLegendContent className="font-mono text-xs" />}
-        />
-        {modelNames.map((modelName, index) => (
-          <Bar
-            key={modelName}
-            dataKey={modelName}
-            name={modelName}
-            fill={CHART_COLORS[index % CHART_COLORS.length]}
-            radius={4}
-            maxBarSize={100}
-          />
-        ))}
-      </BarChart>
-    </ChartContainer>
+          ))}
+        </BarChart>
+      </ChartContainer>
+      <BasicChartLegend items={modelNames} colors={CHART_COLORS} />
+    </div>
   );
 }
 

--- a/ui/app/components/ui/BarChartSkeleton.tsx
+++ b/ui/app/components/ui/BarChartSkeleton.tsx
@@ -10,8 +10,8 @@ const SKELETON_BAR_HEIGHTS = [45, 65, 35, 80, 55, 40, 70, 50, 60, 30];
 export function BarChartSkeleton({ className }: { className?: string }) {
   return (
     <div className={className}>
-      {/* Chart container - h-80 matches ChartContainer in production */}
-      <div className="flex h-80 w-full flex-col">
+      {/* Chart container - h-72 matches ChartContainer in production */}
+      <div className="flex h-72 w-full flex-col">
         {/* Chart area with Y-axis and bars */}
         <div className="flex flex-1">
           {/* Y-axis labels */}
@@ -51,7 +51,7 @@ export function BarChartSkeleton({ className }: { className?: string }) {
         </div>
       </div>
       {/* Legend */}
-      <div className="flex justify-center gap-4 pt-3">
+      <div className="flex justify-center gap-4 pt-6">
         <Skeleton className="h-4 w-20" />
         <Skeleton className="h-4 w-24" />
         <Skeleton className="h-4 w-16" />

--- a/ui/app/components/ui/LineChartSkeleton.tsx
+++ b/ui/app/components/ui/LineChartSkeleton.tsx
@@ -12,8 +12,8 @@ export function LineChartSkeleton({ className }: { className?: string }) {
 
   return (
     <div className={className}>
-      {/* Chart container - h-80 matches ChartContainer in production */}
-      <div className="flex h-80 w-full flex-col">
+      {/* Chart container - h-72 matches ChartContainer in production */}
+      <div className="flex h-72 w-full flex-col">
         {/* Chart area with Y-axis and line */}
         <div className="flex flex-1">
           {/* Y-axis labels */}
@@ -165,7 +165,7 @@ export function LineChartSkeleton({ className }: { className?: string }) {
         </div>
       </div>
       {/* Legend */}
-      <div className="flex justify-center gap-4 pt-3">
+      <div className="flex justify-center gap-4 pt-6">
         <Skeleton className="h-4 w-20" />
         <Skeleton className="h-4 w-24" />
         <Skeleton className="h-4 w-16" />

--- a/ui/app/components/ui/chart.tsx
+++ b/ui/app/components/ui/chart.tsx
@@ -55,7 +55,7 @@ const ChartContainer = React.forwardRef<
         data-chart={chartId}
         ref={ref}
         className={cn(
-          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-orange-500/10 [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
           className,
         )}
         {...props}
@@ -375,8 +375,37 @@ function ChartAsyncErrorState({
   );
 }
 
+/**
+ * Standalone chart legend component for use outside of Recharts
+ * Renders a simple flex-wrap legend with colored indicators
+ */
+function BasicChartLegend({
+  items,
+  colors,
+}: {
+  items: string[];
+  colors: readonly string[];
+}) {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-4 pt-6">
+      {items.map((name, index) => (
+        <div key={name} className="flex items-center gap-1.5">
+          <div
+            className="h-2 w-2 shrink-0 rounded-[2px]"
+            style={{
+              backgroundColor: colors[index % colors.length],
+            }}
+          />
+          <span className="font-mono text-xs">{name}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export {
   BarChartSkeleton,
+  BasicChartLegend,
   ChartAsyncErrorState,
   ChartContainer,
   ChartLegend,

--- a/ui/app/utils/chart.ts
+++ b/ui/app/utils/chart.ts
@@ -11,6 +11,16 @@ export const CHART_COLORS = [
 ] as const;
 
 /**
+ * Standard chart margin for consistent spacing
+ */
+export const CHART_MARGIN = { top: 12, right: 0, bottom: 0, left: 0 } as const;
+
+/**
+ * Standard axis line stroke color
+ */
+export const CHART_AXIS_STROKE = "#e5e5e5";
+
+/**
  * Format numbers for chart axes to avoid overflow with large numbers
  * Uses compact notation (K, M, B) for readability
  */
@@ -80,6 +90,33 @@ export function formatCompactNumber(value: number): string {
   }
   // For decimals < 1, show up to 2 decimal places
   return `${sign}${abs.toFixed(2).replace(/\.?0+$/, "")}`;
+}
+
+/**
+ * Format latency values for chart axes
+ * Converts to appropriate time units (ms or s) for readability
+ */
+export function formatLatency(ms: number): string {
+  if (ms === 0) return "0";
+
+  const abs = Math.abs(ms);
+
+  if (abs >= 1000) {
+    const seconds = abs / 1000;
+    if (seconds >= 100) {
+      return `${Math.round(seconds)}s`;
+    }
+    if (seconds >= 10) {
+      return `${seconds.toFixed(1).replace(/\.0$/, "")}s`;
+    }
+    return `${seconds.toFixed(2).replace(/\.?0+$/, "")}s`;
+  }
+
+  // For ms values, keep it simple
+  if (abs >= 10) {
+    return `${Math.round(abs)}ms`;
+  }
+  return `${abs.toFixed(1).replace(/\.0$/, "")}ms`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Design refinements for chart components on `/observability/models`.

**Stacked on #6046** - This PR contains only design changes. The functional/architectural changes are in the base PR.

### Changes

- **Chart sizing**: Reduce chart height from `h-80` to `h-72` for tighter layout
- **Axis styling**: Add `CHART_MARGIN` and `CHART_AXIS_STROKE` constants
- **Latency formatting**: Add `formatLatency` helper for human-readable latency values (e.g., "1.23s" instead of "1234ms")
- **Legend**: Replace Recharts `ChartLegend` with simpler `BasicChartLegend` with increased spacing (`pt-6`)
- **Tooltip cursor**: Update bar chart tooltip cursor to orange-500/10
- **Grid lines**: Remove `strokeDasharray` from CartesianGrid for cleaner look
- **Bar chart Y-axis**: Remove axisLine for minimal appearance
- **Skeletons**: Update skeleton heights to match new chart heights

## Test plan

- [x] Typecheck passes
- [x] Lint passes
- [x] Format passes
- [ ] Manual verification: Charts render with new styling
- [ ] Manual verification: Latency values formatted correctly
- [ ] Manual verification: Legend spacing looks balanced