### PR TITLE
Guard observability writes when Postgres is the primary datastore

### DIFF
--- a/tensorzero-core/src/config/mod.rs
+++ b/tensorzero-core/src/config/mod.rs
@@ -393,6 +393,14 @@ pub struct ObservabilityConfig {
     pub disable_automatic_migrations: bool,
 }
 
+impl ObservabilityConfig {
+    /// Returns true when observability writes (inferences, feedback) should be persisted.
+    /// Defaults to true when `enabled` is not explicitly set.
+    pub fn writes_enabled(&self) -> bool {
+        self.enabled.unwrap_or(true)
+    }
+}
+
 fn default_flush_interval_ms() -> u64 {
     100
 }

--- a/tensorzero-core/src/endpoints/feedback/mod.rs
+++ b/tensorzero-core/src/endpoints/feedback/mod.rs
@@ -181,6 +181,14 @@ async fn feedback_inner(
     deferred_tasks: &TaskTracker,
     params: Params,
 ) -> Result<FeedbackResponse, Error> {
+    if !config.gateway.observability.writes_enabled() {
+        return Err(Error::new(ErrorDetails::InvalidRequest {
+            message: "Feedback requires observability to be enabled \
+                      (`gateway.observability.enabled` must not be `false`)."
+                .to_string(),
+        }));
+    }
+
     // Get the metric config or return an error if it doesn't exist
     let feedback_metadata = get_feedback_metadata(
         config,
@@ -894,7 +902,10 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
 
-    use crate::config::{Config, MetricConfig, MetricConfigOptimize, SchemaData};
+    use crate::config::gateway::GatewayConfig;
+    use crate::config::{
+        Config, MetricConfig, MetricConfigOptimize, ObservabilityConfig, SchemaData,
+    };
     use crate::db::clickhouse::MockClickHouseConnectionInfo;
     use crate::db::inferences::FunctionInfo;
     use crate::experimentation::ExperimentationConfigWithNamespaces;
@@ -1787,5 +1798,66 @@ mod tests {
             "456".to_string(),
         );
         assert!(validate_feedback_specific_tags(&tags).is_ok());
+    }
+
+    fn mock_db_expecting_no_calls() -> MockClickHouseConnectionInfo {
+        let mut mock_db = MockClickHouseConnectionInfo::new();
+        mock_db.inference_queries.expect_get_function_info().never();
+        mock_db
+            .feedback_queries
+            .expect_insert_comment_feedback()
+            .never();
+        mock_db
+            .feedback_queries
+            .expect_insert_float_feedback()
+            .never();
+        mock_db
+            .feedback_queries
+            .expect_insert_boolean_feedback()
+            .never();
+        mock_db
+            .feedback_queries
+            .expect_insert_demonstration_feedback()
+            .never();
+        mock_db
+    }
+
+    #[tokio::test]
+    async fn test_feedback_rejects_when_observability_disabled() {
+        let config = Config {
+            gateway: GatewayConfig {
+                observability: ObservabilityConfig {
+                    enabled: Some(false),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mock_db = mock_db_expecting_no_calls();
+        let params = Params {
+            episode_id: Some(Uuid::now_v7()),
+            inference_id: None,
+            metric_name: "comment".to_string(),
+            value: json!("test comment"),
+            tags: HashMap::new(),
+            internal: false,
+            dryrun: Some(false),
+        };
+        let deferred_tasks = TaskTracker::new();
+
+        let error = feedback_inner(&config, Arc::new(mock_db), &deferred_tasks, params)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            *error.get_details(),
+            ErrorDetails::InvalidRequest {
+                message: "Feedback requires observability to be enabled \
+                          (`gateway.observability.enabled` must not be `false`)."
+                    .to_string(),
+            },
+            "Feedback should be rejected when observability is disabled"
+        );
     }
 }

--- a/tensorzero-core/src/endpoints/inference.rs
+++ b/tensorzero-core/src/endpoints/inference.rs
@@ -911,7 +911,7 @@ async fn infer_variant(args: InferVariantArgs<'_>) -> Result<InferenceOutput, Er
 
         let result = result?;
 
-        if !dryrun {
+        if !dryrun && config.gateway.observability.writes_enabled() {
             // Spawn a thread for a trailing write to ClickHouse so that it doesn't block the response
             let result_to_write = result.clone();
             let extra_body = inference_config.extra_body.clone();
@@ -1364,7 +1364,7 @@ fn create_stream(
 
         yield Ok(prepare_response_chunk(&metadata, chunk));
 
-        if !metadata.dryrun {
+        if !metadata.dryrun && config.gateway.observability.writes_enabled() {
             // IMPORTANT: The following code will not be reached if the stream is interrupted.
             // Only do things that would be ok to skip in that case.
             //


### PR DESCRIPTION
Currently the way we guard `observability.enabled` is by not creating the database connections; this is incorrect and should be enforced at the db level.

Skip inference and feedback DB writes when `gateway.observability.enabled` is false, regardless of which database backend is active. Previously only ClickHouse was disabled.

- Add `ObservabilityConfig::writes_enabled()` helper
- Guard non-streaming and streaming inference write paths
- Compute `skip_write` in feedback to combine dryrun and observability config
- Return error for batch inference when observability is disabled
- Use `writes_enabled()` in resolved_input.rs for consistency

A step towards #5691.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when/if inference and feedback data are persisted and introduces new hard rejections for batch inference, which could affect deployments relying on previous partial-write behavior.
> 
> **Overview**
> Centralizes observability write gating via `ObservabilityConfig::writes_enabled()` and applies it across the request lifecycle.
> 
> **Behavior change:** inference persistence (non-streaming + streaming trailing writes) and input file object-store uploads are now skipped when observability is disabled, and the feedback endpoint now rejects requests up front instead of attempting any DB work.
> 
> Batch inference now returns an `InvalidRequest` error when observability writes are disabled (both `start_batch_inference` and `poll_batch_inference`), with added unit tests covering the new rejection paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57b3ff7232b1b1c3b7effd166fb49cc0a8b75480. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->