### PR TITLE
Add ErrorBoundary to datasets list page

### DIFF
--- a/ui/app/routes/datasets/route.tsx
+++ b/ui/app/routes/datasets/route.tsx
@@ -1,7 +1,6 @@
 import type { Route } from "./+types/route";
 import DatasetTable from "./DatasetTable";
-import { data } from "react-router";
-import { useNavigate } from "react-router";
+import { data, useNavigate } from "react-router";
 import {
   PageHeader,
   PageLayout,
@@ -9,6 +8,7 @@ import {
 } from "~/components/layout/PageLayout";
 import { DatasetsActions } from "./DatasetsActions";
 import { getTensorZeroClient } from "~/utils/tensorzero.server";
+import { LayoutErrorBoundary } from "~/components/ui/error";
 
 export async function loader() {
   const dataPromise = getTensorZeroClient()
@@ -52,4 +52,8 @@ export default function DatasetListPage({ loaderData }: Route.ComponentProps) {
       </SectionLayout>
     </PageLayout>
   );
+}
+
+export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  return <LayoutErrorBoundary error={error} />;
 }


### PR DESCRIPTION
## Summary

The datasets list page already has good Suspense patterns:
- `DatasetTable` uses Suspense/Await with skeleton and error state
- `PageCount` handles count promises with Suspense

This PR adds the missing route-level `ErrorBoundary` for handling unexpected errors, completing the progressive loading pattern.

## Test plan

- [ ] Navigate to /datasets and verify existing behavior unchanged
- [ ] Verify route-level errors are handled gracefully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a route-level error boundary wrapper without changing data fetching or mutation logic; behavior changes only when unexpected route errors occur.
> 
> **Overview**
> Adds a route-level `ErrorBoundary` to the datasets list route so unexpected loader/action/render errors are handled via the shared `LayoutErrorBoundary` UI.
> 
> Also consolidates the `react-router` imports (`data` and `useNavigate`) into a single statement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33b3ecffa9d0bce7795553535a3ce58622ec30bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->