### PR TITLE
Add as_uninitialized() conversions and SerializableFunctionContext for durable GEPA checkpointing

### DIFF
--- a/tensorzero-core/src/config/mod.rs
+++ b/tensorzero-core/src/config/mod.rs
@@ -1835,6 +1835,18 @@ pub struct UninitializedSchemas {
     inner: HashMap<String, UninitializedSchema>,
 }
 
+impl UninitializedSchemas {
+    /// Constructs `UninitializedSchemas` from a map of schema names to path data.
+    pub fn from_paths(paths: HashMap<String, ResolvedTomlPathData>) -> Self {
+        Self {
+            inner: paths
+                .into_iter()
+                .map(|(k, path)| (k, UninitializedSchema { path }))
+                .collect(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct UninitializedFunctionConfigChat {

--- a/tensorzero-core/src/tool/config.rs
+++ b/tensorzero-core/src/tool/config.rs
@@ -12,6 +12,8 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::config::UninitializedToolConfig;
+use crate::config::path::ResolvedTomlPathData;
 use crate::error::{Error, ErrorDetails};
 use crate::jsonschema_util::JSONSchema;
 
@@ -52,6 +54,20 @@ pub struct StaticToolConfig {
     /// The key used to reference this tool in allowed_tools and function config
     pub key: String,
     pub strict: bool,
+}
+
+impl StaticToolConfig {
+    pub fn as_uninitialized(&self) -> UninitializedToolConfig {
+        UninitializedToolConfig {
+            description: self.description.clone(),
+            parameters: ResolvedTomlPathData::new_fake_path(
+                format!("checkpoint://tool/{}", self.key),
+                self.parameters.value.to_string(),
+            ),
+            name: Some(self.name.clone()),
+            strict: self.strict,
+        }
+    }
 }
 
 /// Contains the configuration information for a tool defined at runtime

--- a/tensorzero-core/src/variant/best_of_n_sampling.rs
+++ b/tensorzero-core/src/variant/best_of_n_sampling.rs
@@ -71,11 +71,11 @@ impl BestOfNSamplingConfig {
 
     /// Converts this initialized config back to its uninitialized form.
     #[expect(deprecated)]
-    pub fn as_uninitialized(self) -> UninitializedBestOfNSamplingConfig {
+    pub fn as_uninitialized(&self) -> UninitializedBestOfNSamplingConfig {
         UninitializedBestOfNSamplingConfig {
             weight: self.weight,
             timeout_s: None,
-            candidates: self.candidates,
+            candidates: self.candidates.clone(),
             evaluator: UninitializedBestOfNEvaluatorConfig {
                 inner: self.evaluator.inner.as_uninitialized(),
             },

--- a/tensorzero-core/src/variant/chain_of_thought.rs
+++ b/tensorzero-core/src/variant/chain_of_thought.rs
@@ -63,7 +63,7 @@ impl UninitializedChainOfThoughtConfig {
 
 impl ChainOfThoughtConfig {
     /// Converts this initialized config back to its uninitialized form.
-    pub fn as_uninitialized(self) -> UninitializedChainOfThoughtConfig {
+    pub fn as_uninitialized(&self) -> UninitializedChainOfThoughtConfig {
         UninitializedChainOfThoughtConfig {
             inner: self.inner.as_uninitialized(),
         }

--- a/tensorzero-core/src/variant/dicl.rs
+++ b/tensorzero-core/src/variant/dicl.rs
@@ -164,31 +164,31 @@ impl DiclConfig {
     /// Converts this initialized config back to its uninitialized form.
     /// Note: Real file paths for system_instructions are preserved. Fake paths
     /// (like defaults) are converted to None and will be regenerated on load.
-    pub fn as_uninitialized(self) -> UninitializedDiclConfig {
+    pub fn as_uninitialized(&self) -> UninitializedDiclConfig {
         UninitializedDiclConfig {
             weight: self.weight,
             embedding_model: self.embedding_model.to_string(),
             k: self.k,
             model: self.model.to_string(),
             system_instructions: if self.system_instructions.is_real_path() {
-                Some(self.system_instructions)
+                Some(self.system_instructions.clone())
             } else {
                 None
             },
             temperature: self.temperature,
             top_p: self.top_p,
-            stop_sequences: self.stop_sequences,
+            stop_sequences: self.stop_sequences.clone(),
             presence_penalty: self.presence_penalty,
             frequency_penalty: self.frequency_penalty,
             max_tokens: self.max_tokens,
             seed: self.seed,
-            reasoning_effort: self.inference_params_v2.reasoning_effort,
+            reasoning_effort: self.inference_params_v2.reasoning_effort.clone(),
             thinking_budget_tokens: self.inference_params_v2.thinking_budget_tokens,
-            verbosity: self.inference_params_v2.verbosity,
+            verbosity: self.inference_params_v2.verbosity.clone(),
             json_mode: self.json_mode,
-            extra_body: self.extra_body,
+            extra_body: self.extra_body.clone(),
             retries: self.retries,
-            extra_headers: self.extra_headers,
+            extra_headers: self.extra_headers.clone(),
             max_distance: self.max_distance,
         }
     }

--- a/tensorzero-core/src/variant/mixture_of_n.rs
+++ b/tensorzero-core/src/variant/mixture_of_n.rs
@@ -75,11 +75,11 @@ impl MixtureOfNConfig {
 
     /// Converts this initialized config back to its uninitialized form.
     #[expect(deprecated)]
-    pub fn as_uninitialized(self) -> UninitializedMixtureOfNConfig {
+    pub fn as_uninitialized(&self) -> UninitializedMixtureOfNConfig {
         UninitializedMixtureOfNConfig {
             weight: self.weight,
             timeout_s: None,
-            candidates: self.candidates,
+            candidates: self.candidates.clone(),
             fuser: UninitializedFuserConfig {
                 inner: self.fuser.inner.as_uninitialized(),
             },


### PR DESCRIPTION
## Summary
- Adds `as_uninitialized()` to `VariantConfig`, `VariantInfo`, `StaticToolConfig`, `FunctionConfig`, `FunctionConfigChat`, `FunctionConfigJson` — converting initialized types back to their Uninitialized counterparts (which already have `Serialize` + `Deserialize`)
- Adds `SerializableFunctionContext` in the optimizer crate with `to_serializable()` / `load()` round-trip for durable GEPA checkpointing
- Refactors existing `as_uninitialized(self)` on `BestOfNSamplingConfig`, `DiclConfig`, `MixtureOfNConfig`, `ChainOfThoughtConfig` to take `&self` instead of consuming `self`

## Test plan
- [x] `cargo check --package tensorzero-core`
- [x] `cargo check --package tensorzero-optimizers`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test-unit-fast` (2389 tests passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new config round-tripping/serialization paths for functions, variants, schemas, and tools used in GEPA checkpointing; mistakes could cause checkpoint load failures or subtle mismatches in reconstructed configs.
> 
> **Overview**
> Enables durable GEPA checkpointing by introducing `SerializableFunctionContext` (with `to_serializable()` and `load()`) that round-trips a function’s configuration, referenced static tools, and evaluation config through `Uninitialized*` types.
> 
> Adds `as_uninitialized()` converters across core runtime types (`FunctionConfig`, `FunctionConfigChat/Json`, `VariantConfig`, `VariantInfo`, `StaticToolConfig`) and a helper `UninitializedSchemas::from_paths`, generating *fake* `ResolvedTomlPathData` URIs (`checkpoint://...`) to embed schema/tool JSON for serialization. Updates several variant configs’ `as_uninitialized` methods to take `&self` (clone-based) instead of consuming the config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e7f8953794bbbaef1a2681a3df04341560ba034. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->