### PR TITLE
Fix variant BasicInfo rendering '0' when numeric fields are zero

### DIFF
--- a/ui/app/routes/observability/functions/$function_name/variants/VariantBasicInfo.tsx
+++ b/ui/app/routes/observability/functions/$function_name/variants/VariantBasicInfo.tsx
@@ -64,7 +64,7 @@ export default function BasicInfo({
             </BasicInfoItemContent>
           </BasicInfoItem>
 
-          {variantConfig.temperature !== null && (
+          {variantConfig.temperature != null && (
             <BasicInfoItem>
               <BasicInfoItemTitle>Temperature</BasicInfoItemTitle>
               <BasicInfoItemContent>
@@ -73,7 +73,7 @@ export default function BasicInfo({
             </BasicInfoItem>
           )}
 
-          {variantConfig.top_p !== null && (
+          {variantConfig.top_p != null && (
             <BasicInfoItem>
               <BasicInfoItemTitle>Top P</BasicInfoItemTitle>
               <BasicInfoItemContent>
@@ -82,7 +82,7 @@ export default function BasicInfo({
             </BasicInfoItem>
           )}
 
-          {variantConfig.max_tokens !== null && (
+          {variantConfig.max_tokens != null && (
             <BasicInfoItem>
               <BasicInfoItemTitle>Max Tokens</BasicInfoItemTitle>
               <BasicInfoItemContent>
@@ -91,7 +91,7 @@ export default function BasicInfo({
             </BasicInfoItem>
           )}
 
-          {variantConfig.presence_penalty !== null && (
+          {variantConfig.presence_penalty != null && (
             <BasicInfoItem>
               <BasicInfoItemTitle>Presence Penalty</BasicInfoItemTitle>
               <BasicInfoItemContent>
@@ -100,7 +100,7 @@ export default function BasicInfo({
             </BasicInfoItem>
           )}
 
-          {variantConfig.frequency_penalty !== null && (
+          {variantConfig.frequency_penalty != null && (
             <BasicInfoItem>
               <BasicInfoItemTitle>Frequency Penalty</BasicInfoItemTitle>
               <BasicInfoItemContent>
@@ -109,7 +109,7 @@ export default function BasicInfo({
             </BasicInfoItem>
           )}
 
-          {variantConfig.seed !== null && (
+          {variantConfig.seed != null && (
             <BasicInfoItem>
               <BasicInfoItemTitle>Seed</BasicInfoItemTitle>
               <BasicInfoItemContent>
@@ -133,7 +133,7 @@ export default function BasicInfo({
                 </BasicInfoItemContent>
               </BasicInfoItem>
 
-              {config.evaluator.temperature !== null && (
+              {config.evaluator.temperature != null && (
                 <BasicInfoItem>
                   <BasicInfoItemTitle>Temperature</BasicInfoItemTitle>
                   <BasicInfoItemContent>
@@ -142,7 +142,7 @@ export default function BasicInfo({
                 </BasicInfoItem>
               )}
 
-              {config.evaluator.top_p !== null && (
+              {config.evaluator.top_p != null && (
                 <BasicInfoItem>
                   <BasicInfoItemTitle>Top P</BasicInfoItemTitle>
                   <BasicInfoItemContent>
@@ -151,7 +151,7 @@ export default function BasicInfo({
                 </BasicInfoItem>
               )}
 
-              {config.evaluator.max_tokens !== null && (
+              {config.evaluator.max_tokens != null && (
                 <BasicInfoItem>
                   <BasicInfoItemTitle>Max Tokens</BasicInfoItemTitle>
                   <BasicInfoItemContent>
@@ -160,7 +160,7 @@ export default function BasicInfo({
                 </BasicInfoItem>
               )}
 
-              {config.evaluator.presence_penalty !== null && (
+              {config.evaluator.presence_penalty != null && (
                 <BasicInfoItem>
                   <BasicInfoItemTitle>Presence Penalty</BasicInfoItemTitle>
                   <BasicInfoItemContent>
@@ -171,7 +171,7 @@ export default function BasicInfo({
                 </BasicInfoItem>
               )}
 
-              {config.evaluator.frequency_penalty !== null && (
+              {config.evaluator.frequency_penalty != null && (
                 <BasicInfoItem>
                   <BasicInfoItemTitle>Frequency Penalty</BasicInfoItemTitle>
                   <BasicInfoItemContent>
@@ -182,7 +182,7 @@ export default function BasicInfo({
                 </BasicInfoItem>
               )}
 
-              {config.evaluator.seed !== null && (
+              {config.evaluator.seed != null && (
                 <BasicInfoItem>
                   <BasicInfoItemTitle>Seed</BasicInfoItemTitle>
                   <BasicInfoItemContent>
@@ -245,7 +245,7 @@ export default function BasicInfo({
                 <BasicInfoItemContent>
                   <Chip
                     label={
-                      config.max_distance !== null
+                      config.max_distance != null
                         ? config.max_distance.toString()
                         : "-"
                     }
@@ -253,7 +253,7 @@ export default function BasicInfo({
                 </BasicInfoItemContent>
               </BasicInfoItem>
 
-              {config.temperature !== null && (
+              {config.temperature != null && (
                 <BasicInfoItem>
                   <BasicInfoItemTitle>Temperature</BasicInfoItemTitle>
                   <BasicInfoItemContent>
@@ -262,7 +262,7 @@ export default function BasicInfo({
                 </BasicInfoItem>
               )}
 
-              {config.top_p !== null && (
+              {config.top_p != null && (
                 <BasicInfoItem>
                   <BasicInfoItemTitle>Top P</BasicInfoItemTitle>
                   <BasicInfoItemContent>
@@ -271,7 +271,7 @@ export default function BasicInfo({
                 </BasicInfoItem>
               )}
 
-              {config.max_tokens !== null && (
+              {config.max_tokens != null && (
                 <BasicInfoItem>
                   <BasicInfoItemTitle>Max Tokens</BasicInfoItemTitle>
                   <BasicInfoItemContent>
@@ -280,7 +280,7 @@ export default function BasicInfo({
                 </BasicInfoItem>
               )}
 
-              {config.presence_penalty !== null && (
+              {config.presence_penalty != null && (
                 <BasicInfoItem>
                   <BasicInfoItemTitle>Presence Penalty</BasicInfoItemTitle>
                   <BasicInfoItemContent>
@@ -289,7 +289,7 @@ export default function BasicInfo({
                 </BasicInfoItem>
               )}
 
-              {config.frequency_penalty !== null && (
+              {config.frequency_penalty != null && (
                 <BasicInfoItem>
                   <BasicInfoItemTitle>Frequency Penalty</BasicInfoItemTitle>
                   <BasicInfoItemContent>
@@ -298,7 +298,7 @@ export default function BasicInfo({
                 </BasicInfoItem>
               )}
 
-              {config.seed !== null && (
+              {config.seed != null && (
                 <BasicInfoItem>
                   <BasicInfoItemTitle>Seed</BasicInfoItemTitle>
                   <BasicInfoItemContent>
@@ -323,7 +323,7 @@ export default function BasicInfo({
                 </BasicInfoItemContent>
               </BasicInfoItem>
 
-              {config.fuser.temperature !== null && (
+              {config.fuser.temperature != null && (
                 <BasicInfoItem>
                   <BasicInfoItemTitle>Temperature</BasicInfoItemTitle>
                   <BasicInfoItemContent>
@@ -332,7 +332,7 @@ export default function BasicInfo({
                 </BasicInfoItem>
               )}
 
-              {config.fuser.top_p !== null && (
+              {config.fuser.top_p != null && (
                 <BasicInfoItem>
                   <BasicInfoItemTitle>Top P</BasicInfoItemTitle>
                   <BasicInfoItemContent>
@@ -341,7 +341,7 @@ export default function BasicInfo({
                 </BasicInfoItem>
               )}
 
-              {config.fuser.max_tokens !== null && (
+              {config.fuser.max_tokens != null && (
                 <BasicInfoItem>
                   <BasicInfoItemTitle>Max Tokens</BasicInfoItemTitle>
                   <BasicInfoItemContent>
@@ -350,7 +350,7 @@ export default function BasicInfo({
                 </BasicInfoItem>
               )}
 
-              {config.fuser.presence_penalty !== null && (
+              {config.fuser.presence_penalty != null && (
                 <BasicInfoItem>
                   <BasicInfoItemTitle>Presence Penalty</BasicInfoItemTitle>
                   <BasicInfoItemContent>
@@ -359,7 +359,7 @@ export default function BasicInfo({
                 </BasicInfoItem>
               )}
 
-              {config.fuser.frequency_penalty !== null && (
+              {config.fuser.frequency_penalty != null && (
                 <BasicInfoItem>
                   <BasicInfoItemTitle>Frequency Penalty</BasicInfoItemTitle>
                   <BasicInfoItemContent>
@@ -368,7 +368,7 @@ export default function BasicInfo({
                 </BasicInfoItem>
               )}
 
-              {config.fuser.seed !== null && (
+              {config.fuser.seed != null && (
                 <BasicInfoItem>
                   <BasicInfoItemTitle>Seed</BasicInfoItemTitle>
                   <BasicInfoItemContent>
@@ -397,7 +397,7 @@ export default function BasicInfo({
         })()}
 
       {/* Weight */}
-      {variantConfig.weight !== null && (
+      {variantConfig.weight != null && (
         <BasicInfoItem>
           <BasicInfoItemTitle>Weight</BasicInfoItemTitle>
           <BasicInfoItemContent>


### PR DESCRIPTION
## Summary
- Fixed a bug where numeric fields (temperature, top_p, max_tokens, etc.) would render a stray "0" when their value was 0
- The issue was caused by using truthy checks (`field &&`) which evaluate to `0 && <JSX>` → `0` when the field is zero, causing React to render "0" as text
- Changed all numeric field checks to use explicit null checks (`field !== null &&`)


<img width="736" height="449" alt="Screenshot 2026-02-04 at 10 29 46 AM" src="https://github.com/user-attachments/assets/67f5810f-2e07-44e7-b0b1-09e26c35bb5a" />



## Test plan
- [x] Verified on `/observability/functions/extract_entities/variants/gpt4o_mini_initial_prompt` which has `temperature: 0`
- Before: Stray "0" appeared below Model without any label
- After: "Temperature: 0" appears correctly with its label


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only conditional rendering changes with minimal logic impact; main risk is inadvertently showing fields that were previously hidden when set to `0`.
> 
> **Overview**
> Fixes variant BasicInfo display so numeric config values of `0` render correctly with their labels instead of producing a stray `0` text node.
> 
> This replaces truthy JSX guards (`field && ...`) with explicit null/undefined checks (`field != null`) across variant types (chat completion, `best_of_n_sampling`, `dicl`, `mixture_of_n`), including `weight` and `max_distance`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7901f4203710fd02197835af29f4588aa68af60c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->