### PR TITLE
Migrate more provider types to another crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6573,6 +6573,8 @@ version = "2026.2.0"
 dependencies = [
  "serde",
  "serde_json",
+ "serde_path_to_error",
+ "tensorzero-derive",
 ]
 
 [[package]]

--- a/internal/tensorzero-types-providers/Cargo.toml
+++ b/internal/tensorzero-types-providers/Cargo.toml
@@ -8,6 +8,8 @@ license.workspace = true
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
+serde_path_to_error.workspace = true
+tensorzero-derive = { path = "../tensorzero-derive" }
 
 [lints]
 workspace = true

--- a/internal/tensorzero-types-providers/src/deepseek.rs
+++ b/internal/tensorzero-types-providers/src/deepseek.rs
@@ -1,0 +1,85 @@
+//! Serde types for DeepSeek API
+//!
+//! These types handle DeepSeek-specific request/response structures, including
+//! support for `reasoning_content` in responses.
+
+use serde::{Deserialize, Serialize};
+
+use crate::openai::{OpenAIFinishReason, OpenAIResponseToolCall, OpenAIUsage};
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[serde(tag = "type")]
+pub enum DeepSeekResponseFormat {
+    #[default]
+    Text,
+    JsonObject,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct DeepSeekFunctionCallChunk {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arguments: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct DeepSeekToolCallChunk {
+    pub index: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    // NOTE: these are externally tagged enums, for now we're gonna just keep this hardcoded as there's only one option
+    // If we were to do this better, we would need to check the `type` field
+    pub function: DeepSeekFunctionCallChunk,
+}
+
+// This doesn't include role
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct DeepSeekDelta {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<DeepSeekToolCallChunk>>,
+}
+
+// This doesn't include logprobs, finish_reason, and index
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct DeepSeekChatChunkChoice {
+    pub delta: DeepSeekDelta,
+    pub finish_reason: Option<OpenAIFinishReason>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct DeepSeekChatChunk {
+    pub choices: Vec<DeepSeekChatChunkChoice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<OpenAIUsage>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct DeepSeekResponseMessage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<OpenAIResponseToolCall>>,
+}
+
+// Leaving out logprobs and finish_reason for now
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct DeepSeekResponseChoice {
+    pub index: u8,
+    pub message: DeepSeekResponseMessage,
+    pub finish_reason: Option<OpenAIFinishReason>,
+}
+
+// Leaving out id, created, model, service_tier, system_fingerprint, object for now
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct DeepSeekResponse {
+    pub choices: Vec<DeepSeekResponseChoice>,
+    pub usage: OpenAIUsage,
+}

--- a/internal/tensorzero-types-providers/src/lib.rs
+++ b/internal/tensorzero-types-providers/src/lib.rs
@@ -3,5 +3,7 @@
 //! This crate contains serde types for communicating with external model provider APIs.
 
 pub mod aws_bedrock;
+pub mod deepseek;
+pub mod openai;
 pub mod openrouter;
 pub mod xai;

--- a/internal/tensorzero-types-providers/src/openai.rs
+++ b/internal/tensorzero-types-providers/src/openai.rs
@@ -1,0 +1,51 @@
+//! Serde types shared across OpenAI-compatible providers.
+//!
+//! These types are used by OpenAI, DeepSeek, xAI, and other providers that
+//! follow the OpenAI chat completions response format.
+
+use serde::{Deserialize, Serialize};
+use tensorzero_derive::TensorZeroDeserialize;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct OpenAIUsage {
+    pub prompt_tokens: Option<u32>,
+    pub completion_tokens: Option<u32>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum OpenAIFinishReason {
+    Stop,
+    Length,
+    ContentFilter,
+    ToolCalls,
+    FunctionCall,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Deserialize)]
+pub struct OpenAIResponseFunctionCall {
+    pub name: String,
+    pub arguments: String,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Deserialize)]
+pub struct OpenAIResponseCustomCall {
+    pub name: String,
+    pub input: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, TensorZeroDeserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub enum OpenAIResponseToolCall {
+    Function {
+        id: String,
+        function: OpenAIResponseFunctionCall,
+    },
+    Custom {
+        id: String,
+        custom: OpenAIResponseCustomCall,
+    },
+}

--- a/tensorzero-core/src/providers/azure.rs
+++ b/tensorzero-core/src/providers/azure.rs
@@ -44,7 +44,8 @@ use super::chat_completions::{
 };
 use super::openai::{
     OpenAIEmbeddingUsage, OpenAIRequestMessage, OpenAIResponse, OpenAIResponseChoice,
-    StreamOptions, SystemOrDeveloper, handle_openai_error, prepare_openai_messages, stream_openai,
+    StreamOptions, SystemOrDeveloper, handle_openai_error,
+    openai_response_tool_call_to_tensorzero_tool_call, prepare_openai_messages, stream_openai,
 };
 use crate::inference::{InferenceProvider, TensorZeroEventError};
 
@@ -859,7 +860,9 @@ impl<'a> TryFrom<AzureResponseWithMetadata<'a>> for ProviderInferenceResponse {
         }
         if let Some(tool_calls) = message.tool_calls {
             for tool_call in tool_calls {
-                content.push(ContentBlockOutput::ToolCall(tool_call.into()));
+                content.push(ContentBlockOutput::ToolCall(
+                    openai_response_tool_call_to_tensorzero_tool_call(tool_call),
+                ));
             }
         }
 

--- a/tensorzero-core/src/providers/deepseek.rs
+++ b/tensorzero-core/src/providers/deepseek.rs
@@ -2,7 +2,7 @@ use futures::StreamExt;
 use lazy_static::lazy_static;
 use reqwest_sse_stream::Event;
 use secrecy::{ExposeSecret, SecretString};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::borrow::Cow;
 use std::time::Duration;
 use tokio::time::Instant;
@@ -35,12 +35,16 @@ use crate::providers::chat_completions::{ChatCompletionTool, ChatCompletionToolC
 use crate::providers::openai::OpenAIMessagesConfig;
 use crate::providers::openai::{
     OpenAIAssistantRequestMessage, OpenAIContentBlock, OpenAIFinishReason, OpenAIRequestMessage,
-    OpenAIResponseToolCall, OpenAISystemRequestMessage, OpenAIUsage, OpenAIUserRequestMessage,
-    StreamOptions, SystemOrDeveloper, get_chat_url, handle_openai_error,
-    prepare_system_or_developer_message, tensorzero_to_openai_messages,
+    OpenAISystemRequestMessage, OpenAIUsage, OpenAIUserRequestMessage, StreamOptions,
+    SystemOrDeveloper, get_chat_url, handle_openai_error,
+    openai_response_tool_call_to_tensorzero_tool_call, prepare_system_or_developer_message,
+    tensorzero_to_openai_messages,
 };
 use crate::tool::ToolCallChunk;
 use serde_json::Value;
+use tensorzero_types_providers::deepseek::{
+    DeepSeekChatChunk, DeepSeekResponse, DeepSeekResponseChoice, DeepSeekResponseFormat,
+};
 use uuid::Uuid;
 
 lazy_static! {
@@ -327,23 +331,14 @@ impl InferenceProvider for DeepSeekProvider {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case")]
-#[serde(tag = "type")]
-enum DeepSeekResponseFormat {
-    #[default]
-    Text,
-    JsonObject,
-}
-
-impl DeepSeekResponseFormat {
-    fn new(json_mode: ModelInferenceRequestJsonMode) -> Option<Self> {
-        match json_mode {
-            ModelInferenceRequestJsonMode::On => Some(DeepSeekResponseFormat::JsonObject),
-            // For now, we never explicitly send `DeepSeekResponseFormat::Text`
-            ModelInferenceRequestJsonMode::Off => None,
-            ModelInferenceRequestJsonMode::Strict => Some(DeepSeekResponseFormat::JsonObject),
-        }
+fn deepseek_response_format(
+    json_mode: ModelInferenceRequestJsonMode,
+) -> Option<DeepSeekResponseFormat> {
+    match json_mode {
+        ModelInferenceRequestJsonMode::On => Some(DeepSeekResponseFormat::JsonObject),
+        // For now, we never explicitly send `DeepSeekResponseFormat::Text`
+        ModelInferenceRequestJsonMode::Off => None,
+        ModelInferenceRequestJsonMode::Strict => Some(DeepSeekResponseFormat::JsonObject),
     }
 }
 
@@ -435,7 +430,7 @@ impl<'a> DeepSeekRequest<'a> {
             );
         }
 
-        let response_format = DeepSeekResponseFormat::new(request.json_mode);
+        let response_format = deepseek_response_format(request.json_mode);
 
         // NOTE: as mentioned by the DeepSeek team here: https://github.com/deepseek-ai/DeepSeek-R1?tab=readme-ov-file#usage-recommendations
         // the R1 series of models does not perform well with the system prompt. As we move towards first-class support for reasoning models we should check
@@ -526,49 +521,6 @@ fn stream_deepseek(
     })
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-struct DeepSeekFunctionCallChunk {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    arguments: Option<String>,
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-struct DeepSeekToolCallChunk {
-    index: u8,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    id: Option<String>,
-    // NOTE: these are externally tagged enums, for now we're gonna just keep this hardcoded as there's only one option
-    // If we were to do this better, we would need to check the `type` field
-    function: DeepSeekFunctionCallChunk,
-}
-
-// This doesn't include role
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-struct DeepSeekDelta {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    content: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    reasoning_content: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    tool_calls: Option<Vec<DeepSeekToolCallChunk>>,
-}
-
-// This doesn't include logprobs, finish_reason, and index
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-struct DeepSeekChatChunkChoice {
-    delta: DeepSeekDelta,
-    finish_reason: Option<OpenAIFinishReason>,
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-struct DeepSeekChatChunk {
-    choices: Vec<DeepSeekChatChunkChoice>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    usage: Option<OpenAIUsage>,
-}
-
 /// Maps a DeepSeek chunk to a TensorZero chunk for streaming inferences
 fn deepseek_to_tensorzero_chunk(
     raw_message: String,
@@ -656,31 +608,6 @@ fn deepseek_to_tensorzero_chunk(
         finish_reason,
         raw_usage,
     ))
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-struct DeepSeekResponseMessage {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    content: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    reasoning_content: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    tool_calls: Option<Vec<OpenAIResponseToolCall>>,
-}
-
-// Leaving out logprobs and finish_reason for now
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-struct DeepSeekResponseChoice {
-    index: u8,
-    message: DeepSeekResponseMessage,
-    finish_reason: Option<OpenAIFinishReason>,
-}
-
-// Leaving out id, created, model, service_tier, system_fingerprint, object for now
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-struct DeepSeekResponse {
-    choices: Vec<DeepSeekResponseChoice>,
-    usage: OpenAIUsage,
 }
 
 pub(super) async fn prepare_deepseek_messages<'a>(
@@ -780,7 +707,9 @@ impl<'a> TryFrom<DeepSeekResponseWithMetadata<'a>> for ProviderInferenceResponse
         }
         if let Some(tool_calls) = message.tool_calls {
             for tool_call in tool_calls {
-                content.push(ContentBlockOutput::ToolCall(tool_call.into()));
+                content.push(ContentBlockOutput::ToolCall(
+                    openai_response_tool_call_to_tensorzero_tool_call(tool_call),
+                ));
             }
         }
         let raw_usage = deepseek_usage_from_raw_response(&raw_response).map(|usage| {
@@ -894,6 +823,7 @@ mod tests {
         OpenAIUsage,
     };
     use crate::providers::test_helpers::{WEATHER_TOOL, WEATHER_TOOL_CONFIG};
+    use tensorzero_types_providers::deepseek::DeepSeekResponseMessage;
 
     #[tokio::test]
     async fn test_deepseek_request_new() {

--- a/tensorzero-core/src/providers/hyperbolic.rs
+++ b/tensorzero-core/src/providers/hyperbolic.rs
@@ -30,7 +30,8 @@ use uuid::Uuid;
 
 use super::openai::{
     OpenAIRequestMessage, OpenAIResponse, OpenAIResponseChoice, SystemOrDeveloper, get_chat_url,
-    handle_openai_error, prepare_openai_messages, stream_openai,
+    handle_openai_error, openai_response_tool_call_to_tensorzero_tool_call,
+    prepare_openai_messages, stream_openai,
 };
 use crate::inference::{InferenceProvider, TensorZeroEventError};
 
@@ -482,7 +483,9 @@ impl<'a> TryFrom<HyperbolicResponseWithMetadata<'a>> for ProviderInferenceRespon
         }
         if let Some(tool_calls) = message.tool_calls {
             for tool_call in tool_calls {
-                content.push(ContentBlockOutput::ToolCall(tool_call.into()));
+                content.push(ContentBlockOutput::ToolCall(
+                    openai_response_tool_call_to_tensorzero_tool_call(tool_call),
+                ));
             }
         }
 

--- a/tensorzero-core/src/providers/openai/mod.rs
+++ b/tensorzero-core/src/providers/openai/mod.rs
@@ -14,7 +14,6 @@ use std::borrow::{Cow, ToOwned};
 use std::io::Write;
 use std::pin::Pin;
 use std::time::Duration;
-use tensorzero_derive::TensorZeroDeserialize;
 use tokio::time::Instant;
 use tracing::instrument;
 use url::Url;
@@ -2555,11 +2554,9 @@ impl<'a> OpenAIBatchRequest<'a> {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub(super) struct OpenAIUsage {
-    pub prompt_tokens: Option<u32>,
-    pub completion_tokens: Option<u32>,
-}
+pub(super) use tensorzero_types_providers::openai::{
+    OpenAIFinishReason, OpenAIResponseToolCall, OpenAIUsage,
+};
 
 impl From<OpenAIUsage> for Usage {
     fn from(usage: OpenAIUsage) -> Self {
@@ -2593,46 +2590,20 @@ impl From<OpenAIEmbeddingUsage> for Usage {
     }
 }
 
-#[derive(Serialize, Debug, Clone, PartialEq, Deserialize)]
-pub(super) struct OpenAIResponseFunctionCall {
-    name: String,
-    arguments: String,
-}
-
-#[derive(Serialize, Debug, Clone, PartialEq, Deserialize)]
-pub(super) struct OpenAIResponseCustomCall {
-    name: String,
-    input: String,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, TensorZeroDeserialize)]
-#[serde(tag = "type")]
-#[serde(rename_all = "snake_case")]
-pub(super) enum OpenAIResponseToolCall {
-    Function {
-        id: String,
-        function: OpenAIResponseFunctionCall,
-    },
-    Custom {
-        id: String,
-        custom: OpenAIResponseCustomCall,
-    },
-}
-
-impl From<OpenAIResponseToolCall> for ToolCall {
-    fn from(openai_tool_call: OpenAIResponseToolCall) -> Self {
-        match openai_tool_call {
-            OpenAIResponseToolCall::Function { id, function } => ToolCall {
-                id,
-                name: function.name,
-                arguments: function.arguments,
-            },
-            OpenAIResponseToolCall::Custom { id, custom } => ToolCall {
-                id,
-                name: custom.name,
-                arguments: custom.input,
-            },
-        }
+pub(super) fn openai_response_tool_call_to_tensorzero_tool_call(
+    openai_tool_call: OpenAIResponseToolCall,
+) -> ToolCall {
+    match openai_tool_call {
+        OpenAIResponseToolCall::Function { id, function } => ToolCall {
+            id,
+            name: function.name,
+            arguments: function.arguments,
+        },
+        OpenAIResponseToolCall::Custom { id, custom } => ToolCall {
+            id,
+            name: custom.name,
+            arguments: custom.input,
+        },
     }
 }
 
@@ -2646,18 +2617,6 @@ pub(super) struct OpenAIResponseMessage {
     pub(super) reasoning_content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) tool_calls: Option<Vec<OpenAIResponseToolCall>>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub(super) enum OpenAIFinishReason {
-    Stop,
-    Length,
-    ContentFilter,
-    ToolCalls,
-    FunctionCall,
-    #[serde(other)]
-    Unknown,
 }
 
 impl From<OpenAIFinishReason> for FinishReason {
@@ -2749,7 +2708,9 @@ impl<'a> TryFrom<OpenAIResponseWithMetadata<'a>> for ProviderInferenceResponse {
         }
         if let Some(tool_calls) = message.tool_calls {
             for tool_call in tool_calls {
-                content.push(ContentBlockOutput::ToolCall(tool_call.into()));
+                content.push(ContentBlockOutput::ToolCall(
+                    openai_response_tool_call_to_tensorzero_tool_call(tool_call),
+                ));
             }
         };
         let raw_usage = openai_usage_from_raw_response(&raw_response).map(|usage| {
@@ -3149,7 +3110,9 @@ impl TryFrom<OpenAIBatchFileRow> for ProviderBatchInferenceOutput {
         }
         if let Some(tool_calls) = message.tool_calls {
             for tool_call in tool_calls {
-                content.push(ContentBlockOutput::ToolCall(tool_call.into()));
+                content.push(ContentBlockOutput::ToolCall(
+                    openai_response_tool_call_to_tensorzero_tool_call(tool_call),
+                ));
             }
         }
 
@@ -3210,6 +3173,7 @@ mod tests {
     };
     use crate::tool::ToolCallConfig;
     use crate::utils::testing::capture_logs;
+    use tensorzero_types_providers::openai::OpenAIResponseFunctionCall;
 
     use super::*;
 

--- a/tensorzero-core/src/providers/sglang.rs
+++ b/tensorzero-core/src/providers/sglang.rs
@@ -39,7 +39,7 @@ use uuid::Uuid;
 use super::openai::{
     OpenAIRequestMessage, OpenAIResponse, OpenAIResponseChoice, OpenAITool, OpenAIToolChoice,
     OpenAIUsage, StreamOptions, SystemOrDeveloper, get_chat_url, handle_openai_error,
-    prepare_openai_messages,
+    openai_response_tool_call_to_tensorzero_tool_call, prepare_openai_messages,
 };
 
 const PROVIDER_NAME: &str = "SGLang";
@@ -768,7 +768,9 @@ impl<'a> TryFrom<SGLangResponseWithMetadata<'a>> for ProviderInferenceResponse {
         }
         if let Some(tool_calls) = message.tool_calls {
             for tool_call in tool_calls {
-                content.push(ContentBlockOutput::ToolCall(tool_call.into()));
+                content.push(ContentBlockOutput::ToolCall(
+                    openai_response_tool_call_to_tensorzero_tool_call(tool_call),
+                ));
             }
         }
         let raw_usage = sglang_usage_from_raw_response(&raw_response).map(|usage| {

--- a/tensorzero-core/src/providers/vllm.rs
+++ b/tensorzero-core/src/providers/vllm.rs
@@ -10,7 +10,8 @@ use url::Url;
 
 use super::openai::{
     OpenAIRequestMessage, OpenAIResponse, OpenAIResponseChoice, OpenAISystemRequestMessage,
-    OpenAITool, OpenAIToolChoice, StreamOptions, get_chat_url, handle_openai_error, stream_openai,
+    OpenAITool, OpenAIToolChoice, StreamOptions, get_chat_url, handle_openai_error,
+    openai_response_tool_call_to_tensorzero_tool_call, stream_openai,
     tensorzero_to_openai_messages,
 };
 use crate::cache::ModelProviderRequest;
@@ -523,7 +524,9 @@ impl<'a> TryFrom<VLLMResponseWithMetadata<'a>> for ProviderInferenceResponse {
         }
         if let Some(tool_calls) = message.tool_calls {
             for tool_call in tool_calls {
-                content.push(ContentBlockOutput::ToolCall(tool_call.into()));
+                content.push(ContentBlockOutput::ToolCall(
+                    openai_response_tool_call_to_tensorzero_tool_call(tool_call),
+                ));
             }
         }
         let raw_usage = vllm_usage_from_raw_response(&raw_response).map(|usage| {

--- a/tensorzero-core/src/providers/xai.rs
+++ b/tensorzero-core/src/providers/xai.rs
@@ -37,7 +37,7 @@ use crate::providers::helpers::{
 };
 use crate::providers::openai::{
     OpenAIMessagesConfig, OpenAIResponseChoice, StreamOptions, get_chat_url, handle_openai_error,
-    prepare_file_message, stream_openai,
+    openai_response_tool_call_to_tensorzero_tool_call, prepare_file_message, stream_openai,
 };
 use uuid::Uuid;
 
@@ -820,7 +820,9 @@ impl<'a> TryFrom<XAIResponseWithMetadata<'a>> for ProviderInferenceResponse {
         }
         if let Some(tool_calls) = message.tool_calls {
             for tool_call in tool_calls {
-                content.push(ContentBlockOutput::ToolCall(tool_call.into()));
+                content.push(ContentBlockOutput::ToolCall(
+                    openai_response_tool_call_to_tensorzero_tool_call(tool_call),
+                ));
             }
         }
 


### PR DESCRIPTION
No functional change. Just making progress towards getting rid of `serde` macros in `tensorzero-core`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a type/mapping refactor, but it touches response parsing and tool-call conversion across multiple providers, so mismatched serde shapes or conversion logic could cause runtime inference failures.
> 
> **Overview**
> **Refactors provider wire-format types** by introducing `tensorzero-types-providers::openai` (shared OpenAI-compatible response/usage/tool-call enums) and `tensorzero-types-providers::deepseek` (DeepSeek chunk/response structs plus `DeepSeekResponseFormat`).
> 
> `tensorzero-core` providers (OpenAI, DeepSeek, Azure, Hyperbolic, SGLang, VLLM, xAI) are updated to consume these moved types, and tool-call handling is standardized by replacing `tool_call.into()` with an explicit `openai_response_tool_call_to_tensorzero_tool_call(...)` conversion helper. DeepSeek’s request `response_format` selection is refactored into a small free function while removing now-duplicated local DeepSeek/OpenAI type definitions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6dd4bc490e65078261c231116a518764fe118eb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->