### PR TITLE
Docs: Anthropic provider tools

### DIFF
--- a/docs/gateway/configuration-reference.mdx
+++ b/docs/gateway/configuration-reference.mdx
@@ -666,6 +666,28 @@ api_base = "https://example.com/v1/messages"
 # ...
 ```
 
+##### `provider_tools`
+
+- **Type:** array of objects
+- **Required:** no (default: `[]`)
+
+Defines provider-specific built-in tools that are available for this model provider.
+These are tools that run server-side on the provider's infrastructure (e.g., Anthropic's web search tool).
+
+Each object in the array should contain the provider-specific tool configuration as defined by Anthropic's API.
+
+This field can be set statically in the configuration file or dynamically at inference time via the `provider_tools` parameter in the `/inference` endpoint or `tensorzero::provider_tools` in the OpenAI-compatible endpoint.
+See the [Inference API Reference](/gateway/api-reference/inference/#provider_tools) for more details on dynamic usage.
+
+```toml title="tensorzero.toml"
+[models.claude-sonnet-4-5.providers.anthropic]
+# ...
+type = "anthropic"
+model_name = "claude-sonnet-4-5"
+provider_tools = [{type = "web_search_20250305", name = "web_search"}]
+# ...
+```
+
 </Accordion>
 
 <Accordion title='type: "aws_bedrock"'>
@@ -1244,6 +1266,30 @@ Defines the project ID of the GCP Vertex AI model.
 # ...
 type = "gcp_vertex"
 project_id = "your-project-id"
+# ...
+```
+
+##### `provider_tools`
+
+- **Type:** array of objects
+- **Required:** no (default: `[]`)
+
+Defines provider-specific built-in tools that are available for this model provider.
+These are tools that run server-side on the provider's infrastructure (e.g., Anthropic's web search tool).
+
+Each object in the array should contain the provider-specific tool configuration as defined by Anthropic's API.
+
+This field can be set statically in the configuration file or dynamically at inference time via the `provider_tools` parameter in the `/inference` endpoint or `tensorzero::provider_tools` in the OpenAI-compatible endpoint.
+See the [Inference API Reference](/gateway/api-reference/inference/#provider_tools) for more details on dynamic usage.
+
+```toml title="tensorzero.toml"
+[models.claude-sonnet-4-5.providers.gcp_vertex]
+# ...
+type = "gcp_vertex_anthropic"
+model_id = "claude-sonnet-4-5@20250929"
+location = "us-east5"
+project_id = "your-project-id"
+provider_tools = [{type = "web_search_20250305", name = "web_search"}]
 # ...
 ```
 

--- a/docs/gateway/guides/tool-use.mdx
+++ b/docs/gateway/guides/tool-use.mdx
@@ -366,14 +366,8 @@ See our [MCP (Model Context Protocol) Example on GitHub](https://github.com/tens
 
 ### Using Built-in Provider Tools
 
-<Warning>
-
-TensorZero currently only supports built-in provider tools from the OpenAI Responses API.
-
-</Warning>
-
 Some model providers offer built-in tools that run server-side on the provider's infrastructure.
-For example, OpenAI's Responses API provides a `web_search` tool that enables models to search the web for information.
+For example, OpenAI's Responses API and Anthropic both provide web search tools that enable models to search the web for information.
 
 You can configure provider tools in your model provider configuration:
 
@@ -385,11 +379,29 @@ api_type = "responses"
 provider_tools = [{type = "web_search"}]
 ```
 
+```toml title="tensorzero.toml"
+[models.claude-sonnet-4-5.providers.anthropic]
+type = "anthropic"
+model_name = "claude-sonnet-4-5"
+provider_tools = [{type = "web_search_20250305", name = "web_search"}]
+```
+
+```toml title="tensorzero.toml"
+[models.claude-sonnet-4-5.providers.gcp_vertex]
+type = "gcp_vertex_anthropic"
+model_id = "claude-sonnet-4-5@20250929"
+location = "us-east5"
+project_id = "your-project-id"
+provider_tools = [{type = "web_search_20250305", name = "web_search"}]
+```
+
 You can also provide them dynamically at inference time via the `provider_tools` parameter.
+
+Provider tools are currently supported by the OpenAI (Responses API), Anthropic, and GCP Vertex AI Anthropic providers.
 
 <Tip>
 
-See [How to call the OpenAI Responses API](/gateway/call-the-openai-responses-api) for a complete guide on using provider tools like web search.
+See [How to call the OpenAI Responses API](/gateway/call-the-openai-responses-api) for a complete guide on using provider tools like web search with OpenAI.
 
 </Tip>
 


### PR DESCRIPTION
Fix #6061 


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes; no runtime or API behavior is modified.
> 
> **Overview**
> Updates the Gateway docs to cover **provider-side built-in tools** for Anthropic and GCP Vertex AI Anthropic.
> 
> Adds `provider_tools` to the configuration reference for `type: "anthropic"` and `type: "gcp_vertex_anthropic"`, including description and TOML examples, and updates the tool-use guide to remove the OpenAI-only warning, add Anthropic/Vertex examples, and explicitly list the supported providers and OpenAI-specific guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebcf91d053d6e59288145c346abc69bd0ee84660. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->