### PR TITLE
Replace lingering clickhouse-only paths

### DIFF
--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -1518,7 +1518,7 @@ impl TensorZeroGateway {
 
         let core_args = EvaluationCoreArgs {
             inference_executor,
-            clickhouse_client: app_state.clickhouse_connection_info.clone(),
+            db: Arc::new(app_state.get_delegating_database()),
             evaluation_config,
             function_configs,
             evaluation_name,
@@ -2786,7 +2786,7 @@ impl AsyncTensorZeroGateway {
 
             let core_args = EvaluationCoreArgs {
                 inference_executor,
-                clickhouse_client: app_state.clickhouse_connection_info.clone(),
+                db: Arc::new(app_state.get_delegating_database()),
                 evaluation_config,
                 function_configs,
                 evaluation_name,

--- a/evaluations/src/evaluators/llm_judge/mod.rs
+++ b/evaluations/src/evaluators/llm_judge/mod.rs
@@ -7,7 +7,6 @@ use tensorzero_core::client::{
     ClientInferenceParams, DynamicToolParams, File, InferenceOutput, InferenceParams,
     InferenceResponse, Input, InputMessage, InputMessageContent, Role,
 };
-use tensorzero_core::db::evaluation_queries::EvaluationQueries;
 use tensorzero_core::endpoints::datasets::Datapoint;
 use tensorzero_core::evaluations::{
     LLMJudgeConfig, LLMJudgeInputFormat, LLMJudgeOutputType, get_evaluator_metric_name,
@@ -75,7 +74,7 @@ pub async fn run_llm_judge_evaluator(
     debug!("Checking for existing human feedback");
     let serialized_output = inference_response.get_serialized_output()?;
     if let Some(human_feedback) = clients
-        .clickhouse_client
+        .db
         .get_inference_evaluation_human_feedback(
             &get_evaluator_metric_name(evaluation_name, evaluator_name),
             &datapoint.id(),

--- a/evaluations/tests/tests.rs
+++ b/evaluations/tests/tests.rs
@@ -2,6 +2,9 @@
     test,
     allow(clippy::expect_used, clippy::unwrap_used, clippy::print_stdout)
 )]
+
+// TODO(#5691): Support running these tests against Postgres.
+
 mod common;
 use clap::Parser;
 use evaluations::evaluators::llm_judge::{RunLLMJudgeEvaluatorParams, run_llm_judge_evaluator};
@@ -528,7 +531,8 @@ async fn test_datapoint_ids_and_max_datapoints_mutually_exclusive_core_streaming
     // Test: Both datapoint_ids and max_datapoints provided should fail
     let core_args = EvaluationCoreArgs {
         inference_executor,
-        clickhouse_client: clickhouse,
+        db: Arc::new(clickhouse),
+
         evaluation_config,
         function_configs,
         evaluation_name,
@@ -1704,7 +1708,7 @@ async fn test_run_llm_judge_evaluator_chat() {
     let inference_executor = Arc::new(ClientInferenceExecutor::new(tensorzero_client));
     let clients = Arc::new(Clients {
         inference_executor,
-        clickhouse_client: get_clickhouse().await,
+        db: Arc::new(get_clickhouse().await),
     });
     let inference_response = InferenceResponse::Chat(ChatInferenceResponse {
         content: vec![ContentBlockChatOutput::Text(Text {
@@ -1889,7 +1893,7 @@ async fn test_run_llm_judge_evaluator_json() {
     let inference_executor = Arc::new(ClientInferenceExecutor::new(tensorzero_client));
     let clients = Arc::new(Clients {
         inference_executor,
-        clickhouse_client: get_clickhouse().await,
+        db: Arc::new(get_clickhouse().await),
     });
     let inference_response = InferenceResponse::Json(JsonInferenceResponse {
         output: JsonInferenceOutput {
@@ -2772,7 +2776,8 @@ async fn test_evaluation_with_dynamic_variant() {
 
     let core_args = EvaluationCoreArgs {
         inference_executor,
-        clickhouse_client: clickhouse,
+        db: Arc::new(clickhouse),
+
         evaluation_config,
         function_configs,
         dataset_name: Some(dataset_name),
@@ -2838,7 +2843,8 @@ async fn test_max_datapoints_parameter() {
     // Test with max_datapoints = 3 (should only process 3 datapoints)
     let core_args = EvaluationCoreArgs {
         inference_executor,
-        clickhouse_client: clickhouse.clone(),
+        db: Arc::new(clickhouse.clone()),
+
         evaluation_config,
         function_configs,
         dataset_name: Some(dataset_name.clone()),
@@ -2938,7 +2944,7 @@ async fn test_precision_targets_parameter() {
 
     let core_args = EvaluationCoreArgs {
         inference_executor,
-        clickhouse_client: clickhouse.clone(),
+        db: Arc::new(clickhouse.clone()),
         evaluation_config,
         function_configs,
         dataset_name: Some(dataset_name.clone()),
@@ -2961,7 +2967,7 @@ async fn test_precision_targets_parameter() {
     .unwrap();
 
     // Consume results and track evaluations, computing statistics as we go
-    let batcher_join_handle = result.batcher_join_handle.clone();
+    let batcher_join_handles = result.batcher_join_handles.clone();
     let mut receiver = result.receiver;
     let mut exact_match_stats = PerEvaluatorStats::new(true); // Bernoulli evaluator (uses Wilson CI)
     let mut topic_stats = PerEvaluatorStats::new(false); // Treated as float evaluator (uses Wald CI)
@@ -3022,10 +3028,10 @@ async fn test_precision_targets_parameter() {
         precision_targets["topic_starts_with_f"]
     );
 
-    if let Some(handle) = batcher_join_handle {
+    for handle in batcher_join_handles {
         handle
             .await
-            .expect("ClickHouse batch writer should complete before tag assertions");
+            .expect("Batch writer should complete before tag assertions");
     }
     clickhouse.flush_pending_writes().await;
     sleep(Duration::from_secs(5)).await;

--- a/internal/durable-tools/src/run_evaluation.rs
+++ b/internal/durable-tools/src/run_evaluation.rs
@@ -262,11 +262,11 @@ async fn collect_results(
         None
     };
 
-    // Wait for ClickHouse writes to complete
-    if let Some(handle) = result.batcher_join_handle {
-        handle.await.map_err(|e| {
-            RunEvaluationError::Runtime(format!("ClickHouse batch writer failed: {e}"))
-        })?;
+    // Wait for batch writes to complete
+    for handle in result.batcher_join_handles {
+        handle
+            .await
+            .map_err(|e| RunEvaluationError::Runtime(format!("Batch writer failed: {e}")))?;
     }
 
     Ok(RunEvaluationResponse {

--- a/internal/tensorzero-node/src/postgres.rs
+++ b/internal/tensorzero-node/src/postgres.rs
@@ -20,7 +20,7 @@ impl PostgresClient {
             .map_err(|e| napi::Error::from_reason(format!("Failed to setup Postgres: {e}")))?
             .dangerous_into_config_without_writing();
 
-        let connection_info = setup_postgres(&config, Some(postgres_url))
+        let connection_info = setup_postgres(&config, Some(&postgres_url))
             .await
             .map_err(|e| napi::Error::from_reason(format!("Failed to setup Postgres: {e}")))?;
 

--- a/tensorzero-core/src/client/mod.rs
+++ b/tensorzero-core/src/client/mod.rs
@@ -599,7 +599,7 @@ impl ClientBuilder {
                 Self::validate_embedded_gateway_config(&config, *allow_batch_writes)?;
                 let postgres_connection_info = match postgres_config {
                     Some(PostgresConfig::Url(url)) => {
-                        setup_postgres(&config, Some(url.clone())).await.map_err(|e| {
+                        setup_postgres(&config, Some(url)).await.map_err(|e| {
                             ClientBuilderError::Postgres(TensorZeroError::Other { source: e.into() })
                         })?
                     }
@@ -784,8 +784,9 @@ impl ClientBuilder {
         Self::validate_embedded_gateway_config(&config, false)?;
 
         // Setup Postgres with runtime URL
-        let postgres_connection_info =
-            setup_postgres(&config, postgres_url).await.map_err(|e| {
+        let postgres_connection_info = setup_postgres(&config, postgres_url.as_deref())
+            .await
+            .map_err(|e| {
                 ClientBuilderError::Postgres(TensorZeroError::Other { source: e.into() })
             })?;
 

--- a/tensorzero-core/src/db/clickhouse/batching.rs
+++ b/tensorzero-core/src/db/clickhouse/batching.rs
@@ -1,11 +1,9 @@
-use std::future::Future;
-use std::pin::Pin;
 use std::time::Duration;
 
 use crate::config::BatchWritesConfig;
+use crate::db::BatchWriterHandle;
 use crate::error::IMPOSSIBLE_ERROR_MESSAGE;
 use enum_map::EnumMap;
-use futures::future::Shared;
 use futures::{FutureExt, TryFutureExt};
 use tokio::runtime::{Handle, RuntimeFlavor};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
@@ -14,8 +12,6 @@ use tokio::task::JoinSet;
 use crate::db::batching::process_channel_with_capacity_and_timeout;
 use crate::db::clickhouse::{ClickHouseConnectionInfo, Rows, TableName};
 use crate::error::{Error, ErrorDetails};
-
-pub type BatchWriterHandle = Shared<Pin<Box<dyn Future<Output = Result<(), String>> + Send>>>;
 
 /// A `BatchSender` is used to submit entries to the batch writer, which aggregates
 /// and submits them to ClickHouse on a schedule defined by a `BatchWritesConfig`.

--- a/tensorzero-core/src/db/clickhouse/clickhouse_client/disabled_clickhouse_client.rs
+++ b/tensorzero-core/src/db/clickhouse/clickhouse_client/disabled_clickhouse_client.rs
@@ -3,7 +3,7 @@ use secrecy::SecretString;
 use std::collections::HashMap;
 use std::sync::{Arc, LazyLock};
 
-use crate::db::clickhouse::batching::BatchWriterHandle;
+use crate::db::BatchWriterHandle;
 use crate::db::clickhouse::clickhouse_client::ClickHouseClientType;
 use crate::db::clickhouse::{
     ClickHouseClient, ClickHouseResponse, ClickHouseResponseMetadata, ExternalDataInfo,

--- a/tensorzero-core/src/db/clickhouse/clickhouse_client/fake_clickhouse_client.rs
+++ b/tensorzero-core/src/db/clickhouse/clickhouse_client/fake_clickhouse_client.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, LazyLock};
 use tokio::sync::{RwLock, RwLockWriteGuard};
 
-use crate::db::clickhouse::batching::BatchWriterHandle;
+use crate::db::BatchWriterHandle;
 use crate::db::clickhouse::clickhouse_client::ClickHouseClientType;
 use crate::db::clickhouse::{
     ClickHouseClient, ClickHouseResponse, ClickHouseResponseMetadata, ExternalDataInfo,

--- a/tensorzero-core/src/db/clickhouse/clickhouse_client/mod.rs
+++ b/tensorzero-core/src/db/clickhouse/clickhouse_client/mod.rs
@@ -4,12 +4,12 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use crate::db::BatchWriterHandle;
 use crate::db::HealthCheckable;
 use crate::db::clickhouse::ClickHouseResponse;
 use crate::db::clickhouse::ExternalDataInfo;
 use crate::db::clickhouse::GetMaybeReplicatedTableEngineNameArgs;
 use crate::db::clickhouse::TableName;
-use crate::db::clickhouse::batching::BatchWriterHandle;
 use crate::error::{DelayedError, Error};
 
 #[cfg(test)]

--- a/tensorzero-core/src/db/clickhouse/clickhouse_client/production_clickhouse_client.rs
+++ b/tensorzero-core/src/db/clickhouse/clickhouse_client/production_clickhouse_client.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use url::Url;
 
 use crate::config::BatchWritesConfig;
+use crate::db::BatchWriterHandle;
 use crate::db::clickhouse::ClickHouseClient;
 use crate::db::clickhouse::ClickHouseConnectionInfo;
 use crate::db::clickhouse::ClickHouseResponse;
@@ -21,7 +22,6 @@ use crate::db::clickhouse::HealthCheckable;
 use crate::db::clickhouse::Rows;
 use crate::db::clickhouse::TableName;
 use crate::db::clickhouse::batching::BatchSender;
-use crate::db::clickhouse::batching::BatchWriterHandle;
 use crate::db::clickhouse::clickhouse_client::ClickHouseClientType;
 use crate::db::clickhouse::migration_manager::migrations::check_table_exists;
 use crate::error::DelayedError;

--- a/tensorzero-core/src/db/clickhouse/mod.rs
+++ b/tensorzero-core/src/db/clickhouse/mod.rs
@@ -17,8 +17,8 @@ use crate::db::clickhouse::clickhouse_client::ProductionClickHouseClient;
 use crate::error::DelayedError;
 use crate::error::{Error, ErrorDetails};
 
-// Export this so evaluations crate can wait for it.
-pub use crate::db::clickhouse::batching::BatchWriterHandle;
+// Re-export for backwards compatibility.
+pub use crate::db::BatchWriterHandle;
 
 pub use clickhouse_client::ClickHouseClient;
 pub use table_name::TableName;

--- a/tensorzero-core/src/db/mod.rs
+++ b/tensorzero-core/src/db/mod.rs
@@ -1,6 +1,10 @@
+use std::future::Future;
+use std::pin::Pin;
+
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use feedback::FeedbackQueries;
+use futures::future::Shared;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -11,6 +15,8 @@ use crate::config::snapshot::{ConfigSnapshot, SnapshotHash};
 use crate::db::datasets::DatasetQueries;
 use crate::error::Error;
 use crate::serde_util::{deserialize_option_u64, deserialize_u64};
+
+pub type BatchWriterHandle = Shared<Pin<Box<dyn Future<Output = Result<(), String>> + Send>>>;
 
 pub mod batch_inference;
 pub mod batching;

--- a/tensorzero-core/src/db/postgres/mod.rs
+++ b/tensorzero-core/src/db/postgres/mod.rs
@@ -9,7 +9,8 @@ use tokio::time::timeout;
 
 use crate::error::{Error, ErrorDetails};
 
-use self::batching::{PostgresBatchSender, PostgresBatchWriterHandle};
+use self::batching::PostgresBatchSender;
+use super::BatchWriterHandle;
 use super::HealthCheckable;
 
 pub mod batch_inference;
@@ -105,7 +106,7 @@ impl PostgresConnectionInfo {
         }
     }
 
-    pub fn batcher_join_handle(&self) -> Option<PostgresBatchWriterHandle> {
+    pub fn batcher_join_handle(&self) -> Option<BatchWriterHandle> {
         match self {
             Self::Enabled { batch_sender, .. } => {
                 batch_sender.as_ref().map(|s| s.writer_handle.clone())

--- a/tensorzero-core/src/endpoints/internal/model_inferences.rs
+++ b/tensorzero-core/src/endpoints/internal/model_inferences.rs
@@ -103,13 +103,11 @@ pub async fn get_model_inferences_handler(
 
 /// Core business logic for getting model inferences
 async fn get_model_inferences(
-    AppStateData {
-        clickhouse_connection_info,
-        ..
-    }: AppStateData,
+    app_state_data: AppStateData,
     inference_id: Uuid,
 ) -> Result<Vec<ModelInference>, Error> {
-    let rows = clickhouse_connection_info
+    let db = app_state_data.get_delegating_database();
+    let rows = db
         .get_model_inferences_by_inference_id(inference_id)
         .await?;
 

--- a/tensorzero-optimizers/src/gepa/evaluate.rs
+++ b/tensorzero-optimizers/src/gepa/evaluate.rs
@@ -8,6 +8,7 @@ use tensorzero_core::{
     client::Client,
     config::{Config, UninitializedVariantConfig, UninitializedVariantInfo},
     db::clickhouse::ClickHouseConnectionInfo,
+    db::delegating_connection::DelegatingDatabaseQueries,
     endpoints::datasets::v1::{
         create_datapoints,
         types::{CreateDatapointRequest, CreateDatapointsRequest, CreateDatapointsResponse},
@@ -192,9 +193,11 @@ pub async fn evaluate_variant(params: EvaluateVariantParams) -> Result<Evaluatio
     let inference_executor = Arc::new(ClientInferenceExecutor::new(params.gateway_client));
 
     // Create EvaluationCoreArgs
+    let db: Arc<dyn DelegatingDatabaseQueries + Send + Sync> =
+        Arc::new(params.clickhouse_connection_info.clone());
     let core_args = EvaluationCoreArgs {
         inference_executor,
-        clickhouse_client: params.clickhouse_connection_info.clone(),
+        db,
         evaluation_config: params.evaluation_config.clone(),
         function_configs,
         evaluation_name: params.evaluation_name,


### PR DESCRIPTION
- Replace ClickHouse-specific database access in evaluations with a delegating database interface that can support multiple database backends.
- Changed `batcher_join_handle` (singular) to `batcher_join_handles` (plural) to support multiple database backends