### PR TITLE
Replace focus ring with darkened border on form controls

### DIFF
--- a/ui/app/components/ui/select.tsx
+++ b/ui/app/components/ui/select.tsx
@@ -20,7 +20,7 @@ const SelectTrigger = React.forwardRef<
       "flex h-9 w-full items-center justify-between gap-1.5",
       "rounded-md border px-3 py-2",
       "border-input bg-background text-sm whitespace-nowrap",
-      "transition-colors focus-visible:border-border-accent focus-visible:ring-0 focus-visible:outline-hidden",
+      "focus-visible:border-border-accent transition-colors focus-visible:ring-0 focus-visible:outline-hidden",
       "placeholder:text-muted-foreground",
       "disabled:cursor-not-allowed disabled:opacity-50",
       "[&>span]:line-clamp-1",

--- a/ui/app/components/ui/textarea.tsx
+++ b/ui/app/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "border-input placeholder:text-muted-foreground flex min-h-[60px] w-full rounded-md border bg-transparent px-3 py-2 text-base transition-colors focus-visible:border-border-accent focus-visible:ring-0 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input placeholder:text-muted-foreground focus-visible:border-border-accent flex min-h-[60px] w-full rounded-md border bg-transparent px-3 py-2 text-base transition-colors focus-visible:ring-0 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className,
       )}
       ref={ref}


### PR DESCRIPTION
## Summary

Unifies focus styling across form controls by replacing focus ring with darkened border:

**Before:** Focus ring appears *outside* the border (visually jarring)
**After:** Border darkens on focus (matches Input pattern, more subtle)

### Components updated:
- **Select**: `focus:ring-ring focus:ring-1` → `focus-visible:border-border-accent focus-visible:ring-0`
- **Textarea**: Same pattern

### Components already using this pattern:
- **Input**: Already uses `focus-visible:border-border-accent`
- **Combobox**: Uses Input internally

### Also includes:
- `gap-1.5` on Select for better text/chevron spacing
- `transition-colors` for smooth border transitions

## Screenshot

Select with focus (note darkened border, no ring):

<img width="800" alt="Select with focus styling" src="https://raw.githubusercontent.com/tensorzero/tensorzero/simeonlee/assets/6144/focus-styling-select.png" />

## Test plan
- [x] Select focus shows darkened border instead of ring
- [x] Textarea focus shows darkened border instead of ring
- [x] Focus styling matches Input component

## Related
- Extracted from #5600

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only changes to shared form controls; main risk is minor focus/contrast regressions across browsers/themes.
> 
> **Overview**
> Updates `SelectTrigger` and `Textarea` focus styling to **remove the focus ring** and instead **darken the border on `:focus-visible`**, aligning with the existing `Input` pattern.
> 
> Also tweaks `SelectTrigger` layout spacing (`gap-1.5`) and adds `transition-colors` for smoother focus state transitions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae4cecb76452adea7fa414f8faab8b14fd933654. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->