### PR TITLE
Auto-focus message input on new autopilot session page

### DIFF
--- a/ui/app/components/autopilot/ChatInput.tsx
+++ b/ui/app/components/autopilot/ChatInput.tsx
@@ -70,6 +70,14 @@ export function ChatInput({
     previousUserMessageEventIdRef.current = undefined;
   }, [sessionId]);
 
+  // Auto-focus textarea when navigating to new session page
+  // Wait for disabled state to clear before focusing
+  useEffect(() => {
+    if (isNewSession && !disabled && textareaRef.current) {
+      textareaRef.current.focus();
+    }
+  }, [isNewSession, disabled]);
+
   // Sample a random placeholder for new sessions, default for existing sessions
   const placeholder = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- Auto-focuses the message input textarea when navigating to `/autopilot/sessions/new`
- Waits for disabled state to clear before focusing to handle race conditions

Closes #5716

## Test plan
- [x] Navigate to `/autopilot/sessions/new` and verify cursor is in textarea
- [x] Verified via Chrome DevTools snapshot: textarea shows `focused` attribute

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a focus side effect when `isNewSession` becomes true and the input is enabled; no data flow or API behavior changes.
> 
> **Overview**
> Automatically focuses the `ChatInput` textarea when navigating to a *new* autopilot session (`isNewSession`), waiting until the input is no longer `disabled` before calling `.focus()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6b4017365cc834595a09c086c1924abdae009f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->