### PR TITLE
Rename SelectQueries to EpisodeQueries and implement for postgres

### DIFF
--- a/tensorzero-core/src/db/clickhouse/evaluation_queries.rs
+++ b/tensorzero-core/src/db/clickhouse/evaluation_queries.rs
@@ -6,8 +6,8 @@ use async_trait::async_trait;
 use serde::Deserialize;
 
 use super::ClickHouseConnectionInfo;
+use super::episode_queries::{parse_count, parse_json_rows};
 use super::escape_string_for_clickhouse_literal;
-use super::select_queries::{parse_count, parse_json_rows};
 use crate::db::evaluation_queries::EvaluationQueries;
 use crate::db::evaluation_queries::EvaluationResultRow;
 use crate::db::evaluation_queries::EvaluationRunInfoByIdRow;

--- a/tensorzero-core/src/db/clickhouse/feedback.rs
+++ b/tensorzero-core/src/db/clickhouse/feedback.rs
@@ -23,8 +23,9 @@ use crate::{
 };
 
 use super::{
-    ClickHouseConnectionInfo, escape_string_for_clickhouse_literal,
-    select_queries::{build_pagination_clause, parse_count, parse_json_rows},
+    ClickHouseConnectionInfo,
+    episode_queries::{build_pagination_clause, parse_count, parse_json_rows},
+    escape_string_for_clickhouse_literal,
 };
 
 /// Raw database result for metrics with feedback (without metric_type)

--- a/tensorzero-core/src/db/clickhouse/inference_queries.rs
+++ b/tensorzero-core/src/db/clickhouse/inference_queries.rs
@@ -8,12 +8,12 @@ use crate::config::{
     Config, MetricConfig, MetricConfigLevel, MetricConfigOptimize, MetricConfigType,
 };
 use crate::db::TimeWindow;
+use crate::db::clickhouse::episode_queries::parse_count;
 use crate::db::clickhouse::query_builder::parameters::add_parameter;
 use crate::db::clickhouse::query_builder::{
     ClickhouseType, JoinRegistry, OrderByTerm, OrderDirection, QueryParameter,
     generate_order_by_sql,
 };
-use crate::db::clickhouse::select_queries::parse_count;
 use crate::db::clickhouse::{ClickHouseConnectionInfo, TableName};
 use crate::db::inferences::{
     ClickHouseStoredInferenceWithDispreferredOutputs, CountByVariant,

--- a/tensorzero-core/src/db/clickhouse/mod.rs
+++ b/tensorzero-core/src/db/clickhouse/mod.rs
@@ -32,13 +32,13 @@ mod batching;
 pub mod clickhouse_client; // Public because tests will use clickhouse_client::FakeClickHouseClient and clickhouse_client::MockClickHouseClient
 pub mod dataset_queries;
 pub mod dicl_queries;
+mod episode_queries;
 pub mod evaluation_queries;
 pub mod feedback;
 pub mod inference_queries;
 pub mod migration_manager;
 pub mod model_inferences;
 pub mod query_builder;
-mod select_queries;
 mod table_name;
 pub mod workflow_evaluation_queries;
 

--- a/tensorzero-core/src/db/clickhouse/workflow_evaluation_queries.rs
+++ b/tensorzero-core/src/db/clickhouse/workflow_evaluation_queries.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use uuid::Uuid;
 
-use super::select_queries::{parse_count, parse_json_rows};
+use super::episode_queries::{parse_count, parse_json_rows};
 use super::{ClickHouseConnectionInfo, escape_string_for_clickhouse_literal};
 use crate::config::snapshot::SnapshotHash;
 use crate::db::workflow_evaluation_queries::{

--- a/tensorzero-core/src/db/mod.rs
+++ b/tensorzero-core/src/db/mod.rs
@@ -34,7 +34,7 @@ pub use rate_limiting::*;
 
 #[async_trait]
 pub trait ClickHouseConnection:
-    SelectQueries + DatasetQueries + FeedbackQueries + HealthCheckable + Send + Sync
+    EpisodeQueries + DatasetQueries + FeedbackQueries + HealthCheckable + Send + Sync
 {
 }
 
@@ -44,17 +44,16 @@ pub trait HealthCheckable {
 }
 
 #[cfg_attr(test, automock)]
-pub trait SelectQueries {
-    fn query_episode_table(
+#[async_trait]
+pub trait EpisodeQueries: Send + Sync {
+    async fn query_episode_table(
         &self,
         limit: u32,
         before: Option<Uuid>,
         after: Option<Uuid>,
-    ) -> impl Future<Output = Result<Vec<EpisodeByIdRow>, Error>> + Send;
+    ) -> Result<Vec<EpisodeByIdRow>, Error>;
 
-    fn query_episode_table_bounds(
-        &self,
-    ) -> impl Future<Output = Result<TableBoundsWithCount, Error>> + Send;
+    async fn query_episode_table_bounds(&self) -> Result<TableBoundsWithCount, Error>;
 }
 
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
@@ -147,7 +146,7 @@ pub struct TableBoundsWithCount {
     pub count: u64,
 }
 
-impl<T: SelectQueries + DatasetQueries + FeedbackQueries + HealthCheckable + Send + Sync>
+impl<T: EpisodeQueries + DatasetQueries + FeedbackQueries + HealthCheckable + Send + Sync>
     ClickHouseConnection for T
 {
 }

--- a/tensorzero-core/src/db/postgres/episode_queries.rs
+++ b/tensorzero-core/src/db/postgres/episode_queries.rs
@@ -1,0 +1,328 @@
+//! EpisodeQueries implementation for Postgres.
+//!
+//! This module implements episode queries for the Postgres database.
+
+use async_trait::async_trait;
+use sqlx::{PgPool, QueryBuilder};
+use uuid::Uuid;
+
+use crate::db::{EpisodeByIdRow, EpisodeQueries, TableBoundsWithCount};
+use crate::error::{Error, ErrorDetails};
+
+use super::PostgresConnectionInfo;
+
+#[async_trait]
+impl EpisodeQueries for PostgresConnectionInfo {
+    async fn query_episode_table(
+        &self,
+        limit: u32,
+        before: Option<Uuid>,
+        after: Option<Uuid>,
+    ) -> Result<Vec<EpisodeByIdRow>, Error> {
+        let pool = self.get_pool_result()?;
+        query_episode_table_impl(pool, limit, before, after).await
+    }
+
+    async fn query_episode_table_bounds(&self) -> Result<TableBoundsWithCount, Error> {
+        let pool = self.get_pool_result()?;
+        query_episode_table_bounds_impl(pool).await
+    }
+}
+
+// =====================================================================
+// Query builder functions (for unit testing)
+// =====================================================================
+
+/// Result of building the episode table query, containing the query builder
+/// and whether results need to be reversed (for "after" pagination).
+struct EpisodeTableQueryResult {
+    query_builder: QueryBuilder<sqlx::Postgres>,
+    reverse_results: bool,
+}
+
+/// Builds a query to fetch episodes with pagination.
+///
+/// Returns an error if both `before` and `after` are specified.
+fn build_query_episode_table(
+    limit: u32,
+    before: Option<Uuid>,
+    after: Option<Uuid>,
+) -> Result<EpisodeTableQueryResult, Error> {
+    // For pagination, we need to handle the before/after cases differently
+    let (where_clause, order_direction, reverse_results) = match (before, after) {
+        (Some(before_id), None) => {
+            // Get episodes with IDs less than the cursor
+            (Some(("episode_id < ", before_id)), "DESC", false)
+        }
+        (None, Some(after_id)) => {
+            // Get episodes with IDs greater than the cursor
+            // Query in ASC order, then reverse the results
+            (Some(("episode_id > ", after_id)), "ASC", true)
+        }
+        (None, None) => (None, "DESC", false),
+        // Both before and after specified - already handled above, but Rust requires exhaustive matching
+        (Some(_), Some(_)) => {
+            return Err(Error::new(ErrorDetails::InvalidRequest {
+                message: "Cannot specify both before and after in query_episode_table".to_string(),
+            }));
+        }
+    };
+
+    // Build the query using a CTE to combine both inference tables
+    let mut query_builder: QueryBuilder<sqlx::Postgres> = QueryBuilder::new("");
+    query_builder.push(
+        r"
+        WITH all_inferences AS (
+            SELECT episode_id, id, created_at FROM tensorzero.chat_inferences
+            UNION ALL
+            SELECT episode_id, id, created_at FROM tensorzero.json_inferences
+        ),
+        episode_aggregates AS (
+            SELECT
+                episode_id,
+                COUNT(*)::BIGINT as count,
+                MIN(created_at) as start_time,
+                MAX(created_at) as end_time,
+                tensorzero.max_uuid(id) as last_inference_id
+            FROM all_inferences
+            GROUP BY episode_id
+        )
+        SELECT
+            episode_id,
+            count,
+            start_time,
+            end_time,
+            last_inference_id
+        FROM episode_aggregates
+        ",
+    );
+
+    // Add WHERE clause if we have pagination
+    if let Some((comparison, cursor_id)) = where_clause {
+        query_builder.push("WHERE ");
+        query_builder.push(comparison);
+        query_builder.push_bind(cursor_id);
+    }
+
+    // Add ORDER BY
+    query_builder.push(" ORDER BY episode_id ");
+    query_builder.push(order_direction);
+
+    // Add LIMIT
+    query_builder.push(" LIMIT ");
+    query_builder.push_bind(limit as i64);
+
+    Ok(EpisodeTableQueryResult {
+        query_builder,
+        reverse_results,
+    })
+}
+
+// =====================================================================
+// Query execution functions
+// =====================================================================
+
+async fn query_episode_table_impl(
+    pool: &PgPool,
+    limit: u32,
+    before: Option<Uuid>,
+    after: Option<Uuid>,
+) -> Result<Vec<EpisodeByIdRow>, Error> {
+    let EpisodeTableQueryResult {
+        mut query_builder,
+        reverse_results,
+    } = build_query_episode_table(limit, before, after)?;
+
+    let mut results: Vec<EpisodeByIdRow> = query_builder
+        .build_query_as::<EpisodeByIdRow>()
+        .fetch_all(pool)
+        .await
+        .map_err(|e| {
+            Error::new(ErrorDetails::PostgresQuery {
+                message: format!("Failed to query episode table: {e}"),
+            })
+        })?;
+
+    // For "after" pagination, we queried in ASC order but want to return DESC
+    // Also, we want the final order to be DESC (most recent first)
+    if reverse_results {
+        results.reverse();
+    }
+
+    Ok(results)
+}
+
+async fn query_episode_table_bounds_impl(pool: &PgPool) -> Result<TableBoundsWithCount, Error> {
+    // Use a CTE to combine both inference tables and get bounds
+    // Use subqueries with ORDER BY/LIMIT instead of MIN/MAX since Postgres doesn't support MIN/MAX on UUID
+    sqlx::query_as(
+        r"
+        WITH all_episodes AS (
+            SELECT DISTINCT episode_id FROM tensorzero.chat_inferences
+            UNION
+            SELECT DISTINCT episode_id FROM tensorzero.json_inferences
+        )
+        SELECT
+            (SELECT episode_id FROM all_episodes ORDER BY episode_id ASC LIMIT 1) as first_id,
+            (SELECT episode_id FROM all_episodes ORDER BY episode_id DESC LIMIT 1) as last_id,
+            COUNT(*)::BIGINT as count
+        FROM all_episodes
+        ",
+    )
+    .fetch_one(pool)
+    .await
+    .map_err(|e| {
+        Error::new(ErrorDetails::PostgresQuery {
+            message: format!("Failed to query episode table bounds: {e}"),
+        })
+    })
+}
+
+// =====================================================================
+// Unit tests
+// =====================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_helpers::assert_query_equals;
+
+    #[test]
+    fn test_build_query_episode_table_no_pagination() {
+        let result = build_query_episode_table(10, None, None).unwrap();
+        assert!(
+            !result.reverse_results,
+            "Should not reverse results without pagination"
+        );
+
+        assert_query_equals(
+            result.query_builder.sql().as_str(),
+            r"
+            WITH all_inferences AS (
+                SELECT episode_id, id, created_at FROM tensorzero.chat_inferences
+                UNION ALL
+                SELECT episode_id, id, created_at FROM tensorzero.json_inferences
+            ),
+            episode_aggregates AS (
+                SELECT
+                    episode_id,
+                    COUNT(*)::BIGINT as count,
+                    MIN(created_at) as start_time,
+                    MAX(created_at) as end_time,
+                    tensorzero.max_uuid(id) as last_inference_id
+                FROM all_inferences
+                GROUP BY episode_id
+            )
+            SELECT
+                episode_id,
+                count,
+                start_time,
+                end_time,
+                last_inference_id
+            FROM episode_aggregates
+            ORDER BY episode_id DESC
+            LIMIT $1
+            ",
+        );
+    }
+
+    #[test]
+    fn test_build_query_episode_table_with_before() {
+        let before_id = Uuid::now_v7();
+        let result = build_query_episode_table(20, Some(before_id), None).unwrap();
+        assert!(
+            !result.reverse_results,
+            "Should not reverse results with before pagination"
+        );
+
+        assert_query_equals(
+            result.query_builder.sql().as_str(),
+            r"
+            WITH all_inferences AS (
+                SELECT episode_id, id, created_at FROM tensorzero.chat_inferences
+                UNION ALL
+                SELECT episode_id, id, created_at FROM tensorzero.json_inferences
+            ),
+            episode_aggregates AS (
+                SELECT
+                    episode_id,
+                    COUNT(*)::BIGINT as count,
+                    MIN(created_at) as start_time,
+                    MAX(created_at) as end_time,
+                    tensorzero.max_uuid(id) as last_inference_id
+                FROM all_inferences
+                GROUP BY episode_id
+            )
+            SELECT
+                episode_id,
+                count,
+                start_time,
+                end_time,
+                last_inference_id
+            FROM episode_aggregates
+            WHERE episode_id < $1
+            ORDER BY episode_id DESC
+            LIMIT $2
+            ",
+        );
+    }
+
+    #[test]
+    fn test_build_query_episode_table_with_after() {
+        let after_id = Uuid::now_v7();
+        let result = build_query_episode_table(15, None, Some(after_id)).unwrap();
+        assert!(
+            result.reverse_results,
+            "Should reverse results with after pagination"
+        );
+
+        assert_query_equals(
+            result.query_builder.sql().as_str(),
+            r"
+            WITH all_inferences AS (
+                SELECT episode_id, id, created_at FROM tensorzero.chat_inferences
+                UNION ALL
+                SELECT episode_id, id, created_at FROM tensorzero.json_inferences
+            ),
+            episode_aggregates AS (
+                SELECT
+                    episode_id,
+                    COUNT(*)::BIGINT as count,
+                    MIN(created_at) as start_time,
+                    MAX(created_at) as end_time,
+                    tensorzero.max_uuid(id) as last_inference_id
+                FROM all_inferences
+                GROUP BY episode_id
+            )
+            SELECT
+                episode_id,
+                count,
+                start_time,
+                end_time,
+                last_inference_id
+            FROM episode_aggregates
+            WHERE episode_id > $1
+            ORDER BY episode_id ASC
+            LIMIT $2
+            ",
+        );
+    }
+
+    #[test]
+    fn test_build_query_episode_table_rejects_both_before_and_after() {
+        let before_id = Uuid::now_v7();
+        let after_id = Uuid::now_v7();
+        let result = build_query_episode_table(10, Some(before_id), Some(after_id));
+
+        match result {
+            Ok(_) => panic!("Should error when both before and after are specified"),
+            Err(err) => {
+                assert!(
+                    err.to_string()
+                        .contains("Cannot specify both before and after"),
+                    "Error message should mention that both before and after cannot be specified"
+                );
+            }
+        }
+    }
+}

--- a/tensorzero-core/src/db/postgres/mod.rs
+++ b/tensorzero-core/src/db/postgres/mod.rs
@@ -19,6 +19,7 @@ pub mod pgcron;
 pub mod rate_limiting;
 pub mod workflow_evaluation_queries;
 
+mod episode_queries;
 mod inference_filter_helpers;
 
 #[cfg(any(test, feature = "e2e_tests"))]

--- a/tensorzero-core/src/endpoints/episodes/internal/list_episodes.rs
+++ b/tensorzero-core/src/endpoints/episodes/internal/list_episodes.rs
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 use tracing::instrument;
 use uuid::Uuid;
 
-use crate::db::{EpisodeByIdRow, SelectQueries, TableBoundsWithCount};
+use crate::db::delegating_connection::DelegatingDatabaseConnection;
+use crate::db::{EpisodeByIdRow, EpisodeQueries, TableBoundsWithCount};
 use crate::error::{Error, ErrorDetails};
 use crate::utils::gateway::{AppState, AppStateData};
 
@@ -35,13 +36,17 @@ pub async fn list_episodes_handler(
     State(app_state): AppState,
     Query(params): Query<ListEpisodesParams>,
 ) -> Result<Json<ListEpisodesResponse>, Error> {
-    let episodes = list_episodes(&app_state.clickhouse_connection_info, params).await?;
+    let database = DelegatingDatabaseConnection::new(
+        app_state.clickhouse_connection_info.clone(),
+        app_state.postgres_connection_info.clone(),
+    );
+    let episodes = list_episodes(&database, params).await?;
     Ok(Json(ListEpisodesResponse { episodes }))
 }
 
 /// Core business logic for listing episodes
 pub async fn list_episodes(
-    clickhouse: &impl SelectQueries,
+    database: &impl EpisodeQueries,
     params: ListEpisodesParams,
 ) -> Result<Vec<EpisodeByIdRow>, Error> {
     if params.limit > 100 {
@@ -50,7 +55,7 @@ pub async fn list_episodes(
         }
         .into());
     }
-    clickhouse
+    database
         .query_episode_table(params.limit, params.before, params.after)
         .await
 }
@@ -61,32 +66,36 @@ pub async fn list_episodes(
 pub async fn query_episode_table_bounds_handler(
     State(app_state): AppState,
 ) -> Result<Json<TableBoundsWithCount>, Error> {
-    let bounds = query_episode_table_bounds(&app_state.clickhouse_connection_info).await?;
+    let database = DelegatingDatabaseConnection::new(
+        app_state.clickhouse_connection_info.clone(),
+        app_state.postgres_connection_info.clone(),
+    );
+    let bounds = query_episode_table_bounds(&database).await?;
     Ok(Json(bounds))
 }
 
 /// Core business logic for querying episode table bounds
 pub async fn query_episode_table_bounds(
-    clickhouse: &impl SelectQueries,
+    database: &impl EpisodeQueries,
 ) -> Result<TableBoundsWithCount, Error> {
-    clickhouse.query_episode_table_bounds().await
+    database.query_episode_table_bounds().await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::MockSelectQueries;
+    use crate::db::MockEpisodeQueries;
     use chrono::Utc;
 
     #[tokio::test]
-    async fn test_query_episode_table_calls_clickhouse() {
-        let mut mock_clickhouse = MockSelectQueries::new();
+    async fn test_query_episode_table_calls_database() {
+        let mut mock_database = MockEpisodeQueries::new();
 
         let episode_id = Uuid::now_v7();
         let last_inference_id = Uuid::now_v7();
         let now = Utc::now();
 
-        mock_clickhouse
+        mock_database
             .expect_query_episode_table()
             .withf(|limit, before, after| {
                 assert_eq!(*limit, 10);
@@ -96,15 +105,13 @@ mod tests {
             })
             .times(1)
             .returning(move |_, _, _| {
-                Box::pin(async move {
-                    Ok(vec![EpisodeByIdRow {
-                        episode_id,
-                        count: 5,
-                        start_time: now,
-                        end_time: now,
-                        last_inference_id,
-                    }])
-                })
+                Ok(vec![EpisodeByIdRow {
+                    episode_id,
+                    count: 5,
+                    start_time: now,
+                    end_time: now,
+                    last_inference_id,
+                }])
             });
 
         let params = ListEpisodesParams {
@@ -113,7 +120,7 @@ mod tests {
             after: None,
         };
 
-        let result = list_episodes(&mock_clickhouse, params).await.unwrap();
+        let result = list_episodes(&mock_database, params).await.unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].episode_id, episode_id);
@@ -123,12 +130,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_query_episode_table_with_pagination() {
-        let mut mock_clickhouse = MockSelectQueries::new();
+        let mut mock_database = MockEpisodeQueries::new();
 
         let before_id = Uuid::now_v7();
         let after_id = Uuid::now_v7();
 
-        mock_clickhouse
+        mock_database
             .expect_query_episode_table()
             .withf(move |limit, before, after| {
                 assert_eq!(*limit, 20);
@@ -137,7 +144,7 @@ mod tests {
                 true
             })
             .times(1)
-            .returning(|_, _, _| Box::pin(async move { Ok(vec![]) }));
+            .returning(|_, _, _| Ok(vec![]));
 
         let params = ListEpisodesParams {
             limit: 20,
@@ -145,32 +152,30 @@ mod tests {
             after: Some(after_id),
         };
 
-        let result = list_episodes(&mock_clickhouse, params).await.unwrap();
+        let result = list_episodes(&mock_database, params).await.unwrap();
 
         assert!(result.is_empty());
     }
 
     #[tokio::test]
-    async fn test_query_episode_table_bounds_calls_clickhouse() {
-        let mut mock_clickhouse = MockSelectQueries::new();
+    async fn test_query_episode_table_bounds_calls_database() {
+        let mut mock_database = MockEpisodeQueries::new();
 
         let first_id = Uuid::now_v7();
         let last_id = Uuid::now_v7();
 
-        mock_clickhouse
+        mock_database
             .expect_query_episode_table_bounds()
             .times(1)
             .returning(move || {
-                Box::pin(async move {
-                    Ok(TableBoundsWithCount {
-                        first_id: Some(first_id),
-                        last_id: Some(last_id),
-                        count: 100,
-                    })
+                Ok(TableBoundsWithCount {
+                    first_id: Some(first_id),
+                    last_id: Some(last_id),
+                    count: 100,
                 })
             });
 
-        let result = query_episode_table_bounds(&mock_clickhouse).await.unwrap();
+        let result = query_episode_table_bounds(&mock_database).await.unwrap();
 
         assert_eq!(result.first_id, Some(first_id));
         assert_eq!(result.last_id, Some(last_id));
@@ -179,22 +184,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_query_episode_table_bounds_empty() {
-        let mut mock_clickhouse = MockSelectQueries::new();
+        let mut mock_database = MockEpisodeQueries::new();
 
-        mock_clickhouse
+        mock_database
             .expect_query_episode_table_bounds()
             .times(1)
             .returning(|| {
-                Box::pin(async move {
-                    Ok(TableBoundsWithCount {
-                        first_id: None,
-                        last_id: None,
-                        count: 0,
-                    })
+                Ok(TableBoundsWithCount {
+                    first_id: None,
+                    last_id: None,
+                    count: 0,
                 })
             });
 
-        let result = query_episode_table_bounds(&mock_clickhouse).await.unwrap();
+        let result = query_episode_table_bounds(&mock_database).await.unwrap();
 
         assert!(result.first_id.is_none());
         assert!(result.last_id.is_none());
@@ -203,7 +206,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_query_episode_table_rejects_limit_over_100() {
-        let mock_clickhouse = MockSelectQueries::new();
+        let mock_database = MockEpisodeQueries::new();
 
         let params = ListEpisodesParams {
             limit: 101,
@@ -211,7 +214,7 @@ mod tests {
             after: None,
         };
 
-        let result = list_episodes(&mock_clickhouse, params).await;
+        let result = list_episodes(&mock_database, params).await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();

--- a/tensorzero-core/tests/e2e/db/mod.rs
+++ b/tensorzero-core/tests/e2e/db/mod.rs
@@ -42,6 +42,7 @@ mod batch_inference_endpoint_internals;
 mod batch_inference_queries;
 mod dataset_queries;
 mod dicl_queries;
+mod episode_queries;
 mod evaluation_queries;
 mod feedback_queries;
 mod inference_count_queries;
@@ -50,7 +51,6 @@ mod model_inference_queries;
 mod model_provider_statistics_queries;
 mod postgres;
 mod rate_limit_queries;
-mod select_queries;
 mod workflow_evaluation_queries;
 
 // ===== CONNECTION HELPERS =====

--- a/tensorzero-core/tests/e2e/endpoints/internal/episodes.rs
+++ b/tensorzero-core/tests/e2e/endpoints/internal/episodes.rs
@@ -10,7 +10,6 @@ use crate::common::get_gateway_endpoint;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_query_episode_table_bounds() {
-    skip_for_postgres!();
     let http_client = Client::new();
     let url = get_gateway_endpoint("/internal/episodes/bounds");
 
@@ -34,7 +33,6 @@ async fn test_query_episode_table_bounds() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_query_episode_table() {
-    skip_for_postgres!();
     let http_client = Client::new();
     let url = get_gateway_endpoint("/internal/episodes?limit=10");
 
@@ -69,7 +67,6 @@ async fn test_query_episode_table() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_query_episode_table_with_pagination() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     // First, get the bounds to know what episodes exist
@@ -113,7 +110,6 @@ async fn test_query_episode_table_with_pagination() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_query_episode_table_limit_zero() {
-    skip_for_postgres!();
     let http_client = Client::new();
     let url = get_gateway_endpoint("/internal/episodes?limit=0");
 
@@ -133,7 +129,6 @@ async fn test_query_episode_table_limit_zero() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_query_episode_table_rejects_limit_over_100() {
-    skip_for_postgres!();
     let http_client = Client::new();
     let url = get_gateway_endpoint("/internal/episodes?limit=101");
 
@@ -147,7 +142,6 @@ async fn test_query_episode_table_rejects_limit_over_100() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_episode_inference_count() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     // First get an episode that exists
@@ -175,7 +169,6 @@ async fn test_get_episode_inference_count() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_episode_inference_count_nonexistent_episode() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     // Use a UUID that likely doesn't exist


### PR DESCRIPTION
A step towards #5691.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new SQL and pagination logic for Postgres episode queries and changes the episodes endpoint to route through the delegating read path, which could affect ordering/bounds correctness across DB backends.
> 
> **Overview**
> Refactors episode data access by replacing `SelectQueries` with an async `EpisodeQueries` trait, updating ClickHouse, the delegating connection, and the episodes endpoints/tests to use the new interface.
> 
> Adds a new Postgres `EpisodeQueries` implementation that queries episodes (with before/after pagination) and episode table bounds by aggregating across `chat_inferences` and `json_inferences`, and removes Postgres skips so episode endpoint e2e tests run against both backends. Also centralizes ClickHouse JSON/count parsing helpers under `clickhouse/episode_queries` and updates other ClickHouse query modules to import them from there.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 619a2926ba63492b7b937530c5858f57e90efad0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->