### PR TITLE
Normalize docker compose space

### DIFF
--- a/docs/deployment/postgres.mdx
+++ b/docs/deployment/postgres.mdx
@@ -51,7 +51,7 @@ You must apply migrations manually with `gateway --run-postgres-migrations`.
 If you've configured the gateway with Docker Compose, you can run the migrations with:
 
 ```bash
-docker-compose run --rm gateway --run-postgres-migrations
+docker compose run --rm gateway --run-postgres-migrations
 ```
 
 See [Deploy the TensorZero Gateway](/deployment/tensorzero-gateway) for more details.

--- a/examples/docs/guides/operations/centralize-auth-rate-limits-and-more/auth/README.md
+++ b/examples/docs/guides/operations/centralize-auth-rate-limits-and-more/auth/README.md
@@ -3,13 +3,13 @@
 2. Set up Postgres:
 
 ```bash
-docker-compose run --rm relay-gateway --run-postgres-migrations
+docker compose run --rm relay-gateway --run-postgres-migrations
 ```
 
 3. Create a TensorZero API key:
 
 ```bash
-docker-compose run --rm relay-gateway --create-api-key
+docker compose run --rm relay-gateway --create-api-key
 ```
 
 4. Set the environment variable `TENSORZERO_RELAY_API_KEY` with the key you just created. (The edge gateway will use it.)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact on runtime behavior or interfaces.
> 
> **Overview**
> Updates documentation examples to use the modern `docker compose` CLI syntax (space-separated) instead of the legacy `docker-compose` command when running Postgres migrations and creating API keys.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ceef67db5f74cacfa7f2c7d7b8fdc0dc0c09311e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->