### PR TITLE
Add WaitingForUserQuestions status variant

### DIFF
--- a/internal/autopilot-client/src/types.rs
+++ b/internal/autopilot-client/src/types.rs
@@ -144,6 +144,7 @@ pub enum AutopilotStatus {
     ServerSideProcessing,
     WaitingForToolCallAuthorization,
     WaitingForToolExecution,
+    WaitingForUserQuestions,
     WaitingForRetry,
     Failed,
 }

--- a/internal/tensorzero-node/lib/bindings/AutopilotStatus.ts
+++ b/internal/tensorzero-node/lib/bindings/AutopilotStatus.ts
@@ -8,5 +8,6 @@ export type AutopilotStatus =
   | { status: "server_side_processing" }
   | { status: "waiting_for_tool_call_authorization" }
   | { status: "waiting_for_tool_execution" }
+  | { status: "waiting_for_user_questions" }
   | { status: "waiting_for_retry" }
   | { status: "failed" };

--- a/ui/app/components/autopilot/EventStream.tsx
+++ b/ui/app/components/autopilot/EventStream.tsx
@@ -783,6 +783,8 @@ function getStatusLabel(status: AutopilotStatus): {
       return { text: "Waiting", showEllipsis: false };
     case "waiting_for_tool_execution":
       return { text: "Executing tool", showEllipsis: true };
+    case "waiting_for_user_questions":
+      return { text: "Waiting for your response", showEllipsis: false };
     case "waiting_for_retry":
       return { text: "Something went wrong. Retrying", showEllipsis: true };
     case "failed":


### PR DESCRIPTION
## Summary
- Add `WaitingForUserQuestions` variant to `AutopilotStatus` enum so the status state machine properly represents when the worker is blocked waiting for the user to answer questions
- Regenerate TS bindings with the new variant
- Add UI status label: "Waiting for your response"

The backend derivation (querying for unanswered `user_questions` events in `status.rs`) will be added in a follow-up autopilot PR after the tensorzero rev is bumped.

## Stack
- Base: #6226 (autopilot ask-user-question UI components)
- Backend: tensorzero/autopilot#596

## Test plan
- [ ] Typecheck passes (new variant is handled in `getStatusLabel` switch)
- [ ] Backend follow-up: autopilot `derive_autopilot_status` returns `WaitingForUserQuestions` when unanswered `user_questions` events exist