### PR TITLE
Add sdist check retry in CI

### DIFF
--- a/.github/workflows/python-client-build.yml
+++ b/.github/workflows/python-client-build.yml
@@ -248,7 +248,16 @@ jobs:
           version: "0.9.27"
       - name: Check local sdist
         run: |
-          ./ci/check-local-wheel.sh ./clients/python/dist/tensorzero-*.tar.gz
+          for attempt in 1 2 3; do
+            if ./ci/check-local-wheel.sh ./clients/python/dist/tensorzero-*.tar.gz; then
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "Failed to check local sdist after 3 attempts"
+              exit 1
+            fi
+            sleep $((10 * attempt))
+          done
       - name: Run twine on sdist
         run: |
           uv pip install twine


### PR DESCRIPTION
Flaky: https://github.com/tensorzero/tensorzero/actions/runs/22414214456/job/64895456332

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adds retries/backoff around an existing check; no product code or release artifacts are modified.
> 
> **Overview**
> Makes the Python client CI `sdist` verification more resilient by retrying the `Check local sdist` step up to 3 times with a backoff before failing.
> 
> This reduces flakiness when running `./ci/check-local-wheel.sh` against the generated `tensorzero-*.tar.gz` prior to `twine check`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75d9add6f50bfdfaa24426c5816d0f5c01f8248c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->