### PR TITLE
Add cursor-pointer to model selector menu items

### DIFF
--- a/ui/app/components/ui/combobox/ComboboxMenuItems.tsx
+++ b/ui/app/components/ui/combobox/ComboboxMenuItems.tsx
@@ -37,7 +37,7 @@ export function ComboboxMenuItems({
           <CommandItem
             value={`create-${searchValue.trim()}`}
             onSelect={() => onSelectItem(searchValue.trim(), true)}
-            className="flex cursor-pointer items-center gap-2"
+            className="flex items-center gap-2"
           >
             {getPrefix?.(null, false)}
             <span className="truncate font-mono" title={searchValue.trim()}>
@@ -55,7 +55,7 @@ export function ComboboxMenuItems({
                 key={item.value}
                 value={item.value}
                 onSelect={() => onSelectItem(item.value, false)}
-                className="group flex w-full cursor-pointer items-center gap-2"
+                className="group flex w-full items-center gap-2"
                 {...getItemDataAttributes?.(item.value)}
               >
                 <div className="flex min-w-0 flex-1 items-center gap-2">

--- a/ui/app/components/ui/command.tsx
+++ b/ui/app/components/ui/command.tsx
@@ -113,7 +113,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "group data-[selected=true]:bg-menu-highlight data-[selected=true]:text-menu-highlight-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "group data-[selected=true]:bg-menu-highlight data-[selected=true]:text-menu-highlight-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       className,
     )}
     {...props}

--- a/ui/app/routes/optimization/supervised-fine-tuning/ModelSelector.tsx
+++ b/ui/app/routes/optimization/supervised-fine-tuning/ModelSelector.tsx
@@ -307,7 +307,7 @@ export function ModelSelector({
                               <CommandItem
                                 value={`custom::${searchValue}`}
                                 onSelect={handleSelectCustom}
-                                className="flex cursor-pointer items-center justify-between gap-2"
+                                className="flex items-center justify-between gap-2"
                               >
                                 <span className="min-w-0 truncate font-mono text-sm">
                                   {searchValue}
@@ -334,7 +334,7 @@ export function ModelSelector({
                               <CommandItem
                                 value={`custom::${field.value.name}`}
                                 onSelect={() => setOpen(false)}
-                                className="flex cursor-pointer items-center justify-between gap-2"
+                                className="flex items-center justify-between gap-2"
                               >
                                 <span className="min-w-0 truncate font-mono text-sm">
                                   {field.value.displayName}
@@ -374,7 +374,7 @@ export function ModelSelector({
                                   key={`${model.provider}::${model.name}`}
                                   value={`${model.provider}::${model.name}`}
                                   onSelect={() => handleSelect(model)}
-                                  className="flex cursor-pointer items-center justify-between"
+                                  className="flex items-center justify-between"
                                 >
                                   <span className="font-mono text-sm">
                                     {model.displayName}


### PR DESCRIPTION
## Summary
- Add cursor-pointer to model selector CommandItem elements for better UX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change that adjusts cursor behavior on interactive menu items; no business logic or data handling changes.
> 
> **Overview**
> Improves menu UX by making `CommandItem` render with `cursor-pointer` by default in `ui/app/components/ui/command.tsx`.
> 
> Removes redundant `cursor-pointer` classes from `ComboboxMenuItems` so combobox/create entries inherit the default cursor styling consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 570881fc9a71982e5897f87dd15995a4e04ea8fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->