### PR TITLE
Bump together-deepseek-r1 max tokens to 1000

### DIFF
--- a/tensorzero-core/tests/e2e/config/tensorzero.functions.basic_test.toml
+++ b/tensorzero-core/tests/e2e/config/tensorzero.functions.basic_test.toml
@@ -796,7 +796,7 @@ max_tokens = 800
 type = "chat_completion"
 model = "together-deepseek-r1"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
-max_tokens = 800
+max_tokens = 1000
 
 [functions.basic_test.variants.together-kimi]
 type = "chat_completion"

--- a/tensorzero-core/tests/e2e/config/tensorzero.functions.json_math.toml
+++ b/tensorzero-core/tests/e2e/config/tensorzero.functions.json_math.toml
@@ -79,7 +79,7 @@ type = "chat_completion"
 model = "together-deepseek-r1"
 system_template = "../../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 json_mode = "off"
-max_tokens = 800
+max_tokens = 1000
 
 [functions.json_math.variants.together-kimi]
 type = "chat_completion"

--- a/tensorzero-core/tests/e2e/config/tensorzero.functions.json_success.toml
+++ b/tensorzero-core/tests/e2e/config/tensorzero.functions.json_success.toml
@@ -208,7 +208,7 @@ model = "together-deepseek-r1"
 system_template = "../../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 user_template = "../../../fixtures/config/functions/json_success/prompt/user_template.minijinja"
 json_mode = "off"
-max_tokens = 800
+max_tokens = 1000
 
 [functions.json_success.variants.together-kimi]
 type = "chat_completion"


### PR DESCRIPTION
We're seeing some tests flake on the daily provider-proxy regen run due to the length limit getting hit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change affecting e2e test variants; primary impact is slightly higher token usage/cost and potentially longer-running tests for Together AI runs.
> 
> **Overview**
> Increases `max_tokens` from 800 to 1000 for the `together-deepseek-r1` variant across the e2e test function configs (`basic_test`, `json_math`, and `json_success`) to reduce flakiness from responses hitting the token limit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83287ce26f292497fb6e74387e505782a958fa9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->