### PR TITLE
added slash command for running autopilot dispatch tests

### DIFF
--- a/.github/workflows/slash-command-autopilot-e2e.yml
+++ b/.github/workflows/slash-command-autopilot-e2e.yml
@@ -1,0 +1,127 @@
+name: Trigger Autopilot E2E from slash command
+
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [autopilot-e2e-command]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  trigger-autopilot-e2e:
+    runs-on: ubuntu-latest
+    if: github.repository == 'tensorzero/tensorzero'
+    steps:
+      - name: Add initial reaction
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reactions: eyes
+
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.AUTOPILOT_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.AUTOPILOT_DISPATCH_PRIVATE_KEY }}
+          owner: tensorzero
+          repositories: autopilot
+
+      - name: Dispatch to autopilot
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: tensorzero/autopilot
+          event-type: tensorzero-main-updated
+          client-payload: |
+            {
+              "tensorzero_commit": "${{ github.event.client_payload.pull_request.head.sha }}",
+              "triggered_by": "${{ github.actor }}",
+              "source_run_id": "${{ github.run_id }}",
+              "source_run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+
+      - name: Wait for autopilot workflow and report status
+        id: wait-for-autopilot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SOURCE_RUN_ID: ${{ github.run_id }}
+        run: |
+          EXPECTED_NAME="Cross-Repo E2E (tensorzero/$SOURCE_RUN_ID)"
+          echo "Looking for workflow run with name: $EXPECTED_NAME"
+
+          sleep 10
+
+          # Find the workflow run by display_title (correlates to our specific dispatch)
+          for i in {1..120}; do
+            RUN_ID=$(gh api repos/tensorzero/autopilot/actions/runs \
+              -q ".workflow_runs[] | select(.display_title==\"$EXPECTED_NAME\") | .id")
+
+            if [ -n "$RUN_ID" ]; then
+              break
+            fi
+            sleep 5
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "Failed to find autopilot workflow run with name: $EXPECTED_NAME"
+            echo "run_url=https://github.com/tensorzero/autopilot/actions" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          RUN_URL="https://github.com/tensorzero/autopilot/actions/runs/$RUN_ID"
+          echo "run_url=$RUN_URL" >> $GITHUB_OUTPUT
+          echo "Autopilot workflow: $RUN_URL"
+
+          # Poll until complete
+          while true; do
+            RESULT=$(gh api "repos/tensorzero/autopilot/actions/runs/$RUN_ID" -q '{status: .status, conclusion: .conclusion}')
+            STATUS=$(echo "$RESULT" | jq -r '.status')
+            CONCLUSION=$(echo "$RESULT" | jq -r '.conclusion')
+
+            if [ "$STATUS" = "completed" ]; then
+              if [ "$CONCLUSION" = "success" ]; then
+                echo "Autopilot E2E tests passed"
+                exit 0
+              else
+                echo "Autopilot E2E tests failed with conclusion: $CONCLUSION"
+                exit 1
+              fi
+            fi
+
+            sleep 30
+          done
+
+      - name: Comment with workflow link
+        if: always()
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          issue-number: ${{ github.event.client_payload.pull_request.number }}
+          body: |
+            🚀 Autopilot E2E tests triggered!
+
+            View the run: ${{ steps.wait-for-autopilot.outputs.run_url }}
+
+      - name: Add success reaction
+        if: success()
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reactions: hooray
+
+      - name: Add failure reaction
+        if: failure()
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reactions: -1

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -41,5 +41,6 @@ jobs:
             regen-fixtures
             merge-queue
             check-fork
+            autopilot-e2e
           # Use our custom permission check above, since `peter-evans/slash-command-dispatch` doesn't handle organizations
           permission: none


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a cross-repo GitHub Actions workflow that mints a GitHub App token and dispatches/polls another repo’s workflow, which can fail due to token/permissions or brittle run-name correlation but doesn’t touch production code paths.
> 
> **Overview**
> Adds a new GitHub Actions workflow, `slash-command-autopilot-e2e.yml`, that reacts to an `autopilot-e2e-command` dispatch, triggers an E2E run in `tensorzero/autopilot`, polls for completion, and reports back to the originating PR via comments and emoji reactions.
> 
> Extends the existing slash-command dispatcher to recognize the new `/autopilot-e2e` command so org members can trigger the cross-repo E2E flow from a PR comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acdd69f2a74b4dd060f7cba80cbdaeefbe7008c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->