### PR TITLE
Add more retries to Azure tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -134,7 +134,6 @@ retries = { backoff = "exponential", count = 8, delay = "5s", jitter = true, max
 
 [[profile.default.overrides]]
 filter = 'binary(e2e) and test(providers::azure::)'
-test-group = 'e2e_groq'
 # We have a low rate limit on Azure, so we often need to retry several times
 retries = { backoff = "exponential", count = 8, delay = "5s", jitter = true, max-delay = "120s" }
 


### PR DESCRIPTION
This helps work around our low rate limit when regenerating the provider-proxy cache

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that only affects test execution behavior; may slightly increase CI runtime when Azure tests hit rate limits.
> 
> **Overview**
> Adds a `cargo-nextest` override to give `providers::azure` E2E tests higher retry tolerance (exponential backoff, up to 8 retries) to better handle Azure rate limiting and reduce flaky failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c12d9ad6df2d86504ec11f82ca2be57ff805a1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->