### PR TITLE
Update inference-time optimization docs

### DIFF
--- a/docs/gateway/guides/inference-time-optimizations.mdx
+++ b/docs/gateway/guides/inference-time-optimizations.mdx
@@ -5,9 +5,10 @@ description: Learn how to use inference-time strategies like dynamic in-context 
 
 Inference-time optimizations are powerful techniques that can significantly enhance the performance of your LLM applications without the need for model fine-tuning.
 
-This guide will explore two key strategies implemented as variant types in TensorZero: Best-of-N (BoN) sampling and Dynamic In-Context Learning (DICL).
-Best-of-N sampling generates multiple response candidates and selects the best one using an evaluator model, while Dynamic In-Context Learning enhances context by incorporating relevant historical examples into the prompt.
-Both techniques can lead to improved response quality and consistency in your LLM applications.
+This guide will explore three key strategies implemented as variant types in TensorZero: Best-of-N (BoN) sampling, Dynamic In-Context Learning (DICL), and Mixture-of-N (MoN) sampling.
+Dynamic In-Context Learning enhances context by incorporating relevant historical examples into the prompt.
+Best-of-N and Mixture-of-N sampling both generate multiple response candidates; Best-of-N selects the best one using an evaluator model, while Mixture-of-N combines the responses using a fuser model.
+All three techniques can lead to improved response quality and consistency in your LLM applications.
 
 ## Best-of-N Sampling
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only wording changes; no runtime, API, or configuration behavior is modified.
> 
> **Overview**
> Updates the `Inference-Time Optimizations` guide to describe **three** strategies (adds **Mixture-of-N sampling**) instead of only Best-of-N and DICL.
> 
> Rewrites the intro to clarify the distinction between Best-of-N (evaluator selects a single best candidate) vs Mixture-of-N (fuser combines candidates), and updates the framing language accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 624e1f781d4cb2a5c440c20e2f2ed8b9e66b1589. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->