### PR TITLE
[STACKED] Update GEPA docs and example to use workflow endpoint

### DIFF
--- a/docs/optimization/gepa.mdx
+++ b/docs/optimization/gepa.mdx
@@ -79,67 +79,8 @@ Please return the entities in the following JSON format:
 
 <Step title="Collect your optimization data">
 
-<Tabs>
-
-<Tab title="TensorZero Dataset">
-
-After deploying the [TensorZero Gateway](/deployment/tensorzero-gateway) with [ClickHouse](/deployment/clickhouse), [build a dataset](/gateway/api-reference/datasets-datapoints) for the `extract_entities` function you configured.
-You can create datapoints from historical inferences or external/synthetic datasets.
-
-```python
-from tensorzero import ListDatapointsRequest
-
-datapoints = t0.list_datapoints(
-    dataset_name="extract_entities_dataset",
-    request=ListDatapointsRequest(
-        function_name="extract_entities",
-    ),
-)
-
-rendered_samples = t0.experimental_render_samples(
-    stored_samples=datapoints.datapoints,
-    variants={"extract_entities": "baseline"},
-)
-```
-
-</Tab>
-
-<Tab title="Historical Inferences">
-
 After deploying the [TensorZero Gateway](/deployment/tensorzero-gateway) with [ClickHouse](/deployment/clickhouse), make [inference calls](/gateway/call-any-llm) to the `extract_entities` function you configured.
 TensorZero automatically collects structured data about those inferences, which can later be used as training examples for GEPA.
-
-```python
-from tensorzero import ListInferencesRequest
-
-inferences_response = t0.list_inferences(
-    request=ListInferencesRequest(
-        function_name="extract_entities",
-        output_source="inference",
-    ),
-)
-
-rendered_samples = t0.experimental_render_samples(
-    stored_samples=inferences_response.inferences,
-    variants={"extract_entities": "baseline"},
-)
-```
-
-</Tab>
-
-</Tabs>
-
-GEPA requires two data splits: training (for template mutation) and validation (for Pareto frontier estimation).
-Let's split samples you queries above using numpy:
-
-```python
-import random
-
-random.shuffle(rendered_samples)
-split_idx = len(rendered_samples) // 2
-train_samples = rendered_samples[:split_idx]
-val_samples = rendered_samples[split_idx:]
-```
 
 </Step>
 
@@ -235,9 +176,9 @@ GEPA supports evaluations with any number of evaluators and any evaluator type (
 
 </Step>
 
-<Step title="Configure GEPA">
+<Step title="Launch GEPA">
 
-Configure GEPA by specifying the name of your function and evaluation.
+Configure and launch GEPA by specifying the name of your function and evaluation.
 You are also free to choose the models used to analyze inferences and generate new templates.
 
 The `analysis_model` reflects on individual inferences, reports on whether they are optimal, need improvement, or are erroneous, and provides suggestions for prompt template improvement.
@@ -245,17 +186,39 @@ The `mutation_model` generates new templates based on the collected analysis rep
 We recommend using strong models for these tasks.
 
 ```python
-from tensorzero import GEPAConfig
+import asyncio
 
-optimization_config = GEPAConfig(
-    function_name="extract_entities",
-    evaluation_name="extract_entities_eval",
-    analysis_model="openai::gpt-5.2",
-    mutation_model="openai::gpt-5.2",
-    initial_variants=["baseline"],
-    max_iterations=10,
-    max_tokens=16384,
+from tensorzero import AsyncTensorZeroGateway, OptimizationJobStatus
+
+t0 = await AsyncTensorZeroGateway.build_http(gateway_url="http://localhost:3000")
+
+job_handle = await t0.experimental_launch_optimization_workflow(
+    params={
+        "function_name": "extract_entities",
+        "template_variant_name": "baseline",
+        "output_source": "inference",
+        "val_fraction": 0.5,
+        "optimizer_config": {
+            "type": "gepa",
+            "function_name": "extract_entities",
+            "evaluation_name": "extract_entities_eval",
+            "analysis_model": "openai::gpt-5.2",
+            "mutation_model": "openai::gpt-5.2",
+            "initial_variants": ["baseline"],
+            "max_iterations": 10,
+            "max_tokens": 16384,
+        },
+    },
 )
+
+# GEPA runs as a durable task — poll until complete
+while True:
+    job_info = await t0.experimental_poll_optimization(job_handle=job_handle)
+    if job_info.status == OptimizationJobStatus.Completed:
+        break
+    if job_info.status == OptimizationJobStatus.Failed:
+        raise RuntimeError(f"GEPA optimization failed: {job_info}")
+    await asyncio.sleep(30)
 ```
 
 <Tip>
@@ -264,24 +227,6 @@ GEPA optimization can take a while to run, so keep `max_iterations` relatively s
 You can manually iterate further by setting `initial_variants` with the result of a previous GEPA run.
 
 </Tip>
-
-</Step>
-
-<Step title="Launch GEPA">
-
-You can now launch your GEPA optimization job using the TensorZero Gateway:
-
-```python
-job_handle = t0.experimental_launch_optimization(
-    train_samples=train_samples,
-    val_samples=val_samples,
-    optimization_config=optimization_config,
-)
-
-job_info = t0.experimental_poll_optimization(
-    job_handle=job_handle
-)
-```
 
 </Step>
 
@@ -395,7 +340,7 @@ You can roll out your new variants with confidence using [adaptive A/B testing](
 
 ## `GEPAConfig`
 
-Configure GEPA optimization by creating a `GEPAConfig` object with the following parameters:
+Configure GEPA optimization by passing the following parameters in the `optimizer_config` field (with `"type": "gepa"`):
 
 {/* Required Parameters */}
 

--- a/examples/docs/guides/optimization/gepa/main.py
+++ b/examples/docs/guides/optimization/gepa/main.py
@@ -1,13 +1,11 @@
 import asyncio
 import os
-import random
 
 from ner import Row, compute_exact_match, compute_jaccard_similarity, load_dataset
 from tensorzero import (
     AsyncTensorZeroGateway,
-    GEPAConfig,
     JsonInferenceResponse,
-    ListInferencesRequest,
+    OptimizationJobStatus,
 )
 from tqdm.asyncio import tqdm
 
@@ -94,51 +92,44 @@ async def main():
     tasks = [process_datapoint(dp, t0, semaphore) for dp in datapoints]
     await tqdm.gather(*tasks, desc="Processing samples")
 
-    inferences_response = await t0.list_inferences(
-        request=ListInferencesRequest(
-            function_name=FUNCTION_NAME,
-            output_source="inference",  # could also be "demonstration"
-            limit=NUM_SAMPLES,
-        ),
+    job_handle = await t0.experimental_launch_optimization_workflow(
+        params={
+            "function_name": FUNCTION_NAME,
+            "template_variant_name": TEMPLATE_VARIANT_NAME,
+            "output_source": "inference",
+            "limit": NUM_SAMPLES,
+            "val_fraction": 0.5,
+            "optimizer_config": {
+                "type": "gepa",
+                "function_name": FUNCTION_NAME,
+                "evaluation_name": EVALUATION_NAME,
+                "analysis_model": ANALYSIS_MODEL,
+                "mutation_model": MUTATION_MODEL,
+                "initial_variants": INITIAL_VARIANTS,
+                "max_iterations": MAX_ITERATIONS,
+                "max_concurrency": MAX_CONCURRENCY,
+                "max_tokens": 16384,
+            },
+        },
     )
 
-    rendered_samples = await t0.experimental_render_samples(
-        stored_samples=inferences_response.inferences,
-        variants={FUNCTION_NAME: TEMPLATE_VARIANT_NAME},
-    )
+    print("GEPA optimization launched. Polling for results...")
+    while True:
+        job_info = await t0.experimental_poll_optimization(job_handle=job_handle)
+        if job_info.status == OptimizationJobStatus.Completed:
+            break
+        if job_info.status == OptimizationJobStatus.Failed:
+            raise RuntimeError(f"GEPA optimization failed: {job_info}")
+        print(f"  Status: {job_info.status} — waiting 30s...")
+        await asyncio.sleep(30)
 
-    random.shuffle(rendered_samples)
-    split_idx = len(rendered_samples) // 2
-    train_samples = rendered_samples[:split_idx]
-    val_samples = rendered_samples[split_idx:]
-
-    optimization_config = GEPAConfig(
-        function_name=FUNCTION_NAME,
-        evaluation_name=EVALUATION_NAME,
-        analysis_model=ANALYSIS_MODEL,
-        mutation_model=MUTATION_MODEL,
-        initial_variants=INITIAL_VARIANTS,
-        max_iterations=MAX_ITERATIONS,
-        max_concurrency=MAX_CONCURRENCY,
-        max_tokens=16384,
-    )
-
-    job_handle = await t0.experimental_launch_optimization(
-        train_samples=train_samples,
-        val_samples=val_samples,
-        optimization_config=optimization_config,
-    )
-
-    job_info = await t0.experimental_poll_optimization(job_handle=job_handle)
-
-    assert job_info.output is not None
     variant_configs = job_info.output["content"]
 
     for variant_name, variant_config in variant_configs.items():
         print(f"\n# Optimized variant: {variant_name}")
         for template_name, template in variant_config["templates"].items():
             print(f"## '{template_name}' template:")
-            print(template["path"]["__data"])
+            print(template["path"]["__data"].strip())
 
 
 if __name__ == "__main__":

--- a/examples/docs/guides/optimization/gepa/pyproject.toml
+++ b/examples/docs/guides/optimization/gepa/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "openai>=2.6.1",
     "pandas>=2.3.3",
-    "tensorzero>=2025.12.3",
+    "tensorzero",
     "tqdm>=4.66.0",
 ]
 
@@ -14,3 +14,7 @@ dependencies = [
 dev = [
     "pyright>=1.1.0",
 ]
+
+# TODO: Remove [tool.uv.sources] and pin tensorzero to a released version once andrew/gepa-python-workflow-method lands
+[tool.uv.sources]
+tensorzero = { path = "../../../../../clients/python", editable = true }

--- a/examples/docs/guides/optimization/gepa/uv.lock
+++ b/examples/docs/guides/optimization/gepa/uv.lock
@@ -646,22 +646,37 @@ wheels = [
 
 [[package]]
 name = "tensorzero"
-version = "2026.1.5"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../../../../../clients/python" }
 dependencies = [
     { name = "dacite" },
     { name = "httpx" },
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/dd/5629b41b7da4bd277741039a7dbc50f5b83994a443b2cb549cea734b47c7/tensorzero-2026.1.5.tar.gz", hash = "sha256:beb805c33fb4217d899e2b824bf24435b93be737ba2967bc488215ba4000f5e4", size = 1663426, upload-time = "2026-01-24T17:52:28.935Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/92/a0724aaff4b90d4994961308515c215c9869cbcdb7b8b94aa85c98b98a9b/tensorzero-2026.1.5-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:160c0f32c3119addfd5f64eb93efc51a920a3cd77398982b7d177676c7a0c9f7", size = 35630038, upload-time = "2026-01-24T17:52:20.683Z" },
-    { url = "https://files.pythonhosted.org/packages/51/78/b5edd0f1b382276d60f5a369d496b144939039511b4c80da238853ceea1d/tensorzero-2026.1.5-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2b0b6571ad51e3116100ae8d40fee8f6aa128ba851fefc2981c184bd0422bf0c", size = 37283165, upload-time = "2026-01-24T17:52:13.684Z" },
-    { url = "https://files.pythonhosted.org/packages/44/c0/82ee0421c45fabcba5124350a92f47c6ff7c6bd4365b25b63262bf88bb4f/tensorzero-2026.1.5-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f58322ea0f7c0460e18ba59bc8540fbfb9d4c13ef1a0f867a5f0bbf32478ccd2", size = 37769093, upload-time = "2026-01-24T17:52:17.609Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/a4/51ecf57e0115c8863aa20adf3cfe9dc8d91657a09cd3e4313e1f2a669b6e/tensorzero-2026.1.5-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a069ad5a20f7011682ccabb2dcd31e470635a57983d332016160b6652ffc9ff9", size = 37504618, upload-time = "2026-01-24T17:52:23.705Z" },
-    { url = "https://files.pythonhosted.org/packages/89/d7/0d740907e3e6252539c025ab3262cb061c8e4d8dd76239fe0e064be0b985/tensorzero-2026.1.5-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:09f655155ffd4618f3202c45e70a21584e14578f09372da8c76d7f3e1ab27925", size = 38217504, upload-time = "2026-01-24T17:52:26.706Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/6c/f88d03195ad628e59ae62026d36563225f4ae304478ed3fc4c5cebbc59dc/tensorzero-2026.1.5-cp310-abi3-win_amd64.whl", hash = "sha256:56835dddb2b50379a8c4056552ed152a4d9e0b25eee7744697f1cb1443a203e8", size = 35166852, upload-time = "2026-01-24T17:52:30.864Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "dacite", specifier = ">=1.9.2" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "typing-extensions", specifier = ">=4.12.2" },
+    { name = "uuid-utils", specifier = ">=0.9.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "clickhouse-connect" },
+    { name = "maturin" },
+    { name = "mypy" },
+    { name = "openai" },
+    { name = "pandas" },
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-httpserver" },
+    { name = "pytest-rerunfailures" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
+    { name = "requests" },
 ]
 
 [[package]]
@@ -684,7 +699,7 @@ dev = [
 requires-dist = [
     { name = "openai", specifier = ">=2.6.1" },
     { name = "pandas", specifier = ">=2.3.3" },
-    { name = "tensorzero", specifier = ">=2025.12.3" },
+    { name = "tensorzero", editable = "../../../../../clients/python" },
     { name = "tqdm", specifier = ">=4.66.0" },
 ]
 


### PR DESCRIPTION
## Summary

- Simplifies GEPA docs to use the new `experimental_launch_optimization_workflow` HTTP endpoint instead of the embedded-only `experimental_render_samples` + `experimental_launch_optimization` approach
- Updates the runnable example (`examples/docs/guides/optimization/gepa/`) to match
- Points `tensorzero` dependency at local client via `[tool.uv.sources]`

## TODO

- [ ] Once `andrew/gepa-python-workflow-method` lands and is released, remove `[tool.uv.sources]` from `examples/docs/guides/optimization/gepa/pyproject.toml` and pin `tensorzero` to the released version

## Test plan

- [ ] Review docs render correctly
- [ ] Run the example end-to-end with gateway + docker