### PR TITLE
Docs: datapoints & datasets

### DIFF
--- a/docs/gateway/api-reference/datasets-datapoints.mdx
+++ b/docs/gateway/api-reference/datasets-datapoints.mdx
@@ -103,7 +103,7 @@ When `type` is `"inference_ids"`:
 - `inference_ids` (list of UUIDs, required) - the inference IDs to create datapoints from
 - `output_source` (string, optional, defaults to `"inference"`) - the source of the output for the datapoint (`"inference"`, `"demonstration"`, or `"none"`)
 
-When `type` is `"inference_query"`, the request body accepts the same parameters as the [List Inferences](/gateway/api-reference/stored-inferences) endpoint (e.g. `function_name`, `variant_name`, `output_source`, `filters`, etc.).
+When `type` is `"inference_query"`, the request body accepts the same parameters as the [List Inferences](/observability/query-historical-inferences) endpoint (e.g. `function_name`, `variant_name`, `output_source`, `filters`, etc.).
 
 The endpoint returns an object with `ids`, a list of IDs (strings, UUIDv7) of the newly created datapoints.
 


### PR DESCRIPTION
Fix #4349

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that update endpoint names/parameters and add coverage for existing operations; no runtime behavior changes.
> 
> **Overview**
> Updates the Datasets/Datapoints API docs to match the v1 gateway surface: replaces single-item `GET` endpoints with batch-style `POST`/`DELETE` endpoints for `get_datapoints`, `list_datapoints`, and `delete_datapoints`, including updated parameters, defaults, and response shapes (e.g., IDs list, `num_deleted_datapoints`, and note that fetching by ID includes stale datapoints).
> 
> Expands and clarifies write operations by documenting `create_datapoints` requirements (`type`, required `function_name`/`input`, optional `episode_id`), adding `create_datapoints_from_inferences`, and refining update semantics (`update_datapoints` vs in-place `update_datapoints_metadata`, plus nullable tool-related fields for chat updates) and adding `delete_dataset` soft-delete behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d7e545a59be2925b47defdb3348c2a86d54abde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->