### PR TITLE
Allow track-and-stop config to be re-used

### DIFF
--- a/tensorzero-core/src/experimentation/track_and_stop/mod.rs
+++ b/tensorzero-core/src/experimentation/track_and_stop/mod.rs
@@ -2086,6 +2086,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_setup_prevents_duplicate_task_spawning() {
+        let logs_contain = crate::utils::testing::capture_logs();
+
         // Create a TrackAndStopConfig instance
         let config = TrackAndStopConfig {
             metric: "test_metric".to_string(),
@@ -2114,17 +2116,21 @@ mod tests {
             .await;
         assert!(result1.is_ok(), "First setup call should succeed");
 
-        // Second call to setup should fail with an error
+        // Second call to setup should also succeed (no-op) and log a message
         let result2 = config
             .setup(db, "test_function", &postgres, cancel_token.clone())
             .await;
-        assert!(result2.is_err(), "Second setup call should fail");
-
-        // Verify the error message mentions the task has already been spawned
-        let err = result2.unwrap_err();
         assert!(
-            err.to_string().contains("already been spawned"),
-            "Error should mention task already spawned, got: {err}"
+            result2.is_ok(),
+            "Second setup call should succeed (task already spawned)"
+        );
+
+        // Verify the info log message is emitted
+        assert!(
+            logs_contain(
+                "Track-and-Stop experimentation background task has already been spawned for function"
+            ),
+            "Expected log message about task already being spawned"
         );
 
         // Clean up: cancel the spawned task


### PR DESCRIPTION
If we're already spawned a background task, then we do nothing when 'TrackAndStopConfig' is re-used. Currently, this can only happen when GEPA re-uses a config via 'ClientBuilderMode::FromComponents'

Since the same top-level `Arc<Config>` is being re-usef, it's fine for the single background task to update our `ArcSwap` for all consumers. Both GEPA and normal gateway inferences will use the same sampling probabilities

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change limited to duplicate background-task spawning; it reduces failure modes and is covered by an updated test and explicit logging.
> 
> **Overview**
> Makes `TrackAndStopConfig::setup()` **idempotent**: if the background probability-update task was already spawned, subsequent `setup()` calls now become a no-op that logs an info message instead of returning a config error (to support config re-use, e.g. GEPA).
> 
> Updates the associated test to expect success on the second `setup()` call and to assert the emitted log message rather than an error string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5068c32c4dc20d7ed317e7a61cd4f6591008100. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->