### PR TITLE
Skip even more jobs for dependabot PR ci

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1017,7 +1017,7 @@ jobs:
       id-token: write
     needs: [build-gateway-container, build-mock-provider-api-container]
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'merge_group' || (github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ github.event_name == 'merge_group' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
     strategy:
       fail-fast: false
       matrix:
@@ -1299,6 +1299,7 @@ jobs:
       DOCKERHUB_LIMITED_TOKEN: ${{ secrets.DOCKERHUB_LIMITED_TOKEN }}
 
   ui-tests:
+    if: ${{ !(github.event_name == 'pull_request' && github.actor == 'dependabot[bot]') }}
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
This leaves the merge queue unchanged (since we always have credentials there)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only conditional changes; main risk is reduced test coverage on Dependabot PRs and unintended job skipping if actor conditions are mis-specified.
> 
> **Overview**
> Further reduces PR CI load for Dependabot by skipping additional jobs.
> 
> `endpoint-tests` now only runs for merge queue or same-repo PRs *excluding* `dependabot[bot]`, and `ui-tests` gains an explicit `if` guard to skip on Dependabot pull requests (merge queue behavior unchanged).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a221c119b076836996be2385c0a30f8ce1f678b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->