### PR TITLE
Show configured variants with zero inferences (client-side)

### DIFF
--- a/ui/app/routes/observability/functions/$function_name/FunctionVariantTable.tsx
+++ b/ui/app/routes/observability/functions/$function_name/FunctionVariantTable.tsx
@@ -21,21 +21,16 @@ import {
 } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 import { ChevronUp, ChevronDown, Search } from "lucide-react";
-import type { InferenceCountByVariant } from "~/types/tensorzero";
 import { Input } from "~/components/ui/input";
+import type { VariantCountWithMetadata } from "./variants-data.server";
 
-type VariantCountsWithMetadata = InferenceCountByVariant & {
-  type: string;
-  weight: number | null;
-};
-
-const columnHelper = createColumnHelper<VariantCountsWithMetadata>();
+const columnHelper = createColumnHelper<VariantCountWithMetadata>();
 
 export default function FunctionVariantTable({
   variant_counts,
   function_name,
 }: {
-  variant_counts: VariantCountsWithMetadata[];
+  variant_counts: VariantCountWithMetadata[];
   function_name: string;
 }) {
   const [sorting, setSorting] = useState<SortingState>([]);

--- a/ui/app/routes/observability/functions/$function_name/variants-data.server.ts
+++ b/ui/app/routes/observability/functions/$function_name/variants-data.server.ts
@@ -1,16 +1,22 @@
 import { getTensorZeroClient } from "~/utils/tensorzero.server";
-import type { FunctionConfig } from "~/types/tensorzero";
+import type {
+  FunctionConfig,
+  InferenceCountByVariant,
+} from "~/types/tensorzero";
 import { DEFAULT_FUNCTION } from "~/utils/constants";
 
-export type VariantsSectionData = {
-  variant_counts: {
-    variant_name: string;
-    inference_count: bigint;
-    last_used_at: string;
-    type: string;
-    weight: number | null;
-  }[];
+export type VariantCountWithMetadata = Omit<
+  InferenceCountByVariant,
+  "inference_count"
+> & {
+  inference_count: number;
+  type: string;
+  weight: number | null;
 };
+
+export interface VariantsSectionData {
+  variant_counts: VariantCountWithMetadata[];
+}
 
 export async function fetchVariantsSectionData(params: {
   function_name: string;
@@ -31,6 +37,7 @@ export async function fetchVariantsSectionData(params: {
     const variant_config = function_config.variants[variant_count.variant_name];
     return {
       ...variant_count,
+      inference_count: Number(variant_count.inference_count),
       type:
         function_name === DEFAULT_FUNCTION
           ? "chat_completion"
@@ -50,7 +57,7 @@ export async function fetchVariantsSectionData(params: {
       if (!observedVariants.has(variant_name)) {
         variant_counts_with_metadata.push({
           variant_name,
-          inference_count: BigInt(0),
+          inference_count: 0,
           last_used_at: "",
           type: variant_config.inner.type,
           weight: variant_config.inner.weight,


### PR DESCRIPTION
## Summary

- Configured variants that have no inferences now appear in the Variants table with `count: 0` and "—" for last used
- After fetching variant counts from ClickHouse, iterates config variants and adds any missing ones
- Simplifies DEFAULT_FUNCTION handling by removing the fake variant config construction (~20 lines of boilerplate)
- UI-only change — no backend modifications

## Test plan

- [ ] Navigate to a function with variants that have no inferences — they should appear with count 0 and "—" for last used
- [ ] Verify existing functions with inferences display correctly
- [ ] Verify DEFAULT_FUNCTION still works (no weight, type = chat_completion)
- [ ] Verify Experimentation → Variant Weights panel still works

Fixes #5894

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/server-side data shaping only for observability tables; main risk is minor type/formatting regressions (e.g., bigint-to-number conversion and empty timestamps) rather than behavioral or security impact.
> 
> **Overview**
> The Variants table now also displays **configured variants that have zero inferences**, synthesizing rows with `inference_count: 0` (and empty `last_used_at`) when ClickHouse returns no data for a configured variant.
> 
> `fetchVariantsSectionData` now tracks observed variants, appends missing configured ones (non-`DEFAULT_FUNCTION` only), simplifies `DEFAULT_FUNCTION` handling to just set `type`/`weight`, and normalizes `inference_count` to a `number`. The UI updates types accordingly and renders `Last Used` as "—" when no timestamp is present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19040211de6f159f1b06f62b0a3d98616f7ac963. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->