### PR TITLE
Docs: GCP Vertex AI Gemini batch inference

### DIFF
--- a/docs/gateway/configuration-reference.mdx
+++ b/docs/gateway/configuration-reference.mdx
@@ -2274,9 +2274,7 @@ credential_location = "dynamic::gcp_credentials_path"
 - **Type:** object
 - **Required:** no (default: `null`)
 
-The `batch` object allows you to configure batch processing for GCP Vertex models.
-Today we support batch inference through GCP Vertex using Google cloud storage as documented [here](https://cloud.google.com/vertex-ai/docs/tabular-data/classification-regression/get-batch-predictions#api:-cloud-storage).
-To do this you must also have object_storage (see the [object_storage](#object_storage) section) configured using GCP.
+The `batch` object allows you to configure [batch inference](/gateway/guides/batch-inference/) for GCP Vertex Gemini models using Google Cloud Storage.
 
 ```toml title="tensorzero.toml"
 [provider_types.gcp_vertex_gemini.batch]

--- a/docs/integrations/model-providers/gcp-vertex-ai-gemini.mdx
+++ b/docs/integrations/model-providers/gcp-vertex-ai-gemini.mdx
@@ -114,6 +114,23 @@ curl -X POST http://localhost:3000/inference \
   }'
 ```
 
+## Batch Inference
+
+GCP Vertex AI Gemini supports [batch inference](/gateway/guides/batch-inference/) using Google Cloud Storage for input and output files.
+
+To enable batch inference, configure the `provider_types.gcp_vertex_gemini.batch` section in your configuration file:
+
+```toml title="tensorzero.toml"
+[provider_types.gcp_vertex_gemini.batch]
+storage_type = "cloud_storage"
+input_uri_prefix = "gs://my-bucket/batch-inputs/"
+output_uri_prefix = "gs://my-bucket/batch-outputs/"
+```
+
+The service account used by the gateway must have read/write access to the specified GCS buckets.
+
+See the [Batch Inference](/gateway/guides/batch-inference/) guide and [Configuration Reference](/gateway/configuration-reference/) for more details.
+
 ## Thinking Parameters
 
 Gemini supports two thinking parameters:


### PR DESCRIPTION
Fix #3285

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes; no runtime behavior or configuration schema changes.
> 
> **Overview**
> Documents **batch inference for GCP Vertex AI Gemini**.
> 
> Updates the configuration reference to replace the older explanatory text with a single link to the Batch Inference guide, and extends the GCP Vertex AI Gemini integration guide with a new “Batch Inference” section showing the required `provider_types.gcp_vertex_gemini.batch` TOML config plus GCS bucket permission requirements and cross-links to the relevant docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f4396cfe6ae4f3087c668f26823d312b314044d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->