### PR TITLE
Improve Buildkite checks

### DIFF
--- a/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0037.rs
+++ b/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0037.rs
@@ -122,7 +122,7 @@ impl Migration for Migration0037<'_> {
                 countState() as count
             FROM ModelInference
             {view_where_clause}
-            GROUP BY (model_name, model_provider_name, minute)
+            GROUP BY model_name, model_provider_name, minute
             "
         );
         self.clickhouse

--- a/tensorzero-core/tests/e2e/db/batch_inference_endpoint_internals.rs
+++ b/tensorzero-core/tests/e2e/db/batch_inference_endpoint_internals.rs
@@ -34,7 +34,7 @@ use tensorzero_core::inference::types::{
 use tensorzero_core::jsonschema_util::JSONSchema;
 use uuid::Uuid;
 
-use crate::utils::poll_for_result::poll_for_result;
+use crate::utils::poll_for_result::{poll_for_result, poll_for_result_with_interval_and_timeout};
 
 // ===== HELPER FUNCTIONS =====
 
@@ -336,9 +336,11 @@ async fn test_write_poll_batch_inference_endpoint(
         inference_id: None,
     };
     // Poll until the Failed batch is visible (it is more recent than the Pending one)
-    let batch_request = poll_for_result(
+    let batch_request = poll_for_result_with_interval_and_timeout(
         || get_batch_request(&database, &query),
         |r| r.status == BatchStatus::Failed,
+        std::time::Duration::from_millis(500),
+        std::time::Duration::from_secs(30),
         "Timed out waiting for batch status to become Failed",
     )
     .await;


### PR DESCRIPTION
- Fix a rollback issue in CHC Fast (we have a later migration that already applies this change to users)
- Improve a flaky test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to SQL string generation and test polling behavior; low production risk aside from migration SQL correctness on ClickHouse.
> 
> **Overview**
> Fixes a ClickHouse migration rollback/apply issue by adjusting `migration_0037` materialized view creation SQL to use a non-parenthesized `GROUP BY model_name, model_provider_name, minute`.
> 
> Improves a flaky batch inference E2E test by switching the “wait for Failed batch” check to `poll_for_result_with_interval_and_timeout` with a longer timeout (30s) and explicit poll interval (500ms).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 881b559868ebcc287310e60042634adcd01b2be8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->