### PR TITLE
Add links to rate limiting guide

### DIFF
--- a/docs/operations/track-usage-and-cost.mdx
+++ b/docs/operations/track-usage-and-cost.mdx
@@ -14,6 +14,7 @@ If you need additional usage information from model providers (e.g. prompt cachi
 In that case, the gateway will additionally report provider-specific usage fields without preprocessing.
 
 You can browse usage data for individual inferences as well as aggregated usage statistics per model provider in the TensorZero UI.
+You can also [enforce custom rate limits](/operations/enforce-custom-rate-limits) based on token usage.
 
 ## Track cost
 
@@ -121,3 +122,4 @@ ChatCompletion(
 ```
 
 You can also browse cost data for individual inferences as well as aggregated cost statistics per model provider in the TensorZero UI.
+You can also [enforce custom rate limits](/operations/enforce-custom-rate-limits) based on cost.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds cross-links; no product or API behavior is modified.
> 
> **Overview**
> Adds references in `docs/operations/track-usage-and-cost.mdx` pointing readers to the `enforce-custom-rate-limits` guide for **token-usage** and **cost-based** rate limiting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b1e5c33b41cb8caebca23e0daec3b526a67acd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->