### PR TITLE
Implement EvaluationQueries for Postgres

### DIFF
--- a/tensorzero-core/src/db/evaluation_queries.rs
+++ b/tensorzero-core/src/db/evaluation_queries.rs
@@ -14,8 +14,8 @@ use crate::function::FunctionConfigType;
 use crate::inference::types::{ContentBlockChatOutput, Input, JsonInferenceOutput, StoredInput};
 use crate::serde_util::deserialize_json_string;
 
-/// Database struct for deserializing evaluation run info from ClickHouse.
-#[derive(Debug, Deserialize)]
+/// Database struct for deserializing evaluation run info.
+#[derive(Debug, Deserialize, sqlx::FromRow)]
 pub struct EvaluationRunInfoRow {
     pub evaluation_run_id: Uuid,
     pub evaluation_name: String,
@@ -25,16 +25,16 @@ pub struct EvaluationRunInfoRow {
     pub last_inference_timestamp: DateTime<Utc>,
 }
 
-/// Database struct for deserializing evaluation run search results from ClickHouse.
-#[derive(Debug, Deserialize)]
+/// Database struct for deserializing evaluation run search results.
+#[derive(Debug, Deserialize, sqlx::FromRow)]
 pub struct EvaluationRunSearchResult {
     pub evaluation_run_id: Uuid,
     pub variant_name: String,
 }
 
-/// Database struct for deserializing evaluation run info by IDs from ClickHouse.
+/// Database struct for deserializing evaluation run info by IDs.
 /// This is a simpler struct than `EvaluationRunInfoRow` - used when querying by specific run IDs.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, sqlx::FromRow)]
 pub struct EvaluationRunInfoByIdRow {
     pub evaluation_run_id: Uuid,
     pub variant_name: String,
@@ -68,9 +68,9 @@ pub struct InferenceEvaluationHumanFeedbackRow {
     pub evaluator_inference_id: Uuid,
 }
 
-/// Internal struct for deserializing evaluation results from ClickHouse.
+/// Internal struct for deserializing evaluation results.
 /// The output fields are kept as strings and converted to typed structs based on function type.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, sqlx::FromRow)]
 pub(crate) struct RawEvaluationResultRow {
     pub inference_id: Uuid,
     pub episode_id: Uuid,
@@ -78,6 +78,7 @@ pub(crate) struct RawEvaluationResultRow {
     pub evaluation_run_id: Uuid,
     pub evaluator_inference_id: Option<Uuid>,
     #[serde(deserialize_with = "deserialize_json_string")]
+    #[sqlx(json)]
     pub input: StoredInput,
     pub generated_output: String,
     pub reference_output: Option<String>,

--- a/tensorzero-core/src/db/postgres/AGENTS.md
+++ b/tensorzero-core/src/db/postgres/AGENTS.md
@@ -1,0 +1,12 @@
+# Postgres Query Guidelines
+
+## Row deserialization
+
+Use `sqlx::FromRow` (derived or manually implemented) for deserializing query results into structs. Use `build_query_as::<T>()` with `QueryBuilder` or `sqlx::query_as!` for static queries to leverage typed deserialization.
+
+Avoid manual `row.get("column")` extraction when `FromRow` can be used instead.
+
+## Static vs dynamic queries
+
+- Use `sqlx::query!` / `sqlx::query_as!` / `sqlx::query_scalar!` for **static queries** where only bind values change but the query structure is fixed. This provides compile-time verification.
+- Use `QueryBuilder` only when the **query structure is dynamic** (e.g., dynamic table names, conditional WHERE clauses, conditional JOINs).

--- a/tensorzero-core/src/db/postgres/evaluation_queries.rs
+++ b/tensorzero-core/src/db/postgres/evaluation_queries.rs
@@ -1,0 +1,892 @@
+//! Postgres queries for evaluation statistics.
+
+use async_trait::async_trait;
+use sqlx::postgres::PgRow;
+use sqlx::{PgPool, QueryBuilder, Row};
+use uuid::Uuid;
+
+use crate::db::evaluation_queries::{
+    EvaluationQueries, EvaluationResultRow, EvaluationRunInfoByIdRow, EvaluationRunInfoRow,
+    EvaluationRunSearchResult, EvaluationStatisticsRow, InferenceEvaluationHumanFeedbackRow,
+    RawEvaluationResultRow,
+};
+use crate::error::Error;
+use crate::function::FunctionConfigType;
+use crate::statistics_util::{wald_confint, wilson_confint};
+
+use super::PostgresConnectionInfo;
+
+/// Raw statistics row from Postgres before CI computation.
+#[derive(sqlx::FromRow)]
+struct RawEvaluationStatisticsRow {
+    evaluation_run_id: Uuid,
+    metric_name: String,
+    is_boolean: bool,
+    datapoint_count: i32,
+    mean_metric: f64,
+    stdev: Option<f64>,
+}
+
+impl RawEvaluationStatisticsRow {
+    fn into_evaluation_statistics_row(self) -> EvaluationStatisticsRow {
+        let (ci_lower, ci_upper) = if self.is_boolean {
+            wilson_confint(self.mean_metric, self.datapoint_count as u32)
+                .map(|(l, u)| (Some(l), Some(u)))
+                .unwrap_or((None, None))
+        } else if let Some(stdev) = self.stdev {
+            wald_confint(self.mean_metric, stdev, self.datapoint_count as u32)
+                .map(|(l, u)| (Some(l), Some(u)))
+                .unwrap_or((None, None))
+        } else {
+            (None, None)
+        };
+
+        EvaluationStatisticsRow {
+            evaluation_run_id: self.evaluation_run_id,
+            metric_name: self.metric_name,
+            datapoint_count: self.datapoint_count as u32,
+            mean_metric: self.mean_metric,
+            ci_lower,
+            ci_upper,
+        }
+    }
+}
+
+// =====================================================================
+// EvaluationQueries trait implementation
+// =====================================================================
+
+#[async_trait]
+impl EvaluationQueries for PostgresConnectionInfo {
+    async fn count_total_evaluation_runs(&self) -> Result<u64, Error> {
+        let pool = self.get_pool_result()?;
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(DISTINCT evaluation_run_id)::BIGINT
+            FROM (
+                SELECT tags->>'tensorzero::evaluation_run_id' as evaluation_run_id
+                FROM tensorzero.chat_inferences
+                WHERE tags ? 'tensorzero::evaluation_run_id'
+                AND NOT function_name LIKE 'tensorzero::%'
+                UNION ALL
+                SELECT tags->>'tensorzero::evaluation_run_id' as evaluation_run_id
+                FROM tensorzero.json_inferences
+                WHERE tags ? 'tensorzero::evaluation_run_id'
+                AND NOT function_name LIKE 'tensorzero::%'
+            ) sub",
+        )
+        .fetch_one(pool)
+        .await?;
+        Ok(count as u64)
+    }
+
+    async fn list_evaluation_runs(
+        &self,
+        limit: u32,
+        offset: u32,
+    ) -> Result<Vec<EvaluationRunInfoRow>, Error> {
+        let pool = self.get_pool_result()?;
+        let mut qb = build_list_evaluation_runs_query(limit, offset);
+        let rows: Vec<EvaluationRunInfoRow> = qb.build_query_as().fetch_all(pool).await?;
+        Ok(rows)
+    }
+
+    async fn count_datapoints_for_evaluation(
+        &self,
+        function_name: &str,
+        evaluation_run_ids: &[Uuid],
+    ) -> Result<u64, Error> {
+        if evaluation_run_ids.is_empty() {
+            return Ok(0);
+        }
+        let pool = self.get_pool_result()?;
+        let mut qb = build_count_datapoints_for_evaluation_query(function_name, evaluation_run_ids);
+        let row: PgRow = qb.build().fetch_one(pool).await?;
+        let count: i64 = row.get("count");
+        Ok(count as u64)
+    }
+
+    async fn search_evaluation_runs(
+        &self,
+        evaluation_name: &str,
+        function_name: &str,
+        query: &str,
+        limit: u32,
+        offset: u32,
+    ) -> Result<Vec<EvaluationRunSearchResult>, Error> {
+        let pool = self.get_pool_result()?;
+        let mut qb = build_search_evaluation_runs_query(
+            evaluation_name,
+            function_name,
+            query,
+            limit,
+            offset,
+        );
+        let rows: Vec<EvaluationRunSearchResult> = qb.build_query_as().fetch_all(pool).await?;
+        Ok(rows)
+    }
+
+    async fn get_evaluation_run_infos(
+        &self,
+        evaluation_run_ids: &[Uuid],
+        function_name: &str,
+    ) -> Result<Vec<EvaluationRunInfoByIdRow>, Error> {
+        if evaluation_run_ids.is_empty() {
+            return Ok(vec![]);
+        }
+        let pool = self.get_pool_result()?;
+        let mut qb = build_get_evaluation_run_infos_query(evaluation_run_ids, function_name);
+        let rows: Vec<EvaluationRunInfoByIdRow> = qb.build_query_as().fetch_all(pool).await?;
+        Ok(rows)
+    }
+
+    async fn get_evaluation_run_infos_for_datapoint(
+        &self,
+        datapoint_id: &Uuid,
+        function_name: &str,
+        function_type: FunctionConfigType,
+    ) -> Result<Vec<EvaluationRunInfoByIdRow>, Error> {
+        let pool = self.get_pool_result()?;
+        let mut qb = build_get_evaluation_run_infos_for_datapoint_query(
+            datapoint_id,
+            function_name,
+            function_type,
+        );
+        let rows: Vec<EvaluationRunInfoByIdRow> = qb.build_query_as().fetch_all(pool).await?;
+        Ok(rows)
+    }
+
+    async fn get_evaluation_statistics(
+        &self,
+        function_name: &str,
+        function_type: FunctionConfigType,
+        metric_names: &[String],
+        evaluation_run_ids: &[Uuid],
+    ) -> Result<Vec<EvaluationStatisticsRow>, Error> {
+        if evaluation_run_ids.is_empty() || metric_names.is_empty() {
+            return Ok(vec![]);
+        }
+        let pool = self.get_pool_result()?;
+        let raw_rows = get_evaluation_statistics_raw(
+            pool,
+            function_name,
+            function_type,
+            metric_names,
+            evaluation_run_ids,
+        )
+        .await?;
+
+        Ok(raw_rows
+            .into_iter()
+            .map(|row| row.into_evaluation_statistics_row())
+            .collect())
+    }
+
+    async fn get_evaluation_results(
+        &self,
+        function_name: &str,
+        evaluation_run_ids: &[Uuid],
+        function_type: FunctionConfigType,
+        metric_names: &[String],
+        datapoint_id: Option<&Uuid>,
+        limit: u32,
+        offset: u32,
+    ) -> Result<Vec<EvaluationResultRow>, Error> {
+        if evaluation_run_ids.is_empty() {
+            return Ok(vec![]);
+        }
+        let pool = self.get_pool_result()?;
+        let mut qb = build_get_evaluation_results_query(
+            function_name,
+            evaluation_run_ids,
+            function_type,
+            metric_names,
+            datapoint_id,
+            limit,
+            offset,
+        );
+        let rows: Vec<RawEvaluationResultRow> = qb.build_query_as().fetch_all(pool).await?;
+
+        rows.into_iter()
+            .map(|raw| match function_type {
+                FunctionConfigType::Chat => raw.into_chat().map(EvaluationResultRow::Chat),
+                FunctionConfigType::Json => raw.into_json().map(EvaluationResultRow::Json),
+            })
+            .collect()
+    }
+
+    async fn get_inference_evaluation_human_feedback(
+        &self,
+        metric_name: &str,
+        datapoint_id: &Uuid,
+        output: &str,
+    ) -> Result<Option<InferenceEvaluationHumanFeedbackRow>, Error> {
+        let pool = self.get_pool_result()?;
+        let mut qb =
+            build_get_inference_evaluation_human_feedback_query(metric_name, datapoint_id, output);
+        let row: Option<PgRow> = qb.build().fetch_optional(pool).await?;
+
+        match row {
+            Some(row) => {
+                let value_str: String = row.get("value");
+                let value: serde_json::Value = serde_json::from_str(&value_str).map_err(|e| {
+                    Error::new(crate::error::ErrorDetails::Serialization {
+                        message: format!("Failed to deserialize human feedback value: {e}"),
+                    })
+                })?;
+                let evaluator_inference_id: Uuid = row.get("evaluator_inference_id");
+                Ok(Some(InferenceEvaluationHumanFeedbackRow {
+                    value,
+                    evaluator_inference_id,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+// =====================================================================
+// Query builder functions
+// =====================================================================
+
+fn build_list_evaluation_runs_query(limit: u32, offset: u32) -> QueryBuilder<sqlx::Postgres> {
+    let mut qb = QueryBuilder::new(
+        r"
+        WITH all_eval_inferences AS (
+            SELECT
+                tags->>'tensorzero::evaluation_run_id' as evaluation_run_id,
+                tags->>'tensorzero::evaluation_name' as evaluation_name,
+                tags->>'tensorzero::dataset_name' as dataset_name,
+                function_name,
+                variant_name,
+                id,
+                created_at
+            FROM tensorzero.chat_inferences
+            WHERE tags ? 'tensorzero::evaluation_run_id'
+            AND NOT function_name LIKE 'tensorzero::%'
+            UNION ALL
+            SELECT
+                tags->>'tensorzero::evaluation_run_id' as evaluation_run_id,
+                tags->>'tensorzero::evaluation_name' as evaluation_name,
+                tags->>'tensorzero::dataset_name' as dataset_name,
+                function_name,
+                variant_name,
+                id,
+                created_at
+            FROM tensorzero.json_inferences
+            WHERE tags ? 'tensorzero::evaluation_run_id'
+            AND NOT function_name LIKE 'tensorzero::%'
+        )
+        SELECT
+            evaluation_run_id::UUID as evaluation_run_id,
+            (ARRAY_AGG(evaluation_name))[1] as evaluation_name,
+            (ARRAY_AGG(function_name))[1] as function_name,
+            (ARRAY_AGG(variant_name))[1] as variant_name,
+            (ARRAY_AGG(dataset_name))[1] as dataset_name,
+            MAX(created_at) as last_inference_timestamp
+        FROM all_eval_inferences
+        GROUP BY evaluation_run_id
+        ORDER BY evaluation_run_id::UUID DESC
+        LIMIT ",
+    );
+    qb.push_bind(limit as i64);
+    qb.push(" OFFSET ");
+    qb.push_bind(offset as i64);
+
+    qb
+}
+
+fn build_count_datapoints_for_evaluation_query(
+    function_name: &str,
+    evaluation_run_ids: &[Uuid],
+) -> QueryBuilder<sqlx::Postgres> {
+    let mut qb = QueryBuilder::new(
+        r"
+        WITH all_inference_ids AS (
+            SELECT DISTINCT id as inference_id
+            FROM tensorzero.chat_inferences
+            WHERE tags->>'tensorzero::evaluation_run_id' = ANY(",
+    );
+    let run_id_strings: Vec<String> = evaluation_run_ids.iter().map(|id| id.to_string()).collect();
+    qb.push_bind(run_id_strings.clone());
+    qb.push(") AND function_name = ");
+    qb.push_bind(function_name.to_string());
+    qb.push(
+        r"
+            UNION ALL
+            SELECT DISTINCT id as inference_id
+            FROM tensorzero.json_inferences
+            WHERE tags->>'tensorzero::evaluation_run_id' = ANY(",
+    );
+    qb.push_bind(run_id_strings);
+    qb.push(") AND function_name = ");
+    qb.push_bind(function_name.to_string());
+    qb.push(
+        r"
+        )
+        SELECT COUNT(DISTINCT tags->>'tensorzero::datapoint_id')::BIGINT as count
+        FROM (
+            SELECT tags FROM tensorzero.chat_inferences WHERE id IN (SELECT inference_id FROM all_inference_ids)
+            UNION ALL
+            SELECT tags FROM tensorzero.json_inferences WHERE id IN (SELECT inference_id FROM all_inference_ids)
+        ) sub
+        WHERE tags ? 'tensorzero::datapoint_id'
+        ",
+    );
+
+    qb
+}
+
+fn build_search_evaluation_runs_query(
+    evaluation_name: &str,
+    function_name: &str,
+    query: &str,
+    limit: u32,
+    offset: u32,
+) -> QueryBuilder<sqlx::Postgres> {
+    let mut qb = QueryBuilder::new(
+        r"
+        WITH evaluation_inferences AS (
+            SELECT DISTINCT
+                tags->>'tensorzero::evaluation_run_id' as evaluation_run_id,
+                variant_name
+            FROM tensorzero.chat_inferences
+            WHERE tags->>'tensorzero::evaluation_name' = ",
+    );
+    qb.push_bind(evaluation_name.to_string());
+    qb.push(" AND function_name = ");
+    qb.push_bind(function_name.to_string());
+    qb.push(
+        r"
+            AND tags ? 'tensorzero::evaluation_run_id'
+            UNION ALL
+            SELECT DISTINCT
+                tags->>'tensorzero::evaluation_run_id' as evaluation_run_id,
+                variant_name
+            FROM tensorzero.json_inferences
+            WHERE tags->>'tensorzero::evaluation_name' = ",
+    );
+    qb.push_bind(evaluation_name.to_string());
+    qb.push(" AND function_name = ");
+    qb.push_bind(function_name.to_string());
+    qb.push(
+        r"
+            AND tags ? 'tensorzero::evaluation_run_id'
+        )
+        SELECT DISTINCT evaluation_run_id::UUID as evaluation_run_id, variant_name
+        FROM evaluation_inferences
+        WHERE (evaluation_run_id ILIKE ",
+    );
+    qb.push_bind(format!("%{query}%"));
+    qb.push(" OR variant_name ILIKE ");
+    qb.push_bind(format!("%{query}%"));
+    qb.push(
+        r")
+        ORDER BY evaluation_run_id::UUID DESC
+        LIMIT ",
+    );
+    qb.push_bind(limit as i64);
+    qb.push(" OFFSET ");
+    qb.push_bind(offset as i64);
+
+    qb
+}
+
+fn build_get_evaluation_run_infos_query(
+    evaluation_run_ids: &[Uuid],
+    function_name: &str,
+) -> QueryBuilder<sqlx::Postgres> {
+    let run_id_strings: Vec<String> = evaluation_run_ids.iter().map(|id| id.to_string()).collect();
+
+    let mut qb = QueryBuilder::new(
+        r"
+        WITH all_eval_inferences AS (
+            SELECT
+                tags->>'tensorzero::evaluation_run_id' as evaluation_run_id,
+                variant_name,
+                created_at
+            FROM tensorzero.chat_inferences
+            WHERE tags->>'tensorzero::evaluation_run_id' = ANY(",
+    );
+    qb.push_bind(run_id_strings.clone());
+    qb.push(") AND function_name = ");
+    qb.push_bind(function_name.to_string());
+    qb.push(
+        r"
+            UNION ALL
+            SELECT
+                tags->>'tensorzero::evaluation_run_id' as evaluation_run_id,
+                variant_name,
+                created_at
+            FROM tensorzero.json_inferences
+            WHERE tags->>'tensorzero::evaluation_run_id' = ANY(",
+    );
+    qb.push_bind(run_id_strings);
+    qb.push(") AND function_name = ");
+    qb.push_bind(function_name.to_string());
+    qb.push(
+        r"
+        )
+        SELECT
+            evaluation_run_id::UUID as evaluation_run_id,
+            (ARRAY_AGG(variant_name))[1] as variant_name,
+            MAX(created_at) as most_recent_inference_date
+        FROM all_eval_inferences
+        GROUP BY evaluation_run_id
+        ORDER BY evaluation_run_id::UUID DESC
+        ",
+    );
+
+    qb
+}
+
+fn build_get_evaluation_run_infos_for_datapoint_query(
+    datapoint_id: &Uuid,
+    function_name: &str,
+    function_type: FunctionConfigType,
+) -> QueryBuilder<sqlx::Postgres> {
+    let inference_table = function_type.postgres_table_name();
+
+    let mut qb = QueryBuilder::new(
+        "SELECT (tags->>'tensorzero::evaluation_run_id')::UUID as evaluation_run_id, (ARRAY_AGG(variant_name))[1] as variant_name, MAX(created_at) as most_recent_inference_date FROM ",
+    );
+    qb.push(inference_table);
+    qb.push(" WHERE tags->>'tensorzero::datapoint_id' = ");
+    qb.push_bind(datapoint_id.to_string());
+    qb.push(" AND function_name = ");
+    qb.push_bind(function_name.to_string());
+    qb.push(
+        r" AND tags ? 'tensorzero::evaluation_run_id'
+        GROUP BY tags->>'tensorzero::evaluation_run_id'
+        ",
+    );
+
+    qb
+}
+
+/// Builds the statistics query using Postgres QueryBuilder.
+fn build_get_evaluation_statistics_query(
+    function_name: &str,
+    function_type: FunctionConfigType,
+    metric_names: &[String],
+    evaluation_run_ids: &[Uuid],
+) -> QueryBuilder<sqlx::Postgres> {
+    let inference_table = function_type.postgres_table_name();
+    let run_id_strings: Vec<String> = evaluation_run_ids.iter().map(|id| id.to_string()).collect();
+    let metric_names_owned: Vec<String> = metric_names.to_vec();
+
+    let mut qb = QueryBuilder::new(
+        "WITH filtered_inference AS (SELECT id, tags->>'tensorzero::evaluation_run_id' as evaluation_run_id FROM ",
+    );
+    qb.push(inference_table);
+    qb.push(" WHERE tags->>'tensorzero::evaluation_run_id' = ANY(");
+    qb.push_bind(run_id_strings);
+    qb.push(") AND function_name = ");
+    qb.push_bind(function_name.to_string());
+    qb.push(
+        r"),
+        float_feedback AS (
+            SELECT DISTINCT ON (target_id, metric_name)
+                metric_name, value, target_id
+            FROM tensorzero.float_metric_feedback
+            WHERE metric_name = ANY(",
+    );
+    qb.push_bind(metric_names_owned.clone());
+    qb.push(
+        r") AND target_id IN (SELECT id FROM filtered_inference)
+            ORDER BY target_id, metric_name, created_at DESC
+        ),
+        boolean_feedback AS (
+            SELECT DISTINCT ON (target_id, metric_name)
+                metric_name, value, target_id
+            FROM tensorzero.boolean_metric_feedback
+            WHERE metric_name = ANY(",
+    );
+    qb.push_bind(metric_names_owned);
+    qb.push(
+        r") AND target_id IN (SELECT id FROM filtered_inference)
+            ORDER BY target_id, metric_name, created_at DESC
+        ),
+        float_stats AS (
+            SELECT
+                fi.evaluation_run_id::UUID as evaluation_run_id,
+                ff.metric_name,
+                false as is_boolean,
+                COUNT(*)::INT as datapoint_count,
+                AVG(ff.value)::DOUBLE PRECISION as mean_metric,
+                STDDEV_SAMP(ff.value)::DOUBLE PRECISION as stdev
+            FROM filtered_inference fi
+            INNER JOIN float_feedback ff ON ff.target_id = fi.id
+            WHERE ff.value IS NOT NULL
+            GROUP BY fi.evaluation_run_id, ff.metric_name
+        ),
+        boolean_stats AS (
+            SELECT
+                fi.evaluation_run_id::UUID as evaluation_run_id,
+                bf.metric_name,
+                true as is_boolean,
+                COUNT(*)::INT as datapoint_count,
+                AVG(bf.value::INT)::DOUBLE PRECISION as mean_metric,
+                NULL::DOUBLE PRECISION as stdev
+            FROM filtered_inference fi
+            INNER JOIN boolean_feedback bf ON bf.target_id = fi.id
+            WHERE bf.value IS NOT NULL
+            GROUP BY fi.evaluation_run_id, bf.metric_name
+        )
+        SELECT * FROM float_stats
+        UNION ALL
+        SELECT * FROM boolean_stats
+        ORDER BY evaluation_run_id DESC, metric_name ASC
+        ",
+    );
+
+    qb
+}
+
+fn build_get_evaluation_results_query(
+    function_name: &str,
+    evaluation_run_ids: &[Uuid],
+    function_type: FunctionConfigType,
+    metric_names: &[String],
+    datapoint_id: Option<&Uuid>,
+    limit: u32,
+    offset: u32,
+) -> QueryBuilder<sqlx::Postgres> {
+    let inference_table = function_type.postgres_table_name();
+    let datapoint_table = function_type.postgres_datapoint_table_name();
+    let run_id_strings: Vec<String> = evaluation_run_ids.iter().map(|id| id.to_string()).collect();
+    let metric_names_owned: Vec<String> = metric_names.to_vec();
+
+    // CTE 1: all_inference_ids - find inferences matching evaluation run IDs
+    let mut qb =
+        QueryBuilder::new("WITH all_inference_ids AS (SELECT DISTINCT id as inference_id FROM ");
+    qb.push(inference_table);
+    qb.push(" WHERE tags->>'tensorzero::evaluation_run_id' = ANY(");
+    qb.push_bind(run_id_strings);
+    qb.push(") AND function_name = ");
+    qb.push_bind(function_name.to_string());
+
+    // CTE 2: all_datapoint_ids - find distinct datapoint IDs with optional filter and pagination
+    qb.push(
+        r"),
+        all_datapoint_ids AS (
+            SELECT DISTINCT (tags->>'tensorzero::datapoint_id')::UUID as datapoint_id
+            FROM ",
+    );
+    qb.push(inference_table);
+    qb.push(
+        r" WHERE id IN (SELECT inference_id FROM all_inference_ids)
+            AND tags ? 'tensorzero::datapoint_id'",
+    );
+
+    if let Some(dp_id) = datapoint_id {
+        qb.push(" AND (tags->>'tensorzero::datapoint_id')::UUID = ");
+        qb.push_bind(*dp_id);
+    }
+
+    qb.push(" ORDER BY datapoint_id DESC");
+
+    // Only apply pagination if no specific datapoint_id is requested
+    if datapoint_id.is_none() {
+        qb.push(" LIMIT ");
+        qb.push_bind(limit as i64);
+        qb.push(" OFFSET ");
+        qb.push_bind(offset as i64);
+    }
+
+    // CTE 3: filtered_dp - datapoints in the result set
+    qb.push("), filtered_dp AS (SELECT * FROM ");
+    qb.push(datapoint_table);
+    qb.push(" WHERE function_name = ");
+    qb.push_bind(function_name.to_string());
+    qb.push(" AND id IN (SELECT datapoint_id FROM all_datapoint_ids)");
+
+    // CTE 4: filtered_inference - inferences matching the evaluation runs
+    qb.push("), filtered_inference AS (SELECT * FROM ");
+    qb.push(inference_table);
+    qb.push(" WHERE id IN (SELECT inference_id FROM all_inference_ids) AND function_name = ");
+    qb.push_bind(function_name.to_string());
+
+    // CTE 5: filtered_feedback - latest feedback per (target_id, metric_name) from both boolean and float
+    qb.push(
+        r"),
+        filtered_feedback AS (
+            SELECT * FROM (
+                SELECT DISTINCT ON (target_id, metric_name)
+                    metric_name,
+                    value::TEXT as value,
+                    NULLIF(tags->>'tensorzero::evaluator_inference_id', '')::UUID as evaluator_inference_id,
+                    id as feedback_id,
+                    (COALESCE(tags->>'tensorzero::human_feedback', '') = 'true') as is_human_feedback,
+                    target_id
+                FROM tensorzero.boolean_metric_feedback
+                WHERE metric_name = ANY(",
+    );
+    qb.push_bind(metric_names_owned.clone());
+    qb.push(
+        r") AND target_id IN (SELECT inference_id FROM all_inference_ids)
+                ORDER BY target_id, metric_name, created_at DESC
+            ) bool_fb
+            UNION ALL
+            SELECT * FROM (
+                SELECT DISTINCT ON (target_id, metric_name)
+                    metric_name,
+                    value::TEXT as value,
+                    NULLIF(tags->>'tensorzero::evaluator_inference_id', '')::UUID as evaluator_inference_id,
+                    id as feedback_id,
+                    (COALESCE(tags->>'tensorzero::human_feedback', '') = 'true') as is_human_feedback,
+                    target_id
+                FROM tensorzero.float_metric_feedback
+                WHERE metric_name = ANY(",
+    );
+    qb.push_bind(metric_names_owned);
+    qb.push(
+        r") AND target_id IN (SELECT inference_id FROM all_inference_ids)
+                ORDER BY target_id, metric_name, created_at DESC
+            ) float_fb
+        )
+        SELECT
+            filtered_dp.input as input,
+            filtered_dp.id as datapoint_id,
+            filtered_dp.name as name,
+            filtered_dp.output::TEXT as reference_output,
+            filtered_inference.output::TEXT as generated_output,
+            (filtered_inference.tags->>'tensorzero::evaluation_run_id')::UUID as evaluation_run_id,
+            filtered_inference.tags->>'tensorzero::dataset_name' as dataset_name,
+            filtered_feedback.evaluator_inference_id as evaluator_inference_id,
+            filtered_inference.id as inference_id,
+            filtered_inference.episode_id as episode_id,
+            filtered_feedback.metric_name as metric_name,
+            filtered_feedback.value as metric_value,
+            filtered_feedback.feedback_id as feedback_id,
+            COALESCE(filtered_feedback.is_human_feedback, false) as is_human_feedback,
+            filtered_dp.staled_at::TEXT as staled_at,
+            filtered_inference.variant_name as variant_name
+        FROM filtered_dp
+        INNER JOIN filtered_inference
+            ON (filtered_inference.tags->>'tensorzero::datapoint_id')::UUID = filtered_dp.id
+        LEFT JOIN filtered_feedback
+            ON filtered_feedback.target_id = filtered_inference.id
+        ORDER BY datapoint_id DESC, metric_name DESC
+        ",
+    );
+
+    qb
+}
+
+fn build_get_inference_evaluation_human_feedback_query(
+    metric_name: &str,
+    datapoint_id: &Uuid,
+    output: &str,
+) -> QueryBuilder<sqlx::Postgres> {
+    let mut qb = QueryBuilder::new(
+        r"
+        SELECT value, evaluator_inference_id
+        FROM tensorzero.inference_evaluation_human_feedback
+        WHERE metric_name = ",
+    );
+    qb.push_bind(metric_name.to_string());
+    qb.push(" AND datapoint_id = ");
+    qb.push_bind(*datapoint_id);
+    qb.push(" AND output = ");
+    qb.push_bind(output.to_string());
+    qb.push(" LIMIT 1");
+
+    qb
+}
+
+// =====================================================================
+// Helper functions
+// =====================================================================
+
+async fn get_evaluation_statistics_raw(
+    pool: &PgPool,
+    function_name: &str,
+    function_type: FunctionConfigType,
+    metric_names: &[String],
+    evaluation_run_ids: &[Uuid],
+) -> Result<Vec<RawEvaluationStatisticsRow>, Error> {
+    let mut qb = build_get_evaluation_statistics_query(
+        function_name,
+        function_type,
+        metric_names,
+        evaluation_run_ids,
+    );
+    let rows: Vec<RawEvaluationStatisticsRow> = qb.build_query_as().fetch_all(pool).await?;
+    Ok(rows)
+}
+
+// =====================================================================
+// Tests
+// =====================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_helpers::assert_query_equals;
+
+    #[test]
+    fn test_build_list_evaluation_runs_query() {
+        let qb = build_list_evaluation_runs_query(100, 0);
+        let sql = qb.sql();
+        let sql = sql.as_str();
+
+        assert_query_equals(
+            sql,
+            r"
+            WITH all_eval_inferences AS (
+                SELECT
+                    tags->>'tensorzero::evaluation_run_id' as evaluation_run_id,
+                    tags->>'tensorzero::evaluation_name' as evaluation_name,
+                    tags->>'tensorzero::dataset_name' as dataset_name,
+                    function_name,
+                    variant_name,
+                    id,
+                    created_at
+                FROM tensorzero.chat_inferences
+                WHERE tags ? 'tensorzero::evaluation_run_id'
+                AND NOT function_name LIKE 'tensorzero::%'
+                UNION ALL
+                SELECT
+                    tags->>'tensorzero::evaluation_run_id' as evaluation_run_id,
+                    tags->>'tensorzero::evaluation_name' as evaluation_name,
+                    tags->>'tensorzero::dataset_name' as dataset_name,
+                    function_name,
+                    variant_name,
+                    id,
+                    created_at
+                FROM tensorzero.json_inferences
+                WHERE tags ? 'tensorzero::evaluation_run_id'
+                AND NOT function_name LIKE 'tensorzero::%'
+            )
+            SELECT
+                evaluation_run_id::UUID as evaluation_run_id,
+                (ARRAY_AGG(evaluation_name))[1] as evaluation_name,
+                (ARRAY_AGG(function_name))[1] as function_name,
+                (ARRAY_AGG(variant_name))[1] as variant_name,
+                (ARRAY_AGG(dataset_name))[1] as dataset_name,
+                MAX(created_at) as last_inference_timestamp
+            FROM all_eval_inferences
+            GROUP BY evaluation_run_id
+            ORDER BY evaluation_run_id::UUID DESC
+            LIMIT $1 OFFSET $2
+            ",
+        );
+    }
+
+    #[test]
+    fn test_build_search_evaluation_runs_query() {
+        let qb =
+            build_search_evaluation_runs_query("test_eval", "test_func", "search_term", 50, 10);
+        let sql = qb.sql();
+        let sql = sql.as_str();
+
+        assert_query_equals(
+            sql,
+            r"
+            WITH evaluation_inferences AS (
+                SELECT DISTINCT
+                    tags->>'tensorzero::evaluation_run_id' as evaluation_run_id,
+                    variant_name
+                FROM tensorzero.chat_inferences
+                WHERE tags->>'tensorzero::evaluation_name' = $1 AND function_name = $2
+                AND tags ? 'tensorzero::evaluation_run_id'
+                UNION ALL
+                SELECT DISTINCT
+                    tags->>'tensorzero::evaluation_run_id' as evaluation_run_id,
+                    variant_name
+                FROM tensorzero.json_inferences
+                WHERE tags->>'tensorzero::evaluation_name' = $3 AND function_name = $4
+                AND tags ? 'tensorzero::evaluation_run_id'
+            )
+            SELECT DISTINCT evaluation_run_id::UUID as evaluation_run_id, variant_name
+            FROM evaluation_inferences
+            WHERE (evaluation_run_id ILIKE $5 OR variant_name ILIKE $6)
+            ORDER BY evaluation_run_id::UUID DESC
+            LIMIT $7 OFFSET $8
+            ",
+        );
+    }
+
+    #[test]
+    fn test_build_get_evaluation_run_infos_query() {
+        let run_ids = vec![Uuid::now_v7()];
+        let qb = build_get_evaluation_run_infos_query(&run_ids, "test_func");
+        let sql = qb.sql();
+        let sql = sql.as_str();
+
+        assert_query_equals(
+            sql,
+            r"
+            WITH all_eval_inferences AS (
+                SELECT
+                    tags->>'tensorzero::evaluation_run_id' as evaluation_run_id,
+                    variant_name,
+                    created_at
+                FROM tensorzero.chat_inferences
+                WHERE tags->>'tensorzero::evaluation_run_id' = ANY($1) AND function_name = $2
+                UNION ALL
+                SELECT
+                    tags->>'tensorzero::evaluation_run_id' as evaluation_run_id,
+                    variant_name,
+                    created_at
+                FROM tensorzero.json_inferences
+                WHERE tags->>'tensorzero::evaluation_run_id' = ANY($3) AND function_name = $4
+            )
+            SELECT
+                evaluation_run_id::UUID as evaluation_run_id,
+                (ARRAY_AGG(variant_name))[1] as variant_name,
+                MAX(created_at) as most_recent_inference_date
+            FROM all_eval_inferences
+            GROUP BY evaluation_run_id
+            ORDER BY evaluation_run_id::UUID DESC
+            ",
+        );
+    }
+
+    #[test]
+    fn test_build_get_evaluation_run_infos_for_datapoint_query_chat() {
+        let datapoint_id = Uuid::now_v7();
+        let qb = build_get_evaluation_run_infos_for_datapoint_query(
+            &datapoint_id,
+            "test_func",
+            FunctionConfigType::Chat,
+        );
+        let sql = qb.sql();
+        let sql = sql.as_str();
+
+        assert_query_equals(
+            sql,
+            r"
+            SELECT (tags->>'tensorzero::evaluation_run_id')::UUID as evaluation_run_id,
+                (ARRAY_AGG(variant_name))[1] as variant_name,
+                MAX(created_at) as most_recent_inference_date
+            FROM tensorzero.chat_inferences
+            WHERE tags->>'tensorzero::datapoint_id' = $1
+            AND function_name = $2
+            AND tags ? 'tensorzero::evaluation_run_id'
+            GROUP BY tags->>'tensorzero::evaluation_run_id'
+            ",
+        );
+    }
+
+    #[test]
+    fn test_build_get_inference_evaluation_human_feedback_query() {
+        let datapoint_id = Uuid::now_v7();
+        let qb = build_get_inference_evaluation_human_feedback_query(
+            "test_metric",
+            &datapoint_id,
+            "test output",
+        );
+        let sql = qb.sql();
+        let sql = sql.as_str();
+
+        assert_query_equals(
+            sql,
+            r"
+            SELECT value, evaluator_inference_id
+            FROM tensorzero.inference_evaluation_human_feedback
+            WHERE metric_name = $1 AND datapoint_id = $2 AND output = $3 LIMIT 1
+            ",
+        );
+    }
+}

--- a/tensorzero-core/src/db/postgres/mod.rs
+++ b/tensorzero-core/src/db/postgres/mod.rs
@@ -18,6 +18,7 @@ pub mod config_queries;
 pub mod dataset_queries;
 pub mod deployment_queries;
 pub mod dicl_queries;
+pub mod evaluation_queries;
 pub mod experimentation;
 pub mod feedback;
 mod howdy_queries;

--- a/tensorzero-core/src/endpoints/internal/evaluations/count_runs.rs
+++ b/tensorzero-core/src/endpoints/internal/evaluations/count_runs.rs
@@ -5,6 +5,7 @@ use axum::extract::State;
 use tracing::instrument;
 
 use super::types::EvaluationRunStatsResponse;
+use crate::db::delegating_connection::DelegatingDatabaseConnection;
 use crate::db::evaluation_queries::EvaluationQueries;
 use crate::error::Error;
 use crate::utils::gateway::{AppState, AppStateData};
@@ -17,10 +18,11 @@ use crate::utils::gateway::{AppState, AppStateData};
 pub async fn count_evaluation_runs_handler(
     State(app_state): AppState,
 ) -> Result<Json<EvaluationRunStatsResponse>, Error> {
-    let count = app_state
-        .clickhouse_connection_info
-        .count_total_evaluation_runs()
-        .await?;
+    let database = DelegatingDatabaseConnection::new(
+        app_state.clickhouse_connection_info.clone(),
+        app_state.postgres_connection_info.clone(),
+    );
+    let count = database.count_total_evaluation_runs().await?;
 
     Ok(Json(EvaluationRunStatsResponse { count }))
 }

--- a/tensorzero-core/src/endpoints/internal/evaluations/get_run_infos.rs
+++ b/tensorzero-core/src/endpoints/internal/evaluations/get_run_infos.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use tracing::instrument;
 use uuid::Uuid;
 
+use crate::db::delegating_connection::DelegatingDatabaseConnection;
 use crate::db::evaluation_queries::EvaluationQueries;
 use crate::error::{Error, ErrorDetails};
 use crate::function::{FunctionConfigType, get_function};
@@ -66,12 +67,12 @@ pub async fn get_evaluation_run_infos_handler(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    let response = get_evaluation_run_infos(
-        &app_state.clickhouse_connection_info,
-        &evaluation_run_ids,
-        &params.function_name,
-    )
-    .await?;
+    let database = DelegatingDatabaseConnection::new(
+        app_state.clickhouse_connection_info.clone(),
+        app_state.postgres_connection_info.clone(),
+    );
+    let response =
+        get_evaluation_run_infos(&database, &evaluation_run_ids, &params.function_name).await?;
 
     Ok(Json(response))
 }
@@ -112,8 +113,12 @@ pub async fn get_evaluation_run_infos_for_datapoint_handler(
     let function_config = get_function(&app_state.config.functions, &params.function_name)?;
     let function_type = function_config.config_type();
 
+    let database = DelegatingDatabaseConnection::new(
+        app_state.clickhouse_connection_info.clone(),
+        app_state.postgres_connection_info.clone(),
+    );
     let response = get_evaluation_run_infos_for_datapoint(
-        &app_state.clickhouse_connection_info,
+        &database,
         &datapoint_id,
         &params.function_name,
         function_type,

--- a/tensorzero-core/src/endpoints/internal/evaluations/get_statistics.rs
+++ b/tensorzero-core/src/endpoints/internal/evaluations/get_statistics.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 use super::types::{
     EvaluationStatistics, GetEvaluationStatisticsParams, GetEvaluationStatisticsResponse,
 };
+use crate::db::delegating_connection::DelegatingDatabaseConnection;
 use crate::db::evaluation_queries::EvaluationQueries;
 use crate::error::Error;
 use crate::function::FunctionConfigType;
@@ -23,8 +24,12 @@ pub async fn get_evaluation_statistics_handler(
     State(app_state): AppState,
     Query(params): Query<GetEvaluationStatisticsParams>,
 ) -> Result<Json<GetEvaluationStatisticsResponse>, Error> {
+    let database = DelegatingDatabaseConnection::new(
+        app_state.clickhouse_connection_info.clone(),
+        app_state.postgres_connection_info.clone(),
+    );
     let response = get_evaluation_statistics_internal(
-        &app_state.clickhouse_connection_info,
+        &database,
         params.function_name,
         params.function_type,
         params.metric_names,

--- a/tensorzero-core/src/endpoints/internal/evaluations/list_runs.rs
+++ b/tensorzero-core/src/endpoints/internal/evaluations/list_runs.rs
@@ -5,6 +5,7 @@ use axum::extract::{Query, State};
 use tracing::instrument;
 
 use super::types::{ListEvaluationRunsParams, ListEvaluationRunsResponse};
+use crate::db::delegating_connection::DelegatingDatabaseConnection;
 use crate::db::evaluation_queries::EvaluationQueries;
 use crate::endpoints::internal::evaluations::types::EvaluationRunInfo;
 use crate::error::Error;
@@ -19,12 +20,12 @@ pub async fn list_evaluation_runs_handler(
     State(app_state): AppState,
     Query(params): Query<ListEvaluationRunsParams>,
 ) -> Result<Json<ListEvaluationRunsResponse>, Error> {
-    let list_evaluation_runs_response = list_evaluation_runs(
-        &app_state.clickhouse_connection_info,
-        params.limit,
-        params.offset,
-    )
-    .await?;
+    let database = DelegatingDatabaseConnection::new(
+        app_state.clickhouse_connection_info.clone(),
+        app_state.postgres_connection_info.clone(),
+    );
+    let list_evaluation_runs_response =
+        list_evaluation_runs(&database, params.limit, params.offset).await?;
 
     Ok(Json(list_evaluation_runs_response))
 }

--- a/tensorzero-core/src/function/function_config.rs
+++ b/tensorzero-core/src/function/function_config.rs
@@ -110,6 +110,14 @@ impl FunctionConfigType {
             FunctionConfigType::Json => "JsonInferenceDatapoint",
         }
     }
+
+    /// Returns the Postgres datapoint table name for the given function type.
+    pub fn postgres_datapoint_table_name(&self) -> &'static str {
+        match self {
+            FunctionConfigType::Chat => "tensorzero.chat_datapoints",
+            FunctionConfigType::Json => "tensorzero.json_datapoints",
+        }
+    }
 }
 
 impl FunctionConfig {

--- a/tensorzero-core/tests/e2e/db/evaluation_queries.rs
+++ b/tensorzero-core/tests/e2e/db/evaluation_queries.rs
@@ -1,6 +1,5 @@
-//! E2E tests for evaluation ClickHouse queries.
+//! E2E tests for evaluation queries (ClickHouse and Postgres).
 
-use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
 use tensorzero_core::db::evaluation_queries::{
     ChatEvaluationResultRow, EvaluationQueries, EvaluationResultRow, JsonEvaluationResultRow,
 };
@@ -12,16 +11,13 @@ use uuid::Uuid;
 // ============================================================================
 
 /// Test that get_evaluation_run_infos returns correct run infos for multiple evaluation runs.
-#[tokio::test]
-async fn test_get_evaluation_run_infos_multiple_runs() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_run_infos_multiple_runs(conn: impl EvaluationQueries) {
     let evaluation_run_id1 =
         Uuid::parse_str("0196368f-19bd-7082-a677-1c0bf346ff24").expect("Valid UUID");
     let evaluation_run_id2 =
         Uuid::parse_str("0196368e-53a8-7e82-a88d-db7086926d81").expect("Valid UUID");
 
-    let run_infos = clickhouse
+    let run_infos = conn
         .get_evaluation_run_infos(
             &[evaluation_run_id1, evaluation_run_id2],
             "extract_entities",
@@ -40,16 +36,14 @@ async fn test_get_evaluation_run_infos_multiple_runs() {
     assert_eq!(second.evaluation_run_id, evaluation_run_id2);
     assert_eq!(second.variant_name, "gpt4o_initial_prompt");
 }
+make_db_test!(test_get_evaluation_run_infos_multiple_runs);
 
 /// Test that get_evaluation_run_infos returns correct info for a single evaluation run.
-#[tokio::test]
-async fn test_get_evaluation_run_infos_single_run() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_run_infos_single_run(conn: impl EvaluationQueries) {
     let evaluation_run_id =
         Uuid::parse_str("0196368f-19bd-7082-a677-1c0bf346ff24").expect("Valid UUID");
 
-    let run_infos = clickhouse
+    let run_infos = conn
         .get_evaluation_run_infos(&[evaluation_run_id], "extract_entities")
         .await
         .unwrap();
@@ -58,16 +52,14 @@ async fn test_get_evaluation_run_infos_single_run() {
     assert_eq!(run_infos[0].evaluation_run_id, evaluation_run_id);
     assert_eq!(run_infos[0].variant_name, "gpt4o_mini_initial_prompt");
 }
+make_db_test!(test_get_evaluation_run_infos_single_run);
 
 /// Test that get_evaluation_run_infos returns empty for nonexistent run IDs.
-#[tokio::test]
-async fn test_get_evaluation_run_infos_nonexistent_run() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_run_infos_nonexistent_run(conn: impl EvaluationQueries) {
     let nonexistent_id =
         Uuid::parse_str("00000000-0000-0000-0000-000000000000").expect("Valid UUID");
 
-    let run_infos = clickhouse
+    let run_infos = conn
         .get_evaluation_run_infos(&[nonexistent_id], "extract_entities")
         .await
         .unwrap();
@@ -78,16 +70,14 @@ async fn test_get_evaluation_run_infos_nonexistent_run() {
         "Expected 0 evaluation run infos for nonexistent run"
     );
 }
+make_db_test!(test_get_evaluation_run_infos_nonexistent_run);
 
 /// Test that get_evaluation_run_infos returns empty when function name doesn't match.
-#[tokio::test]
-async fn test_get_evaluation_run_infos_wrong_function() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_run_infos_wrong_function(conn: impl EvaluationQueries) {
     let evaluation_run_id =
         Uuid::parse_str("0196368f-19bd-7082-a677-1c0bf346ff24").expect("Valid UUID");
 
-    let run_infos = clickhouse
+    let run_infos = conn
         .get_evaluation_run_infos(&[evaluation_run_id], "nonexistent_function")
         .await
         .unwrap();
@@ -98,13 +88,11 @@ async fn test_get_evaluation_run_infos_wrong_function() {
         "Expected 0 evaluation run infos for wrong function"
     );
 }
+make_db_test!(test_get_evaluation_run_infos_wrong_function);
 
 /// Test that get_evaluation_run_infos returns empty for empty input.
-#[tokio::test]
-async fn test_get_evaluation_run_infos_empty_input() {
-    let clickhouse = get_clickhouse().await;
-
-    let run_infos = clickhouse
+async fn test_get_evaluation_run_infos_empty_input(conn: impl EvaluationQueries) {
+    let run_infos = conn
         .get_evaluation_run_infos(&[], "extract_entities")
         .await
         .unwrap();
@@ -115,20 +103,18 @@ async fn test_get_evaluation_run_infos_empty_input() {
         "Expected 0 evaluation run infos for empty input"
     );
 }
+make_db_test!(test_get_evaluation_run_infos_empty_input);
 
 // ============================================================================
 // get_evaluation_run_infos_for_datapoint tests
 // ============================================================================
 
 /// Test that get_evaluation_run_infos_for_datapoint returns correct info for a JSON function datapoint.
-#[tokio::test]
-async fn test_get_evaluation_run_infos_for_datapoint_json_function() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_run_infos_for_datapoint_json_function(conn: impl EvaluationQueries) {
     // Datapoint ID from the test fixture for extract_entities function
     let datapoint_id = Uuid::parse_str("0196368e-0b64-7321-ab5b-c32eefbf3e9f").expect("Valid UUID");
 
-    let run_infos = clickhouse
+    let run_infos = conn
         .get_evaluation_run_infos_for_datapoint(
             &datapoint_id,
             "extract_entities",
@@ -144,16 +130,14 @@ async fn test_get_evaluation_run_infos_for_datapoint_json_function() {
     );
     assert_eq!(run_infos[0].variant_name, "gpt4o_initial_prompt");
 }
+make_db_test!(test_get_evaluation_run_infos_for_datapoint_json_function);
 
 /// Test that get_evaluation_run_infos_for_datapoint returns correct info for a chat function datapoint.
-#[tokio::test]
-async fn test_get_evaluation_run_infos_for_datapoint_chat_function() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_run_infos_for_datapoint_chat_function(conn: impl EvaluationQueries) {
     // Datapoint ID from the test fixture for write_haiku function
     let datapoint_id = Uuid::parse_str("0196374a-d03f-7420-9da5-1561cba71ddb").expect("Valid UUID");
 
-    let run_infos = clickhouse
+    let run_infos = conn
         .get_evaluation_run_infos_for_datapoint(
             &datapoint_id,
             "write_haiku",
@@ -169,16 +153,14 @@ async fn test_get_evaluation_run_infos_for_datapoint_chat_function() {
     );
     assert_eq!(run_infos[0].variant_name, "better_prompt_haiku_4_5");
 }
+make_db_test!(test_get_evaluation_run_infos_for_datapoint_chat_function);
 
 /// Test that get_evaluation_run_infos_for_datapoint returns empty for nonexistent datapoint.
-#[tokio::test]
-async fn test_get_evaluation_run_infos_for_datapoint_nonexistent() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_run_infos_for_datapoint_nonexistent(conn: impl EvaluationQueries) {
     let nonexistent_id =
         Uuid::parse_str("00000000-0000-0000-0000-000000000000").expect("Valid UUID");
 
-    let run_infos = clickhouse
+    let run_infos = conn
         .get_evaluation_run_infos_for_datapoint(
             &nonexistent_id,
             "extract_entities",
@@ -193,16 +175,14 @@ async fn test_get_evaluation_run_infos_for_datapoint_nonexistent() {
         "Expected 0 evaluation run infos for nonexistent datapoint"
     );
 }
+make_db_test!(test_get_evaluation_run_infos_for_datapoint_nonexistent);
 
 /// Test that get_evaluation_run_infos_for_datapoint returns empty when function name doesn't match.
-#[tokio::test]
-async fn test_get_evaluation_run_infos_for_datapoint_wrong_function() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_run_infos_for_datapoint_wrong_function(conn: impl EvaluationQueries) {
     // Use a valid datapoint ID but with wrong function name
     let datapoint_id = Uuid::parse_str("0196368e-0b64-7321-ab5b-c32eefbf3e9f").expect("Valid UUID");
 
-    let run_infos = clickhouse
+    let run_infos = conn
         .get_evaluation_run_infos_for_datapoint(
             &datapoint_id,
             "nonexistent_function",
@@ -217,6 +197,7 @@ async fn test_get_evaluation_run_infos_for_datapoint_wrong_function() {
         "Expected 0 evaluation run infos for wrong function"
     );
 }
+make_db_test!(test_get_evaluation_run_infos_for_datapoint_wrong_function);
 
 // ============================================================================
 // count_datapoints_for_evaluation tests
@@ -225,14 +206,11 @@ async fn test_get_evaluation_run_infos_for_datapoint_wrong_function() {
 /// Test using the shared test database with pre-existing fixture data.
 /// This test verifies that the correct number of datapoints is returned for a chat function evaluation.
 /// The count should not include data that was created after the evaluation run.
-#[tokio::test]
-async fn test_count_datapoints_for_haiku_evaluation() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_count_datapoints_for_haiku_evaluation(conn: impl EvaluationQueries) {
     let evaluation_run_id =
         Uuid::parse_str("01963690-dff2-7cd3-b724-62fb705772a1").expect("Valid UUID");
 
-    let count = clickhouse
+    let count = conn
         .count_datapoints_for_evaluation("write_haiku", &[evaluation_run_id])
         .await
         .unwrap();
@@ -243,17 +221,15 @@ async fn test_count_datapoints_for_haiku_evaluation() {
         "Expected 77 datapoints for haiku evaluation, got {count}"
     );
 }
+make_db_test!(test_count_datapoints_for_haiku_evaluation);
 
 /// Test using the shared test database with pre-existing fixture data.
 /// This test verifies that the correct number of datapoints is returned for a JSON function evaluation.
-#[tokio::test]
-async fn test_count_datapoints_for_entity_extraction_evaluation() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_count_datapoints_for_entity_extraction_evaluation(conn: impl EvaluationQueries) {
     let evaluation_run_id =
         Uuid::parse_str("0196368f-19bd-7082-a677-1c0bf346ff24").expect("Valid UUID");
 
-    let count = clickhouse
+    let count = conn
         .count_datapoints_for_evaluation("extract_entities", &[evaluation_run_id])
         .await
         .unwrap();
@@ -263,16 +239,14 @@ async fn test_count_datapoints_for_entity_extraction_evaluation() {
         "Expected 41 datapoints for entity_extraction evaluation, got {count}"
     );
 }
+make_db_test!(test_count_datapoints_for_entity_extraction_evaluation);
 
 // ============================================================================
 // get_evaluation_statistics tests
 // ============================================================================
 
 /// Test that get_evaluation_statistics returns correct statistics for a JSON function evaluation.
-#[tokio::test]
-async fn test_get_evaluation_statistics_json_function() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_statistics_json_function(conn: impl EvaluationQueries) {
     let evaluation_run_id =
         Uuid::parse_str("0196368f-19bd-7082-a677-1c0bf346ff24").expect("Valid UUID");
 
@@ -281,7 +255,7 @@ async fn test_get_evaluation_statistics_json_function() {
         "tensorzero::evaluation_name::entity_extraction::evaluator_name::count_sports".to_string(),
     ];
 
-    let statistics = clickhouse
+    let statistics = conn
         .get_evaluation_statistics(
             "extract_entities",
             FunctionConfigType::Json,
@@ -306,12 +280,10 @@ async fn test_get_evaluation_statistics_json_function() {
         assert!((0.0..=1.0).contains(&stat.mean_metric) || stat.mean_metric > 1.0);
     }
 }
+make_db_test!(test_get_evaluation_statistics_json_function);
 
 /// Test that get_evaluation_statistics returns correct statistics for multiple evaluation runs.
-#[tokio::test]
-async fn test_get_evaluation_statistics_multiple_runs() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_statistics_multiple_runs(conn: impl EvaluationQueries) {
     let evaluation_run_id1 =
         Uuid::parse_str("0196368f-19bd-7082-a677-1c0bf346ff24").expect("Valid UUID");
     let evaluation_run_id2 =
@@ -321,7 +293,7 @@ async fn test_get_evaluation_statistics_multiple_runs() {
         "tensorzero::evaluation_name::entity_extraction::evaluator_name::exact_match".to_string(),
     ];
 
-    let statistics = clickhouse
+    let statistics = conn
         .get_evaluation_statistics(
             "extract_entities",
             FunctionConfigType::Json,
@@ -337,12 +309,10 @@ async fn test_get_evaluation_statistics_multiple_runs() {
         "Expected statistics for at least one run"
     );
 }
+make_db_test!(test_get_evaluation_statistics_multiple_runs);
 
 /// Test that get_evaluation_statistics returns empty for nonexistent evaluation runs.
-#[tokio::test]
-async fn test_get_evaluation_statistics_nonexistent_run() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_statistics_nonexistent_run(conn: impl EvaluationQueries) {
     let nonexistent_id =
         Uuid::parse_str("00000000-0000-0000-0000-000000000000").expect("Valid UUID");
 
@@ -350,7 +320,7 @@ async fn test_get_evaluation_statistics_nonexistent_run() {
         "tensorzero::evaluation_name::entity_extraction::evaluator_name::exact_match".to_string(),
     ];
 
-    let statistics = clickhouse
+    let statistics = conn
         .get_evaluation_statistics(
             "extract_entities",
             FunctionConfigType::Json,
@@ -366,18 +336,16 @@ async fn test_get_evaluation_statistics_nonexistent_run() {
         "Expected 0 statistics for nonexistent run"
     );
 }
+make_db_test!(test_get_evaluation_statistics_nonexistent_run);
 
 /// Test that get_evaluation_statistics returns empty for nonexistent metrics.
-#[tokio::test]
-async fn test_get_evaluation_statistics_nonexistent_metric() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_statistics_nonexistent_metric(conn: impl EvaluationQueries) {
     let evaluation_run_id =
         Uuid::parse_str("0196368f-19bd-7082-a677-1c0bf346ff24").expect("Valid UUID");
 
     let metric_names = vec!["nonexistent_metric".to_string()];
 
-    let statistics = clickhouse
+    let statistics = conn
         .get_evaluation_statistics(
             "extract_entities",
             FunctionConfigType::Json,
@@ -393,12 +361,10 @@ async fn test_get_evaluation_statistics_nonexistent_metric() {
         "Expected 0 statistics for nonexistent metric"
     );
 }
+make_db_test!(test_get_evaluation_statistics_nonexistent_metric);
 
 /// Test that get_evaluation_statistics returns empty for wrong function name.
-#[tokio::test]
-async fn test_get_evaluation_statistics_wrong_function() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_statistics_wrong_function(conn: impl EvaluationQueries) {
     let evaluation_run_id =
         Uuid::parse_str("0196368f-19bd-7082-a677-1c0bf346ff24").expect("Valid UUID");
 
@@ -406,7 +372,7 @@ async fn test_get_evaluation_statistics_wrong_function() {
         "tensorzero::evaluation_name::entity_extraction::evaluator_name::exact_match".to_string(),
     ];
 
-    let statistics = clickhouse
+    let statistics = conn
         .get_evaluation_statistics(
             "nonexistent_function",
             FunctionConfigType::Json,
@@ -422,12 +388,10 @@ async fn test_get_evaluation_statistics_wrong_function() {
         "Expected 0 statistics for wrong function"
     );
 }
+make_db_test!(test_get_evaluation_statistics_wrong_function);
 
 /// Test that get_evaluation_statistics handles chat function type correctly.
-#[tokio::test]
-async fn test_get_evaluation_statistics_chat_function() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_statistics_chat_function(conn: impl EvaluationQueries) {
     let evaluation_run_id =
         Uuid::parse_str("0196374b-04a3-7013-9049-e59ed5fe3f74").expect("Valid UUID");
 
@@ -435,7 +399,7 @@ async fn test_get_evaluation_statistics_chat_function() {
     let metric_names =
         vec!["tensorzero::evaluation_name::haiku_eval::evaluator_name::haiku_score".to_string()];
 
-    let statistics = clickhouse
+    let statistics = conn
         .get_evaluation_statistics(
             "write_haiku",
             FunctionConfigType::Chat,
@@ -451,20 +415,18 @@ async fn test_get_evaluation_statistics_chat_function() {
         assert_eq!(stat.evaluation_run_id, evaluation_run_id);
     }
 }
+make_db_test!(test_get_evaluation_statistics_chat_function);
 
 // ============================================================================
 // get_evaluation_results tests
 // ============================================================================
 
 /// Test that get_evaluation_results returns correct results for haiku evaluation.
-#[tokio::test]
-async fn test_get_evaluation_results_haiku() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_results_haiku(conn: impl EvaluationQueries) {
     let evaluation_run_id =
         Uuid::parse_str("01963691-9d3c-7793-a8be-3937ebb849c1").expect("Valid UUID");
 
-    let results = clickhouse
+    let results = conn
         .get_evaluation_results(
             "write_haiku",
             &[evaluation_run_id],
@@ -527,16 +489,14 @@ async fn test_get_evaluation_results_haiku() {
         .collect();
     assert_eq!(datapoint_ids.len(), 5, "Expected 5 unique datapoints");
 }
+make_db_test!(test_get_evaluation_results_haiku);
 
 /// Test that get_evaluation_results handles entity_extraction (JSON function) correctly.
-#[tokio::test]
-async fn test_get_evaluation_results_entity_extraction() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_results_entity_extraction(conn: impl EvaluationQueries) {
     let evaluation_run_id =
         Uuid::parse_str("0196368f-19bd-7082-a677-1c0bf346ff24").expect("Valid UUID");
 
-    let results = clickhouse
+    let results = conn
         .get_evaluation_results(
             "extract_entities",
             &[evaluation_run_id],
@@ -598,18 +558,16 @@ async fn test_get_evaluation_results_entity_extraction() {
         };
     }
 }
+make_db_test!(test_get_evaluation_results_entity_extraction);
 
 /// Test that get_evaluation_results handles multiple evaluation runs (ragged case).
-#[tokio::test]
-async fn test_get_evaluation_results_multiple_runs() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_results_multiple_runs(conn: impl EvaluationQueries) {
     let evaluation_run_id1 =
         Uuid::parse_str("0196374b-04a3-7013-9049-e59ed5fe3f74").expect("Valid UUID");
     let evaluation_run_id2 =
         Uuid::parse_str("01963691-9d3c-7793-a8be-3937ebb849c1").expect("Valid UUID");
 
-    let results = clickhouse
+    let results = conn
         .get_evaluation_results(
             "write_haiku",
             &[evaluation_run_id1, evaluation_run_id2],
@@ -661,16 +619,14 @@ async fn test_get_evaluation_results_multiple_runs() {
         .collect();
     assert_eq!(datapoint_ids.len(), 5, "Expected 5 unique datapoints");
 }
+make_db_test!(test_get_evaluation_results_multiple_runs);
 
 /// Test that get_evaluation_results returns empty for nonexistent function.
-#[tokio::test]
-async fn test_get_evaluation_results_nonexistent_function() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_results_nonexistent_function(conn: impl EvaluationQueries) {
     let evaluation_run_id =
         Uuid::parse_str("01963691-9d3c-7793-a8be-3937ebb849c1").expect("Valid UUID");
 
-    let results = clickhouse
+    let results = conn
         .get_evaluation_results(
             "nonexistent_function",
             &[evaluation_run_id],
@@ -688,17 +644,15 @@ async fn test_get_evaluation_results_nonexistent_function() {
         "Expected no results for nonexistent function"
     );
 }
+make_db_test!(test_get_evaluation_results_nonexistent_function);
 
 /// Test that get_evaluation_results respects pagination offset.
-#[tokio::test]
-async fn test_get_evaluation_results_pagination() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_results_pagination(conn: impl EvaluationQueries) {
     let evaluation_run_id =
         Uuid::parse_str("01963691-9d3c-7793-a8be-3937ebb849c1").expect("Valid UUID");
 
     // Get first page (5 datapoints)
-    let first_page = clickhouse
+    let first_page = conn
         .get_evaluation_results(
             "write_haiku",
             &[evaluation_run_id],
@@ -712,7 +666,7 @@ async fn test_get_evaluation_results_pagination() {
         .unwrap();
 
     // Get second page (5 datapoints starting from offset 5)
-    let second_page = clickhouse
+    let second_page = conn
         .get_evaluation_results(
             "write_haiku",
             &[evaluation_run_id],
@@ -745,17 +699,15 @@ async fn test_get_evaluation_results_pagination() {
         "Pages should not have overlapping datapoints"
     );
 }
+make_db_test!(test_get_evaluation_results_pagination);
 
 /// Test that get_evaluation_results with datapoint_id filter returns results for only that datapoint.
-#[tokio::test]
-async fn test_get_evaluation_results_with_datapoint_id_filter() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_results_with_datapoint_id_filter(conn: impl EvaluationQueries) {
     let evaluation_run_id =
         Uuid::parse_str("01963691-9d3c-7793-a8be-3937ebb849c1").expect("Valid UUID");
 
     // First get all results without a filter to find a valid datapoint_id
-    let all_results = clickhouse
+    let all_results = conn
         .get_evaluation_results(
             "write_haiku",
             &[evaluation_run_id],
@@ -772,7 +724,7 @@ async fn test_get_evaluation_results_with_datapoint_id_filter() {
     let target_datapoint_id = all_results[0].datapoint_id();
 
     // Now filter by that specific datapoint_id
-    let filtered_results = clickhouse
+    let filtered_results = conn
         .get_evaluation_results(
             "write_haiku",
             &[evaluation_run_id],
@@ -798,18 +750,18 @@ async fn test_get_evaluation_results_with_datapoint_id_filter() {
         );
     }
 }
+make_db_test!(test_get_evaluation_results_with_datapoint_id_filter);
 
 /// Test that get_evaluation_results with datapoint_id filter returns empty for nonexistent datapoint.
-#[tokio::test]
-async fn test_get_evaluation_results_with_datapoint_id_filter_nonexistent() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_results_with_datapoint_id_filter_nonexistent(
+    conn: impl EvaluationQueries,
+) {
     let evaluation_run_id =
         Uuid::parse_str("01963691-9d3c-7793-a8be-3937ebb849c1").expect("Valid UUID");
     let nonexistent_datapoint_id =
         Uuid::parse_str("00000000-0000-0000-0000-000000000000").expect("Valid UUID");
 
-    let results = clickhouse
+    let results = conn
         .get_evaluation_results(
             "write_haiku",
             &[evaluation_run_id],
@@ -827,18 +779,16 @@ async fn test_get_evaluation_results_with_datapoint_id_filter_nonexistent() {
         "Should have no results for nonexistent datapoint"
     );
 }
+make_db_test!(test_get_evaluation_results_with_datapoint_id_filter_nonexistent);
 
 /// Test get_evaluation_results for a specific chat datapoint with detailed assertions.
 /// This mirrors the TypeScript test "should return correct array for chat datapoint".
-#[tokio::test]
-async fn test_get_evaluation_results_chat_datapoint_details() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_results_chat_datapoint_details(conn: impl EvaluationQueries) {
     let datapoint_id = Uuid::parse_str("0196374a-d03f-7420-9da5-1561cba71ddb").expect("Valid UUID");
     let evaluation_run_id =
         Uuid::parse_str("0196374b-04a3-7013-9049-e59ed5fe3f74").expect("Valid UUID");
 
-    let results = clickhouse
+    let results = conn
         .get_evaluation_results(
             "write_haiku",
             &[evaluation_run_id],
@@ -939,18 +889,16 @@ async fn test_get_evaluation_results_chat_datapoint_details() {
         "Generated output should contain 'Swallowing moonlight'"
     );
 }
+make_db_test!(test_get_evaluation_results_chat_datapoint_details);
 
 /// Test get_evaluation_results for a specific JSON datapoint with detailed assertions.
 /// This mirrors the TypeScript test "should return correct array for json datapoint".
-#[tokio::test]
-async fn test_get_evaluation_results_json_datapoint_details() {
-    let clickhouse = get_clickhouse().await;
-
+async fn test_get_evaluation_results_json_datapoint_details(conn: impl EvaluationQueries) {
     let datapoint_id = Uuid::parse_str("0193994e-5560-7610-a3a0-45fdd59338aa").expect("Valid UUID");
     let evaluation_run_id =
         Uuid::parse_str("0196368f-19bd-7082-a677-1c0bf346ff24").expect("Valid UUID");
 
-    let results = clickhouse
+    let results = conn
         .get_evaluation_results(
             "extract_entities",
             &[evaluation_run_id],
@@ -1026,3 +974,186 @@ async fn test_get_evaluation_results_json_datapoint_details() {
         );
     }
 }
+make_db_test!(test_get_evaluation_results_json_datapoint_details);
+
+// ============================================================================
+// search_evaluation_runs tests
+// ============================================================================
+
+/// Test that search_evaluation_runs returns all runs for an evaluation with an empty query.
+async fn test_search_evaluation_runs_empty_query(conn: impl EvaluationQueries) {
+    let results = conn
+        .search_evaluation_runs("entity_extraction", "extract_entities", "", 100, 0)
+        .await
+        .unwrap();
+
+    assert!(results.len() > 1, "There should be at lease 2 results");
+    assert!(
+        results[0].evaluation_run_id > results[1].evaluation_run_id,
+        "Result IDs should be ordered DESC"
+    );
+}
+make_db_test!(test_search_evaluation_runs_empty_query);
+
+/// Test that search_evaluation_runs filters by variant name substring.
+async fn test_search_evaluation_runs_by_variant_name(conn: impl EvaluationQueries) {
+    // "mini" should only match the gpt4o_mini_initial_prompt variant
+    let results = conn
+        .search_evaluation_runs("entity_extraction", "extract_entities", "mini", 100, 0)
+        .await
+        .unwrap();
+
+    assert!(
+        !results.is_empty(),
+        "Expected some evaluation runs matching 'mini'"
+    );
+    assert_eq!(results[0].variant_name, "gpt4o_mini_initial_prompt");
+}
+make_db_test!(test_search_evaluation_runs_by_variant_name);
+
+/// Test that search_evaluation_runs matches both runs when query matches a common variant substring.
+async fn test_search_evaluation_runs_common_variant_substring(conn: impl EvaluationQueries) {
+    // "gpt4o" should match both variants
+    let results = conn
+        .search_evaluation_runs("entity_extraction", "extract_entities", "gpt4o", 100, 0)
+        .await
+        .unwrap();
+
+    assert!(
+        results.len() > 1,
+        "Expected some evaluation runs matching 'gpt4o'"
+    );
+}
+make_db_test!(test_search_evaluation_runs_common_variant_substring);
+
+/// Test that search_evaluation_runs is case-insensitive.
+async fn test_search_evaluation_runs_case_insensitive(conn: impl EvaluationQueries) {
+    let results = conn
+        .search_evaluation_runs(
+            "entity_extraction",
+            "extract_entities",
+            "GPT4O_MINI",
+            100,
+            0,
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        results.len() > 1,
+        "Case-insensitive search should match 'GPT4O_MINI' to gpt4o_mini_initial_prompt"
+    );
+    assert_eq!(results[0].variant_name, "gpt4o_mini_initial_prompt");
+}
+make_db_test!(test_search_evaluation_runs_case_insensitive);
+
+/// Test that search_evaluation_runs can match by evaluation_run_id substring.
+async fn test_search_evaluation_runs_by_run_id(conn: impl EvaluationQueries) {
+    // "19bd" is a substring of "0196368f-19bd-7082-a677-1c0bf346ff24" but not of the other run ID
+    let results = conn
+        .search_evaluation_runs("entity_extraction", "extract_entities", "19bd", 100, 0)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        results.len(),
+        1,
+        "Expected 1 evaluation run matching '19bd'"
+    );
+    assert_eq!(
+        results[0].evaluation_run_id,
+        Uuid::parse_str("0196368f-19bd-7082-a677-1c0bf346ff24").expect("Valid UUID"),
+    );
+}
+make_db_test!(test_search_evaluation_runs_by_run_id);
+
+/// Test that search_evaluation_runs returns empty when query matches nothing.
+async fn test_search_evaluation_runs_no_match(conn: impl EvaluationQueries) {
+    let results = conn
+        .search_evaluation_runs(
+            "entity_extraction",
+            "extract_entities",
+            "zzz_nonexistent_zzz",
+            100,
+            0,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        results.len(),
+        0,
+        "Expected 0 results for a query that matches nothing"
+    );
+}
+make_db_test!(test_search_evaluation_runs_no_match);
+
+/// Test that search_evaluation_runs returns empty for a nonexistent evaluation name.
+async fn test_search_evaluation_runs_wrong_evaluation_name(conn: impl EvaluationQueries) {
+    let results = conn
+        .search_evaluation_runs("nonexistent_evaluation", "extract_entities", "", 100, 0)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        results.len(),
+        0,
+        "Expected 0 results for nonexistent evaluation name"
+    );
+}
+make_db_test!(test_search_evaluation_runs_wrong_evaluation_name);
+
+/// Test that search_evaluation_runs returns empty for a nonexistent function name.
+async fn test_search_evaluation_runs_wrong_function_name(conn: impl EvaluationQueries) {
+    let results = conn
+        .search_evaluation_runs("entity_extraction", "nonexistent_function", "", 100, 0)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        results.len(),
+        0,
+        "Expected 0 results for nonexistent function name"
+    );
+}
+make_db_test!(test_search_evaluation_runs_wrong_function_name);
+
+/// Test that search_evaluation_runs respects the limit parameter.
+async fn test_search_evaluation_runs_with_limit(conn: impl EvaluationQueries) {
+    let results = conn
+        .search_evaluation_runs("entity_extraction", "extract_entities", "", 1, 0)
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 1, "Expected 1 result with limit=1");
+}
+make_db_test!(test_search_evaluation_runs_with_limit);
+
+/// Test that search_evaluation_runs respects the offset parameter.
+async fn test_search_evaluation_runs_with_offset(conn: impl EvaluationQueries) {
+    let results = conn
+        .search_evaluation_runs("entity_extraction", "extract_entities", "", 100, 1)
+        .await
+        .unwrap();
+
+    assert!(
+        !results.is_empty(),
+        "Expected >1 results with offset=1 (skipping first)"
+    );
+}
+make_db_test!(test_search_evaluation_runs_with_offset);
+
+/// Test that search_evaluation_runs returns empty when offset is beyond all results.
+async fn test_search_evaluation_runs_offset_beyond_results(conn: impl EvaluationQueries) {
+    let results = conn
+        .search_evaluation_runs("entity_extraction", "extract_entities", "", 100, 100)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        results.len(),
+        0,
+        "Expected 0 results when offset is beyond all available runs"
+    );
+}
+make_db_test!(test_search_evaluation_runs_offset_beyond_results);

--- a/tensorzero-core/tests/e2e/endpoints/internal/evaluations.rs
+++ b/tensorzero-core/tests/e2e/endpoints/internal/evaluations.rs
@@ -19,7 +19,6 @@ use crate::common::get_gateway_endpoint;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_run_infos_endpoint() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     // Use evaluation run IDs from the test fixture data
@@ -65,7 +64,6 @@ async fn test_get_evaluation_run_infos_endpoint() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_run_infos_single_run() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     let evaluation_run_id = "0196368f-19bd-7082-a677-1c0bf346ff24";
@@ -99,7 +97,6 @@ async fn test_get_evaluation_run_infos_single_run() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_run_infos_nonexistent_run() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     let url = get_gateway_endpoint("/internal/evaluations/run_infos").to_string()
@@ -123,7 +120,6 @@ async fn test_get_evaluation_run_infos_nonexistent_run() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_run_infos_wrong_function() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     // Use a valid evaluation run ID but with wrong function name
@@ -154,7 +150,6 @@ async fn test_get_evaluation_run_infos_wrong_function() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_run_infos_for_datapoint_json_function() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     // Use datapoint ID from the test fixture data for extract_entities function
@@ -192,7 +187,6 @@ async fn test_get_evaluation_run_infos_for_datapoint_json_function() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_run_infos_for_datapoint_chat_function() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     // Use datapoint ID from the test fixture data for write_haiku function
@@ -229,7 +223,6 @@ async fn test_get_evaluation_run_infos_for_datapoint_chat_function() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_run_infos_for_datapoint_nonexistent() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     let datapoint_id = "00000000-0000-0000-0000-000000000000";
@@ -258,7 +251,6 @@ async fn test_get_evaluation_run_infos_for_datapoint_nonexistent() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_run_infos_for_datapoint_wrong_function() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     // Use a valid datapoint ID but with wrong function name - this will return an error since
@@ -286,7 +278,6 @@ async fn test_get_evaluation_run_infos_for_datapoint_wrong_function() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_statistics_endpoint() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     let evaluation_run_id = "0196368f-19bd-7082-a677-1c0bf346ff24";
@@ -324,7 +315,6 @@ async fn test_get_evaluation_statistics_endpoint() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_statistics_multiple_runs() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     let evaluation_run_id1 = "0196368f-19bd-7082-a677-1c0bf346ff24";
@@ -355,7 +345,6 @@ async fn test_get_evaluation_statistics_multiple_runs() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_statistics_empty_run_ids() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     let url = get_gateway_endpoint("/internal/evaluations/statistics").to_string()
@@ -379,7 +368,6 @@ async fn test_get_evaluation_statistics_empty_run_ids() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_statistics_nonexistent_run() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     let url = get_gateway_endpoint("/internal/evaluations/statistics").to_string()
@@ -403,7 +391,6 @@ async fn test_get_evaluation_statistics_nonexistent_run() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_statistics_invalid_function_type() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     let url = get_gateway_endpoint("/internal/evaluations/statistics").to_string()
@@ -419,7 +406,6 @@ async fn test_get_evaluation_statistics_invalid_function_type() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_statistics_invalid_uuid() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     let url = get_gateway_endpoint("/internal/evaluations/statistics").to_string()
@@ -437,7 +423,6 @@ async fn test_get_evaluation_statistics_invalid_uuid() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_results_haiku() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     // Use evaluation run ID from the test fixture data for haiku evaluation
@@ -477,7 +462,6 @@ async fn test_get_evaluation_results_haiku() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_results_entity_extraction() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     // Use evaluation run ID from the test fixture data for entity_extraction (JSON function)
@@ -514,7 +498,6 @@ async fn test_get_evaluation_results_entity_extraction() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_results_multiple_runs() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     // Use two evaluation run IDs from the test fixture data
@@ -557,7 +540,6 @@ async fn test_get_evaluation_results_multiple_runs() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_results_pagination() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     let evaluation_run_id = "01963691-9d3c-7793-a8be-3937ebb849c1";
@@ -617,7 +599,6 @@ async fn test_get_evaluation_results_pagination() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_results_evaluation_not_found() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     let evaluation_run_id = "01963691-9d3c-7793-a8be-3937ebb849c1";
@@ -637,7 +618,6 @@ async fn test_get_evaluation_results_evaluation_not_found() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_results_invalid_uuid() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     let url = get_gateway_endpoint("/internal/evaluations/results").to_string()
@@ -653,7 +633,6 @@ async fn test_get_evaluation_results_invalid_uuid() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_results_nonexistent_run() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     let url = get_gateway_endpoint("/internal/evaluations/results").to_string()
@@ -676,7 +655,6 @@ async fn test_get_evaluation_results_nonexistent_run() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_evaluation_results_default_pagination() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     let evaluation_run_id = "01963691-9d3c-7793-a8be-3937ebb849c1";
@@ -742,7 +720,6 @@ async fn create_test_chat_datapoint(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_run_evaluation_streaming_success() {
-    skip_for_postgres!();
     let http_client = Client::new();
     let _clickhouse = get_clickhouse().await;
 
@@ -864,7 +841,6 @@ async fn test_run_evaluation_streaming_success() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_run_evaluation_streaming_missing_variant() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     // Request without variant_name or internal_dynamic_variant_config
@@ -904,7 +880,6 @@ async fn test_run_evaluation_streaming_missing_variant() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_run_evaluation_streaming_nonexistent_dataset() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     let payload = json!({
@@ -975,7 +950,6 @@ async fn test_run_evaluation_streaming_nonexistent_dataset() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_run_evaluation_streaming_with_specific_datapoint_ids() {
-    skip_for_postgres!();
     let http_client = Client::new();
     let _clickhouse = get_clickhouse().await;
 
@@ -1060,7 +1034,6 @@ async fn test_run_evaluation_streaming_with_specific_datapoint_ids() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_run_evaluation_streaming_conflicting_variant_config() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     // Provide both variant_name AND internal_dynamic_variant_config (should fail)
@@ -1105,7 +1078,6 @@ async fn test_run_evaluation_streaming_conflicting_variant_config() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_run_evaluation_streaming_invalid_inference_cache() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     let payload = json!({
@@ -1151,7 +1123,6 @@ async fn test_run_evaluation_streaming_invalid_inference_cache() {
 /// and then verifies the endpoint returns the correct feedback.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_human_feedback_returns_feedback_when_exists() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     // First, run an inference to get an inference_id
@@ -1256,7 +1227,6 @@ async fn test_get_human_feedback_returns_feedback_when_exists() {
 /// Test that get_human_feedback returns None when no feedback exists.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_human_feedback_returns_none_when_not_exists() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     let nonexistent_datapoint_id = Uuid::now_v7();
@@ -1290,7 +1260,6 @@ async fn test_get_human_feedback_returns_none_when_not_exists() {
 /// Test that get_human_feedback works with boolean feedback values.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_human_feedback_with_boolean_value() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     // First, run an inference to get an inference_id
@@ -1379,7 +1348,6 @@ async fn test_get_human_feedback_with_boolean_value() {
 /// Test that get_human_feedback returns the correct feedback when output doesn't match.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_human_feedback_output_mismatch() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     // First, run an inference to get an inference_id
@@ -1476,7 +1444,6 @@ async fn test_get_human_feedback_output_mismatch() {
 /// Test that get_human_feedback handles invalid UUID in datapoint_id.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_human_feedback_invalid_uuid() {
-    skip_for_postgres!();
     let http_client = Client::new();
 
     let resp = http_client
@@ -1500,7 +1467,6 @@ async fn test_get_human_feedback_invalid_uuid() {
 /// Test that get_human_feedback requires all parameters.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_human_feedback_missing_parameters() {
-    skip_for_postgres!();
     let http_client = Client::new();
     let datapoint_id = Uuid::now_v7();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new Postgres query paths for evaluation reads and switches endpoints to use the delegating DB, so correctness/performance of the new SQL and feature-flag routing is the main risk.
> 
> **Overview**
> Adds a full Postgres-backed implementation of `EvaluationQueries`, including listing/searching evaluation runs, counting datapoints, fetching per-metric statistics, retrieving paginated evaluation results, and looking up existing human feedback.
> 
> Routes all internal evaluation endpoints through `DelegatingDatabaseConnection` (honoring `ENABLE_POSTGRES_READ`), and updates shared evaluation row structs to support typed Postgres deserialization via `sqlx::FromRow` (plus a new `FunctionConfigType::postgres_datapoint_table_name`). E2E evaluation tests are generalized to run against both ClickHouse and Postgres, and Postgres query guidelines are documented in `src/db/postgres/AGENTS.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64064edf899e8738d9c4bc476931633244f3cac3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->