### PR TITLE
Fix typo

### DIFF
--- a/tensorzero-core/src/db/postgres/pgcron.rs
+++ b/tensorzero-core/src/db/postgres/pgcron.rs
@@ -33,7 +33,7 @@ pub async fn check_pgcron_configured_correctly(pool: &PgPool) -> Result<(), Dela
 
     if !extension_exists {
         return Err(DelayedError::new(ErrorDetails::PostgresMigration {
-            message: "pg_cron extension is not installed.".to_string(),
+            message: "pg_cron extension is not installed".to_string(),
         }));
     }
 


### PR DESCRIPTION
Duplicate period in combined message

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only change to an error message; no behavioral, security, or data-handling impact.
> 
> **Overview**
> Removes a trailing period from the `pg_cron`-missing migration error message emitted by `check_pgcron_configured_correctly`, making the wording consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff0babe72986bd9e0809f60d8f5e94e0bb0d20de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->