### PR TITLE
Docs: signature blocks, extended thinking

### DIFF
--- a/docs/gateway/api-reference/batch-inference.mdx
+++ b/docs/gateway/api-reference/batch-inference.mdx
@@ -192,7 +192,8 @@ If the content block has type `raw_text`, it must have the following additional 
 
 If the content block has type `thought`, it must have the following additional fields:
 
-- `text`: The text for the content block.
+- `text` (string, optional): The text for the content block.
+- `signature` (string, optional): An opaque signature used for multi-turn reasoning conversations with Anthropic and OpenRouter. Pass through the `signature` from the model's response to continue a reasoning conversation.
 
 If the content block has type `unknown`, it must have the following additional fields:
 

--- a/docs/gateway/api-reference/inference.mdx
+++ b/docs/gateway/api-reference/inference.mdx
@@ -477,7 +477,8 @@ If the content block has type `raw_text`, it must have the following additional 
 
 If the content block has type `thought`, it must have the following additional fields:
 
-- `text`: The text for the content block.
+- `text` (string, optional): The text for the content block.
+- `signature` (string, optional): An opaque signature used for multi-turn reasoning conversations with Anthropic and OpenRouter. Pass through the `signature` from the model's response to continue a reasoning conversation.
 
 If the content block has type `unknown`, it must have the following additional fields:
 
@@ -915,7 +916,9 @@ If `type` is `tool_call`, the content block has the following fields:
 
 If `type` is `thought`, the content block has the following fields:
 
-- `text` (string): The text of the thought.
+- `text` (string, optional): The text of the thought. May be absent for encrypted reasoning.
+- `signature` (string, optional): An opaque signature for multi-turn reasoning conversations. Pass this back in subsequent requests to continue a reasoning conversation with Anthropic or OpenRouter.
+- `summary` (array, optional): A summary of the thought, provided by some providers when the full reasoning is encrypted.
 
 If the model provider responds with a content block of an unknown type, it will be included in the response as a content block of type `unknown` with the following additional fields:
 
@@ -1021,6 +1024,7 @@ If `type` is `thought`, the chunk has the following fields:
 
 - `id`: The ID of the content block.
 - `text`: The text delta for the thought.
+- `signature` (string, optional): An opaque signature for multi-turn reasoning conversations (see above).
 
 ##### `episode_id`
 

--- a/docs/integrations/model-providers/anthropic.mdx
+++ b/docs/integrations/model-providers/anthropic.mdx
@@ -239,6 +239,21 @@ project_id = "YOUR-PROJECT-ID"  # TODO: set your GCP project ID
 
 Read more about the [GCP Vertex AI Anthropic model provider](/integrations/model-providers/gcp-vertex-ai-anthropic).
 
+## Extended Thinking
+
+TensorZero supports Anthropic's [Extended Thinking](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking) feature.
+You can enable it by setting `thinking_budget_tokens` on your variant:
+
+```toml title="tensorzero.toml"
+[functions.my_function_name.variants.my_variant_name]
+type = "chat_completion"
+model = "anthropic::claude-sonnet-4-5"
+thinking_budget_tokens = 10000
+```
+
+The model's reasoning will be returned as `thought` content blocks in the response.
+For multi-turn reasoning conversations, pass the `signature` field from the response's `thought` blocks back in subsequent requests.
+
 ## Other Features
 
 See [Extend TensorZero](/operations/extend-tensorzero) for information about Anthropic Computer Use and other beta features.


### PR DESCRIPTION
Fix #3216

I'm planning to follow up with a comprehensive guide on reasoning models.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit a350033d75853cc7157a28ac090d892a5d826665. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->