### PR TITLE
Show waiting status when user questions are pending

### DIFF
--- a/ui/app/components/autopilot/EventStream.tsx
+++ b/ui/app/components/autopilot/EventStream.tsx
@@ -793,8 +793,18 @@ function getStatusLabel(status: AutopilotStatus): {
   }
 }
 
-function StatusIndicator({ status }: { status: AutopilotStatus }) {
-  const { text, showEllipsis } = getStatusLabel(status);
+function StatusIndicator({
+  status,
+  hasPendingQuestions,
+}: {
+  status: AutopilotStatus;
+  hasPendingQuestions: boolean;
+}) {
+  const label = getStatusLabel(status);
+  const { text, showEllipsis } =
+    hasPendingQuestions && status.status === "server_side_processing"
+      ? { text: "Waiting for your response", showEllipsis: false }
+      : label;
   return (
     <Divider>
       {text}
@@ -896,7 +906,14 @@ export default function EventStream({
       ))}
 
       {/* Status indicator at the bottom */}
-      {status && <StatusIndicator status={status} />}
+      {status && (
+        <StatusIndicator
+          status={status}
+          hasPendingQuestions={Boolean(
+            pendingUserQuestionIds && pendingUserQuestionIds.size > 0,
+          )}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Override status indicator from "Thinking..." to "Waiting for your response" when the UI detects unanswered `user_questions` events during `server_side_processing`
- No backend changes needed — the UI already computes `pendingUserQuestionIds` from event stream data

## Stack
- Base: #6226 (autopilot ask-user-question UI components)
- Backend: tensorzero/autopilot#596

## Test plan
- [ ] Verify status shows "Waiting for your response" when questions are pending
- [ ] Verify status shows "Thinking..." during normal server processing
- [ ] Verify status returns to normal after questions are answered