### PR TITLE
Fix send button hover state when disabled

### DIFF
--- a/ui/app/components/autopilot/ChatInput.tsx
+++ b/ui/app/components/autopilot/ChatInput.tsx
@@ -211,10 +211,11 @@ export function ChatInput({
           disabled={!canSend}
           className={cn(
             "absolute right-2 bottom-1",
-            "flex h-9 w-9 cursor-pointer items-center justify-center rounded-md",
-            "text-fg-primary hover:text-fg-secondary",
-            "disabled:cursor-not-allowed disabled:opacity-50",
-            "transition-colors",
+            "flex h-9 w-9 items-center justify-center rounded-md",
+            "text-fg-primary transition-colors",
+            canSend
+              ? "hover:text-fg-secondary cursor-pointer"
+              : "cursor-not-allowed opacity-50",
           )}
           aria-label="Send message"
         >


### PR DESCRIPTION
## Summary
Fix the send button hover state - previously hover styles were applied even when the button was disabled.

## Changes
Use conditional styling to only apply `hover:text-fg-secondary` when the button is enabled (`canSend`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that only adjusts Tailwind class composition for the send button; no behavior, data, or API flow changes.
> 
> **Overview**
> Fixes the chat send button styling so hover/cursor styles only apply when the button is actually enabled.
> 
> Updates `ChatInput` to conditionally apply `hover:text-fg-secondary` and pointer cursor based on `canSend`, while using non-interactive cursor/opacity styles when disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8650cbb150a3e827710c14e0e69f9f1d81eba467. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->