### PR TITLE
Extract VariantsSection with independent Suspense boundary

### DIFF
--- a/ui/app/routes/observability/functions/$function_name/VariantsSection.tsx
+++ b/ui/app/routes/observability/functions/$function_name/VariantsSection.tsx
@@ -1,0 +1,131 @@
+import { Suspense } from "react";
+import { Await, useAsyncError } from "react-router";
+import { Skeleton } from "~/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "~/components/ui/table";
+import {
+  TableErrorNotice,
+  getErrorMessage,
+} from "~/components/ui/error/ErrorContentPrimitives";
+import { AlertCircle } from "lucide-react";
+import { SectionHeader, SectionLayout } from "~/components/layout/PageLayout";
+import FunctionVariantTable from "./FunctionVariantTable";
+import type { VariantsSectionData } from "./function-data.server";
+
+interface VariantsSectionProps {
+  promise: Promise<VariantsSectionData>;
+  functionName: string;
+  locationKey: string;
+}
+
+export function VariantsSection({
+  promise,
+  functionName,
+  locationKey,
+}: VariantsSectionProps) {
+  return (
+    <SectionLayout>
+      <Suspense key={`variants-${locationKey}`} fallback={<VariantsSkeleton />}>
+        <Await resolve={promise} errorElement={<VariantsError />}>
+          {(data) => (
+            <VariantsContent data={data} functionName={functionName} />
+          )}
+        </Await>
+      </Suspense>
+    </SectionLayout>
+  );
+}
+
+function VariantsContent({
+  data,
+  functionName,
+}: {
+  data: VariantsSectionData;
+  functionName: string;
+}) {
+  return (
+    <>
+      <SectionHeader heading="Variants" />
+      <FunctionVariantTable
+        variant_counts={data.variant_counts}
+        function_name={functionName}
+      />
+    </>
+  );
+}
+
+function VariantsTableHeaders() {
+  return (
+    <TableHeader>
+      <TableRow>
+        <TableHead>Name</TableHead>
+        <TableHead>Type</TableHead>
+        <TableHead>Weight</TableHead>
+        <TableHead>Inferences</TableHead>
+      </TableRow>
+    </TableHeader>
+  );
+}
+
+function VariantsSkeleton() {
+  return (
+    <>
+      <SectionHeader heading="Variants" />
+      <Table>
+        <VariantsTableHeaders />
+        <TableBody>
+          {[1, 2, 3].map((i) => (
+            <TableRow key={i}>
+              <TableCell>
+                <Skeleton className="h-4 w-32" />
+              </TableCell>
+              <TableCell>
+                <Skeleton className="h-4 w-24" />
+              </TableCell>
+              <TableCell>
+                <Skeleton className="h-4 w-12" />
+              </TableCell>
+              <TableCell>
+                <Skeleton className="h-4 w-16" />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </>
+  );
+}
+
+function VariantsError() {
+  const error = useAsyncError();
+  const message = getErrorMessage({
+    error,
+    fallback: "Failed to load variants",
+  });
+
+  return (
+    <>
+      <SectionHeader heading="Variants" />
+      <Table>
+        <VariantsTableHeaders />
+        <TableBody>
+          <TableRow>
+            <TableCell colSpan={4}>
+              <TableErrorNotice
+                icon={AlertCircle}
+                title="Error loading data"
+                description={message}
+              />
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </>
+  );
+}

--- a/ui/app/routes/observability/functions/$function_name/function-data.server.ts
+++ b/ui/app/routes/observability/functions/$function_name/function-data.server.ts
@@ -256,7 +256,7 @@ export async function fetchExperimentationSectionData(
   return { feedback_timeseries, variant_sampling_probabilities };
 }
 
-// === Combined Fetch (used while sections share a single Suspense boundary) ===
+// === Combined Fetch (used while remaining sections share a single Suspense boundary) ===
 
 type FetchAllParams = {
   function_name: string;
@@ -280,7 +280,6 @@ export type FunctionDetailData = {
   metricsWithFeedback: MetricsSectionData["metricsWithFeedback"];
   variant_performances: MetricsSectionData["variant_performances"];
   variant_throughput: ThroughputSectionData;
-  variant_counts: VariantsSectionData["variant_counts"];
   feedback_timeseries: ExperimentationSectionData["feedback_timeseries"];
   variant_sampling_probabilities: ExperimentationSectionData["variant_sampling_probabilities"];
 };
@@ -301,9 +300,8 @@ export async function fetchAllFunctionDetailData(
     feedback_time_granularity,
   } = params;
 
-  const [variants, experimentation, throughput, metrics, inferences] =
+  const [experimentation, throughput, metrics, inferences] =
     await Promise.all([
-      fetchVariantsSectionData({ function_name, function_config }),
       fetchExperimentationSectionData({
         function_name,
         function_config,
@@ -336,7 +334,6 @@ export async function fetchAllFunctionDetailData(
     metricsWithFeedback: metrics.metricsWithFeedback,
     variant_performances: metrics.variant_performances,
     variant_throughput: throughput,
-    variant_counts: variants.variant_counts,
     feedback_timeseries: experimentation.feedback_timeseries,
     variant_sampling_probabilities:
       experimentation.variant_sampling_probabilities,


### PR DESCRIPTION
## Summary
- Extracts the variants table into its own `VariantsSection` component with independent Suspense boundary
- Variants now stream independently — they render as soon as their data loads, isolated from other sections
- Includes dedicated skeleton (3-row table) and error state (table with error notice)
- Remaining sections still share a single combined Suspense boundary

Part 3 of the function detail page streaming refactor (split from #6082). Stacks on #6181.