### PR TITLE
Check for broken links in docs in CI

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -22,6 +22,26 @@ env:
   RUST_MSRV: 1.88.0
 
 jobs:
+  check-docs-broken-links:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    if: github.repository == 'tensorzero/tensorzero'
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Setup Node.js
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
+        with:
+          node-version: "24.13.0"
+
+      - name: Install Mintlify CLI
+        run: npm install -g mint@latest
+
+      - name: Check for broken links
+        working-directory: docs
+        run: mint broken-links
+
   check-version-consistency:
     permissions:
       contents: read
@@ -1476,6 +1496,7 @@ jobs:
     if: always() && github.repository == 'tensorzero/tensorzero'
     needs:
       [
+        check-docs-broken-links,
         check-version-consistency,
         check-production-deployment-docker-compose,
         check-docker-compose-released,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change that adds an additional documentation validation step; primary risk is increased CI time/flakiness from external tooling.
> 
> **Overview**
> Adds a new **required** CI job, `check-docs-broken-links`, to run `mint broken-links` in `docs/` (installing the Mintlify CLI via Node.js) to catch broken documentation links.
> 
> Updates the `check-all-general-jobs-passed` aggregator to depend on this new job so it’s enforced on PRs in the main repo.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1fc104460427aad8165a7c884248b6577044329. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->