### PR TITLE
Filter metrics by function in InferenceFilterBuilder

### DIFF
--- a/ui/app/components/querybuilder/InferenceQueryBuilder.tsx
+++ b/ui/app/components/querybuilder/InferenceQueryBuilder.tsx
@@ -1,4 +1,4 @@
-import { useForm, useController } from "react-hook-form";
+import { useForm, useController, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { Form } from "~/components/ui/form";
@@ -45,6 +45,11 @@ export default function InferenceQueryBuilder({
     control: form.control,
   });
 
+  const functionName = useWatch({
+    control: form.control,
+    name: "function",
+  });
+
   return (
     <Form {...form}>
       <form className="space-y-6" onSubmit={form.handleSubmit(handleSubmit)}>
@@ -52,6 +57,7 @@ export default function InferenceQueryBuilder({
         <InferenceFilterBuilder
           inferenceFilter={inferenceFilter}
           setInferenceFilter={setInferenceFilter}
+          functionName={functionName || null}
         />
       </form>
     </Form>

--- a/ui/app/routes/datasets/builder/DatasetBuilderForm.tsx
+++ b/ui/app/routes/datasets/builder/DatasetBuilderForm.tsx
@@ -255,6 +255,7 @@ export function DatasetBuilderForm() {
                   <InferenceFilterBuilder
                     inferenceFilter={inferenceFilter}
                     setInferenceFilter={setInferenceFilter}
+                    functionName={functionName}
                   />
                 </div>
               </div>

--- a/ui/app/routes/observability/inferences/InferencesTable.tsx
+++ b/ui/app/routes/observability/inferences/InferencesTable.tsx
@@ -468,6 +468,7 @@ export default function InferencesTable({
                 <InferenceFilterBuilder
                   inferenceFilter={filterAdvanced}
                   setInferenceFilter={setFilterAdvanced}
+                  functionName={filterFunctionName}
                 />
               </div>
             </div>


### PR DESCRIPTION
Supersedes #5581 (pushed to origin to trigger CI).

Original work by @Nfemz. Addresses #5154.

When a function is selected, the metric popover now only shows metrics that have feedback data for inferences of that function, rather than showing all metrics from config.

- Add optional `functionName` prop to InferenceFilterBuilder
- Fetch metrics with feedback using existing endpoint
- Show loading spinner while fetching
- Pass functionName from DatasetBuilderForm, InferencesTable, and InferenceQueryBuilder

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only filtering and loading-state changes; risk is limited to potentially hiding metrics due to fetch failures or mismatched function names.
> 
> **Overview**
> When a function is selected in query/filter UIs, the **Metric** popover in `InferenceFilterBuilder` now only lists metrics that have feedback data for that function by fetching `/api/function/:function_name/feedback_counts` via `useFetcher`.
> 
> This adds an optional `functionName` prop, threads it through `InferenceQueryBuilder`, `DatasetBuilderForm`, and `InferencesTable`, and updates the metric picker to show a spinner/disable the button while loading and a function-specific empty-state message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d86119b50c9073bbed6c507b7a9f603f0a4ffb21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->