### PR TITLE
added handling for model inferences to resolve UUID endpoint

### DIFF
--- a/internal/tensorzero-node/lib/bindings/ResolvedObject.ts
+++ b/internal/tensorzero-node/lib/bindings/ResolvedObject.ts
@@ -18,4 +18,10 @@ export type ResolvedObject =
   | { type: "comment_feedback" }
   | { type: "demonstration_feedback" }
   | { type: "chat_datapoint"; dataset_name: string; function_name: string }
-  | { type: "json_datapoint"; dataset_name: string; function_name: string };
+  | { type: "json_datapoint"; dataset_name: string; function_name: string }
+  | {
+      type: "model_inference";
+      inference_id: string;
+      model_name: string;
+      model_provider_name: string;
+    };

--- a/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0046.rs
+++ b/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0046.rs
@@ -6,18 +6,19 @@ use crate::db::clickhouse::ClickHouseConnectionInfo;
 use crate::db::clickhouse::migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
 
-/// This migration adds bloom filter indices on `id` columns to the feedback tables:
-/// `BooleanMetricFeedback`, `FloatMetricFeedback`, `CommentFeedback`, and `DemonstrationFeedback`.
-/// This allows efficient lookup of feedback rows by their primary ID (used by the resolve_uuid endpoint).
+/// This migration adds bloom filter indices on `id` columns to the feedback tables
+/// and the `ModelInference` table.
+/// This allows efficient lookup of rows by their primary ID (used by the resolve_uuid endpoint).
 pub struct Migration0046<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
 }
 
-const TABLES: [&str; 4] = [
+const TABLES: [&str; 5] = [
     "BooleanMetricFeedback",
     "FloatMetricFeedback",
     "CommentFeedback",
     "DemonstrationFeedback",
+    "ModelInference",
 ];
 
 #[async_trait]

--- a/tensorzero-core/src/db/resolve_uuid.rs
+++ b/tensorzero-core/src/db/resolve_uuid.rs
@@ -32,6 +32,11 @@ pub enum ResolvedObject {
         dataset_name: String,
         function_name: String,
     },
+    ModelInference {
+        inference_id: Uuid,
+        model_name: String,
+        model_provider_name: String,
+    },
 }
 
 /// Response type for the resolve_uuid endpoint.


### PR DESCRIPTION
oops, forgot this

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches DB query paths and a ClickHouse migration; risk is mainly around correctness/performance of the new lookup and successful index creation on existing ClickHouse deployments.
> 
> **Overview**
> The internal `resolve_uuid` endpoint now resolves UUIDs that belong to `ModelInference` records, returning a new `ResolvedObject::ModelInference` variant containing `inference_id`, `model_name`, and `model_provider_name` (implemented for both Postgres and ClickHouse).
> 
> ClickHouse migration `0046` is expanded to also add/materialize a bloom-filter `id_index` on the `ModelInference` table to keep ID lookups efficient, and TS bindings plus an e2e test are updated to cover the new object type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc7fe47089ff86a202ea4cfa1d067535ced4e161. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->