### PR TITLE
Docs: Google AI Studio + embeddings

### DIFF
--- a/docs/integrations/model-providers/google-ai-studio-gemini.mdx
+++ b/docs/integrations/model-providers/google-ai-studio-gemini.mdx
@@ -130,6 +130,23 @@ curl -X POST http://localhost:3000/inference \
   }'
 ```
 
+## Other Features
+
+### Generate Embeddings
+
+You can generate embeddings from Google AI Studio using the [OpenAI-compatible provider](/integrations/model-providers/openai-compatible). For example:
+
+```toml title="tensorzero.toml" {5-7}
+[embedding_models.gemini-embedding-001]
+routing = ["google_ai_studio"]
+
+[embedding_models.gemini-embedding-001.providers.google_ai_studio]
+type = "openai"
+api_base = "https://generativelanguage.googleapis.com/v1beta/openai"
+api_key_location = "env::GOOGLE_AI_STUDIO_API_KEY"
+model_name = "gemini-embedding-001"
+```
+
 ## Thinking Parameters
 
 Gemini supports two thinking parameters:


### PR DESCRIPTION
Fix #6045

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a new configuration example; no runtime or API behavior changes.
> 
> **Overview**
> Adds an **“Other Features → Generate Embeddings”** section to the Google AI Studio (Gemini API) docs, showing how to configure `embedding_models` to call Gemini embeddings via the *OpenAI-compatible* provider and Google’s OpenAI-style endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8f0eb973bb3c2efa223d7bd87c323c84bcb1aa8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->