### PR TITLE
Add WaitingForUserQuestionsAnswers status variant

### DIFF
--- a/internal/autopilot-client/src/types.rs
+++ b/internal/autopilot-client/src/types.rs
@@ -144,6 +144,7 @@ pub enum AutopilotStatus {
     ServerSideProcessing,
     WaitingForToolCallAuthorization,
     WaitingForToolExecution,
+    WaitingForUserQuestionsAnswers,
     WaitingForRetry,
     Failed,
 }

--- a/internal/tensorzero-node/lib/bindings/AutopilotStatus.ts
+++ b/internal/tensorzero-node/lib/bindings/AutopilotStatus.ts
@@ -8,5 +8,6 @@ export type AutopilotStatus =
   | { status: "server_side_processing" }
   | { status: "waiting_for_tool_call_authorization" }
   | { status: "waiting_for_tool_execution" }
+  | { status: "waiting_for_user_questions_answers" }
   | { status: "waiting_for_retry" }
   | { status: "failed" };

--- a/ui/app/components/autopilot/EventStream.tsx
+++ b/ui/app/components/autopilot/EventStream.tsx
@@ -697,6 +697,8 @@ function getStatusLabel(status: AutopilotStatus): {
       return { text: "Waiting", showEllipsis: false };
     case "waiting_for_tool_execution":
       return { text: "Executing tool", showEllipsis: true };
+    case "waiting_for_user_questions_answers":
+      return { text: "Waiting for your response", showEllipsis: false };
     case "waiting_for_retry":
       return { text: "Something went wrong. Retrying", showEllipsis: true };
     case "failed":


### PR DESCRIPTION
## Summary
- Adds `WaitingForUserQuestionsAnswers` variant to the `AutopilotStatus` enum
- Regenerates TS bindings and adds the UI status label case
- Wire type only — the autopilot backend will return this status when user questions are pending (follow-up in autopilot#596)

## Test plan
- [x] Cargo check passes
- [x] All pre-commit hooks pass (including typecheck)
- [x] Purely additive — nothing produces this status yet, so no runtime impact

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely additive type/label change with minimal logic and no behavior changes unless the backend begins emitting the new status.
> 
> **Overview**
> Introduces a new `AutopilotStatus::WaitingForUserQuestionsAnswers` wire status (serialized as `waiting_for_user_questions_answers`) in the Rust client types and regenerates the corresponding TypeScript union.
> 
> Updates the Autopilot UI (`EventStream.tsx`) to handle this status and display **“Waiting for your response”** in the status indicator.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee5169ec9c89b46757fae57d2f5d71130fcadc37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->