### PR TITLE
Fix aws/s3_initiate_upload paths in autopilot client

### DIFF
--- a/gateway/src/routes/internal.rs
+++ b/gateway/src/routes/internal.rs
@@ -262,7 +262,7 @@ pub fn build_internal_non_otel_enabled_routes() -> Router<AppStateData> {
             get(endpoints::internal::autopilot::list_config_writes_handler),
         )
         .route(
-            "/internal/autopilot/v1/aws/s3_initiate_upload",
+            "/internal/autopilot/v1/sessions/{session_id}/aws/s3_initiate_upload",
             post(endpoints::internal::autopilot::s3_initiate_upload_handler),
         )
         // Resolve UUID endpoint

--- a/internal/autopilot-client/src/client.rs
+++ b/internal/autopilot-client/src/client.rs
@@ -359,9 +359,12 @@ impl AutopilotClient {
     /// Initiates an S3 upload by requesting temporary credentials from the Autopilot API.
     pub async fn s3_initiate_upload(
         &self,
+        session_id: Uuid,
         request: S3UploadRequest,
     ) -> Result<S3UploadResponse, AutopilotError> {
-        let url = self.base_url.join("/v1/aws/s3_initiate_upload")?;
+        let url = self
+            .base_url
+            .join(&format!("/v1/sessions/{session_id}/aws/s3_initiate_upload"))?;
         let response = self
             .http_client
             .post(url)

--- a/internal/autopilot-tools/src/tools/prod/upload_dataset.rs
+++ b/internal/autopilot-tools/src/tools/prod/upload_dataset.rs
@@ -229,11 +229,11 @@ impl TaskTool for UploadDatasetTool {
         let credentials: S3UploadResponse = ctx
             .step(
                 "get_credentials",
-                side_info.tool_call_event_id,
-                |tool_call_event_id, state| async move {
+                (side_info.tool_call_event_id, side_info.session_id),
+                |(tool_call_event_id, session_id), state| async move {
                     let response = state
                         .t0_client()
-                        .s3_initiate_upload(S3UploadRequest { tool_call_event_id })
+                        .s3_initiate_upload(session_id, S3UploadRequest { tool_call_event_id })
                         .await
                         .map_err(|e| anyhow::Error::msg(e.to_string()))?;
                     Ok(response)

--- a/internal/autopilot-tools/tests/common/mod.rs
+++ b/internal/autopilot-tools/tests/common/mod.rs
@@ -66,6 +66,7 @@ mock! {
 
         async fn s3_initiate_upload(
             &self,
+            session_id: Uuid,
             request: durable_tools::S3UploadRequest,
         ) -> Result<durable_tools::S3UploadResponse, TensorZeroClientError>;
 

--- a/internal/autopilot-worker/src/wrapper.rs
+++ b/internal/autopilot-worker/src/wrapper.rs
@@ -414,6 +414,7 @@ mod tests {
 
             async fn s3_initiate_upload(
                 &self,
+                session_id: Uuid,
                 request: durable_tools::S3UploadRequest,
             ) -> Result<durable_tools::S3UploadResponse, TensorZeroClientError>;
 

--- a/internal/durable-tools/src/tensorzero_client/client_ext.rs
+++ b/internal/durable-tools/src/tensorzero_client/client_ext.rs
@@ -282,13 +282,16 @@ impl TensorZeroClient for Client {
 
     async fn s3_initiate_upload(
         &self,
+        session_id: Uuid,
         request: S3UploadRequest,
     ) -> Result<S3UploadResponse, TensorZeroClientError> {
         match self.mode() {
             ClientMode::HTTPGateway(http) => {
                 let url = http
                     .base_url
-                    .join("internal/autopilot/v1/aws/s3_initiate_upload")
+                    .join(&format!(
+                        "internal/autopilot/v1/sessions/{session_id}/aws/s3_initiate_upload"
+                    ))
                     .map_err(|e: url::ParseError| {
                         TensorZeroClientError::Autopilot(AutopilotError::InvalidUrl(e))
                     })?;
@@ -328,6 +331,7 @@ impl TensorZeroClient for Client {
 
                 tensorzero_core::endpoints::internal::autopilot::s3_initiate_upload(
                     autopilot_client,
+                    session_id,
                     request,
                 )
                 .await

--- a/internal/durable-tools/src/tensorzero_client/embedded.rs
+++ b/internal/durable-tools/src/tensorzero_client/embedded.rs
@@ -176,6 +176,7 @@ impl TensorZeroClient for EmbeddedClient {
 
     async fn s3_initiate_upload(
         &self,
+        session_id: Uuid,
         request: S3UploadRequest,
     ) -> Result<S3UploadResponse, TensorZeroClientError> {
         let autopilot_client = self
@@ -184,7 +185,7 @@ impl TensorZeroClient for EmbeddedClient {
             .as_ref()
             .ok_or(TensorZeroClientError::AutopilotUnavailable)?;
 
-        s3_initiate_upload(autopilot_client, request)
+        s3_initiate_upload(autopilot_client, session_id, request)
             .await
             .map_err(|e| {
                 TensorZeroClientError::TensorZero(TensorZeroError::Other { source: e.into() })

--- a/internal/durable-tools/src/tensorzero_client/mod.rs
+++ b/internal/durable-tools/src/tensorzero_client/mod.rs
@@ -158,6 +158,7 @@ pub trait TensorZeroClient: Send + Sync + 'static {
     /// Returns temporary S3 credentials for uploading data.
     async fn s3_initiate_upload(
         &self,
+        session_id: Uuid,
         request: S3UploadRequest,
     ) -> Result<S3UploadResponse, TensorZeroClientError>;
 


### PR DESCRIPTION
This now takes in a session_id

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> API shape change for an internal endpoint and multiple client signatures; low algorithmic risk but callers must be updated together or they will break at runtime/compile time.
> 
> **Overview**
> Fixes the internal Autopilot S3 upload initiation endpoint to be *session-scoped* by moving it from `/internal/autopilot/v1/aws/s3_initiate_upload` to `/internal/autopilot/v1/sessions/{session_id}/aws/s3_initiate_upload` and updating the gateway route + Axum handler to require `session_id` in the path.
> 
> Threads `session_id` through the full call chain (`autopilot-client`, `tensorzero-core` core function, `durable-tools` `TensorZeroClient` trait + HTTP/embedded implementations, and the `upload_dataset` tool/tests) so all callers hit the corrected URL and API signature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f84aa6078a4e9a2dd6e954b8dc10e883292f4de1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->