### PR TITLE
Add docs on Apply changes

### DIFF
--- a/docs/deployment/tensorzero-autopilot.mdx
+++ b/docs/deployment/tensorzero-autopilot.mdx
@@ -55,6 +55,35 @@ Learn more about how to:
 
 </Step>
 
+<Step title="Allow TensorZero Autopilot to edit your local configuration (optional)">
+
+TensorZero Autopilot can edit your local TensorZero configuration.
+
+When this feature is enabled, an "Apply changes" button appears in the UI, allowing you to easily apply any configuration changes proposed by Autopilot.
+
+<Warning>
+
+We recommend enabling this feature only in a local setup.
+Do not enable this feature if the TensorZero UI is shared by multiple users.
+
+</Warning>
+
+To enable it, mount the configuration directory as a writable volume and pass the `--config-file` flag to the TensorZero UI container.
+For example:
+
+```yaml
+# ...
+ui:
+  image: tensorzero/ui
+  # ...
+  command: --config-file /app/config/tensorzero.toml
+  volumes:
+    - ./config:/app/config
+  # ...
+```
+
+</Step>
+
 <Step title="Use TensorZero Autopilot">
 
 Visit `/autopilot` in the self-hosted TensorZero UI to use Autopilot.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that adds guidance for an optional local deployment configuration; no runtime code changes.
> 
> **Overview**
> Adds a new optional deployment step documenting how to let TensorZero Autopilot write to the local TensorZero config, enabling an **“Apply changes”** button in the UI.
> 
> The docs include a safety warning (local-only; not for shared UIs) and a Docker Compose example showing mounting the config directory as a writable volume and passing `--config-file` to the UI container.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 532b65ad159044b23dc0cd259c6311ece9e85db5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->