### PR TITLE
Make ENABLE_POSTGRES_WRITE write only to Postgres

### DIFF
--- a/tensorzero-core/src/cache.rs
+++ b/tensorzero-core/src/cache.rs
@@ -28,8 +28,6 @@ use std::fmt::Debug;
 use uuid::Uuid;
 
 /// Manager for cache operations, wrapping a `dyn CacheQueries` backend.
-///
-/// Uses Valkey if available, otherwise falls back to ClickHouse.
 #[derive(Clone)]
 pub struct CacheManager {
     client: Arc<dyn CacheQueries>,
@@ -42,8 +40,9 @@ impl CacheManager {
 
     /// Select the appropriate cache backend.
     ///
-    /// When `ENABLE_POSTGRES_WRITE` is off (legacy mode), uses ClickHouse.
-    /// When `ENABLE_POSTGRES_WRITE` is on, uses Valkey if available, otherwise disabled.
+    /// When `ENABLE_POSTGRES_WRITE` is off, uses ClickHouse.
+    /// When `ENABLE_POSTGRES_WRITE` is on (Postgres is the write target), uses Valkey
+    /// if available, otherwise falls back to ClickHouse.
     pub fn new_from_connections(
         valkey_connection_info: &ValkeyConnectionInfo,
         clickhouse_connection_info: &ClickHouseConnectionInfo,

--- a/tensorzero-core/src/feature_flags/flags.rs
+++ b/tensorzero-core/src/feature_flags/flags.rs
@@ -29,7 +29,7 @@ define_flags! {
     /// A dummy test flag for unit tests.
     pub TEST_FLAG: bool = ("test_flag", false);
 
-    /// Enable writing to Postgres for data in addition to ClickHouse.
+    /// Write data to Postgres instead of ClickHouse.
     pub ENABLE_POSTGRES_WRITE: bool = ("enable_postgres_write", false);
 
     /// Enable reading from Postgres for data instead of ClickHouse.


### PR DESCRIPTION
When ENABLE_POSTGRES_WRITE is set, write exclusively to Postgres and skip ClickHouse. Previously the flag enabled dual-write where ClickHouse was always written first and Postgres errors were swallowed.

This makes our lives easier for the initial Postgres rollout - descope it to new-users only. We'll figure out dual-write and data migration story later.

A step towards #5691.