### PR TITLE
Bump E2E timeout

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -32,16 +32,11 @@ slow-timeout = { period = "20s", terminate-after = 5 }
 # - binding generation
 [profile.e2e]
 retries = { backoff = "exponential", count = 4, delay = "5s", jitter = true, max-delay = "60s" }
+slow-timeout = { period = "30s", terminate-after = 2 }
 default-filter = '''
 not (test(batch) | test(test_dummy_only) | test(clickhouse::) | (test(db::) & !test(postgres) & !test(valkey)) | test(export_bindings_) | test(export_schema_) | binary(optimization-mock) | package(tensorzero-derive))
 '''
 junit.path = "junit.xml"
-
-# E2E GEPA tests - integration tests with API calls and evaluation
-[[profile.e2e.overrides]]
-filter = 'binary(e2e_gepa)'
-# Analysis or mutation using gpt-4.1-nano occasionally fails to generate a properly formatted output, so we add retries
-slow-timeout = { period = "30s", terminate-after = 2 }
 
 [profile.live-batch]
 default-filter = 'test(batch) and not test(mock)'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-runner configuration change only; main risk is longer CI/runtime or masking slow/flaky E2E failures.
> 
> **Overview**
> **Increases the default slow-test timeout for the `e2e` nextest profile** by applying `slow-timeout = { period = "30s", terminate-after = 2 }` to all E2E tests.
> 
> Removes the special-case `e2e_gepa` override and its comment, since the E2E timeout/retry behavior is now configured at the profile level.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd38d2f460e46e4da4e3ac914d6b45b923a1ecf7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->