### PR TITLE
Remove ClickHouse URL configuration from UI service

### DIFF
--- a/examples/babyai/docker-compose.yml
+++ b/examples/babyai/docker-compose.yml
@@ -48,15 +48,12 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     env_file:
       - ${ENV_FILE:-.env}
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/blog/bandits-in-your-llm-gateway/docker-compose.yml
+++ b/examples/blog/bandits-in-your-llm-gateway/docker-compose.yml
@@ -66,14 +66,11 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_POSTGRES_URL: postgres://postgres:postgres@postgres:5432/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
       postgres:

--- a/examples/chess-puzzles/docker-compose.yml
+++ b/examples/chess-puzzles/docker-compose.yml
@@ -55,15 +55,12 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     env_file:
       - ${ENV_FILE:-.env}
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/data-extraction-ner/docker-compose.yml
+++ b/examples/data-extraction-ner/docker-compose.yml
@@ -97,7 +97,6 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_POSTGRES_URL: postgres://postgres:postgres@postgres:5432/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     env_file:
@@ -105,8 +104,6 @@ services:
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway-postgres-migrations:
         condition: service_healthy
       gateway:

--- a/examples/docs/guides/experimentation/run-adaptive-ab-tests/docker-compose.yml
+++ b/examples/docs/guides/experimentation/run-adaptive-ab-tests/docker-compose.yml
@@ -66,14 +66,11 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_POSTGRES_URL: postgres://postgres:postgres@postgres:5432/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
       postgres:

--- a/examples/docs/guides/gateway/call-the-openai-responses-api/docker-compose.yml
+++ b/examples/docs/guides/gateway/call-the-openai-responses-api/docker-compose.yml
@@ -44,13 +44,10 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/docs/guides/gateway/create-a-prompt-template/docker-compose.yml
+++ b/examples/docs/guides/gateway/create-a-prompt-template/docker-compose.yml
@@ -43,13 +43,10 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/docs/guides/gateway/generate-structured-outputs/docker-compose.yml
+++ b/examples/docs/guides/gateway/generate-structured-outputs/docker-compose.yml
@@ -43,13 +43,10 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/docs/guides/observability/query-historical-inferences/docker-compose.yml
+++ b/examples/docs/guides/observability/query-historical-inferences/docker-compose.yml
@@ -43,13 +43,10 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/docs/guides/operations/enforce-custom-rate-limits/postgres/docker-compose.yml
+++ b/examples/docs/guides/operations/enforce-custom-rate-limits/postgres/docker-compose.yml
@@ -67,13 +67,10 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/docs/guides/operations/enforce-custom-rate-limits/valkey-redis/docker-compose.yml
+++ b/examples/docs/guides/operations/enforce-custom-rate-limits/valkey-redis/docker-compose.yml
@@ -63,13 +63,10 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/docs/guides/operations/organize-your-configuration/docker-compose.yml
+++ b/examples/docs/guides/operations/organize-your-configuration/docker-compose.yml
@@ -51,13 +51,10 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/docs/guides/operations/set-up-auth-for-tensorzero/docker-compose.yml
+++ b/examples/docs/guides/operations/set-up-auth-for-tensorzero/docker-compose.yml
@@ -66,15 +66,12 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_POSTGRES_URL: postgres://postgres:postgres@postgres:5432/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
       TENSORZERO_API_KEY: $TENSORZERO_API_KEY
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
       postgres:

--- a/examples/docs/guides/optimization/dynamic-in-context-learning-dicl/docker-compose.yml
+++ b/examples/docs/guides/optimization/dynamic-in-context-learning-dicl/docker-compose.yml
@@ -49,13 +49,10 @@ services:
     volumes:
       - ./config:/app/config:ro
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/docs/guides/optimization/gepa/docker-compose.yml
+++ b/examples/docs/guides/optimization/gepa/docker-compose.yml
@@ -49,13 +49,10 @@ services:
     volumes:
       - ./config:/app/config:ro
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/docs/guides/optimization/supervised-fine-tuning/docker-compose.yml
+++ b/examples/docs/guides/optimization/supervised-fine-tuning/docker-compose.yml
@@ -49,13 +49,10 @@ services:
     volumes:
       - ./config:/app/config:ro
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/dynamic_evaluations/simple-agentic-rag/docker-compose.yml
+++ b/examples/dynamic_evaluations/simple-agentic-rag/docker-compose.yml
@@ -55,15 +55,12 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero
       - TENSORZERO_GATEWAY_URL=http://gateway:3000
     env_file:
       - ${ENV_FILE:-.env}
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/evaluations/tutorial/docker-compose.yml
+++ b/examples/evaluations/tutorial/docker-compose.yml
@@ -53,13 +53,10 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/guides/datasets-datapoints/docker-compose.yml
+++ b/examples/guides/datasets-datapoints/docker-compose.yml
@@ -43,13 +43,10 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/guides/tool-use/docker-compose.yml
+++ b/examples/guides/tool-use/docker-compose.yml
@@ -46,13 +46,10 @@ services:
     volumes:
       - ./object_storage:/app/object_storage
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/haiku-hidden-preferences/docker-compose.yml
+++ b/examples/haiku-hidden-preferences/docker-compose.yml
@@ -56,15 +56,12 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     env_file:
       - ${ENV_FILE:-.env}
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/integrations/crewai/example/tensorzero/docker-compose.yml
+++ b/examples/integrations/crewai/example/tensorzero/docker-compose.yml
@@ -38,13 +38,8 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero
       - TENSORZERO_GATEWAY_URL=http://gateway:3000
     ports:
       - "4000:4000"
-    depends_on:
-      clickhouse:
-        condition: service_healthy
-
 volumes:
   clickhouse-data:

--- a/examples/integrations/cursor/docker-compose.yml
+++ b/examples/integrations/cursor/docker-compose.yml
@@ -51,15 +51,12 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero
       - TENSORZERO_GATEWAY_URL=http://gateway:3000
     env_file:
       - ${ENV_FILE:-.env}
     ports:
       - "14000:4000" # UI port exposed to local machine on 14000
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/integrations/openai-codex/docker-compose.yml
+++ b/examples/integrations/openai-codex/docker-compose.yml
@@ -54,15 +54,12 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     env_file:
       - .env
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/mcp-model-context-protocol/docker-compose.yml
+++ b/examples/mcp-model-context-protocol/docker-compose.yml
@@ -51,13 +51,10 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: "http://chuser:chpassword@clickhouse:8123/tensorzero"
       TENSORZERO_GATEWAY_URL: "http://gateway:3000"
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/multimodal-vision-finetuning/docker-compose.yml
+++ b/examples/multimodal-vision-finetuning/docker-compose.yml
@@ -46,13 +46,10 @@ services:
     volumes:
       - ./object_storage:/app/object_storage
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/optimization/dicl/docker-compose.yml
+++ b/examples/optimization/dicl/docker-compose.yml
@@ -58,13 +58,10 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 

--- a/examples/production-deployment-k8s-helm/values.yaml
+++ b/examples/production-deployment-k8s-helm/values.yaml
@@ -100,8 +100,6 @@ ui:
   additionalEnv:
     secretName: "tensorzero-secret"
     keys:
-      - name: TENSORZERO_CLICKHOUSE_URL
-        key: TENSORZERO_CLICKHOUSE_URL
       - name: TENSORZERO_GATEWAY_URL
         key: TENSORZERO_GATEWAY_URL
 

--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -44,13 +44,8 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      - TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@clickhouse:8123/tensorzero
       - TENSORZERO_GATEWAY_URL=http://gateway:3000
     ports:
       - "4000:4000"
-    depends_on:
-      clickhouse:
-        condition: service_healthy
-
 volumes:
   clickhouse-data:

--- a/examples/readme/docker-compose.yml
+++ b/examples/readme/docker-compose.yml
@@ -48,13 +48,10 @@ services:
   ui:
     image: tensorzero/ui
     environment:
-      TENSORZERO_CLICKHOUSE_URL: http://chuser:chpassword@clickhouse:8123/tensorzero
       TENSORZERO_GATEWAY_URL: http://gateway:3000
     ports:
       - "4000:4000"
     depends_on:
-      clickhouse:
-        condition: service_healthy
       gateway:
         condition: service_healthy
 


### PR DESCRIPTION
## Summary
This PR removes the `TENSORZERO_CLICKHOUSE_URL` environment variable configuration from the UI service across all example and deployment configurations. The UI service no longer requires direct ClickHouse connectivity and will no longer wait for ClickHouse to be healthy before starting.

## Key Changes
- Removed `TENSORZERO_CLICKHOUSE_URL` environment variable from all UI service configurations in docker-compose files
- Removed ClickHouse health check dependency (`depends_on: clickhouse: condition: service_healthy`) from UI services
- Updated 35+ docker-compose.yml files across examples, guides, integrations, and documentation
- Updated Kubernetes Helm values.yaml to remove ClickHouse URL from UI secrets

## Implementation Details
- The UI service now only requires the `TENSORZERO_GATEWAY_URL` environment variable for gateway communication
- ClickHouse connectivity is no longer a startup requirement for the UI service
- This change simplifies the service dependency graph and allows the UI to start independently of ClickHouse availability
- All other services and their configurations remain unchanged

https://claude.ai/code/session_018r4XKnkHvAC7dnZ22rx1Dq

Fixes #5541