### PR TITLE
Docs: `discard_unknown_chunks`

### DIFF
--- a/docs/gateway/configuration-reference.mdx
+++ b/docs/gateway/configuration-reference.mdx
@@ -443,10 +443,11 @@ routing = ["openai", "azure"]
 - **Type:** boolean
 - **Required:** no (default: `false`)
 
-When set to `true`, the gateway will silently discard streaming chunks with unknown or unsupported types instead of producing an error in the stream.
+When set to `true`, the gateway will silently discard streaming chunks with unknown or unsupported types instead of forwarding them.
 A warning is emitted for each discarded chunk.
 
-This is useful when a model provider introduces new chunk types that TensorZero doesn't yet support, and you'd prefer to ignore them rather than fail the stream.
+By default (`false`), unknown chunks are forwarded in the stream as-is.
+This is useful when a model provider introduces new chunk types that TensorZero doesn't yet support, and you'd prefer to drop them rather than receive unrecognized data.
 
 ```toml title="tensorzero.toml"
 [models.my-model.providers.my-provider]

--- a/internal/tensorzero-node/lib/bindings/UninitializedModelProvider.ts
+++ b/internal/tensorzero-node/lib/bindings/UninitializedModelProvider.ts
@@ -10,9 +10,7 @@ export type UninitializedModelProvider = {
   /**
    * If `true`, we emit a warning and discard chunks that we don't recognize
    * (on a best-effort, per-provider basis).
-   * By default, we produce an error in the stream
-   * We can't meaningfully return unknown chunks to the user, as we don't
-   * know how to correctly merge them.
+   * By default, unknown chunks are forwarded as-is in the stream.
    */
   discard_unknown_chunks: boolean;
 } & (

--- a/tensorzero-core/src/model.rs
+++ b/tensorzero-core/src/model.rs
@@ -961,9 +961,7 @@ pub struct UninitializedModelProvider {
     pub timeouts: TimeoutsConfig,
     /// If `true`, we emit a warning and discard chunks that we don't recognize
     /// (on a best-effort, per-provider basis).
-    /// By default, we produce an error in the stream
-    /// We can't meaningfully return unknown chunks to the user, as we don't
-    /// know how to correctly merge them.
+    /// By default, unknown chunks are forwarded as-is in the stream.
     #[serde(default)]
     pub discard_unknown_chunks: bool,
 }


### PR DESCRIPTION
Fix #3213

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/comment-only changes; no runtime behavior or configuration parsing is modified.
> 
> **Overview**
> Documents the `discard_unknown_chunks` provider setting in the gateway configuration reference, including default behavior and an example.
> 
> Updates the Rust and generated Node/TS bindings docstrings for `UninitializedModelProvider.discard_unknown_chunks` to reflect that *unknown streaming chunks are forwarded by default* (and only discarded with warnings when the flag is enabled).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93c1c8a1fea72133136a68bc4a388fdea18632b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->