### PR TITLE
Add ErrorBoundary to inferences list page

### DIFF
--- a/ui/app/routes/observability/inferences/route.tsx
+++ b/ui/app/routes/observability/inferences/route.tsx
@@ -8,6 +8,7 @@ import {
   PageLayout,
   SectionLayout,
 } from "~/components/layout/PageLayout";
+import { LayoutErrorBoundary } from "~/components/ui/error";
 import type { InferenceFilter, InferenceMetadata } from "~/types/tensorzero";
 import { getTensorZeroClient } from "~/utils/tensorzero.server";
 import { applyPaginationLogic } from "~/utils/pagination";
@@ -147,4 +148,8 @@ export default function InferencesPage({ loaderData }: Route.ComponentProps) {
       </SectionLayout>
     </PageLayout>
   );
+}
+
+export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  return <LayoutErrorBoundary error={error} />;
 }


### PR DESCRIPTION
## Summary

The inferences list page already has good Suspense patterns:
- `InferencesTable` uses Suspense/Await with skeleton rows and error state
- Pagination buttons have their own Suspense/Await
- `PageCount` handles count promises with Suspense

This PR adds the missing route-level `ErrorBoundary` for handling unexpected errors, completing the progressive loading pattern.

## Test plan

- [ ] Navigate to /observability/inferences and verify existing behavior unchanged
- [ ] Verify route-level errors are handled gracefully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change that only affects how unexpected route errors are displayed; no changes to data fetching logic or APIs.
> 
> **Overview**
> Adds a route-level `ErrorBoundary` to the `/observability/inferences` list page by rendering the shared `LayoutErrorBoundary`, so uncaught loader/render errors surface in a consistent, user-friendly layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ce4c3e5ef0538c4db411ca0a7f68c8d2657cee2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->