### PR TITLE
Bump NS setup

### DIFF
--- a/.github/workflows/build-fixtures-container.yml
+++ b/.github/workflows/build-fixtures-container.yml
@@ -30,7 +30,7 @@ jobs:
       # (where the oidc token is not available)
 
       - name: Install Namespace CLI
-        uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
+        uses: namespacelabs/nscloud-setup@f378676225212387f1283f4da878712af2c4cd60
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx

--- a/.github/workflows/build-gateway-container.yml
+++ b/.github/workflows/build-gateway-container.yml
@@ -32,7 +32,7 @@ jobs:
       # (where the oidc token is not available)
 
       - name: Install Namespace CLI
-        uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
+        uses: namespacelabs/nscloud-setup@f378676225212387f1283f4da878712af2c4cd60
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx

--- a/.github/workflows/build-gateway-e2e-container.yml
+++ b/.github/workflows/build-gateway-e2e-container.yml
@@ -35,7 +35,7 @@ jobs:
       # (where the oidc token is not available)
 
       - name: Install Namespace CLI
-        uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
+        uses: namespacelabs/nscloud-setup@f378676225212387f1283f4da878712af2c4cd60
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx

--- a/.github/workflows/build-live-tests-container.yml
+++ b/.github/workflows/build-live-tests-container.yml
@@ -30,7 +30,7 @@ jobs:
       # (where the GitHub OIDC token is not available)
 
       - name: Install Namespace CLI
-        uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
+        uses: namespacelabs/nscloud-setup@f378676225212387f1283f4da878712af2c4cd60
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx

--- a/.github/workflows/build-mock-provider-api-container.yml
+++ b/.github/workflows/build-mock-provider-api-container.yml
@@ -30,7 +30,7 @@ jobs:
       # (where the oidc token is not available)
 
       - name: Install Namespace CLI
-        uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
+        uses: namespacelabs/nscloud-setup@f378676225212387f1283f4da878712af2c4cd60
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx

--- a/.github/workflows/build-provider-proxy-container.yml
+++ b/.github/workflows/build-provider-proxy-container.yml
@@ -30,7 +30,7 @@ jobs:
       # (where the oidc token is not available)
 
       - name: Install Namespace CLI
-        uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
+        uses: namespacelabs/nscloud-setup@f378676225212387f1283f4da878712af2c4cd60
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx

--- a/.github/workflows/build-ui-container.yml
+++ b/.github/workflows/build-ui-container.yml
@@ -32,7 +32,7 @@ jobs:
       # (where the oidc token is not available)
 
       - name: Install Namespace CLI
-        uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
+        uses: namespacelabs/nscloud-setup@f378676225212387f1283f4da878712af2c4cd60
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx

--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -69,7 +69,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Install Namespace CLI
-        uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
+        uses: namespacelabs/nscloud-setup@f378676225212387f1283f4da878712af2c4cd60
 
       - name: Configure Namespace-powered Buildx
         uses: namespacelabs/nscloud-setup-buildx-action@91c2e6537780e3b092cb8476406be99a8f91bd5e

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -129,7 +129,7 @@ jobs:
       # (where the oidc token is not available)
 
       - name: Install Namespace CLI
-        uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
+        uses: namespacelabs/nscloud-setup@f378676225212387f1283f4da878712af2c4cd60
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
       - name: Configure Namespace-powered Buildx


### PR DESCRIPTION
New release has retries, by yours truly.

https://github.com/namespacelabs/nscloud-setup/releases/tag/v0.0.11

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pins `namespacelabs/nscloud-setup` to a new commit SHA across several GitHub Actions workflows; risk is limited to potential CI/buildx setup behavior changes impacting container builds.
> 
> **Overview**
> Updates GitHub Actions workflows to use a newer pinned revision of `namespacelabs/nscloud-setup` for installing the Namespace CLI.
> 
> This bumps the action SHA consistently across all container-build and publish pipelines (fixtures, gateway, e2e, live-tests, mock-provider-api, provider-proxy, UI, Docker Hub publish, and `general.yml`) without changing the build/push logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0d40b1d5d6a9765ef5e7f5016cff01254db9b5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->