### PR TITLE
Bring Ollama to gemma3:1b

### DIFF
--- a/examples/guides/providers/aws-sagemaker/config/tensorzero.toml
+++ b/examples/guides/providers/aws-sagemaker/config/tensorzero.toml
@@ -3,7 +3,7 @@ routing = ["aws_sagemaker"]
 
 [models.gemma_3.providers.aws_sagemaker]
 type = "aws_sagemaker"
-model_name = "qwen3:0.6b"
+model_name = "gemma3:1b"
 endpoint_name = "my-sagemaker-endpoint"
 region = "us-east-1"
 # ... or use `region = "sdk"` to auto-detect region with the AWS SDK

--- a/tensorzero-core/fixtures/deployment/sagemaker-ollama/README.md
+++ b/tensorzero-core/fixtures/deployment/sagemaker-ollama/README.md
@@ -1,7 +1,7 @@
 # AWS Sagemaker ollama Docker Image
 
 This image is used to run [ollama](https://github.com/ollama/ollama) on AWS Sagemaker, with
-`qwen3:0.6b` automatically pulled.
+`gemma3:1b` automatically pulled.
 We use it to provide a persistent endpoint for our e2e tests
 
 ## Deploying (for TensorZero team)

--- a/tensorzero-core/fixtures/deployment/sagemaker-ollama/entrypoint.sh
+++ b/tensorzero-core/fixtures/deployment/sagemaker-ollama/entrypoint.sh
@@ -6,7 +6,7 @@ export HOME=/home/ec2-user/SageMaker/temp
 ollama serve &
 # Retry pulling, since the server may not have started or the pull may fail
 for i in {1..10}; do
-    ollama pull qwen3:0.6b && break || sleep 1
+    ollama pull gemma3:1b && break || sleep 1
 done
 
 # The flask dev server is good enough for our use case (running e2e tests on CI)

--- a/tensorzero-core/fixtures/deployment/sagemaker-ollama/scripts/test.sh
+++ b/tensorzero-core/fixtures/deployment/sagemaker-ollama/scripts/test.sh
@@ -3,7 +3,7 @@
 curl "http://localhost:8080/invocations" \
     -H "Content-Type: application/json" \
     -d '{
-        "model": "qwen3:0.6b",
+        "model": "gemma3:1b",
         "messages": [
             {
                 "role": "user",

--- a/tensorzero-core/fixtures/deployment/sagemaker-tgi/scripts/test.sh
+++ b/tensorzero-core/fixtures/deployment/sagemaker-tgi/scripts/test.sh
@@ -3,7 +3,7 @@
 curl "http://localhost:8080/invocations" \
     -H "Content-Type: application/json" \
     -d '{
-        "model": "qwen3:0.6b",
+        "model": "gemma3:1b",
         "messages": [
             {
                 "role": "user",

--- a/tensorzero-core/tests/e2e/config/tensorzero.models.toml
+++ b/tensorzero-core/tests/e2e/config/tensorzero.models.toml
@@ -200,7 +200,7 @@ routing = ["aws_sagemaker"]
 type = "aws_sagemaker"
 endpoint_name = "ollama-provisioned-endpoint"
 region = "us-east-2"
-model_name = "qwen3:0.6b"
+model_name = "gemma3:1b"
 # We actually host an ollama container, but we don't have an ollama provider yet
 hosted_provider = "openai"
 
@@ -211,7 +211,7 @@ routing = ["aws_sagemaker"]
 type = "aws_sagemaker"
 endpoint_name = "text-generation-inference-2025-05-21-17-14-43-396"
 region = "us-east-2"
-model_name = "qwen3:0.6b"
+model_name = "gemma3:1b"
 hosted_provider = "tgi"
 
 [models.claude-haiku-4-5-gcp-vertex]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only updates example/fixture configs and test scripts to use a different Ollama model name; no production logic changes. Risk is limited to CI/e2e or fixture deployments failing if the model isn’t available/pullable.
> 
> **Overview**
> Updates the AWS SageMaker Ollama example and deployment fixtures to use `gemma3:1b` instead of `smollm2:135m`, including the model configured in `tensorzero.toml` and the model pulled at container startup.
> 
> Adjusts SageMaker fixture test scripts (Ollama and TGI) and e2e model configs to request `gemma3:1b`, keeping the persistent SageMaker endpoint tests aligned with the new default model.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e61714790fa79e2f1b2c30ebada416269c00529. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->