### PR TITLE
Add documentation for enabling pgvector for dicl

### DIFF
--- a/docs/deployment/postgres.mdx
+++ b/docs/deployment/postgres.mdx
@@ -252,14 +252,15 @@ You should re-run this command when upgrading TensorZero from an earlier version
 
 </Steps>
 
-## Configure Postgres for TensorZero optimizations (optional)
+## Configure Postgres for dynamic in-context learning (optional)
 
-When Postgres is configured as the primary data store for TensorZero, some TensorZero inference-time optimizations (e.g. [Dynamic In-Context Learning](/optimization/dynamic-in-context-learning-dicl)) require the [`pgvector`](https://github.com/pgvector/pgvector) extension.
-If you plan to enable these optimizations, you must install `pgvector` in your Postgres instance.
+When Postgres is configured as the primary data store for TensorZero, `experimental_dynamic_in_context_learning` variants (see [Dynamic In-Context Learning (DICL)](/optimization/dynamic-in-context-learning-dicl)) require the [`pgvector`](https://github.com/pgvector/pgvector) extension.
+If you plan to use DICL, you must install `pgvector` in your Postgres instance.
 
-Most managed Postgres providers include `pgvector` out of the box. For self-hosted Postgres, follow the [pgvector installation instructions](https://github.com/pgvector/pgvector#installation).
+Most managed Postgres providers include `pgvector` out of the box.
+For self-hosted Postgres, follow the [pgvector installation instructions](https://github.com/pgvector/pgvector#installation).
 
-When applying migrations, pass the `--enable-optimization-postgres-migrations` flag to apply the additional schema:
+When applying Postgres migrations, pass the `--enable-optimization-postgres-migrations` flag to apply the additional schema:
 
 ```bash
 docker compose run --rm gateway --run-postgres-migrations --enable-optimization-postgres-migrations


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change; no runtime or schema changes are introduced in this PR.
> 
> **Overview**
> Adds a new optional Postgres deployment doc section explaining that Dynamic In-Context Learning (`experimental_dynamic_in_context_learning`) requires the `pgvector` extension when Postgres is the primary store.
> 
> Documents installing `pgvector` (managed vs self-hosted) and instructs running Postgres migrations with `--enable-optimization-postgres-migrations` to apply the additional optimization schema.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a60481f1082339f6580ee0db1211b6c4962b717d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->