### PR TITLE
Retry generate-python-schemas in CI

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -254,24 +254,18 @@ jobs:
         with:
           version: "0.9.27"
 
-      # The `packageManager` field in package.json triggers corepack to download pnpm on first invocation,
-      # which can fail with transient 403s from the npm registry. Retry the bootstrap separately so the
-      # actual script doesn't need retry logic.
-      - name: Bootstrap pnpm
+      - name: Generate Python schemas
         run: |
           for attempt in 1 2 3; do
-            if pnpm --version; then
+            if pnpm generate-python-schemas; then
               break
             fi
             if [ $attempt -eq 3 ]; then
-              echo "Failed to bootstrap pnpm after 3 attempts"
+              echo "Failed to generate Python schemas after 3 attempts"
               exit 1
             fi
             sleep $((10 * attempt))
           done
-
-      - name: Generate Python schemas
-        run: pnpm generate-python-schemas
 
       - name: Check for git diff after generating schemas
         id: git_diff_check


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only change that adds retry logic around schema generation; low risk aside from potentially masking persistent generator failures for a bit longer.
> 
> **Overview**
> Makes the `check-python-schemas` CI job retry `pnpm generate-python-schemas` up to 3 times (with backoff) to reduce transient failures.
> 
> Removes the separate “Bootstrap pnpm” retry step and updates the failure message accordingly, keeping the existing `git diff --exit-code` verification after schema generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad3b119db9004c7fceb5d0a71e9b523efe6d222a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->