### PR TITLE
Fix re-exports from autopilot-client

### DIFF
--- a/internal/autopilot-client/src/lib.rs
+++ b/internal/autopilot-client/src/lib.rs
@@ -51,21 +51,4 @@ pub use client::{
 };
 pub use error::AutopilotError;
 pub use reject_missing_tool::reject_missing_tool;
-pub use types::{
-    ApproveAllToolCallsRequest, ApproveAllToolCallsResponse, AutopilotSideInfo, AutopilotStatus,
-    AutopilotToolResult, Base64File, CreateEventRequest, CreateEventResponse, ErrorDetail,
-    ErrorResponse, Event, EventPayload, EventPayloadError, EventPayloadMessage,
-    EventPayloadMessageContent, EventPayloadStatusUpdate, EventPayloadToolCall,
-    EventPayloadToolCallAuthorization, EventPayloadToolResult, EventPayloadUserQuestion,
-    EventPayloadUserQuestionInner, EventPayloadUserQuestions, EventPayloadUserQuestionsAnswers,
-    EventPayloadVisualization, File, FreeResponseAnswer, GatewayEvent, GatewayEventPayload,
-    GatewayEventPayloadToolCallAuthorization, GatewayListConfigWritesResponse,
-    GatewayListEventsResponse, GatewayStreamUpdate, GatewayToolCallAuthorizationStatus,
-    ListConfigWritesParams, ListConfigWritesResponse, ListEventsParams, ListEventsResponse,
-    ListSessionsParams, ListSessionsResponse, MultipleChoiceAnswer, MultipleChoiceOption,
-    MultipleChoiceQuestion, ObjectStoragePointer, OptimizationWorkflowSideInfo, RawText, Role,
-    Session, StatusUpdate, StreamEventsParams, StreamUpdate, Template, Text, Thought,
-    ToolCallAuthorizationStatus, ToolCallDecisionSource, ToolCallWrapper, ToolOutcome,
-    TopKEvaluationVisualization, Unknown, UrlFile, UserQuestionAnswer, VariantSummary,
-    VisualizationType,
-};
+pub use types::*;


### PR DESCRIPTION
We now re-export everything from the `types` module, so that we don't accidentally break things again when resolving merge conflicts

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Change is limited to `pub use` surface-area adjustments; main risk is a minor compile/breaking change for downstream crates expecting the previous re-exports.
> 
> **Overview**
> Fixes the `autopilot-client` crate’s public API re-exports in `lib.rs`.
> 
> The root module now re-exports newly added user-question and answer/MCQ-related types (e.g. `EventPayloadUserQuestion*`, `MultipleChoice*`, `FreeResponseAnswer`, `UserQuestionAnswer`) and stops re-exporting some previously listed items (notably `S3UploadRequest`/`S3UploadResponse`, `Gateway*` authorization status helper types, and a few other type aliases/structs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4fcf0cf210e22c89f9caa2f920282e539e495fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->