### PR TITLE
Docs: `tensorzero_extra_content`

### DIFF
--- a/docs/gateway/api-reference/inference-openai-compatible.mdx
+++ b/docs/gateway/api-reference/inference-openai-compatible.mdx
@@ -512,6 +512,11 @@ Each message is an object with the following fields:
   - `function`: An object containing:
     - `name`: The name of the function to call
     - `arguments`: A JSON string containing the function arguments
+- `tensorzero_extra_content` (optional for `assistant` messages, otherwise disallowed): An array of extra content blocks to include in the message. This is used to round-trip non-text content blocks (such as thoughts from reasoning models) that were returned in a previous response. See [`tensorzero_extra_content`](#tensorzero_extra_content) in the response section for more details.
+  Each block has the following fields:
+  - `type`: The type of the extra content block (`"thought"` or `"unknown"`)
+  - `insert_index` (optional): The position in the message's content array where this block should be inserted. If omitted, the block is prepended to the beginning of the content.
+  - Additional fields depending on the type (e.g. `text`, `signature` for `"thought"` blocks; `data` for `"unknown"` blocks).
 - `tool_call_id` (required for `tool` messages, otherwise disallowed): The ID of the tool call to associate with the message. This should be one that was originally returned by the gateway in a tool call `id` field.
 
 A content block is an object that can have type `text`, `image_url`, or TensorZero-specific types.
@@ -820,17 +825,8 @@ In regular (non-streaming) mode, the response is a JSON object with the followin
   - **`message`**: An object containing:
     - **`content`**: The message content (string, optional)
     - **`tool_calls`**: List of tool calls made by the model (optional). The format is the same as in the request.
+    - **`tensorzero_extra_content`**: An array of extra content blocks not representable as standard OpenAI `content` or `tool_calls` (optional). See [`tensorzero_extra_content`](#tensorzero_extra_content) below for details.
     - **`role`**: The role of the message sender (always `"assistant"`).
-
-<Warning>
-
-The OpenAI-compatible inference endpoint can't handle unknown content blocks in the response.
-If the model provider returns an unknown content block, the gateway will drop the content block from the response and log a warning.
-
-If you need to access unknown content blocks, use the native TensorZero API.
-See the [Inference API Reference](/gateway/api-reference/inference/) for details.
-
-</Warning>
 
 #### `created`
 
@@ -878,6 +874,42 @@ Contains token usage information for the request and response, with the followin
 - **`completion_tokens`**: Number of tokens in the completion (integer)
 - **`total_tokens`**: Total number of tokens used (integer)
 
+#### `tensorzero_extra_content`
+
+- **Type:** array (optional)
+
+An array of extra content blocks that are not representable as standard OpenAI `content` or `tool_calls`.
+This field is present when the model returns non-text content blocks, such as reasoning thoughts from models like Anthropic Claude with extended thinking.
+
+Each block has the following fields:
+
+- `type` (string): The type of the extra content block. Currently supported types are:
+  - `"thought"`: A reasoning/thinking block from a model that supports extended thinking.
+  - `"unknown"`: A provider-specific content block that doesn't fit standard categories.
+- `insert_index` (integer): The position this block occupied in the full content array returned by the model. This indicates where the block appeared relative to text and other content blocks.
+
+For `"thought"` blocks, the following additional fields are available:
+
+- `text` (string, optional): The text content of the thought.
+- `signature` (string, optional): An opaque signature used by some providers (e.g. Anthropic) for multi-turn reasoning conversations. You should pass this back when round-tripping.
+- `summary` (array, optional): Summary blocks for the thought.
+- `provider_type` (string, optional): The provider type that generated this thought (e.g. `"anthropic"`). When round-tripping, TensorZero uses this to send the thought only to compatible providers.
+- `extra_data` (object, optional): Provider-specific opaque data for multi-turn reasoning support.
+
+For `"unknown"` blocks, the following additional fields are available:
+
+- `data` (any): The underlying content block as returned by the model provider.
+- `model_name` (string, optional): The model name associated with this content block.
+- `provider_name` (string, optional): The provider name associated with this content block.
+
+<Tip>
+
+You can round-trip `tensorzero_extra_content` by including it in an `assistant` message in a follow-up request.
+This preserves reasoning context across multi-turn conversations.
+See the [round-trip example](#chat-function-with-extra-content-round-trip) below.
+
+</Tip>
+
 #### `tensorzero_raw_response`
 
 - **Type:** array (optional, only when `tensorzero::include_raw_response` is `true`)
@@ -916,9 +948,10 @@ A list of choices from the model, where each choice contains:
 
 - `index`: The index of the choice (integer)
 - `finish_reason`: always ""
-- `delta`: An object containing either:
-  - `content`: The next piece of generated text (string), or
+- `delta`: An object containing any of:
+  - `content`: The next piece of generated text (string)
   - `tool_calls`: A list of tool calls, each containing the next piece of the tool call being generated
+  - `tensorzero_extra_content`: An array of extra content block chunks (e.g. thought deltas). Each chunk includes an `insert_index` field indicating the block's position in the full content array, along with the incremental content for that block.
 
 #### `created`
 


### PR DESCRIPTION
Fix #6381

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change describing additional response/request fields; no runtime behavior is modified.
> 
> **Overview**
> Adds documentation for `tensorzero_extra_content` in the OpenAI-compatible `POST /openai/v1/chat/completions` API, allowing clients to *round-trip* non-text blocks (e.g. reasoning thoughts or provider-specific blocks) by including them on `assistant` messages.
> 
> Updates both regular and streaming response schemas to expose these extra blocks (including `insert_index` and per-type fields), and removes the prior warning that unknown content blocks are always dropped from OpenAI-compatible responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99b45eb0ecad163a6f3c339601ac4c7116138c23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->