### PR TITLE
Fix broken link

### DIFF
--- a/docs/optimization/index.mdx
+++ b/docs/optimization/index.mdx
@@ -18,7 +18,7 @@ For example, you can use this dataset to curate data to fine-tune a custom LLM, 
 Supervised Fine-Tuning (SFT) trains a language model on curated examples of good behavior, resulting in a custom model that performs better on your specific use case.
 
 TensorZero has fine-tuning integrations with OpenAI, GCP Vertex AI, Fireworks AI, and Together AI.
-See the [Supervised Fine-Tuning Guide](/optimization/supervised-fine-tuning) to learn more.
+See the [Supervised Fine-Tuning Guide](/optimization/supervised-fine-tuning-sft) to learn more.
 
 Additionally, we provide recipes for self-hosted fine-tuning with [`axolotl`](https://github.com/tensorzero/tensorzero/tree/main/recipes/supervised_fine_tuning/axolotl/), [`torchtune`](https://github.com/tensorzero/tensorzero/tree/main/recipes/supervised_fine_tuning/torchtune/), and [`unsloth`](https://github.com/tensorzero/tensorzero/tree/main/recipes/supervised_fine_tuning/unsloth/).
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that updates a single internal link; low risk aside from potential for a still-incorrect route.
> 
> **Overview**
> Fixes a broken link in the optimization docs by updating the *Supervised Fine-tuning (SFT)* guide URL in `docs/optimization/index.mdx` from `/optimization/supervised-fine-tuning` to `/optimization/supervised-fine-tuning-sft`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c6376b70c898c614ce58ae92d2232c276189027. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->