### PR TITLE
Bump to 2026.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,7 +334,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot-client"
-version = "2026.1.8"
+version = "2026.2.0"
 dependencies = [
  "chrono",
  "durable-tools-spawn",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-tools"
-version = "2026.1.8"
+version = "2026.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-worker"
-version = "2026.1.8"
+version = "2026.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools"
-version = "2026.1.8"
+version = "2026.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1946,7 +1946,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools-spawn"
-version = "2026.1.8"
+version = "2026.2.0"
 dependencies = [
  "async-trait",
  "durable",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2026.1.8"
+version = "2026.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2180,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2026.1.8"
+version = "2026.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2026.1.8"
+version = "2026.2.0"
 dependencies = [
  "async-stream",
  "autopilot-tools",
@@ -3673,7 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-utils"
-version = "2026.1.8"
+version = "2026.2.0"
 dependencies = [
  "minijinja",
  "serde",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2026.1.8"
+version = "2026.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5233,7 +5233,7 @@ dependencies = [
 
 [[package]]
 name = "reqwest-sse-stream"
-version = "2026.1.8"
+version = "2026.2.0"
 dependencies = [
  "async-stream",
  "futures",
@@ -6337,7 +6337,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2026.1.8"
+version = "2026.2.0"
 dependencies = [
  "axum",
  "chrono",
@@ -6357,7 +6357,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-core"
-version = "2026.1.8"
+version = "2026.2.0"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -6477,7 +6477,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2026.1.8"
+version = "2026.2.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -6490,7 +6490,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-optimizers"
-version = "2026.1.8"
+version = "2026.2.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -6524,7 +6524,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2026.1.8"
+version = "2026.2.0"
 dependencies = [
  "evaluations",
  "futures",
@@ -6542,7 +6542,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types"
-version = "2026.1.8"
+version = "2026.2.0"
 dependencies = [
  "aws-smithy-types",
  "infer",
@@ -6562,7 +6562,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types-providers"
-version = "2026.1.8"
+version = "2026.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6570,7 +6570,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-unsafe-helpers"
-version = "2026.1.8"
+version = "2026.2.0"
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2026.1.8"
+version = "2026.2.0"
 rust-version = "1.88.0"
 license = "Apache-2.0"
 edition = "2024"

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2026.1.8"
+appVersion: "2026.2.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "tensorzero-ui",
   "private": true,
   "type": "module",
-  "version": "2026.1.8",
+  "version": "2026.2.0",
   "scripts": {
     "build": "NODE_ENV=production react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version-bump-only change touching release metadata (Rust workspace, lockfile, Helm chart, and UI package version) with no functional code modifications.
> 
> **Overview**
> Bumps the project version to `2026.2.0` across the Rust workspace (`Cargo.toml` + `Cargo.lock`), the Helm production deployment chart (`Chart.yaml`), and the UI package (`ui/package.json`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36f5a536a6a90684aa3423e59a044044d2fc02f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->