### PR TITLE
Fix VariantLink for DEFAULT_FUNCTION variants

### DIFF
--- a/ui/app/components/function/variant/VariantLink.tsx
+++ b/ui/app/components/function/variant/VariantLink.tsx
@@ -3,6 +3,7 @@ import { useFunctionConfig } from "~/context/config";
 import { toVariantUrl } from "~/utils/urls";
 import type { ReactNode } from "react";
 import { useToast } from "~/hooks/use-toast";
+import { DEFAULT_FUNCTION } from "~/utils/constants";
 
 type VariantLinkProps = {
   variantName: string;
@@ -18,7 +19,10 @@ export function VariantLink({
   const { toast } = useToast();
   const functionConfig = useFunctionConfig(functionName);
   const variantConfig = functionConfig?.variants[variantName];
-  return variantConfig ? (
+  // For DEFAULT_FUNCTION, variants are dynamically generated based on model names
+  // and won't be in the config, but the variant detail page handles this
+  const isValidVariant = variantConfig || functionName === DEFAULT_FUNCTION;
+  return isValidVariant ? (
     <Link to={toVariantUrl(functionName, variantName)}>{children}</Link>
   ) : (
     <button


### PR DESCRIPTION
## Summary
- DEFAULT_FUNCTION variants are dynamically generated based on model names and won't be present in the config
- Previously, clicking a DEFAULT_FUNCTION variant showed an error toast instead of navigating to the detail page
- The variant detail page already handles DEFAULT_FUNCTION variants correctly, so this just allows the link

Arose during function detail page streaming refactor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only conditional change gated to `DEFAULT_FUNCTION`; low risk aside from potentially linking to non-existent variant pages if upstream routing assumptions change.
> 
> **Overview**
> Fixes `VariantLink` so variants under `DEFAULT_FUNCTION` navigate to the variant detail page even when they are not present in the loaded config (they’re dynamically derived), instead of showing the “not present in your configuration file” error toast.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a13f527de17cf67f8e05e37c2959b0688a99f7ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->