### PR TITLE
Add snapshot_hash field to BatchRequestRow for ClickHouse

### DIFF
--- a/tensorzero-core/src/endpoints/batch_inference.rs
+++ b/tensorzero-core/src/endpoints/batch_inference.rs
@@ -773,6 +773,7 @@ async fn write_start_batch_inference<'a>(
         model_provider_name: &result.model_provider_name,
         status: BatchStatus::Pending,
         errors: result.errors,
+        snapshot_hash: Some(config.hash.clone()),
     });
     write_batch_request_row(clickhouse_connection_info, &batch_request_insert).await?;
 
@@ -888,6 +889,7 @@ async fn write_batch_request_status_update(
         model_provider_name: &batch_request.model_provider_name,
         status,
         errors: vec![], // TODO (#503): add better error handling
+        snapshot_hash: batch_request.snapshot_hash.clone(),
     });
     clickhouse_connection_info
         .write_batched(&[batch_request_insert], TableName::BatchRequest)

--- a/tensorzero-core/src/inference/types/batch.rs
+++ b/tensorzero-core/src/inference/types/batch.rs
@@ -8,6 +8,7 @@ use super::{
     chat_completion_inference_params::ServiceTier,
 };
 
+use crate::config::snapshot::SnapshotHash;
 use crate::inference::types::StoredRequestMessage;
 use crate::serde_util::deserialize_json_string;
 use crate::{
@@ -160,6 +161,8 @@ pub struct BatchRequestRow<'a> {
     pub function_name: Cow<'a, str>,
     pub variant_name: Cow<'a, str>,
     pub errors: Vec<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snapshot_hash: Option<SnapshotHash>,
 }
 
 #[derive(Debug)]
@@ -228,6 +231,7 @@ pub struct UnparsedBatchRequestRow<'a> {
     pub model_provider_name: &'a str,
     pub status: BatchStatus,
     pub errors: Vec<Value>,
+    pub snapshot_hash: Option<SnapshotHash>,
 }
 
 impl<'a> BatchRequestRow<'a> {
@@ -243,6 +247,7 @@ impl<'a> BatchRequestRow<'a> {
             model_provider_name,
             status,
             errors,
+            snapshot_hash,
         } = unparsed;
         let id = Uuid::now_v7();
         Self {
@@ -257,6 +262,7 @@ impl<'a> BatchRequestRow<'a> {
             model_provider_name: Cow::Borrowed(model_provider_name),
             status,
             errors,
+            snapshot_hash,
         }
     }
 }

--- a/tensorzero-core/tests/e2e/batch/mod.rs
+++ b/tensorzero-core/tests/e2e/batch/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use serde_json::json;
 use tensorzero_core::config::Config;
+use tensorzero_core::config::snapshot::SnapshotHash;
 use tensorzero_core::db::clickhouse::{ClickHouseConnectionInfo, TableName};
 use tensorzero_core::db::postgres::PostgresConnectionInfo;
 /// End-to-end tests for particular internal functionality in the batch inference endpoint
@@ -54,6 +55,7 @@ async fn test_get_batch_request() {
         model_provider_name,
         status: BatchStatus::Pending,
         errors: vec![],
+        snapshot_hash: None,
     });
     write_batch_request_row(&clickhouse, &batch_request)
         .await
@@ -136,6 +138,7 @@ async fn test_write_poll_batch_inference() {
     let raw_response = "raw response".to_string();
     let status = BatchStatus::Pending;
     let errors = vec![];
+    let snapshot_hash = SnapshotHash::new_test();
     let batch_request = BatchRequestRow::new(UnparsedBatchRequestRow {
         batch_id,
         batch_params: &batch_params,
@@ -147,6 +150,7 @@ async fn test_write_poll_batch_inference() {
         raw_response: &raw_response,
         status,
         errors,
+        snapshot_hash: Some(snapshot_hash.clone()),
     });
     let config = Config::new_empty()
         .await
@@ -190,6 +194,7 @@ async fn test_write_poll_batch_inference() {
         raw_response: &raw_response,
         status,
         errors: vec![],
+        snapshot_hash: Some(snapshot_hash.clone()),
     });
     let poll_inference_response = write_poll_batch_inference(
         &clickhouse,
@@ -345,6 +350,7 @@ async fn test_write_read_completed_batch_inference_chat() {
         raw_response: &raw_response,
         status,
         errors,
+        snapshot_hash: None,
     });
     let function_config = Arc::new(FunctionConfig::Chat(FunctionConfigChat {
         variants: HashMap::new(),
@@ -578,6 +584,7 @@ async fn test_write_read_completed_batch_inference_json() {
         model_provider_name,
         status,
         errors: vec![],
+        snapshot_hash: None,
     });
     let output_schema = JSONSchema::from_value(json!({
         "type": "object",

--- a/tensorzero-core/tests/e2e/db/batch_inference_queries.rs
+++ b/tensorzero-core/tests/e2e/db/batch_inference_queries.rs
@@ -35,6 +35,7 @@ async fn create_batch_request(
         raw_response: "{}",
         status: BatchStatus::Completed,
         errors: vec![],
+        snapshot_hash: None,
     });
     write_batch_request_row(clickhouse, &batch_request)
         .await


### PR DESCRIPTION
This was uncovered because we never ran tests with "batch" in the name for clickhouse in CI, only in cron.

`cargo nextest run -E 'test(test_write_poll_batch_inference)' --retries 0` now pass (it's failing at HEAD).

We need to refactor nextest profiles; TODO is tracked at https://github.com/tensorzero/tensorzero/issues/5862.

Store the config's snapshot hash when creating batch requests so that batch inference results can be associated with the config version that was used. This enables tracking which configuration was active when a batch was submitted.

- Add snapshot_hash field to BatchRequestRow and UnparsedBatchRequestRow
- Pass config.hash when creating new batch requests in write_start_batch_inference
- Preserve existing snapshot_hash when updating batch request status
- Update all test call sites with the new field