### PR TITLE
Consolidate postgres feature flags into one

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1088,11 +1088,10 @@ jobs:
           echo "TENSORZERO_MOCK_PROVIDER_API_TAG=sha-${{ github.sha }}" >> $GITHUB_ENV
           echo "TENSORZERO_SKIP_LARGE_FIXTURES=1" >> $GITHUB_ENV
 
-      - name: Set Postgres read and write feature flags
+      - name: Set Postgres as primary datastore
         if: matrix.database == 'postgres'
         run: |
-          echo "TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_READ=1" >> $GITHUB_ENV
-          echo "TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_WRITE=1" >> $GITHUB_ENV
+          echo "TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_AS_PRIMARY_DATASTORE=1" >> $GITHUB_ENV
 
       - name: Launch dependency services
         run: docker compose -f tensorzero-core/tests/e2e/docker-compose.yml up --wait

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -68,11 +68,9 @@ def embedded_sync_client():
 
 @pytest.fixture
 def embedded_sync_client_using_postgres():
-    original_enable_postgres_read_flag = os.environ.pop("TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_READ", None)
-    original_enable_postgres_write_flag = os.environ.pop("TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_WRITE", None)
+    original_flag = os.environ.pop("TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_AS_PRIMARY_DATASTORE", None)
 
-    os.environ["TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_READ"] = "1"
-    os.environ["TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_WRITE"] = "1"
+    os.environ["TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_AS_PRIMARY_DATASTORE"] = "1"
 
     with TensorZeroGateway.build_embedded(
         config_file=TEST_CONFIG_FILE,
@@ -81,13 +79,10 @@ def embedded_sync_client_using_postgres():
     ) as client:
         yield client
 
-    # Reset flags
-    os.environ.pop("TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_READ", None)
-    if original_enable_postgres_read_flag:
-        os.environ["TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_READ"] = original_enable_postgres_read_flag
-    os.environ.pop("TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_WRITE", None)
-    if original_enable_postgres_write_flag:
-        os.environ["TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_WRITE"] = original_enable_postgres_write_flag
+    # Reset flag
+    os.environ.pop("TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_AS_PRIMARY_DATASTORE", None)
+    if original_flag:
+        os.environ["TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_AS_PRIMARY_DATASTORE"] = original_flag
 
 
 @pytest_asyncio.fixture

--- a/clients/rust/src/test_helpers.rs
+++ b/clients/rust/src/test_helpers.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use crate::{Client, ClientBuilder, ClientBuilderMode, PostgresConfig};
 use tempfile::NamedTempFile;
 use tensorzero_core::db::clickhouse::test_helpers::CLICKHOUSE_URL;
-use tensorzero_core::feature_flags::{ENABLE_POSTGRES_READ, ENABLE_POSTGRES_WRITE};
+use tensorzero_core::feature_flags::ENABLE_POSTGRES_AS_PRIMARY_DATASTORE;
 use url::Url;
 use uuid::Uuid;
 
@@ -22,7 +22,7 @@ pub async fn make_http_gateway() -> Client {
 }
 
 pub async fn make_embedded_gateway() -> Client {
-    let postgres_config = if ENABLE_POSTGRES_READ.get() || ENABLE_POSTGRES_WRITE.get() {
+    let postgres_config = if ENABLE_POSTGRES_AS_PRIMARY_DATASTORE.get() {
         let postgres_url = std::env::var("TENSORZERO_POSTGRES_URL")
             .expect("TENSORZERO_POSTGRES_URL must be set when Postgres flags are enabled");
         Some(PostgresConfig::Url(postgres_url))
@@ -223,7 +223,7 @@ pub async fn make_embedded_gateway_e2e_with_unique_db(db_prefix: &str) -> Client
 
 /// Creates an embedded gateway using the e2e config with a unique ClickHouse database,
 /// plus Postgres and Valkey connections from env vars.
-/// Use this when testing with `ENABLE_POSTGRES_WRITE=true` (e.g. Valkey cache backend).
+/// Use this when testing with `ENABLE_POSTGRES_AS_PRIMARY_DATASTORE=true` (e.g. Valkey cache backend).
 pub async fn make_embedded_gateway_e2e_with_unique_db_all_backends(db_prefix: &str) -> Client {
     let clickhouse_url = create_unique_clickhouse_url(db_prefix);
     let config_path = get_e2e_config_path();

--- a/tensorzero-core/src/db/postgres/README.md
+++ b/tensorzero-core/src/db/postgres/README.md
@@ -7,7 +7,7 @@ For developing Postgres features (writing queries, testing locally):
 ```bash
 # 1. Set environment variables
 export TENSORZERO_POSTGRES_URL="postgres://postgres:postgres@localhost:5432/postgres_migration_dev"
-export TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_READ=1
+export TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_AS_PRIMARY_DATASTORE=1
 
 # 2. Reset Postgres and load fixture data
 ./ui/fixtures/reset-dev-postgres.sh

--- a/tensorzero-core/src/endpoints/episodes/internal/get_episode_inference_count.rs
+++ b/tensorzero-core/src/endpoints/episodes/internal/get_episode_inference_count.rs
@@ -2,7 +2,7 @@ use crate::{
     config::Config,
     db::inferences::{CountInferencesParams, InferenceQueries},
     error::Error,
-    feature_flags::ENABLE_POSTGRES_READ,
+    feature_flags::ENABLE_POSTGRES_AS_PRIMARY_DATASTORE,
     utils::gateway::{AppState, AppStateData},
 };
 use axum::{
@@ -33,7 +33,7 @@ pub async fn get_episode_inference_count_handler(
     State(app_state): AppState,
     Path(episode_id): Path<Uuid>,
 ) -> Result<Json<GetEpisodeInferenceCountResponse>, Error> {
-    let stats = if ENABLE_POSTGRES_READ.get() {
+    let stats = if ENABLE_POSTGRES_AS_PRIMARY_DATASTORE.get() {
         get_episode_inference_count(
             &app_state.config,
             &app_state.postgres_connection_info,

--- a/tensorzero-core/src/endpoints/internal/inference_count.rs
+++ b/tensorzero-core/src/endpoints/internal/inference_count.rs
@@ -17,7 +17,7 @@ use crate::db::inferences::{
 };
 use crate::endpoints::stored_inferences::v1::types::DemonstrationFeedbackFilter;
 use crate::error::{Error, ErrorDetails};
-use crate::feature_flags::ENABLE_POSTGRES_READ;
+use crate::feature_flags::ENABLE_POSTGRES_AS_PRIMARY_DATASTORE;
 use crate::function::DEFAULT_FUNCTION_NAME;
 use crate::utils::gateway::{AppState, AppStateData};
 
@@ -347,7 +347,7 @@ pub async fn get_function_throughput_by_variant(
 pub async fn list_functions_with_inference_count_handler(
     State(state): State<AppStateData>,
 ) -> Result<Json<ListFunctionsWithInferenceCountResponse>, Error> {
-    let database: &(dyn InferenceQueries + Sync) = if ENABLE_POSTGRES_READ.get() {
+    let database: &(dyn InferenceQueries + Sync) = if ENABLE_POSTGRES_AS_PRIMARY_DATASTORE.get() {
         &state.postgres_connection_info
     } else {
         &state.clickhouse_connection_info
@@ -627,7 +627,7 @@ mod tests {
         assert_eq!(result.inference_count, 10);
     }
 
-    // Tests for ENABLE_POSTGRES_READ flag dispatch
+    // Tests for ENABLE_POSTGRES_AS_PRIMARY_DATASTORE flag dispatch
     // Note: The business logic functions take `&impl InferenceCountQueries` and are database-agnostic.
     // The flag only affects which connection the handlers pass to the business logic.
     // These tests verify the Postgres implementation can be invoked through the same interface.

--- a/tensorzero-core/src/feature_flags/flags.rs
+++ b/tensorzero-core/src/feature_flags/flags.rs
@@ -29,9 +29,6 @@ define_flags! {
     /// A dummy test flag for unit tests.
     pub TEST_FLAG: bool = ("test_flag", false);
 
-    /// Write data to Postgres instead of ClickHouse.
-    pub ENABLE_POSTGRES_WRITE: bool = ("enable_postgres_write", false);
-
-    /// Enable reading from Postgres for data instead of ClickHouse.
-    pub ENABLE_POSTGRES_READ: bool = ("enable_postgres_read", false);
+    /// Use Postgres as the primary datastore instead of ClickHouse.
+    pub ENABLE_POSTGRES_AS_PRIMARY_DATASTORE: bool = ("enable_postgres_as_primary_datastore", false);
 }

--- a/tensorzero-core/src/howdy.rs
+++ b/tensorzero-core/src/howdy.rs
@@ -122,9 +122,7 @@ async fn synchronize_deployment_id(
     clickhouse: &ClickHouseConnectionInfo,
     postgres: &PostgresConnectionInfo,
 ) -> Result<(), ()> {
-    // Even though this writes deployment ID to Postgres, we gate it behind ENABLE_POSTGRES_READ
-    // because it's serving a read query.
-    if !feature_flags::ENABLE_POSTGRES_READ.get() {
+    if !feature_flags::ENABLE_POSTGRES_AS_PRIMARY_DATASTORE.get() {
         return Ok(());
     }
     if clickhouse.client_type() != ClickHouseClientType::Production {

--- a/tensorzero-core/tests/e2e/cache.rs
+++ b/tensorzero-core/tests/e2e/cache.rs
@@ -63,8 +63,8 @@ macro_rules! make_cache_tests {
 
 /// Creates a gateway configured to use the specified cache backend.
 ///
-/// - `CacheBackend::Clickhouse`: default mode with `ENABLE_POSTGRES_WRITE=false`
-/// - `CacheBackend::Valkey`: sets `ENABLE_POSTGRES_WRITE=true` and `ENABLE_POSTGRES_READ=true`,
+/// - `CacheBackend::Clickhouse`: default mode (ClickHouse as primary datastore)
+/// - `CacheBackend::Valkey`: sets `ENABLE_POSTGRES_AS_PRIMARY_DATASTORE=true`,
 ///   uses Postgres + Valkey connections
 async fn make_cache_test_gateway(backend: CacheBackend, db_prefix: &str) -> tensorzero::Client {
     match backend {
@@ -72,11 +72,7 @@ async fn make_cache_test_gateway(backend: CacheBackend, db_prefix: &str) -> tens
         CacheBackend::Valkey => {
             // Must be set before the first flag access (OnceLock caches on first read)
             tensorzero_unsafe_helpers::set_env_var_tests_only(
-                "TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_WRITE",
-                "true",
-            );
-            tensorzero_unsafe_helpers::set_env_var_tests_only(
-                "TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_READ",
+                "TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_AS_PRIMARY_DATASTORE",
                 "true",
             );
             make_embedded_gateway_e2e_with_unique_db_all_backends(db_prefix).await

--- a/tensorzero-core/tests/e2e/common.rs
+++ b/tensorzero-core/tests/e2e/common.rs
@@ -11,7 +11,7 @@ lazy_static::lazy_static! {
 /// This is not really perfect because we rely on the tests running in the same context as when we
 /// launch the gateway container, but it's true for our CI setup and is good enough for today.
 pub fn is_postgres_test() -> bool {
-    feature_flags::ENABLE_POSTGRES_READ.get() || feature_flags::ENABLE_POSTGRES_WRITE.get()
+    feature_flags::ENABLE_POSTGRES_AS_PRIMARY_DATASTORE.get()
 }
 
 /// Skips the current test if running against Postgres.


### PR DESCRIPTION
This removes the previous flag setup with separate flags that enable Postgres read and writes into a single one, `TENSORZERO_INTERNAL_FLAG_ENABLE_POSTGRES_AS_PRIMARY_DATASTORE`. When the flag is enabled (for new Postgres-only deployments), we only talk to ClickHouse for two things:
- on gateway startup to synchronize deployment ID
- if model inference caching is enabled and Valkey is not set (TBD if we want to keep this)