### PR TITLE
Start running tests against latest clickhouse release again

### DIFF
--- a/.github/workflows/clickhouse-tests.yml
+++ b/.github/workflows/clickhouse-tests.yml
@@ -35,17 +35,16 @@ jobs:
     runs-on: ${{ matrix.replicated && 'namespace-profile-tensorzero-8x16;ephemeral-storage.size-multiplier=2' || 'namespace-profile-tensorzero-8x16' }}
     continue-on-error: ${{ matrix.clickhouse_version.allow_failure }}
     if: github.repository == 'tensorzero/tensorzero'
-    # TODO - switch back to 'latest': https://github.com/tensorzero/tensorzero/issues/6080
     strategy:
       matrix:
         # Only include replicated: true when running in merge queue
         replicated: ${{ inputs.is_merge_group && fromJSON('[true, false]') || fromJSON('[false]') }}
-        clickhouse_version: ${{ inputs.is_merge_group && fromJSON('[{"tag":"lts","prefix":"lts","allow_failure":false},{"tag":"25.11","prefix":"25.11","allow_failure":false}]') || fromJSON('[{"tag":"lts","prefix":"lts","allow_failure":false}]') }}
+        clickhouse_version: ${{ inputs.is_merge_group && fromJSON('[{"tag":"lts","prefix":"lts","allow_failure":false},{"tag":"latest","prefix":"latest","allow_failure":false}]') || fromJSON('[{"tag":"lts","prefix":"lts","allow_failure":false}]') }}
         exclude:
           - replicated: true
             clickhouse_version:
-              { "tag": "25.11", "prefix": "25.11", "allow_failure": false }
-        include: ${{ inputs.is_merge_group && fromJSON('[{"clickhouse_version":{"tag":"25.11","prefix":"25.11","allow_failure":false},"replicated":true}]') || fromJson('[]') }}
+              { "tag": "latest", "prefix": "latest", "allow_failure": false }
+        include: ${{ inputs.is_merge_group && fromJSON('[{"clickhouse_version":{"tag":"latest","prefix":"latest","allow_failure":false},"replicated":true}]') || fromJson('[]') }}
 
     env:
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low-risk CI-only change, but moving the test matrix back to `latest` ClickHouse may introduce new CI failures due to upstream behavior changes.
> 
> **Overview**
> Updates the `clickhouse-tests` GitHub Actions workflow to run merge-queue CI against ClickHouse `latest` again (instead of the previously pinned `25.11`), including the replicated-cluster variant.
> 
> Adjusts the matrix `include`/`exclude` entries accordingly and removes the temporary TODO about staying on a pinned version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34262eaae1922f8d9a8fa8042007f766d6c46629. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->