### PR TITLE
made the edit payloads in config writes a Vec

### DIFF
--- a/internal/autopilot-tools/src/tools/prod/write_config.rs
+++ b/internal/autopilot-tools/src/tools/prod/write_config.rs
@@ -28,8 +28,9 @@ pub struct WriteConfigToolParams {
     /// Templates that should be stored with the config.
     #[serde(default)]
     pub extra_templates: HashMap<String, String>,
-    /// Only set if the config write is an upsert to a single TOML entry (so that we can add nice edit handling)
-    pub edit: Option<EditPayload>,
+    /// We could have consolidated an array of server-side edits into one client-side edit, so this type contains a Vec
+    /// Unset means an older API. This should always be set and we should make it mandatory once upstream merges.
+    pub edit: Option<Vec<EditPayload>>,
 }
 
 #[derive(Clone, Debug, Serialize, TensorZeroDeserialize, JsonSchema)]


### PR DESCRIPTION
One `write_config` call might be downstream of many edit operations. 
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 1464cc6f1e63f6b578324ac73b039af85219b58d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->