### PR TITLE
Docs: raw_text doesn't work for system

### DIFF
--- a/docs/gateway/api-reference/batch-inference.mdx
+++ b/docs/gateway/api-reference/batch-inference.mdx
@@ -190,6 +190,12 @@ If the content block has type `raw_text`, it must have the following additional 
 - `value`: The text for the content block.
   This content block will ignore any relevant templates and schemas for this function.
 
+<Note>
+
+`raw_text` only works for user and assistant messages. For system messages, `raw_text` is treated as plain text and will not bypass templates.
+
+</Note>
+
 If the content block has type `thought`, it must have the following additional fields:
 
 - `text`: The text for the content block.

--- a/docs/gateway/api-reference/inference-openai-compatible.mdx
+++ b/docs/gateway/api-reference/inference-openai-compatible.mdx
@@ -535,7 +535,7 @@ If a content block has type `input_audio`, it must have the following additional
 
 The TensorZero-specific content block types are:
 
-- `tensorzero::raw_text`: Bypasses templates and schemas, sending text directly to the model. Useful for testing prompts or dynamic injection without configuration changes. Must have a `value` field containing the text.
+- `tensorzero::raw_text`: Bypasses templates and schemas, sending text directly to the model. Useful for testing prompts or dynamic injection without configuration changes. Must have a `value` field containing the text. Only works for user and assistant messages; for system messages, it is treated as plain text and will not bypass templates.
 - `tensorzero::template`: Explicitly specify a template to use. Must have `name` and `arguments` fields.
 
 #### `model`

--- a/docs/gateway/api-reference/inference.mdx
+++ b/docs/gateway/api-reference/inference.mdx
@@ -475,6 +475,12 @@ If the content block has type `raw_text`, it must have the following additional 
 - `value`: The text for the content block.
   This content block will ignore any relevant templates and schemas for this function.
 
+<Note>
+
+`raw_text` only works for user and assistant messages. For system messages, `raw_text` is treated as plain text and will not bypass templates.
+
+</Note>
+
 If the content block has type `thought`, it must have the following additional fields:
 
 - `text`: The text for the content block.


### PR DESCRIPTION
Fix #3206 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies an existing limitation; no runtime behavior is modified.
> 
> **Overview**
> Clarifies in the gateway API reference docs that `raw_text`/`tensorzero::raw_text` **does not bypass templates for system messages** (it only works for user/assistant), adding an explicit note in the `/inference` and `/batch_inference` docs and updating the OpenAI-compatible endpoint description accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 190f224f3ae4ef2f35bf31c4f0422c0a8c39593f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->