### PR TITLE
Revert "Disable fireworks bad headers test" / bump Fireworks models

### DIFF
--- a/tensorzero-core/fixtures/config/tensorzero.toml
+++ b/tensorzero-core/fixtures/config/tensorzero.toml
@@ -221,7 +221,7 @@ json_mode = "strict"
 
 [evaluations.evaluation1.evaluators.llm_judge_bool.variants.llama_promptA]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
+model = "fireworks::accounts/fireworks/models/kimi-k2p5"
 system_instructions = "fixtures/config/evaluations/evaluation1/llm_judge_bool/system_instructions.txt"
 json_mode = "strict"
 

--- a/tensorzero-core/tests/e2e/config/tensorzero.evaluations.toml
+++ b/tensorzero-core/tests/e2e/config/tensorzero.evaluations.toml
@@ -287,7 +287,7 @@ json_mode = "strict"
 
 [evaluations.best_of_3.evaluators.llm_judge_bool.variants.llama_promptA]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
+model = "fireworks::accounts/fireworks/models/kimi-k2p5"
 system_instructions = "../../../fixtures/config/evaluations/best_of_3/llm_judge_bool/system_instructions.txt"
 json_mode = "strict"
 
@@ -325,7 +325,7 @@ json_mode = "strict"
 
 [evaluations.mixture_of_3.evaluators.llm_judge_bool.variants.llama_promptA]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
+model = "fireworks::accounts/fireworks/models/kimi-k2p5"
 system_instructions = "../../../fixtures/config/evaluations/best_of_3/llm_judge_bool/system_instructions.txt"
 json_mode = "strict"
 

--- a/tensorzero-core/tests/e2e/config/tensorzero.functions.basic_test.toml
+++ b/tensorzero-core/tests/e2e/config/tensorzero.functions.basic_test.toml
@@ -197,29 +197,29 @@ max_tokens = 100
 
 [functions.basic_test.variants.fireworks]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
+model = "fireworks::accounts/fireworks/models/kimi-k2p5"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
-max_tokens = 500
+max_tokens = 1500
 
 [functions.basic_test.variants.fireworks-extra-body]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
+model = "fireworks::accounts/fireworks/models/kimi-k2p5"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
-max_tokens = 100
+max_tokens = 1500
 extra_body = [{ pointer = "/temperature", value = 0.123 }]
 
 [functions.basic_test.variants.fireworks-extra-headers]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/deepseek-r1-0528"
+model = "fireworks::accounts/fireworks/models/kimi-k2p5"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
-max_tokens = 100
+max_tokens = 1500
 extra_headers = [{ name = "Authorization", value = "invalid_fireworks_auth" }]
 
 [functions.basic_test.variants.fireworks-dynamic]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
+model = "fireworks::accounts/fireworks/models/kimi-k2p5"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
-max_tokens = 100
+max_tokens = 1500
 
 [functions.basic_test.variants.fireworks-shorthand]
 type = "chat_completion"
@@ -769,15 +769,15 @@ model = "deepseek::deepseek-chat"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 100
 
-[functions.basic_test.variants.fireworks-deepseek]
+[functions.basic_test.variants.fireworks-kimi-k2p5-reasoning]
 type = "chat_completion"
-model = "deepseek-r1"
+model = "kimi-k2p5-fireworks-reasoning"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 800
 
-[functions.basic_test.variants.fireworks-gpt-oss-20b]
+[functions.basic_test.variants.fireworks-kimi-k2p5]
 type = "chat_completion"
-model = "gpt-oss-20b-fireworks"
+model = "kimi-k2p5-fireworks"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 800
 

--- a/tensorzero-core/tests/e2e/config/tensorzero.functions.dynamic_json.toml
+++ b/tensorzero-core/tests/e2e/config/tensorzero.functions.dynamic_json.toml
@@ -119,27 +119,27 @@ max_tokens = 100
 
 [functions.dynamic_json.variants.fireworks]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
+model = "fireworks::accounts/fireworks/models/kimi-k2p5"
 system_template = "../../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 json_mode = "on"
-max_tokens = 100
+max_tokens = 1500
 
 [functions.dynamic_json.variants.fireworks-strict]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
+model = "fireworks::accounts/fireworks/models/kimi-k2p5"
 system_template = "../../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
-max_tokens = 100
+max_tokens = 1500
 json_mode = "strict"
 
 [functions.dynamic_json.variants.fireworks-implicit]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
+model = "fireworks::accounts/fireworks/models/kimi-k2p5"
 system_template = "../../../fixtures/config/functions/dynamic_json/prompt/system_template.minijinja"
 user_template = "../../../fixtures/config/functions/dynamic_json/prompt/user_template.minijinja"
 json_mode = "tool"
-max_tokens = 100
+max_tokens = 1500
 
 [functions.dynamic_json.variants.gcp-vertex-gemini-flash]
 type = "chat_completion"

--- a/tensorzero-core/tests/e2e/config/tensorzero.functions.json_success.toml
+++ b/tensorzero-core/tests/e2e/config/tensorzero.functions.json_success.toml
@@ -159,21 +159,21 @@ max_tokens = 100
 
 [functions.json_success.variants.fireworks]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
+model = "fireworks::accounts/fireworks/models/kimi-k2p5"
 system_template = "../../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "on"
-max_tokens = 100
+max_tokens = 1500
 
-[functions.json_success.variants.fireworks-gpt-oss-20b]
+[functions.json_success.variants.fireworks-kimi-k2p5]
 type = "chat_completion"
-model = "gpt-oss-20b-fireworks"
+model = "kimi-k2p5-fireworks"
 system_template = "../../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 # Fireworks gives us 'Failed to format non-streaming choice: Expected message start token but ran out of tokens' if
-# we try to explicitly request a 'json_object' response format for gpt-oss-20b.
+# we try to explicitly request a 'json_object' response format for kimi-k2p5.
 json_mode = "off"
-max_tokens = 100
+max_tokens = 1500
 
 [functions.json_success.variants.google-ai-studio-gemini-3-flash]
 type = "chat_completion"
@@ -185,11 +185,11 @@ max_tokens = 1000
 
 [functions.json_success.variants.fireworks-implicit]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
+model = "fireworks::accounts/fireworks/models/kimi-k2p5"
 system_template = "../../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "tool"
-max_tokens = 100
+max_tokens = 1500
 
 [functions.json_success.variants.deepseek-reasoner]
 type = "chat_completion"
@@ -209,10 +209,10 @@ max_tokens = 800
 
 [functions.json_success.variants.fireworks-strict]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
+model = "fireworks::accounts/fireworks/models/kimi-k2p5"
 system_template = "../../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
-max_tokens = 100
+max_tokens = 1500
 json_mode = "strict"
 
 [functions.json_success.variants.gcp-vertex-gemini-flash]
@@ -585,9 +585,9 @@ user_template = "../../../fixtures/config/functions/json_success/prompt/user_tem
 max_tokens = 100
 json_mode = "strict"
 
-[functions.json_success.variants.fireworks-deepseek]
+[functions.json_success.variants.fireworks-kimi-k2p5-reasoning]
 type = "chat_completion"
-model = "deepseek-r1"
+model = "kimi-k2p5-fireworks-reasoning"
 system_template = "../../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "off"
@@ -651,11 +651,11 @@ max_tokens = 100
 
 [functions.json_success.variants.fireworks_json_mode_off]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
+model = "fireworks::accounts/fireworks/models/kimi-k2p5"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 user_template = "../../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "off"
-max_tokens = 100
+max_tokens = 1500
 
 [functions.json_success.variants.together_deepseek_r1_json_mode_off]
 type = "chat_completion"

--- a/tensorzero-core/tests/e2e/config/tensorzero.functions.weather_helper.toml
+++ b/tensorzero-core/tests/e2e/config/tensorzero.functions.weather_helper.toml
@@ -103,9 +103,9 @@ max_tokens = 100
 
 [functions.weather_helper.variants.fireworks]
 type = "chat_completion"
-model = "fireworks::accounts/fireworks/models/deepseek-v3p1"
+model = "fireworks::accounts/fireworks/models/kimi-k2p5"
 system_template = "../../../fixtures/config/functions/weather_helper/prompt/system_template.minijinja"
-max_tokens = 100
+max_tokens = 1500
 
 [functions.weather_helper.variants.gcp-vertex-gemini-flash]
 type = "chat_completion"
@@ -169,15 +169,15 @@ model = "deepseek-reasoner"
 system_template = "../../../fixtures/config/functions/weather_helper/prompt/system_template.minijinja"
 max_tokens = 800
 
-[functions.weather_helper.variants.fireworks-deepseek]
+[functions.weather_helper.variants.fireworks-kimi-k2p5-reasoning]
 type = "chat_completion"
-model = "deepseek-r1"
+model = "kimi-k2p5-fireworks-reasoning"
 system_template = "../../../fixtures/config/functions/weather_helper/prompt/system_template.minijinja"
 max_tokens = 800
 
-[functions.weather_helper.variants.fireworks-gpt-oss-20b]
+[functions.weather_helper.variants.fireworks-kimi-k2p5]
 type = "chat_completion"
-model = "gpt-oss-20b-fireworks"
+model = "kimi-k2p5-fireworks"
 system_template = "../../../fixtures/config/functions/weather_helper/prompt/system_template.minijinja"
 
 

--- a/tensorzero-core/tests/e2e/config/tensorzero.models.toml
+++ b/tensorzero-core/tests/e2e/config/tensorzero.models.toml
@@ -25,12 +25,12 @@ extra_body = [
     { pointer = "/frequency_penalty", value = 1.42 },
 ]
 
-[models."gpt-oss-20b-fireworks"]
+[models."kimi-k2p5-fireworks"]
 routing = ["fireworks"]
 
-[models."gpt-oss-20b-fireworks".providers.fireworks]
+[models."kimi-k2p5-fireworks".providers.fireworks]
 type = "fireworks"
-model_name = "accounts/fireworks/models/gpt-oss-20b"
+model_name = "accounts/fireworks/models/kimi-k2p5"
 parse_think_blocks = false
 
 [models."gpt-oss-20b-vllm"]
@@ -360,12 +360,12 @@ region = "us-east-1"
 [models.qwen2p5-72b-instruct]
 routing = ["fireworks"]
 
-[models."deepseek-r1"]
+[models."kimi-k2p5-fireworks-reasoning"]
 routing = ["fireworks"]
 
-[models."deepseek-r1".providers.fireworks]
+[models."kimi-k2p5-fireworks-reasoning".providers.fireworks]
 type = "fireworks"
-model_name = "accounts/fireworks/models/deepseek-r1-0528"
+model_name = "accounts/fireworks/models/kimi-k2p5"
 
 [models.qwen2p5-72b-instruct.providers.fireworks]
 type = "fireworks"

--- a/tensorzero-core/tests/e2e/providers/fireworks.rs
+++ b/tensorzero-core/tests/e2e/providers/fireworks.rs
@@ -14,7 +14,7 @@ async fn get_providers() -> E2ETestProviders {
     let providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks".to_string(),
-        model_name: "fireworks::accounts/fireworks/models/deepseek-v3p1".into(),
+        model_name: "fireworks::accounts/fireworks/models/kimi-k2p5".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];
@@ -22,7 +22,7 @@ async fn get_providers() -> E2ETestProviders {
     let extra_body_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks-extra-body".to_string(),
-        model_name: "fireworks::accounts/fireworks/models/deepseek-v3p1".into(),
+        model_name: "fireworks::accounts/fireworks/models/kimi-k2p5".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];
@@ -30,7 +30,7 @@ async fn get_providers() -> E2ETestProviders {
     let bad_auth_extra_headers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks-extra-headers".to_string(),
-        model_name: "fireworks::accounts/fireworks/models/deepseek-r1-0528".into(),
+        model_name: "fireworks::accounts/fireworks/models/kimi-k2p5".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];
@@ -38,7 +38,7 @@ async fn get_providers() -> E2ETestProviders {
     let inference_params_dynamic_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks-dynamic".to_string(),
-        model_name: "fireworks::accounts/fireworks/models/deepseek-v3p1".into(),
+        model_name: "fireworks::accounts/fireworks/models/kimi-k2p5".into(),
         model_provider_name: "fireworks".into(),
         credentials,
     }];
@@ -46,7 +46,7 @@ async fn get_providers() -> E2ETestProviders {
     let tool_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks".to_string(),
-        model_name: "fireworks::accounts/fireworks/models/deepseek-v3p1".into(),
+        model_name: "fireworks::accounts/fireworks/models/kimi-k2p5".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];
@@ -55,21 +55,21 @@ async fn get_providers() -> E2ETestProviders {
         E2ETestProvider {
             supports_batch_inference: false,
             variant_name: "fireworks".to_string(),
-            model_name: "fireworks::accounts/fireworks/models/deepseek-v3p1".into(),
+            model_name: "fireworks::accounts/fireworks/models/kimi-k2p5".into(),
             model_provider_name: "fireworks".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             supports_batch_inference: false,
             variant_name: "fireworks-implicit".to_string(),
-            model_name: "fireworks::accounts/fireworks/models/deepseek-v3p1".into(),
+            model_name: "fireworks::accounts/fireworks/models/kimi-k2p5".into(),
             model_provider_name: "fireworks".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             supports_batch_inference: false,
             variant_name: "fireworks-strict".to_string(),
-            model_name: "fireworks::accounts/fireworks/models/deepseek-v3p1".into(),
+            model_name: "fireworks::accounts/fireworks/models/kimi-k2p5".into(),
             model_provider_name: "fireworks".into(),
             credentials: HashMap::new(),
         },
@@ -78,7 +78,7 @@ async fn get_providers() -> E2ETestProviders {
     let json_mode_off_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks_json_mode_off".to_string(),
-        model_name: "fireworks::accounts/fireworks/models/deepseek-v3p1".into(),
+        model_name: "fireworks::accounts/fireworks/models/kimi-k2p5".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];
@@ -94,15 +94,15 @@ async fn get_providers() -> E2ETestProviders {
     let thinking_block_providers = vec![
         E2ETestProvider {
             supports_batch_inference: false,
-            variant_name: "fireworks-deepseek".to_string(),
-            model_name: "deepseek-r1".into(),
+            variant_name: "fireworks-kimi-k2p5-reasoning".to_string(),
+            model_name: "kimi-k2p5-fireworks-reasoning".into(),
             model_provider_name: "fireworks".into(),
             credentials: HashMap::new(),
         },
         E2ETestProvider {
             supports_batch_inference: false,
-            variant_name: "fireworks-gpt-oss-20b".to_string(),
-            model_name: "gpt-oss-20b-fireworks".into(),
+            variant_name: "fireworks-kimi-k2p5".to_string(),
+            model_name: "kimi-k2p5-fireworks".into(),
             model_provider_name: "fireworks".into(),
             credentials: HashMap::new(),
         },
@@ -111,7 +111,7 @@ async fn get_providers() -> E2ETestProviders {
     let provider_type_default_credentials_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks".to_string(),
-        model_name: "accounts/fireworks/models/deepseek-v3p1".into(),
+        model_name: "accounts/fireworks/models/kimi-k2p5".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];
@@ -119,7 +119,7 @@ async fn get_providers() -> E2ETestProviders {
     let provider_type_default_credentials_shorthand_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "fireworks-shorthand".to_string(),
-        model_name: "fireworks::accounts/fireworks/models/deepseek-v3p1".into(),
+        model_name: "fireworks::accounts/fireworks/models/kimi-k2p5".into(),
         model_provider_name: "fireworks".into(),
         credentials: HashMap::new(),
     }];
@@ -128,7 +128,7 @@ async fn get_providers() -> E2ETestProviders {
         provider_type: "fireworks".to_string(),
         model_info: HashMap::from([(
             "model_name".to_string(),
-            "accounts/fireworks/models/deepseek-v3p1".to_string(),
+            "accounts/fireworks/models/kimi-k2p5".to_string(),
         )]),
         use_modal_headers: false,
     }];


### PR DESCRIPTION
Reverts tensorzero/tensorzero#6319
Fixes https://github.com/tensorzero/tensorzero/issues/6318

Bump Fireworks models (DeepSeek no longer serverless)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches only test/configuration, but changes provider/model selection and expected output shapes; failures could mask real regressions in Fireworks integration if the relaxed assertions are too permissive.
> 
> **Overview**
> Switches Fireworks-backed fixtures and E2E configs from DeepSeek/GPT-OSS to `fireworks::.../kimi-k2p5`, including renaming model entries to `kimi-k2p5-fireworks` and `kimi-k2p5-fireworks-reasoning` and increasing Fireworks `max_tokens` (typically to 1500) to support reasoning overhead.
> 
> Re-enables the previously disabled Fireworks *bad auth extra headers* provider test and updates Fireworks provider definitions accordingly.
> 
> Adjusts E2E assertions in `tests/e2e/providers/common.rs` to be compatible with reasoning outputs (ignore thought blocks, expect dynamic `max_tokens` for kimi, and broaden text/unknown block checks), and skips/limits certain assistant-prefill and tool-choice tests for Fireworks due to provider/model behavior (e.g., ignoring trailing assistant messages and `tool_choice=none`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abe5582787763c7f1186a9634882280e761a723b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->