### PR TITLE
Wire up postgres e2e tests for dataset endpoints

### DIFF
--- a/tensorzero-core/tests/e2e/endpoints/datasets/clone_datapoints.rs
+++ b/tensorzero-core/tests/e2e/endpoints/datasets/clone_datapoints.rs
@@ -1,14 +1,11 @@
 use reqwest::Client;
 use serde::Deserialize;
 use serde_json::json;
-use std::sync::Arc;
 use uuid::Uuid;
 
 use tensorzero::{ClientExt, GetDatapointParams, StoredDatapoint};
-use tensorzero_core::config::Config;
-use tensorzero_core::db::clickhouse::ClickHouseConnectionInfo;
-use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
 use tensorzero_core::db::datasets::DatasetQueries;
+use tensorzero_core::db::delegating_connection::DelegatingDatabaseConnection;
 use tensorzero_core::db::inferences::{
     InferenceOutputSource, InferenceQueries, ListInferencesParams,
 };
@@ -26,27 +23,12 @@ struct CloneDatapointsResponse {
 
 use crate::common::get_gateway_endpoint;
 
-lazy_static::lazy_static! {
-    static ref TEST_SETUP: tokio::sync::OnceCell<(ClickHouseConnectionInfo, Arc<Config>)> = tokio::sync::OnceCell::new();
-}
-
-async fn get_test_setup() -> &'static (ClickHouseConnectionInfo, Arc<Config>) {
-    TEST_SETUP
-        .get_or_init(|| async {
-            let clickhouse: ClickHouseConnectionInfo = get_clickhouse().await;
-
-            let client = tensorzero::test_helpers::make_embedded_gateway().await;
-            let config = client.get_config().unwrap();
-            (clickhouse, config)
-        })
-        .await
-}
-
 #[tokio::test(flavor = "multi_thread")]
 async fn test_clone_datapoint_preserves_source_inference_id() {
-    skip_for_postgres!();
     let client = Client::new();
-    let (clickhouse, config) = get_test_setup().await;
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
+    let embedded_client = tensorzero::test_helpers::make_embedded_gateway().await;
+    let config = embedded_client.get_config().unwrap();
 
     // Step 1: Get an existing inference from the database
     let params = ListInferencesParams {
@@ -54,7 +36,7 @@ async fn test_clone_datapoint_preserves_source_inference_id() {
         limit: 1,
         ..Default::default()
     };
-    let inferences = clickhouse.list_inferences(config, &params).await.unwrap();
+    let inferences = database.list_inferences(&config, &params).await.unwrap();
     assert!(!inferences.is_empty(), "Need at least 1 inference for test");
     let inference_id = inferences[0].id();
 
@@ -82,7 +64,7 @@ async fn test_clone_datapoint_preserves_source_inference_id() {
     let source_datapoint_id = create_result.ids[0];
 
     // Step 3: Verify the source datapoint has source_inference_id set
-    let source_datapoint = clickhouse
+    let source_datapoint = database
         .get_datapoint(&GetDatapointParams {
             dataset_name: source_dataset.clone(),
             datapoint_id: source_datapoint_id,
@@ -122,7 +104,7 @@ async fn test_clone_datapoint_preserves_source_inference_id() {
     let cloned_datapoint_id = clone_result.datapoint_ids[0].expect("Clone should succeed");
 
     // Step 5: Verify the cloned datapoint preserves source_inference_id
-    let cloned_datapoint = clickhouse
+    let cloned_datapoint = database
         .get_datapoint(&GetDatapointParams {
             dataset_name: target_dataset.clone(),
             datapoint_id: cloned_datapoint_id,
@@ -147,9 +129,8 @@ async fn test_clone_datapoint_preserves_source_inference_id() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_clone_chat_datapoint_success() {
-    skip_for_postgres!();
     let client = Client::new();
-    let (clickhouse, _config) = get_test_setup().await;
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
     // Step 1: Create a chat datapoint
     let source_dataset = format!("test_clone_chat_source_{}", Uuid::now_v7());
@@ -207,7 +188,7 @@ async fn test_clone_chat_datapoint_success() {
     let cloned_datapoint_id = clone_result.datapoint_ids[0].expect("Clone should succeed");
 
     // Step 3: Verify the cloned datapoint
-    let cloned_datapoint = clickhouse
+    let cloned_datapoint = database
         .get_datapoint(&GetDatapointParams {
             dataset_name: target_dataset.clone(),
             datapoint_id: cloned_datapoint_id,
@@ -228,9 +209,8 @@ async fn test_clone_chat_datapoint_success() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_clone_to_same_dataset() {
-    skip_for_postgres!();
     let client = Client::new();
-    let (clickhouse, _config) = get_test_setup().await;
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
     // Step 1: Create a datapoint
     let dataset_name = format!("test_clone_same_{}", Uuid::now_v7());
@@ -284,7 +264,7 @@ async fn test_clone_to_same_dataset() {
     let cloned_datapoint_id = clone_result.datapoint_ids[0].expect("Clone should succeed");
 
     // Step 3: Verify both datapoints exist
-    let source_datapoint = clickhouse
+    let source_datapoint = database
         .get_datapoint(&GetDatapointParams {
             dataset_name: dataset_name.clone(),
             datapoint_id: source_datapoint_id,
@@ -293,7 +273,7 @@ async fn test_clone_to_same_dataset() {
         .await
         .unwrap();
 
-    let cloned_datapoint = clickhouse
+    let cloned_datapoint = database
         .get_datapoint(&GetDatapointParams {
             dataset_name: dataset_name.clone(),
             datapoint_id: cloned_datapoint_id,
@@ -310,9 +290,8 @@ async fn test_clone_to_same_dataset() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_clone_multiple_datapoints() {
-    skip_for_postgres!();
     let client = Client::new();
-    let (clickhouse, _config) = get_test_setup().await;
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
     // Step 1: Create multiple datapoints
     let source_dataset = format!("test_clone_multi_source_{}", Uuid::now_v7());
@@ -389,7 +368,7 @@ async fn test_clone_multiple_datapoints() {
         .collect();
 
     for cloned_id in &cloned_ids {
-        let cloned_datapoint = clickhouse
+        let cloned_datapoint = database
             .get_datapoint(&GetDatapointParams {
                 dataset_name: target_dataset.clone(),
                 datapoint_id: *cloned_id,
@@ -409,7 +388,6 @@ async fn test_clone_multiple_datapoints() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_clone_nonexistent_datapoint_returns_null() {
-    skip_for_postgres!();
     let client = Client::new();
 
     // Try to clone a nonexistent datapoint

--- a/tensorzero-core/tests/e2e/endpoints/datasets/create_datapoints.rs
+++ b/tensorzero-core/tests/e2e/endpoints/datasets/create_datapoints.rs
@@ -1,42 +1,22 @@
 use reqwest::Client;
 use serde_json::json;
-use std::sync::Arc;
-use tensorzero::{ClientExt, Role, StoredDatapoint};
+use tensorzero::{Role, StoredDatapoint};
 use tensorzero_core::inference::types::{
     Arguments, ContentBlockChatOutput, JsonInferenceOutput, StoredInput, StoredInputMessage,
     StoredInputMessageContent, Template, Text,
 };
 use uuid::Uuid;
 
-use tensorzero_core::config::Config;
-use tensorzero_core::db::clickhouse::ClickHouseConnectionInfo;
-use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
 use tensorzero_core::db::datasets::{DatasetQueries, GetDatapointsParams};
+use tensorzero_core::db::delegating_connection::DelegatingDatabaseConnection;
 use tensorzero_core::endpoints::datasets::v1::types::CreateDatapointsResponse;
 
 use crate::common::get_gateway_endpoint;
 
-lazy_static::lazy_static! {
-    static ref TEST_SETUP: tokio::sync::OnceCell<(ClickHouseConnectionInfo, Arc<Config>)> = tokio::sync::OnceCell::new();
-}
-
-async fn get_test_setup() -> &'static (ClickHouseConnectionInfo, Arc<Config>) {
-    TEST_SETUP
-        .get_or_init(|| async {
-            let clickhouse: ClickHouseConnectionInfo = get_clickhouse().await;
-
-            let client = tensorzero::test_helpers::make_embedded_gateway().await;
-            let config = client.get_config().unwrap();
-            (clickhouse, config)
-        })
-        .await
-}
-
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_chat_datapoint_basic() {
-    skip_for_postgres!();
     let client = Client::new();
-    let (clickhouse, _config) = get_test_setup().await;
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
     let request = json!({
         "datapoints": [{
@@ -97,7 +77,7 @@ async fn test_create_chat_datapoint_basic() {
         search_query_experimental: None,
     };
 
-    let datapoints = clickhouse.get_datapoints(&params).await.unwrap();
+    let datapoints = database.get_datapoints(&params).await.unwrap();
     assert_eq!(datapoints.len(), 1);
     assert_eq!(datapoints[0].id(), result.ids[0]);
 
@@ -128,28 +108,12 @@ async fn test_create_chat_datapoint_basic() {
                 .to_string(),
         })]),
     );
-
-    // Assert ChatInferenceDatapoint has snapshot_hash
-    let query = format!(
-        "SELECT snapshot_hash FROM ChatInferenceDatapoint WHERE id = '{}' FORMAT JSONEachRow",
-        result.ids[0]
-    );
-    let response = clickhouse
-        .run_query_synchronous_no_params(query)
-        .await
-        .unwrap();
-    let datapoint_row: serde_json::Value = serde_json::from_str(&response.response).unwrap();
-    assert!(
-        !datapoint_row["snapshot_hash"].is_null(),
-        "ChatInferenceDatapoint should have snapshot_hash"
-    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_json_datapoint_basic() {
-    skip_for_postgres!();
     let client = Client::new();
-    let (clickhouse, _config) = get_test_setup().await;
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
     let request = json!({
         "datapoints": [{
@@ -217,7 +181,7 @@ async fn test_create_json_datapoint_basic() {
         search_query_experimental: None,
     };
 
-    let datapoints = clickhouse.get_datapoints(&params).await.unwrap();
+    let datapoints = database.get_datapoints(&params).await.unwrap();
     assert_eq!(datapoints.len(), 1);
     assert_eq!(datapoints[0].id(), result.ids[0]);
 
@@ -232,28 +196,12 @@ async fn test_create_json_datapoint_basic() {
             parsed: Some(json!({"sentiment": "positive", "confidence": 0.95})),
         })
     );
-
-    // Assert JsonInferenceDatapoint has snapshot_hash
-    let query = format!(
-        "SELECT snapshot_hash FROM JsonInferenceDatapoint WHERE id = '{}' FORMAT JSONEachRow",
-        result.ids[0]
-    );
-    let response = clickhouse
-        .run_query_synchronous_no_params(query)
-        .await
-        .unwrap();
-    let datapoint_row: serde_json::Value = serde_json::from_str(&response.response).unwrap();
-    assert!(
-        !datapoint_row["snapshot_hash"].is_null(),
-        "JsonInferenceDatapoint should have snapshot_hash"
-    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_multiple_datapoints() {
-    skip_for_postgres!();
     let client = Client::new();
-    let (_clickhouse, _config) = get_test_setup().await;
+    let _database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
     let request = json!({
         "datapoints": [
@@ -325,9 +273,8 @@ async fn test_create_multiple_datapoints() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_chat_datapoint_with_tools() {
-    skip_for_postgres!();
     let client = Client::new();
-    let (_clickhouse, _config) = get_test_setup().await;
+    let _database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
     let request = json!({
         "datapoints": [{
@@ -372,9 +319,8 @@ async fn test_create_chat_datapoint_with_tools() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_datapoint_with_tags() {
-    skip_for_postgres!();
     let client = Client::new();
-    let (_clickhouse, _config) = get_test_setup().await;
+    let _database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
     let request = json!({
         "datapoints": [{
@@ -412,9 +358,8 @@ async fn test_create_datapoint_with_tags() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_datapoint_invalid_function() {
-    skip_for_postgres!();
     let client = Client::new();
-    let (_clickhouse, _config) = get_test_setup().await;
+    let _database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
     let request = json!({
         "datapoints": [{
@@ -441,9 +386,8 @@ async fn test_create_datapoint_invalid_function() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_datapoint_wrong_function_type() {
-    skip_for_postgres!();
     let client = Client::new();
-    let (_clickhouse, _config) = get_test_setup().await;
+    let _database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
     // Try to create a JSON datapoint for a chat function
     let request = json!({
@@ -477,9 +421,8 @@ async fn test_create_datapoint_wrong_function_type() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_datapoint_empty_list() {
-    skip_for_postgres!();
     let client = Client::new();
-    let (_clickhouse, _config) = get_test_setup().await;
+    let _database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
     let request = json!({
         "datapoints": []
@@ -497,9 +440,8 @@ async fn test_create_datapoint_empty_list() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_json_datapoint_invalid_schema() {
-    skip_for_postgres!();
     let client = Client::new();
-    let (clickhouse, _config) = get_test_setup().await;
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
     let request = json!({
         "datapoints": [{
@@ -558,7 +500,7 @@ async fn test_create_json_datapoint_invalid_schema() {
         search_query_experimental: None,
     };
 
-    let datapoints = clickhouse.get_datapoints(&params).await.unwrap();
+    let datapoints = database.get_datapoints(&params).await.unwrap();
     assert_eq!(datapoints.len(), 1);
     let StoredDatapoint::Json(ref json_datapoint) = datapoints[0] else {
         panic!("Expected json datapoint");
@@ -576,9 +518,8 @@ async fn test_create_json_datapoint_invalid_schema() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_datapoint_with_episode_id() {
-    skip_for_postgres!();
     let client = Client::new();
-    let (_clickhouse, _config) = get_test_setup().await;
+    let _database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
     let episode_id = Uuid::now_v7();
 
@@ -619,9 +560,8 @@ async fn test_create_datapoint_with_episode_id() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_datapoint_without_output() {
-    skip_for_postgres!();
     let client = Client::new();
-    let (_clickhouse, _config) = get_test_setup().await;
+    let _database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
     let request = json!({
         "datapoints": [{
@@ -652,9 +592,8 @@ async fn test_create_datapoint_without_output() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_json_datapoint_default_schema() {
-    skip_for_postgres!();
     let client = Client::new();
-    let (_clickhouse, _config) = get_test_setup().await;
+    let _database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
     // Test that output_schema is optional and defaults to function's schema
     let request = json!({

--- a/tensorzero-core/tests/e2e/endpoints/datasets/create_from_inferences.rs
+++ b/tensorzero-core/tests/e2e/endpoints/datasets/create_from_inferences.rs
@@ -1,18 +1,14 @@
 use reqwest::Client;
-use std::sync::Arc;
 use uuid::Uuid;
 
 use tensorzero::ClientExt;
-use tensorzero_core::config::Config;
 use tensorzero_core::db::clickhouse::query_builder::{
     InferenceFilter, TagComparisonOperator, TagFilter,
 };
-use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
 use tensorzero_core::db::delegating_connection::DelegatingDatabaseConnection;
 use tensorzero_core::db::inferences::{
     InferenceOutputSource, InferenceQueries, ListInferencesParams,
 };
-use tensorzero_core::db::postgres::test_helpers::get_postgres;
 use tensorzero_core::endpoints::datasets::v1::types::{
     CreateDatapointsFromInferenceRequest, CreateDatapointsFromInferenceRequestParams,
     CreateDatapointsResponse,
@@ -21,28 +17,12 @@ use tensorzero_core::endpoints::stored_inferences::v1::types::ListInferencesRequ
 
 use crate::common::get_gateway_endpoint;
 
-lazy_static::lazy_static! {
-    static ref TEST_SETUP: tokio::sync::OnceCell<(DelegatingDatabaseConnection, Arc<Config>)> = tokio::sync::OnceCell::new();
-}
-
-async fn get_test_setup() -> &'static (DelegatingDatabaseConnection, Arc<Config>) {
-    TEST_SETUP
-        .get_or_init(|| async {
-            let clickhouse = get_clickhouse().await;
-            let postgres = get_postgres().await;
-            let database = DelegatingDatabaseConnection::new(clickhouse, postgres);
-
-            let client = tensorzero::test_helpers::make_embedded_gateway().await;
-            let config = client.get_config().unwrap();
-            (database, config)
-        })
-        .await
-}
-
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_from_inference_ids_success() {
     let client = Client::new();
-    let (database, config) = get_test_setup().await;
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
+    let embedded_client = tensorzero::test_helpers::make_embedded_gateway().await;
+    let config = embedded_client.get_config().unwrap();
 
     // Get some existing inferences from the database
     let params = ListInferencesParams {
@@ -50,7 +30,7 @@ async fn test_create_from_inference_ids_success() {
         limit: 2,
         ..Default::default()
     };
-    let inferences = database.list_inferences(config, &params).await.unwrap();
+    let inferences = database.list_inferences(&config, &params).await.unwrap();
     assert!(inferences.len() >= 2, "Need at least 2 inferences for test");
 
     let inference_id1 = inferences[0].id();
@@ -114,7 +94,9 @@ async fn test_create_from_inference_query_success() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_from_same_inference_multiple_times_succeeds() {
     let client = Client::new();
-    let (database, config) = get_test_setup().await;
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
+    let embedded_client = tensorzero::test_helpers::make_embedded_gateway().await;
+    let config = embedded_client.get_config().unwrap();
 
     // Get an existing inference from the database
     let params = ListInferencesParams {
@@ -122,7 +104,7 @@ async fn test_create_from_same_inference_multiple_times_succeeds() {
         limit: 1,
         ..Default::default()
     };
-    let inferences = database.list_inferences(config, &params).await.unwrap();
+    let inferences = database.list_inferences(&config, &params).await.unwrap();
     assert!(!inferences.is_empty(), "Need at least 1 inference for test");
 
     let inference_id = inferences[0].id();
@@ -167,7 +149,9 @@ async fn test_create_from_same_inference_multiple_times_succeeds() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_from_inference_missing_ids_error() {
     let client = Client::new();
-    let (database, config) = get_test_setup().await;
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
+    let embedded_client = tensorzero::test_helpers::make_embedded_gateway().await;
+    let config = embedded_client.get_config().unwrap();
 
     // Get one real inference
     let params = ListInferencesParams {
@@ -175,7 +159,7 @@ async fn test_create_from_inference_missing_ids_error() {
         limit: 1,
         ..Default::default()
     };
-    let inferences = database.list_inferences(config, &params).await.unwrap();
+    let inferences = database.list_inferences(&config, &params).await.unwrap();
     assert!(!inferences.is_empty(), "Need at least 1 inference for test");
 
     let real_inference_id = inferences[0].id();

--- a/tensorzero-core/tests/e2e/endpoints/datasets/delete_datapoints.rs
+++ b/tensorzero-core/tests/e2e/endpoints/datasets/delete_datapoints.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 use tensorzero::DeleteDatapointsRequest;
 use uuid::Uuid;
 
-use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
 use tensorzero_core::db::datasets::{DatasetQueries, GetDatapointsParams};
+use tensorzero_core::db::delegating_connection::DelegatingDatabaseConnection;
 use tensorzero_core::db::stored_datapoint::{
     StoredChatInferenceDatapoint, StoredDatapoint, StoredJsonInferenceDatapoint,
 };
@@ -20,9 +20,8 @@ use crate::common::get_gateway_endpoint;
 
 #[tokio::test]
 async fn test_delete_datapoints_single_chat() {
-    skip_for_postgres!();
     let http_client = Client::new();
-    let clickhouse = get_clickhouse().await;
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
     let dataset_name = format!("test-delete-dp-single-chat-{}", Uuid::now_v7());
 
     // Create a chat datapoint
@@ -58,7 +57,7 @@ async fn test_delete_datapoints_single_chat() {
         snapshot_hash: None,
     });
 
-    clickhouse
+    database
         .insert_datapoints(&[datapoint_insert])
         .await
         .unwrap();
@@ -66,7 +65,7 @@ async fn test_delete_datapoints_single_chat() {
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Verify the datapoint exists
-    let datapoints = clickhouse
+    let datapoints = database
         .get_datapoints(&GetDatapointsParams {
             dataset_name: Some(dataset_name.clone()),
             function_name: None,
@@ -101,7 +100,7 @@ async fn test_delete_datapoints_single_chat() {
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Verify the datapoint is now stale (doesn't show up in normal queries)
-    let datapoints = clickhouse
+    let datapoints = database
         .get_datapoints(&GetDatapointsParams {
             dataset_name: Some(dataset_name.clone()),
             function_name: None,
@@ -118,7 +117,7 @@ async fn test_delete_datapoints_single_chat() {
     assert_eq!(datapoints.len(), 0, "Deleted datapoint should not appear");
 
     // Verify we can still fetch it with allow_stale=true
-    let stale_datapoints = clickhouse
+    let stale_datapoints = database
         .get_datapoints(&GetDatapointsParams {
             dataset_name: Some(dataset_name.clone()),
             function_name: None,
@@ -143,9 +142,8 @@ async fn test_delete_datapoints_single_chat() {
 
 #[tokio::test]
 async fn test_delete_datapoints_multiple_mixed() {
-    skip_for_postgres!();
     let http_client = Client::new();
-    let clickhouse = get_clickhouse().await;
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
     let dataset_name = format!("test-delete-dp-multiple-{}", Uuid::now_v7());
 
     // Create multiple datapoints: 2 chat and 1 JSON
@@ -245,7 +243,7 @@ async fn test_delete_datapoints_multiple_mixed() {
         snapshot_hash: None,
     });
 
-    clickhouse
+    database
         .insert_datapoints(&[chat_insert1, chat_insert2, json_insert])
         .await
         .unwrap();
@@ -271,7 +269,7 @@ async fn test_delete_datapoints_multiple_mixed() {
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Verify all are now stale
-    let datapoints = clickhouse
+    let datapoints = database
         .get_datapoints(&GetDatapointsParams {
             dataset_name: Some(dataset_name.clone()),
             function_name: None,
@@ -294,7 +292,6 @@ async fn test_delete_datapoints_multiple_mixed() {
 
 #[tokio::test]
 async fn test_delete_datapoints_empty_ids_list() {
-    skip_for_postgres!();
     let http_client = Client::new();
     let dataset_name = format!("test-delete-dp-empty-{}", Uuid::now_v7());
 
@@ -313,9 +310,8 @@ async fn test_delete_datapoints_empty_ids_list() {
 
 #[tokio::test]
 async fn test_delete_datapoints_non_existent_id() {
-    skip_for_postgres!();
     let http_client = Client::new();
-    let clickhouse = get_clickhouse().await;
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
     let dataset_name = format!("test-delete-dp-non-existent-{}", Uuid::now_v7());
 
     // Create one datapoint
@@ -351,7 +347,7 @@ async fn test_delete_datapoints_non_existent_id() {
         snapshot_hash: None,
     });
 
-    clickhouse
+    database
         .insert_datapoints(&[datapoint_insert])
         .await
         .unwrap();
@@ -377,7 +373,7 @@ async fn test_delete_datapoints_non_existent_id() {
     assert_eq!(delete_response.num_deleted_datapoints, 1);
 
     // Verify the existing datapoint was deleted.
-    let datapoints = clickhouse
+    let datapoints = database
         .get_datapoints(&GetDatapointsParams {
             dataset_name: Some(dataset_name.clone()),
             function_name: None,
@@ -396,7 +392,6 @@ async fn test_delete_datapoints_non_existent_id() {
 
 #[tokio::test]
 async fn test_delete_datapoints_invalid_dataset_name() {
-    skip_for_postgres!();
     let http_client = Client::new();
     let datapoint_id = Uuid::now_v7();
 
@@ -418,7 +413,6 @@ async fn test_delete_datapoints_invalid_dataset_name() {
 
 #[tokio::test]
 async fn test_delete_datapoints_from_empty_dataset() {
-    skip_for_postgres!();
     let http_client = Client::new();
     let dataset_name = format!("test-delete-dp-empty-dataset-{}", Uuid::now_v7());
     let non_existent_id = Uuid::now_v7();
@@ -443,9 +437,8 @@ async fn test_delete_datapoints_from_empty_dataset() {
 
 #[tokio::test]
 async fn test_delete_datapoints_already_stale() {
-    skip_for_postgres!();
     let http_client = Client::new();
-    let clickhouse = get_clickhouse().await;
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
     let dataset_name = format!("test-delete-dp-already-stale-{}", Uuid::now_v7());
 
     // Create a datapoint
@@ -481,7 +474,7 @@ async fn test_delete_datapoints_already_stale() {
         snapshot_hash: None,
     });
 
-    clickhouse
+    database
         .insert_datapoints(&[datapoint_insert])
         .await
         .unwrap();

--- a/tensorzero-core/tests/e2e/endpoints/datasets/get_datapoints.rs
+++ b/tensorzero-core/tests/e2e/endpoints/datasets/get_datapoints.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 use tensorzero::GetDatapointsRequest;
 use uuid::Uuid;
 
-use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
 use tensorzero_core::db::datasets::DatasetQueries;
+use tensorzero_core::db::delegating_connection::DelegatingDatabaseConnection;
 use tensorzero_core::db::stored_datapoint::{
     StoredChatInferenceDatapoint, StoredDatapoint, StoredJsonInferenceDatapoint,
 };
@@ -26,9 +26,8 @@ mod get_datapoints_tests {
 
     #[tokio::test]
     async fn test_get_datapoints_single_chat_datapoint_without_dataset_name() {
-        skip_for_postgres!();
         let http_client = Client::new();
-        let clickhouse = get_clickhouse().await;
+        let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
         let dataset_name = format!("test-get-dp-single-chat-{}", Uuid::now_v7());
 
         // Create a chat datapoint
@@ -72,7 +71,7 @@ mod get_datapoints_tests {
             snapshot_hash: None,
         });
 
-        clickhouse
+        database
             .insert_datapoints(&[datapoint_insert])
             .await
             .unwrap();
@@ -112,9 +111,8 @@ mod get_datapoints_tests {
 
     #[tokio::test]
     async fn test_get_datapoints_single_chat_datapoint() {
-        skip_for_postgres!();
         let http_client = Client::new();
-        let clickhouse = get_clickhouse().await;
+        let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
         let dataset_name = format!("test-get-dp-single-chat-{}", Uuid::now_v7());
 
         // Create a chat datapoint
@@ -158,7 +156,7 @@ mod get_datapoints_tests {
             snapshot_hash: None,
         });
 
-        clickhouse
+        database
             .insert_datapoints(&[datapoint_insert])
             .await
             .unwrap();
@@ -200,9 +198,8 @@ mod get_datapoints_tests {
 
     #[tokio::test]
     async fn test_get_datapoints_single_json_datapoint() {
-        skip_for_postgres!();
         let http_client = Client::new();
-        let clickhouse = get_clickhouse().await;
+        let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
         let dataset_name = format!("test-get-dp-single-json-{}", Uuid::now_v7());
 
         // Create a JSON datapoint
@@ -249,7 +246,7 @@ mod get_datapoints_tests {
             snapshot_hash: None,
         });
 
-        clickhouse
+        database
             .insert_datapoints(&[datapoint_insert])
             .await
             .unwrap();
@@ -284,9 +281,8 @@ mod get_datapoints_tests {
 
     #[tokio::test]
     async fn test_get_datapoints_multiple_mixed_datapoints() {
-        skip_for_postgres!();
         let http_client = Client::new();
-        let clickhouse = get_clickhouse().await;
+        let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
         let dataset_name = format!("test-get-dp-multiple-{}", Uuid::now_v7());
 
         // Create multiple datapoints
@@ -386,7 +382,7 @@ mod get_datapoints_tests {
             snapshot_hash: None,
         });
 
-        clickhouse
+        database
             .insert_datapoints(&[chat_insert1, chat_insert2, json_insert])
             .await
             .unwrap();
@@ -429,9 +425,8 @@ mod get_datapoints_tests {
 
     #[tokio::test]
     async fn test_get_datapoints_with_non_existent_ids() {
-        skip_for_postgres!();
         let http_client = Client::new();
-        let clickhouse = get_clickhouse().await;
+        let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
         let dataset_name = format!("test-get-dp-non-existent-{}", Uuid::now_v7());
 
         // Create one datapoint
@@ -467,7 +462,7 @@ mod get_datapoints_tests {
             snapshot_hash: None,
         });
 
-        clickhouse
+        database
             .insert_datapoints(&[datapoint_insert])
             .await
             .unwrap();
@@ -501,9 +496,8 @@ mod get_datapoints_tests {
 
     #[tokio::test]
     async fn test_get_datapoints_returns_stale_datapoints() {
-        skip_for_postgres!();
         let http_client = Client::new();
-        let clickhouse = get_clickhouse().await;
+        let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
         let dataset_name = format!("test-get-dp-stale-{}", Uuid::now_v7());
 
         // Create a datapoint
@@ -539,7 +533,7 @@ mod get_datapoints_tests {
             snapshot_hash: None,
         });
 
-        clickhouse
+        database
             .insert_datapoints(&[datapoint_insert])
             .await
             .unwrap();
@@ -547,7 +541,7 @@ mod get_datapoints_tests {
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         // Mark it as stale
-        clickhouse
+        database
             .delete_datapoints(&dataset_name, Some(&[datapoint_id]))
             .await
             .unwrap();
@@ -578,9 +572,8 @@ mod get_datapoints_tests {
 
     #[tokio::test]
     async fn test_get_datapoints_empty_ids_list() {
-        skip_for_postgres!();
         let http_client = Client::new();
-        let clickhouse = get_clickhouse().await;
+        let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
         let dataset_name = format!("test-get-dp-empty-ids-list-{}", Uuid::now_v7());
 
         // Create a datapoint so we have a valid dataset name.
@@ -616,7 +609,7 @@ mod get_datapoints_tests {
             snapshot_hash: None,
         });
 
-        clickhouse
+        database
             .insert_datapoints(&[datapoint_insert])
             .await
             .unwrap();
@@ -641,11 +634,10 @@ mod get_datapoints_tests {
 
     #[tokio::test]
     async fn test_get_datapoints_invalid_uuid() {
-        skip_for_postgres!();
         // Create a valid dataset name so we have a valid dataset name.
         let dataset_name = format!("test-get-dp-invalid-uuid-{}", Uuid::now_v7());
         let http_client = Client::new();
-        let clickhouse = get_clickhouse().await;
+        let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
         // Create a datapoint so we have a valid dataset name.
         let datapoint_id = Uuid::now_v7();
@@ -680,7 +672,7 @@ mod get_datapoints_tests {
             snapshot_hash: None,
         });
 
-        clickhouse
+        database
             .insert_datapoints(&[datapoint_insert])
             .await
             .unwrap();
@@ -709,9 +701,8 @@ mod list_datapoints_tests {
 
     #[tokio::test]
     async fn test_list_datapoints_basic_pagination() {
-        skip_for_postgres!();
         let http_client = Client::new();
-        let clickhouse = get_clickhouse().await;
+        let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
         let dataset_name = format!("test-list-dp-pagination-{}", Uuid::now_v7());
 
         // Create 5 datapoints
@@ -749,7 +740,7 @@ mod list_datapoints_tests {
             }));
         }
 
-        clickhouse.insert_datapoints(&inserts).await.unwrap();
+        database.insert_datapoints(&inserts).await.unwrap();
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         // Test default pagination (limit: 20, offset: 0)
@@ -824,9 +815,8 @@ mod list_datapoints_tests {
 
     #[tokio::test]
     async fn test_list_datapoints_filter_by_function_name() {
-        skip_for_postgres!();
         let http_client = Client::new();
-        let clickhouse = get_clickhouse().await;
+        let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
         let dataset_name = format!("test-list-dp-function-{}", Uuid::now_v7());
 
         // Create datapoints with different function names
@@ -894,7 +884,7 @@ mod list_datapoints_tests {
             snapshot_hash: None,
         });
 
-        clickhouse
+        database
             .insert_datapoints(&[function1_insert, function2_insert])
             .await
             .unwrap();
@@ -938,9 +928,8 @@ mod list_datapoints_tests {
 
     #[tokio::test]
     async fn test_list_datapoints_filter_by_tags() {
-        skip_for_postgres!();
         let http_client = Client::new();
-        let clickhouse = get_clickhouse().await;
+        let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
         let dataset_name = format!("test-list-dp-tags-{}", Uuid::now_v7());
 
         // Create datapoints with different tags
@@ -1015,7 +1004,7 @@ mod list_datapoints_tests {
             snapshot_hash: None,
         });
 
-        clickhouse
+        database
             .insert_datapoints(&[datapoint1, datapoint2])
             .await
             .unwrap();
@@ -1071,9 +1060,8 @@ mod list_datapoints_tests {
 
     #[tokio::test]
     async fn test_list_datapoints_filter_by_time() {
-        skip_for_postgres!();
         let http_client = Client::new();
-        let clickhouse = get_clickhouse().await;
+        let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
         let dataset_name = format!("test-list-dp-time-{}", Uuid::now_v7());
 
         // Create a datapoint
@@ -1109,7 +1097,7 @@ mod list_datapoints_tests {
             snapshot_hash: None,
         });
 
-        clickhouse.insert_datapoints(&[datapoint]).await.unwrap();
+        database.insert_datapoints(&[datapoint]).await.unwrap();
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         // Filter with time before (should not return the datapoint)
@@ -1162,9 +1150,8 @@ mod list_datapoints_tests {
 
     #[tokio::test]
     async fn test_list_datapoints_complex_filters() {
-        skip_for_postgres!();
         let http_client = Client::new();
-        let clickhouse = get_clickhouse().await;
+        let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
         let dataset_name = format!("test-list-dp-complex-{}", Uuid::now_v7());
 
         // Create datapoints with various tags
@@ -1276,7 +1263,7 @@ mod list_datapoints_tests {
             snapshot_hash: None,
         });
 
-        clickhouse
+        database
             .insert_datapoints(&[datapoint1, datapoint2, datapoint3])
             .await
             .unwrap();
@@ -1354,7 +1341,6 @@ mod list_datapoints_tests {
 
     #[tokio::test]
     async fn test_list_datapoints_empty_dataset() {
-        skip_for_postgres!();
         let http_client = Client::new();
         let dataset_name = format!("test-list-dp-empty-{}", Uuid::now_v7());
 
@@ -1376,9 +1362,8 @@ mod list_datapoints_tests {
 
     #[tokio::test]
     async fn test_list_datapoints_does_not_return_stale() {
-        skip_for_postgres!();
         let http_client = Client::new();
-        let clickhouse = get_clickhouse().await;
+        let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
         let dataset_name = format!("test-list-dp-no-stale-{}", Uuid::now_v7());
 
         // Create a datapoint
@@ -1414,7 +1399,7 @@ mod list_datapoints_tests {
             snapshot_hash: None,
         });
 
-        clickhouse.insert_datapoints(&[datapoint]).await.unwrap();
+        database.insert_datapoints(&[datapoint]).await.unwrap();
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         // Verify it's returned before staling
@@ -1434,7 +1419,7 @@ mod list_datapoints_tests {
         assert_eq!(datapoints[0]["id"], datapoint_id.to_string());
 
         // Mark it as stale
-        clickhouse
+        database
             .delete_datapoints(&dataset_name, Some(&[datapoint_id]))
             .await
             .unwrap();
@@ -1459,9 +1444,8 @@ mod list_datapoints_tests {
 
     #[tokio::test]
     async fn test_list_datapoints_mixed_chat_and_json() {
-        skip_for_postgres!();
         let http_client = Client::new();
-        let clickhouse = get_clickhouse().await;
+        let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
         let dataset_name = format!("test-list-dp-mixed-{}", Uuid::now_v7());
 
         // Create both chat and JSON datapoints
@@ -1528,7 +1512,7 @@ mod list_datapoints_tests {
             snapshot_hash: None,
         });
 
-        clickhouse
+        database
             .insert_datapoints(&[chat_insert, json_insert])
             .await
             .unwrap();
@@ -1567,9 +1551,8 @@ mod list_datapoints_tests {
 
     #[tokio::test]
     async fn test_list_datapoints_with_large_limit() {
-        skip_for_postgres!();
         let http_client = Client::new();
-        let clickhouse = get_clickhouse().await;
+        let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
         let dataset_name = format!("test-list-dp-large-page-{}", Uuid::now_v7());
 
         // Create 3 datapoints
@@ -1607,7 +1590,7 @@ mod list_datapoints_tests {
             }));
         }
 
-        clickhouse.insert_datapoints(&inserts).await.unwrap();
+        database.insert_datapoints(&inserts).await.unwrap();
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         // Request with limit larger than available datapoints

--- a/tensorzero-core/tests/e2e/endpoints/datasets/list_datasets.rs
+++ b/tensorzero-core/tests/e2e/endpoints/datasets/list_datasets.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use tensorzero_core::config::snapshot::SnapshotHash;
 use uuid::Uuid;
 
-use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
 use tensorzero_core::db::datasets::DatasetQueries;
+use tensorzero_core::db::delegating_connection::DelegatingDatabaseConnection;
 use tensorzero_core::db::stored_datapoint::{StoredChatInferenceDatapoint, StoredDatapoint};
 use tensorzero_core::endpoints::datasets::v1::types::ListDatasetsResponse;
 use tensorzero_core::inference::types::{
@@ -16,9 +16,8 @@ use crate::common::get_gateway_endpoint;
 
 #[tokio::test]
 async fn test_list_datasets_no_params() {
-    skip_for_postgres!();
     let http_client = Client::new();
-    let clickhouse = get_clickhouse().await;
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
     // Create a test dataset with a datapoint
     let dataset_name = format!("test-list-datasets-{}", Uuid::now_v7());
@@ -55,7 +54,7 @@ async fn test_list_datasets_no_params() {
         snapshot_hash: Some(SnapshotHash::new_test()),
     });
 
-    clickhouse
+    database
         .insert_datapoints(&[datapoint_insert])
         .await
         .unwrap();
@@ -107,9 +106,8 @@ async fn test_list_datasets_no_params() {
 
 #[tokio::test]
 async fn test_list_datasets_with_function_filter() {
-    skip_for_postgres!();
     let http_client = Client::new();
-    let clickhouse = get_clickhouse().await;
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
     // Create two datasets with different functions
     let dataset_name_1 = format!("test-list-func-1-{}", Uuid::now_v7());
@@ -171,7 +169,7 @@ async fn test_list_datasets_with_function_filter() {
         snapshot_hash: Some(SnapshotHash::new_test()),
     });
 
-    clickhouse
+    database
         .insert_datapoints(&[datapoint_1, datapoint_2])
         .await
         .unwrap();
@@ -240,9 +238,8 @@ async fn test_list_datasets_with_function_filter() {
 
 #[tokio::test]
 async fn test_list_datasets_with_pagination() {
-    skip_for_postgres!();
     let http_client = Client::new();
-    let clickhouse = get_clickhouse().await;
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
 
     // Create multiple datasets to test pagination
     let mut dataset_names = Vec::new();
@@ -282,7 +279,7 @@ async fn test_list_datasets_with_pagination() {
         datapoints.push(datapoint);
     }
 
-    clickhouse.insert_datapoints(&datapoints).await.unwrap();
+    database.insert_datapoints(&datapoints).await.unwrap();
 
     // Wait for all datasets to be visible
     let mut all_found = false;
@@ -361,7 +358,6 @@ async fn test_list_datasets_with_pagination() {
 
 #[tokio::test]
 async fn test_list_datasets_empty_result() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     // Filter by a function that doesn't exist


### PR DESCRIPTION
Step towards #5691.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches dataset endpoint wiring and Postgres datapoint serialization/parsing (notably `staled_at` datetime and tag null/empty behavior), which could change API-visible results and data written to Postgres alongside ClickHouse.
> 
> **Overview**
> **Routes dataset endpoint DB access through `DelegatingDatabaseConnection`** so `/v1/datasets/.../from_inferences` and `/v1/datasets/.../datapoints/metadata` operate against the ClickHouse+Postgres delegating layer rather than ClickHouse-only.
> 
> **Improves Postgres dataset compatibility** by parsing ClickHouse-formatted datetime strings for `staled_at` using an explicit `%Y-%m-%d %H:%M:%S%.6f` parser (with a unit test), and by always returning `tags` as `Some(map)` even when empty.
> 
> **Enables Postgres in dataset E2E coverage** by adding `DelegatingDatabaseConnection::new_for_e2e_test()` plus `TestDatabaseHelpers` support, then updating dataset endpoint E2E tests to use the delegating DB (removing ClickHouse-only setup, skip guards, and a couple of ClickHouse-specific assertions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ae41e215093c8d1cf4c55b131c2dbd6144dc757. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->