### PR TITLE
added documentation of how to do cross repo ui autopilot dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,6 +214,14 @@ Separately, you can run headless tests with `pnpm ui:test` and Playwright tests 
 
 We also maintain a Docker Compose for e2e tests `ui/fixtures/docker-compose.e2e.yml` that is used in CI for the Playwright tests. This file uses a different configuration that mandates credentials for image fetching.
 
+##### Autopilot Tests (Internal Only)
+
+> [!NOTE]
+>
+> The Autopilot feature depends on a closed-source internal API. The tests in `ui/e2e_tests/autopilot/` require access to the private `autopilot` repository and cannot be run by external contributors. These tests are excluded by default and run in CI via repository dispatch from the autopilot repo.
+
+For internal contributors with access to the autopilot repository, see `ui/AGENTS.md` for detailed instructions on running the autopilot development environment and tests.
+
 ### Advanced
 
 - To test batch and optimization workflows without real provider APIs, spin up the `mock-provider-api` and set `TENSORZERO_INTERNAL_MOCK_PROVIDER_API=http://localhost:3030` when running the gateway.

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -3,3 +3,59 @@
 - Prefer `logger` from `~/utils/logger` over `console.error`, `console.warn`, `console.log`, `console.debug`.
 - Prefer using React Router's `useFetcher` over direct calls to `fetch`. [Reference](https://reactrouter.com/api/hooks/useFetcher)
 - After modifying UI code, run from the `ui/` directory: `pnpm run format`, `pnpm run lint`, `pnpm run typecheck`. All commands must pass.
+
+## Autopilot Feature (Internal Only)
+
+> **Note for external contributors:** The Autopilot feature depends on a closed-source internal API. The tests in `e2e_tests/autopilot/` require access to the private `autopilot` repository and cannot be run by external contributors. These tests are run in CI via repository dispatch from the autopilot repo.
+
+If you're an internal contributor with access to the autopilot repository:
+
+### Setup
+
+Set the `AUTOPILOT_REPO` environment variable to point to your local autopilot checkout:
+
+```bash
+export AUTOPILOT_REPO=/path/to/autopilot
+```
+
+### Running Autopilot Dependencies
+
+```bash
+docker compose --profile e2e up -d
+```
+
+Run from the `$AUTOPILOT_REPO` directory, or:
+
+```bash
+docker compose -f "$AUTOPILOT_REPO/docker-compose.yml" --profile e2e up -d
+```
+
+### Running the UI Dev Server with Autopilot
+
+From the `ui/` directory:
+
+```bash
+TENSORZERO_UI_CONFIG_FILE="$AUTOPILOT_REPO/e2e_tests/fixtures/config/tensorzero.toml" \
+TENSORZERO_GATEWAY_URL=http://localhost:3040 \
+pnpm dev
+```
+
+### Running Autopilot E2E Tests
+
+From the `ui/` directory:
+
+```bash
+TENSORZERO_UI_CONFIG_FILE="$AUTOPILOT_REPO/e2e_tests/fixtures/config/tensorzero.toml" \
+TENSORZERO_GATEWAY_URL=http://localhost:3040 \
+TENSORZERO_PLAYWRIGHT_INCLUDE_AUTOPILOT=1 \
+pnpm exec playwright test e2e_tests/autopilot/
+```
+
+To run a specific test file:
+
+```bash
+TENSORZERO_UI_CONFIG_FILE="$AUTOPILOT_REPO/e2e_tests/fixtures/config/tensorzero.toml" \
+TENSORZERO_GATEWAY_URL=http://localhost:3040 \
+TENSORZERO_PLAYWRIGHT_INCLUDE_AUTOPILOT=1 \
+pnpm exec playwright test e2e_tests/autopilot/autopilot.spec.ts
+```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no code, runtime, or security-impacting behavior changes.
> 
> **Overview**
> Documents the *internal-only* Autopilot UI development/testing workflow.
> 
> Updates `CONTRIBUTING.md` to clarify that `ui/e2e_tests/autopilot/` depends on a closed-source API, is excluded by default, and runs in CI via repository dispatch, and adds a new `ui/AGENTS.md` section with step-by-step setup (e.g., `AUTOPILOT_REPO`), Docker dependency bring-up, and commands/env vars to run the dev server and Playwright Autopilot e2e tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81fe1af7b196f7c63f470e8c26dd77aad8c79bb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->