### PR TITLE
Refactor optimizer crate to use Arc<dyn DelegatingDatabaseQueries>

### DIFF
--- a/internal/durable-tools/src/tensorzero_client/embedded.rs
+++ b/internal/durable-tools/src/tensorzero_client/embedded.rs
@@ -5,6 +5,7 @@
 
 use async_trait::async_trait;
 use autopilot_client::GatewayListEventsResponse;
+use std::sync::Arc;
 use tensorzero::{
     ClientInferenceParams, CreateDatapointRequest, CreateDatapointsFromInferenceRequestParams,
     CreateDatapointsResponse, DeleteDatapointsResponse, FeedbackParams, FeedbackResponse,
@@ -15,7 +16,9 @@ use tensorzero::{
 };
 use tensorzero_core::config::snapshot::{ConfigSnapshot, SnapshotHash};
 use tensorzero_core::db::ConfigQueries;
-use tensorzero_core::db::delegating_connection::DelegatingDatabaseConnection;
+use tensorzero_core::db::delegating_connection::{
+    DelegatingDatabaseConnection, DelegatingDatabaseQueries,
+};
 use tensorzero_core::db::feedback::FeedbackByVariant;
 use tensorzero_core::db::feedback::FeedbackQueries;
 use tensorzero_core::endpoints::datasets::v1::types::{
@@ -398,10 +401,12 @@ impl TensorZeroClient for EmbeddedClient {
         &self,
         params: tensorzero_optimizers::endpoints::LaunchOptimizationWorkflowParams,
     ) -> Result<super::OptimizationJobHandle, TensorZeroClientError> {
+        let db: Arc<dyn DelegatingDatabaseQueries + Send + Sync> =
+            Arc::new(self.app_state.get_delegating_database());
         tensorzero_optimizers::endpoints::launch_optimization_workflow(
             &self.app_state.http_client,
             self.app_state.config.clone(),
-            &self.app_state.clickhouse_connection_info,
+            &db,
             params,
         )
         .await

--- a/tensorzero-optimizers/src/dicl.rs
+++ b/tensorzero-optimizers/src/dicl.rs
@@ -8,9 +8,8 @@ use tensorzero_core::{
     cache::{CacheManager, CacheOptions},
     config::{Config, UninitializedVariantConfig, provider_types::ProviderTypesConfig},
     db::{
-        DICLQueries, StoredDICLExample,
-        clickhouse::{ClickHouseConnectionInfo, clickhouse_client::ClickHouseClientType},
-        postgres::PostgresConnectionInfo,
+        DICLQueries, StoredDICLExample, clickhouse::ClickHouseConnectionInfo,
+        delegating_connection::DelegatingDatabaseQueries, postgres::PostgresConnectionInfo,
     },
     embeddings::{Embedding, EmbeddingEncodingFormat, EmbeddingInput, EmbeddingRequest},
     endpoints::inference::{InferenceClients, InferenceCredentials},
@@ -39,7 +38,7 @@ impl Optimizer for DiclOptimizationConfig {
         train_examples: Vec<RenderedSample>,
         val_examples: Option<Vec<RenderedSample>>,
         credentials: &InferenceCredentials,
-        clickhouse_connection_info: &ClickHouseConnectionInfo,
+        db: &Arc<dyn DelegatingDatabaseQueries + Send + Sync>,
         config: Arc<Config>,
     ) -> Result<Self::Handle, Error> {
         // Warn if using deprecated default model
@@ -60,14 +59,6 @@ impl Optimizer for DiclOptimizationConfig {
             tracing::warn!("val_examples provided for DICL optimization but will be ignored");
         }
 
-        // Check if ClickHouse is available (required for DICL)
-        if clickhouse_connection_info.client_type() == ClickHouseClientType::Disabled {
-            return Err(Error::new(ErrorDetails::AppState {
-                message: "DICL optimization requires ClickHouse to be enabled to store examples"
-                    .to_string(),
-            }));
-        }
-
         // 1. Check that the function exists in the config
         let function_config = config.functions.get(&self.function_name).ok_or_else(|| {
             Error::new(ErrorDetails::Config {
@@ -83,7 +74,7 @@ impl Optimizer for DiclOptimizationConfig {
 
         // 3. Check if DICL examples already exist in the database for this variant (unless appending is enabled)
         if !self.append_to_existing_variants
-            && clickhouse_connection_info
+            && db
                 .has_dicl_examples(&self.function_name, &self.variant_name)
                 .await?
         {
@@ -141,7 +132,7 @@ impl Optimizer for DiclOptimizationConfig {
         tracing::info!("Phase transition: Embedding → ClickHouse storage");
 
         insert_dicl_examples_with_batching(
-            clickhouse_connection_info,
+            db.as_ref(),
             examples_with_embeddings,
             &self.function_name,
             &self.variant_name,
@@ -484,7 +475,7 @@ async fn process_embeddings_with_batching(
 
 /// Inserts DICL examples into the database via the DICLQueries trait.
 pub async fn insert_dicl_examples_with_batching(
-    db: &impl DICLQueries,
+    db: &(dyn DICLQueries + Sync),
     examples: Vec<(RenderedSample, Vec<f64>)>,
     function_name: &str,
     variant_name: &str,

--- a/tensorzero-optimizers/src/endpoints.rs
+++ b/tensorzero-optimizers/src/endpoints.rs
@@ -16,9 +16,9 @@ use rand::seq::SliceRandom;
 use tensorzero_core::{
     config::{Config, provider_types::ProviderTypesConfig},
     db::{
-        clickhouse::ClickHouseConnectionInfo,
         clickhouse::query_builder::{InferenceFilter, OrderBy},
-        inferences::{InferenceOutputSource, InferenceQueries, ListInferencesParams},
+        delegating_connection::DelegatingDatabaseQueries,
+        inferences::{InferenceOutputSource, ListInferencesParams},
     },
     endpoints::{inference::InferenceCredentials, stored_inferences::render_samples},
     error::{Error, ErrorDetails},
@@ -51,17 +51,13 @@ pub struct LaunchOptimizationWorkflowParams {
 }
 
 pub async fn launch_optimization_workflow_handler(
-    State(AppStateData {
-        config,
-        http_client,
-        clickhouse_connection_info,
-        ..
-    }): AppState,
+    State(app_state): AppState,
     StructuredJson(params): StructuredJson<LaunchOptimizationWorkflowParams>,
 ) -> Result<Response<Body>, Error> {
+    let db: Arc<dyn DelegatingDatabaseQueries + Send + Sync> =
+        Arc::new(app_state.get_delegating_database());
     let job_handle =
-        launch_optimization_workflow(&http_client, config, &clickhouse_connection_info, params)
-            .await?;
+        launch_optimization_workflow(&app_state.http_client, app_state.config, &db, params).await?;
     let encoded_job_handle = job_handle.to_base64_urlencoded()?;
     Ok(encoded_job_handle.into_response())
 }
@@ -74,7 +70,7 @@ pub async fn launch_optimization_workflow_handler(
 pub async fn launch_optimization_workflow(
     http_client: &TensorzeroHttpClient,
     config: Arc<Config>,
-    clickhouse_connection_info: &ClickHouseConnectionInfo,
+    db: &Arc<dyn DelegatingDatabaseQueries + Send + Sync>,
     params: LaunchOptimizationWorkflowParams,
 ) -> Result<OptimizationJobHandle, Error> {
     let LaunchOptimizationWorkflowParams {
@@ -90,7 +86,7 @@ pub async fn launch_optimization_workflow(
         optimizer_config,
     } = params;
     // Query the database for the stored inferences
-    let stored_inferences = clickhouse_connection_info
+    let stored_inferences = db
         .list_inferences(
             &config,
             &ListInferencesParams {
@@ -130,7 +126,7 @@ pub async fn launch_optimization_workflow(
             train_examples,
             val_examples,
             &InferenceCredentials::default(),
-            clickhouse_connection_info,
+            db,
             config.clone(),
         )
         .await
@@ -153,7 +149,7 @@ pub struct LaunchOptimizationParams {
 pub async fn launch_optimization(
     http_client: &TensorzeroHttpClient,
     params: LaunchOptimizationParams,
-    clickhouse_connection_info: &ClickHouseConnectionInfo,
+    db: Arc<dyn DelegatingDatabaseQueries + Send + Sync>,
     config: Arc<Config>,
     // For the TODO above: will need to pass config in here
 ) -> Result<OptimizationJobHandle, Error> {
@@ -169,7 +165,7 @@ pub async fn launch_optimization(
             train_examples,
             val_examples,
             &InferenceCredentials::default(),
-            clickhouse_connection_info,
+            &db,
             config.clone(),
         )
         .await

--- a/tensorzero-optimizers/src/fireworks_sft.rs
+++ b/tensorzero-optimizers/src/fireworks_sft.rs
@@ -30,7 +30,7 @@ use tensorzero_core::{
         Config, TimeoutsConfig,
         provider_types::{FireworksSFTConfig as FireworksProviderSFTConfig, ProviderTypesConfig},
     },
-    db::clickhouse::ClickHouseConnectionInfo,
+    db::delegating_connection::DelegatingDatabaseQueries,
     endpoints::inference::InferenceCredentials,
     error::{DisplayOrDebugGateway, Error, ErrorDetails, IMPOSSIBLE_ERROR_MESSAGE},
     http::TensorzeroHttpClient,
@@ -75,7 +75,7 @@ impl Optimizer for FireworksSFTConfig {
         train_examples: Vec<RenderedSample>,
         val_examples: Option<Vec<RenderedSample>>,
         credentials: &InferenceCredentials,
-        _clickhouse_connection_info: &ClickHouseConnectionInfo,
+        _db: &Arc<dyn DelegatingDatabaseQueries + Send + Sync>,
         config: Arc<Config>,
     ) -> Result<Self::Handle, Error> {
         // Get provider-level configuration

--- a/tensorzero-optimizers/src/gcp_vertex_gemini_sft.rs
+++ b/tensorzero-optimizers/src/gcp_vertex_gemini_sft.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 use tensorzero_core::{
     config::{Config, provider_types::GCPSFTConfig, provider_types::ProviderTypesConfig},
-    db::clickhouse::ClickHouseConnectionInfo,
+    db::delegating_connection::DelegatingDatabaseQueries,
     endpoints::inference::InferenceCredentials,
     error::{DisplayOrDebugGateway, Error, ErrorDetails},
     http::TensorzeroHttpClient,
@@ -59,7 +59,7 @@ impl Optimizer for GCPVertexGeminiSFTConfig {
         train_examples: Vec<RenderedSample>,
         val_examples: Option<Vec<RenderedSample>>,
         credentials: &InferenceCredentials,
-        _clickhouse_connection_info: &ClickHouseConnectionInfo,
+        _db: &Arc<dyn DelegatingDatabaseQueries + Send + Sync>,
         config: Arc<Config>,
     ) -> Result<Self::Handle, Error> {
         // Get provider-level config

--- a/tensorzero-optimizers/src/gepa/evaluate.rs
+++ b/tensorzero-optimizers/src/gepa/evaluate.rs
@@ -7,7 +7,6 @@ use tensorzero_core::{
     cache::CacheEnabledMode,
     client::Client,
     config::{Config, UninitializedVariantConfig, UninitializedVariantInfo},
-    db::clickhouse::ClickHouseConnectionInfo,
     db::delegating_connection::DelegatingDatabaseQueries,
     endpoints::datasets::v1::{
         create_datapoints,
@@ -52,7 +51,7 @@ pub type VariantScores = HashMap<DatapointId, DatapointScores>;
 /// # Arguments
 /// * `config` - The TensorZero configuration
 /// * `http_client` - The HTTP client for fetching resources
-/// * `clickhouse_connection_info` - The ClickHouse connection info
+/// * `db` - The database connection for dataset storage
 /// * `samples` - The rendered samples to convert into datapoints
 /// * `dataset_name` - The name of the dataset to create
 ///
@@ -61,7 +60,7 @@ pub type VariantScores = HashMap<DatapointId, DatapointScores>;
 pub async fn create_evaluation_dataset(
     config: &Config,
     http_client: &TensorzeroHttpClient,
-    clickhouse_connection_info: &ClickHouseConnectionInfo,
+    db: &(dyn DelegatingDatabaseQueries + Sync),
     samples: Vec<RenderedSample>,
     dataset_name: &str,
 ) -> Result<CreateDatapointsResponse, Error> {
@@ -76,14 +75,7 @@ pub async fn create_evaluation_dataset(
     };
 
     // Call the datasets v1 create_datapoints function
-    let response = create_datapoints(
-        config,
-        http_client,
-        clickhouse_connection_info,
-        dataset_name,
-        request,
-    )
-    .await?;
+    let response = create_datapoints(config, http_client, db, dataset_name, request).await?;
 
     Ok(response)
 }
@@ -150,7 +142,7 @@ impl EvaluationResults {
 /// Parameters for evaluating a single variant
 pub struct EvaluateVariantParams {
     pub gateway_client: Client,
-    pub clickhouse_connection_info: ClickHouseConnectionInfo,
+    pub db: Arc<dyn DelegatingDatabaseQueries + Send + Sync>,
     pub functions: HashMap<String, Arc<FunctionConfig>>,
     pub evaluation_config: Arc<EvaluationConfig>,
     pub evaluation_name: String,
@@ -193,11 +185,9 @@ pub async fn evaluate_variant(params: EvaluateVariantParams) -> Result<Evaluatio
     let inference_executor = Arc::new(ClientInferenceExecutor::new(params.gateway_client));
 
     // Create EvaluationCoreArgs
-    let db: Arc<dyn DelegatingDatabaseQueries + Send + Sync> =
-        Arc::new(params.clickhouse_connection_info.clone());
     let core_args = EvaluationCoreArgs {
         inference_executor,
-        db,
+        db: params.db,
         evaluation_config: params.evaluation_config.clone(),
         function_configs,
         evaluation_name: params.evaluation_name,

--- a/tensorzero-optimizers/src/gepa/mod.rs
+++ b/tensorzero-optimizers/src/gepa/mod.rs
@@ -9,8 +9,8 @@ use tensorzero_core::{
     client::{ClientBuilder, ClientBuilderMode},
     config::{Config, UninitializedVariantConfig, provider_types::ProviderTypesConfig},
     db::{
-        clickhouse::ClickHouseConnectionInfo, postgres::PostgresConnectionInfo,
-        valkey::ValkeyConnectionInfo,
+        clickhouse::ClickHouseConnectionInfo, delegating_connection::DelegatingDatabaseQueries,
+        postgres::PostgresConnectionInfo, valkey::ValkeyConnectionInfo,
     },
     endpoints::{datasets::v1::delete_dataset, inference::InferenceCredentials},
     error::{Error, ErrorDetails},
@@ -57,7 +57,7 @@ impl Optimizer for GEPAConfig {
         train_examples: Vec<RenderedSample>,
         val_examples: Option<Vec<RenderedSample>>,
         _credentials: &InferenceCredentials,
-        clickhouse_connection_info: &ClickHouseConnectionInfo,
+        db: &Arc<dyn DelegatingDatabaseQueries + Send + Sync>,
         config: std::sync::Arc<Config>,
     ) -> Result<Self::Handle, Error> {
         // Validate configuration and examples, get the FunctionContext (function_config, static_tools, and evaluation_config)
@@ -82,10 +82,23 @@ impl Optimizer for GEPAConfig {
             val_examples.len()
         );
 
-        // Build the gateway client once for the entire optimization run
+        // Build the gateway client once for the entire optimization run.
+        // The gateway client needs its own ClickHouseConnectionInfo for observability writes.
+        // Read TENSORZERO_CLICKHOUSE_URL from env, consistent with gateway startup
+        // (see tensorzero-core/src/utils/gateway.rs).
+        let gateway_clickhouse = match std::env::var("TENSORZERO_CLICKHOUSE_URL") {
+            Ok(url) => {
+                ClickHouseConnectionInfo::new(
+                    &url,
+                    config.gateway.observability.batch_writes.clone(),
+                )
+                .await?
+            }
+            Err(_) => ClickHouseConnectionInfo::new_disabled(),
+        };
         let gateway_client = ClientBuilder::new(ClientBuilderMode::FromComponents {
             config: config.clone(),
-            clickhouse_connection_info: clickhouse_connection_info.clone(),
+            clickhouse_connection_info: gateway_clickhouse,
             postgres_connection_info: PostgresConnectionInfo::Disabled,
             valkey_connection_info: ValkeyConnectionInfo::Disabled,
             valkey_cache_connection_info: ValkeyConnectionInfo::Disabled,
@@ -132,7 +145,7 @@ impl Optimizer for GEPAConfig {
         let val_create_datapoints_response = create_evaluation_dataset(
             &config,
             client,
-            clickhouse_connection_info,
+            db.as_ref(),
             val_examples,
             &val_dataset_name,
         )
@@ -165,7 +178,7 @@ impl Optimizer for GEPAConfig {
             .iter()
             .map(|(variant_name, variant_config)| {
                 let gateway_client = gateway_client.clone();
-                let clickhouse_connection_info = clickhouse_connection_info.clone();
+                let db = Arc::clone(db);
                 let functions = config.functions.clone();
                 let evaluation_config_param = Arc::clone(&function_context.evaluation_config);
                 let evaluation_name = evaluation_name.clone();
@@ -176,7 +189,7 @@ impl Optimizer for GEPAConfig {
                 async move {
                     match evaluate_variant(EvaluateVariantParams {
                         gateway_client,
-                        clickhouse_connection_info,
+                        db,
                         functions,
                         evaluation_config: evaluation_config_param,
                         evaluation_name,
@@ -315,7 +328,7 @@ impl Optimizer for GEPAConfig {
             let _mutation_create_datapoints_response = create_evaluation_dataset(
                 &config,
                 client,
-                clickhouse_connection_info,
+                db.as_ref(),
                 mutation_examples,
                 &mutation_dataset_name,
             )
@@ -331,7 +344,7 @@ impl Optimizer for GEPAConfig {
             // to the next iteration rather than stopping the entire optimization.
             let parent_evaluation_results = match evaluate_variant(EvaluateVariantParams {
                 gateway_client: gateway_client.clone(),
-                clickhouse_connection_info: clickhouse_connection_info.clone(),
+                db: Arc::clone(db),
                 functions: config.functions.clone(),
                 evaluation_config: Arc::clone(&function_context.evaluation_config),
                 evaluation_name: self.evaluation_name.clone(),
@@ -434,7 +447,7 @@ impl Optimizer for GEPAConfig {
             // evaluation fails, consistent with parent evaluation error handling.
             let child_evaluation_results = match evaluate_variant(EvaluateVariantParams {
                 gateway_client: gateway_client.clone(),
-                clickhouse_connection_info: clickhouse_connection_info.clone(),
+                db: Arc::clone(db),
                 functions: config.functions.clone(),
                 evaluation_config: Arc::clone(&function_context.evaluation_config),
                 evaluation_name: self.evaluation_name.clone(),
@@ -486,7 +499,7 @@ impl Optimizer for GEPAConfig {
 
                 match evaluate_variant(EvaluateVariantParams {
                     gateway_client: gateway_client.clone(),
-                    clickhouse_connection_info: clickhouse_connection_info.clone(),
+                    db: Arc::clone(db),
                     functions: config.functions.clone(),
                     evaluation_config: Arc::clone(&function_context.evaluation_config),
                     evaluation_name: self.evaluation_name.clone(),
@@ -568,7 +581,7 @@ impl Optimizer for GEPAConfig {
 
         // Clean up temporary datasets
         for dataset_name in &temporary_datasets {
-            if let Err(err) = delete_dataset(clickhouse_connection_info, dataset_name).await {
+            if let Err(err) = delete_dataset(db.as_ref(), dataset_name).await {
                 tracing::warn!(
                     "Failed to delete temporary GEPA dataset '{}': {}",
                     dataset_name,

--- a/tensorzero-optimizers/src/lib.rs
+++ b/tensorzero-optimizers/src/lib.rs
@@ -12,7 +12,7 @@ use std::future::Future;
 use std::sync::Arc;
 use tensorzero_core::{
     config::{Config, provider_types::ProviderTypesConfig},
-    db::clickhouse::ClickHouseConnectionInfo,
+    db::delegating_connection::DelegatingDatabaseQueries,
     endpoints::inference::InferenceCredentials,
     error::Error,
     http::TensorzeroHttpClient,
@@ -102,7 +102,7 @@ pub trait Optimizer {
         train_examples: Vec<RenderedSample>,
         val_examples: Option<Vec<RenderedSample>>,
         credentials: &InferenceCredentials,
-        clickhouse_connection_info: &ClickHouseConnectionInfo,
+        db: &Arc<dyn DelegatingDatabaseQueries + Send + Sync>,
         config: Arc<Config>,
     ) -> impl Future<Output = Result<Self::Handle, Error>> + Send;
 }
@@ -116,7 +116,7 @@ impl Optimizer for OptimizerInfo {
         train_examples: Vec<RenderedSample>,
         val_examples: Option<Vec<RenderedSample>>,
         credentials: &InferenceCredentials,
-        clickhouse_connection_info: &ClickHouseConnectionInfo,
+        db: &Arc<dyn DelegatingDatabaseQueries + Send + Sync>,
         config: Arc<Config>,
     ) -> Result<Self::Handle, Error> {
         match &self.inner {
@@ -126,7 +126,7 @@ impl Optimizer for OptimizerInfo {
                     train_examples,
                     val_examples,
                     credentials,
-                    clickhouse_connection_info,
+                    db,
                     config.clone(),
                 )
                 .await
@@ -137,7 +137,7 @@ impl Optimizer for OptimizerInfo {
                     train_examples,
                     val_examples,
                     credentials,
-                    clickhouse_connection_info,
+                    db,
                     config.clone(),
                 )
                 .await
@@ -148,7 +148,7 @@ impl Optimizer for OptimizerInfo {
                     train_examples,
                     val_examples,
                     credentials,
-                    clickhouse_connection_info,
+                    db,
                     config.clone(),
                 )
                 .await
@@ -159,7 +159,7 @@ impl Optimizer for OptimizerInfo {
                     train_examples,
                     val_examples,
                     credentials,
-                    clickhouse_connection_info,
+                    db,
                     config.clone(),
                 )
                 .await
@@ -170,7 +170,7 @@ impl Optimizer for OptimizerInfo {
                     train_examples,
                     val_examples,
                     credentials,
-                    clickhouse_connection_info,
+                    db,
                     config.clone(),
                 )
                 .await
@@ -181,7 +181,7 @@ impl Optimizer for OptimizerInfo {
                     train_examples,
                     val_examples,
                     credentials,
-                    clickhouse_connection_info,
+                    db,
                     config.clone(),
                 )
                 .await
@@ -192,7 +192,7 @@ impl Optimizer for OptimizerInfo {
                     train_examples,
                     val_examples,
                     credentials,
-                    clickhouse_connection_info,
+                    db,
                     config.clone(),
                 )
                 .await

--- a/tensorzero-optimizers/src/openai_rft.rs
+++ b/tensorzero-optimizers/src/openai_rft.rs
@@ -8,7 +8,7 @@ use url::Url;
 
 use tensorzero_core::{
     config::{Config, provider_types::ProviderTypesConfig},
-    db::clickhouse::ClickHouseConnectionInfo,
+    db::delegating_connection::DelegatingDatabaseQueries,
     endpoints::inference::InferenceCredentials,
     error::{DisplayOrDebugGateway, Error, ErrorDetails, IMPOSSIBLE_ERROR_MESSAGE},
     http::TensorzeroHttpClient,
@@ -43,7 +43,7 @@ impl Optimizer for OpenAIRFTConfig {
         train_examples: Vec<RenderedSample>,
         val_examples: Option<Vec<RenderedSample>>,
         credentials: &InferenceCredentials,
-        _clickhouse_connection_info: &ClickHouseConnectionInfo,
+        _db: &Arc<dyn DelegatingDatabaseQueries + Send + Sync>,
         config: Arc<Config>,
     ) -> Result<Self::Handle, Error> {
         // Get credentials from provider defaults

--- a/tensorzero-optimizers/src/openai_sft.rs
+++ b/tensorzero-optimizers/src/openai_sft.rs
@@ -8,7 +8,7 @@ use url::Url;
 
 use tensorzero_core::{
     config::{Config, provider_types::ProviderTypesConfig},
-    db::clickhouse::ClickHouseConnectionInfo,
+    db::delegating_connection::DelegatingDatabaseQueries,
     endpoints::inference::InferenceCredentials,
     error::{DisplayOrDebugGateway, Error, ErrorDetails, IMPOSSIBLE_ERROR_MESSAGE},
     http::TensorzeroHttpClient,
@@ -42,7 +42,7 @@ impl Optimizer for OpenAISFTConfig {
         train_examples: Vec<RenderedSample>,
         val_examples: Option<Vec<RenderedSample>>,
         credentials: &InferenceCredentials,
-        _clickhouse_connection_info: &ClickHouseConnectionInfo,
+        _db: &Arc<dyn DelegatingDatabaseQueries + Send + Sync>,
         config: Arc<Config>,
     ) -> Result<Self::Handle, Error> {
         // Get credentials from provider defaults

--- a/tensorzero-optimizers/src/together_sft.rs
+++ b/tensorzero-optimizers/src/together_sft.rs
@@ -15,7 +15,7 @@ use tensorzero_core::{
         Config, TimeoutsConfig,
         provider_types::{ProviderTypesConfig, TogetherSFTConfig as TogetherProviderSFTConfig},
     },
-    db::clickhouse::ClickHouseConnectionInfo,
+    db::delegating_connection::DelegatingDatabaseQueries,
     endpoints::inference::InferenceCredentials,
     error::{DisplayOrDebugGateway, Error, ErrorDetails, IMPOSSIBLE_ERROR_MESSAGE},
     http::TensorzeroHttpClient,
@@ -136,7 +136,7 @@ impl Optimizer for TogetherSFTConfig {
         train_examples: Vec<RenderedSample>,
         val_examples: Option<Vec<RenderedSample>>,
         credentials: &InferenceCredentials,
-        _clickhouse_connection_info: &ClickHouseConnectionInfo,
+        _db: &Arc<dyn DelegatingDatabaseQueries + Send + Sync>,
         config: Arc<Config>,
     ) -> Result<Self::Handle, Error> {
         // Get optional provider-level configuration

--- a/tensorzero-optimizers/tests/common/dicl.rs
+++ b/tensorzero-optimizers/tests/common/dicl.rs
@@ -18,6 +18,7 @@ use tensorzero_core::{
         CLICKHOUSE_URL, get_clickhouse, select_chat_inference_clickhouse,
         select_json_inference_clickhouse, select_model_inferences_clickhouse,
     },
+    db::delegating_connection::DelegatingDatabaseQueries,
     http::TensorzeroHttpClient,
     inference::types::{
         Arguments, ContentBlockChatOutput, ContentBlockChunk, FunctionType, JsonInferenceOutput,
@@ -117,13 +118,14 @@ pub async fn test_dicl_optimization_chat() {
         .into_config_without_writing_for_tests(),
     );
 
+    let db: Arc<dyn DelegatingDatabaseQueries + Send + Sync> = Arc::new(clickhouse);
     let job_handle = optimizer_info
         .launch(
             &client,
             test_examples,
             val_examples,
             &credentials,
-            &clickhouse,
+            &db,
             config.clone(),
         )
         .await
@@ -403,13 +405,14 @@ pub async fn test_dicl_optimization_json() {
         .into_config_without_writing_for_tests(),
     );
 
+    let db: Arc<dyn DelegatingDatabaseQueries + Send + Sync> = Arc::new(clickhouse);
     let job_handle = optimizer_info
         .launch(
             &client,
             test_examples,
             val_examples,
             &credentials,
-            &clickhouse,
+            &db,
             config.clone(),
         )
         .await

--- a/tensorzero-optimizers/tests/common/gepa.rs
+++ b/tensorzero-optimizers/tests/common/gepa.rs
@@ -6,6 +6,7 @@ use tensorzero::{RenderedSample, Role, System};
 use tensorzero_core::{
     config::{Config, ConfigFileGlob},
     db::clickhouse::test_helpers::get_clickhouse,
+    db::delegating_connection::DelegatingDatabaseQueries,
     http::TensorzeroHttpClient,
     inference::types::{
         Arguments, ContentBlockChatOutput, FunctionType, JsonInferenceOutput, ModelInput,
@@ -69,13 +70,14 @@ pub async fn test_gepa_optimization_chat() {
     );
 
     // Launch GEPA optimization
+    let db: Arc<dyn DelegatingDatabaseQueries + Send + Sync> = Arc::new(clickhouse);
     let job_handle = gepa_config
         .launch(
             &client,
             train_examples,
             val_examples,
             &credentials,
-            &clickhouse,
+            &db,
             config.clone(),
         )
         .await
@@ -205,13 +207,14 @@ pub async fn test_gepa_optimization_json() {
     );
 
     // Launch GEPA optimization
+    let db: Arc<dyn DelegatingDatabaseQueries + Send + Sync> = Arc::new(clickhouse);
     let job_handle = gepa_config
         .launch(
             &client,
             train_examples,
             val_examples,
             &credentials,
-            &clickhouse,
+            &db,
             config.clone(),
         )
         .await

--- a/tensorzero-optimizers/tests/common/mod.rs
+++ b/tensorzero-optimizers/tests/common/mod.rs
@@ -15,6 +15,7 @@ use tensorzero_core::{
     config::{Config, ConfigFileGlob, provider_types::ProviderTypesConfig},
     db::{
         clickhouse::{ClickHouseConnectionInfo, test_helpers::CLICKHOUSE_URL},
+        delegating_connection::DelegatingDatabaseQueries,
         postgres::PostgresConnectionInfo,
     },
     endpoints::inference::InferenceClients,
@@ -109,13 +110,14 @@ pub async fn run_test_case(test_case: &impl OptimizationTestCase) {
         .unwrap()
         .into_config_without_writing_for_tests(),
     );
+    let db: Arc<dyn DelegatingDatabaseQueries + Send + Sync> = Arc::new(clickhouse);
     let job_handle = optimizer_info
         .launch(
             &client,
             test_examples,
             val_examples,
             &credentials,
-            &clickhouse,
+            &db,
             config.clone(),
         )
         .await

--- a/tensorzero-optimizers/tests/e2e/gepa/evaluate.rs
+++ b/tensorzero-optimizers/tests/e2e/gepa/evaluate.rs
@@ -55,7 +55,7 @@ async fn test_evaluate_variant_chat() {
     // Evaluate variant
     let evaluation_params = EvaluateVariantParams {
         gateway_client,
-        clickhouse_connection_info: clickhouse.clone(),
+        db: Arc::new(clickhouse.clone()),
         functions: config.functions.clone(),
         evaluation_config: Arc::clone(&function_context.evaluation_config),
         evaluation_name: gepa_config.evaluation_name.clone(),
@@ -127,7 +127,7 @@ async fn test_evaluate_variant_json() {
     // Evaluate variant
     let evaluation_params = EvaluateVariantParams {
         gateway_client,
-        clickhouse_connection_info: clickhouse.clone(),
+        db: Arc::new(clickhouse.clone()),
         functions: config.functions.clone(),
         evaluation_config: Arc::clone(&function_context.evaluation_config),
         evaluation_name: gepa_config.evaluation_name.clone(),
@@ -200,7 +200,7 @@ async fn test_evaluate_variant_per_datapoint_scores() {
     // Evaluate variant
     let evaluation_params = EvaluateVariantParams {
         gateway_client,
-        clickhouse_connection_info: clickhouse.clone(),
+        db: Arc::new(clickhouse.clone()),
         functions: config.functions.clone(),
         evaluation_config: Arc::clone(&function_context.evaluation_config),
         evaluation_name: gepa_config.evaluation_name.clone(),

--- a/tensorzero-optimizers/tests/e2e/gepa/mutate.rs
+++ b/tensorzero-optimizers/tests/e2e/gepa/mutate.rs
@@ -56,7 +56,7 @@ async fn test_mutate_variant_chat() {
     // Evaluate parent
     let evaluation_params = EvaluateVariantParams {
         gateway_client: gateway_client.clone(),
-        clickhouse_connection_info: clickhouse.clone(),
+        db: Arc::new(clickhouse.clone()),
         functions: config.functions.clone(),
         evaluation_config: Arc::clone(&function_context.evaluation_config),
         evaluation_name: gepa_config.evaluation_name.clone(),
@@ -191,7 +191,7 @@ async fn test_mutate_variant_json() {
     // Evaluate parent
     let evaluation_params = EvaluateVariantParams {
         gateway_client: gateway_client.clone(),
-        clickhouse_connection_info: clickhouse.clone(),
+        db: Arc::new(clickhouse.clone()),
         functions: config.functions.clone(),
         evaluation_config: Arc::clone(&function_context.evaluation_config),
         evaluation_name: gepa_config.evaluation_name.clone(),
@@ -300,7 +300,7 @@ async fn test_mutate_variant_preserves_variables() {
     // Evaluate and analyze
     let evaluation_params = EvaluateVariantParams {
         gateway_client: gateway_client.clone(),
-        clickhouse_connection_info: clickhouse.clone(),
+        db: Arc::new(clickhouse.clone()),
         functions: config.functions.clone(),
         evaluation_config: Arc::clone(&function_context.evaluation_config),
         evaluation_name: gepa_config.evaluation_name.clone(),
@@ -397,7 +397,7 @@ async fn test_mutate_variant_preserves_schema_references() {
     // Evaluate and analyze
     let evaluation_params = EvaluateVariantParams {
         gateway_client: gateway_client.clone(),
-        clickhouse_connection_info: clickhouse.clone(),
+        db: Arc::new(clickhouse.clone()),
         functions: config.functions.clone(),
         evaluation_config: Arc::clone(&function_context.evaluation_config),
         evaluation_name: gepa_config.evaluation_name.clone(),
@@ -512,7 +512,7 @@ async fn test_mutate_variant_naming() {
     // Evaluate and analyze
     let evaluation_params = EvaluateVariantParams {
         gateway_client: gateway_client.clone(),
-        clickhouse_connection_info: clickhouse.clone(),
+        db: Arc::new(clickhouse.clone()),
         functions: config.functions.clone(),
         evaluation_config: Arc::clone(&function_context.evaluation_config),
         evaluation_name: gepa_config.evaluation_name.clone(),

--- a/tensorzero-optimizers/tests/e2e/gepa/pareto.rs
+++ b/tensorzero-optimizers/tests/e2e/gepa/pareto.rs
@@ -105,7 +105,7 @@ async fn test_pareto_frontier_update_with_initial_variants() {
     for (variant_name, variant_config) in &initial_variants {
         let evaluation_params = EvaluateVariantParams {
             gateway_client: gateway_client.clone(),
-            clickhouse_connection_info: clickhouse.clone(),
+            db: Arc::new(clickhouse.clone()),
             functions: config.functions.clone(),
             evaluation_config: Arc::clone(&function_context.evaluation_config),
             evaluation_name: gepa_config.evaluation_name.clone(),
@@ -223,7 +223,7 @@ async fn test_pareto_frontier_sample_by_frequency() {
     for (variant_name, variant_config) in &initial_variants {
         let evaluation_params = EvaluateVariantParams {
             gateway_client: gateway_client.clone(),
-            clickhouse_connection_info: clickhouse.clone(),
+            db: Arc::new(clickhouse.clone()),
             functions: config.functions.clone(),
             evaluation_config: Arc::clone(&function_context.evaluation_config),
             evaluation_name: gepa_config.evaluation_name.clone(),
@@ -338,7 +338,7 @@ async fn test_pareto_frontier_maintains_valid_state() {
     for (variant_name, variant_config) in &initial_variants {
         let evaluation_params = EvaluateVariantParams {
             gateway_client: gateway_client.clone(),
-            clickhouse_connection_info: clickhouse.clone(),
+            db: Arc::new(clickhouse.clone()),
             functions: config.functions.clone(),
             evaluation_config: Arc::clone(&function_context.evaluation_config),
             evaluation_name: gepa_config.evaluation_name.clone(),


### PR DESCRIPTION
Refactored optimizer code to use the `DelegatingDatabaseQueries` trait instead of directly depending on `ClickHouseConnectionInfo`.