### PR TITLE
Exclude integration tests from nextest unit test settings

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -197,7 +197,7 @@ slow-timeout = { period = "60s", terminate-after = 2 }
 
 [[profile.default.overrides]]
 # Settings for running unit tests
-filter = 'not (kind(test) | binary(e2e) | test(export_bindings_) | test(export_schema_))'
+filter = 'kind(lib)'
 retries = 0
 slow-timeout = { period = "10s", terminate-after = 2 }
 


### PR DESCRIPTION
Any standalone binary in the 'tests' directory will no longer hvae the zero-retries and short timeout settings applied. This should prevent 'tensorzero-optimizers::e2e_gepa analyze::test_analyze_input_format_scenarios' from getting treated as a unit test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to test selection/behavior; main risk is inadvertently shifting which tests get zero retries/short timeouts in CI.
> 
> **Overview**
> Tightens the `profile.default` nextest override for *unit tests* by changing its filter from an exclusion-based expression (`not (binary(e2e) | ...)`) to `kind(lib)`.
> 
> This prevents standalone test binaries (e.g., integration tests under `tests/`) from inheriting the unit-test settings of `retries = 0` and the shorter `slow-timeout`, reducing accidental flakiness/failures from overly strict limits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f69edbaed094b69ffc93d521edefd4b6437e9572. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->