### PR TITLE
Change cache enabled mode to OFF by default

### DIFF
--- a/clients/openai-go/tests/openai_compatibility_test.go
+++ b/clients/openai-go/tests/openai_compatibility_test.go
@@ -399,12 +399,17 @@ func TestBasicInference(t *testing.T) {
 			openai.UserMessage("Hello"),
 		}
 
-		// First request (non-cached)
+		// First request (write_only to populate cache)
 		req := &openai.ChatCompletionNewParams{
 			Model:       "tensorzero::function_name::basic_test",
 			Messages:    messages,
 			Temperature: openai.Float(0.4),
 		}
+		req.SetExtraFields(map[string]any{
+			"tensorzero::cache_options": map[string]any{
+				"enabled": "write_only",
+			},
+		})
 
 		resp, err := client.Chat.Completions.New(ctx, *req)
 		require.NoError(t, err, "Unexpected error while getting completion")
@@ -924,7 +929,7 @@ func TestStreamingInference(t *testing.T) {
 			" pizza.",
 		}
 
-		// First request without cache to populate the cache
+		// First request with write_only cache to populate the cache
 		req := &openai.ChatCompletionNewParams{
 			Model:    "tensorzero::function_name::basic_test",
 			Messages: messages,
@@ -934,6 +939,11 @@ func TestStreamingInference(t *testing.T) {
 			},
 		}
 		addEpisodeIDToRequest(t, req, episodeID)
+		req.SetExtraFields(map[string]any{
+			"tensorzero::cache_options": map[string]any{
+				"enabled": "write_only",
+			},
+		})
 
 		stream := client.Chat.Completions.NewStreaming(ctx, *req)
 		require.NotNil(t, stream, "Streaming response should not be nil")

--- a/clients/openai-node/tests/openai-compatibility.test.ts
+++ b/clients/openai-node/tests/openai-compatibility.test.ts
@@ -859,6 +859,10 @@ describe("OpenAI Compatibility", () => {
       messages,
       model: "tensorzero::function_name::basic_test",
       temperature: 0.4,
+      // @ts-expect-error - custom TensorZero property
+      "tensorzero::cache_options": {
+        enabled: "write_only",
+      },
     });
 
     expect(result.choices[0].message.content).toBe(
@@ -911,7 +915,8 @@ describe("OpenAI Compatibility", () => {
       { role: "user", content: "Hello" },
     ];
 
-    // First streaming request
+    // First streaming request (write_only to populate cache)
+    // @ts-expect-error - custom TensorZero property
     const stream = await client.chat.completions.create({
       messages,
       model: "tensorzero::function_name::basic_test",
@@ -920,6 +925,9 @@ describe("OpenAI Compatibility", () => {
         include_usage: true,
       },
       seed: 69,
+      "tensorzero::cache_options": {
+        enabled: "write_only",
+      },
     });
 
     const chunks = [];

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -192,6 +192,7 @@ async def test_async_basic_inference(async_client: AsyncTensorZeroGateway):
         input=input,
         episode_id=uuid7(),  # This would not typically be done but this partially verifies that uuid7 is using a correct implementation
         # because the gateway validates some of the properties needed
+        cache_options={"enabled": "write_only"},
     )
     assert isinstance(result, ChatInferenceResponse)
     assert input == input_copy, "Input should not be modified by the client"
@@ -1123,6 +1124,7 @@ def test_sync_inference_caching(sync_client: TensorZeroGateway):
             "messages": [{"role": "user", "content": "Hello"}],
         },
         tags={"key": "value"},
+        cache_options={"enabled": "write_only"},
     )
     assert isinstance(result, ChatInferenceResponse)
     assert result.variant_name == "test"
@@ -1174,6 +1176,7 @@ def test_sync_inference_streaming_caching(sync_client: TensorZeroGateway):
             "messages": [{"role": "user", "content": "Hello"}],
         },
         stream=True,
+        cache_options={"enabled": "write_only"},
     )
     assert isinstance(stream, t.Iterator)
 

--- a/clients/python/tests/test_openai_compatibility.py
+++ b/clients/python/tests/test_openai_compatibility.py
@@ -124,6 +124,9 @@ async def test_async_inference_cache(async_openai_client):
     ]
 
     result = await async_openai_client.chat.completions.create(
+        extra_body={
+            "tensorzero::cache_options": {"enabled": "write_only"},
+        },
         messages=messages,
         model="tensorzero::function_name::basic_test",
         temperature=0.4,
@@ -175,9 +178,12 @@ async def test_async_inference_streaming_with_cache(async_openai_client):
         {"role": "user", "content": "Hello"},
     ]
 
-    # First request without cache to populate the cache
+    # First request with write_only cache to populate the cache
     stream = await async_openai_client.chat.completions.create(
-        extra_body={"tensorzero::episode_id": str(uuid7())},
+        extra_body={
+            "tensorzero::episode_id": str(uuid7()),
+            "tensorzero::cache_options": {"enabled": "write_only"},
+        },
         messages=messages,
         model="tensorzero::function_name::basic_test",
         stream=True,

--- a/tensorzero-core/src/cache.rs
+++ b/tensorzero-core/src/cache.rs
@@ -38,9 +38,9 @@ use uuid::Uuid;
 #[clap(rename_all = "snake_case")]
 pub enum CacheEnabledMode {
     On,
+    #[default]
     Off,
     ReadOnly,
-    #[default]
     WriteOnly,
 }
 

--- a/tensorzero-core/src/model.rs
+++ b/tensorzero-core/src/model.rs
@@ -763,16 +763,21 @@ fn wrap_provider_stream(
                     Err(e) => {
                         tracing::warn!("Skipping cache write for stream response due to error in stream: {e}");
                         errored = true;
-                        // If we see a `FatalStreamError`, then yield it and stop processing the stream,
-                        // to avoid holding open a stream that might never produce more chunks.
-                        // We'll still compute rate-limiting usage using all of the chunks that we've seen so far.
-                        if let ErrorDetails::FatalStreamError { .. } = e.get_details() {
-                            yield chunk;
-                            break;
-                        }
                     }
                 }
             }
+
+            // If we see a `FatalStreamError`, yield it and stop processing the stream,
+            // to avoid holding open a stream that might never produce more chunks.
+            // We'll still compute rate-limiting usage using all of the chunks that we've seen so far.
+            if let Err(e) = chunk.as_ref()
+                && let ErrorDetails::FatalStreamError { .. } = e.get_details()
+            {
+                errored = true;
+                yield chunk;
+                break;
+            }
+
             yield chunk;
         }
 

--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -2767,6 +2767,7 @@ pub async fn test_simple_inference_request_with_provider(provider: E2ETestProvid
             ]},
         "stream": false,
         "tags": {"foo": "bar"},
+        "cache_options": {"enabled": "write_only"},
         "extra_headers": extra_headers.extra_headers,
     });
 


### PR DESCRIPTION
Breaking change. We no longer write the cache if the user didn't explicitly request a cache write, so we avoid needlessly writing to the database.

Afterwards, as we work on Valkey backed model inference cache, we'll add a global option to allow users to configure the default cache write/read behavior.

Fixes #6162.