### PR TITLE
Fix Ask Autopilot button width and add missing button on inference page

### DIFF
--- a/ui/app/components/autopilot/AskAutopilotButton.tsx
+++ b/ui/app/components/autopilot/AskAutopilotButton.tsx
@@ -21,6 +21,7 @@ export function AskAutopilotButton({ message }: AskAutopilotButtonProps) {
     <Button
       variant="outline"
       size="sm"
+      className="w-fit"
       onClick={() => navigate(`/autopilot/sessions/new?${params.toString()}`)}
     >
       <ButtonIcon as={Chat} variant="tertiary" />

--- a/ui/app/routes/observability/inferences/$inference_id/InferenceActionBar.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/InferenceActionBar.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from "~/components/ui/skeleton";
 import { ActionBarAsyncError } from "~/components/ui/error/ErrorContentPrimitives";
 import { ActionBar } from "~/components/layout/ActionBar";
 import { AddToDatasetButton } from "~/components/dataset/AddToDatasetButton";
+import { AskAutopilotButton } from "~/components/autopilot/AskAutopilotButton";
 import { TryWithVariantAction } from "./TryWithVariantAction";
 import { HumanFeedbackAction } from "./HumanFeedbackAction";
 import type { ModelInferencesData } from "./inference-data.server";
@@ -50,6 +51,9 @@ export function InferenceActionBar({
         key={`human-${locationKey}`}
         inference={inference}
         onFeedbackAdded={onFeedbackAdded}
+      />
+      <AskAutopilotButton
+        message={`Inference ID: ${inference.inference_id}\n\n`}
       />
     </ActionBar>
   );


### PR DESCRIPTION
## Summary
- Add `w-fit` to `AskAutopilotButton` so it doesn't stretch full-width in flex-col containers (function detail, variant pages)
- Add missing `AskAutopilotButton` to the inference detail page's `InferenceActionBar` — it was omitted when the action bar was extracted during the streaming refactor (#5804)

Fast follow with e2e tests coming in a stacked PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only changes (styling + adding an existing button) with minimal behavioral impact beyond navigation to the Autopilot session page.
> 
> **Overview**
> Restores the missing `AskAutopilotButton` to the inference detail page `InferenceActionBar`, pre-populating the Autopilot session message with the current `inference_id`.
> 
> Tweaks `AskAutopilotButton` styling by adding `className="w-fit"` so it no longer stretches full width in column/flex layouts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5699f9f7e7a45759da6ca01b0c356701f5b2fbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->