### PR TITLE
Replace flaky sleep with poll_for_result in batch inference test

### DIFF
--- a/tensorzero-core/tests/e2e/db/batch_inference_endpoint_internals.rs
+++ b/tensorzero-core/tests/e2e/db/batch_inference_endpoint_internals.rs
@@ -34,6 +34,8 @@ use tensorzero_core::inference::types::{
 use tensorzero_core::jsonschema_util::JSONSchema;
 use uuid::Uuid;
 
+use crate::utils::poll_for_result::poll_for_result;
+
 // ===== HELPER FUNCTIONS =====
 
 fn create_delegating_connection(
@@ -281,21 +283,19 @@ async fn test_write_poll_batch_inference_endpoint(
         PollInferenceResponse::Pending,
         "Response should be Pending"
     );
-    database.sleep_for_writes_to_be_visible().await;
-
     let query = PollPathParams {
         batch_id,
         inference_id: None,
     };
-    let batch_request_result = get_batch_request(&database, &query).await.unwrap();
+    let batch_request_result = poll_for_result(
+        || get_batch_request(&database, &query),
+        |r| r.status == BatchStatus::Pending,
+        "Timed out waiting for batch status to become Pending",
+    )
+    .await;
     assert_eq!(
         batch_request_result.batch_id, batch_id,
         "batch_id should match"
-    );
-    assert_eq!(
-        batch_request_result.status,
-        BatchStatus::Pending,
-        "status should be Pending"
     );
 
     // Write a failed batch
@@ -331,19 +331,18 @@ async fn test_write_poll_batch_inference_endpoint(
         "Response should be Failed"
     );
 
-    database.sleep_for_writes_to_be_visible().await;
     let query = PollPathParams {
         batch_id,
         inference_id: None,
     };
-    // This should return the failed batch as it is more recent
-    let batch_request = get_batch_request(&database, &query).await.unwrap();
+    // Poll until the Failed batch is visible (it is more recent than the Pending one)
+    let batch_request = poll_for_result(
+        || get_batch_request(&database, &query),
+        |r| r.status == BatchStatus::Failed,
+        "Timed out waiting for batch status to become Failed",
+    )
+    .await;
     assert_eq!(batch_request.batch_id, batch_id, "batch_id should match");
-    assert_eq!(
-        batch_request.status,
-        BatchStatus::Failed,
-        "status should be Failed"
-    );
 }
 make_db_test!(test_write_poll_batch_inference_endpoint);
 

--- a/tensorzero-core/tests/e2e/tests.rs
+++ b/tensorzero-core/tests/e2e/tests.rs
@@ -47,4 +47,5 @@ mod retries;
 mod streaming_errors;
 mod template;
 mod timeouts;
+mod utils;
 mod workflow_evaluations;

--- a/tensorzero-core/tests/e2e/utils/mod.rs
+++ b/tensorzero-core/tests/e2e/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod poll_for_result;

--- a/tensorzero-core/tests/e2e/utils/poll_for_result.rs
+++ b/tensorzero-core/tests/e2e/utils/poll_for_result.rs
@@ -1,0 +1,64 @@
+use std::fmt::Debug;
+use std::future::Future;
+use std::time::Duration;
+
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+const POLL_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Polls a query until the result matches a predicate.
+///
+/// Returns the first `Ok` result that satisfies `predicate`. Retries on both errors and
+/// non-matching results. Panics if the timeout (default 5s) is reached.
+pub async fn poll_for_result<T, E, F, Fut>(
+    query_fn: F,
+    predicate: impl Fn(&T) -> bool,
+    timeout_msg: &str,
+) -> T
+where
+    T: Debug,
+    E: Debug,
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+{
+    poll_for_result_with_interval_and_timeout(
+        query_fn,
+        predicate,
+        POLL_INTERVAL,
+        POLL_TIMEOUT,
+        timeout_msg,
+    )
+    .await
+}
+
+/// Polls a query every `poll_interval` until the result matches a predicate.
+///
+/// Returns the first `Ok` result that satisfies `predicate`. Retries on both `Err` results and
+/// `Ok` results that don't satisfy the predicate. Panics only when the `timeout` is reached,
+/// reporting the last non-matching outcome.
+pub async fn poll_for_result_with_interval_and_timeout<T, E, F, Fut>(
+    mut query_fn: F,
+    predicate: impl Fn(&T) -> bool,
+    poll_interval: Duration,
+    timeout: Duration,
+    timeout_msg: &str,
+) -> T
+where
+    T: Debug,
+    E: Debug,
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        match query_fn().await {
+            Ok(result) if predicate(&result) => return result,
+            other => {
+                assert!(
+                    tokio::time::Instant::now() < deadline,
+                    "{timeout_msg}: {other:?}",
+                );
+            }
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+}


### PR DESCRIPTION
Extract reusable poll_for_result async function into tests/e2e/utils/ that flushes pending writes and retries queries until a predicate is satisfied or a 5s timeout is reached.