### PR TITLE
Expose 'extra_state' from ToolContext

### DIFF
--- a/internal/durable-tools/src/context.rs
+++ b/internal/durable-tools/src/context.rs
@@ -163,6 +163,11 @@ impl<'a, S: Clone + Send + Sync + 'static> ToolContext<'a, S> {
         self.app_state.tool_registry.read().await
     }
 
+    /// Get access to the 'extra_side' provided when building the 'DurableClient'
+    pub fn extra_state(&self) -> &S {
+        &self.app_state.extra_state
+    }
+
     /// Get mutable access to the underlying durable `TaskContext`.
     ///
     /// Use this for advanced operations not exposed by `ToolContext`.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a read-only accessor with no behavior changes; risk is limited to minor API compatibility considerations for downstream users.
> 
> **Overview**
> Exposes the `extra_state` value (provided when constructing the `DurableClient`) to running tools by adding `ToolContext::extra_state()`.
> 
> This is a small API surface change that lets `TaskTool` code read custom per-client state without reaching into `TaskContext`/`ToolAppState` directly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65dc4a6ca515669eec29cc9a4233512ab8c86969. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->