### PR TITLE
Remove AWS rustflags

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,3 @@
-[target.'cfg(not(target_arch = "wasm32"))']
-rustflags = [
-    "--cfg",
-    "aws_sdk_unstable", # needed for aws-smithy-types + serde-(de)serialize
-]
-
 [target.x86_64-apple-darwin]
 rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"] # for NAPI
 

--- a/clients/python/.cargo/config.toml
+++ b/clients/python/.cargo/config.toml
@@ -4,8 +4,3 @@
 # so we need a .cargo/config inside `python`
 # During a normal build, cargo will pick up both of these config.toml files -
 # that's fine, as we'll just end up passing the same cfg twice.
-[target.'cfg(not(target_arch = "wasm32"))']
-rustflags = [
-    "--cfg",
-    "aws_sdk_unstable", # needed for aws-smithy-types + serde-(de)serialize
-]


### PR DESCRIPTION
No longer needed since we removed the Bedrock and SageMaker SDKs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-config-only change that drops an unused compiler cfg; low risk aside from potentially exposing any remaining accidental reliance on `aws_sdk_unstable`.
> 
> **Overview**
> Removes the non-wasm `rustflags` that injected `--cfg aws_sdk_unstable` from both the root `.cargo/config.toml` and `clients/python/.cargo/config.toml`.
> 
> This simplifies build configuration and avoids passing an unused AWS-specific cfg during compilation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8954034f98efcfe77818e69e4f12596ba7dd5da8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->