### PR TITLE
Limit height of tool call and tool result blocks in autopilot

### DIFF
--- a/ui/app/components/autopilot/EventStream.tsx
+++ b/ui/app/components/autopilot/EventStream.tsx
@@ -34,6 +34,12 @@ import { cn } from "~/utils/common";
 import TopKEvaluationViz from "./TopKEvaluationViz";
 
 /**
+ * Max height for expandable tool content (tool call arguments, tool results, errors).
+ * Keeps long content from dominating the chat view by making it scrollable.
+ */
+export const TOOL_CONTENT_MAX_HEIGHT = "400px";
+
+/**
  * Optimistic messages are shown after the API confirms receipt but before
  * SSE delivers the real event.
  *
@@ -573,8 +579,14 @@ function EventItem({
                 "text-fg-secondary text-sm whitespace-pre-wrap",
                 (event.payload.type === "tool_result" ||
                   event.payload.type === "error") &&
-                  "font-mono",
+                  "overflow-y-auto font-mono",
               )}
+              style={
+                event.payload.type === "tool_result" ||
+                event.payload.type === "error"
+                  ? { maxHeight: TOOL_CONTENT_MAX_HEIGHT }
+                  : undefined
+              }
             >
               {summary.description}
             </p>

--- a/ui/app/components/autopilot/PendingToolCallCard.tsx
+++ b/ui/app/components/autopilot/PendingToolCallCard.tsx
@@ -5,7 +5,12 @@ import { DotSeparator } from "~/components/ui/DotSeparator";
 import { TableItemTime } from "~/components/ui/TableItems";
 import type { GatewayEvent } from "~/types/tensorzero";
 import { cn } from "~/utils/common";
-import { getToolCallEventId, isToolEvent, ToolEventId } from "./EventStream";
+import {
+  getToolCallEventId,
+  isToolEvent,
+  TOOL_CONTENT_MAX_HEIGHT,
+  ToolEventId,
+} from "./EventStream";
 
 type PendingToolCallCardProps = {
   event: GatewayEvent;
@@ -167,7 +172,10 @@ export function PendingToolCallCard({
 
       {/* Tool arguments (expandable) */}
       {isExpanded && args && (
-        <pre className="text-fg-secondary overflow-x-auto font-mono text-xs whitespace-pre-wrap">
+        <pre
+          className="text-fg-secondary overflow-auto font-mono text-xs whitespace-pre-wrap"
+          style={{ maxHeight: TOOL_CONTENT_MAX_HEIGHT }}
+        >
           {JSON.stringify(args, null, 2)}
         </pre>
       )}


### PR DESCRIPTION
## Summary
- Introduce a shared `TOOL_CONTENT_MAX_HEIGHT` constant (`400px`) for bounding long tool content
- Apply max-height with overflow scrolling to tool result success/failure content and error messages in the event stream
- Apply the same height limit to the pending tool call card's expandable arguments
- Tool call arguments were already bounded by `CodeEditor`'s default `maxHeight`
- Only tool-related content is bounded — user messages, status updates, and assistant messages are unaffected

Closes #5930

## Test plan
- [ ] Open an autopilot session with long tool call arguments — verify they scroll within a bounded area
- [ ] Expand a tool result with long success/failure content — verify scrollable
- [ ] Verify short tool calls/results display normally without scrollbar
- [ ] Check pending tool call card with long arguments scrolls properly
- [ ] Verify user messages and assistant messages are not height-limited