### PR TITLE
Support errors in include_raw_response [v2]

### DIFF
--- a/clients/python/tensorzero/types.py
+++ b/clients/python/tensorzero/types.py
@@ -47,10 +47,10 @@ class RawResponseEntry:
     This contains the original provider-specific response string for debugging and advanced use cases.
     """
 
-    model_inference_id: UUID
     provider_type: str
     api_type: ApiType
     data: str
+    model_inference_id: Optional[UUID] = None
 
 
 @dataclass
@@ -286,7 +286,7 @@ def parse_raw_usage(
 
 def parse_raw_response_entry(entry: Dict[str, Any]) -> RawResponseEntry:
     return RawResponseEntry(
-        model_inference_id=UUID(entry["model_inference_id"]),
+        model_inference_id=UUID(entry["model_inference_id"]) if entry.get("model_inference_id") else None,
         provider_type=entry["provider_type"],
         api_type=entry["api_type"],
         data=entry["data"],

--- a/internal/tensorzero-node/lib/bindings/RawResponseEntry.ts
+++ b/internal/tensorzero-node/lib/bindings/RawResponseEntry.ts
@@ -6,7 +6,7 @@ import type { ApiType } from "./ApiType";
  * This preserves the original provider-specific response string that TensorZero normalizes.
  */
 export type RawResponseEntry = {
-  model_inference_id: string;
+  model_inference_id: string | null;
   provider_type: string;
   api_type: ApiType;
   data: string;

--- a/tensorzero-core/src/endpoints/embeddings.rs
+++ b/tensorzero-core/src/endpoints/embeddings.rs
@@ -111,7 +111,7 @@ pub async fn embeddings(
     let usage = response.usage_considering_cached();
     let tensorzero_raw_response = if params.include_raw_response && !response.cached {
         Some(vec![RawResponseEntry {
-            model_inference_id: response.id,
+            model_inference_id: Some(response.id),
             provider_type: response.embedding_provider_name.to_string(),
             api_type: ApiType::Embeddings,
             data: response.raw_response.clone(),

--- a/tensorzero-core/src/endpoints/inference.rs
+++ b/tensorzero-core/src/endpoints/inference.rs
@@ -999,7 +999,7 @@ fn create_previous_raw_response_chunk(
                     .map(|entry| entry.api_type)
                     .unwrap_or(ApiType::ChatCompletions);
                 vec![RawResponseEntry {
-                    model_inference_id: r.id,
+                    model_inference_id: Some(r.id),
                     provider_type: r.model_provider_name.to_string(),
                     api_type,
                     data: r.raw_response.clone(),
@@ -1535,7 +1535,7 @@ impl InferenceResponse {
                             .map(|entry| entry.api_type)
                             .unwrap_or(ApiType::ChatCompletions);
                         vec![RawResponseEntry {
-                            model_inference_id: r.id,
+                            model_inference_id: Some(r.id),
                             provider_type: r.model_provider_name.to_string(),
                             api_type,
                             data: r.raw_response.clone(),

--- a/tensorzero-core/src/inference/types/usage.rs
+++ b/tensorzero-core/src/inference/types/usage.rs
@@ -43,10 +43,10 @@ pub fn raw_usage_entries_from_value(
 /// A single entry in the raw response array, representing raw response data from one model inference.
 /// This preserves the original provider-specific response string that TensorZero normalizes.
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[cfg_attr(feature = "ts-bindings", ts(export))]
 pub struct RawResponseEntry {
-    pub model_inference_id: Uuid,
+    pub model_inference_id: Option<Uuid>,
     pub provider_type: String,
     pub api_type: ApiType,
     pub data: String,

--- a/tensorzero-core/tests/e2e/raw_response/cache.rs
+++ b/tensorzero-core/tests/e2e/raw_response/cache.rs
@@ -23,7 +23,7 @@ use uuid::Uuid;
 
 fn assert_raw_response_entry(entry: &RawResponseEntry) {
     assert!(
-        !entry.model_inference_id.is_nil(),
+        entry.model_inference_id.is_some_and(|id| !id.is_nil()),
         "raw_response entry should have valid model_inference_id"
     );
     assert!(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Type-shape change to the `raw_response` payload; main risk is downstream clients assuming `model_inference_id` is always present.
> 
> **Overview**
> Makes `RawResponseEntry.model_inference_id` nullable across Rust core, TS bindings, and the Python client so `include_raw_response` can represent entries even when an inference id is unavailable (e.g., error paths).
> 
> Updates gateway code to populate `model_inference_id: Some(id)` where available (embeddings + inference endpoints), adjusts Python parsing to tolerate missing/empty `model_inference_id`, and updates e2e cache assertions to handle the optional id.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de97f570fe27512315841eccb688fdb63aa14bc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->