### PR TITLE
Re-enable Clickhouse Cloud fast release channel tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,14 +11,13 @@ steps:
     concurrency: 1
     concurrency_group: "clickhouse-cloud-normal-${CLICKHOUSE_ID}"
     command: CLICKHOUSE_PREFIX="dev-tensorzero-e2e-tests-instance-" ./ci/buildkite/test-clickhouse-cloud.sh
-  # Temporarily disabled - see https://github.com/tensorzero/tensorzero/issues/5887
-  # - label: "Clickhouse Cloud tests - fast release channel"
-  #   plugins:
-  #     - peakon/git-shallow-clone#006b6c0e9e5c73a95c8ac62a60f10cb9ca3c455f:
-  #         depth: 1
-  #   concurrency: 1
-  #   concurrency_group: "clickhouse-cloud-fast-${CLICKHOUSE_ID}"
-  #   command: CLICKHOUSE_PREFIX="dev-tensorzero-e2e-tests-fast-instance-" TENSORZERO_CLICKHOUSE_FAST_CHANNEL=1 ./ci/buildkite/test-clickhouse-cloud.sh
+  - label: "Clickhouse Cloud tests - fast release channel"
+    plugins:
+      - peakon/git-shallow-clone#006b6c0e9e5c73a95c8ac62a60f10cb9ca3c455f:
+          depth: 1
+    concurrency: 1
+    concurrency_group: "clickhouse-cloud-fast-${CLICKHOUSE_ID}"
+    command: CLICKHOUSE_PREFIX="dev-tensorzero-e2e-tests-fast-instance-" TENSORZERO_CLICKHOUSE_FAST_CHANNEL=1 ./ci/buildkite/test-clickhouse-cloud.sh
 
 notify:
   - github_commit_status:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change that increases test coverage by running an additional pipeline step; no production code paths are modified.
> 
> **Overview**
> Re-enables the Buildkite step that runs Clickhouse Cloud E2E tests against the *fast* release channel, in addition to the existing *normal* channel run.
> 
> The fast-channel job uses its own `concurrency_group` and sets `TENSORZERO_CLICKHOUSE_FAST_CHANNEL=1` with a distinct `CLICKHOUSE_PREFIX` to isolate the test instance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 307444b4677db10b3dd2592c6248647a47687899. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Fixes https://github.com/tensorzero/tensorzero/issues/5887