### PR TITLE
Add cost to the UI (individual inferences)

### DIFF
--- a/ui/app/components/icons/Icons.tsx
+++ b/ui/app/components/icons/Icons.tsx
@@ -1,4 +1,4 @@
-import { RefreshCw, UserPen } from "lucide-react";
+import { DollarSign, RefreshCw, UserPen } from "lucide-react";
 import React from "react";
 
 export interface IconProps {
@@ -655,6 +655,12 @@ export const SequenceChecks: React.FC<IconProps> = (props) => (
 );
 
 export const UserFeedback: React.FC = () => <UserPen size={12} />;
+
+export const Cost: React.FC<IconProps> = (props) => (
+  <IconWrapper {...props}>
+    <DollarSign size={16} />
+  </IconWrapper>
+);
 
 export const Refresh: React.FC<IconProps> = (props) => (
   <IconWrapper {...props}>

--- a/ui/app/components/inference/VariantResponseModal.tsx
+++ b/ui/app/components/inference/VariantResponseModal.tsx
@@ -19,6 +19,7 @@ import type {
 } from "~/types/tensorzero";
 import { Card, CardContent } from "~/components/ui/card";
 import type { VariantResponseInfo } from "~/routes/api/tensorzero/inference.utils";
+import { formatCost } from "~/utils/cost";
 import { Link } from "react-router";
 import { toInferenceUrl } from "~/utils/urls";
 import type { Datapoint, InferenceResponse } from "~/types/tensorzero";
@@ -97,6 +98,11 @@ function ResponseColumn({
                   <p className="text-xs">
                     Output tokens: {response.usage.output_tokens}
                   </p>
+                  {response.usage.cost != null && (
+                    <p className="text-xs">
+                      Cost: {formatCost(response.usage.cost)}
+                    </p>
+                  )}
                 </div>
               )}
             </div>

--- a/ui/app/routes/observability/inferences/$inference_id/BasicInfo.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/BasicInfo.tsx
@@ -18,8 +18,10 @@ import {
   InputIcon,
   Output,
   Cached,
+  Cost,
 } from "~/components/icons/Icons";
 import { toFunctionUrl, toVariantUrl, toEpisodeUrl } from "~/utils/urls";
+import { formatCost } from "~/utils/cost";
 import { formatDateWithSeconds } from "~/utils/date";
 import { TimestampTooltip } from "~/components/ui/TimestampTooltip";
 import { getFunctionTypeIcon } from "~/utils/icon";
@@ -129,6 +131,13 @@ export function BasicInfo({ inference, modelInferences = [] }: BasicInfoProps) {
             label={`${inferenceUsage?.output_tokens ?? ""} tok`}
             tooltip="Output Tokens"
           />
+          {inferenceUsage?.cost != null && (
+            <Chip
+              icon={<Cost className="text-fg-tertiary" />}
+              label={formatCost(inferenceUsage.cost)}
+              tooltip="Cost"
+            />
+          )}
           <Chip
             icon={<Timer className="text-fg-tertiary" />}
             label={`${inference.processing_time_ms} ms`}

--- a/ui/app/routes/observability/inferences/$inference_id/ModelInferenceItem.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/ModelInferenceItem.tsx
@@ -19,8 +19,10 @@ import {
   Output,
   Calendar,
   Cached,
+  Cost,
 } from "~/components/icons/Icons";
 import Chip from "~/components/ui/Chip";
+import { formatCost } from "~/utils/cost";
 import { formatDateWithSeconds } from "~/utils/date";
 import { TimestampTooltip } from "~/components/ui/TimestampTooltip";
 import {
@@ -67,6 +69,13 @@ export function ModelInferenceItem({ inference }: ModelInferenceItemProps) {
                   label={`${inference.output_tokens === undefined ? "null" : inference.output_tokens} tok`}
                   tooltip="Output Tokens"
                 />
+                {inference.cost !== undefined && (
+                  <Chip
+                    icon={<Cost className="text-fg-tertiary" />}
+                    label={formatCost(inference.cost)}
+                    tooltip="Cost"
+                  />
+                )}
                 {inference.response_time_ms !== null && (
                   <Chip
                     icon={<Timer className="text-fg-tertiary" />}

--- a/ui/app/utils/clickhouse/helpers.ts
+++ b/ui/app/utils/clickhouse/helpers.ts
@@ -17,6 +17,7 @@ export const getMetricName = (feedback: FeedbackRow) => {
 export const inferenceUsageSchema = z.object({
   input_tokens: z.number().nullish(),
   output_tokens: z.number().nullish(),
+  cost: z.number().nullish(),
 });
 
 export type InferenceUsage = z.infer<typeof inferenceUsageSchema>;
@@ -24,14 +25,18 @@ export type InferenceUsage = z.infer<typeof inferenceUsageSchema>;
 export function getTotalInferenceUsage(
   model_inferences: ParsedModelInferenceRow[],
 ): InferenceUsage {
+  const allCostsPresent =
+    model_inferences.length > 0 &&
+    model_inferences.every((m) => m.cost != null);
   return model_inferences.reduce(
     (acc, curr) => {
       return {
         input_tokens: acc.input_tokens + (curr.input_tokens ?? 0),
         output_tokens: acc.output_tokens + (curr.output_tokens ?? 0),
+        cost: allCostsPresent ? (acc.cost ?? 0) + (curr.cost ?? 0) : null,
       };
     },
-    { input_tokens: 0, output_tokens: 0 },
+    { input_tokens: 0, output_tokens: 0, cost: allCostsPresent ? 0 : null },
   );
 }
 

--- a/ui/app/utils/clickhouse/inference.ts
+++ b/ui/app/utils/clickhouse/inference.ts
@@ -202,6 +202,7 @@ const parsedModelInferenceRowSchema = z.object({
   input_messages: z.array(displayModelInferenceInputMessageSchema),
   output: z.array(modelInferenceOutputContentBlockSchema),
   cached: z.boolean(),
+  cost: z.number().optional(),
 });
 
 export type ParsedModelInferenceRow = z.infer<

--- a/ui/app/utils/cost.ts
+++ b/ui/app/utils/cost.ts
@@ -1,0 +1,16 @@
+/**
+ * Format a dollar amount with trailing zeros trimmed but always at least 2 decimal places.
+ *
+ * Examples:
+ *   formatCost(0.0042)   → "$0.0042"
+ *   formatCost(0)        → "$0.00"
+ *   formatCost(1.5)      → "$1.50"
+ */
+export function formatCost(cost: number): string {
+  const fixed = cost.toFixed(9);
+  // Trim trailing zeros but keep at least 2 decimal places
+  const trimmed = fixed.replace(/0+$/, "");
+  const [integer, decimal = ""] = trimmed.split(".");
+  const paddedDecimal = decimal.padEnd(2, "0");
+  return `$${integer}.${paddedDecimal}`;
+}

--- a/ui/e2e_tests/observability.inferences.inference_id.spec.ts
+++ b/ui/e2e_tests/observability.inferences.inference_id.spec.ts
@@ -637,6 +637,61 @@ test("should handle model inference with null input and output tokens", async ({
   await expect(sheet.getByText("cartoon-style crab").first()).toBeVisible();
 });
 
+test("should display cost chip when cost data exists", async ({ page }) => {
+  // This inference has a model inference with cost = 0.0000348
+  await page.goto(
+    "/observability/inferences/0196367a-842d-74c2-9e62-67e058632503",
+  );
+
+  // Wait for the page to load
+  await page.waitForLoadState("networkidle");
+
+  // Verify the cost chip is visible in the BasicInfo usage section
+  await expect(
+    page.getByText("$0.0000348", { exact: true }).first(),
+  ).toBeVisible();
+
+  // Click on the model inference ID to open the detail sheet
+  await page.getByText("0196367a-8434-7bb3-8f53-3aab0e39ae22").click();
+
+  // Wait for the sheet/dialog to appear
+  const sheet = page.getByRole("dialog");
+  await sheet.waitFor({ state: "visible" });
+
+  // Verify cost chip is visible in the model inference sheet
+  await expect(sheet.getByText("$0.0000348", { exact: true })).toBeVisible();
+});
+
+test("should not display cost chip when cost data is missing", async ({
+  page,
+}) => {
+  // This inference has null input/output tokens and no cost field
+  await page.goto(
+    "/observability/inferences/01954435-76a5-7331-8a3a-16296a0ba5b6",
+  );
+
+  // Wait for the page to load
+  await page.waitForLoadState("networkidle");
+
+  // Verify the inference page loads
+  await expect(
+    page.getByText("01954435-76a5-7331-8a3a-16296a0ba5b6").first(),
+  ).toBeVisible();
+
+  // Verify no cost chip is displayed (no dollar sign in usage area)
+  await expect(page.getByText(/^\$\d/)).not.toBeVisible();
+
+  // Click on the model inference ID to open the detail sheet
+  await page.getByText("01954435-76ab-78b1-a76e-d5676b0dd2f9").click();
+
+  // Wait for the sheet/dialog to appear
+  const sheet = page.getByRole("dialog");
+  await sheet.waitFor({ state: "visible" });
+
+  // Verify no cost chip in the sheet either
+  await expect(sheet.getByText(/^\$\d/)).not.toBeVisible();
+});
+
 // TODO(#5691): Run all UI e2e tests against Postgres-backed gateway too.
 // These are commented out because these tests are only supported on Postgres
 // because we don't TTL inference data in ClickHouse.

--- a/ui/fixtures/config/tensorzero.toml
+++ b/ui/fixtures/config/tensorzero.toml
@@ -11,6 +11,10 @@ routing = ["openai"]
 [models."gpt-4o-mini-2024-07-18".providers.openai]
 type = "openai"
 model_name = "gpt-4o-mini-2024-07-18"
+cost = [
+    { pointer = "/usage/prompt_tokens", cost_per_million = 0.15, required = true },
+    { pointer = "/usage/completion_tokens", cost_per_million = 0.60, required = true },
+]
 
 [models."llama-3.1-8b-instruct"]
 routing = ["fireworks"]

--- a/ui/fixtures/download_fixtures_consts.py
+++ b/ui/fixtures/download_fixtures_consts.py
@@ -10,7 +10,7 @@ PART_SIZE = 8388608
 # When a file needs updating, add version suffix to remote name (e.g., "file_v2.jsonl")
 # and keep the local name unchanged (e.g., "file.jsonl")
 SMALL_FIXTURES = {
-    "model_inference_examples_20260203.jsonl": "model_inference_examples.jsonl",
+    "model_inference_examples_20260224.jsonl": "model_inference_examples.jsonl",
     "chat_inference_examples_20260123.jsonl": "chat_inference_examples.jsonl",
     "json_inference_examples.jsonl": "json_inference_examples.jsonl",
     "boolean_metric_feedback_examples.jsonl": "boolean_metric_feedback_examples.jsonl",

--- a/ui/fixtures/upload-small-fixtures.sh
+++ b/ui/fixtures/upload-small-fixtures.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")"
 # When updating a file, rename it with a version suffix (e.g., model_inference_examples_v2.jsonl)
 # and update download-small-fixtures.py to use the new filename
 JSONL_FILES=(
-    "model_inference_examples_20260203.jsonl"
+    "model_inference_examples_20260224.jsonl"
     "chat_inference_examples_20260123.jsonl"
     "json_inference_examples.jsonl"
     "boolean_metric_feedback_examples.jsonl"


### PR DESCRIPTION
Fix #6263 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches inference parsing/usage aggregation and multiple UI surfaces; low algorithmic complexity, but incorrect null/undefined handling could hide or misreport costs.
> 
> **Overview**
> Adds *cost visibility* to inference observability: cost is now parsed from model inference rows, aggregated into total inference usage, and conditionally rendered in the inference detail header, model inference sheet, and variant comparison modal.
> 
> Introduces `formatCost` for consistent dollar formatting, adds a `Cost` icon, and updates fixtures/config plus unit/e2e tests to cover both “cost present” and “cost missing” cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 894193d078cdbc902497d3c5a2f609e978ca32c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->