### PR TITLE
Bump bytes to 1.11.1 for RUSTSEC-2026-0007

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,9 +1126,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -23,9 +23,6 @@ multiple-versions = "allow"
 [advisories]
 ignore = [
     "RUSTSEC-2024-0436", # We don't care that 'paste' is unmaintained
-    "RUSTSEC-2025-0057", # fxhash is unmaintained, used by rlt crate
-    "RUSTSEC-2024-0370", # proc-macro-error is unmaintained, used by rlt crate
-    "RUSTSEC-2025-0134", # rustls-pemfile is unmaintained, used by google-cloud-auth crate
 ]
 
 [licenses]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk dependency/config-only change; behavior impact is limited to the `bytes` crate patch update and cargo-deny advisory reporting.
> 
> **Overview**
> Bumps the `bytes` crate from `1.11.0` to `1.11.1` in `Cargo.lock` (addressing `RUSTSEC-2026-0007`).
> 
> Updates `deny.toml` to stop ignoring several RustSec advisories, tightening `cargo-deny` checks so those issues are reported again.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d379f03f9dcab42e8bb6d685d85ef76e7ae82b47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->