### PR TITLE
Remove UI references to evaluator cutoffs

### DIFF
--- a/ui/app/components/metric/MetricValue.tsx
+++ b/ui/app/components/metric/MetricValue.tsx
@@ -6,14 +6,12 @@ export default function MetricValue({
   metricType,
   optimize,
   isHumanFeedback,
-  cutoff,
   className = "",
 }: {
   value: string;
   metricType: "boolean" | "float" | "comment" | "demonstration";
   optimize: "min" | "max";
   isHumanFeedback: boolean;
-  cutoff?: number;
   className?: string;
 }): React.ReactElement {
   if (metricType === "boolean") {
@@ -40,14 +38,9 @@ export default function MetricValue({
     // Try to parse as number
     const numValue = parseFloat(value);
     if (!isNaN(numValue)) {
-      // Check if value fails the cutoff criteria
-      const failsCutoff =
-        optimize && cutoff ? isCutoffFailed(numValue, optimize, cutoff) : false;
       return (
         <span
-          className={`inline-flex items-center gap-2 whitespace-nowrap ${
-            failsCutoff ? "text-red-700" : "text-gray-700"
-          } ${className}`}
+          className={`inline-flex items-center gap-2 whitespace-nowrap text-gray-700 ${className}`}
         >
           {numValue}
           {isHumanFeedback && <UserFeedback />}
@@ -58,20 +51,4 @@ export default function MetricValue({
 
   // Default case: return as string
   return <span className={`whitespace-nowrap ${className}`}>{value}</span>;
-}
-
-export function isCutoffFailed(
-  value: number | boolean,
-  optimize: "min" | "max",
-  cutoff: number,
-) {
-  const numericValue = typeof value === "number" ? value : value ? 1 : 0;
-  if (cutoff === undefined) {
-    return false;
-  }
-  if (optimize === "max") {
-    return numericValue < cutoff;
-  } else {
-    return numericValue > cutoff;
-  }
 }

--- a/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/route.tsx
+++ b/ui/app/routes/evaluations/$evaluation_name/$datapoint_id/route.tsx
@@ -620,14 +620,6 @@ const MetricRow = ({
                 {metricProperties.optimize}
               </span>
             </div>
-            {evaluatorConfig.cutoff !== undefined && (
-              <div>
-                <span className="font-medium">Cutoff:</span>
-                <span className="ml-2 font-medium">
-                  {evaluatorConfig.cutoff}
-                </span>
-              </div>
-            )}
           </div>
         </TooltipContent>
       </Tooltip>
@@ -639,7 +631,6 @@ const MetricRow = ({
             ? evaluatorConfig.optimize
             : "max"
         }
-        cutoff={evaluatorConfig.cutoff ?? undefined}
         isHumanFeedback={isHumanFeedback}
         className="text-sm"
       />

--- a/ui/app/routes/evaluations/$evaluation_name/EvaluationTable.tsx
+++ b/ui/app/routes/evaluations/$evaluation_name/EvaluationTable.tsx
@@ -37,7 +37,6 @@ import {
   formatConfidenceInterval,
 } from "~/utils/config/feedback";
 import type {
-  EvaluatorConfig,
   MetricConfig,
   JsonInferenceOutput,
   ContentBlockChatOutput,
@@ -46,7 +45,7 @@ import {
   useColorAssigner,
   ColorAssignerProvider,
 } from "~/hooks/evaluations/ColorAssigner";
-import MetricValue, { isCutoffFailed } from "~/components/metric/MetricValue";
+import MetricValue from "~/components/metric/MetricValue";
 import EvaluationFeedbackEditor from "~/components/evaluations/EvaluationFeedbackEditor";
 import { InferenceButton } from "~/components/utils/InferenceButton";
 import { InputElement } from "~/components/input_output/InputElement";
@@ -614,10 +613,6 @@ export function EvaluationTable({
                                                 ? evaluatorConfig.optimize
                                                 : "max"
                                             }
-                                            cutoff={
-                                              evaluatorConfig.cutoff ??
-                                              undefined
-                                            }
                                           />
                                           {/* Make feedback editor appear on hover */}
                                           {evaluatorConfig.type ===
@@ -715,7 +710,6 @@ const EvaluatorHeader = ({
           <EvaluatorProperties
             metricConfig={metricProperties}
             summaryStats={summaryStats}
-            evaluatorConfig={evaluatorConfig}
           />
         </div>
       </TooltipTrigger>
@@ -731,12 +725,6 @@ const EvaluatorHeader = ({
               {metricProperties.optimize}
             </span>
           </div>
-          {evaluatorConfig.cutoff !== undefined && (
-            <div>
-              <span className="font-medium">Cutoff:</span>
-              <span className="ml-2 font-medium">{evaluatorConfig.cutoff}</span>
-            </div>
-          )}
         </div>
       </TooltipContent>
     </Tooltip>
@@ -746,11 +734,9 @@ const EvaluatorHeader = ({
 const EvaluatorProperties = ({
   metricConfig,
   summaryStats,
-  evaluatorConfig,
 }: {
   metricConfig: MetricConfig;
   summaryStats: EvaluationStatistics[];
-  evaluatorConfig: EvaluatorConfig;
 }) => {
   const [searchParams] = useSearchParams();
   const selectedRunIdsParam = searchParams.get("evaluation_run_ids") || "";
@@ -780,20 +766,10 @@ const EvaluatorProperties = ({
               stat.evaluation_run_id,
               false,
             ); // Pass 'false' to get non-hover version
-            const failed =
-              evaluatorConfig.type === "llm_judge" && evaluatorConfig.cutoff
-                ? isCutoffFailed(
-                    stat.mean_metric,
-                    evaluatorConfig.optimize,
-                    evaluatorConfig.cutoff,
-                  )
-                : false;
             return (
               <div
                 key={stat.evaluation_run_id}
-                className={`mt-1 flex items-center justify-center gap-1.5 ${
-                  failed ? "text-red-700" : ""
-                }`}
+                className="mt-1 flex items-center justify-center gap-1.5"
               >
                 <div
                   className={`h-2 w-2 rounded-full ${variantColorClass} shrink-0`}

--- a/ui/app/routes/workflow-evaluations/runs/$run_id/WorkflowEvaluationRunEpisodesTable.tsx
+++ b/ui/app/routes/workflow-evaluations/runs/$run_id/WorkflowEvaluationRunEpisodesTable.tsx
@@ -166,7 +166,6 @@ function FeedbackMetricValue({
         value={value}
         metricType={metricConfig.type}
         optimize={metricConfig.optimize}
-        cutoff={metricConfig.type === "boolean" ? 0.5 : undefined}
         isHumanFeedback={false}
       />
     );


### PR DESCRIPTION
I don't think evaluators should have cutoffs defined inline - the output should be interpreted in context and it's usually relative numbers not absolute numbers that matter.

This removes a styling and a display in the cutoff.