### PR TITLE
Add delete_dataset to TensorZeroClient trait

### DIFF
--- a/internal/autopilot-tools/tests/common/mod.rs
+++ b/internal/autopilot-tools/tests/common/mod.rs
@@ -128,6 +128,11 @@ mock! {
             ids: Vec<Uuid>,
         ) -> Result<DeleteDatapointsResponse, TensorZeroClientError>;
 
+        async fn delete_dataset(
+            &self,
+            dataset_name: String,
+        ) -> Result<DeleteDatapointsResponse, TensorZeroClientError>;
+
         async fn list_inferences(
             &self,
             request: ListInferencesRequest,

--- a/internal/autopilot-worker/src/wrapper.rs
+++ b/internal/autopilot-worker/src/wrapper.rs
@@ -475,6 +475,12 @@ mod tests {
                 ids: Vec<Uuid>,
             ) -> Result<DeleteDatapointsResponse, TensorZeroClientError>;
 
+            /// Delete an entire dataset.
+            async fn delete_dataset(
+                &self,
+                dataset_name: String,
+            ) -> Result<DeleteDatapointsResponse, TensorZeroClientError>;
+
             /// List inferences with filtering and pagination.
             async fn list_inferences(
                 &self,

--- a/internal/durable-tools/src/tensorzero_client/client_ext.rs
+++ b/internal/durable-tools/src/tensorzero_client/client_ext.rs
@@ -483,6 +483,15 @@ impl TensorZeroClient for Client {
             .map_err(TensorZeroClientError::TensorZero)
     }
 
+    async fn delete_dataset(
+        &self,
+        dataset_name: String,
+    ) -> Result<DeleteDatapointsResponse, TensorZeroClientError> {
+        ClientExt::delete_dataset(self, dataset_name)
+            .await
+            .map_err(TensorZeroClientError::TensorZero)
+    }
+
     // ========== Inference Query Operations ==========
 
     async fn list_inferences(

--- a/internal/durable-tools/src/tensorzero_client/embedded.rs
+++ b/internal/durable-tools/src/tensorzero_client/embedded.rs
@@ -386,6 +386,18 @@ impl TensorZeroClient for EmbeddedClient {
         .map_err(|e| TensorZeroClientError::TensorZero(TensorZeroError::Other { source: e.into() }))
     }
 
+    async fn delete_dataset(
+        &self,
+        dataset_name: String,
+    ) -> Result<DeleteDatapointsResponse, TensorZeroClientError> {
+        tensorzero_core::endpoints::datasets::v1::delete_dataset(
+            &self.app_state.get_delegating_database(),
+            &dataset_name,
+        )
+        .await
+        .map_err(|e| TensorZeroClientError::TensorZero(TensorZeroError::Other { source: e.into() }))
+    }
+
     // ========== Inference Query Operations ==========
 
     async fn list_inferences(

--- a/internal/durable-tools/src/tensorzero_client/mod.rs
+++ b/internal/durable-tools/src/tensorzero_client/mod.rs
@@ -241,6 +241,12 @@ pub trait TensorZeroClient: Send + Sync + 'static {
         ids: Vec<Uuid>,
     ) -> Result<DeleteDatapointsResponse, TensorZeroClientError>;
 
+    /// Delete an entire dataset.
+    async fn delete_dataset(
+        &self,
+        dataset_name: String,
+    ) -> Result<DeleteDatapointsResponse, TensorZeroClientError>;
+
     // ========== Inference Query Operations ==========
 
     /// List inferences with filtering and pagination.


### PR DESCRIPTION
## Summary
- Adds `delete_dataset` method to the `TensorZeroClient` trait, mirroring the existing `delete_datapoints` pattern
- Implements it for embedded gateway, HTTP client, and both mock types

## Context
Durable GEPA will depend on this.

## Test plan
- [x] `cargo check` passes for `durable-tools`, `autopilot-tools`, `autopilot-worker`
- [x] `cargo clippy --all-targets --all-features` passes
- [x] `cargo fmt` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive trait/API change with straightforward pass-through implementations; primary risk is compile-time breakage for any downstream `TensorZeroClient` implementors not updated.
> 
> **Overview**
> Adds a new `TensorZeroClient::delete_dataset(dataset_name)` operation to support deleting an entire dataset (in addition to per-datapoint deletes).
> 
> Implements the method across the durable-tools clients (`Client` via `ClientExt`, and `EmbeddedClient` via the core `datasets::v1::delete_dataset` endpoint) and updates the mock `TensorZeroClient` implementations used by `autopilot-tools` and `autopilot-worker` tests to include the new API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c21cc303827471a48cdc305bab1ae5f7172731cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->