### PR TITLE
Incremental model provider stats computation

### DIFF
--- a/tensorzero-core/src/db/postgres/migrations/20260209183000_incremental_model_provider_statistics.sql
+++ b/tensorzero-core/src/db/postgres/migrations/20260209183000_incremental_model_provider_statistics.sql
@@ -1,0 +1,153 @@
+-- Replace `model_provider_statistics` materialized view with an incrementally maintained table:
+-- each row is (model, provider, minute, total input tokens, total output tokens, inference count)
+--
+-- The online path for computing model statistics over a time window becomes:
+-- SELECT .. FROM model_provider_statistics WHERE minute >= (NOW() - INTERVAL window)
+--
+-- The offline aggregation path is:
+-- SELECT (aggregate values)
+-- FROM model_inferences
+-- WHERE timestamp in window
+-- GROUP BY model, provider, (timestamp truncated to minute)
+
+-- Convert the existing materialized view into a regular table, preserving existing data.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_matviews
+        WHERE schemaname = 'tensorzero'
+          AND matviewname = 'model_provider_statistics'
+    ) THEN
+        CREATE TABLE tensorzero.model_provider_statistics_table AS
+        SELECT *
+        FROM tensorzero.model_provider_statistics;
+
+        DROP MATERIALIZED VIEW tensorzero.model_provider_statistics;
+
+        ALTER TABLE tensorzero.model_provider_statistics_table
+            RENAME TO model_provider_statistics;
+    END IF;
+END $$;
+
+-- Recreate indexes that were previously attached to the materialized view.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_model_provider_stats_pk
+    ON tensorzero.model_provider_statistics(model_name, model_provider_name, minute);
+
+CREATE INDEX IF NOT EXISTS idx_model_provider_stats_minute
+    ON tensorzero.model_provider_statistics(minute);
+
+-- Watermark state for incremental refresh.
+CREATE TABLE IF NOT EXISTS tensorzero.model_provider_statistics_refresh_state (
+    singleton BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
+    last_processed_created_at TIMESTAMPTZ,
+    last_processed_id UUID
+);
+
+-- Initialize watermark at the current tail to avoid a full-table first refresh.
+INSERT INTO tensorzero.model_provider_statistics_refresh_state (
+    singleton,
+    last_processed_created_at,
+    last_processed_id
+)
+SELECT
+    TRUE,
+    latest.created_at,
+    latest.id
+FROM (
+    SELECT created_at, id
+    FROM tensorzero.model_inferences
+    ORDER BY created_at DESC, id DESC
+    LIMIT 1
+) AS latest
+ON CONFLICT (singleton) DO NOTHING;
+
+-- Incremental refresh for `model_provider_statistics`.
+-- We reprocess a trailing lookback window to absorb slightly late-arriving rows.
+CREATE OR REPLACE FUNCTION tensorzero.refresh_model_provider_statistics_incremental(
+    lookback INTERVAL DEFAULT INTERVAL '10 minutes',
+    full_refresh BOOLEAN DEFAULT FALSE
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    state_created_at TIMESTAMPTZ;
+    refresh_from TIMESTAMPTZ;
+    refresh_to TIMESTAMPTZ := NOW();
+    newest_created_at TIMESTAMPTZ;
+    newest_id UUID;
+    oldest_created_at TIMESTAMPTZ;
+BEGIN
+    INSERT INTO tensorzero.model_provider_statistics_refresh_state (singleton)
+    VALUES (TRUE)
+    ON CONFLICT (singleton) DO NOTHING;
+
+    SELECT last_processed_created_at
+    INTO state_created_at
+    FROM tensorzero.model_provider_statistics_refresh_state
+    WHERE singleton = TRUE
+    FOR UPDATE;
+
+    IF full_refresh THEN
+        TRUNCATE TABLE tensorzero.model_provider_statistics;
+        refresh_from := TIMESTAMPTZ '-infinity';
+    ELSIF state_created_at IS NULL THEN
+        refresh_from := TIMESTAMPTZ '-infinity';
+    ELSE
+        refresh_from := date_trunc('minute', state_created_at - lookback);
+    END IF;
+
+    -- Upsert only affected minute buckets in the trailing refresh window.
+    INSERT INTO tensorzero.model_provider_statistics (
+        model_name,
+        model_provider_name,
+        minute,
+        total_input_tokens,
+        total_output_tokens,
+        inference_count
+    )
+    SELECT
+        model_name,
+        model_provider_name,
+        date_trunc('minute', created_at) AS minute,
+        -- Don't coalesce NULL values to 0
+        SUM(input_tokens)::BIGINT AS total_input_tokens,
+        SUM(output_tokens)::BIGINT AS total_output_tokens,
+        COUNT(*)::BIGINT AS inference_count
+    FROM tensorzero.model_inferences
+    WHERE created_at >= refresh_from
+      AND created_at <= refresh_to
+    GROUP BY model_name, model_provider_name, date_trunc('minute', created_at)
+    ON CONFLICT (model_name, model_provider_name, minute) DO UPDATE
+    SET
+        total_input_tokens = EXCLUDED.total_input_tokens,
+        total_output_tokens = EXCLUDED.total_output_tokens,
+        inference_count = EXCLUDED.inference_count;
+
+    -- Keep retention behavior correct: if old source partitions were dropped,
+    -- remove stale stats buckets that are now older than the earliest source row.
+    SELECT MIN(created_at)
+    INTO oldest_created_at
+    FROM tensorzero.model_inferences;
+
+    IF oldest_created_at IS NULL THEN
+        TRUNCATE TABLE tensorzero.model_provider_statistics;
+    ELSE
+        DELETE FROM tensorzero.model_provider_statistics
+        WHERE minute < date_trunc('minute', oldest_created_at);
+    END IF;
+
+    SELECT created_at, id
+    INTO newest_created_at, newest_id
+    FROM tensorzero.model_inferences
+    ORDER BY created_at DESC, id DESC
+    LIMIT 1;
+
+    UPDATE tensorzero.model_provider_statistics_refresh_state
+    SET
+        last_processed_created_at = newest_created_at,
+        last_processed_id = newest_id
+    WHERE singleton = TRUE;
+END;
+$$;

--- a/tensorzero-core/tests/e2e/db/postgres/pgcron_tests.rs
+++ b/tensorzero-core/tests/e2e/db/postgres/pgcron_tests.rs
@@ -68,6 +68,19 @@ async fn test_setup_pgcron_is_idempotent() {
         refresh_views_count, 1,
         "Should have exactly one 'tensorzero_refresh_materialized_views' job after running setup twice"
     );
+
+    // Verify there's exactly one job for incremental model provider statistics refresh
+    let refresh_model_provider_stats_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM cron.job WHERE jobname = 'tensorzero_refresh_model_provider_statistics_incremental'",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("Should be able to query cron.job table");
+
+    assert_eq!(
+        refresh_model_provider_stats_count, 1,
+        "Should have exactly one 'tensorzero_refresh_model_provider_statistics_incremental' job after running setup twice"
+    );
 }
 
 /// Tests that `check_pgcron_configured_correctly` returns an error when pg_cron is not installed.

--- a/ui/fixtures/load_fixtures_postgres.sh
+++ b/ui/fixtures/load_fixtures_postgres.sh
@@ -413,9 +413,11 @@ FROM tmp_jsonl, LATERAL (SELECT data::jsonb AS j) AS parsed
 ON CONFLICT (episode_id) DO NOTHING;
 "
 
-echo "Refreshing materialized views..."
+echo "Backfilling model provider statistics and refreshing materialized views..."
 psql -q "$POSTGRES_URL" <<EOF
-REFRESH MATERIALIZED VIEW tensorzero.model_provider_statistics;
+SELECT tensorzero.refresh_model_provider_statistics_incremental(
+    full_refresh => TRUE
+);
 REFRESH MATERIALIZED VIEW tensorzero.model_latency_quantiles;
 REFRESH MATERIALIZED VIEW tensorzero.model_latency_quantiles_hour;
 REFRESH MATERIALIZED VIEW tensorzero.model_latency_quantiles_day;

--- a/ui/fixtures/reset-dev-postgres.sh
+++ b/ui/fixtures/reset-dev-postgres.sh
@@ -49,7 +49,9 @@ SQLX_OFFLINE=1 cargo run --package gateway --bin gateway -- --run-postgres-migra
 
 echo "==> Refreshing materialized views..."
 PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" <<EOF
-REFRESH MATERIALIZED VIEW tensorzero.model_provider_statistics;
+SELECT tensorzero.refresh_model_provider_statistics_incremental(
+    full_refresh => TRUE
+);
 REFRESH MATERIALIZED VIEW tensorzero.model_latency_quantiles;
 REFRESH MATERIALIZED VIEW tensorzero.model_latency_quantiles_hour;
 REFRESH MATERIALIZED VIEW tensorzero.model_latency_quantiles_day;


### PR DESCRIPTION
This adds a way to incrementally refresh model provider stats, and schedules a pgcron job every 5 minutes to refresh the last 10 minutes of data. Also adds a way to do a full refresh (we use this in our tests). We will need to figure out the right way to schedule this job for existing users, but it's sufficient for new users.

Can get merged independently of the model inference table split, because it only touches the metadata columns.

A step towards #5691.

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Touches Postgres migration logic and scheduled refresh behavior for production aggregates; correctness depends on the incremental window/watermark and could lead to stale or incorrect stats if misconfigured.
>
> **Overview**
> Switches `model_provider_statistics` from a materialized view to a regular table that is maintained via new PL/pgSQL refresh functions and a persisted watermark, avoiding full refreshes on large datasets.
>
> Updates pg_cron setup to run `refresh_model_provider_statistics_incremental` every 5 minutes (with a 10-minute lookback), adjusts e2e tests to assert this job is scheduled exactly once, and changes the Postgres fixture loader to call a full backfill function instead of `REFRESH MATERIALIZED VIEW`.
>
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cac4cfb5b0ebb5d3d0bbe42661c386219a15019. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

<!-- /CURSOR_SUMMARY -->