### PR TITLE
Wait for images to show up on docker hub after publishing

### DIFF
--- a/.github/workflows/build-fixtures-container.yml
+++ b/.github/workflows/build-fixtures-container.yml
@@ -58,6 +58,21 @@ jobs:
       - name: Push `fixtures` container to Docker Hub
         run: docker push tensorzero/fixtures:sha-${{ github.sha }}
 
+      - name: Wait for image to be available on Docker Hub
+        run: |
+          IMAGE="tensorzero/fixtures:sha-${{ github.sha }}"
+          echo "Waiting for ${IMAGE} to be available on Docker Hub..."
+          for i in $(seq 1 30); do
+            if docker manifest inspect "${IMAGE}" > /dev/null 2>&1; then
+              echo "Image ${IMAGE} is available on Docker Hub"
+              exit 0
+            fi
+            echo "Attempt ${i}/30: Image not yet available, waiting 10s..."
+            sleep 10
+          done
+          echo "Timed out waiting for ${IMAGE} to appear on Docker Hub"
+          exit 1
+
       - name: Login to Namespace registry
         run: nsc docker login
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}

--- a/.github/workflows/build-gateway-e2e-container.yml
+++ b/.github/workflows/build-gateway-e2e-container.yml
@@ -66,3 +66,18 @@ jobs:
       # It does *not* push to the production 'tensorzero/gateway' repo.
       - name: Push `gateway-e2e` container to DockerHub
         run: docker push tensorzero/gateway-e2e:sha-${{ github.sha }}
+
+      - name: Wait for image to be available on Docker Hub
+        run: |
+          IMAGE="tensorzero/gateway-e2e:sha-${{ github.sha }}"
+          echo "Waiting for ${IMAGE} to be available on Docker Hub..."
+          for i in $(seq 1 30); do
+            if docker manifest inspect "${IMAGE}" > /dev/null 2>&1; then
+              echo "Image ${IMAGE} is available on Docker Hub"
+              exit 0
+            fi
+            echo "Attempt ${i}/30: Image not yet available, waiting 10s..."
+            sleep 10
+          done
+          echo "Timed out waiting for ${IMAGE} to appear on Docker Hub"
+          exit 1

--- a/.github/workflows/build-provider-proxy-container.yml
+++ b/.github/workflows/build-provider-proxy-container.yml
@@ -59,3 +59,18 @@ jobs:
 
       - name: Push `provider-proxy` container to DockerHub
         run: docker push tensorzero/provider-proxy:sha-${{ github.sha }}
+
+      - name: Wait for image to be available on Docker Hub
+        run: |
+          IMAGE="tensorzero/provider-proxy:sha-${{ github.sha }}"
+          echo "Waiting for ${IMAGE} to be available on Docker Hub..."
+          for i in $(seq 1 30); do
+            if docker manifest inspect "${IMAGE}" > /dev/null 2>&1; then
+              echo "Image ${IMAGE} is available on Docker Hub"
+              exit 0
+            fi
+            echo "Attempt ${i}/30: Image not yet available, waiting 10s..."
+            sleep 10
+          done
+          echo "Timed out waiting for ${IMAGE} to appear on Docker Hub"
+          exit 1

--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -164,6 +164,17 @@ jobs:
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.DOCKERHUB_USER }}/${{ matrix.container.name }}@sha256:%s ' *)
 
-      - name: Inspect image
+      - name: Wait for image to be available on Docker Hub
         run: |
-          docker buildx imagetools inspect ${{ env.DOCKERHUB_USER }}/${{ matrix.container.name }}:${{ steps.meta.outputs.version }}
+          IMAGE="${{ env.DOCKERHUB_USER }}/${{ matrix.container.name }}:${{ steps.meta.outputs.version }}"
+          echo "Waiting for ${IMAGE} to be available on Docker Hub..."
+          for i in $(seq 1 30); do
+            if docker manifest inspect "${IMAGE}" > /dev/null 2>&1; then
+              echo "Image ${IMAGE} is available on Docker Hub"
+              exit 0
+            fi
+            echo "Attempt ${i}/30: Image not yet available, waiting 10s..."
+            sleep 10
+          done
+          echo "Timed out waiting for ${IMAGE} to appear on Docker Hub"
+          exit 1


### PR DESCRIPTION
There seems to occasionally be a several-minute delay in between publishing and the image becoming pullable, which causes CI failures. Let's wait for 'docker manifest inspect' to succeed after the publish step

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes that add bounded retries/sleeps after image pushes; main risk is slightly longer workflow runtime or new failures if Docker Hub remains unavailable.
> 
> **Overview**
> Adds a post-push wait loop to multiple GitHub Actions workflows to reduce flakiness from Docker Hub propagation delays.
> 
> After pushing images (including the multi-arch manifest publish), workflows now poll `docker manifest inspect` for up to ~5 minutes and fail with a clear timeout if the tag is not yet available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit feebe1390a3ea864575c1d16eadf996c2dfdf150. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->