### PR TITLE
Skip even more ci jobs for PR ci on forks

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1136,7 +1136,7 @@ jobs:
       id-token: write
     needs: [build-gateway-container]
     runs-on: ubuntu-latest
-    if: github.repository == 'tensorzero/tensorzero' && !(github.event_name == 'pull_request' && github.actor == 'dependabot[bot]')
+    if: github.repository == 'tensorzero/tensorzero' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'))
     env:
       OPENAI_API_KEY: not_used
       FIREWORKS_API_KEY: not_used
@@ -1230,6 +1230,7 @@ jobs:
         run: cat e2e_logs.txt
 
   build-gateway-e2e-container:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: ./.github/workflows/build-gateway-e2e-container.yml
     permissions:
       # Permission to checkout the repository
@@ -1241,6 +1242,7 @@ jobs:
       DOCKERHUB_LIMITED_TOKEN: ${{ secrets.DOCKERHUB_LIMITED_TOKEN }}
 
   build-provider-proxy-container:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: ./.github/workflows/build-provider-proxy-container.yml
     permissions:
       # Permission to checkout the repository
@@ -1289,7 +1291,7 @@ jobs:
 
   build-fixtures-container:
     uses: ./.github/workflows/build-fixtures-container.yml
-    if: ${{ !(github.event_name == 'pull_request' && github.actor == 'dependabot[bot]') }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
     permissions:
       # Permission to checkout the repository
       contents: read


### PR DESCRIPTION
This should hopefully remove the need to use the
force-add-to-merge-queue label on prs from forks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes GitHub Actions job gating logic; main risk is unintentionally skipping needed checks on some PR event edge cases.
> 
> **Overview**
> Updates `general.yml` to **skip additional CI jobs on forked pull requests** by requiring PRs to originate from the same repository before running certain workflows.
> 
> This tightens conditions for `mock-optimization-tests`, `build-gateway-e2e-container`, `build-provider-proxy-container`, and `build-fixtures-container` (while still allowing them on non-PR events), and keeps the Dependabot exclusion where applicable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b117cdda26dcdcd57c64228cf24a1e521f9bbd93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->