### PR TITLE
Fix broken links/anchors and add CI check

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1299,44 +1299,75 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
+  check-docs-broken-links:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    if: github.repository == 'tensorzero/tensorzero'
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Setup Node.js
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
+        with:
+          node-version: "24.13.0"
+
+      - name: Install Mintlify CLI
+        run: |
+          for attempt in 1 2 3; do
+            if npm install -g mint@4.2.390; then
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "Failed to install Mintlify CLI after 3 attempts"
+              exit 1
+            fi
+            sleep $((10 * attempt))
+          done
+
+      - name: Check for broken links
+        working-directory: docs
+        run: mint broken-links --check-anchors
+
   # See 'ci/README.md' at the repository root for more details.
   check-all-general-jobs-passed:
     permissions: {}
     if: always() && github.repository == 'tensorzero/tensorzero'
     needs:
       [
-        check-version-consistency,
-        check-production-deployment-docker-compose,
-        check-docker-compose-released,
-        check-docker-compose-commit,
-        check-python-client-build,
-        check-node-bindings,
-        check-python-schemas,
-        build-windows,
-        build-ui-container,
+        autopilot-e2e,
         build-gateway-container,
         build-gateway-e2e-container,
-        build-provider-proxy-container,
         build-live-tests-container,
         build-mock-provider-api-container,
-        mocked-batch-tests,
-        publish-dev-docker-hub-images,
+        build-provider-proxy-container,
+        build-ui-container,
+        build-windows,
+        check-docker-compose-commit,
+        check-docker-compose-released,
+        check-docs-broken-links,
+        check-node-bindings,
+        check-production-deployment-docker-compose,
+        check-python-client-build,
+        check-python-schemas,
+        check-version-consistency,
+        clickhouse-tests,
+        client-tests,
+        endpoint-tests,
+        lint-rust,
+        live-tests,
         minikube,
+        mock-optimization-tests,
+        mocked-batch-tests,
+        postgres-tests,
+        publish-dev-docker-hub-images,
         rust-build,
         rust-test,
+        ui-tests,
+        ui-tests-e2e,
         validate,
         validate-node,
         validate-python,
-        lint-rust,
-        clickhouse-tests,
-        postgres-tests,
-        endpoint-tests,
-        ui-tests,
-        ui-tests-e2e,
-        mock-optimization-tests,
-        live-tests,
-        client-tests,
-        autopilot-e2e,
       ]
     runs-on: ubuntu-latest
     steps:

--- a/docs/evaluations/inference-evaluations/configuration-reference.mdx
+++ b/docs/evaluations/inference-evaluations/configuration-reference.mdx
@@ -213,12 +213,12 @@ It helps TensorZero Autopilot understand the intent behind the evaluator.
 An LLM Judge evaluator defines a TensorZero function that is used to judge the output of another TensorZero function.
 Therefore, all the variant types that are available for a normal TensorZero function are also available for LLMs as judges &mdash; including all of our [inference-time optimizations](/gateway/guides/inference-time-optimizations/).
 
-You can include a standard [variant configuration](/gateway/configuration-reference/#functionsfunction_namevariantsvariant_name) in this block, with two modifications:
+You can include a standard [variant configuration](/gateway/configuration-reference/#functions-function_name-variants-variant_name) in this block, with two modifications:
 
 - You must mark a single variant as `active`.
 - For `chat_completion` variants, instead of a `system_template` we require `system_instructions` as a text file and take no other templates.
 
-Here we list only the configuration for variants that differs from the configuration for a normal TensorZero function. Please refer the [variant configuration reference](/gateway/configuration-reference/#functionsfunction_namevariantsvariant_name) for the remaining options.
+Here we list only the configuration for variants that differs from the configuration for a normal TensorZero function. Please refer the [variant configuration reference](/gateway/configuration-reference/#functions-function_name-variants-variant_name) for the remaining options.
 
 ```toml
 // tensorzero.toml

--- a/docs/gateway/api-reference/batch-inference.mdx
+++ b/docs/gateway/api-reference/batch-inference.mdx
@@ -51,7 +51,7 @@ Only use this field if dynamic tool use is necessary for your use case.
 Each tool is an object with the following fields: `description`, `name`, `parameters`, and `strict`.
 
 The fields are identical to those in the configuration file, except that the `parameters` field should contain the JSON schema itself rather than a path to it.
-See [Configuration Reference](/gateway/configuration-reference/#toolstool_name) for more details.
+See [Configuration Reference](/gateway/configuration-reference/#tools-tool_name) for more details.
 
 #### `allowed_tools`
 
@@ -75,7 +75,7 @@ For providers that do not natively support this feature, we filter the tool list
 - **Required:** no (default: no credentials)
 
 Each model provider in your TensorZero configuration can be configured to accept credentials at inference time by using the `dynamic` location (e.g. `dynamic::my_dynamic_api_key_name`).
-See the [configuration reference](/gateway/configuration-reference/#modelsmodel_nameprovidersprovider_name) for more details.
+See the [configuration reference](/gateway/configuration-reference/#models-model_name-providers-provider_name) for more details.
 The gateway expects the credentials to be provided in the `credentials` field of the request body as specified below.
 The gateway will return a 400 error if the credentials are not provided and the model provider has been configured with dynamic credentials.
 
@@ -374,7 +374,7 @@ Currently, we support the following:
   - `top_p`
   - `verbosity`
 
-See [Configuration Reference](/gateway/configuration-reference/#functionsfunction_namevariantsvariant_name) for more details on the parameters, and Examples below for usage.
+See [Configuration Reference](/gateway/configuration-reference/#functions-function_name-variants-variant_name) for more details on the parameters, and Examples below for usage.
 
 <Accordion title="Example">
 

--- a/docs/gateway/api-reference/inference-openai-compatible.mdx
+++ b/docs/gateway/api-reference/inference-openai-compatible.mdx
@@ -58,7 +58,7 @@ See the [Inference Caching](/gateway/guides/inference-caching) guide for more de
 - **Required:** no (default: no credentials)
 
 Each model provider in your TensorZero configuration can be configured to accept credentials at inference time by using the `dynamic` location (e.g. `dynamic::my_dynamic_api_key_name`).
-See the [configuration reference](/gateway/configuration-reference/#modelsmodel_nameprovidersprovider_name) for more details.
+See the [configuration reference](/gateway/configuration-reference/#models-model_name-providers-provider_name) for more details.
 The gateway expects the credentials to be provided in the `credentials` field of the request body as specified below.
 The gateway will return a 400 error if the credentials are not provided and the model provider has been configured with dynamic credentials.
 
@@ -392,7 +392,7 @@ Each object in the array has the following fields:
 When using OpenAI client libraries, pass this parameter via `extra_body`.
 
 This field allows for dynamic provider tool configuration at runtime.
-You should prefer to define provider tools in the configuration file if possible (see [Configuration Reference](/gateway/configuration-reference/#provider_tools)).
+You should prefer to define provider tools in the configuration file if possible (see [Configuration Reference](/gateway/configuration-reference)).
 Only use this field if dynamic provider tool configuration is necessary for your use case.
 
 <Accordion title="Example: OpenAI Web Search (Unscoped)">

--- a/docs/gateway/api-reference/inference.mdx
+++ b/docs/gateway/api-reference/inference.mdx
@@ -43,7 +43,7 @@ Each function tool is an object with the following fields:
 - `parameters` (object, required): A JSON Schema defining the tool's parameters
 - `strict` (boolean, optional): Whether to enforce strict schema validation (defaults to `false`)
 
-See [Configuration Reference](/gateway/configuration-reference/#toolstool_name) for more details.
+See [Configuration Reference](/gateway/configuration-reference/#tools-tool_name) for more details.
 
 ##### OpenAI Custom Tools
 
@@ -179,7 +179,7 @@ For example, if you set `max_age_s=3600`, the gateway will only use cache entrie
 - **Required:** no (default: no credentials)
 
 Each model provider in your TensorZero configuration can be configured to accept credentials at inference time by using the `dynamic` location (e.g. `dynamic::my_dynamic_api_key_name`).
-See the [configuration reference](/gateway/configuration-reference/#modelsmodel_nameprovidersprovider_name) for more details.
+See the [configuration reference](/gateway/configuration-reference/#models-model_name-providers-provider_name) for more details.
 The gateway expects the credentials to be provided in the `credentials` field of the request body as specified below.
 The gateway will return a 400 error if the credentials are not provided and the model provider has been configured with dynamic credentials.
 
@@ -732,7 +732,7 @@ Currently, we support the following:
   - `top_p`
   - `verbosity`
 
-See [Configuration Reference](/gateway/configuration-reference/#functionsfunction_namevariantsvariant_name) for more details on the parameters, and Examples below for usage.
+See [Configuration Reference](/gateway/configuration-reference/#functions-function_name-variants-variant_name) for more details on the parameters, and Examples below for usage.
 
 <Accordion title="Example">
 
@@ -770,7 +770,7 @@ Each object in the array has the following fields:
 - `tool` (object, required): The provider-specific tool configuration as defined by the provider's API
 
 This field allows for dynamic provider tool use at runtime.
-You should prefer to define provider tools in the configuration file if possible (see [Configuration Reference](/gateway/configuration-reference/#provider_tools)).
+You should prefer to define provider tools in the configuration file if possible (see [Configuration Reference](/gateway/configuration-reference)).
 Only use this field if dynamic provider tool configuration is necessary for your use case.
 
 <Accordion title="Example: OpenAI Web Search (Unscoped)">

--- a/docs/gateway/configuration-reference.mdx
+++ b/docs/gateway/configuration-reference.mdx
@@ -120,7 +120,7 @@ When this field is set to `true`, the gateway will log more verbose errors to as
 - **Type:** boolean
 - **Required:** no (default: `false`)
 
-If set to `true`, TensorZero will not collect or share [pseudonymous usage analytics](/deployment/tensorzero-gateway/#disabling-pseudonymous-usage-analytics).
+If set to `true`, TensorZero will not collect or share pseudonymous usage analytics.
 
 ### `export.otlp.traces.enabled`
 

--- a/docs/gateway/configure-models-and-providers.mdx
+++ b/docs/gateway/configure-models-and-providers.mdx
@@ -29,7 +29,7 @@ TensorZero supports proprietary models (e.g. OpenAI, Anthropic), inference servi
 
 <Tip>
 
-See [Integrations](/integrations/model-providers/) for a complete list of supported providers and the [Configuration Reference](/gateway/configuration-reference/#modelsmodel_nameprovidersprovider_name) for all available configuration parameters.
+See [Integrations](/integrations/model-providers/) for a complete list of supported providers and the [Configuration Reference](/gateway/configuration-reference/#models-model_name-providers-provider_name) for all available configuration parameters.
 
 </Tip>
 

--- a/docs/gateway/generate-embeddings.mdx
+++ b/docs/gateway/generate-embeddings.mdx
@@ -162,7 +162,7 @@ api_key_location = "none"
 
 <Tip>
 
-See the [Configuration Reference](/gateway/configuration-reference#%5Bembedding-models-model-name%5D) for details on configuring your embedding models.
+See the [Configuration Reference](/gateway/configuration-reference#embedding_models-model_name) for details on configuring your embedding models.
 
 </Tip>
 

--- a/docs/gateway/generate-structured-outputs.mdx
+++ b/docs/gateway/generate-structured-outputs.mdx
@@ -347,7 +347,7 @@ curl -X POST "http://localhost:3000/inference" \
 
 While we recommend specifying a fixed schema in the configuration whenever possible, you can provide the output schema dynamically at inference time if your use case demands it.
 
-See `output_schema` in the [Inference API Reference](/gateway/api-reference/inference#output-schema) or `response_format` in the [Inference (OpenAI) API Reference](/gateway/api-reference/inference-openai-compatible#json-function-with-dynamic-output-schema).
+See `output_schema` in the [Inference API Reference](/gateway/api-reference/inference#output_schema) or `response_format` in the [Inference (OpenAI) API Reference](/gateway/api-reference/inference-openai-compatible#json-function-with-dynamic-output-schema).
 
 You can also override `json_mode` at inference time if necessary.
 

--- a/docs/gateway/guides/inference-time-optimizations.mdx
+++ b/docs/gateway/guides/inference-time-optimizations.mdx
@@ -71,7 +71,7 @@ TensorZero will automatically make the necessary prompt modifications to evaluat
 
 </Tip>
 
-Read more about the `experimental_best_of_n` variant type in [Configuration Reference](/gateway/configuration-reference/#type-experimental_best_of_n).
+Read more about the `experimental_best_of_n` variant type in [Configuration Reference](/gateway/configuration-reference).
 
 <Tip>
 
@@ -152,7 +152,7 @@ TensorZero will automatically make the necessary prompt modifications to combine
 
 </Tip>
 
-Read more about the `experimental_mixture_of_n` variant type in [Configuration Reference](/gateway/configuration-reference/#type-experimental_mixture_of_n).
+Read more about the `experimental_mixture_of_n` variant type in [Configuration Reference](/gateway/configuration-reference).
 
 <Tip>
 

--- a/docs/gateway/guides/metrics-feedback.mdx
+++ b/docs/gateway/guides/metrics-feedback.mdx
@@ -25,7 +25,7 @@ TensorZero currently supports the following types of feedback:
 | Comment        | Natural-language feedback from users or developers |
 | Demonstration  | Edited drafts, labels, human-generated content     |
 
-You can send feedback data to the gateway by using the [`/feedback` endpoint](/gateway/api-reference/feedback/#post-feedback).
+You can send feedback data to the gateway by using the [`/feedback` endpoint](/gateway/api-reference/feedback).
 
 ## Metrics
 
@@ -177,4 +177,4 @@ Another example that uses feedback is [Optimizing Data Extraction (NER) with Ten
 This example collects metrics and demonstrations for an LLM-powered data extraction tool, which can be used for fine-tuning and other optimization recipes.
 These optimized variants achieve substantial improvements over the original model.
 
-See [Configuration Reference](/gateway/configuration-reference/#metrics) and [API Reference](/gateway/api-reference/feedback/#post-feedback) for more details.
+See [Configuration Reference](/gateway/configuration-reference/#metrics) and [API Reference](/gateway/api-reference/feedback) for more details.

--- a/tensorzero-core/src/client/mod.rs
+++ b/tensorzero-core/src/client/mod.rs
@@ -966,7 +966,7 @@ impl Client {
     }
 
     /// Assigns feedback for a TensorZero inference.
-    /// See https://www.tensorzero.com/docs/gateway/api-reference#post-feedback
+    /// See https://www.tensorzero.com/docs/gateway/api-reference
     pub async fn feedback(
         &self,
         params: FeedbackParams,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new required CI job that can now fail PRs/merge-queue runs on documentation link/anchor issues, potentially blocking merges until docs are fixed. No production/runtime behavior changes beyond a doc-comment URL update.
> 
> **Overview**
> **Adds docs link validation to CI.** The `general.yml` workflow now runs `mint broken-links --check-anchors` (via Mintlify CLI) and includes the job in `check-all-general-jobs-passed`, making broken docs links/anchors a merge blocker.
> 
> **Fixes broken docs references.** Updates multiple `.mdx` pages to correct internal link fragments (notably `configuration-reference` anchors, `output_schema`, and guide paths) and adjusts a Rust client doc comment to point at the updated API reference URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80d98c149765118fea85d47573233007b8b95f89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->