### PR TITLE
Switch together llama to a supported serverless model

### DIFF
--- a/tensorzero-core/tests/e2e/config/tensorzero.functions.basic_test.toml
+++ b/tensorzero-core/tests/e2e/config/tensorzero.functions.basic_test.toml
@@ -592,7 +592,7 @@ max_tokens = 100
 
 [functions.basic_test.variants.together-tool]
 type = "chat_completion"
-model = "llama3.1-405b-instruct-turbo-together"
+model = "llama4-maverick-instruct-together"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 

--- a/tensorzero-core/tests/e2e/config/tensorzero.functions.toml
+++ b/tensorzero-core/tests/e2e/config/tensorzero.functions.toml
@@ -343,7 +343,7 @@ system_template = "../../../fixtures/config/functions/weather_helper_parallel/pr
 [functions.weather_helper_parallel.variants.together-tool]
 type = "chat_completion"
 weight = 1
-model = "llama3.1-405b-instruct-turbo-together"
+model = "llama4-maverick-instruct-together"
 system_template = "../../../fixtures/config/functions/weather_helper_parallel/prompt/system_template.minijinja"
 
 [functions.weather_helper_parallel.variants.vllm]

--- a/tensorzero-core/tests/e2e/config/tensorzero.functions.weather_helper.toml
+++ b/tensorzero-core/tests/e2e/config/tensorzero.functions.weather_helper.toml
@@ -225,7 +225,7 @@ max_tokens = 100
 
 [functions.weather_helper.variants.together-tool]
 type = "chat_completion"
-model = "llama3.1-405b-instruct-turbo-together"
+model = "llama4-maverick-instruct-together"
 system_template = "../../../fixtures/config/functions/weather_helper/prompt/system_template.minijinja"
 max_tokens = 100
 

--- a/tensorzero-core/tests/e2e/config/tensorzero.models.toml
+++ b/tensorzero-core/tests/e2e/config/tensorzero.models.toml
@@ -393,12 +393,12 @@ type = "together"
 model_name = "Qwen/Qwen3-Next-80B-A3B-Instruct"
 api_key_location = "dynamic::together_api_key"
 
-[models."llama3.1-405b-instruct-turbo-together"]
+[models."llama4-maverick-instruct-together"]
 routing = ["together"]
 
-[models."llama3.1-405b-instruct-turbo-together".providers.together]
+[models."llama4-maverick-instruct-together".providers.together]
 type = "together"
-model_name = "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo"
+model_name = "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8"
 
 [models."Qwen/Qwen2.5-1.5B-Instruct"]
 routing = ["sglang"]

--- a/tensorzero-core/tests/e2e/providers/together.rs
+++ b/tensorzero-core/tests/e2e/providers/together.rs
@@ -71,7 +71,7 @@ async fn get_providers() -> E2ETestProviders {
     let tool_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "together-tool".to_string(),
-        model_name: "llama3.1-405b-instruct-turbo-together".into(),
+        model_name: "llama4-maverick-instruct-together".into(),
         model_provider_name: "together".into(),
         credentials: HashMap::new(),
     }];


### PR DESCRIPTION
The previous model is no longer available as a serverless model

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only config changes to swap a Together model alias and underlying `model_name`; primary risk is E2E failures if the new serverless model behaves differently or is misnamed.
> 
> **Overview**
> Updates the Together *tool-use* E2E coverage to use a supported serverless model by replacing `llama3.1-405b-instruct-turbo-together` with `llama4-maverick-instruct-together` across the test function configs (`basic_test`, `weather_helper`, and `weather_helper_parallel`).
> 
> Renames the Together model entry in `tensorzero.models.toml` and points it at `meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8`, and updates the Together E2E provider harness (`providers/together.rs`) to reference the new model key.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3747cb5ac1665d47d1093e47be306321711fbbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->