### PR TITLE
Fix chart legend layout shift

### DIFF
--- a/ui/app/components/experimentation/PieChart.tsx
+++ b/ui/app/components/experimentation/PieChart.tsx
@@ -11,7 +11,6 @@ import {
 import {
   ChartContainer,
   ChartLegend,
-  ChartLegendContent,
   ChartTooltip,
 } from "~/components/ui/chart";
 
@@ -77,7 +76,7 @@ export const ExperimentationPieChart = memo(function ExperimentationPieChart({
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig} className="h-80 w-full">
+        <ChartContainer config={chartConfig}>
           <PieChart>
             <Pie
               data={data}
@@ -97,11 +96,12 @@ export const ExperimentationPieChart = memo(function ExperimentationPieChart({
               ))}
             </Pie>
             <ChartTooltip content={<CustomTooltipContent />} />
-            <ChartLegend
-              content={<ChartLegendContent className="font-mono text-xs" />}
-            />
           </PieChart>
         </ChartContainer>
+        <ChartLegend
+          items={data.map((d) => d.variant_name)}
+          colors={data.map((d) => chartConfig[d.variant_name]?.color ?? "")}
+        />
       </CardContent>
     </Card>
   );

--- a/ui/app/components/function/variant/FeedbackCountsTimeseries.tsx
+++ b/ui/app/components/function/variant/FeedbackCountsTimeseries.tsx
@@ -17,7 +17,6 @@ import { TimeGranularitySelector } from "./TimeGranularitySelector";
 import {
   ChartContainer,
   ChartLegend,
-  ChartLegendContent,
   ChartTooltip,
 } from "~/components/ui/chart";
 import type { FeedbackCountsTimeseriesData } from "./FeedbackSamplesTimeseries";
@@ -76,7 +75,7 @@ export function FeedbackCountsTimeseries({
         />
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig} className="h-80 w-full">
+        <ChartContainer config={chartConfig}>
           <AreaChart accessibilityLayer data={countsDataWithTimestamps}>
             <CartesianGrid vertical={false} />
             <XAxis
@@ -155,9 +154,6 @@ export function FeedbackCountsTimeseries({
                 );
               }}
             />
-            <ChartLegend
-              content={<ChartLegendContent className="font-mono text-xs" />}
-            />
             {variantNames.map((variantName) => (
               <Area
                 key={variantName}
@@ -173,6 +169,10 @@ export function FeedbackCountsTimeseries({
             ))}
           </AreaChart>
         </ChartContainer>
+        <ChartLegend
+          items={variantNames}
+          colors={variantNames.map((name) => chartConfig[name].color)}
+        />
       </CardContent>
     </Card>
   );

--- a/ui/app/components/function/variant/FeedbackMeansTimeseries.tsx
+++ b/ui/app/components/function/variant/FeedbackMeansTimeseries.tsx
@@ -26,7 +26,6 @@ import { TimeGranularitySelector } from "./TimeGranularitySelector";
 import {
   ChartContainer,
   ChartLegend,
-  ChartLegendContent,
   ChartTooltip,
 } from "~/components/ui/chart";
 import type {
@@ -121,20 +120,8 @@ export function FeedbackMeansTimeseries({
   const meanContainerConfig =
     Object.keys(meanChartConfig).length > 0 ? meanChartConfig : chartConfig;
 
-  const meanLegendPayload =
-    variantsWithMeanData.length > 0
-      ? variantsWithMeanData.map((variantName) => ({
-          value: variantName,
-          type: "line" as const,
-          color: chartConfig[variantName].color,
-          dataKey: variantName,
-        }))
-      : variantNames.map((variantName) => ({
-          value: variantName,
-          type: "line" as const,
-          color: chartConfig[variantName].color,
-          dataKey: variantName,
-        }));
+  const legendItems =
+    variantsWithMeanData.length > 0 ? variantsWithMeanData : variantNames;
 
   // Format x-axis labels based on time granularity
   const formatXAxisTick = (value: number) =>
@@ -171,7 +158,7 @@ export function FeedbackMeansTimeseries({
         />
       </CardHeader>
       <CardContent>
-        <ChartContainer config={meanContainerConfig} className="h-80 w-full">
+        <ChartContainer config={meanContainerConfig}>
           <ComposedChart accessibilityLayer data={meanChartData}>
             <CartesianGrid vertical={false} />
             <XAxis
@@ -304,10 +291,6 @@ export function FeedbackMeansTimeseries({
                 );
               }}
             />
-            <ChartLegend
-              payload={meanLegendPayload}
-              content={<ChartLegendContent className="font-mono text-xs" />}
-            />
             {variantsWithMeanData.flatMap((variantName) => {
               const color = chartConfig[variantName].color;
               const meanKey = variantName;
@@ -374,6 +357,10 @@ export function FeedbackMeansTimeseries({
             })}
           </ComposedChart>
         </ChartContainer>
+        <ChartLegend
+          items={legendItems}
+          colors={legendItems.map((name) => chartConfig[name].color)}
+        />
       </CardContent>
     </Card>
   );

--- a/ui/app/components/function/variant/VariantPerformance.tsx
+++ b/ui/app/components/function/variant/VariantPerformance.tsx
@@ -18,7 +18,6 @@ import {
 import {
   ChartContainer,
   ChartLegend,
-  ChartLegendContent,
   ChartTooltip,
   ChartTooltipContent,
 } from "~/components/ui/chart";
@@ -84,7 +83,7 @@ export function VariantPerformance({
           />
         </CardHeader>
         <CardContent>
-          <ChartContainer config={chartConfig} className="h-80 w-full">
+          <ChartContainer config={chartConfig}>
             <BarChart accessibilityLayer data={data}>
               <CartesianGrid vertical={false} />
               <XAxis
@@ -130,9 +129,6 @@ export function VariantPerformance({
                   />
                 }
               />
-              <ChartLegend
-                content={<ChartLegendContent className="font-mono text-xs" />}
-              />
               {singleVariantMode ? (
                 <Bar
                   key={variantNames[0]}
@@ -166,6 +162,16 @@ export function VariantPerformance({
               )}
             </BarChart>
           </ChartContainer>
+          <ChartLegend
+            items={variantNames}
+            colors={
+              singleVariantMode
+                ? [CHART_COLORS[0]]
+                : variantNames.map(
+                    (name) => chartConfig[name]?.color ?? CHART_COLORS[0],
+                  )
+            }
+          />
         </CardContent>
       </Card>
     </div>

--- a/ui/app/components/function/variant/VariantThroughput.tsx
+++ b/ui/app/components/function/variant/VariantThroughput.tsx
@@ -11,7 +11,6 @@ import { Card, CardContent, CardHeader } from "~/components/ui/card";
 import {
   ChartContainer,
   ChartLegend,
-  ChartLegendContent,
   ChartTooltip,
 } from "~/components/ui/chart";
 import { TimeGranularitySelector } from "./TimeGranularitySelector";
@@ -51,7 +50,7 @@ export function VariantThroughput({
           />
         </CardHeader>
         <CardContent>
-          <ChartContainer config={chartConfig} className="h-80 w-full">
+          <ChartContainer config={chartConfig}>
             <AreaChart accessibilityLayer data={data}>
               <CartesianGrid vertical={false} />
               <XAxis
@@ -130,9 +129,6 @@ export function VariantThroughput({
                   );
                 }}
               />
-              <ChartLegend
-                content={<ChartLegendContent className="font-mono text-xs" />}
-              />
               {variantNames.map((variantName) => (
                 <Area
                   key={variantName}
@@ -147,6 +143,7 @@ export function VariantThroughput({
               ))}
             </AreaChart>
           </ChartContainer>
+          <ChartLegend items={variantNames} colors={CHART_COLORS} />
         </CardContent>
       </Card>
     </div>

--- a/ui/app/components/model/ModelLatency.tsx
+++ b/ui/app/components/model/ModelLatency.tsx
@@ -26,11 +26,7 @@ import {
   CardHeader,
   CardTitle,
 } from "~/components/ui/card";
-import {
-  ChartContainer,
-  ChartLegend,
-  ChartLegendContent,
-} from "~/components/ui/chart";
+import { ChartContainer, ChartLegend } from "~/components/ui/chart";
 import { useTimeGranularityParam } from "~/hooks/use-time-granularity-param";
 
 type LatencyMetric = "response_time_ms" | "ttft_ms";
@@ -162,57 +158,56 @@ export function LatencyQuantileChart({
   );
 
   return (
-    <ChartContainer config={chartConfig} className="h-80 w-full">
-      <LineChart accessibilityLayer data={data} margin={MARGIN}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis
-          dataKey="percentile"
-          domain={[0, 1]}
-          tickLine={false}
-          tickMargin={10}
-          axisLine={true}
-          ticks={[
-            0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1.0,
-          ]}
-          tickFormatter={(v) => `${(v * 100).toFixed(0)}%`}
-        />
-        <YAxis
-          scale="log"
-          domain={["dataMin", "dataMax"]}
-          tickLine={false}
-          tickMargin={10}
-          axisLine={true}
-          tickFormatter={(v) => `${v}ms`}
-        />
-
-        <Tooltip
-          content={<CustomTooltipContent />}
-          cursor={{
-            stroke: "#666666",
-            strokeDasharray: "3 3",
-            strokeWidth: 2,
-          }}
-        />
-
-        <ChartLegend
-          content={<ChartLegendContent className="font-mono text-xs" />}
-        />
-
-        {modelNames.map((name, index) => (
-          <Line
-            key={name}
-            type="monotone"
-            dataKey={name}
-            name={name}
-            stroke={CHART_COLORS[index % CHART_COLORS.length]}
-            strokeWidth={2}
-            dot={false}
-            connectNulls={false}
-            isAnimationActive={false}
+    <>
+      <ChartContainer config={chartConfig}>
+        <LineChart accessibilityLayer data={data} margin={MARGIN}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis
+            dataKey="percentile"
+            domain={[0, 1]}
+            tickLine={false}
+            tickMargin={10}
+            axisLine={true}
+            ticks={[
+              0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1.0,
+            ]}
+            tickFormatter={(v) => `${(v * 100).toFixed(0)}%`}
           />
-        ))}
-      </LineChart>
-    </ChartContainer>
+          <YAxis
+            scale="log"
+            domain={["dataMin", "dataMax"]}
+            tickLine={false}
+            tickMargin={10}
+            axisLine={true}
+            tickFormatter={(v) => `${v}ms`}
+          />
+
+          <Tooltip
+            content={<CustomTooltipContent />}
+            cursor={{
+              stroke: "#666666",
+              strokeDasharray: "3 3",
+              strokeWidth: 2,
+            }}
+          />
+
+          {modelNames.map((name, index) => (
+            <Line
+              key={name}
+              type="monotone"
+              dataKey={name}
+              name={name}
+              stroke={CHART_COLORS[index % CHART_COLORS.length]}
+              strokeWidth={2}
+              dot={false}
+              connectNulls={false}
+              isAnimationActive={false}
+            />
+          ))}
+        </LineChart>
+      </ChartContainer>
+      <ChartLegend items={modelNames} colors={CHART_COLORS} />
+    </>
   );
 }
 

--- a/ui/app/components/model/ModelUsage.tsx
+++ b/ui/app/components/model/ModelUsage.tsx
@@ -22,7 +22,6 @@ import {
 import {
   ChartContainer,
   ChartLegend,
-  ChartLegendContent,
   ChartTooltip,
   ChartTooltipContent,
 } from "~/components/ui/chart";
@@ -165,90 +164,92 @@ export function ModelUsage({
               );
 
               return (
-                <ChartContainer config={chartConfig} className="h-80 w-full">
-                  <BarChart accessibilityLayer data={data}>
-                    <CartesianGrid vertical={false} />
-                    {timeGranularity !== "cumulative" && (
-                      <XAxis
-                        dataKey="date"
+                <>
+                  <ChartContainer config={chartConfig}>
+                    <BarChart accessibilityLayer data={data}>
+                      <CartesianGrid vertical={false} />
+                      {timeGranularity !== "cumulative" && (
+                        <XAxis
+                          dataKey="date"
+                          tickLine={false}
+                          tickMargin={10}
+                          axisLine={true}
+                          tickFormatter={(value) =>
+                            formatXAxisTimestamp(
+                              new Date(value),
+                              timeGranularity,
+                            )
+                          }
+                        />
+                      )}
+                      <YAxis
                         tickLine={false}
                         tickMargin={10}
                         axisLine={true}
-                        tickFormatter={(value) =>
-                          formatXAxisTimestamp(new Date(value), timeGranularity)
+                        tickFormatter={formatChartNumber}
+                      />
+                      <ChartTooltip
+                        content={
+                          <ChartTooltipContent
+                            labelFormatter={(label) =>
+                              timeGranularity === "cumulative"
+                                ? "Total"
+                                : formatTooltipTimestamp(
+                                    new Date(label),
+                                    timeGranularity,
+                                  )
+                            }
+                            formatter={(value, name, entry) => {
+                              const count = entry.payload[`${name}_count`];
+                              const inputTokens =
+                                entry.payload[`${name}_input_tokens`];
+                              const outputTokens =
+                                entry.payload[`${name}_output_tokens`];
+                              const totalTokens = inputTokens + outputTokens;
+
+                              return (
+                                <div className="flex flex-1 items-center justify-between leading-none">
+                                  <span className="text-muted-foreground mr-2 font-mono text-xs">
+                                    {name}
+                                  </span>
+                                  <div className="grid text-right">
+                                    <span className="text-foreground font-mono font-medium tabular-nums">
+                                      {METRIC_TYPE_CONFIG[
+                                        selectedMetric
+                                      ].formatter(value as number)}
+                                    </span>
+                                    {selectedMetric === "inferences" && (
+                                      <span className="text-muted-foreground text-[10px]">
+                                        {formatDetailedNumber(totalTokens)}{" "}
+                                        tokens
+                                      </span>
+                                    )}
+                                    {selectedMetric !== "inferences" && (
+                                      <span className="text-muted-foreground text-[10px]">
+                                        {formatDetailedNumber(count)} requests
+                                      </span>
+                                    )}
+                                  </div>
+                                </div>
+                              );
+                            }}
+                          />
                         }
                       />
-                    )}
-                    <YAxis
-                      tickLine={false}
-                      tickMargin={10}
-                      axisLine={true}
-                      tickFormatter={formatChartNumber}
-                    />
-                    <ChartTooltip
-                      content={
-                        <ChartTooltipContent
-                          labelFormatter={(label) =>
-                            timeGranularity === "cumulative"
-                              ? "Total"
-                              : formatTooltipTimestamp(
-                                  new Date(label),
-                                  timeGranularity,
-                                )
-                          }
-                          formatter={(value, name, entry) => {
-                            const count = entry.payload[`${name}_count`];
-                            const inputTokens =
-                              entry.payload[`${name}_input_tokens`];
-                            const outputTokens =
-                              entry.payload[`${name}_output_tokens`];
-                            const totalTokens = inputTokens + outputTokens;
-
-                            return (
-                              <div className="flex flex-1 items-center justify-between leading-none">
-                                <span className="text-muted-foreground mr-2 font-mono text-xs">
-                                  {name}
-                                </span>
-                                <div className="grid text-right">
-                                  <span className="text-foreground font-mono font-medium tabular-nums">
-                                    {METRIC_TYPE_CONFIG[
-                                      selectedMetric
-                                    ].formatter(value as number)}
-                                  </span>
-                                  {selectedMetric === "inferences" && (
-                                    <span className="text-muted-foreground text-[10px]">
-                                      {formatDetailedNumber(totalTokens)} tokens
-                                    </span>
-                                  )}
-                                  {selectedMetric !== "inferences" && (
-                                    <span className="text-muted-foreground text-[10px]">
-                                      {formatDetailedNumber(count)} requests
-                                    </span>
-                                  )}
-                                </div>
-                              </div>
-                            );
-                          }}
+                      {modelNames.map((modelName, index) => (
+                        <Bar
+                          key={modelName}
+                          dataKey={modelName}
+                          name={modelName}
+                          fill={CHART_COLORS[index % CHART_COLORS.length]}
+                          radius={4}
+                          maxBarSize={100}
                         />
-                      }
-                    />
-                    <ChartLegend
-                      content={
-                        <ChartLegendContent className="font-mono text-xs" />
-                      }
-                    />
-                    {modelNames.map((modelName, index) => (
-                      <Bar
-                        key={modelName}
-                        dataKey={modelName}
-                        name={modelName}
-                        fill={CHART_COLORS[index % CHART_COLORS.length]}
-                        radius={4}
-                        maxBarSize={100}
-                      />
-                    ))}
-                  </BarChart>
-                </ChartContainer>
+                      ))}
+                    </BarChart>
+                  </ChartContainer>
+                  <ChartLegend items={modelNames} colors={CHART_COLORS} />
+                </>
               );
             }}
           </Await>

--- a/ui/app/components/ui/chart.tsx
+++ b/ui/app/components/ui/chart.tsx
@@ -50,7 +50,23 @@ const ChartContainer = React.forwardRef<
         data-chart={chartId}
         ref={ref}
         className={cn(
-          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          "flex h-72 w-full justify-center text-xs",
+
+          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground",
+          "[&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50",
+          "[&_.recharts-reference-line_[stroke='#ccc']]:stroke-border",
+          "[&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border",
+
+          "[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted",
+          "[&_.recharts-curve.recharts-tooltip-cursor]:stroke-border",
+          "[&_.recharts-radial-bar-background-sector]:fill-muted",
+
+          "[&_.recharts-dot[stroke='#fff']]:stroke-transparent",
+          "[&_.recharts-sector[stroke='#fff']]:stroke-transparent",
+          "[&_.recharts-layer]:outline-hidden",
+          "[&_.recharts-sector]:outline-hidden",
+          "[&_.recharts-surface]:outline-hidden",
+
           className,
         )}
         {...props}
@@ -254,66 +270,6 @@ const ChartTooltipContent = React.forwardRef<
 );
 ChartTooltipContent.displayName = "ChartTooltip";
 
-const ChartLegend = RechartsPrimitive.Legend;
-
-const ChartLegendContent = React.forwardRef<
-  HTMLDivElement,
-  React.ComponentProps<"div"> &
-    Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
-      hideIcon?: boolean;
-      nameKey?: string;
-    }
->(
-  (
-    { className, hideIcon = false, payload, verticalAlign = "bottom", nameKey },
-    ref,
-  ) => {
-    const { config } = useChart();
-
-    if (!payload?.length) {
-      return null;
-    }
-
-    return (
-      <div
-        ref={ref}
-        className={cn(
-          "flex flex-wrap items-center justify-center gap-4",
-          verticalAlign === "top" ? "pb-3" : "pt-3",
-          className,
-        )}
-      >
-        {payload.map((item) => {
-          const key = `${nameKey || item.dataKey || "value"}`;
-          const itemConfig = getPayloadConfigFromPayload(config, item, key);
-
-          return (
-            <div
-              key={item.value}
-              className={cn(
-                "[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3",
-              )}
-            >
-              {itemConfig?.icon && !hideIcon ? (
-                <itemConfig.icon />
-              ) : (
-                <div
-                  className="h-2 w-2 shrink-0 rounded-[2px]"
-                  style={{
-                    backgroundColor: item.color,
-                  }}
-                />
-              )}
-              {itemConfig?.label}
-            </div>
-          );
-        })}
-      </div>
-    );
-  },
-);
-ChartLegendContent.displayName = "ChartLegend";
-
 // Helper to extract item config from a payload.
 function getPayloadConfigFromPayload(
   config: ChartConfig,
@@ -353,11 +309,39 @@ function getPayloadConfigFromPayload(
     : config[key as keyof typeof config];
 }
 
+/**
+ * Standalone chart legend rendered outside the chart container.
+ * Prevents layout shift caused by Recharts positioning legends
+ * dynamically inside the chart area.
+ */
+function ChartLegend({
+  items,
+  colors,
+}: {
+  items: string[];
+  colors: readonly string[];
+}) {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-4 pt-6">
+      {items.map((name, index) => (
+        <div key={name} className="flex items-center gap-1.5">
+          <div
+            className="h-2 w-2 shrink-0 rounded-[2px]"
+            style={{
+              backgroundColor: colors[index % colors.length],
+            }}
+          />
+          <span className="font-mono text-xs">{name}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export {
   ChartContainer,
+  ChartLegend,
+  ChartStyle,
   ChartTooltip,
   ChartTooltipContent,
-  ChartLegend,
-  ChartLegendContent,
-  ChartStyle,
 };


### PR DESCRIPTION
## Summary

- Render chart legends outside the Recharts SVG container to eliminate layout shift
- Bake default `h-72 w-full` into `ChartContainer` (replacing dead `aspect-video`), removing redundant className from all callers
- Remove dead `ChartLegendContent` (~60 lines) and Recharts `Legend` re-export — all charts now use `ChartLegend`
- Migrate `ExperimentationPieChart` to external legend (was the last remaining internal Recharts legend)

## Why

Recharts positions its built-in legend dynamically inside the chart container, causing layout shift when chart data loads. By moving the legend outside the SVG container, its position is predictable and doesn't affect chart sizing.

While making this change, also cleaned up the chart component API: baked sensible defaults into `ChartContainer` so callers don't need to repeat `className="h-72 w-full"`, and removed ~60 lines of dead `ChartLegendContent` code that is no longer used.

### Models page — Usage chart
![Models usage chart](https://raw.githubusercontent.com/tensorzero/tensorzero/simeonlee/assets/6197/models-usage-chart.png)

### Models page — Long legend names (5 models)
![Models long legends](https://raw.githubusercontent.com/tensorzero/tensorzero/simeonlee/assets/6197/models-long-legends.png)

### Models page — Latency chart with long legends
![Models latency long legends](https://raw.githubusercontent.com/tensorzero/tensorzero/simeonlee/assets/6197/models-latency-long-legends.png)

### Function detail — Experimentation pie chart with long legends
![Function experimentation pie chart](https://raw.githubusercontent.com/tensorzero/tensorzero/simeonlee/assets/6197/fn-detail-pie-long-legends.png)

### Function detail — Throughput + Metrics charts with long legends
![Function throughput long legends](https://raw.githubusercontent.com/tensorzero/tensorzero/simeonlee/assets/6197/fn-detail-throughput-long-legends.png)

### Function detail — Metrics performance chart with long legends
![Function metrics long legends](https://raw.githubusercontent.com/tensorzero/tensorzero/simeonlee/assets/6197/fn-detail-metrics-long-legends.png)

## Test plan

- [x] `pnpm format:check` / `lint:check` / `typecheck` pass
- [x] `pnpm test --run` passes (1 pre-existing SFT failure)
- [x] `pnpm test-e2e` — no chart-related failures (18 pre-existing infra failures)
- [x] Visual verification: Models page (usage + latency charts)
- [x] Visual verification: Function detail (pie, throughput, performance charts)
- [x] Long legend names (5+ items with 50+ char names) wrap correctly via `flex-wrap`
- [x] FeedbackMeans/FeedbackCounts use same `ChartLegend` component (only visible on `track_and_stop` functions)