### PR TITLE
Prevent any other tests from running concurrently with overhead metric

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -104,6 +104,12 @@ slow-timeout = { period = "60s", terminate-after = 4 }
 retries = 0
 
 [[profile.default.overrides]]
+filter = 'test(test_prometheus_metrics_overhead)'
+# Prevent any other tests from running concurrently, to avoid inflating
+# the overhead metric due to CPU load from concurrent tests
+threads-required = "num-test-threads"
+
+[[profile.default.overrides]]
 filter = 'test(test_variant_failover)'
 # This test makes lots of requests, so give it extra time for the slower Github runners.
 slow-timeout = { period = "60s", terminate-after = 2 }


### PR DESCRIPTION
Having increased CPU load from other tests causes the overhead metric to get artificially inflated, which can cause this test to flake on CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that affects test scheduling (not production code), with the main downside being potentially longer overall test runtime when this test runs.
> 
> **Overview**
> Updates `nextest` configuration so `test_prometheus_metrics_overhead` runs with exclusive access to the test thread pool (`threads-required = "num-test-threads"`), preventing concurrent tests from inflating CPU load and causing CI flakiness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7a0f6724d50494dbe81810eaf316af899520341. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->