### PR TITLE
Workflow Evals: Refactor project page data fetching

### DIFF
--- a/ui/app/routes/workflow-evaluations/projects/$project_name/route.server.ts
+++ b/ui/app/routes/workflow-evaluations/projects/$project_name/route.server.ts
@@ -1,0 +1,57 @@
+import type { WorkflowEvaluationRunStatistics } from "~/types/tensorzero";
+import { getTensorZeroClient } from "~/utils/tensorzero.server";
+
+export type ResultsData = {
+  runInfos: Awaited<
+    ReturnType<
+      ReturnType<typeof getTensorZeroClient>["getWorkflowEvaluationRuns"]
+    >
+  >["runs"];
+  runStats: Record<string, WorkflowEvaluationRunStatistics[]>;
+  episodeInfo: Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getTensorZeroClient
+      >["listWorkflowEvaluationRunEpisodesByTaskName"]
+    >
+  >["episodes"];
+  count: number;
+};
+
+export async function fetchResultsData(
+  runIds: string[],
+  projectName: string,
+  limit: number,
+  offset: number,
+): Promise<ResultsData> {
+  const client = getTensorZeroClient();
+  const statsPromises = runIds.map((runId) =>
+    client
+      .getWorkflowEvaluationRunStatistics(runId)
+      .then((response) => response.statistics),
+  );
+  const runInfosPromise = client
+    .getWorkflowEvaluationRuns(runIds, projectName)
+    .then((response) => response.runs);
+  const episodeInfoPromise = client
+    .listWorkflowEvaluationRunEpisodesByTaskName(runIds, limit, offset)
+    .then((response) => response.episodes);
+  const countPromise =
+    client.countWorkflowEvaluationRunEpisodeGroupsByTaskName(runIds);
+
+  const [statsResults, runInfos, episodeInfo, count] = await Promise.all([
+    Promise.all(statsPromises),
+    runInfosPromise,
+    episodeInfoPromise,
+    countPromise,
+  ]);
+
+  const runStats: Record<string, WorkflowEvaluationRunStatistics[]> = {};
+  runIds.forEach((runId, index) => {
+    runStats[runId] = statsResults[index];
+  });
+  // Sort runInfos by the same order as the url params
+  runInfos.sort((a, b) => runIds.indexOf(a.id) - runIds.indexOf(b.id));
+
+  return { runInfos, runStats, episodeInfo, count };
+}


### PR DESCRIPTION
## Summary
- Extract `fetchResultsData` helper to consolidate data fetching logic
- Extract `ResultsContent` component for results table and pagination
- Remove duplicate `getTensorZeroClient()` call
- Use `useSearchParams` instead of `window.location.search`
- Pure refactor — no behavior changes, prepares for streaming in a follow-up PR

## Test plan
- [ ] Verify project page works identically to before
- [ ] Verify run selection and comparison works
- [ ] Verify pagination works
- [ ] Run e2e tests: `pnpm test-e2e`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of data-fetching and pagination wiring with no expected behavior change; risk is limited to potential query param/pagination regressions.
> 
> **Overview**
> Refactors the workflow evaluation project page by extracting the loader’s multi-request fetch logic into a new `fetchResultsData` helper in `route.server.ts`, including typed return data and preserving run ordering.
> 
> Also extracts the results table + pagination controls into a `ResultsContent` component, switching pagination navigation to `useSearchParams` (instead of `window.location.search`) while keeping the same `offset/limit` query param behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb9b16663c237cae1f42364184f44d45e202c846. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->