### PR TITLE
Test `ns-setup` with retries [do not merge]

### DIFF
--- a/.github/workflows/build-fixtures-container.yml
+++ b/.github/workflows/build-fixtures-container.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Install Namespace CLI
         uses: GabrielBianconi/nscloud-setup@add-exponential-backoff-retry
+        with:
+          retries: 4
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx

--- a/.github/workflows/build-gateway-container.yml
+++ b/.github/workflows/build-gateway-container.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Install Namespace CLI
         uses: GabrielBianconi/nscloud-setup@add-exponential-backoff-retry
+        with:
+          retries: 4
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx

--- a/.github/workflows/build-gateway-e2e-container.yml
+++ b/.github/workflows/build-gateway-e2e-container.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Install Namespace CLI
         uses: GabrielBianconi/nscloud-setup@add-exponential-backoff-retry
+        with:
+          retries: 4
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx

--- a/.github/workflows/build-live-tests-container.yml
+++ b/.github/workflows/build-live-tests-container.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Install Namespace CLI
         uses: GabrielBianconi/nscloud-setup@add-exponential-backoff-retry
+        with:
+          retries: 4
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx

--- a/.github/workflows/build-mock-provider-api-container.yml
+++ b/.github/workflows/build-mock-provider-api-container.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Install Namespace CLI
         uses: GabrielBianconi/nscloud-setup@add-exponential-backoff-retry
+        with:
+          retries: 4
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx

--- a/.github/workflows/build-provider-proxy-container.yml
+++ b/.github/workflows/build-provider-proxy-container.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Install Namespace CLI
         uses: GabrielBianconi/nscloud-setup@add-exponential-backoff-retry
+        with:
+          retries: 4
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx

--- a/.github/workflows/build-ui-container.yml
+++ b/.github/workflows/build-ui-container.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Install Namespace CLI
         uses: GabrielBianconi/nscloud-setup@add-exponential-backoff-retry
+        with:
+          retries: 4
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx

--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -70,6 +70,8 @@ jobs:
 
       - name: Install Namespace CLI
         uses: GabrielBianconi/nscloud-setup@add-exponential-backoff-retry
+        with:
+          retries: 4
 
       - name: Configure Namespace-powered Buildx
         uses: namespacelabs/nscloud-setup-buildx-action@91c2e6537780e3b092cb8476406be99a8f91bd5e

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -130,6 +130,8 @@ jobs:
 
       - name: Install Namespace CLI
         uses: GabrielBianconi/nscloud-setup@add-exponential-backoff-retry
+        with:
+          retries: 4
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches many CI workflows and changes a third-party action source, which could impact build/publish reliability if the forked action behaves differently.
> 
> **Overview**
> Switches the **Namespace CLI install** step across container-build and general CI workflows from `namespacelabs/nscloud-setup@...` to `GabrielBianconi/nscloud-setup@add-exponential-backoff-retry` and configures `retries: 4`.
> 
> This change affects the build workflows for `fixtures`, `gateway`, `gateway-e2e`, `live-tests`, `mock-provider-api`, `provider-proxy`, `ui`, the Docker Hub publish workflow, and `general.yml`, aiming to reduce transient failures during Namespace setup while keeping existing `continue-on-error` behavior where already used.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4241c81857646dc2996a89dc1568b6de29d51d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->