### PR TITLE
Add deduplication tests for tool call authorization

### DIFF
--- a/ui/e2e_tests/autopilot/autopilot.spec.ts
+++ b/ui/e2e_tests/autopilot/autopilot.spec.ts
@@ -143,12 +143,20 @@ test.describe("Tool call authorization deduplication", () => {
     const approveButton = page.getByRole("button", { name: "Approve" }).first();
     await expect(approveButton).toBeVisible({ timeout: 60000 });
 
-    // Spam-click the button rapidly using force to bypass stability checks
-    // (button may be removed/disabled after first click)
+    // Get button position before clicking - use mouse.click at fixed coordinates
+    // to avoid flakiness if the button is removed/disabled after first click
+    const boundingBox = await approveButton.boundingBox();
+    if (!boundingBox) {
+      throw new Error("Approve button bounding box not found");
+    }
+    const clickX = boundingBox.x + boundingBox.width / 2;
+    const clickY = boundingBox.y + boundingBox.height / 2;
+
+    // Spam-click at the fixed position rapidly
     await Promise.all([
-      approveButton.click({ force: true, noWaitAfter: true }),
-      approveButton.click({ force: true, noWaitAfter: true }),
-      approveButton.click({ force: true, noWaitAfter: true }),
+      page.mouse.click(clickX, clickY),
+      page.mouse.click(clickX, clickY),
+      page.mouse.click(clickX, clickY),
     ]);
 
     // Wait for request to complete
@@ -211,12 +219,20 @@ test.describe("Tool call authorization deduplication", () => {
       .first();
     await expect(confirmButton).toBeVisible();
 
-    // Spam-click the button rapidly using force to bypass stability checks
-    // (button may be removed/disabled after first click)
+    // Get button position before clicking - use mouse.click at fixed coordinates
+    // to avoid flakiness if the button is removed/disabled after first click
+    const boundingBox = await confirmButton.boundingBox();
+    if (!boundingBox) {
+      throw new Error("Confirm rejection button bounding box not found");
+    }
+    const clickX = boundingBox.x + boundingBox.width / 2;
+    const clickY = boundingBox.y + boundingBox.height / 2;
+
+    // Spam-click at the fixed position rapidly
     await Promise.all([
-      confirmButton.click({ force: true, noWaitAfter: true }),
-      confirmButton.click({ force: true, noWaitAfter: true }),
-      confirmButton.click({ force: true, noWaitAfter: true }),
+      page.mouse.click(clickX, clickY),
+      page.mouse.click(clickX, clickY),
+      page.mouse.click(clickX, clickY),
     ]);
 
     // Wait for request to complete


### PR DESCRIPTION
## Summary

Adds e2e tests for tool call authorization deduplication.

Moved from tensorzero/autopilot#514.

## Tests Added

1. **spam-clicking Approve sends only one request** - Intercepts authorize API, rapid-clicks Approve button, verifies single request
2. **spam-clicking Reject sends only one request** - Same pattern for Reject → confirm flow

## Test plan

- [ ] CI passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only adds Playwright E2E coverage and does not change production logic; the main risk is increased E2E flakiness due to timing/UI interactions.
> 
> **Overview**
> Adds new Playwright E2E coverage to ensure tool-call authorization is **deduplicated** when users spam-click action buttons.
> 
> The tests intercept `POST **/events/authorize` and assert that rapid repeated clicks on **Approve** and **Reject → Confirm rejection** result in only a single request for the same `tool_call_event_id`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bd57b072e8281ec9604348c837e1ff5b353cd80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->