### PR TITLE
Fix schemas for autopilot test tools to work in strict mode

### DIFF
--- a/internal/autopilot-tools/src/fix_strict_tool_schema.rs
+++ b/internal/autopilot-tools/src/fix_strict_tool_schema.rs
@@ -1,0 +1,22 @@
+use schemars::{
+    Schema,
+    transform::{RecursiveTransform, Transform},
+};
+
+/// Applies various fixes to make a tool schema compatible with OpenAI and Anthropic strict mode:
+/// * Removes the 'minimum' field from 'uint' schemas (which are added by schemars)
+///
+/// This should be applied as-needed to make the `test_list_tools_` tests pass
+pub fn fix_strict_tool_schema(mut schema: Schema) -> Schema {
+    let mut transform = RecursiveTransform(|schema: &mut Schema| {
+        if let Some(obj) = schema.as_object_mut()
+            && obj
+                .get("format")
+                .is_some_and(|f| f == "uint" || f == "uint32" || f == "uint64")
+        {
+            obj.remove("minimum");
+        }
+    });
+    transform.transform(&mut schema);
+    schema
+}

--- a/internal/autopilot-tools/src/lib.rs
+++ b/internal/autopilot-tools/src/lib.rs
@@ -44,6 +44,7 @@
 use std::collections::HashSet;
 
 pub mod error;
+pub mod fix_strict_tool_schema;
 pub mod tools;
 mod visitor;
 

--- a/internal/autopilot-tools/src/tools/test/echo.rs
+++ b/internal/autopilot-tools/src/tools/test/echo.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 /// Parameters for the echo tool (visible to LLM).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub struct EchoParams {
     /// The message to echo back.
     pub message: String,

--- a/internal/autopilot-tools/src/tools/test/error_simple.rs
+++ b/internal/autopilot-tools/src/tools/test/error_simple.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 /// Parameters for the error simple tool (visible to LLM).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub struct ErrorSimpleParams {
     /// The error message to return.
     pub error_message: String,

--- a/internal/autopilot-tools/src/tools/test/failing.rs
+++ b/internal/autopilot-tools/src/tools/test/failing.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 /// Parameters for the failing tool (visible to LLM).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub struct FailingToolParams {
     /// The error message to return.
     pub error_message: String,

--- a/internal/autopilot-tools/src/tools/test/flaky.rs
+++ b/internal/autopilot-tools/src/tools/test/flaky.rs
@@ -4,13 +4,15 @@ use std::borrow::Cow;
 
 use async_trait::async_trait;
 use durable_tools::{TaskTool, ToolContext, ToolMetadata, ToolResult};
+use schemars::{JsonSchema, Schema, schema_for};
+use serde::{Deserialize, Serialize};
 
 use crate::error::AutopilotToolError;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use crate::fix_strict_tool_schema::fix_strict_tool_schema;
 
 /// Parameters for the flaky tool (visible to LLM).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub struct FlakyToolParams {
     /// Fail when attempt_number % fail_on_attempt == 0.
     pub fail_on_attempt: u32,
@@ -41,6 +43,10 @@ impl ToolMetadata for FlakyTool {
 
     fn name(&self) -> Cow<'static, str> {
         Cow::Borrowed("flaky")
+    }
+
+    fn parameters_schema(&self) -> ToolResult<Schema> {
+        Ok(fix_strict_tool_schema(schema_for!(FlakyToolParams)))
     }
 
     fn description(&self) -> Cow<'static, str> {

--- a/internal/autopilot-tools/src/tools/test/good_simple.rs
+++ b/internal/autopilot-tools/src/tools/test/good_simple.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 /// Parameters for the good simple tool (visible to LLM).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub struct GoodSimpleParams {
     /// The message to echo back.
     pub message: String,

--- a/internal/autopilot-tools/src/tools/test/panic.rs
+++ b/internal/autopilot-tools/src/tools/test/panic.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 /// Parameters for the panic tool (visible to LLM).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub struct PanicToolParams {
     /// The panic message.
     pub panic_message: String,

--- a/internal/autopilot-tools/src/tools/test/slow.rs
+++ b/internal/autopilot-tools/src/tools/test/slow.rs
@@ -5,11 +5,14 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use durable_tools::{TaskTool, ToolContext, ToolMetadata, ToolResult};
-use schemars::JsonSchema;
+use schemars::{JsonSchema, Schema, schema_for};
 use serde::{Deserialize, Serialize};
+
+use crate::fix_strict_tool_schema::fix_strict_tool_schema;
 
 /// Parameters for the slow tool (visible to LLM).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub struct SlowToolParams {
     /// How long to sleep before returning (in milliseconds).
     pub delay_ms: u64,
@@ -35,6 +38,10 @@ impl ToolMetadata for SlowTool {
     type SideInfo = ();
     type Output = SlowToolOutput;
     type LlmParams = SlowToolParams;
+
+    fn parameters_schema(&self) -> ToolResult<Schema> {
+        Ok(fix_strict_tool_schema(schema_for!(SlowToolParams)))
+    }
 
     fn name(&self) -> Cow<'static, str> {
         Cow::Borrowed("slow")

--- a/internal/autopilot-tools/src/tools/test/slow_simple.rs
+++ b/internal/autopilot-tools/src/tools/test/slow_simple.rs
@@ -5,11 +5,14 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use durable_tools::{SimpleTool, SimpleToolContext, ToolMetadata, ToolResult};
-use schemars::JsonSchema;
+use schemars::{JsonSchema, Schema, schema_for};
+
+use crate::fix_strict_tool_schema::fix_strict_tool_schema;
 use serde::{Deserialize, Serialize};
 
 /// Parameters for the slow simple tool (visible to LLM).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub struct SlowSimpleParams {
     /// How long to sleep before returning (in milliseconds).
     pub delay_ms: u64,
@@ -38,6 +41,10 @@ impl ToolMetadata for SlowSimpleTool {
 
     fn name(&self) -> Cow<'static, str> {
         Cow::Borrowed("slow_simple")
+    }
+
+    fn parameters_schema(&self) -> ToolResult<Schema> {
+        Ok(fix_strict_tool_schema(schema_for!(SlowSimpleParams)))
     }
 
     fn description(&self) -> Cow<'static, str> {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to schema generation/validation for e2e test tools and do not alter production tool execution paths; main risk is stricter schemas rejecting previously-accepted extra fields in tests.
> 
> **Overview**
> Improves strict-mode compatibility for the `autopilot-tools` *test tools* by tightening their generated JSON Schemas.
> 
> Adds `fix_strict_tool_schema` to post-process schemars output (currently removing `minimum` from `uint*` formats) and wires it into `parameters_schema()` for `FlakyTool`, `SlowTool`, and `SlowSimpleTool`. Additionally, all test tool param structs now use `#[schemars(deny_unknown_fields)]` to disallow extra properties in tool inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a803cd005f37102b73b56200fa4fb93b54491e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->