### PR TITLE
Exclude more jobs from dependabot prs

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1266,7 +1266,7 @@ jobs:
 
   build-fixtures-container:
     uses: ./.github/workflows/build-fixtures-container.yml
-    if: !(github.event_name == 'pull_request' && github.actor == 'dependabot[bot]')
+    if: ${{ !(github.event_name == 'pull_request' && github.actor == 'dependabot[bot]') }}
     permissions:
       # Permission to checkout the repository
       contents: read


### PR DESCRIPTION
This does not affect the actual merge queue - it just prevents PR CI failures due to missing credentials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limits CI execution on Dependabot PRs by skipping jobs that require repo secrets/credentials; low risk since it only changes workflow conditions.
> 
> **Overview**
> Reduces Dependabot PR CI failures by skipping jobs that require credentials/secrets.
> 
> `mock-optimization-tests` and the reusable `build-fixtures-container` job are now gated to *not* run on `pull_request` events authored by `dependabot[bot]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5237b191f1518f0a347bff9d31582d24024d75a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->