### PR TITLE
Extract ThroughputSection with independent Suspense boundary

### DIFF
--- a/ui/app/routes/observability/functions/$function_name/ThroughputSection.tsx
+++ b/ui/app/routes/observability/functions/$function_name/ThroughputSection.tsx
@@ -1,0 +1,36 @@
+import { Suspense } from "react";
+import { Await } from "react-router";
+import { Skeleton } from "~/components/ui/skeleton";
+import { SectionHeader, SectionLayout } from "~/components/layout/PageLayout";
+import { SectionAsyncErrorState } from "~/components/ui/error/ErrorContentPrimitives";
+import { VariantThroughput } from "~/components/function/variant/VariantThroughput";
+import type { ThroughputSectionData } from "./function-data.server";
+
+interface ThroughputSectionProps {
+  promise: Promise<ThroughputSectionData>;
+  locationKey: string;
+}
+
+export function ThroughputSection({
+  promise,
+  locationKey,
+}: ThroughputSectionProps) {
+  return (
+    <SectionLayout>
+      <SectionHeader heading="Throughput" />
+      <Suspense
+        key={`throughput-${locationKey}`}
+        fallback={<Skeleton className="h-64 w-full" />}
+      >
+        <Await
+          resolve={promise}
+          errorElement={
+            <SectionAsyncErrorState defaultMessage="Failed to load throughput" />
+          }
+        >
+          {(data) => <VariantThroughput variant_throughput={data} />}
+        </Await>
+      </Suspense>
+    </SectionLayout>
+  );
+}

--- a/ui/app/routes/observability/functions/$function_name/function-data.server.ts
+++ b/ui/app/routes/observability/functions/$function_name/function-data.server.ts
@@ -279,7 +279,6 @@ export type FunctionDetailData = {
   num_inferences: number;
   metricsWithFeedback: MetricsSectionData["metricsWithFeedback"];
   variant_performances: MetricsSectionData["variant_performances"];
-  variant_throughput: ThroughputSectionData;
 };
 
 export async function fetchAllFunctionDetailData(
@@ -298,17 +297,13 @@ export async function fetchAllFunctionDetailData(
     feedback_time_granularity,
   } = params;
 
-  const [throughput, metrics, inferences] = await Promise.all([
-    fetchThroughputSectionData({
-        function_name,
-        time_granularity: throughput_time_granularity,
-      }),
-      fetchMetricsSectionData({
-        function_name,
-        metric_name,
-        time_granularity,
-        config,
-      }),
+  const [metrics, inferences] = await Promise.all([
+    fetchMetricsSectionData({
+      function_name,
+      metric_name,
+      time_granularity,
+      config,
+    }),
     fetchInferencesSectionData({
       function_name,
       beforeInference,
@@ -325,6 +320,5 @@ export async function fetchAllFunctionDetailData(
     num_inferences: inferences.count,
     metricsWithFeedback: metrics.metricsWithFeedback,
     variant_performances: metrics.variant_performances,
-    variant_throughput: throughput,
   };
 }

--- a/ui/app/routes/observability/functions/$function_name/route.tsx
+++ b/ui/app/routes/observability/functions/$function_name/route.tsx
@@ -16,7 +16,6 @@ import { useFunctionConfig } from "~/context/config";
 import { MetricSelector } from "~/components/function/variant/MetricSelector";
 import { Suspense, useMemo } from "react";
 import { VariantPerformance } from "~/components/function/variant/VariantPerformance";
-import { VariantThroughput } from "~/components/function/variant/VariantThroughput";
 import {
   PageHeader,
   PageLayout,
@@ -41,11 +40,13 @@ import {
 import {
   fetchAllFunctionDetailData,
   fetchExperimentationSectionData,
+  fetchThroughputSectionData,
   fetchVariantsSectionData,
   type FunctionDetailData,
 } from "./function-data.server";
 import { VariantsSection } from "./VariantsSection";
 import { ExperimentationSection } from "./ExperimentationSection";
+import { ThroughputSection } from "./ThroughputSection";
 
 function FunctionDetailPageHeader({
   functionName,
@@ -76,11 +77,6 @@ function FunctionDetailPageHeader({
 function SectionsSkeleton() {
   return (
     <>
-      <SectionLayout>
-        <SectionHeader heading="Throughput" />
-        <Skeleton className="h-64 w-full" />
-      </SectionLayout>
-
       <SectionLayout>
         <SectionHeader heading="Metrics" />
         <Skeleton className="mb-4 h-10 w-64" />
@@ -171,6 +167,10 @@ export async function loader({ request, params }: Route.LoaderArgs) {
             time_granularity: feedback_time_granularity,
           })
         : Promise.resolve(undefined),
+    throughputData: fetchThroughputSectionData({
+      function_name,
+      time_granularity: throughput_time_granularity,
+    }),
     functionDetailData: fetchAllFunctionDetailData({
       function_name,
       function_config,
@@ -202,7 +202,6 @@ function SectionsContent({
     num_inferences,
     metricsWithFeedback,
     variant_performances,
-    variant_throughput,
   } = data;
 
   const navigate = useNavigate();
@@ -249,11 +248,6 @@ function SectionsContent({
   return (
     <>
       <SectionLayout>
-        <SectionHeader heading="Throughput" />
-        <VariantThroughput variant_throughput={variant_throughput} />
-      </SectionLayout>
-
-      <SectionLayout>
         <SectionHeader heading="Metrics" />
         <MetricSelector
           metricsWithFeedback={metricsExcludingDemonstrations}
@@ -290,8 +284,13 @@ function SectionsContent({
 export default function FunctionDetailPage({
   loaderData,
 }: Route.ComponentProps) {
-  const { function_name, variantsData, experimentationData, functionDetailData } =
-    loaderData;
+  const {
+    function_name,
+    variantsData,
+    experimentationData,
+    throughputData,
+    functionDetailData,
+  } = loaderData;
   const location = useLocation();
   const function_config = useFunctionConfig(function_name);
 
@@ -321,6 +320,11 @@ export default function FunctionDetailPage({
             locationKey={location.key}
           />
         )}
+
+        <ThroughputSection
+          promise={throughputData}
+          locationKey={location.key}
+        />
 
         <Suspense key={location.key} fallback={<SectionsSkeleton />}>
           <Await


### PR DESCRIPTION
## Summary
- Extracts the throughput chart into its own `ThroughputSection` component with independent Suspense boundary
- Throughput renders independently with a simple skeleton placeholder
- Errors in throughput data no longer block other sections from rendering

Part 5 of the function detail page streaming refactor (split from #6082). Stacks on #6187.