### PR TITLE
Fix horizontal overflow in Tool Call/Result details

### DIFF
--- a/ui/app/components/input_output/content_blocks/ThoughtContentBlock.tsx
+++ b/ui/app/components/input_output/content_blocks/ThoughtContentBlock.tsx
@@ -65,7 +65,7 @@ export function ThoughtContentBlock({
       >
         Thought
       </ContentBlockLabel>
-      <div className="border-border bg-bg-tertiary/50 grid grid-flow-row grid-cols-[min-content_1fr] place-content-center gap-x-4 gap-y-1 rounded-sm px-3 py-2 text-xs">
+      <div className="border-border bg-bg-tertiary/50 grid grid-flow-row grid-cols-[min-content_minmax(0,1fr)] gap-x-4 gap-y-1 rounded-sm px-3 py-2 text-xs">
         {/* Empty state */}
         {isEmpty && !isEditing && (
           <div className="text-fg-muted col-span-2 flex items-center justify-center py-8 text-sm">

--- a/ui/app/components/input_output/content_blocks/ToolPayload.tsx
+++ b/ui/app/components/input_output/content_blocks/ToolPayload.tsx
@@ -27,7 +27,7 @@ export function ToolPayload({
   const formattedPayload = useFormattedJson(payload);
 
   return (
-    <div className="border-border bg-bg-tertiary/50 grid grid-flow-row grid-cols-[min-content_1fr] grid-rows-[repeat(3,min-content)] place-content-center gap-x-4 gap-y-1 rounded-sm px-3 py-2 text-xs">
+    <div className="border-border bg-bg-tertiary/50 grid grid-flow-row grid-cols-[min-content_minmax(0,1fr)] grid-rows-[repeat(3,min-content)] gap-x-4 gap-y-1 rounded-sm px-3 py-2 text-xs">
       <p className="text-fg-secondary font-medium">Name</p>
       {!isEditing ? (
         <p className="self-center truncate font-mono text-[0.6875rem]">

--- a/ui/app/components/layout/SnippetContent.tsx
+++ b/ui/app/components/layout/SnippetContent.tsx
@@ -178,7 +178,7 @@ function ToolDetails({
   const formattedPayload = useFormattedJson(payload);
 
   return (
-    <div className="border-border bg-bg-tertiary/50 grid grid-flow-row grid-cols-[min-content_1fr] grid-rows-[repeat(3,min-content)] place-content-center gap-x-4 gap-y-1 rounded-sm px-3 py-2 text-xs">
+    <div className="border-border bg-bg-tertiary/50 grid grid-flow-row grid-cols-[min-content_minmax(0,1fr)] grid-rows-[repeat(3,min-content)] gap-x-4 gap-y-1 rounded-sm px-3 py-2 text-xs">
       <p className="text-fg-secondary font-medium">{nameLabel}</p>
       {!isEditing ? (
         <p className="self-center truncate font-mono text-[0.6875rem]">


### PR DESCRIPTION
## Summary

- Fix horizontal overflow in the `ToolDetails` component (used for Tool Call and Tool Result sections on inference pages)
- Long content was breaking out of its container instead of being contained with horizontal scrolling


BEFORE
<img width="1080" height="735" alt="Screenshot 2026-02-04 at 4 27 43 PM" src="https://github.com/user-attachments/assets/f825a90b-9f95-4e43-844a-09b41bb8ad47" />



AFTER


https://github.com/user-attachments/assets/190de046-f1f0-4471-8883-5c730496a917




## Changes

- Changed grid column from `1fr` to `minmax(0,1fr)` to prevent the column from expanding beyond its container
- Removed unnecessary `place-content-center` class

## Test plan

- [ ] Verify that Tool Call and Tool Result sections with long content no longer overflow horizontally
- [ ] Check that the CodeEditor within these sections properly scrolls horizontally for long lines



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only layout tweaks (grid column sizing and alignment) affecting how long strings/code blocks render; behavior changes are limited to UI presentation.
> 
> **Overview**
> Prevents long tool call/result payloads (and thought blocks) from expanding past their container and causing horizontal overflow.
> 
> Updates the detail grid layouts in `ToolDetails`/`ToolPayload`/`ThoughtContentBlock` to use `grid-cols-[min-content_minmax(0,1fr)]` (and drops `place-content-center`) so the flexible column can properly shrink and keep scrolling/truncation contained.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59a290a50b82906a6f11c0066c28579e0942809e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>59a290a</u></sup><!-- /BUGBOT_STATUS -->