### PR TITLE
Fix `process_jsonschema_for_gcp_vertex_gemini`

### DIFF
--- a/tensorzero-core/src/providers/gcp_vertex_gemini/mod.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_gemini/mod.rs
@@ -2564,8 +2564,8 @@ pub async fn tensorzero_to_gcp_vertex_gemini_content<'a>(
     Ok(message)
 }
 
-/// Recursively removes `$schema` and `additionalProperties` from JSON schemas
-/// for GCP Vertex API compatibility.
+/// Recursively removes fields unsupported by Google's Schema spec
+/// (`$schema`, `additionalProperties`, bare `ref`) from JSON schemas.
 pub(crate) fn process_jsonschema_for_gcp_vertex_gemini(schema: &Value) -> Value {
     let mut schema = schema.clone();
 
@@ -2574,6 +2574,8 @@ pub(crate) fn process_jsonschema_for_gcp_vertex_gemini(schema: &Value) -> Value 
             Value::Object(obj) => {
                 obj.remove("additionalProperties");
                 obj.remove("$schema");
+                // Bare "ref" (without $) is not a valid Google Schema field
+                obj.remove("ref");
                 for (_, v) in obj.iter_mut() {
                     remove_properties(v);
                 }

--- a/tensorzero-core/src/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-core/src/providers/google_ai_studio_gemini.rs
@@ -708,11 +708,7 @@ struct GeminiTool<'a> {
 
 impl<'a> GeminiFunctionDeclaration<'a> {
     fn from_tool_config(tool: &'a FunctionToolConfig) -> Self {
-        let mut parameters = tool.parameters().clone();
-        if let Some(obj) = parameters.as_object_mut() {
-            obj.remove("additionalProperties");
-            obj.remove("$schema");
-        }
+        let parameters = process_jsonschema_for_gcp_vertex_gemini(tool.parameters());
 
         GeminiFunctionDeclaration {
             name: tool.name(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how tool/output JSON schemas are transformed before being sent to Google providers, which could affect function calling/json-mode behavior if any integrations relied on previously-passed-through fields.
> 
> **Overview**
> Improves Gemini JSON Schema sanitization for Google compatibility by extending `process_jsonschema_for_gcp_vertex_gemini` to also remove bare `ref` fields (in addition to `$schema` and `additionalProperties`) recursively.
> 
> Updates Google AI Studio Gemini tool schema generation to reuse this shared sanitizer, replacing its previous top-level-only field stripping so nested tool parameter schemas are cleaned consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ce35d7de0209c2e4ede0760a2f79d76821f0a82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->