### PR TITLE
Hide pagination buttons when no evaluation runs selected

### DIFF
--- a/ui/app/routes/evaluations/$evaluation_name/route.tsx
+++ b/ui/app/routes/evaluations/$evaluation_name/route.tsx
@@ -387,13 +387,14 @@ function ResultsContent({
         selectedRows={selectedRows}
         setSelectedRows={setSelectedRows}
       />
-      <PageButtons
-        onPreviousPage={handlePreviousPage}
-        onNextPage={handleNextPage}
-        disablePrevious={offset <= 0}
-        disableNext={offset + limit >= total_datapoints}
-      />
-      {!has_selected_runs && (
+      {has_selected_runs ? (
+        <PageButtons
+          onPreviousPage={handlePreviousPage}
+          onNextPage={handleNextPage}
+          disablePrevious={offset <= 0}
+          disableNext={offset + limit >= total_datapoints}
+        />
+      ) : (
         <div className="mt-4 text-center text-gray-500">
           Select evaluation run IDs to view results
         </div>


### PR DESCRIPTION
## Summary
- Hide PageButtons on evaluation detail page when no evaluation runs are selected
- Show helpful "Select evaluation run IDs to view results" text instead

This fixes a UI issue where floating pagination arrows appeared even with no data to paginate.

## Test plan
- [x] Navigate to `/evaluations/entity_extraction` without selecting runs
- [x] Verify pagination buttons are hidden
- [x] Verify helper text is shown
- [x] Select an evaluation run and verify pagination appears

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only conditional rendering change with no impact on data fetching or state management.
> 
> **Overview**
> Updates the evaluation detail results section to **only render** `PageButtons` when `has_selected_runs` is true.
> 
> When no runs are selected, the pagination controls are replaced with a centered helper message prompting the user to select evaluation run IDs, preventing empty-state pagination UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45530c6c3a8be47828f7e1629f6bcbe2b874f10c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->