### PR TITLE
Accept more S3 configuration options from autopilot server

### DIFF
--- a/internal/autopilot-client/src/types.rs
+++ b/internal/autopilot-client/src/types.rs
@@ -861,6 +861,9 @@ pub struct S3UploadResponse {
     pub bucket: String,
     pub key: String,
     pub region: String,
+    pub endpoint: Option<String>,
+    pub virtual_hosted_style_request: Option<bool>,
+    pub allow_http: Option<bool>,
     // Credentials can be null when running locally
     pub access_key_id: Option<String>,
     pub secret_access_key: Option<String>,

--- a/internal/autopilot-tools/src/tools/prod/upload_dataset.rs
+++ b/internal/autopilot-tools/src/tools/prod/upload_dataset.rs
@@ -265,6 +265,15 @@ impl TaskTool for UploadDatasetTool {
                     if let Some(ref token) = creds.session_token {
                         builder = builder.with_token(token);
                     }
+                    if let Some(ref endpoint) = creds.endpoint {
+                        builder = builder.with_endpoint(endpoint);
+                    }
+                    if let Some(val) = creds.virtual_hosted_style_request {
+                        builder = builder.with_virtual_hosted_style_request(val);
+                    }
+                    if let Some(val) = creds.allow_http {
+                        builder = builder.with_allow_http(val);
+                    }
                     let s3: Arc<dyn ObjectStore> = Arc::new(builder.build().map_err(|e| {
                         anyhow::Error::msg(format!("Failed to build S3 client: {e}"))
                     })?);


### PR DESCRIPTION
This will allow us to upload to localhost (e.g. minio, localstack) in e2e tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive plumbing of optional S3 client configuration; main risk is misconfiguration causing upload failures in environments that start sending these fields.
> 
> **Overview**
> Extends `S3UploadResponse` to optionally include extra S3 connection settings (`endpoint`, `virtual_hosted_style_request`, `allow_http`) returned by the Autopilot server.
> 
> Updates the `upload_dataset` tool to apply these options when constructing the `AmazonS3Builder`, enabling uploads to non-AWS S3-compatible endpoints (e.g., MinIO/LocalStack) in tests/local environments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7eac4798ce458cd55d906982c04bf7f03d39ddff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->