### PR TITLE
Bump version to 2026.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot-client"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "chrono",
  "durable-tools-spawn",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-tools"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-worker"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "config-applier"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "pathdiff",
  "schemars 1.2.1",
@@ -2193,7 +2193,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2226,7 +2226,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools-spawn"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "async-trait",
  "durable",
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "async-stream",
  "autopilot-client",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-utils"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "minijinja",
  "serde",
@@ -4810,7 +4810,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postgres-inference-load-test"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5396,7 +5396,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5731,7 +5731,7 @@ dependencies = [
 
 [[package]]
 name = "reqwest-sse-stream"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "async-stream",
  "futures",
@@ -6866,7 +6866,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "axum",
  "chrono",
@@ -6886,11 +6886,11 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-config-paths"
-version = "2026.2.1"
+version = "2026.2.2"
 
 [[package]]
 name = "tensorzero-core"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -7014,7 +7014,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "config-applier",
  "napi",
@@ -7029,7 +7029,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-optimizers"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -7064,7 +7064,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "evaluations",
  "futures",
@@ -7082,11 +7082,11 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-ts-types"
-version = "2026.2.1"
+version = "2026.2.2"
 
 [[package]]
 name = "tensorzero-types"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "aws-smithy-types",
  "infer",
@@ -7107,7 +7107,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types-providers"
-version = "2026.2.1"
+version = "2026.2.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -7117,7 +7117,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-unsafe-helpers"
-version = "2026.2.1"
+version = "2026.2.2"
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2026.2.1"
+version = "2026.2.2"
 rust-version = "1.93.0"
 license = "Apache-2.0"
 edition = "2024"

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2026.2.1"
+appVersion: "2026.2.2"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorzero-ui",
-  "version": "2026.2.1",
+  "version": "2026.2.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only version bump across manifests/lockfile with no behavioral code changes.
> 
> **Overview**
> Bumps the workspace release version from `2026.2.1` to `2026.2.2` across the Rust workspace (`Cargo.toml`/`Cargo.lock`), the Kubernetes Helm chart (`appVersion`), and the UI package (`ui/package.json`).
> 
> No functional or dependency changes beyond version metadata updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18f871904ee61406c8405be6683f13183b49fd39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->