### PR TITLE
[STACKED] Block GEPA optimization in embedded gateway mode

### DIFF
--- a/clients/python/tests/test_optimization.py
+++ b/clients/python/tests/test_optimization.py
@@ -188,8 +188,8 @@ def test_sync_together_sft(
 
 
 @pytest.mark.mock
-def test_sync_gepa_chat(
-    embedded_sync_client: TensorZeroGateway,
+def test_sync_gepa_errors_in_embedded_mode(
+    embedded_sync_client_using_postgres: TensorZeroGateway,
     chat_function_rendered_samples: List[RenderedSample],
 ):
     optimization_config = GEPAConfig(
@@ -200,16 +200,12 @@ def test_sync_gepa_chat(
         initial_variants=["anthropic"],
     )
 
-    optimization_job_handle = embedded_sync_client.experimental_launch_optimization(
-        train_samples=chat_function_rendered_samples,
-        val_samples=chat_function_rendered_samples,
-        optimization_config=optimization_config,
-    )
-    while True:
-        job_info = embedded_sync_client.experimental_poll_optimization(job_handle=optimization_job_handle)
-        if job_info.status == OptimizationJobStatus.Completed:
-            break
-        sleep(1)
+    with pytest.raises(Exception, match="GEPA must be launched via the HTTP gateway"):
+        embedded_sync_client_using_postgres.experimental_launch_optimization(
+            train_samples=chat_function_rendered_samples,
+            val_samples=chat_function_rendered_samples,
+            optimization_config=optimization_config,
+        )
 
 
 @pytest.mark.mock
@@ -376,32 +372,6 @@ async def test_async_together_sft(
     optimization_job_handle = await embedded_async_client.experimental_launch_optimization(
         train_samples=mixed_rendered_samples,
         val_samples=None,
-        optimization_config=optimization_config,
-    )
-    while True:
-        job_info = await embedded_async_client.experimental_poll_optimization(job_handle=optimization_job_handle)
-        if job_info.status == OptimizationJobStatus.Completed:
-            break
-        sleep(1)
-
-
-@pytest.mark.mock
-@pytest.mark.asyncio
-async def test_async_gepa_json(
-    embedded_async_client: AsyncTensorZeroGateway,
-    json_function_rendered_samples: List[RenderedSample],
-):
-    optimization_config = GEPAConfig(
-        function_name="json_success",
-        evaluation_name="json_evaluation",
-        analysis_model="openai::gpt-4o-mini",
-        mutation_model="openai::gpt-4o-mini",
-        initial_variants=["anthropic", "openai"],
-    )
-
-    optimization_job_handle = await embedded_async_client.experimental_launch_optimization(
-        train_samples=json_function_rendered_samples,
-        val_samples=json_function_rendered_samples,
         optimization_config=optimization_config,
     )
     while True:

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -97,7 +97,9 @@ pub use tensorzero_core::inference::types::{
     Base64File, ContentBlockChunk, File, ObjectStoragePointer, Role, System, Unknown, UnknownChunk,
     UrlFile, Usage,
 };
-pub use tensorzero_core::optimization::{OptimizationJobHandle, OptimizationJobInfo};
+pub use tensorzero_core::optimization::{
+    OptimizationJobHandle, OptimizationJobInfo, UninitializedOptimizerConfig,
+};
 pub use tensorzero_core::stored_inference::{
     RenderedSample, StoredChatInference, StoredChatInferenceDatabase, StoredInference,
     StoredInferenceDatabase, StoredJsonInference,
@@ -1176,6 +1178,17 @@ impl ClientExt for Client {
     ) -> Result<OptimizationJobHandle, TensorZeroError> {
         match self.mode() {
             ClientMode::EmbeddedGateway { gateway, timeout } => {
+                if matches!(
+                    params.optimization_config.inner,
+                    UninitializedOptimizerConfig::GEPA(_)
+                ) {
+                    return Err(TensorZeroError::Other {
+                        source: Error::new(ErrorDetails::InvalidRequest {
+                            message: "GEPA must be launched via the HTTP gateway's `/experimental_optimization_workflow` endpoint, not the embedded client".to_string(),
+                        })
+                        .into(),
+                    });
+                }
                 Ok(Box::pin(with_embedded_timeout(*timeout, async {
                     let db: Arc<dyn DelegatingDatabaseQueries + Send + Sync> =
                         Arc::new(gateway.handle.app_state.get_delegating_database());
@@ -1208,6 +1221,17 @@ impl ClientExt for Client {
     ) -> Result<OptimizationJobHandle, TensorZeroError> {
         match self.mode() {
             ClientMode::EmbeddedGateway { gateway, timeout } => {
+                if matches!(
+                    params.optimizer_config.inner,
+                    UninitializedOptimizerConfig::GEPA(_)
+                ) {
+                    return Err(TensorZeroError::Other {
+                        source: Error::new(ErrorDetails::InvalidRequest {
+                            message: "GEPA must be launched via the HTTP gateway's `/experimental_optimization_workflow` endpoint, not the embedded client".to_string(),
+                        })
+                        .into(),
+                    });
+                }
                 Box::pin(with_embedded_timeout(*timeout, async {
                     let db: Arc<dyn DelegatingDatabaseQueries + Send + Sync> =
                         Arc::new(gateway.handle.app_state.get_delegating_database());

--- a/tensorzero-optimizers/src/endpoints.rs
+++ b/tensorzero-optimizers/src/endpoints.rs
@@ -24,7 +24,10 @@ use tensorzero_core::{
     error::{Error, ErrorDetails},
     http::TensorzeroHttpClient,
     model_table::ProviderTypeDefaultCredentials,
-    optimization::{OptimizationJobHandle, OptimizationJobInfo, UninitializedOptimizerInfo},
+    optimization::{
+        OptimizationJobHandle, OptimizationJobInfo, UninitializedOptimizerConfig,
+        UninitializedOptimizerInfo,
+    },
     stored_inference::RenderedSample,
     utils::gateway::{AppState, AppStateData, StructuredJson},
 };
@@ -158,6 +161,14 @@ pub async fn launch_optimization(
         val_samples: val_examples,
         optimization_config: optimizer_config,
     } = params;
+    if matches!(
+        optimizer_config.inner,
+        UninitializedOptimizerConfig::GEPA(_)
+    ) {
+        return Err(Error::new(ErrorDetails::InvalidRequest {
+            message: "GEPA must be launched via the HTTP gateway's `/experimental_optimization_workflow` endpoint, not the embedded client".to_string(),
+        }));
+    }
     let optimizer = optimizer_config.load();
     optimizer
         .launch(


### PR DESCRIPTION
## Summary
- Block GEPA from being launched through the embedded client — it requires durable execution via the HTTP gateway
- Add error checks in both `launch_optimization` (optimizers crate) and `experimental_launch_optimization` (Rust client)
- Update Python tests to verify the error is raised

Pre-requisite for durable GEPA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes for embedded clients: GEPA optimizations now hard-fail with an `InvalidRequest` error, which could break existing embedded workflows relying on GEPA. The change is otherwise a small guardrail with test coverage and no data-mutation logic changes.
> 
> **Overview**
> **Blocks GEPA optimization in embedded gateway mode.** The Rust embedded client now rejects `GEPA` configs in both `experimental_launch_optimization` and `experimental_launch_optimization_workflow`, returning a clear `InvalidRequest` message directing users to the HTTP gateway endpoint.
> 
> Adds the same `GEPA` guard in `tensorzero-optimizers` `launch_optimization` to prevent embedded launches at the optimizer layer as well.
> 
> Updates Python optimization tests to expect the new error when attempting to launch `GEPA` in embedded mode, and removes the prior embedded/async GEPA success coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 646e68ba641b15bde4323b9048dd9a380a908258. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->