### PR TITLE
Use global EntitySheet context for episode page inference preview

### DIFF
--- a/ui/app/routes/observability/episodes/$episode_id/EpisodeInferenceTable.tsx
+++ b/ui/app/routes/observability/episodes/$episode_id/EpisodeInferenceTable.tsx
@@ -15,13 +15,13 @@ import {
   TableItemShortUuid,
 } from "~/components/ui/TableItems";
 import { toFunctionUrl, toInferenceUrl } from "~/utils/urls";
-import { InferencePreviewSheet } from "~/components/inference/InferencePreviewSheet";
 import { Button } from "~/components/ui/button";
 import { Eye } from "lucide-react";
 import { Suspense } from "react";
 import { useLocation, Await } from "react-router";
 import { Skeleton } from "~/components/ui/skeleton";
 import type { InferencesData } from "./route";
+import { useEntitySheet } from "~/context/entity-sheet";
 
 function SkeletonRows() {
   return (
@@ -49,13 +49,12 @@ function SkeletonRows() {
   );
 }
 
-function TableRows({
-  data,
-  onOpenSheet,
-}: {
+interface TableRowsProps {
   data: InferencesData;
   onOpenSheet: (inferenceId: string) => void;
-}) {
+}
+
+function TableRows({ data, onOpenSheet }: TableRowsProps) {
   const { inferences } = data;
 
   if (inferences.length === 0) {
@@ -110,55 +109,42 @@ function TableRows({
 
 interface EpisodeInferenceTableProps {
   data: Promise<InferencesData>;
-  onOpenSheet: (inferenceId: string) => void;
-  onCloseSheet: () => void;
-  openSheetInferenceId: string | null;
 }
 
 export default function EpisodeInferenceTable({
   data,
-  onOpenSheet,
-  onCloseSheet,
-  openSheetInferenceId,
 }: EpisodeInferenceTableProps) {
   const location = useLocation();
+  const { openInferenceSheet } = useEntitySheet();
 
   return (
-    <>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>ID</TableHead>
-            <TableHead>Function</TableHead>
-            <TableHead>Variant</TableHead>
-            <TableHead>Time</TableHead>
-            <TableHead className="text-center">Preview</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          <Suspense key={location.key} fallback={<SkeletonRows />}>
-            <Await
-              resolve={data}
-              errorElement={
-                <TableAsyncErrorState
-                  colSpan={5}
-                  defaultMessage="Failed to load inferences"
-                />
-              }
-            >
-              {(resolvedData) => (
-                <TableRows data={resolvedData} onOpenSheet={onOpenSheet} />
-              )}
-            </Await>
-          </Suspense>
-        </TableBody>
-      </Table>
-
-      <InferencePreviewSheet
-        inferenceId={openSheetInferenceId}
-        isOpen={!!openSheetInferenceId}
-        onClose={onCloseSheet}
-      />
-    </>
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>ID</TableHead>
+          <TableHead>Function</TableHead>
+          <TableHead>Variant</TableHead>
+          <TableHead>Time</TableHead>
+          <TableHead className="text-center">Preview</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <Suspense key={location.key} fallback={<SkeletonRows />}>
+          <Await
+            resolve={data}
+            errorElement={
+              <TableAsyncErrorState
+                colSpan={5}
+                defaultMessage="Failed to load inferences"
+              />
+            }
+          >
+            {(resolvedData) => (
+              <TableRows data={resolvedData} onOpenSheet={openInferenceSheet} />
+            )}
+          </Await>
+        </Suspense>
+      </TableBody>
+    </Table>
   );
 }

--- a/ui/app/routes/observability/episodes/$episode_id/route.tsx
+++ b/ui/app/routes/observability/episodes/$episode_id/route.tsx
@@ -25,7 +25,7 @@ import {
   Breadcrumbs,
 } from "~/components/layout/PageLayout";
 import { useToast } from "~/hooks/use-toast";
-import { Suspense, useEffect, useState, useCallback } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { ActionBar } from "~/components/layout/ActionBar";
 import { HumanFeedbackButton } from "~/components/feedback/HumanFeedbackButton";
 import { HumanFeedbackModal } from "~/components/feedback/HumanFeedbackModal";
@@ -63,12 +63,10 @@ export const handle: RouteHandle = {
 
 /**
  * Prevent revalidation of this route when actions are submitted to API routes.
- * This is needed because:
- * 1. The InferencePreviewSheet submits feedback to /api/feedback
- * 2. The AddToDatasetButton submits to /api/datasets/datapoints/from-inference
- * 3. By default, React Router revalidates all active loaders after any action
- * 4. We don't want to reload the entire episode page when these actions complete
- *    because the sheet handles its own data refresh
+ * The global inference side sheet and AddToDatasetButton submit to /api/feedback
+ * and /api/datasets/datapoints/from-inference respectively. By default, React
+ * Router revalidates all active loaders after any action — we opt out here to
+ * avoid reloading the entire episode page when these actions complete.
  */
 export function shouldRevalidate({
   formAction,
@@ -324,18 +322,6 @@ export default function EpisodeDetailPage({
   } = loaderData;
   const navigate = useNavigate();
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [openSheetInferenceId, setOpenSheetInferenceId] = useState<
-    string | null
-  >(null);
-
-  const handleOpenSheet = useCallback((inferenceId: string) => {
-    setOpenSheetInferenceId(inferenceId);
-  }, []);
-
-  const handleCloseSheet = useCallback(() => {
-    setOpenSheetInferenceId(null);
-  }, []);
-
   const { toast } = useToast();
   useEffect(() => {
     if (newFeedbackId) {
@@ -402,12 +388,7 @@ export default function EpisodeDetailPage({
       <SectionsGroup>
         <SectionLayout>
           <SectionHeader heading="Inferences" count={num_inferences} />
-          <EpisodeInferenceTable
-            data={inferencesData}
-            onOpenSheet={handleOpenSheet}
-            onCloseSheet={handleCloseSheet}
-            openSheetInferenceId={openSheetInferenceId}
-          />
+          <EpisodeInferenceTable data={inferencesData} />
           <Suspense fallback={<PageButtons disabled />}>
             <Await
               resolve={inferencesData}


### PR DESCRIPTION
## Summary
- Replaces the episode detail page's local InferencePreviewSheet state management (`openSheetInferenceId`, `handleOpenSheet`, `handleCloseSheet`) with the global `EntitySheet` context's `openInferenceSheet`
- Removes direct `InferencePreviewSheet` import/render from `EpisodeInferenceTable` — the global `EntitySheet` in `root.tsx` handles rendering
- Simplifies `EpisodeInferenceTable` props from 4 to 1 (`data` only)

This gives the episode page's inference preview the same URL-backed state benefits as the autopilot page: deep linking, back-button navigation, and HMR persistence.

Stacked on #6334