### PR TITLE
Convert autopilot sessions from use() to Await with error handling

### DIFF
--- a/ui/app/routes/autopilot/sessions/route.tsx
+++ b/ui/app/routes/autopilot/sessions/route.tsx
@@ -1,14 +1,7 @@
-import { AlertCircle, Plus } from "lucide-react";
+import { Plus } from "lucide-react";
 import { Suspense } from "react";
 import type { Route } from "./+types/route";
-import {
-  Await,
-  data,
-  isRouteErrorResponse,
-  useAsyncError,
-  useLocation,
-  useNavigate,
-} from "react-router";
+import { Await, data, useLocation, useNavigate } from "react-router";
 import { useTensorZeroStatusFetcher } from "~/routes/api/tensorzero/status";
 import {
   PageHeader,
@@ -25,6 +18,7 @@ import type { Session } from "~/types/tensorzero";
 import { Skeleton } from "~/components/ui/skeleton";
 import {
   Table,
+  TableAsyncErrorState,
   TableBody,
   TableCell,
   TableHead,
@@ -102,26 +96,6 @@ function SkeletonRows() {
   );
 }
 
-function TableErrorState() {
-  const error = useAsyncError();
-  let message = "Failed to load sessions";
-  if (isRouteErrorResponse(error)) {
-    message = typeof error.data === "string" ? error.data : message;
-  } else if (error instanceof Error) {
-    message = error.message;
-  }
-  return (
-    <TableRow>
-      <TableCell colSpan={2}>
-        <div className="flex items-center justify-center gap-2 py-8 text-red-600">
-          <AlertCircle className="h-4 w-4" />
-          <span>{message}</span>
-        </div>
-      </TableCell>
-    </TableRow>
-  );
-}
-
 export default function AutopilotSessionsPage({
   loaderData,
 }: Route.ComponentProps) {
@@ -171,7 +145,15 @@ export default function AutopilotSessionsPage({
           </TableHeader>
           <TableBody>
             <Suspense key={location.search} fallback={<SkeletonRows />}>
-              <Await resolve={sessionsData} errorElement={<TableErrorState />}>
+              <Await
+                resolve={sessionsData}
+                errorElement={
+                  <TableAsyncErrorState
+                    colSpan={3}
+                    defaultMessage="Failed to load sessions"
+                  />
+                }
+              >
                 {({ sessions }) => (
                   <SessionsTableRows
                     sessions={sessions}


### PR DESCRIPTION
## Summary
- Replace React's `use()` hook with React Router's `<Await>` component
- Add `errorElement` for section-level error handling
- Display user-friendly error message in table when sessions fail to load

This provides consistent error handling patterns across the codebase.

<img width="1148" height="982" alt="Screenshot 2026-02-03 at 6 12 05 PM" src="https://github.com/user-attachments/assets/1fa5895d-5872-40a5-be25-77aa9f0d49f6" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only refactor that changes how the sessions promise is resolved and how load failures are displayed; low risk aside from potential differences in error/suspense rendering behavior.
> 
> **Overview**
> Updates the Autopilot Sessions list to stop using React’s `use()` for resolving loader promises and instead render session rows and pagination via React Router’s `<Await>`.
> 
> Adds section-level async error handling: session-load failures now render a `TableAsyncErrorState` message in the table, and pagination falls back to disabled `PageButtons` on error, while keeping the existing skeleton loading UX.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e2414c07942086622834da6b58d55ef4875e204. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->