### PR TITLE
Extract ExperimentationSection with independent Suspense boundary

### DIFF
--- a/ui/app/routes/observability/functions/$function_name/ExperimentationSection.tsx
+++ b/ui/app/routes/observability/functions/$function_name/ExperimentationSection.tsx
@@ -1,0 +1,52 @@
+import { Suspense } from "react";
+import { Await } from "react-router";
+import { Skeleton } from "~/components/ui/skeleton";
+import { SectionHeader, SectionLayout } from "~/components/layout/PageLayout";
+import { SectionAsyncErrorState } from "~/components/ui/error/ErrorContentPrimitives";
+import { FunctionExperimentation } from "./FunctionExperimentation";
+import type { FunctionConfig } from "~/types/tensorzero";
+import type { ExperimentationSectionData } from "./function-data.server";
+
+interface ExperimentationSectionProps {
+  promise: Promise<ExperimentationSectionData | undefined>;
+  functionName: string;
+  functionConfig: FunctionConfig;
+  locationKey: string;
+}
+
+export function ExperimentationSection({
+  promise,
+  functionName,
+  functionConfig,
+  locationKey,
+}: ExperimentationSectionProps) {
+  return (
+    <SectionLayout>
+      <SectionHeader heading="Experimentation" />
+      <Suspense
+        key={`experimentation-${locationKey}`}
+        fallback={<Skeleton className="h-32 w-full" />}
+      >
+        <Await
+          resolve={promise}
+          errorElement={
+            <SectionAsyncErrorState defaultMessage="Failed to load experimentation data" />
+          }
+        >
+          {(data) =>
+            data ? (
+              <FunctionExperimentation
+                functionConfig={functionConfig}
+                functionName={functionName}
+                feedbackTimeseries={data.feedback_timeseries}
+                variantSamplingProbabilities={
+                  data.variant_sampling_probabilities
+                }
+              />
+            ) : null
+          }
+        </Await>
+      </Suspense>
+    </SectionLayout>
+  );
+}

--- a/ui/app/routes/observability/functions/$function_name/function-data.server.ts
+++ b/ui/app/routes/observability/functions/$function_name/function-data.server.ts
@@ -280,8 +280,6 @@ export type FunctionDetailData = {
   metricsWithFeedback: MetricsSectionData["metricsWithFeedback"];
   variant_performances: MetricsSectionData["variant_performances"];
   variant_throughput: ThroughputSectionData;
-  feedback_timeseries: ExperimentationSectionData["feedback_timeseries"];
-  variant_sampling_probabilities: ExperimentationSectionData["variant_sampling_probabilities"];
 };
 
 export async function fetchAllFunctionDetailData(
@@ -300,14 +298,8 @@ export async function fetchAllFunctionDetailData(
     feedback_time_granularity,
   } = params;
 
-  const [experimentation, throughput, metrics, inferences] =
-    await Promise.all([
-      fetchExperimentationSectionData({
-        function_name,
-        function_config,
-        time_granularity: feedback_time_granularity,
-      }),
-      fetchThroughputSectionData({
+  const [throughput, metrics, inferences] = await Promise.all([
+    fetchThroughputSectionData({
         function_name,
         time_granularity: throughput_time_granularity,
       }),
@@ -317,13 +309,13 @@ export async function fetchAllFunctionDetailData(
         time_granularity,
         config,
       }),
-      fetchInferencesSectionData({
-        function_name,
-        beforeInference,
-        afterInference,
-        limit,
-      }),
-    ]);
+    fetchInferencesSectionData({
+      function_name,
+      beforeInference,
+      afterInference,
+      limit,
+    }),
+  ]);
 
   return {
     function_name,
@@ -334,8 +326,5 @@ export async function fetchAllFunctionDetailData(
     metricsWithFeedback: metrics.metricsWithFeedback,
     variant_performances: metrics.variant_performances,
     variant_throughput: throughput,
-    feedback_timeseries: experimentation.feedback_timeseries,
-    variant_sampling_probabilities:
-      experimentation.variant_sampling_probabilities,
   };
 }


### PR DESCRIPTION
## Summary
- Extracts the experimentation section into its own `ExperimentationSection` component with independent Suspense boundary
- Conditionally skips data fetching for `DEFAULT_FUNCTION` (optimization: no network call when section won't render)
- Errors in experimentation data no longer block other sections from rendering

Part 4 of the function detail page streaming refactor (split from #6082). Stacks on #6186.