### PR TITLE
Add extra 'S' generic parameter to ToolExecutor

### DIFF
--- a/internal/autopilot-tools/src/tools/prod/auto_reject_tool_call.rs
+++ b/internal/autopilot-tools/src/tools/prod/auto_reject_tool_call.rs
@@ -68,6 +68,7 @@ impl ToolMetadata for AutoRejectToolCallTool {
 
 #[async_trait]
 impl TaskTool for AutoRejectToolCallTool {
+    type ExtraState = ();
     async fn execute(
         &self,
         _llm_params: <Self as ToolMetadata>::LlmParams,

--- a/internal/autopilot-tools/src/tools/prod/launch_optimization_workflow.rs
+++ b/internal/autopilot-tools/src/tools/prod/launch_optimization_workflow.rs
@@ -418,6 +418,7 @@ impl ToolMetadata for LaunchOptimizationWorkflowTool {
 
 #[async_trait]
 impl TaskTool for LaunchOptimizationWorkflowTool {
+    type ExtraState = ();
     async fn execute(
         &self,
         llm_params: <Self as ToolMetadata>::LlmParams,

--- a/internal/autopilot-tools/src/tools/test/echo.rs
+++ b/internal/autopilot-tools/src/tools/test/echo.rs
@@ -45,6 +45,7 @@ impl ToolMetadata for EchoTool {
 
 #[async_trait]
 impl TaskTool for EchoTool {
+    type ExtraState = ();
     async fn execute(
         &self,
         llm_params: Self::LlmParams,

--- a/internal/autopilot-tools/src/tools/test/failing.rs
+++ b/internal/autopilot-tools/src/tools/test/failing.rs
@@ -41,6 +41,7 @@ impl ToolMetadata for FailingTool {
 
 #[async_trait]
 impl TaskTool for FailingTool {
+    type ExtraState = ();
     async fn execute(
         &self,
         llm_params: Self::LlmParams,

--- a/internal/autopilot-tools/src/tools/test/flaky.rs
+++ b/internal/autopilot-tools/src/tools/test/flaky.rs
@@ -59,6 +59,7 @@ impl ToolMetadata for FlakyTool {
 
 #[async_trait]
 impl TaskTool for FlakyTool {
+    type ExtraState = ();
     async fn execute(
         &self,
         llm_params: Self::LlmParams,

--- a/internal/autopilot-tools/src/tools/test/panic.rs
+++ b/internal/autopilot-tools/src/tools/test/panic.rs
@@ -37,6 +37,7 @@ impl ToolMetadata for PanicTool {
 
 #[async_trait]
 impl TaskTool for PanicTool {
+    type ExtraState = ();
     #[expect(
         clippy::panic,
         reason = "This tool is specifically for testing panic handling"

--- a/internal/autopilot-tools/src/tools/test/slow.rs
+++ b/internal/autopilot-tools/src/tools/test/slow.rs
@@ -57,6 +57,7 @@ impl ToolMetadata for SlowTool {
 
 #[async_trait]
 impl TaskTool for SlowTool {
+    type ExtraState = ();
     async fn execute(
         &self,
         llm_params: Self::LlmParams,

--- a/internal/autopilot-tools/src/visitor.rs
+++ b/internal/autopilot-tools/src/visitor.rs
@@ -42,7 +42,7 @@ pub trait ToolVisitor {
     /// For remote execution, this wraps the tool in an adapter.
     async fn visit_task_tool<T>(&self, tool: T) -> Result<(), Self::Error>
     where
-        T: TaskTool<SideInfo = AutopilotSideInfo>;
+        T: TaskTool<SideInfo = AutopilotSideInfo, ExtraState = ()>;
 
     /// Visit a `SimpleTool`.
     ///
@@ -90,7 +90,7 @@ impl ToolVisitor for ToolNameCollector {
 
     async fn visit_task_tool<T>(&self, tool: T) -> Result<(), Self::Error>
     where
-        T: TaskTool<SideInfo = AutopilotSideInfo>,
+        T: TaskTool<SideInfo = AutopilotSideInfo, ExtraState = ()>,
     {
         let mut names = self
             .names

--- a/internal/autopilot-tools/tests/launch_optimization_workflow_tool.rs
+++ b/internal/autopilot-tools/tests/launch_optimization_workflow_tool.rs
@@ -115,7 +115,7 @@ async fn test_launch_optimization_workflow_tool_immediate_completion(
 
     let t0_client: Arc<dyn TensorZeroClient> = Arc::new(mock_client);
 
-    let executor = ToolExecutor::builder()
+    let executor = ToolExecutor::builder(())
         .pool(pool)
         .queue_name(&queue_name)
         .t0_client(t0_client)
@@ -194,7 +194,7 @@ async fn test_launch_optimization_workflow_tool_multiple_polls(pool: PgPool) -> 
 
     let t0_client: Arc<dyn TensorZeroClient> = Arc::new(mock_client);
 
-    let executor = ToolExecutor::builder()
+    let executor = ToolExecutor::builder(())
         .pool(pool)
         .queue_name(&queue_name)
         .t0_client(t0_client)
@@ -262,7 +262,7 @@ async fn test_launch_optimization_workflow_tool_failed(pool: PgPool) -> sqlx::Re
 
     let t0_client: Arc<dyn TensorZeroClient> = Arc::new(mock_client);
 
-    let executor = ToolExecutor::builder()
+    let executor = ToolExecutor::builder(())
         .pool(pool)
         .queue_name(&queue_name)
         .t0_client(t0_client)
@@ -325,7 +325,7 @@ async fn test_launch_optimization_workflow_tool_launch_error(pool: PgPool) -> sq
 
     let t0_client: Arc<dyn TensorZeroClient> = Arc::new(mock_client);
 
-    let executor = ToolExecutor::builder()
+    let executor = ToolExecutor::builder(())
         .pool(pool)
         .queue_name(&queue_name)
         .t0_client(t0_client)

--- a/internal/autopilot-worker/src/worker.rs
+++ b/internal/autopilot-worker/src/worker.rs
@@ -79,7 +79,7 @@ impl AutopilotWorker {
     ///
     /// Returns an error if the executor cannot be created.
     pub async fn new(config: AutopilotWorkerConfig) -> Result<Self> {
-        let executor = ToolExecutor::builder()
+        let executor = ToolExecutor::builder(())
             .pool(config.pool)
             .queue_name(&config.queue_name)
             .t0_client(config.t0_client)
@@ -164,7 +164,7 @@ impl ToolVisitor for LocalToolVisitor<'_> {
 
     async fn visit_task_tool<T>(&self, tool: T) -> Result<(), ToolError>
     where
-        T: TaskTool<SideInfo = AutopilotSideInfo>,
+        T: TaskTool<SideInfo = AutopilotSideInfo, ExtraState = ()>,
     {
         self.executor
             .register_task_tool_instance(ClientTaskToolWrapper::new(tool))

--- a/internal/autopilot-worker/src/wrapper.rs
+++ b/internal/autopilot-worker/src/wrapper.rs
@@ -83,8 +83,9 @@ impl<T: TaskTool> ToolMetadata for ClientTaskToolWrapper<T> {
 #[async_trait]
 impl<T> TaskTool for ClientTaskToolWrapper<T>
 where
-    T: TaskTool<SideInfo = AutopilotSideInfo>,
+    T: TaskTool<SideInfo = AutopilotSideInfo, ExtraState = ()>,
 {
+    type ExtraState = ();
     async fn execute(
         &self,
         llm_params: Self::LlmParams,
@@ -220,6 +221,7 @@ struct SimpleToolStepParams<L, S> {
 
 #[async_trait]
 impl<T: SimpleTool<SideInfo = AutopilotSideInfo>> TaskTool for ClientSimpleToolWrapper<T> {
+    type ExtraState = ();
     async fn execute(
         &self,
         llm_params: Self::LlmParams,
@@ -539,6 +541,7 @@ mod tests {
 
     #[async_trait]
     impl TaskTool for TestTaskTool {
+        type ExtraState = ();
         async fn execute(
             &self,
             llm_params: Self::LlmParams,

--- a/internal/durable-tools/src/context.rs
+++ b/internal/durable-tools/src/context.rs
@@ -28,32 +28,35 @@ pub enum ToolHandle {
 }
 
 /// Type alias for the Durable client with `ToolAppState`.
-pub type DurableClient = Durable<ToolAppState>;
+pub type DurableClient<S> = Durable<ToolAppState<S>>;
 
 /// Application state passed to all tools via durable's `State` type parameter.
 ///
 /// This is cloned and passed to each task execution by the durable worker.
 #[derive(Clone)]
-pub struct ToolAppState {
+pub struct ToolAppState<S = ()> {
     /// Database connection pool for database operations.
     pool: PgPool,
     /// Tool registry for looking up and calling other tools.
     tool_registry: Arc<tokio::sync::RwLock<ToolRegistry>>,
     /// TensorZero client for calling inference and autopilot operations.
     t0_client: Arc<dyn TensorZeroClient>,
+    extra_state: S,
 }
 
-impl ToolAppState {
+impl<S> ToolAppState<S> {
     /// Create a new application state.
     pub fn new(
         pool: PgPool,
         tool_registry: Arc<tokio::sync::RwLock<ToolRegistry>>,
         t0_client: Arc<dyn TensorZeroClient>,
+        extra_state: S,
     ) -> Self {
         Self {
             pool,
             tool_registry,
             t0_client,
+            extra_state,
         }
     }
 
@@ -68,25 +71,30 @@ impl ToolAppState {
     pub fn t0_client(&self) -> &Arc<dyn TensorZeroClient> {
         &self.t0_client
     }
+
+    /// Get a reference to the extra state.
+    pub fn extra_state(&self) -> &S {
+        &self.extra_state
+    }
 }
 
 /// Context provided to `TaskTool` execution.
 ///
 /// Wraps durable's `TaskContext` and provides access to the application context
 /// along with helper methods for calling other tools and checkpointing operations.
-pub struct ToolContext<'a> {
-    task_ctx: &'a mut TaskContext<ToolAppState>,
-    app_state: &'a ToolAppState,
+pub struct ToolContext<'a, S: Clone + Send + Sync + 'static = ()> {
+    task_ctx: &'a mut TaskContext<ToolAppState<S>>,
+    app_state: &'a ToolAppState<S>,
     episode_id: Uuid,
     /// Counter for generating unique tool call identifiers.
     tool_call_counter: u32,
 }
 
-impl<'a> ToolContext<'a> {
+impl<'a, S: Clone + Send + Sync + 'static> ToolContext<'a, S> {
     /// Create a new tool context.
     pub fn new(
-        task_ctx: &'a mut TaskContext<ToolAppState>,
-        app_ctx: &'a ToolAppState,
+        task_ctx: &'a mut TaskContext<ToolAppState<S>>,
+        app_ctx: &'a ToolAppState<S>,
         episode_id: Uuid,
     ) -> Self {
         Self {
@@ -158,7 +166,7 @@ impl<'a> ToolContext<'a> {
     /// Get mutable access to the underlying durable `TaskContext`.
     ///
     /// Use this for advanced operations not exposed by `ToolContext`.
-    pub fn task_ctx(&mut self) -> &mut TaskContext<ToolAppState> {
+    pub fn task_ctx(&mut self) -> &mut TaskContext<ToolAppState<S>> {
         self.task_ctx
     }
 
@@ -175,7 +183,7 @@ impl<'a> ToolContext<'a> {
         &mut self,
         base_name: &str,
         params: P,
-        f: fn(P, ToolAppState) -> Fut,
+        f: fn(P, ToolAppState<S>) -> Fut,
     ) -> ToolResult<T>
     where
         P: Serialize,

--- a/internal/durable-tools/src/tests.rs
+++ b/internal/durable-tools/src/tests.rs
@@ -93,6 +93,7 @@ impl ToolMetadata for EchoTaskTool {
 
 #[async_trait]
 impl TaskTool for EchoTaskTool {
+    type ExtraState = ();
     async fn execute(
         &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
@@ -126,6 +127,7 @@ impl ToolMetadata for DefaultTimeoutTaskTool {
 
 #[async_trait]
 impl TaskTool for DefaultTimeoutTaskTool {
+    type ExtraState = ();
     async fn execute(
         &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
@@ -529,7 +531,7 @@ mod builder_tests {
 
     #[test]
     fn builder_default_queue_name_is_tools() {
-        let builder = ToolExecutorBuilder::new();
+        let builder = ToolExecutorBuilder::new(());
         // We can't directly inspect the builder, but we can verify behavior
         // by checking the default is used when not overridden.
         // For now, just verify the builder can be created.
@@ -538,7 +540,7 @@ mod builder_tests {
 
     #[test]
     fn builder_methods_return_self_for_chaining() {
-        let builder = ToolExecutorBuilder::new()
+        let builder = ToolExecutorBuilder::new(())
             .queue_name("custom_queue")
             .default_max_attempts(10);
 
@@ -548,7 +550,7 @@ mod builder_tests {
 
     #[test]
     fn builder_accepts_database_url() {
-        let builder = ToolExecutorBuilder::new().database_url("postgres://localhost/test".into());
+        let builder = ToolExecutorBuilder::new(()).database_url("postgres://localhost/test".into());
 
         let _ = builder;
     }

--- a/internal/durable-tools/tests/integration.rs
+++ b/internal/durable-tools/tests/integration.rs
@@ -151,6 +151,7 @@ impl ToolMetadata for EchoTaskTool {
 
 #[async_trait]
 impl TaskTool for EchoTaskTool {
+    type ExtraState = ();
     async fn execute(
         &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
@@ -274,6 +275,7 @@ impl ToolMetadata for InferenceTaskTool {
 
 #[async_trait]
 impl TaskTool for InferenceTaskTool {
+    type ExtraState = ();
     async fn execute(
         &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
@@ -351,7 +353,7 @@ async fn execute_erased_returns_error_on_invalid_params(pool: PgPool) -> sqlx::R
 #[sqlx::test(migrator = "MIGRATOR")]
 async fn tool_executor_registers_and_lists_tools(pool: PgPool) -> sqlx::Result<()> {
     let t0_client: Arc<dyn TensorZeroClient> = Arc::new(mock_client_error_on_call());
-    let executor = ToolExecutor::builder()
+    let executor = ToolExecutor::builder(())
         .pool(pool)
         .queue_name(format!("test_queue_{}", Uuid::now_v7()))
         .t0_client(t0_client)
@@ -389,7 +391,7 @@ async fn tool_executor_spawns_task_tool(pool: PgPool) -> sqlx::Result<()> {
     let queue_name = format!("test_queue_{}", Uuid::now_v7());
     let t0_client: Arc<dyn TensorZeroClient> = Arc::new(mock_client_error_on_call());
 
-    let executor = ToolExecutor::builder()
+    let executor = ToolExecutor::builder(())
         .pool(pool)
         .queue_name(&queue_name)
         .t0_client(t0_client)
@@ -434,7 +436,7 @@ async fn spawn_tool_by_name_works(pool: PgPool) -> sqlx::Result<()> {
     let queue_name = format!("test_queue_{}", Uuid::now_v7());
     let t0_client: Arc<dyn TensorZeroClient> = Arc::new(mock_client_error_on_call());
 
-    let executor = ToolExecutor::builder()
+    let executor = ToolExecutor::builder(())
         .pool(pool)
         .queue_name(&queue_name)
         .t0_client(t0_client)
@@ -537,6 +539,7 @@ impl ToolMetadata for MultiCallTaskTool {
 
 #[async_trait]
 impl TaskTool for MultiCallTaskTool {
+    type ExtraState = ();
     async fn execute(
         &self,
         _llm_params: <Self as ToolMetadata>::LlmParams,
@@ -584,7 +587,7 @@ async fn calling_same_tool_multiple_times_generates_unique_idempotency_keys(
     let queue_name = format!("test_queue_{}", Uuid::now_v7());
     let t0_client: Arc<dyn TensorZeroClient> = Arc::new(mock_client_error_on_call());
 
-    let executor = ToolExecutor::builder()
+    let executor = ToolExecutor::builder(())
         .pool(pool)
         .queue_name(&queue_name)
         .t0_client(t0_client)
@@ -702,7 +705,7 @@ async fn task_tool_with_inference_can_be_registered(pool: PgPool) -> sqlx::Resul
     let mock_response = create_mock_chat_response("Response from TaskTool!");
     let t0_client: Arc<dyn TensorZeroClient> = Arc::new(mock_client_with_response(mock_response));
 
-    let executor = ToolExecutor::builder()
+    let executor = ToolExecutor::builder(())
         .pool(pool)
         .queue_name(format!("test_queue_{}", Uuid::now_v7()))
         .t0_client(t0_client)
@@ -737,7 +740,7 @@ async fn task_tool_with_inference_can_be_spawned(pool: PgPool) -> sqlx::Result<(
     let mock_response = create_mock_chat_response("Spawned response!");
     let t0_client: Arc<dyn TensorZeroClient> = Arc::new(mock_client_with_response(mock_response));
 
-    let executor = ToolExecutor::builder()
+    let executor = ToolExecutor::builder(())
         .pool(pool)
         .queue_name(&queue_name)
         .t0_client(t0_client)
@@ -840,7 +843,7 @@ async fn task_tool_inference_fails_on_empty_chat_response(pool: PgPool) -> sqlx:
     let queue_name = format!("test_queue_{}", Uuid::now_v7());
     let t0_client: Arc<dyn TensorZeroClient> = Arc::new(mock_client_with_empty_chat_response());
 
-    let executor = ToolExecutor::builder()
+    let executor = ToolExecutor::builder(())
         .pool(pool.clone())
         .queue_name(&queue_name)
         .t0_client(t0_client)
@@ -919,7 +922,7 @@ async fn task_tool_inference_fails_on_empty_json_response(pool: PgPool) -> sqlx:
     let queue_name = format!("test_queue_{}", Uuid::now_v7());
     let t0_client: Arc<dyn TensorZeroClient> = Arc::new(mock_client_with_empty_json_response());
 
-    let executor = ToolExecutor::builder()
+    let executor = ToolExecutor::builder(())
         .pool(pool.clone())
         .queue_name(&queue_name)
         .t0_client(t0_client)


### PR DESCRIPTION
This will allow downstream code (e.g. the autopilot server) to make more state available to tools, accessible through 'ToolAppState.extra_state()'

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad, cross-cutting generic/signature changes across the durable execution stack and all tools; risk is mainly compile-time/API breakage and subtle type mismatches rather than behavioral logic changes.
> 
> **Overview**
> **Adds support for executor-scoped extra state.** `ToolExecutor` and `ToolAppState` are now generic over an `S` extra state value that’s stored on the app state and exposed via `ToolAppState::extra_state()`.
> 
> **Threads the extra state through task execution.** `TaskTool` now declares an `ExtraState` associated type and receives `ToolContext<'_, ExtraState>`; the durable `TaskToolAdapter`, worker wrappers/visitors, and all in-tree task tools/tests are updated to set `type ExtraState = ()` and to construct executors via `ToolExecutor::builder(())` (and `register_task_tool_instance` is constrained to matching `ExtraState = S`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58fd5052799b330c167d5f4ceeebaaebe68eb393. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->