### PR TITLE
Bump durable crate for validate_params improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,7 +1910,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 [[package]]
 name = "durable"
 version = "0.1.0"
-source = "git+https://github.com/tensorzero/durable?rev=5e0e7863a725f656ddd6b1ff3ea5b00594c203db#5e0e7863a725f656ddd6b1ff3ea5b00594c203db"
+source = "git+https://github.com/tensorzero/durable?rev=3884f0d875130c1854a6eee8557ff8bd04b0b683#3884f0d875130c1854a6eee8557ff8bd04b0b683"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ metrics-exporter-prometheus = { version = "0.18.1", features = [
 schemars = "1.1.0"
 blake3 = "1.8.3"
 moka = { version = "0.12.13", features = ["sync"] }
-durable = { git = "https://github.com/tensorzero/durable", rev = "5e0e7863a725f656ddd6b1ff3ea5b00594c203db" }
+durable = { git = "https://github.com/tensorzero/durable", rev = "3884f0d875130c1854a6eee8557ff8bd04b0b683" }
 durable-tools-spawn = { path = "internal/durable-tools-spawn" }
 tensorzero = { path = "clients/rust" }
 tensorzero-core = { path = "tensorzero-core" }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency-only update to a git-sourced crate; risk is limited to behavioral changes introduced by the new `durable` revision.
> 
> **Overview**
> Updates the workspace `durable` dependency to a newer git revision (`5e0e786…` -> `3884f0d…`) and refreshes `Cargo.lock` to match.
> 
> No application code changes are included; the functional impact is entirely driven by what changed upstream in `durable` (notably the referenced `validate_params` improvement).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 108f9833c46c1d98b4f5083df712d9d854ea0b12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->