### PR TITLE
Export UploadDatasetFormat for use in autopilot

### DIFF
--- a/internal/autopilot-tools/src/tools/prod/mod.rs
+++ b/internal/autopilot-tools/src/tools/prod/mod.rs
@@ -48,7 +48,8 @@ pub use list_inferences::{ListInferencesTool, ListInferencesToolParams};
 pub use run_evaluation::{RunEvaluationTool, RunEvaluationToolParams};
 pub use update_datapoints::{UpdateDatapointsTool, UpdateDatapointsToolParams};
 pub use upload_dataset::{
-    UploadDatasetTool, UploadDatasetToolOutput, UploadDatasetToolParams, upload_dataset_parquet,
+    UploadDatasetFormat, UploadDatasetTool, UploadDatasetToolOutput, UploadDatasetToolParams,
+    upload_dataset_parquet,
 };
 pub use write_config::{
     EditPayload, UpsertEvaluationPayload, UpsertEvaluatorPayload, UpsertExperimentationPayload,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Simple public API surface change (re-export) with no behavioral or data-path modifications.
> 
> **Overview**
> Exports `UploadDatasetFormat` from `internal/autopilot-tools/src/tools/prod/mod.rs`, making the dataset-upload format enum available to external autopilot consumers alongside the existing `UploadDatasetTool` re-exports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55b6c0650eba9c6ad1316718e0d7d86d41488be2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->