### PR TITLE
Add getErrorMessage utility for consistent error handling

### DIFF
--- a/ui/app/components/ui/error/ErrorContentPrimitives.tsx
+++ b/ui/app/components/ui/error/ErrorContentPrimitives.tsx
@@ -7,12 +7,16 @@ import { cn } from "~/utils/common";
 /**
  * Extracts a user-friendly message from an error of any type.
  * Handles React Router's route error responses, standard Errors, and unknown types.
- *
- * @param error - The error to extract a message from (typically from useAsyncError())
- * @param fallback - Default message if error type is unrecognized
- * @returns A string message suitable for display to users
  */
-export function getErrorMessage(error: unknown, fallback: string): string {
+export function getErrorMessage({
+  error,
+  fallback,
+}: {
+  /** The error to extract a message from (typically from useAsyncError()) */
+  error: unknown;
+  /** Default message if error type is unrecognized */
+  fallback: string;
+}): string {
   if (isRouteErrorResponse(error)) {
     return typeof error.data === "string"
       ? error.data
@@ -246,7 +250,7 @@ export function SectionAsyncErrorState({
     <SectionErrorNotice
       icon={AlertCircle}
       title="Error loading data"
-      description={getErrorMessage(error, defaultMessage)}
+      description={getErrorMessage({ error, fallback: defaultMessage })}
     />
   );
 }


### PR DESCRIPTION
## Summary

- Adds a `getErrorMessage(error, fallback)` utility function to `ErrorContentPrimitives.tsx` for extracting user-friendly messages from errors of any type
- Handles React Router route error responses, standard Errors, and unknown error types consistently
- Refactors `SectionAsyncErrorState` to use the new utility

This utility simplifies error handling across async error components by providing a single source of truth for error message extraction logic. This pattern will be reused in many places and worth consolidating.

## Test plan

- [ ] Verify `pnpm typecheck` passes
- [ ] Verify error messages display correctly in error states

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to UI error rendering; behavior should remain the same aside from more consistent handling of unknown error shapes.
> 
> **Overview**
> Introduces a shared `getErrorMessage` helper in `ErrorContentPrimitives.tsx` to consistently derive a user-facing message from React Router route errors, `Error` instances, or unknown values.
> 
> Refactors `SectionAsyncErrorState` to use this helper instead of duplicating message-extraction logic inline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3433c8a109d7331fa9abdcad528a54fa217e41a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->