### PR TITLE
Mute orange UUID link color

### DIFF
--- a/ui/app/components/autopilot/UuidLink.tsx
+++ b/ui/app/components/autopilot/UuidLink.tsx
@@ -41,7 +41,7 @@ export function UuidLink({ uuid }: { uuid: string }) {
     <code
       className={cn(
         "relative rounded px-1.5 py-0.5 font-mono text-xs font-medium transition-colors duration-300",
-        url ? "bg-orange-50 text-orange-500" : "bg-muted",
+        url ? "bg-orange-50 text-orange-400" : "bg-muted",
       )}
     >
       {url ? (


### PR DESCRIPTION
## Summary

- Soften UUID link color from `text-orange-500` to `text-orange-400` for a less visually aggressive appearance

## Screenshot

### Muted orange (this PR: `text-orange-400`)
![Muted orange](https://raw.githubusercontent.com/tensorzero/tensorzero/simeonlee/assets/6332/pr-6332-muted-orange.png)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change affecting only visual styling; no behavior, data, or routing logic changes.
> 
> **Overview**
> Adjusts `UuidLink` styling so resolved UUIDs render with a softer orange text color (`text-orange-400` instead of `text-orange-500`) while keeping the same background and link behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6107f1a53bbc1d5d3d3013cf2478a23ba5634c07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->