### PR TITLE
Parameterize gateway URL in client tests

### DIFF
--- a/clients/openai-go/tests/openai_compatibility_test.go
+++ b/clients/openai-go/tests/openai_compatibility_test.go
@@ -41,10 +41,17 @@ var (
 	ctx     context.Context
 )
 
+func gatewayURL() string {
+	if url := os.Getenv("TENSORZERO_GATEWAY_URL"); url != "" {
+		return url
+	}
+	return "http://localhost:3000"
+}
+
 func TestMain(m *testing.M) {
 	ctx = context.Background()
 	client = openai.NewClient(
-		option.WithBaseURL("http://127.0.0.1:3000/openai/v1"),
+		option.WithBaseURL(gatewayURL()+"/openai/v1"),
 		option.WithAPIKey("donotuse"),
 	)
 	// Run the tests and exit with the result code
@@ -101,7 +108,7 @@ func overrideUserMessage(t *testing.T, data map[string]interface{}) openai.ChatC
 func sendRequestTzGateway(t *testing.T, body map[string]interface{}) (map[string]interface{}, error) {
 	// Send a request to the TensorZero gateway
 	t.Helper()
-	url := "http://127.0.0.1:3000/openai/v1/chat/completions"
+	url := gatewayURL() + "/openai/v1/chat/completions"
 	jsonBody, err := json.Marshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request body: %w", err)

--- a/clients/openai-node/tests/extra-content.test.ts
+++ b/clients/openai-node/tests/extra-content.test.ts
@@ -9,13 +9,14 @@ import { describe, it, expect, beforeAll } from "vitest";
 import OpenAI from "openai";
 import { ChatCompletionMessageParam } from "openai/resources";
 import { v7 as uuidv7 } from "uuid";
+import { GATEWAY_URL } from "./helpers";
 
 let client: OpenAI;
 
 beforeAll(() => {
   client = new OpenAI({
     apiKey: "donotuse",
-    baseURL: "http://127.0.0.1:3000/openai/v1",
+    baseURL: `${GATEWAY_URL}/openai/v1`,
   });
 });
 

--- a/clients/openai-node/tests/helpers.ts
+++ b/clients/openai-node/tests/helpers.ts
@@ -1,0 +1,2 @@
+export const GATEWAY_URL =
+  process.env.TENSORZERO_GATEWAY_URL ?? "http://localhost:3000";

--- a/clients/openai-node/tests/inference-openai-responses-api.test.ts
+++ b/clients/openai-node/tests/inference-openai-responses-api.test.ts
@@ -8,6 +8,7 @@ import {
   ChatCompletionMessageFunctionToolCall,
 } from "openai/resources";
 import { v7 as uuidv7 } from "uuid";
+import { GATEWAY_URL } from "./helpers";
 
 // Client setup
 let client: OpenAI;
@@ -15,7 +16,7 @@ let client: OpenAI;
 beforeAll(() => {
   client = new OpenAI({
     apiKey: "donotuse",
-    baseURL: "http://127.0.0.1:3000/openai/v1",
+    baseURL: `${GATEWAY_URL}/openai/v1`,
   });
 });
 

--- a/clients/openai-node/tests/json-mode-tool.test.ts
+++ b/clients/openai-node/tests/json-mode-tool.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import OpenAI from "openai";
 import { ChatCompletionMessageParam } from "openai/resources";
+import { GATEWAY_URL } from "./helpers";
 
 // Client setup
 let client: OpenAI;
@@ -15,7 +16,7 @@ let client: OpenAI;
 beforeAll(() => {
   client = new OpenAI({
     apiKey: "donotuse",
-    baseURL: "http://127.0.0.1:3000/openai/v1",
+    baseURL: `${GATEWAY_URL}/openai/v1`,
   });
 });
 

--- a/clients/openai-node/tests/openai-compatibility.test.ts
+++ b/clients/openai-node/tests/openai-compatibility.test.ts
@@ -16,6 +16,7 @@ import { v7 as uuidv7 } from "uuid";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { GATEWAY_URL } from "./helpers";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -25,7 +26,7 @@ let client: OpenAI;
 beforeAll(() => {
   client = new OpenAI({
     apiKey: "donotuse",
-    baseURL: "http://127.0.0.1:3000/openai/v1",
+    baseURL: `${GATEWAY_URL}/openai/v1`,
   });
 });
 
@@ -1426,7 +1427,7 @@ it("should handle multi-turn parallel tool calls using TensorZero gateway direct
 
   // First request to get tool calls
   const firstResponse = await fetch(
-    "http://127.0.0.1:3000/openai/v1/chat/completions",
+    `${GATEWAY_URL}/openai/v1/chat/completions`,
     {
       method: "POST",
       headers: {
@@ -1474,7 +1475,7 @@ it("should handle multi-turn parallel tool calls using TensorZero gateway direct
 
   // Second request with tool responses
   const secondResponse = await fetch(
-    "http://127.0.0.1:3000/openai/v1/chat/completions",
+    `${GATEWAY_URL}/openai/v1/chat/completions`,
     {
       method: "POST",
       headers: {

--- a/clients/openai-node/tests/otlp-traces-extra-headers/test_openai_sdk.test.ts
+++ b/clients/openai-node/tests/otlp-traces-extra-headers/test_openai_sdk.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import OpenAI from "openai";
 import { v7 as uuidv7 } from "uuid";
+import { GATEWAY_URL } from "../helpers";
 
 // Client setup
 let client: OpenAI;
@@ -15,7 +16,7 @@ let client: OpenAI;
 beforeAll(() => {
   client = new OpenAI({
     apiKey: "not-used",
-    baseURL: "http://127.0.0.1:3000/openai/v1",
+    baseURL: `${GATEWAY_URL}/openai/v1`,
   });
 });
 

--- a/clients/openai-node/tests/raw-response.test.ts
+++ b/clients/openai-node/tests/raw-response.test.ts
@@ -8,13 +8,14 @@ import { describe, it, expect, beforeAll } from "vitest";
 import OpenAI from "openai";
 import { ChatCompletionMessageParam } from "openai/resources";
 import { v7 as uuidv7 } from "uuid";
+import { GATEWAY_URL } from "./helpers";
 
 let client: OpenAI;
 
 beforeAll(() => {
   client = new OpenAI({
     apiKey: "donotuse",
-    baseURL: "http://127.0.0.1:3000/openai/v1",
+    baseURL: `${GATEWAY_URL}/openai/v1`,
   });
 });
 

--- a/clients/openai-node/tests/raw-usage.test.ts
+++ b/clients/openai-node/tests/raw-usage.test.ts
@@ -8,13 +8,14 @@ import { describe, it, expect, beforeAll } from "vitest";
 import OpenAI from "openai";
 import { ChatCompletionMessageParam } from "openai/resources";
 import { v7 as uuidv7 } from "uuid";
+import { GATEWAY_URL } from "./helpers";
 
 let client: OpenAI;
 
 beforeAll(() => {
   client = new OpenAI({
     apiKey: "donotuse",
-    baseURL: "http://127.0.0.1:3000/openai/v1",
+    baseURL: `${GATEWAY_URL}/openai/v1`,
   });
 });
 

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -48,6 +48,7 @@ TEST_CONFIG_FILE = os.path.join(
     "../../../tensorzero-core/tests/e2e/config/tensorzero.*.toml",
 )
 
+GATEWAY_URL = os.environ.get("TENSORZERO_GATEWAY_URL", "http://localhost:3000")
 CLICKHOUSE_URL = "http://chuser:chpassword@localhost:8123/tensorzero_e2e_tests"
 POSTGRES_URL = "postgresql://postgres:postgres@localhost:5432/tensorzero-e2e-tests"
 
@@ -101,7 +102,7 @@ async def embedded_async_client():
 async def async_client(request: FixtureRequest):
     if request.param == ClientType.HttpGateway:
         client_fut = AsyncTensorZeroGateway.build_http(
-            gateway_url="http://localhost:3000",
+            gateway_url=GATEWAY_URL,
             verbose_errors=True,
         )
         assert inspect.isawaitable(client_fut)
@@ -121,7 +122,7 @@ async def async_client(request: FixtureRequest):
 def sync_client(request: FixtureRequest):
     if request.param == ClientType.HttpGateway:
         with TensorZeroGateway.build_http(
-            gateway_url="http://localhost:3000",
+            gateway_url=GATEWAY_URL,
             verbose_errors=True,
         ) as client:
             yield client
@@ -290,7 +291,7 @@ class OpenAIClientType(Enum):
 @pytest_asyncio.fixture(params=[OpenAIClientType.HttpGateway, OpenAIClientType.PatchedClient])
 async def async_openai_client(request: FixtureRequest):
     if request.param == OpenAIClientType.HttpGateway:
-        async with AsyncOpenAI(api_key="donotuse", base_url="http://localhost:3000/openai/v1") as client:
+        async with AsyncOpenAI(api_key="donotuse", base_url=f"{GATEWAY_URL}/openai/v1") as client:
             yield client
     else:
         async with AsyncOpenAI(api_key="donotuse") as client:

--- a/clients/python/tests/json_mode_tool/test_json_mode_tool_tensorzero_sdk.py
+++ b/clients/python/tests/json_mode_tool/test_json_mode_tool_tensorzero_sdk.py
@@ -7,9 +7,12 @@ tool calls to text responses, both in streaming and non-streaming modes.
 """
 
 import json
+import os
 
 import pytest
 from tensorzero import AsyncTensorZeroGateway, ChatInferenceResponse
+
+GATEWAY_URL = os.environ.get("TENSORZERO_GATEWAY_URL", "http://localhost:3000")
 
 
 @pytest.mark.asyncio
@@ -23,7 +26,7 @@ async def test_chat_json_mode_tool_non_streaming():
     - JSON is valid and matches output_schema
     """
     client = AsyncTensorZeroGateway.build_http(
-        gateway_url="http://localhost:3000",
+        gateway_url=GATEWAY_URL,
         verbose_errors=True,
         async_setup=False,
     )
@@ -83,7 +86,7 @@ async def test_chat_json_mode_tool_streaming():
     - Accumulated JSON is valid and matches output_schema
     """
     client = AsyncTensorZeroGateway.build_http(
-        gateway_url="http://localhost:3000",
+        gateway_url=GATEWAY_URL,
         verbose_errors=True,
         async_setup=False,
     )

--- a/clients/python/tests/otlp_traces_extra_headers/test_otlp_traces_extra_headers_openai_sdk.py
+++ b/clients/python/tests/otlp_traces_extra_headers/test_otlp_traces_extra_headers_openai_sdk.py
@@ -7,6 +7,7 @@ correctly exported to Tempo.
 """
 
 import asyncio
+import os
 import time
 
 import pytest
@@ -15,13 +16,15 @@ from uuid_utils.compat import uuid7
 
 from .helpers import verify_otlp_header_in_tempo
 
+GATEWAY_URL = os.environ.get("TENSORZERO_GATEWAY_URL", "http://localhost:3000")
+
 
 @pytest.mark.tempo
 @pytest.mark.asyncio
 async def test_async_openai_compatible_otlp_traces_extra_headers_tempo():
     """Test that OTLP headers are sent to Tempo via OpenAI-compatible endpoint with async client."""
     # Use HTTP gateway directly (not patched client)
-    async with AsyncOpenAI(api_key="not-used", base_url="http://localhost:3000/openai/v1") as client:
+    async with AsyncOpenAI(api_key="not-used", base_url=f"{GATEWAY_URL}/openai/v1") as client:
         # Use a unique header value to identify this specific trace
         test_value = f"openai-async-test-{uuid7()}"
 
@@ -61,7 +64,7 @@ async def test_async_openai_compatible_otlp_traces_extra_headers_tempo():
 def test_sync_openai_compatible_otlp_traces_extra_headers_tempo():
     """Test that OTLP headers are sent to Tempo via OpenAI-compatible endpoint with sync client."""
     # Use HTTP gateway directly
-    client = OpenAI(api_key="not-used", base_url="http://localhost:3000/openai/v1")
+    client = OpenAI(api_key="not-used", base_url=f"{GATEWAY_URL}/openai/v1")
 
     # Use a unique header value to identify this specific trace
     test_value = f"openai-sync-test-{uuid7()}"

--- a/clients/python/tests/otlp_traces_extra_headers/test_otlp_traces_extra_headers_tensorzero_sdk.py
+++ b/clients/python/tests/otlp_traces_extra_headers/test_otlp_traces_extra_headers_tensorzero_sdk.py
@@ -6,6 +6,7 @@ when using the native TensorZero Python SDK.
 """
 
 import asyncio
+import os
 import time
 
 import pytest
@@ -15,13 +16,15 @@ from uuid_utils.compat import uuid7
 
 from .helpers import verify_otlp_header_in_tempo
 
+GATEWAY_URL = os.environ.get("TENSORZERO_GATEWAY_URL", "http://localhost:3000")
+
 
 @pytest.mark.tempo
 def test_otlp_traces_extra_headers_tempo():
     """Test that OTLP headers are actually sent to Tempo (requires Tempo running and HTTP gateway)."""
     # Only use HTTP gateway for this test (embedded doesn't send to external Tempo)
     client = TensorZeroGateway.build_http(
-        gateway_url="http://localhost:3000",
+        gateway_url=GATEWAY_URL,
         verbose_errors=True,
     )
 
@@ -58,7 +61,7 @@ async def test_async_otlp_traces_extra_headers_tempo():
     """Test that OTLP headers are actually sent to Tempo with async client (requires Tempo running and HTTP gateway)."""
     # Only use HTTP gateway for this test (embedded doesn't send to external Tempo)
     client = AsyncTensorZeroGateway.build_http(
-        gateway_url="http://localhost:3000",
+        gateway_url=GATEWAY_URL,
         verbose_errors=True,
         async_setup=False,
     )

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -74,6 +74,8 @@ from tensorzero.types import (
 )
 from uuid_utils import uuid7
 
+GATEWAY_URL = os.environ.get("TENSORZERO_GATEWAY_URL", "http://localhost:3000")
+
 TEST_CONFIG_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
     "../../../tensorzero-core/tests/e2e/config/tensorzero.*.toml",
@@ -237,7 +239,7 @@ async def test_async_basic_inference(async_client: AsyncTensorZeroGateway):
 @pytest.mark.asyncio
 async def test_async_client_build_http_sync():
     client_ = AsyncTensorZeroGateway.build_http(
-        gateway_url="http://localhost:3000",
+        gateway_url=GATEWAY_URL,
         async_setup=False,
     )
     assert isinstance(client_, AsyncTensorZeroGateway)
@@ -1044,7 +1046,7 @@ async def test_async_feedback_invalid_input(
 @pytest.mark.asyncio
 async def test_async_tensorzero_error_http():
     async_client = AsyncTensorZeroGateway.build_http(
-        gateway_url="http://localhost:3000",
+        gateway_url=GATEWAY_URL,
         verbose_errors=True,
         async_setup=False,
     )
@@ -1101,7 +1103,7 @@ async def test_async_dynamic_credentials(async_client: AsyncTensorZeroGateway):
 
 def test_sync_error():
     with pytest.raises(Exception) as exc_info:
-        with TensorZeroGateway.build_http(gateway_url="http://localhost:3000"):
+        with TensorZeroGateway.build_http(gateway_url=GATEWAY_URL):
             raise Exception("My error")
     assert str(exc_info.value) == "My error"
 
@@ -1109,7 +1111,7 @@ def test_sync_error():
 @pytest.mark.asyncio
 async def test_async_error():
     with pytest.raises(Exception) as exc_info:
-        client_fut = AsyncTensorZeroGateway.build_http(gateway_url="http://localhost:3000")
+        client_fut = AsyncTensorZeroGateway.build_http(gateway_url=GATEWAY_URL)
         assert isinstance(client_fut, t.Awaitable)
         async with await client_fut:
             raise Exception("My error")
@@ -2178,7 +2180,7 @@ def test_sync_feedback_invalid_input(sync_client: TensorZeroGateway):
 
 def test_sync_tensorzero_error_http():
     sync_client = TensorZeroGateway.build_http(
-        gateway_url="http://localhost:3000",
+        gateway_url=GATEWAY_URL,
         verbose_errors=True,
     )
     with pytest.raises(TensorZeroError) as excinfo:
@@ -2679,7 +2681,7 @@ async def test_async_err_in_stream(async_client: AsyncTensorZeroGateway):
 @pytest.mark.asyncio
 async def test_async_timeout_int_http():
     client_fut = AsyncTensorZeroGateway.build_http(
-        gateway_url="http://localhost:3000",
+        gateway_url=GATEWAY_URL,
         timeout=1,
     )
     assert isinstance(client_fut, t.Awaitable)
@@ -2720,7 +2722,7 @@ async def test_async_timeout_int_embedded():
 @pytest.mark.asyncio
 async def test_async_timeout_float_http():
     client_fut = AsyncTensorZeroGateway.build_http(
-        gateway_url="http://localhost:3000",
+        gateway_url=GATEWAY_URL,
         timeout=0.1,
     )
     assert inspect.isawaitable(client_fut)
@@ -2760,7 +2762,7 @@ async def test_async_timeout_float_embedded():
 
 def test_sync_timeout_invalid():
     with pytest.raises(ValueError) as exc_info:
-        TensorZeroGateway.build_http(gateway_url="http://localhost:3000", timeout=-1)
+        TensorZeroGateway.build_http(gateway_url=GATEWAY_URL, timeout=-1)
     assert "Invalid timeout: cannot convert float seconds to Duration: value is negative" == str(exc_info.value)
 
 
@@ -3614,7 +3616,7 @@ def test_sync_chat_function_named_template(sync_client: TensorZeroGateway):
 
 def test_http_client_no_spurious_log(capfd: CaptureFixture[str]):
     client = TensorZeroGateway.build_http(
-        gateway_url="http://localhost:3000",
+        gateway_url=GATEWAY_URL,
         verbose_errors=True,
     )
     assert client is not None
@@ -3632,7 +3634,7 @@ def test_http_client_no_spurious_log(capfd: CaptureFixture[str]):
 @pytest.mark.asyncio
 async def test_async_http_client_no_spurious_log(capfd: CaptureFixture[str]):
     client_fut = AsyncTensorZeroGateway.build_http(
-        gateway_url="http://localhost:3000",
+        gateway_url=GATEWAY_URL,
         verbose_errors=True,
     )
     assert inspect.isawaitable(client_fut)


### PR DESCRIPTION
So we can use `TENSORZERO_GATEWAY_URL` to run many worktrees in parallel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that centralizes/configures the gateway URL; low risk beyond potential CI env var misconfiguration or URL formatting issues.
> 
> **Overview**
> Client integration tests no longer hardcode `http://127.0.0.1:3000`/`http://localhost:3000` for the TensorZero gateway; they now derive the base URL from `TENSORZERO_GATEWAY_URL` (defaulting to `http://localhost:3000`).
> 
> This updates Go (`openai-go`), Node (`openai-node`, via a new `tests/helpers.ts` constant), and Python test fixtures and direct `fetch`/SDK client setup to use the configurable gateway address, enabling parallel test/worktree runs against different gateways.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64f36485b2ab3c5761a09104c5c1f5a0f7917eb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->