### PR TITLE
Docs: valkey:// and valkeys://

### DIFF
--- a/docs/deployment/valkey-redis.mdx
+++ b/docs/deployment/valkey-redis.mdx
@@ -72,6 +72,15 @@ TENSORZERO_VALKEY_URL="redis://[hostname]:[port]"
 TENSORZERO_VALKEY_URL="redis://localhost:6379"
 ```
 
+The following URL schemes are supported:
+
+| Scheme       | Description                           |
+| :----------- | :------------------------------------ |
+| `valkey://`  | Standard Valkey/Redis connection      |
+| `valkeys://` | TLS-encrypted Valkey/Redis connection |
+| `redis://`   | Alias for `valkey://`                 |
+| `rediss://`  | Alias for `valkeys://`                |
+
 TensorZero automatically loads the required Lua functions into Valkey on startup.
 No manual setup is required.
 


### PR DESCRIPTION
Fix #6138

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that clarifies configuration options; no runtime behavior is modified.
> 
> **Overview**
> Updates the Valkey/Redis deployment docs to explicitly document supported `TENSORZERO_VALKEY_URL` schemes, adding a table covering `valkey://`/`valkeys://` plus `redis://`/`rediss://` aliases (including TLS behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fe729d2f7a65e6aa6b6c6c2ef915e58787f2f7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->