### PR TITLE
Return quantiles together with latencies for UI to prepare for postgres

### DIFF
--- a/internal/tensorzero-node/lib/bindings/GetModelLatencyResponse.ts
+++ b/internal/tensorzero-node/lib/bindings/GetModelLatencyResponse.ts
@@ -6,6 +6,10 @@ import type { ModelLatencyDatapoint } from "./ModelLatencyDatapoint";
  */
 export type GetModelLatencyResponse = {
   /**
+   * The quantile inputs (e.g. [0.001, 0.005, ..., 0.999]) used to compute the distributions.
+   */
+  quantiles: Array<number>;
+  /**
    * The model latency data points with quantile distributions.
    */
   data: Array<ModelLatencyDatapoint>;

--- a/tensorzero-core/src/db/clickhouse/mock_clickhouse_connection_info.rs
+++ b/tensorzero-core/src/db/clickhouse/mock_clickhouse_connection_info.rs
@@ -282,7 +282,7 @@ impl ModelInferenceQueries for MockClickHouseConnectionInfo {
     }
 
     fn get_model_latency_quantile_function_inputs(&self) -> &[f64] {
-        // Return ClickHouse quantiles since this is a mock for ClickHouse
-        super::migration_manager::migrations::migration_0037::QUANTILES
+        self.model_inference_queries
+            .get_model_latency_quantile_function_inputs()
     }
 }

--- a/tensorzero-core/src/db/postgres/model_inferences.rs
+++ b/tensorzero-core/src/db/postgres/model_inferences.rs
@@ -93,7 +93,6 @@ impl ModelInferenceQueries for PostgresConnectionInfo {
         Ok(rows)
     }
 
-    // TODO(#5691): Need to return this from the backend, so frontend can render correctly.
     fn get_model_latency_quantile_function_inputs(&self) -> &[f64] {
         POSTGRES_QUANTILES
     }

--- a/tensorzero-core/src/endpoints/internal/models/mod.rs
+++ b/tensorzero-core/src/endpoints/internal/models/mod.rs
@@ -71,9 +71,12 @@ pub async fn get_model_latency_handler(
         app_state.postgres_connection_info.clone(),
     );
 
+    let quantiles = database
+        .get_model_latency_quantile_function_inputs()
+        .to_vec();
     let data = database
         .get_model_latency_quantiles(params.time_window)
         .await?;
 
-    Ok(Json(GetModelLatencyResponse { data }))
+    Ok(Json(GetModelLatencyResponse { quantiles, data }))
 }

--- a/tensorzero-core/src/endpoints/internal/models/types.rs
+++ b/tensorzero-core/src/endpoints/internal/models/types.rs
@@ -43,6 +43,8 @@ pub struct GetModelLatencyQueryParams {
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "ts-bindings", ts(export))]
 pub struct GetModelLatencyResponse {
+    /// The quantile inputs (e.g. [0.001, 0.005, ..., 0.999]) used to compute the distributions.
+    pub quantiles: Vec<f64>,
     /// The model latency data points with quantile distributions.
     pub data: Vec<ModelLatencyDatapoint>,
 }

--- a/tensorzero-core/tests/e2e/endpoints/internal/models.rs
+++ b/tensorzero-core/tests/e2e/endpoints/internal/models.rs
@@ -61,9 +61,24 @@ async fn test_model_latency_endpoint() {
 
     let response: GetModelLatencyResponse = resp.json().await.unwrap();
 
-    // The response should have data (may be empty if no recent usage)
-    // Just verify we can deserialize the response successfully
-    let _ = response.data;
+    assert!(
+        !response.quantiles.is_empty(),
+        "Expected non-empty quantiles in latency response"
+    );
+    for datapoint in &response.data {
+        assert_eq!(
+            datapoint.response_time_ms_quantiles.len(),
+            response.quantiles.len(),
+            "response_time_ms_quantiles length should match quantiles length for model `{}`",
+            datapoint.model_name
+        );
+        assert_eq!(
+            datapoint.ttft_ms_quantiles.len(),
+            response.quantiles.len(),
+            "ttft_ms_quantiles length should match quantiles length for model `{}`",
+            datapoint.model_name
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/ui/app/components/model/ModelLatency.tsx
+++ b/ui/app/components/model/ModelLatency.tsx
@@ -1,4 +1,8 @@
-import type { ModelLatencyDatapoint, TimeWindow } from "~/types/tensorzero";
+import type {
+  GetModelLatencyResponse,
+  ModelLatencyDatapoint,
+  TimeWindow,
+} from "~/types/tensorzero";
 import {
   Line,
   LineChart,
@@ -256,11 +260,9 @@ function transformLatencyData(
 }
 
 export function ModelLatency({
-  modelLatencyDataPromise,
-  quantiles,
+  modelLatencyResponsePromise,
 }: {
-  modelLatencyDataPromise: Promise<ModelLatencyDatapoint[]>;
-  quantiles: number[];
+  modelLatencyResponsePromise: Promise<GetModelLatencyResponse>;
 }) {
   const [timeGranularity, onTimeGranularityChange] = useTimeGranularityParam(
     "latencyTimeGranularity",
@@ -300,14 +302,14 @@ export function ModelLatency({
       <CardContent>
         <React.Suspense fallback={<div>Loading latency data...</div>}>
           <Await
-            resolve={modelLatencyDataPromise}
+            resolve={modelLatencyResponsePromise}
             errorElement={<ModelLatencyError />}
           >
-            {(latencyData) => (
+            {(response) => (
               <LatencyQuantileChart
-                latencyData={latencyData}
+                latencyData={response.data}
                 selectedMetric={selectedMetric}
-                quantiles={quantiles}
+                quantiles={response.quantiles}
               />
             )}
           </Await>

--- a/ui/app/routes/observability/models/route.tsx
+++ b/ui/app/routes/observability/models/route.tsx
@@ -7,16 +7,6 @@ export const handle: RouteHandle = {
 };
 import { getTensorZeroClient } from "~/utils/tensorzero.server";
 import type { TimeWindow } from "~/types/tensorzero";
-
-// Quantiles used for TDigest latency percentiles (from migration_0037)
-const QUANTILES: number[] = [
-  0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.12,
-  0.14, 0.16, 0.18, 0.2, 0.22, 0.24, 0.26, 0.28, 0.3, 0.32, 0.34, 0.36, 0.38,
-  0.4, 0.42, 0.44, 0.46, 0.48, 0.5, 0.52, 0.54, 0.56, 0.58, 0.6, 0.62, 0.64,
-  0.66, 0.68, 0.7, 0.72, 0.74, 0.76, 0.78, 0.8, 0.82, 0.84, 0.86, 0.88, 0.9,
-  0.91, 0.92, 0.93, 0.94, 0.95, 0.96, 0.97, 0.98, 0.99, 0.991, 0.992, 0.993,
-  0.994, 0.995, 0.996, 0.997, 0.998, 0.999,
-];
 import { ModelUsage } from "~/components/model/ModelUsage";
 import { ModelLatency } from "~/components/model/ModelLatency";
 import {
@@ -62,24 +52,20 @@ export async function loader({ request }: Route.LoaderArgs) {
   const modelUsageTimeseriesPromise = client
     .getModelUsageTimeseries(usageTimeGranularity, numPeriods)
     .then((response) => response.data);
-  const modelLatencyQuantilesPromise = client
-    .getModelLatencyQuantiles(latencyTimeGranularity)
-    .then((response) => response.data);
+  const modelLatencyQuantilesPromise = client.getModelLatencyQuantiles(
+    latencyTimeGranularity,
+  );
   return {
     modelUsageTimeseriesPromise,
     usageTimeGranularity,
     latencyTimeGranularity,
     modelLatencyQuantilesPromise,
-    quantiles: QUANTILES,
   };
 }
 
 export default function ModelsPage({ loaderData }: Route.ComponentProps) {
-  const {
-    modelUsageTimeseriesPromise,
-    modelLatencyQuantilesPromise,
-    quantiles,
-  } = loaderData;
+  const { modelUsageTimeseriesPromise, modelLatencyQuantilesPromise } =
+    loaderData;
 
   return (
     <PageLayout>
@@ -93,8 +79,7 @@ export default function ModelsPage({ loaderData }: Route.ComponentProps) {
         <SectionLayout>
           <SectionHeader heading="Latency" />
           <ModelLatency
-            modelLatencyDataPromise={modelLatencyQuantilesPromise}
-            quantiles={quantiles}
+            modelLatencyResponsePromise={modelLatencyQuantilesPromise}
           />
         </SectionLayout>
       </SectionsGroup>


### PR DESCRIPTION
A step towards #5691.

Postgres and Clickhouse use different quantile buckets so this allows the frontend to handle either.