### PR TITLE
Run UI tests in 0.0.0.0

### DIFF
--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL:
       baseURLOverride ||
-      (useUIDocker ? "http://localhost:4000" : "http://localhost:5173"),
+      (useUIDocker ? "http://0.0.0.0:4000" : "http://localhost:5173"),
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a one-line Playwright config change affecting only the UI E2E test base URL in Docker/CI runs.
> 
> **Overview**
> Updates `ui/playwright.config.ts` so Playwright uses `http://0.0.0.0:4000` (instead of `http://localhost:4000`) as the default `baseURL` when `useUIDocker` is enabled, improving connectivity in Docker/CI environments while leaving the non-Docker dev URL unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a19f87fb8e7ff2d6385bc79da1f2f85890fb44ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->