### PR TITLE
Forward tensorzero-beta-tools header to autopilot server

### DIFF
--- a/internal/durable-tools/src/tensorzero_client/client_ext.rs
+++ b/internal/durable-tools/src/tensorzero_client/client_ext.rs
@@ -142,6 +142,7 @@ impl TensorZeroClient for Client {
                     autopilot_client,
                     session_id,
                     full_request,
+                    &[],
                 )
                 .await
                 .map_err(|e| {

--- a/internal/durable-tools/src/tensorzero_client/embedded.rs
+++ b/internal/durable-tools/src/tensorzero_client/embedded.rs
@@ -135,7 +135,7 @@ impl TensorZeroClient for EmbeddedClient {
             config_snapshot_hash,
         };
 
-        create_event(autopilot_client, session_id, full_request)
+        create_event(autopilot_client, session_id, full_request, &[])
             .await
             .map_err(|e| {
                 TensorZeroClientError::TensorZero(TensorZeroError::Other { source: e.into() })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small plumbing change that only adds optional header forwarding on the create-event path; main risk is minor behavior differences if malformed header values are ignored.
> 
> **Overview**
> Adds end-to-end support for forwarding `tensorzero-beta-tools` from the gateway to the remote Autopilot API when creating session events.
> 
> This threads a new `beta_tools: &[String]` parameter through the core `create_event` wrapper and embedded clients, extracts the incoming header in `create_event_handler`, and has `AutopilotClient::create_event` attach it as a comma-separated `tensorzero-beta-tools` request header (when non-empty).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65bcc1d273333e1332742e0e1665bd51316916f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->