### PR TITLE
Docs: dynamic AWS credentials

### DIFF
--- a/docs/integrations/model-providers/aws-bedrock.mdx
+++ b/docs/integrations/model-providers/aws-bedrock.mdx
@@ -69,7 +69,8 @@ TensorZero will attempt the following methods in order:
 3. `AWS_BEARER_TOKEN_BEDROCK` environment variable (bearer auth)
 4. AWS SDK credential chain (SigV4)
 
-See the [Configuration Reference](/gateway/configuration-reference/) for more details on authentication options.
+You can also provide credentials dynamically at inference time using the `dynamic::` prefix (e.g. `access_key_id = "dynamic::aws_access_key_id"`).
+See the [Credential Management](/operations/manage-credentials/) guide and [Configuration Reference](/gateway/configuration-reference/) for more details on authentication options.
 
 ### AWS Region
 

--- a/docs/integrations/model-providers/aws-sagemaker.mdx
+++ b/docs/integrations/model-providers/aws-sagemaker.mdx
@@ -73,7 +73,7 @@ The relevant fields will depend on the `hosted_provider`.
 ### Credentials
 
 You must make sure that the gateway has the necessary permissions to access AWS SageMaker.
-The TensorZero Gateway will use the AWS SDK to retrieve the relevant credentials.
+By default, the TensorZero Gateway will use the AWS SDK to retrieve the relevant credentials.
 
 The simplest way is to set the following environment variables before running the gateway:
 
@@ -83,7 +83,8 @@ AWS_REGION=us-east-1
 AWS_SECRET_ACCESS_KEY=...
 ```
 
-Alternatively, you can use other authentication methods supported by the AWS SDK.
+You can also provide credentials dynamically at inference time using the `dynamic::` prefix (e.g. `access_key_id = "dynamic::aws_access_key_id"`).
+See the [Credential Management](/operations/manage-credentials/) guide and [Configuration Reference](/gateway/configuration-reference/) for more details on authentication options.
 
 ### Deployment (Docker Compose)
 


### PR DESCRIPTION
Fix #6058

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that clarify credential configuration; no runtime behavior is modified.
> 
> **Overview**
> Updates the AWS Bedrock and AWS SageMaker provider docs to explicitly document *dynamic credentials* via the `dynamic::` prefix (with an example) and link to the new Credential Management guide.
> 
> Also clarifies SageMaker’s credential behavior by stating the AWS SDK credential chain is the default, and adjusts surrounding authentication guidance accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a274c056b8c9a4cf8070204b31ed008e7050d962. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->