### PR TITLE
Adjust force-merge-queue restart logic to handle forks

### DIFF
--- a/.github/workflows/force-merge-queue.yml
+++ b/.github/workflows/force-merge-queue.yml
@@ -1,5 +1,6 @@
 name: Force add to merge queue
 permissions:
+  checks: read
   contents: read
   actions: write
   statuses: write
@@ -35,15 +36,17 @@ jobs:
         if: github.event.action == 'labeled'
         continue-on-error: true
         run: |
-          # Find the latest general.yml run for this PR's head commit
-          RUN_ID=$(gh run list \
-            --workflow=general.yml \
-            --commit=${{ github.event.pull_request.head.sha }} \
-            --limit=1 \
-            --json databaseId,conclusion \
-            --jq '.[0] | select(.conclusion == "failure") | .databaseId')
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
 
-          if [ -n "$RUN_ID" ]; then
+          # Find the workflow run ID through the check-runs API, which works reliably
+          # for both fork and non-fork PRs (fork commits are reachable via refs/pull/N/head).
+          # gh run list --commit doesn't always find runs for fork PRs.
+          DETAILS_URL=$(gh api "repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs?per_page=100" \
+            --jq '[.check_runs[] | select(.name == "check-all-general-jobs-passed" and .conclusion == "failure")] | .[0].details_url // empty')
+
+          if [ -n "$DETAILS_URL" ]; then
+            # Extract the run ID from the details URL (format: .../actions/runs/{run_id}/job/{job_id})
+            RUN_ID=$(echo "$DETAILS_URL" | sed 's|.*/actions/runs/||; s|/.*||')
             echo "Restarting failed general.yml run: $RUN_ID"
             gh run rerun "$RUN_ID"
           else


### PR DESCRIPTION
We cannot directly look up the general.yml run by commit when a PR comes from a fork, since the commit does not exist in tensorzero/tensorzero.

This new approach should hopefully make the force-add-to-merge-queue label work on prs with failing checks, even if they come from a fork

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI-only change limited to a label-triggered workflow; risk is mainly incorrect run lookup/restart causing the workaround to fail rather than affecting production code.
> 
> **Overview**
> Improves `.github/workflows/force-merge-queue.yml` so the “Restart general.yml if it failed” step works for fork PRs by switching from `gh run list --commit` to querying the commit’s check-runs via `gh api`, extracting the `actions/runs/{run_id}` from `details_url`, and rerunning that workflow.
> 
> Adds `permissions.checks: read` to support the new check-runs API call, while keeping the existing behavior of attaching a fake `check-all-general-jobs-passed` success status when the label is applied.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2030b3166ed5963bc928d0b5214c27b527d9d79d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->