### PR TITLE
Fix autopilot tool definitions to work with Anthropic

### DIFF
--- a/internal/autopilot-tools/src/tools/prod/create_datapoints.rs
+++ b/internal/autopilot-tools/src/tools/prod/create_datapoints.rs
@@ -45,6 +45,10 @@ impl ToolMetadata for CreateDatapointsTool {
         )
     }
 
+    fn strict(&self) -> bool {
+        false // Datapoints have arbitrary input/output objects
+    }
+
     fn parameters_schema(&self) -> ToolResult<Schema> {
         let schema = serde_json::json!({
             "type": "object",
@@ -87,7 +91,8 @@ impl ToolMetadata for CreateDatapointsTool {
                                 "description": "Optional tags for the datapoint."
                             }
                         },
-                        "required": ["type", "function_name", "input"]
+                        "required": ["type", "function_name", "input"],
+                        "additionalProperties": false
                     }
                 }
             },

--- a/internal/autopilot-tools/src/tools/prod/create_datapoints_from_inferences.rs
+++ b/internal/autopilot-tools/src/tools/prod/create_datapoints_from_inferences.rs
@@ -100,7 +100,6 @@ impl ToolMetadata for CreateDatapointsFromInferencesTool {
                                 "limit": {
                                     "type": "integer",
                                     "description": "Maximum number of inferences to use.",
-                                    "minimum": 1
                                 },
                                 "output_source": {
                                     "type": "string",

--- a/internal/autopilot-tools/src/tools/prod/feedback.rs
+++ b/internal/autopilot-tools/src/tools/prod/feedback.rs
@@ -62,6 +62,10 @@ impl ToolMetadata for FeedbackTool {
         )
     }
 
+    fn strict(&self) -> bool {
+        false // Value uses anyOf with array type without explicit items
+    }
+
     fn parameters_schema(&self) -> ToolResult<Schema> {
         let schema = serde_json::json!({
             "type": "object",
@@ -82,7 +86,13 @@ impl ToolMetadata for FeedbackTool {
                     "description": "The metric name: 'comment' for free-text, 'demonstration' for demonstrations, or a configured metric name for float/boolean values."
                 },
                 "value": {
-                    "description": "The feedback value. Type depends on metric_name: string for 'comment', string/array for 'demonstration', number for float metrics, boolean for boolean metrics."
+                    "description": "The feedback value. Type depends on metric_name: string for 'comment', string/array for 'demonstration', number for float metrics, boolean for boolean metrics.",
+                    "anyOf": [
+                        { "type": "string" },
+                        { "type": "array", "items": { "type": "object" } },
+                        { "type": "number" },
+                        { "type": "boolean" }
+                    ]
                 },
                 "dryrun": {
                     "type": "boolean",

--- a/internal/autopilot-tools/src/tools/prod/inference.rs
+++ b/internal/autopilot-tools/src/tools/prod/inference.rs
@@ -83,7 +83,7 @@ impl ToolMetadata for InferenceTool {
                     "properties": {
                         "system": {
                             "description": "System prompt (string or array of content blocks)",
-                            "oneOf": [
+                            "anyOf": [
                                 { "type": "string" },
                                 { "type": "array", "items": { "type": "object" } }
                             ]
@@ -97,17 +97,19 @@ impl ToolMetadata for InferenceTool {
                                     "role": { "type": "string", "enum": ["user", "assistant"] },
                                     "content": {
                                         "description": "Message content (string or array of content blocks)",
-                                        "oneOf": [
+                                        "anyOf": [
                                             { "type": "string" },
                                             { "type": "array", "items": { "type": "object" } }
                                         ]
                                     }
                                 },
-                                "required": ["role", "content"]
+                                "required": ["role", "content"],
+                                "additionalProperties": false
                             }
                         }
                     },
-                    "required": ["messages"]
+                    "required": ["messages"],
+                    "additionalProperties": false
                 },
                 "params": {
                     "type": "object",
@@ -119,9 +121,11 @@ impl ToolMetadata for InferenceTool {
                                 "temperature": { "type": "number", "description": "Sampling temperature (0.0-2.0)" },
                                 "max_tokens": { "type": "integer", "description": "Maximum tokens to generate" },
                                 "seed": { "type": "integer", "description": "Random seed for reproducibility" }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "variant_name": {
                     "type": "string",
@@ -142,6 +146,10 @@ impl ToolMetadata for InferenceTool {
             }
             .into()
         })
+    }
+
+    fn strict(&self) -> bool {
+        false // We need an arbitrary object for 'output_schema'
     }
 
     fn timeout(&self) -> Duration {

--- a/internal/autopilot-tools/src/tools/prod/launch_optimization_workflow.rs
+++ b/internal/autopilot-tools/src/tools/prod/launch_optimization_workflow.rs
@@ -155,7 +155,8 @@ impl ToolMetadata for LaunchOptimizationWorkflowTool {
                                     "description": "Suffix for the fine-tuned model name in OpenAI."
                                 }
                             },
-                            "required": ["type", "model"]
+                            "required": ["type", "model"],
+                            "additionalProperties": false
                         },
                         {
                             "type": "object",
@@ -207,7 +208,8 @@ impl ToolMetadata for LaunchOptimizationWorkflowTool {
                                     "description": "Whether to deploy the model after training."
                                 }
                             },
-                            "required": ["type", "model"]
+                            "required": ["type", "model"],
+                            "additionalProperties": false
                         },
                         {
                             "type": "object",
@@ -243,7 +245,8 @@ impl ToolMetadata for LaunchOptimizationWorkflowTool {
                                     "description": "Display name for the tuned model."
                                 }
                             },
-                            "required": ["type", "model"]
+                            "required": ["type", "model"],
+                            "additionalProperties": false
                         },
                         {
                             "type": "object",
@@ -279,7 +282,8 @@ impl ToolMetadata for LaunchOptimizationWorkflowTool {
                                     "description": "Suffix for the fine-tuned model name."
                                 }
                             },
-                            "required": ["type", "model"]
+                            "required": ["type", "model"],
+                            "additionalProperties": false
                         },
                         {
                             "type": "object",
@@ -327,7 +331,8 @@ impl ToolMetadata for LaunchOptimizationWorkflowTool {
                                     "description": "Whether to append to existing variants. Default: false."
                                 }
                             },
-                            "required": ["type", "embedding_model", "variant_name", "function_name"]
+                            "required": ["type", "embedding_model", "variant_name", "function_name"],
+                            "additionalProperties": false
                         },
                         {
                             "type": "object",
@@ -388,7 +393,8 @@ impl ToolMetadata for LaunchOptimizationWorkflowTool {
                                     "description": "Max tokens for analysis/mutation model calls."
                                 }
                             },
-                            "required": ["type", "function_name", "evaluation_name", "analysis_model", "mutation_model"]
+                            "required": ["type", "function_name", "evaluation_name", "analysis_model", "mutation_model"],
+                            "additionalProperties": false
                         }
                     ]
                 }
@@ -403,6 +409,10 @@ impl ToolMetadata for LaunchOptimizationWorkflowTool {
             }
             .into()
         })
+    }
+
+    fn strict(&self) -> bool {
+        false // Too many optional parameters for anthropic
     }
 }
 

--- a/internal/autopilot-tools/src/tools/prod/list_datapoints.rs
+++ b/internal/autopilot-tools/src/tools/prod/list_datapoints.rs
@@ -44,6 +44,10 @@ impl ToolMetadata for ListDatapointsTool {
         )
     }
 
+    fn strict(&self) -> bool {
+        false // Filter children are recursive arbitrary objects
+    }
+
     fn parameters_schema(&self) -> ToolResult<Schema> {
         let schema = serde_json::json!({
             "type": "object",
@@ -67,7 +71,7 @@ impl ToolMetadata for ListDatapointsTool {
                 },
                 "filter": {
                     "description": "Optional filter to apply when querying datapoints. Supports filtering by tags, time, and logical combinations (AND/OR/NOT).",
-                    "oneOf": [
+                    "anyOf": [
                         {
                             "type": "object",
                             "description": "Filter by tag key-value pair.",
@@ -81,7 +85,8 @@ impl ToolMetadata for ListDatapointsTool {
                                     "description": "Comparison operator."
                                 }
                             },
-                            "required": ["type", "key", "value", "comparison_operator"]
+                            "required": ["type", "key", "value", "comparison_operator"],
+                            "additionalProperties": false
                         },
                         {
                             "type": "object",
@@ -95,7 +100,8 @@ impl ToolMetadata for ListDatapointsTool {
                                     "description": "Comparison operator."
                                 }
                             },
-                            "required": ["type", "time", "comparison_operator"]
+                            "required": ["type", "time", "comparison_operator"],
+                            "additionalProperties": false
                         },
                         {
                             "type": "object",
@@ -104,7 +110,8 @@ impl ToolMetadata for ListDatapointsTool {
                                 "type": { "const": "and" },
                                 "children": { "type": "array", "description": "Array of filters to AND together.", "items": { "type": "object" } }
                             },
-                            "required": ["type", "children"]
+                            "required": ["type", "children"],
+                            "additionalProperties": false
                         },
                         {
                             "type": "object",
@@ -113,7 +120,8 @@ impl ToolMetadata for ListDatapointsTool {
                                 "type": { "const": "or" },
                                 "children": { "type": "array", "description": "Array of filters to OR together.", "items": { "type": "object" } }
                             },
-                            "required": ["type", "children"]
+                            "required": ["type", "children"],
+                            "additionalProperties": false
                         },
                         {
                             "type": "object",
@@ -122,7 +130,8 @@ impl ToolMetadata for ListDatapointsTool {
                                 "type": { "const": "not" },
                                 "child": { "type": "object", "description": "Filter to negate." }
                             },
-                            "required": ["type", "child"]
+                            "required": ["type", "child"],
+                            "additionalProperties": false
                         }
                     ]
                 },
@@ -144,7 +153,8 @@ impl ToolMetadata for ListDatapointsTool {
                                 "description": "The ordering direction."
                             }
                         },
-                        "required": ["by", "direction"]
+                        "required": ["by", "direction"],
+                        "additionalProperties": false
                     }
                 },
                 "search_query_experimental": {

--- a/internal/autopilot-tools/src/tools/prod/list_inferences.rs
+++ b/internal/autopilot-tools/src/tools/prod/list_inferences.rs
@@ -44,6 +44,10 @@ impl ToolMetadata for ListInferencesTool {
         )
     }
 
+    fn strict(&self) -> bool {
+        false // Filter children are recursive arbitrary objects
+    }
+
     fn parameters_schema(&self) -> ToolResult<Schema> {
         let schema = serde_json::json!({
             "type": "object",
@@ -92,7 +96,7 @@ impl ToolMetadata for ListInferencesTool {
                 },
                 "filters": {
                     "description": "Optional filter to apply when querying inferences. Supports filtering by metrics, tags, time, and logical combinations (AND/OR/NOT).",
-                    "oneOf": [
+                    "anyOf": [
                         {
                             "type": "object",
                             "description": "Filter by float metric value.",
@@ -106,7 +110,8 @@ impl ToolMetadata for ListInferencesTool {
                                     "description": "Comparison operator."
                                 }
                             },
-                            "required": ["type", "metric_name", "value", "comparison_operator"]
+                            "required": ["type", "metric_name", "value", "comparison_operator"],
+                            "additionalProperties": false
                         },
                         {
                             "type": "object",
@@ -116,7 +121,8 @@ impl ToolMetadata for ListInferencesTool {
                                 "metric_name": { "type": "string", "description": "Name of the metric to filter by." },
                                 "value": { "type": "boolean", "description": "Value to compare against." }
                             },
-                            "required": ["type", "metric_name", "value"]
+                            "required": ["type", "metric_name", "value"],
+                            "additionalProperties": false
                         },
                         {
                             "type": "object",
@@ -125,7 +131,8 @@ impl ToolMetadata for ListInferencesTool {
                                 "type": { "const": "demonstration_feedback" },
                                 "has_demonstration": { "type": "boolean", "description": "Whether the inference has a demonstration." }
                             },
-                            "required": ["type", "has_demonstration"]
+                            "required": ["type", "has_demonstration"],
+                            "additionalProperties": false
                         },
                         {
                             "type": "object",
@@ -140,7 +147,8 @@ impl ToolMetadata for ListInferencesTool {
                                     "description": "Comparison operator."
                                 }
                             },
-                            "required": ["type", "key", "value", "comparison_operator"]
+                            "required": ["type", "key", "value", "comparison_operator"],
+                            "additionalProperties": false
                         },
                         {
                             "type": "object",
@@ -154,7 +162,8 @@ impl ToolMetadata for ListInferencesTool {
                                     "description": "Comparison operator."
                                 }
                             },
-                            "required": ["type", "time", "comparison_operator"]
+                            "required": ["type", "time", "comparison_operator"],
+                            "additionalProperties": false
                         },
                         {
                             "type": "object",
@@ -163,7 +172,8 @@ impl ToolMetadata for ListInferencesTool {
                                 "type": { "const": "and" },
                                 "children": { "type": "array", "description": "Array of filters to AND together.", "items": { "type": "object" } }
                             },
-                            "required": ["type", "children"]
+                            "required": ["type", "children"],
+                            "additionalProperties": false
                         },
                         {
                             "type": "object",
@@ -172,7 +182,8 @@ impl ToolMetadata for ListInferencesTool {
                                 "type": { "const": "or" },
                                 "children": { "type": "array", "description": "Array of filters to OR together.", "items": { "type": "object" } }
                             },
-                            "required": ["type", "children"]
+                            "required": ["type", "children"],
+                            "additionalProperties": false
                         },
                         {
                             "type": "object",
@@ -181,7 +192,8 @@ impl ToolMetadata for ListInferencesTool {
                                 "type": { "const": "not" },
                                 "child": { "type": "object", "description": "Filter to negate." }
                             },
-                            "required": ["type", "child"]
+                            "required": ["type", "child"],
+                            "additionalProperties": false
                         }
                     ]
                 },
@@ -207,7 +219,8 @@ impl ToolMetadata for ListInferencesTool {
                                 "description": "The ordering direction."
                             }
                         },
-                        "required": ["by", "direction"]
+                        "required": ["by", "direction"],
+                        "additionalProperties": false
                     }
                 },
                 "search_query_experimental": {

--- a/internal/autopilot-tools/src/tools/prod/run_evaluation.rs
+++ b/internal/autopilot-tools/src/tools/prod/run_evaluation.rs
@@ -88,6 +88,10 @@ impl ToolMetadata for RunEvaluationTool {
         )
     }
 
+    fn strict(&self) -> bool {
+        false // precision_targets uses additionalProperties: {type: number} not supported in strict mode
+    }
+
     fn parameters_schema(&self) -> ToolResult<Schema> {
         let schema = serde_json::json!({
             "type": "object",

--- a/internal/autopilot-tools/src/tools/prod/update_datapoints.rs
+++ b/internal/autopilot-tools/src/tools/prod/update_datapoints.rs
@@ -45,6 +45,10 @@ impl ToolMetadata for UpdateDatapointsTool {
         )
     }
 
+    fn strict(&self) -> bool {
+        false // Datapoints have arbitrary input/output_schema objects
+    }
+
     fn parameters_schema(&self) -> ToolResult<Schema> {
         let schema = serde_json::json!({
             "type": "object",
@@ -88,7 +92,8 @@ impl ToolMetadata for UpdateDatapointsTool {
                                 "description": "New tags (optional)."
                             }
                         },
-                        "required": ["type", "id"]
+                        "required": ["type", "id"],
+                        "additionalProperties": false
                     }
                 }
             },

--- a/internal/autopilot-tools/src/tools/prod/write_config.rs
+++ b/internal/autopilot-tools/src/tools/prod/write_config.rs
@@ -89,6 +89,10 @@ impl ToolMetadata for WriteConfigTool {
         )
     }
 
+    fn strict(&self) -> bool {
+        false // Config objects have arbitrary nested structures (tools, gateway)
+    }
+
     fn parameters_schema(&self) -> ToolResult<Schema> {
         let schema = serde_json::json!({
             "type": "object",
@@ -114,7 +118,8 @@ impl ToolMetadata for WriteConfigTool {
                                         "type": "object",
                                         "description": "Map of variant names to variant configurations."
                                     }
-                                }
+                                },
+                                "additionalProperties": false
                             }
                         },
                         "metrics": {
@@ -138,7 +143,8 @@ impl ToolMetadata for WriteConfigTool {
                                         "enum": ["inference", "episode"],
                                         "description": "Whether metric applies to individual inferences or episodes."
                                     }
-                                }
+                                },
+                                "additionalProperties": false
                             }
                         },
                         "tools": {
@@ -149,7 +155,8 @@ impl ToolMetadata for WriteConfigTool {
                             "type": "object",
                             "description": "Gateway configuration settings."
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "extra_templates": {
                     "type": "object",


### PR DESCRIPTION
Some of these schemas cannot be uesd in strict mode due to Anthropic limitations, so we override 'fn strict()'. In other cases, we can make minor tweaks to make the schemas work.

I'm adding a test case in the autopilot repo that tries to pass all of the tools to Anthropic and OpenAI (with the specified strict mode), and verifies that a simple inference succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema/metadata-only changes that primarily affect LLM tool validation behavior; runtime business logic and API calls are unchanged.
> 
> **Overview**
> Adjusts multiple autopilot production tool definitions to be compatible with Anthropic’s tool schema constraints.
> 
> Several tools now explicitly disable strict schema mode via `fn strict() -> false` (e.g., datapoint CRUD, listing tools, `inference`, `run_evaluation`, `write_config`, and `launch_optimization_workflow`) where inputs include arbitrary/recursive objects or unsupported `additionalProperties` patterns. Schemas are also tightened/normalized by adding `additionalProperties: false` to nested objects, switching `oneOf` to `anyOf` for polymorphic fields, and explicitly defining the `feedback.value` union type; additionally, the `create_datapoints_from_inferences` schema removes a `minimum` constraint on `limit`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00c14b5ae2925991718a1f3fd1fb5a877ee42f2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->