### PR TITLE
Restart a failed general.yml workflow in force-merge-queue workflow

### DIFF
--- a/.github/workflows/force-merge-queue.yml
+++ b/.github/workflows/force-merge-queue.yml
@@ -28,6 +28,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      # This is a workaround for a github limitation - if the check-all-general-checks job
+      # has already failed, then the failure will take priority over the fake status that
+      # we add.
+      - name: Restart general.yml if it failed for this PR
+        if: github.event.action == 'labeled'
+        continue-on-error: true
+        run: |
+          # Find the latest general.yml run for this PR's head commit
+          RUN_ID=$(gh run list \
+            --workflow=general.yml \
+            --commit=${{ github.event.pull_request.head.sha }} \
+            --limit=1 \
+            --json databaseId,conclusion \
+            --jq '.[0] | select(.conclusion == "failure") | .databaseId')
+
+          if [ -n "$RUN_ID" ]; then
+            echo "Restarting failed general.yml run: $RUN_ID"
+            gh run rerun "$RUN_ID"
+          else
+            echo "No failed general.yml run found for this commit"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Attach a 'check-all-general-jobs-passed' status to the PR
         # Note that GitHub doesn't let you remove a commit status, so we don't do anything if the label is removed.
         # Pushing a new commit to the PR will trigger a new 'general.yml' run, which will become the latest status


### PR DESCRIPTION
This should workaround a Github limitation (currently, developers need to manually restart the workflow if it's already failed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small GitHub Actions-only change that best-effort reruns a workflow and does not affect build/test logic; main risk is unintended reruns/API usage due to `gh` query assumptions.
> 
> **Overview**
> Adds a workaround to `force-merge-queue.yml` so that when the `force-add-to-merge-queue` label is applied, the workflow will attempt to *rerun the latest failed* `general.yml` run for the PR’s head SHA before posting the synthetic `check-all-general-jobs-passed` commit status.
> 
> This is done via `gh run list` + `gh run rerun` (best-effort with `continue-on-error`) to avoid an existing failure status taking precedence over the forced success status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a2ad1190e31a27ccb8382835c649a0a09d1a86e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->