### PR TITLE
Fix non-deterministic evaluation ordering in GEPA

### DIFF
--- a/tensorzero-optimizers/src/gepa/mod.rs
+++ b/tensorzero-optimizers/src/gepa/mod.rs
@@ -363,12 +363,12 @@ impl Optimizer for GEPAConfig {
             tracing::info!(
                 "GEPA iteration {}: analyzing {} parent inferences",
                 iteration,
-                parent_evaluation_results.evaluation_infos.len()
+                parent_evaluation_results.evaluation_infos().len()
             );
 
             let parent_analyses = match analyze_inferences(
                 &gateway_client,
-                &parent_evaluation_results.evaluation_infos,
+                parent_evaluation_results.evaluation_infos(),
                 &function_context,
                 &parent.config,
                 self,
@@ -517,7 +517,7 @@ impl Optimizer for GEPAConfig {
                             "GEPA iteration {}: child variant '{}' validation scores collected ({} datapoints)",
                             iteration,
                             child.name,
-                            val_mutation_evaluation_results.evaluation_infos.len()
+                            val_mutation_evaluation_results.evaluation_infos().len()
                         );
                         match pareto_frontier.update(candidate) {
                             Ok(()) => {

--- a/tensorzero-optimizers/tests/e2e/gepa/evaluate.rs
+++ b/tensorzero-optimizers/tests/e2e/gepa/evaluate.rs
@@ -74,7 +74,7 @@ async fn test_evaluate_variant_chat() {
 
     let evaluation_results = evaluation_result.unwrap();
     assert_eq!(
-        evaluation_results.evaluation_infos.len(),
+        evaluation_results.evaluation_infos().len(),
         2,
         "Expected 2 evaluation results"
     );
@@ -146,7 +146,7 @@ async fn test_evaluate_variant_json() {
 
     let evaluation_results = evaluation_result.unwrap();
     assert_eq!(
-        evaluation_results.evaluation_infos.len(),
+        evaluation_results.evaluation_infos().len(),
         2,
         "Expected 2 evaluation results"
     );

--- a/tensorzero-optimizers/tests/e2e/gepa/mutate.rs
+++ b/tensorzero-optimizers/tests/e2e/gepa/mutate.rs
@@ -73,7 +73,7 @@ async fn test_mutate_variant_chat() {
     // Analyze parent results
     let analyses = analyze_inferences(
         &gateway_client,
-        &parent_results.evaluation_infos,
+        parent_results.evaluation_infos(),
         &function_context,
         parent_config,
         &gepa_config,
@@ -208,7 +208,7 @@ async fn test_mutate_variant_json() {
     // Analyze parent results
     let analyses = analyze_inferences(
         &gateway_client,
-        &parent_results.evaluation_infos,
+        parent_results.evaluation_infos(),
         &function_context,
         parent_config,
         &gepa_config,
@@ -316,7 +316,7 @@ async fn test_mutate_variant_preserves_variables() {
 
     let analyses = analyze_inferences(
         &gateway_client,
-        &parent_results.evaluation_infos,
+        parent_results.evaluation_infos(),
         &function_context,
         parent_config,
         &gepa_config,
@@ -413,7 +413,7 @@ async fn test_mutate_variant_preserves_schema_references() {
 
     let analyses = analyze_inferences(
         &gateway_client,
-        &parent_results.evaluation_infos,
+        parent_results.evaluation_infos(),
         &function_context,
         parent_config,
         &gepa_config,
@@ -528,7 +528,7 @@ async fn test_mutate_variant_naming() {
 
     let analyses = analyze_inferences(
         &gateway_client,
-        &parent_results.evaluation_infos,
+        parent_results.evaluation_infos(),
         &function_context,
         parent_config,
         &gepa_config,


### PR DESCRIPTION
GEPA tests are flaky due to evaluation results arriving from concurrent tasks in non-deterministic completion order.

### Changes

- Sort `evaluation_infos` by datapoint ID at the start of `analyze_inferences` to ensure deterministic ordering regardless of task completion order

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only affects ordering/visibility of evaluation results; main risk is any latent reliance on the previous non-deterministic ordering.
> 
> **Overview**
> Ensures GEPA evaluation outputs are deterministic by **sorting per-datapoint `EvaluationInfo` by datapoint ID** before exposing them downstream.
> 
> This changes `EvaluationResults` to own a private, sorted `evaluation_infos` vector (constructed via `EvaluationResults::new`) and updates GEPA runtime + e2e tests to use the new `evaluation_infos()` accessor instead of direct field access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc4e0ab978022fb5c15a18d9262de8cff0665507. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->