### PR TITLE
Implement Encode and Decode on SnapshotHash

### DIFF
--- a/tensorzero-core/src/db/postgres/config_queries.rs
+++ b/tensorzero-core/src/db/postgres/config_queries.rs
@@ -22,7 +22,7 @@ impl ConfigQueries for PostgresConnectionInfo {
                WHERE hash = $1
                LIMIT 1",
         )
-        .bind(snapshot_hash.as_bytes())
+        .bind(&snapshot_hash)
         .fetch_optional(pool)
         .await?;
 

--- a/tensorzero-core/src/db/postgres/dataset_queries.rs
+++ b/tensorzero-core/src/db/postgres/dataset_queries.rs
@@ -633,7 +633,6 @@ async fn insert_chat_datapoints(
     qb.push_values(
         datapoints.iter().zip(&timestamps),
         |mut b, (dp, (staled_at, created_at))| {
-            let snapshot_hash_bytes = dp.snapshot_hash.as_ref().map(|h| h.as_bytes());
             let tool_params_ref = dp.tool_params.as_ref();
 
             b.push_bind(dp.id)
@@ -659,7 +658,7 @@ async fn insert_chat_datapoints(
                 .push_bind(dp.is_custom)
                 .push_bind(dp.source_inference_id)
                 .push_bind(&dp.name)
-                .push_bind(snapshot_hash_bytes)
+                .push_bind(dp.snapshot_hash.as_ref())
                 .push_bind(*staled_at)
                 .push_bind(*created_at);
         },
@@ -733,8 +732,6 @@ async fn insert_json_datapoints(
     qb.push_values(
         datapoints.iter().zip(&timestamps),
         |mut b, (dp, (staled_at, created_at))| {
-            let snapshot_hash_bytes = dp.snapshot_hash.as_ref().map(|h| h.as_bytes());
-
             b.push_bind(dp.id)
                 .push_bind(&dp.dataset_name)
                 .push_bind(&dp.function_name)
@@ -746,7 +743,7 @@ async fn insert_json_datapoints(
                 .push_bind(dp.is_custom)
                 .push_bind(dp.source_inference_id)
                 .push_bind(&dp.name)
-                .push_bind(snapshot_hash_bytes)
+                .push_bind(dp.snapshot_hash.as_ref())
                 .push_bind(*staled_at)
                 .push_bind(*created_at);
         },
@@ -793,7 +790,7 @@ impl<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow> for StoredChatInferenceDatapoi
         let tool_choice: Option<Json<ToolChoice>> = row.try_get("tool_choice")?;
         let parallel_tool_calls: Option<bool> = row.try_get("parallel_tool_calls")?;
         let tags: Json<HashMap<String, String>> = row.try_get("tags")?;
-        let snapshot_hash_bytes: Option<Vec<u8>> = row.try_get("snapshot_hash")?;
+        let snapshot_hash: Option<SnapshotHash> = row.try_get("snapshot_hash")?;
         let staled_at: Option<DateTime<Utc>> = row.try_get("staled_at")?;
         let updated_at: DateTime<Utc> = row.try_get("updated_at")?;
 
@@ -804,8 +801,6 @@ impl<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow> for StoredChatInferenceDatapoi
             tool_choice.map(|v| v.0),
             parallel_tool_calls,
         );
-
-        let snapshot_hash = snapshot_hash_bytes.map(|b| SnapshotHash::from_bytes(&b));
         let tags = tags.0;
 
         Ok(StoredChatInferenceDatapoint {
@@ -838,11 +833,9 @@ impl<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow> for StoredJsonInferenceDatapoi
         let output: Option<Json<JsonInferenceOutput>> = row.try_get("output")?;
         let output_schema: serde_json::Value = row.try_get("output_schema")?;
         let tags: Json<HashMap<String, String>> = row.try_get("tags")?;
-        let snapshot_hash_bytes: Option<Vec<u8>> = row.try_get("snapshot_hash")?;
+        let snapshot_hash: Option<SnapshotHash> = row.try_get("snapshot_hash")?;
         let staled_at: Option<DateTime<Utc>> = row.try_get("staled_at")?;
         let updated_at: DateTime<Utc> = row.try_get("updated_at")?;
-
-        let snapshot_hash = snapshot_hash_bytes.map(|b| SnapshotHash::from_bytes(&b));
         let tags = tags.0;
 
         Ok(StoredJsonInferenceDatapoint {

--- a/tensorzero-core/src/db/postgres/workflow_evaluation_queries.rs
+++ b/tensorzero-core/src/db/postgres/workflow_evaluation_queries.rs
@@ -249,7 +249,7 @@ impl WorkflowEvaluationQueries for PostgresConnectionInfo {
             &tags_json,
             project_name,
             run_display_name,
-            snapshot_hash.as_bytes(),
+            snapshot_hash,
             created_at,
         );
 
@@ -284,7 +284,7 @@ impl WorkflowEvaluationQueries for PostgresConnectionInfo {
             run_id,
             task_name,
             &tags_json,
-            snapshot_hash.as_bytes(),
+            snapshot_hash,
             created_at,
         );
 
@@ -746,7 +746,7 @@ fn build_insert_workflow_evaluation_run_query(
     tags_json: &serde_json::Value,
     project_name: Option<&str>,
     run_display_name: Option<&str>,
-    snapshot_hash_bytes: &[u8],
+    snapshot_hash: &SnapshotHash,
     created_at: DateTime<Utc>,
 ) -> QueryBuilder<sqlx::Postgres> {
     let mut qb = QueryBuilder::new(
@@ -765,7 +765,7 @@ fn build_insert_workflow_evaluation_run_query(
     qb.push(", ");
     qb.push_bind(run_display_name.map(|s| s.to_string()));
     qb.push(", ");
-    qb.push_bind(snapshot_hash_bytes.to_vec());
+    qb.push_bind(snapshot_hash);
     qb.push(", ");
     qb.push_bind(created_at);
     qb.push(")");
@@ -779,7 +779,7 @@ fn build_insert_workflow_evaluation_run_episode_query(
     run_id: Uuid,
     task_name: Option<&str>,
     tags_json: &serde_json::Value,
-    snapshot_hash_bytes: &[u8],
+    snapshot_hash: &SnapshotHash,
     created_at: DateTime<Utc>,
 ) -> QueryBuilder<sqlx::Postgres> {
     let mut qb = QueryBuilder::new(
@@ -801,7 +801,7 @@ fn build_insert_workflow_evaluation_run_episode_query(
     qb.push(", r.tags || ");
     qb.push_bind(tags_json.clone());
     qb.push(", ");
-    qb.push_bind(snapshot_hash_bytes.to_vec());
+    qb.push_bind(snapshot_hash);
     qb.push(", ");
     qb.push_bind(created_at);
     qb.push(
@@ -1299,7 +1299,7 @@ mod tests {
         let run_id = Uuid::now_v7();
         let variant_pins_json = serde_json::json!({});
         let tags_json = serde_json::json!({});
-        let snapshot_hash_bytes = vec![0u8; 32];
+        let snapshot_hash = SnapshotHash::from_bytes(&[0u8; 32]);
         let created_at = Utc::now();
 
         let qb = build_insert_workflow_evaluation_run_query(
@@ -1308,7 +1308,7 @@ mod tests {
             &tags_json,
             Some("my_project"),
             Some("my_run"),
-            &snapshot_hash_bytes,
+            &snapshot_hash,
             created_at,
         );
         let sql = qb.sql();
@@ -1329,7 +1329,7 @@ mod tests {
         let episode_id = Uuid::now_v7();
         let run_id = Uuid::now_v7();
         let tags_json = serde_json::json!({});
-        let snapshot_hash_bytes = vec![0u8; 32];
+        let snapshot_hash = SnapshotHash::from_bytes(&[0u8; 32]);
         let created_at = Utc::now();
 
         let qb = build_insert_workflow_evaluation_run_episode_query(
@@ -1337,7 +1337,7 @@ mod tests {
             run_id,
             Some("my_task"),
             &tags_json,
-            &snapshot_hash_bytes,
+            &snapshot_hash,
             created_at,
         );
         let sql = qb.sql();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches many Postgres read/write paths by changing how `snapshot_hash` is encoded/decoded; a mismatch with the actual column type or null-handling could surface at runtime despite being a mostly mechanical refactor.
> 
> **Overview**
> `SnapshotHash` now implements `sqlx::Type`, `Encode`, and `Decode` for Postgres `BYTEA`, allowing it to be used directly in `push_bind`/`.bind()` and `FromRow`.
> 
> Postgres query code is updated across batch inference, inference/model inference inserts, dataset datapoint inserts/reads, config snapshot fetch, and workflow evaluation inserts/tests to remove ad-hoc `as_bytes()`/`from_bytes()` conversions and read/write `Option<SnapshotHash>` directly (with string conversion only at the final metadata boundary).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63d4358591c207b01aa527fcded376a250f6f00d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->