### PR TITLE
Docs: latency metrics

### DIFF
--- a/docs/gateway/configuration-reference.mdx
+++ b/docs/gateway/configuration-reference.mdx
@@ -178,19 +178,19 @@ Setting this value too low may cause legitimate requests to timeout before recei
 
 </Warning>
 
-### `metrics.tensorzero_inference_latency_overhead_seconds_histogram_buckets`
+### `metrics.tensorzero_inference_latency_overhead_seconds_buckets`
 
 - **Type:** array of floats
-- **Required:** no (default: disabled)
+- **Required:** no (default: `[0.001, 0.01, 0.1]`)
 
-Enable the `tensorzero_inference_latency_overhead_seconds_histogram` Prometheus metric with the specified histogram buckets.
+Configures the histogram buckets for the `tensorzero_inference_latency_overhead_seconds` Prometheus metric.
 This metric tracks the latency overhead introduced by TensorZero on HTTP requests.
 
 The buckets must be in strictly ascending order and contain at least one value.
 
 ```toml title="tensorzero.toml"
 [gateway.metrics]
-tensorzero_inference_latency_overhead_seconds_histogram_buckets = [0.001, 0.01, 0.1]
+tensorzero_inference_latency_overhead_seconds_buckets = [0.001, 0.005, 0.01, 0.05, 0.1]
 ```
 
 See [Export Prometheus metrics](/operations/export-prometheus-metrics) for more details.

--- a/docs/operations/export-prometheus-metrics.mdx
+++ b/docs/operations/export-prometheus-metrics.mdx
@@ -16,43 +16,25 @@ This metric tracks the latency overhead introduced by TensorZero on inference re
 It measures the total request duration minus the time spent waiting for external model provider HTTP requests.
 This is useful for understanding how much latency TensorZero adds to your inference requests, independently of model provider latency.
 
-This metric is reported as a summary with quantiles (e.g. p50, p90, p99).
-
-```txt title="GET /metrics"
-# HELP tensorzero_inference_latency_overhead_seconds Overhead of TensorZero on HTTP requests
-# TYPE tensorzero_inference_latency_overhead_seconds summary
-tensorzero_inference_latency_overhead_seconds{function_name="tensorzero::default",variant_name="openai::gpt-5-mini",quantile="0"} 0.087712334
-tensorzero_inference_latency_overhead_seconds{function_name="tensorzero::default",variant_name="openai::gpt-5-mini",quantile="0.5"} 0.08771169702129712
-tensorzero_inference_latency_overhead_seconds{function_name="tensorzero::default",variant_name="openai::gpt-5-mini",quantile="0.9"} 0.08771169702129712
-tensorzero_inference_latency_overhead_seconds{function_name="tensorzero::default",variant_name="openai::gpt-5-mini",quantile="0.95"} 0.08771169702129712
-tensorzero_inference_latency_overhead_seconds{function_name="tensorzero::default",variant_name="openai::gpt-5-mini",quantile="0.99"} 0.08771169702129712
-tensorzero_inference_latency_overhead_seconds{function_name="tensorzero::default",variant_name="openai::gpt-5-mini",quantile="0.999"} 0.08771169702129712
-tensorzero_inference_latency_overhead_seconds{function_name="tensorzero::default",variant_name="openai::gpt-5-mini",quantile="1"} 0.087712334
-tensorzero_inference_latency_overhead_seconds_sum{function_name="tensorzero::default",variant_name="openai::gpt-5-mini"} 0.087712334
-tensorzero_inference_latency_overhead_seconds_count{function_name="tensorzero::default",variant_name="openai::gpt-5-mini"} 1
-```
-
-## `tensorzero_inference_latency_overhead_seconds_histogram`
-
-This metric is an optional histogram variant of `tensorzero_inference_latency_overhead_seconds` (see above).
-It provides traditional histogram buckets instead of pre-computed quantiles, which is useful if you want to compute custom quantiles or aggregate across multiple instances.
-
-To enable it, configure the histogram buckets in your configuration file:
+This metric is reported as a histogram with configurable buckets (default: `[0.001, 0.01, 0.1]`).
+You can customize the buckets in your configuration file using [`gateway.metrics.tensorzero_inference_latency_overhead_seconds_buckets`](/gateway/configuration-reference):
 
 ```toml title="tensorzero.toml"
 [gateway.metrics]
-tensorzero_inference_latency_overhead_seconds_histogram_buckets = [0.001, 0.01, 0.1]
+tensorzero_inference_latency_overhead_seconds_buckets = [0.001, 0.005, 0.01, 0.05, 0.1]
 ```
 
 ```txt title="GET /metrics"
-# HELP tensorzero_inference_latency_overhead_seconds_histogram Overhead of TensorZero on HTTP requests (histogram)
-# TYPE tensorzero_inference_latency_overhead_seconds_histogram histogram
-tensorzero_inference_latency_overhead_seconds_histogram_bucket{function_name="my_function",variant_name="my_variant",le="0.001"} 0
-tensorzero_inference_latency_overhead_seconds_histogram_bucket{function_name="my_function",variant_name="my_variant",le="0.01"} 5
-tensorzero_inference_latency_overhead_seconds_histogram_bucket{function_name="my_function",variant_name="my_variant",le="0.1"} 10
-tensorzero_inference_latency_overhead_seconds_histogram_bucket{function_name="my_function",variant_name="my_variant",le="+Inf"} 10
-tensorzero_inference_latency_overhead_seconds_histogram_sum{function_name="my_function",variant_name="my_variant"} 0.025
-tensorzero_inference_latency_overhead_seconds_histogram_count{function_name="my_function",variant_name="my_variant"} 10
+# HELP tensorzero_inference_latency_overhead_seconds Overhead of TensorZero on HTTP requests
+# TYPE tensorzero_inference_latency_overhead_seconds histogram
+tensorzero_inference_latency_overhead_seconds_bucket{function_name="my_function",variant_name="my_variant",le="0.001"} 0
+tensorzero_inference_latency_overhead_seconds_bucket{function_name="my_function",variant_name="my_variant",le="0.005"} 2
+tensorzero_inference_latency_overhead_seconds_bucket{function_name="my_function",variant_name="my_variant",le="0.01"} 5
+tensorzero_inference_latency_overhead_seconds_bucket{function_name="my_function",variant_name="my_variant",le="0.05"} 8
+tensorzero_inference_latency_overhead_seconds_bucket{function_name="my_function",variant_name="my_variant",le="0.1"} 10
+tensorzero_inference_latency_overhead_seconds_bucket{function_name="my_function",variant_name="my_variant",le="+Inf"} 10
+tensorzero_inference_latency_overhead_seconds_sum{function_name="my_function",variant_name="my_variant"} 0.025
+tensorzero_inference_latency_overhead_seconds_count{function_name="my_function",variant_name="my_variant"} 10
 ```
 
 ## `tensorzero_inferences_total`


### PR DESCRIPTION
Fix https://github.com/tensorzero/tensorzero/issues/6049

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that rename a documented config key and clarify metric type/output; no runtime behavior changes in this PR.
> 
> **Overview**
> Updates Prometheus metrics documentation to present `tensorzero_inference_latency_overhead_seconds` as a *histogram* (removing the prior summary/quantiles description and the separate `*_histogram` metric variant) and refreshes the example `/metrics` output accordingly.
> 
> Renames the gateway config knob for this metric from `metrics.tensorzero_inference_latency_overhead_seconds_histogram_buckets` to `metrics.tensorzero_inference_latency_overhead_seconds_buckets`, documents a default bucket set, and updates TOML examples to match.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9f64efd181cbe8ec53d9b9839aa2d7d7c9d9950. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->