### PR TITLE
Use s5cmd sync

### DIFF
--- a/ui/fixtures/download-large-fixtures.py
+++ b/ui/fixtures/download-large-fixtures.py
@@ -106,7 +106,7 @@ def verify_etags():
 
 def download_fixtures_from_r2(retries: int = 3) -> None:
     """Download fixtures from R2 using s5cmd with retry logic."""
-    batch_commands = "\n".join(f"cp s3://tensorzero-fixtures/{f} {LARGE_FIXTURES_DIR}/" for f in FIXTURES)
+    batch_commands = "\n".join(f"sync s3://tensorzero-fixtures/{f} {LARGE_FIXTURES_DIR}/" for f in FIXTURES)
 
     cmd = [
         "s5cmd",

--- a/ui/fixtures/download-small-fixtures.py
+++ b/ui/fixtures/download-small-fixtures.py
@@ -111,7 +111,7 @@ def rename_fixtures():
 
 def download_fixtures_from_r2(retries: int = 3) -> None:
     """Download fixtures from R2 using s5cmd with retry logic."""
-    batch_commands = "\n".join(f"cp s3://tensorzero-fixtures/{f} {FIXTURES_DIR}/" for f in FIXTURES.keys())
+    batch_commands = "\n".join(f"sync s3://tensorzero-fixtures/{f} {FIXTURES_DIR}/" for f in FIXTURES.keys())
 
     cmd = [
         "s5cmd",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to CI fixture download commands; main risk is unintended `sync` behavior differences affecting which files get updated or removed.
> 
> **Overview**
> Updates the authenticated R2 download path in both `download-large-fixtures.py` and `download-small-fixtures.py` to run `s5cmd sync` instead of `s5cmd cp` for each fixture.
> 
> This changes how fixtures are fetched in CI (favoring sync semantics) while keeping the existing retry flow and post-download ETag verification/renaming behavior intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11ea1bec44c39b451664f8e5bb15efe524eae2d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->