### PR TITLE
Add missing 'build-gateway-e2e-container' dependency to workflow

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1295,6 +1295,7 @@ jobs:
     needs:
       [
         build-gateway-container,
+        build-gateway-e2e-container,
         build-ui-container,
         build-mock-provider-api-container,
       ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only dependency change; affects CI job ordering but not runtime code or security-sensitive logic.
> 
> **Overview**
> Ensures the `ui-tests-e2e` GitHub Actions job in `general.yml` explicitly depends on `build-gateway-e2e-container`, so merge-queue UI E2E runs wait for the `gateway-e2e` image artifact to be produced before executing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf9ec77ba66dc58529063ed533aeb56ae72e4bc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->