### PR TITLE
Extract MetricsSection with independent Suspense boundary

### DIFF
--- a/ui/app/routes/observability/functions/$function_name/MetricsSection.tsx
+++ b/ui/app/routes/observability/functions/$function_name/MetricsSection.tsx
@@ -1,0 +1,78 @@
+import { Suspense, useMemo } from "react";
+import { Await, useNavigate, useSearchParams } from "react-router";
+import { Skeleton } from "~/components/ui/skeleton";
+import { SectionHeader, SectionLayout } from "~/components/layout/PageLayout";
+import { SectionAsyncErrorState } from "~/components/ui/error/ErrorContentPrimitives";
+import { MetricSelector } from "~/components/function/variant/MetricSelector";
+import { VariantPerformance } from "~/components/function/variant/VariantPerformance";
+import type { MetricsSectionData } from "./function-data.server";
+
+interface MetricsSectionProps {
+  promise: Promise<MetricsSectionData>;
+  locationKey: string;
+}
+
+export function MetricsSection({ promise, locationKey }: MetricsSectionProps) {
+  return (
+    <SectionLayout>
+      <SectionHeader heading="Metrics" />
+      <Suspense key={`metrics-${locationKey}`} fallback={<MetricsSkeleton />}>
+        <Await
+          resolve={promise}
+          errorElement={
+            <SectionAsyncErrorState defaultMessage="Failed to load metrics" />
+          }
+        >
+          {(data) => <MetricsContent data={data} />}
+        </Await>
+      </Suspense>
+    </SectionLayout>
+  );
+}
+
+function MetricsContent({ data }: { data: MetricsSectionData }) {
+  const { metricsWithFeedback, variant_performances } = data;
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const metric_name = searchParams.get("metric_name") || "";
+
+  const metricsExcludingDemonstrations = useMemo(
+    () => ({
+      metrics: metricsWithFeedback.metrics.filter(
+        ({ metric_type }) => metric_type !== "demonstration",
+      ),
+    }),
+    [metricsWithFeedback],
+  );
+
+  const handleMetricChange = (metric: string) => {
+    const newSearchParams = new URLSearchParams(window.location.search);
+    newSearchParams.set("metric_name", metric);
+    navigate(`?${newSearchParams.toString()}`, { preventScrollReset: true });
+  };
+
+  return (
+    <>
+      <MetricSelector
+        metricsWithFeedback={metricsExcludingDemonstrations}
+        selectedMetric={metric_name}
+        onMetricChange={handleMetricChange}
+      />
+      {variant_performances && (
+        <VariantPerformance
+          variant_performances={variant_performances}
+          metric_name={metric_name}
+        />
+      )}
+    </>
+  );
+}
+
+function MetricsSkeleton() {
+  return (
+    <>
+      <Skeleton className="mb-4 h-10 w-64" />
+      <Skeleton className="h-64 w-full" />
+    </>
+  );
+}

--- a/ui/app/routes/observability/functions/$function_name/function-data.server.ts
+++ b/ui/app/routes/observability/functions/$function_name/function-data.server.ts
@@ -260,15 +260,9 @@ export async function fetchExperimentationSectionData(
 
 type FetchAllParams = {
   function_name: string;
-  function_config: FunctionConfig;
-  config: Awaited<ReturnType<typeof getConfig>>;
   beforeInference: string | null;
   afterInference: string | null;
   limit: number;
-  metric_name: string | undefined;
-  time_granularity: TimeWindow;
-  throughput_time_granularity: TimeWindow;
-  feedback_time_granularity: TimeWindow;
 };
 
 export type FunctionDetailData = {
@@ -277,40 +271,19 @@ export type FunctionDetailData = {
   hasNextInferencePage: boolean;
   hasPreviousInferencePage: boolean;
   num_inferences: number;
-  metricsWithFeedback: MetricsSectionData["metricsWithFeedback"];
-  variant_performances: MetricsSectionData["variant_performances"];
 };
 
 export async function fetchAllFunctionDetailData(
   params: FetchAllParams,
 ): Promise<FunctionDetailData> {
-  const {
+  const { function_name, beforeInference, afterInference, limit } = params;
+
+  const inferences = await fetchInferencesSectionData({
     function_name,
-    function_config,
-    config,
     beforeInference,
     afterInference,
     limit,
-    metric_name,
-    time_granularity,
-    throughput_time_granularity,
-    feedback_time_granularity,
-  } = params;
-
-  const [metrics, inferences] = await Promise.all([
-    fetchMetricsSectionData({
-      function_name,
-      metric_name,
-      time_granularity,
-      config,
-    }),
-    fetchInferencesSectionData({
-      function_name,
-      beforeInference,
-      afterInference,
-      limit,
-    }),
-  ]);
+  });
 
   return {
     function_name,
@@ -318,7 +291,5 @@ export async function fetchAllFunctionDetailData(
     hasNextInferencePage: inferences.hasNextPage,
     hasPreviousInferencePage: inferences.hasPreviousPage,
     num_inferences: inferences.count,
-    metricsWithFeedback: metrics.metricsWithFeedback,
-    variant_performances: metrics.variant_performances,
   };
 }


### PR DESCRIPTION
## Summary
- Extracts the metrics selector and variant performance chart into their own `MetricsSection` component with independent Suspense boundary
- Includes dedicated skeleton (dropdown + chart placeholder) and error state
- Metric selection and navigation logic is self-contained in the component

Part 6 of the function detail page streaming refactor (split from #6082). Stacks on #6188.