### PR TITLE
Add 'validate_params' to `ToolMetadata`

### DIFF
--- a/internal/durable-tools/src/registry.rs
+++ b/internal/durable-tools/src/registry.rs
@@ -114,16 +114,7 @@ impl<T: TaskTool> ErasedTool for ErasedTaskToolWrapper<T> {
     }
 
     fn validate_params(&self, llm_params: &JsonValue, side_info: &JsonValue) -> ToolResult<()> {
-        let _: <T as ToolMetadata>::LlmParams = serde_json::from_value(llm_params.clone())
-            .map_err(|e| NonControlToolError::InvalidParams {
-                message: format!("llm_params: {e}"),
-            })?;
-        let _: T::SideInfo = serde_json::from_value(side_info.clone()).map_err(|e| {
-            NonControlToolError::InvalidParams {
-                message: format!("side_info: {e}"),
-            }
-        })?;
-        Ok(())
+        self.0.validate_params(llm_params, side_info)
     }
 }
 
@@ -154,16 +145,7 @@ impl<T: SimpleTool> ErasedTool for T {
     }
 
     fn validate_params(&self, llm_params: &JsonValue, side_info: &JsonValue) -> ToolResult<()> {
-        let _: <T as ToolMetadata>::LlmParams = serde_json::from_value(llm_params.clone())
-            .map_err(|e| NonControlToolError::InvalidParams {
-                message: format!("llm_params: {e}"),
-            })?;
-        let _: T::SideInfo = serde_json::from_value(side_info.clone()).map_err(|e| {
-            NonControlToolError::InvalidParams {
-                message: format!("side_info: {e}"),
-            }
-        })?;
-        Ok(())
+        ToolMetadata::validate_params(self, llm_params, side_info)
     }
 }
 


### PR DESCRIPTION
This allows both simple tools and task tools to override `validate_params` with custom logic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor that centralizes existing parameter deserialization/validation and adds an override point; main risk is behavior changes if any tools relied on the exact prior error formatting or validation timing.
> 
> **Overview**
> Adds a new `ToolMetadata::validate_params` method with a default implementation that deserializes `llm_params`/`side_info` and returns `NonControlToolError::InvalidParams` on failure, allowing tools to override validation logic.
> 
> Updates `registry.rs` to delegate `ErasedTool::validate_params` for both `TaskTool` wrappers and `SimpleTool` blanket impls to this new metadata hook, removing the duplicated inline JSON deserialization logic in the registry layer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a95a9bf0ab322cea3c4057f7fca7f7196683a6fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->