### PR TITLE
Do not eagerly log invalid Uuid error

### DIFF
--- a/tensorzero-core/src/db/query_helpers.rs
+++ b/tensorzero-core/src/db/query_helpers.rs
@@ -26,13 +26,13 @@ pub fn json_double_escape_string_without_quotes(s: &str) -> Result<String, Error
 
 /// Converts a UUIDv7 to a DateTime<Utc> by extracting its embedded timestamp.
 pub fn uuid_to_datetime(uuid: Uuid) -> Result<DateTime<Utc>, Error> {
-    let timestamp = uuid.get_timestamp().ok_or({
+    let timestamp = uuid.get_timestamp().ok_or_else(|| {
         Error::new(ErrorDetails::InvalidUuid {
             raw_uuid: uuid.to_string(),
         })
     })?;
     let (secs, nanos) = timestamp.to_unix();
-    DateTime::from_timestamp(secs as i64, nanos).ok_or({
+    DateTime::from_timestamp(secs as i64, nanos).ok_or_else(|| {
         Error::new(ErrorDetails::InvalidUuid {
             raw_uuid: uuid.to_string(),
         })


### PR DESCRIPTION
This eagerly constructs the Error which calls detail.log() so even with valid UUIDs we are getting log output.