### PR TITLE
added &self to SimpleTool execute

### DIFF
--- a/internal/autopilot-tools/src/tools/prod/create_datapoints.rs
+++ b/internal/autopilot-tools/src/tools/prod/create_datapoints.rs
@@ -142,6 +142,7 @@ fn add_tags_to_datapoint(
 #[async_trait]
 impl SimpleTool for CreateDatapointsTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         side_info: <Self as ToolMetadata>::SideInfo,
         ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-tools/src/tools/prod/create_datapoints_from_inferences.rs
+++ b/internal/autopilot-tools/src/tools/prod/create_datapoints_from_inferences.rs
@@ -129,6 +129,7 @@ impl ToolMetadata for CreateDatapointsFromInferencesTool {
 #[async_trait]
 impl SimpleTool for CreateDatapointsFromInferencesTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: <Self as ToolMetadata>::SideInfo,
         ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-tools/src/tools/prod/delete_datapoints.rs
+++ b/internal/autopilot-tools/src/tools/prod/delete_datapoints.rs
@@ -74,6 +74,7 @@ impl ToolMetadata for DeleteDatapointsTool {
 #[async_trait]
 impl SimpleTool for DeleteDatapointsTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: <Self as ToolMetadata>::SideInfo,
         ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-tools/src/tools/prod/feedback.rs
+++ b/internal/autopilot-tools/src/tools/prod/feedback.rs
@@ -115,6 +115,7 @@ impl ToolMetadata for FeedbackTool {
 #[async_trait]
 impl SimpleTool for FeedbackTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         side_info: <Self as ToolMetadata>::SideInfo,
         ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-tools/src/tools/prod/get_config.rs
+++ b/internal/autopilot-tools/src/tools/prod/get_config.rs
@@ -53,6 +53,7 @@ impl ToolMetadata for GetConfigTool {
 #[async_trait]
 impl SimpleTool for GetConfigTool {
     async fn execute(
+        &self,
         _llm_params: <Self as ToolMetadata>::LlmParams,
         side_info: <Self as ToolMetadata>::SideInfo,
         ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-tools/src/tools/prod/get_datapoints.rs
+++ b/internal/autopilot-tools/src/tools/prod/get_datapoints.rs
@@ -76,6 +76,7 @@ impl ToolMetadata for GetDatapointsTool {
 #[async_trait]
 impl SimpleTool for GetDatapointsTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: <Self as ToolMetadata>::SideInfo,
         ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-tools/src/tools/prod/get_feedback_by_variant.rs
+++ b/internal/autopilot-tools/src/tools/prod/get_feedback_by_variant.rs
@@ -90,6 +90,7 @@ impl ToolMetadata for GetFeedbackByVariantTool {
 #[async_trait]
 impl SimpleTool for GetFeedbackByVariantTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: <Self as ToolMetadata>::SideInfo,
         ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-tools/src/tools/prod/get_inferences.rs
+++ b/internal/autopilot-tools/src/tools/prod/get_inferences.rs
@@ -85,6 +85,7 @@ impl ToolMetadata for GetInferencesTool {
 #[async_trait]
 impl SimpleTool for GetInferencesTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: <Self as ToolMetadata>::SideInfo,
         ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-tools/src/tools/prod/get_latest_feedback_by_metric.rs
+++ b/internal/autopilot-tools/src/tools/prod/get_latest_feedback_by_metric.rs
@@ -69,6 +69,7 @@ impl ToolMetadata for GetLatestFeedbackByMetricTool {
 #[async_trait]
 impl SimpleTool for GetLatestFeedbackByMetricTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: <Self as ToolMetadata>::SideInfo,
         ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-tools/src/tools/prod/inference.rs
+++ b/internal/autopilot-tools/src/tools/prod/inference.rs
@@ -160,6 +160,7 @@ impl ToolMetadata for InferenceTool {
 #[async_trait]
 impl SimpleTool for InferenceTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         side_info: <Self as ToolMetadata>::SideInfo,
         ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-tools/src/tools/prod/list_datapoints.rs
+++ b/internal/autopilot-tools/src/tools/prod/list_datapoints.rs
@@ -178,6 +178,7 @@ impl ToolMetadata for ListDatapointsTool {
 #[async_trait]
 impl SimpleTool for ListDatapointsTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: <Self as ToolMetadata>::SideInfo,
         ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-tools/src/tools/prod/list_datasets.rs
+++ b/internal/autopilot-tools/src/tools/prod/list_datasets.rs
@@ -89,6 +89,7 @@ impl ToolMetadata for ListDatasetsTool {
 #[async_trait]
 impl SimpleTool for ListDatasetsTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: <Self as ToolMetadata>::SideInfo,
         ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-tools/src/tools/prod/list_inferences.rs
+++ b/internal/autopilot-tools/src/tools/prod/list_inferences.rs
@@ -243,6 +243,7 @@ impl ToolMetadata for ListInferencesTool {
 #[async_trait]
 impl SimpleTool for ListInferencesTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: <Self as ToolMetadata>::SideInfo,
         ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-tools/src/tools/prod/run_evaluation.rs
+++ b/internal/autopilot-tools/src/tools/prod/run_evaluation.rs
@@ -157,6 +157,7 @@ impl ToolMetadata for RunEvaluationTool {
 #[async_trait]
 impl SimpleTool for RunEvaluationTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         side_info: <Self as ToolMetadata>::SideInfo,
         ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-tools/src/tools/prod/update_datapoints.rs
+++ b/internal/autopilot-tools/src/tools/prod/update_datapoints.rs
@@ -113,6 +113,7 @@ impl ToolMetadata for UpdateDatapointsTool {
 #[async_trait]
 impl SimpleTool for UpdateDatapointsTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: <Self as ToolMetadata>::SideInfo,
         ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-tools/src/tools/prod/write_config.rs
+++ b/internal/autopilot-tools/src/tools/prod/write_config.rs
@@ -145,6 +145,7 @@ impl ToolMetadata for WriteConfigTool {
 #[async_trait]
 impl SimpleTool for WriteConfigTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         side_info: <Self as ToolMetadata>::SideInfo,
         ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-tools/src/tools/test/error_simple.rs
+++ b/internal/autopilot-tools/src/tools/test/error_simple.rs
@@ -42,6 +42,7 @@ impl ToolMetadata for ErrorSimpleTool {
 #[async_trait]
 impl SimpleTool for ErrorSimpleTool {
     async fn execute(
+        &self,
         llm_params: Self::LlmParams,
         _side_info: Self::SideInfo,
         _ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-tools/src/tools/test/good_simple.rs
+++ b/internal/autopilot-tools/src/tools/test/good_simple.rs
@@ -47,6 +47,7 @@ impl ToolMetadata for GoodSimpleTool {
 #[async_trait]
 impl SimpleTool for GoodSimpleTool {
     async fn execute(
+        &self,
         llm_params: Self::LlmParams,
         _side_info: Self::SideInfo,
         _ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-tools/src/tools/test/slow_simple.rs
+++ b/internal/autopilot-tools/src/tools/test/slow_simple.rs
@@ -58,6 +58,7 @@ impl ToolMetadata for SlowSimpleTool {
 #[async_trait]
 impl SimpleTool for SlowSimpleTool {
     async fn execute(
+        &self,
         llm_params: Self::LlmParams,
         _side_info: Self::SideInfo,
         _ctx: SimpleToolContext<'_>,

--- a/internal/autopilot-worker/src/wrapper.rs
+++ b/internal/autopilot-worker/src/wrapper.rs
@@ -219,7 +219,9 @@ struct SimpleToolStepParams<L, S> {
 }
 
 #[async_trait]
-impl<T: SimpleTool<SideInfo = AutopilotSideInfo>> TaskTool for ClientSimpleToolWrapper<T> {
+impl<T: SimpleTool<SideInfo = AutopilotSideInfo> + Default> TaskTool
+    for ClientSimpleToolWrapper<T>
+{
     async fn execute(
         &self,
         llm_params: Self::LlmParams,
@@ -278,7 +280,7 @@ impl<T: SimpleTool<SideInfo = AutopilotSideInfo>> TaskTool for ClientSimpleToolW
 /// success or failure. This ensures tool errors are checkpointed rather than
 /// causing step retries. The error is converted to structured JSON for
 /// programmatic parsing by the autopilot API.
-async fn execute_simple_tool_step<T: SimpleTool<SideInfo = AutopilotSideInfo>>(
+async fn execute_simple_tool_step<T: SimpleTool<SideInfo = AutopilotSideInfo> + Default>(
     params: SimpleToolStepParams<T::LlmParams, AutopilotSideInfo>,
     state: ToolAppState,
 ) -> anyhow::Result<Result<T::Output, serde_json::Value>> {
@@ -288,16 +290,19 @@ async fn execute_simple_tool_step<T: SimpleTool<SideInfo = AutopilotSideInfo>>(
         params.tool_name, params.tool_call_event_id
     );
 
+    let tool = T::default();
+
     // Wrap the result in Ok so tool errors are checkpointed, not retried.
     // Convert ToolError to structured JSON for programmatic error handling.
-    Ok(T::execute(
-        params.llm_params,
-        params.side_info,
-        simple_ctx,
-        &idempotency_key,
-    )
-    .await
-    .map_err(tool_error_to_json))
+    Ok(tool
+        .execute(
+            params.llm_params,
+            params.side_info,
+            simple_ctx,
+            &idempotency_key,
+        )
+        .await
+        .map_err(tool_error_to_json))
 }
 
 /// Convert a `ToolError` to structured JSON for the autopilot API.
@@ -595,6 +600,7 @@ mod tests {
     #[async_trait]
     impl SimpleTool for TestSimpleTool {
         async fn execute(
+            &self,
             llm_params: Self::LlmParams,
             _side_info: Self::SideInfo,
             _ctx: SimpleToolContext<'_>,

--- a/internal/durable-tools/README.md
+++ b/internal/durable-tools/README.md
@@ -175,6 +175,7 @@ impl ToolMetadata for SearchTool {
 #[async_trait]
 impl SimpleTool for SearchTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: <Self as ToolMetadata>::SideInfo,
         _ctx: SimpleToolContext<'_>,

--- a/internal/durable-tools/src/lib.rs
+++ b/internal/durable-tools/src/lib.rs
@@ -71,6 +71,7 @@
 //! #[async_trait]
 //! impl SimpleTool for SearchTool {
 //!     async fn execute(
+//!         &self,
 //!         llm_params: <Self as ToolMetadata>::LlmParams,
 //!         _side_info: <Self as ToolMetadata>::SideInfo,
 //!         ctx: SimpleToolContext<'_>,

--- a/internal/durable-tools/src/registry.rs
+++ b/internal/durable-tools/src/registry.rs
@@ -163,8 +163,10 @@ impl<T: SimpleTool> ErasedSimpleTool for T {
         let typed_llm_params: <T as ToolMetadata>::LlmParams = serde_json::from_value(llm_params)?;
         let typed_side_info: T::SideInfo = serde_json::from_value(side_info)?;
 
-        // Execute (static method)
-        let result = T::execute(typed_llm_params, typed_side_info, ctx, idempotency_key).await?;
+        // Execute
+        let result = self
+            .execute(typed_llm_params, typed_side_info, ctx, idempotency_key)
+            .await?;
 
         // Serialize output
         Ok(serde_json::to_value(&result)?)

--- a/internal/durable-tools/src/simple_tool.rs
+++ b/internal/durable-tools/src/simple_tool.rs
@@ -66,6 +66,7 @@ use crate::tool_metadata::ToolMetadata;
 /// #[async_trait]
 /// impl SimpleTool for SearchTool {
 ///     async fn execute(
+///         &self,
 ///         llm_params: <Self as ToolMetadata>::LlmParams,
 ///         _side_info: <Self as ToolMetadata>::SideInfo,
 ///         ctx: SimpleToolContext<'_>,
@@ -88,6 +89,7 @@ pub trait SimpleTool: ToolMetadata {
     /// * `ctx` - The simple tool context (provides database access)
     /// * `idempotency_key` - A unique key for this execution (use for external API calls)
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         side_info: Self::SideInfo,
         ctx: SimpleToolContext<'_>,

--- a/internal/durable-tools/src/tests.rs
+++ b/internal/durable-tools/src/tests.rs
@@ -58,6 +58,7 @@ impl ToolMetadata for EchoSimpleTool {
 #[async_trait]
 impl SimpleTool for EchoSimpleTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: Self::SideInfo,
         _ctx: SimpleToolContext<'_>,
@@ -160,6 +161,7 @@ impl ToolMetadata for DefaultTimeoutSimpleTool {
 #[async_trait]
 impl SimpleTool for DefaultTimeoutSimpleTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: Self::SideInfo,
         _ctx: SimpleToolContext<'_>,
@@ -415,6 +417,7 @@ mod registry_tests {
         #[async_trait::async_trait]
         impl SimpleTool for ConflictingSimpleTool {
             async fn execute(
+                &self,
                 llm_params: <Self as ToolMetadata>::LlmParams,
                 _side_info: Self::SideInfo,
                 _ctx: SimpleToolContext<'_>,

--- a/internal/durable-tools/tests/integration.rs
+++ b/internal/durable-tools/tests/integration.rs
@@ -116,6 +116,7 @@ impl ToolMetadata for EchoSimpleTool {
 #[async_trait]
 impl SimpleTool for EchoSimpleTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: Self::SideInfo,
         _ctx: SimpleToolContext<'_>,
@@ -217,6 +218,7 @@ impl ToolMetadata for InferenceSimpleTool {
 #[async_trait]
 impl SimpleTool for InferenceSimpleTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: Self::SideInfo,
         ctx: SimpleToolContext<'_>,
@@ -503,6 +505,7 @@ impl ToolMetadata for KeyCapturingSimpleTool {
 #[async_trait]
 impl SimpleTool for KeyCapturingSimpleTool {
     async fn execute(
+        &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: Self::SideInfo,
         _ctx: SimpleToolContext<'_>,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> This is a cross-crate trait signature change plus a new `Default` bound in the worker wrapper, which can break downstream implementations or alter behavior for tools that expected static/state-free execution.
> 
> **Overview**
> Updates the `durable-tools` `SimpleTool` trait so `execute` takes `&self` (instead of being callable as an associated/static function), and adjusts docs/tests accordingly.
> 
> Propagates the signature change across all autopilot prod/test `SimpleTool` implementations, and updates execution plumbing: the type-erased registry now calls `self.execute(...)`, and the autopilot worker’s `ClientSimpleToolWrapper`/step runner now requires `T: Default` and constructs a fresh tool instance inside the step before calling `execute`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67d61b7fb39fbc645dfcad5a73705e3c494bb51d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->