### PR TITLE
Bump max_tokens for gcp vertex gemini models in tests

### DIFF
--- a/tensorzero-core/tests/e2e/config/tensorzero.functions.basic_test.toml
+++ b/tensorzero-core/tests/e2e/config/tensorzero.functions.basic_test.toml
@@ -231,20 +231,20 @@ max_tokens = 100
 type = "chat_completion"
 model = "gcp-gemini-2.5-flash"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
-max_tokens = 100
+max_tokens = 200
 
 [functions.basic_test.variants.gcp-vertex-gemini-flash-extra-body]
 type = "chat_completion"
 model = "gcp-gemini-2.5-flash"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
-max_tokens = 100
+max_tokens = 200
 extra_body = [{ pointer = "/generationConfig/temperature", value = 0.123 }]
 
 [functions.basic_test.variants.gcp-vertex-gemini-flash-extra-headers]
 type = "chat_completion"
 model = "gcp-gemini-2.5-flash"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
-max_tokens = 100
+max_tokens = 200
 extra_headers = [{ name = "Authorization", value = "invalid_gcp_vertex_auth" }]
 
 [functions.basic_test.variants.gcp-vertex-gemini-pro]
@@ -474,7 +474,7 @@ max_tokens = 100
 type = "chat_completion"
 model = "gcp_vertex_gemini::projects/tensorzero-public/locations/us-central1/publishers/google/models/gemini-2.5-flash"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
-max_tokens = 100
+max_tokens = 200
 
 [functions.basic_test.variants.gcp_vertex_gemini_shorthand_endpoint]
 type = "chat_completion"


### PR DESCRIPTION
We've seen test flakes due to stop_reason 'length', so let's allow more output tokens

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only configuration change that slightly increases token usage for affected Gemini variants but doesn’t alter production logic.
> 
> **Overview**
> Reduces e2e test flakiness by increasing `max_tokens` from `100` to `200` for the GCP Vertex Gemini Flash variants in `tensorzero.functions.basic_test.toml`, including the base, `extra_body`, `extra_headers`, and `gcp_vertex_gemini` shorthand configs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02f880dc9aec2bc49d1fad23804228766c6ca776. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->