### PR TITLE
Add entity type icons to UUID links

### DIFF
--- a/ui/app/components/autopilot/UuidLink.tsx
+++ b/ui/app/components/autopilot/UuidLink.tsx
@@ -1,9 +1,17 @@
+import type { ReactNode } from "react";
 import { Link } from "react-router";
 import { useResolveUuid } from "~/hooks/useResolveUuid";
 import type { ResolvedObject } from "~/types/tensorzero";
 import { cn } from "~/utils/common";
 import { toDatapointUrl, toEpisodeUrl, toInferenceUrl } from "~/utils/urls";
+import { CircleDot, CircleHelp } from "lucide-react";
 import { Inferences, Episodes, Dataset } from "~/components/icons/Icons";
+import { Skeleton } from "~/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "~/components/ui/tooltip";
 
 const ICON_SIZE = 12;
 const ICON_CLASS = "mr-1 inline align-middle -translate-y-px";
@@ -33,6 +41,29 @@ function getUrlForResolvedObject(
   }
 }
 
+function getEntityLabel(type: ResolvedObject["type"]): string {
+  switch (type) {
+    case "inference":
+      return "Inference";
+    case "episode":
+      return "Episode";
+    case "chat_datapoint":
+    case "json_datapoint":
+      return "Datapoint";
+    case "model_inference":
+      return "Model Inference";
+    case "boolean_feedback":
+    case "float_feedback":
+    case "comment_feedback":
+    case "demonstration_feedback":
+      return "Feedback";
+    default: {
+      const _exhaustiveCheck: never = type;
+      return _exhaustiveCheck;
+    }
+  }
+}
+
 function EntityIcon({ type }: { type: ResolvedObject["type"] }) {
   switch (type) {
     case "inference":
@@ -47,12 +78,29 @@ function EntityIcon({ type }: { type: ResolvedObject["type"] }) {
     case "float_feedback":
     case "comment_feedback":
     case "demonstration_feedback":
-      return null;
+      return <CircleDot className={ICON_CLASS} size={ICON_SIZE} />;
     default: {
       const _exhaustiveCheck: never = type;
       return _exhaustiveCheck;
     }
   }
+}
+
+function IconWithTooltip({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="relative z-10 cursor-help">{children}</span>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
 }
 
 export function UuidLink({ uuid }: { uuid: string }) {
@@ -73,11 +121,32 @@ export function UuidLink({ uuid }: { uuid: string }) {
           to={url}
           className="text-inherit no-underline after:absolute after:inset-0 hover:underline"
         >
-          {obj && <EntityIcon type={obj.type} />}
+          {obj && (
+            <IconWithTooltip label={getEntityLabel(obj.type)}>
+              <EntityIcon type={obj.type} />
+            </IconWithTooltip>
+          )}
           {uuid}
         </Link>
       ) : (
-        uuid
+        <>
+          {obj ? (
+            <IconWithTooltip label={getEntityLabel(obj.type)}>
+              <EntityIcon type={obj.type} />
+            </IconWithTooltip>
+          ) : data ? (
+            <IconWithTooltip label="Unknown">
+              <CircleHelp className={ICON_CLASS} size={ICON_SIZE} />
+            </IconWithTooltip>
+          ) : (
+            <IconWithTooltip label="Loading">
+              <Skeleton
+                className={cn(ICON_CLASS, "inline-block h-3 w-3 rounded-full")}
+              />
+            </IconWithTooltip>
+          )}
+          {uuid}
+        </>
       )}
     </code>
   );


### PR DESCRIPTION
## Summary

- Add a small icon to the left of each resolved UUID link in autopilot chat
- Inference links get the Inferences icon, episode links get the Episodes icon, datapoint links get the Dataset icon
- Icons use `currentColor` so they match the orange link text
- Icon flows inline with text using `align-middle` — wraps naturally with UUID text in narrow viewports
- `break-all` allows UUIDs to wrap at character boundaries

## Screenshot

![UUID links with entity icons](https://raw.githubusercontent.com/tensorzero/tensorzero/simeonlee/assets/6331/pr-6331-icons-inline.png)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to `UuidLink` rendering; main risk is minor layout/interaction regressions (tooltip layering, inline icon spacing) with no data or auth impact.
> 
> **Overview**
> UUID rendering in autopilot now shows an inline **entity-type icon** next to the UUID (inference/episode/datapoint/feedback), with a tooltip label for quick identification.
> 
> When a UUID can’t be linked (or while resolution is pending), the component now displays a corresponding icon state: the resolved entity icon, an *Unknown* help icon, or a *Loading* skeleton indicator, while preserving existing link behavior when a URL is available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdc1e2d2d5beaa57d935fc64572c498b69ce91de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->