### PR TITLE
unflagged session cancellation; added a test

### DIFF
--- a/ui/app/context/feature-flags.tsx
+++ b/ui/app/context/feature-flags.tsx
@@ -15,13 +15,10 @@ import { createContext, use } from "react";
 export interface FeatureFlags {
   /** When TENSORZERO_UI_FORCE_CACHE_ON=1, sets `cache_options.enabled = "on"` on all inference calls */
   FORCE_CACHE_ON: boolean;
-  /** When TENSORZERO_UI_FF_INTERRUPT_SESSION=1, enables the interrupt session button in autopilot sessions */
-  FF_INTERRUPT_SESSION: boolean;
 }
 
 export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   FORCE_CACHE_ON: false,
-  FF_INTERRUPT_SESSION: false,
 };
 
 const FeatureFlagsContext = createContext<FeatureFlags>(DEFAULT_FEATURE_FLAGS);

--- a/ui/app/routes/autopilot/sessions/$session_id/route.tsx
+++ b/ui/app/routes/autopilot/sessions/$session_id/route.tsx
@@ -46,7 +46,6 @@ import type { AutopilotStatus, GatewayEvent } from "~/types/tensorzero";
 import { useToast } from "~/hooks/use-toast";
 import { LayoutErrorBoundary } from "~/components/ui/error/LayoutErrorBoundary";
 import { SectionErrorNotice } from "~/components/ui/error/ErrorContentPrimitives";
-import { useFeatureFlags } from "~/context/feature-flags";
 
 // Nil UUID for creating new sessions
 const NIL_UUID = "00000000-0000-0000-0000-000000000000";
@@ -600,12 +599,9 @@ function AutopilotSessionEventsPageContent({
     }
   }, [interruptFetcher.state, interruptFetcher.data, toast, sessionId]);
 
-  // Interruptible when actively processing (not idle or failed) and feature flag is enabled
-  const { FF_INTERRUPT_SESSION } = useFeatureFlags();
+  // Interruptible when actively processing (not idle or failed)
   const isInterruptible =
-    FF_INTERRUPT_SESSION &&
-    autopilotStatus.status !== "idle" &&
-    autopilotStatus.status !== "failed";
+    autopilotStatus.status !== "idle" && autopilotStatus.status !== "failed";
 
   // Disable submit unless status is idle or failed
   const submitDisabled =

--- a/ui/app/utils/feature_flags.server.ts
+++ b/ui/app/utils/feature_flags.server.ts
@@ -17,8 +17,6 @@ export type { FeatureFlags } from "~/context/feature-flags";
 export function loadFeatureFlags(): FeatureFlags {
   return {
     FORCE_CACHE_ON: process.env.TENSORZERO_UI_FORCE_CACHE_ON === "1",
-    FF_INTERRUPT_SESSION:
-      process.env.TENSORZERO_UI_FF_INTERRUPT_SESSION === "1",
   };
 }
 

--- a/ui/e2e_tests/autopilot/autopilot.spec.ts
+++ b/ui/e2e_tests/autopilot/autopilot.spec.ts
@@ -1,4 +1,70 @@
 import { test, expect } from "@playwright/test";
+import { v7 } from "uuid";
+
+test("should interrupt an active session", async ({ page }) => {
+  // Increase timeout for this test since it involves LLM responses
+  test.setTimeout(120000);
+
+  // Navigate to autopilot sessions
+  await page.goto("/autopilot/sessions");
+
+  // Wait for the page to load
+  await expect(
+    page.getByRole("heading", { name: "Autopilot Sessions" }),
+  ).toBeVisible();
+
+  // Click to create a new session
+  await page.getByRole("button", { name: /new session/i }).click();
+
+  // Wait for the new session page
+  await expect(page).toHaveURL(/\/autopilot\/sessions\/new/);
+
+  // Find the message textarea and type a message that will trigger tool calls
+  const messageInput = page.getByRole("textbox");
+  // We randomize this message so it misses the provider proxy cache and we have time to click the stop button
+  await messageInput.fill(
+    `What functions are available in my TensorZero config? ${v7()}`,
+  );
+
+  // Send the message
+  await page.getByRole("button", { name: "Send message" }).click();
+
+  // Wait for redirect to the actual session page
+  await expect(page).toHaveURL(/\/autopilot\/sessions\/[a-f0-9-]+$/, {
+    timeout: 30000,
+  });
+
+  // Wait for the stop button to appear (session is processing)
+  const stopButton = page.getByRole("button", {
+    name: /stop session/i,
+  });
+  await expect(stopButton).toBeVisible({ timeout: 30000 });
+
+  // Click the stop button
+  await stopButton.click();
+
+  // Verify the success toast appears
+  await expect(
+    page.getByRole("status").filter({ hasText: "Session interrupted" }),
+  ).toBeVisible({
+    timeout: 10000,
+  });
+
+  // Verify the status update message appears in the event stream
+  await expect(page.getByText("Interrupted session")).toBeVisible({
+    timeout: 10000,
+  });
+
+  // Verify the send button reappears after interruption (session returns to idle)
+  const sendButton = page.getByRole("button", { name: /send message/i });
+  await expect(sendButton).toBeVisible({ timeout: 30000 });
+
+  // Verify the status indicator shows "Ready" (which is the label for "idle" status)
+  await expect(page.getByText("Ready")).toBeVisible({ timeout: 10000 });
+
+  // Verify no error message is shown - the session should be cleanly idle, not failed
+  await expect(page.getByText("Something went wrong")).not.toBeVisible();
+});
 
 test("should create a session, send a message, approve tool calls, and get a response", async ({
   page,


### PR DESCRIPTION
Blocked on https://github.com/tensorzero/autopilot/pull/457


https://github.com/user-attachments/assets/8e32d6fc-ab51-4c48-af69-b96f9b9d6bf4


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes when users can interrupt running autopilot sessions (now always available when non-idle), which can affect in-flight session behavior and UX; also adds an e2e test that may be flaky due to timing/LLM variability.
> 
> **Overview**
> Autopilot session interruption is now **always enabled** when a session is actively processing (not `idle`/`failed`), removing the `FF_INTERRUPT_SESSION` feature flag and its `TENSORZERO_UI_FF_INTERRUPT_SESSION` env var wiring.
> 
> Adds a Playwright e2e test (`ui/e2e_tests/autopilot/autopilot.spec.ts`) that starts a new session, triggers processing with a randomized prompt, clicks *Stop session*, and asserts the interruption toast/event and return to the *Ready* state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35c42c6cb984ccf1d4f751a74564637782db7a1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->