### PR TITLE
Deprecate postgres.enabled config

### DIFF
--- a/docs/gateway/configuration-reference.mdx
+++ b/docs/gateway/configuration-reference.mdx
@@ -48,6 +48,7 @@ Enable authentication for the TensorZero Gateway.
 When enabled, all gateway endpoints except `/status` and `/health` will require a valid API key.
 
 You must set up Postgres to use authentication features.
+The gateway will fail to start if authentication is enabled but `TENSORZERO_POSTGRES_URL` is not set.
 API keys can be created and managed through the TensorZero UI or CLI.
 
 ```toml title="tensorzero.toml"
@@ -4882,18 +4883,6 @@ You can connect to Postgres by setting the `TENSORZERO_POSTGRES_URL` environment
 
 Defines the maximum number of connections in the Postgres connection pool.
 
-### `enabled`
-
-- **Type:** boolean
-- **Required:** no (default: `null`)
-
-Enable Postgres connectivity.
-If `true`, the gateway will throw an error on startup if it fails to connect to Postgres (requires `TENSORZERO_POSTGRES_URL` environment variable).
-If `false`, the gateway will not use Postgres even if the `TENSORZERO_POSTGRES_URL` environment variable is set.
-If omitted, the gateway will connect to Postgres if the `TENSORZERO_POSTGRES_URL` environment variable is set, otherwise it will disable Postgres with a warning.
-
-If you have features that require Postgres (e.g. adaptive experimentation, authentication) configured but set `postgres.enabled = false` or don't provide the `TENSORZERO_POSTGRES_URL` environment variable, the gateway will fail to start with a configuration error.
-
 ## `[rate_limiting]`
 
 The `[rate_limiting]` section allows you to configure granular rate limits for your TensorZero Gateway.
@@ -4921,7 +4910,8 @@ default_cost = 0.50
 - **Required:** no (default: `true`)
 
 Enable or disable rate limiting enforcement.
-When set to `false`, rate limiting rules will not be enforced even if they are defined.
+When `true` and there are rate limiting rules, we validate that a valid rate limiting backend (Postgres or Valkey) is available, and fail gateway startup otherwise.
+When `false`, rate limiting rules will not be enforced even if they are defined.
 
 ```toml
 [rate_limiting]

--- a/tensorzero-core/src/config/mod.rs
+++ b/tensorzero-core/src/config/mod.rs
@@ -2453,6 +2453,13 @@ impl PathWithContents {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct PostgresConfig {
+    /// DEPRECATED (2026.3+): Postgres connectivity is now determined by the
+    /// `TENSORZERO_POSTGRES_URL` environment variable. This field is accepted
+    /// for backward compatibility but will be removed in a future release.
+    #[deprecated(
+        note = "Postgres connectivity is now determined by the `TENSORZERO_POSTGRES_URL` environment variable. Remove `postgres.enabled` from your config."
+    )]
+    #[serde(default, skip_serializing)]
     pub enabled: Option<bool>,
     #[serde(default = "default_connection_pool_size")]
     pub connection_pool_size: u32,
@@ -2480,6 +2487,7 @@ fn default_connection_pool_size() -> u32 {
 
 impl Default for PostgresConfig {
     fn default() -> Self {
+        #[expect(deprecated)]
         Self {
             enabled: None,
             connection_pool_size: 20,

--- a/tensorzero-core/src/config/rate_limiting.rs
+++ b/tensorzero-core/src/config/rate_limiting.rs
@@ -50,19 +50,19 @@ pub struct TomlUninitializedRateLimitingConfig {
     pub(crate) default_cost: Option<f64>,
 }
 
+fn default_enabled() -> bool {
+    true
+}
+
 impl Default for TomlUninitializedRateLimitingConfig {
     fn default() -> Self {
         Self {
             rules: Vec::new(),
-            enabled: true,
+            enabled: default_enabled(),
             backend: RateLimitingBackend::default(),
             default_cost: None,
         }
     }
-}
-
-fn default_enabled() -> bool {
-    true
 }
 
 impl TryFrom<TomlUninitializedRateLimitingConfig> for UninitializedRateLimitingConfig {
@@ -841,7 +841,7 @@ mod tests {
     }
 
     #[test]
-    fn test_default_enabled_true() {
+    fn test_default_enabled_true_with_rules() {
         let toml_str = r"
             [[rules]]
             model_inferences_per_second = 10
@@ -849,6 +849,7 @@ mod tests {
         ";
 
         let toml_config: TomlUninitializedRateLimitingConfig = toml::from_str(toml_str).unwrap();
+        assert!(toml_config.enabled, "Default enabled should be true");
         let uninitialized_config: UninitializedRateLimitingConfig = toml_config.try_into().unwrap();
         let config: RateLimitingConfig = uninitialized_config.try_into().unwrap();
         assert!(config.enabled());
@@ -880,7 +881,7 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_rules_configuration() {
+    fn test_explicit_enabled_true() {
         let toml_str = r"
             enabled = true
         ";
@@ -896,11 +897,11 @@ mod tests {
     fn test_default_enabled_when_section_missing() {
         // When the entire [rate_limiting] section is missing from the TOML config,
         // serde uses Default::default() for the struct. This test ensures that
-        // rate limiting is enabled by default in that case.
+        // the default enabled value is true.
         let default_config = TomlUninitializedRateLimitingConfig::default();
         assert!(
             default_config.enabled,
-            "Rate limiting should be enabled by default when section is missing"
+            "Rate limiting enabled should default to true when section is missing"
         );
 
         // Also test that an empty string deserializes with enabled = true
@@ -908,7 +909,7 @@ mod tests {
         let toml_config: TomlUninitializedRateLimitingConfig = toml::from_str(toml_str).unwrap();
         assert!(
             toml_config.enabled,
-            "Rate limiting should be enabled by default when section is empty"
+            "Rate limiting enabled should default to true when section is empty"
         );
     }
 
@@ -1448,7 +1449,7 @@ mod tests {
         assert_eq!(config.rules[0].limits.len(), 1);
         assert_eq!(config.rules[0].limits[0].capacity, 100);
         assert_eq!(config.rules[0].limits[0].refill_rate, 50);
-        assert!(config.enabled);
+        assert!(config.enabled, "Expected enabled to be true");
     }
 
     #[test]

--- a/tensorzero-core/src/config/stored/mod.rs
+++ b/tensorzero-core/src/config/stored/mod.rs
@@ -414,4 +414,43 @@ mod tests {
         assert!(uninit.gateway.observability.async_writes);
         assert!(uninit.gateway.debug);
     }
+
+    /// Old snapshots with deprecated `postgres.enabled` should still parse correctly.
+    #[test]
+    #[expect(deprecated)]
+    fn test_stored_config_with_deprecated_postgres_enabled() {
+        let toml_str = r"
+            [postgres]
+            enabled = true
+            connection_pool_size = 10
+        ";
+
+        let stored: StoredConfig =
+            toml::from_str(toml_str).expect("should parse deprecated postgres.enabled");
+        assert_eq!(stored.postgres.enabled, Some(true));
+        assert_eq!(stored.postgres.connection_pool_size, 10);
+
+        let uninit: UninitializedConfig = stored.try_into().expect("should convert to uninit");
+        assert_eq!(
+            uninit.postgres.enabled,
+            Some(true),
+            "deprecated field should be preserved during conversion"
+        );
+    }
+
+    /// Serialized config should NOT include deprecated `postgres.enabled`.
+    #[test]
+    #[expect(deprecated)]
+    fn test_serialized_config_omits_deprecated_postgres_enabled() {
+        let config = PostgresConfig {
+            enabled: Some(true),
+            connection_pool_size: 10,
+            ..Default::default()
+        };
+        let serialized = toml::to_string(&config).expect("should serialize");
+        assert!(
+            !serialized.contains("enabled"),
+            "serialized PostgresConfig should not include deprecated enabled field: {serialized}"
+        );
+    }
 }

--- a/tensorzero-core/src/rate_limiting/mod.rs
+++ b/tensorzero-core/src/rate_limiting/mod.rs
@@ -82,6 +82,8 @@ pub enum RateLimitingBackend {
 #[derive(Debug, Clone)]
 pub struct RateLimitingConfig {
     pub(crate) rules: Vec<RateLimitingConfigRule>,
+    /// Whether rate limiting is enabled. Defaults to `true`.
+    /// When `true` and rules are defined, a rate limiting backend must be available.
     pub(crate) enabled: bool,
     pub(crate) backend: RateLimitingBackend,
     /// Default cost in nano-dollars used for cost estimation when actual cost is unknown.
@@ -113,6 +115,14 @@ impl TryFrom<UninitializedRateLimitingConfig> for RateLimitingConfig {
                 }));
             }
         }
+
+        if !config.enabled && !config.rules.is_empty() {
+            tracing::warn!(
+                "`rate_limiting.enabled` is `false` but rate limiting rules are defined. \
+                 Rules will not be enforced."
+            );
+        }
+
         Ok(Self {
             rules: config.rules,
             enabled: config.enabled,
@@ -152,7 +162,7 @@ impl Default for UninitializedRateLimitingConfig {
     fn default() -> Self {
         Self {
             rules: Vec::new(),
-            enabled: true,
+            enabled: default_enabled(),
             backend: RateLimitingBackend::default(),
             default_nano_cost: default_nano_cost(),
         }
@@ -163,13 +173,12 @@ impl Default for RateLimitingConfig {
     fn default() -> Self {
         Self {
             rules: Vec::new(),
-            enabled: true,
+            enabled: default_enabled(),
             backend: RateLimitingBackend::default(),
             default_nano_cost: default_nano_cost(),
         }
     }
 }
-
 // Utility struct to pass in at "check time"
 // This should contain the information about the current request
 // needed to determine if a rate limit is exceeded.
@@ -1550,12 +1559,12 @@ mod tests {
 
     #[test]
     fn test_rate_limiting_config_states() {
-        // Test default configuration
+        // Test default configuration (enabled = true, no rules)
         let default_config = RateLimitingConfig::default();
-        assert!(default_config.enabled());
+        assert!(default_config.enabled(), "Default enabled should be true");
         assert!(default_config.rules().is_empty());
 
-        // Test enabled/disabled states
+        // Test explicitly enabled (no rules → nothing to enforce)
         let config_enabled = RateLimitingConfig {
             rules: vec![],
             enabled: true,
@@ -1563,6 +1572,7 @@ mod tests {
         };
         assert!(config_enabled.enabled());
 
+        // Test explicitly disabled
         let config_disabled = RateLimitingConfig {
             rules: vec![],
             enabled: false,
@@ -1578,11 +1588,11 @@ mod tests {
             api_key_public_id: None,
         };
 
-        // Disabled config should return empty limits
+        // Explicitly disabled config should return empty limits
         let active_limits_disabled = config_disabled.get_active_limits(&scope_info);
         assert!(active_limits_disabled.is_empty());
 
-        // Enabled config with no rules should return empty limits
+        // Explicitly enabled config with no rules should return empty limits
         let active_limits_no_rules = config_enabled.get_active_limits(&scope_info);
         assert!(active_limits_no_rules.is_empty());
     }

--- a/tensorzero-core/src/rate_limiting/rate_limiting_manager.rs
+++ b/tensorzero-core/src/rate_limiting/rate_limiting_manager.rs
@@ -107,15 +107,15 @@ impl RateLimitingManager {
             ));
         }
 
-        // No backend available - this is only an error if rate limiting is enabled and rules are configured
-        let rate_limiting_enabled = config.enabled() && !config.rules().is_empty();
-        if !rate_limiting_enabled {
-            return Ok(Self::new(config, Arc::new(DisabledRateLimitQueries)));
+        // No backend available
+        if config.enabled() && !config.rules().is_empty() {
+            return Err(Error::new(ErrorDetails::Config {
+                message: "Rate limiting is enabled with rules configured, but no backend is available. \
+                          Please set either `TENSORZERO_VALKEY_URL` or `TENSORZERO_POSTGRES_URL` environment variable, \
+                          or set `rate_limiting.enabled = false`.".to_string(),
+            }));
         }
-
-        Err(Error::new(ErrorDetails::Config {
-            message: "No rate limiting backend is available and rate limiting rules are configured. Please set either `TENSORZERO_VALKEY_URL` or `TENSORZERO_POSTGRES_URL` environment variable, or disable rate limiting.".to_string(),
-        }))
+        Ok(Self::new(config, Arc::new(DisabledRateLimitQueries)))
     }
 
     /// Create a new, dummy RateLimitingManager for unit tests.

--- a/tensorzero-core/src/utils/gateway.rs
+++ b/tensorzero-core/src/utils/gateway.rs
@@ -441,6 +441,19 @@ impl GatewayHandle {
         )
         .await?;
 
+        // Validate auth config: auth requires Postgres
+        if config.gateway.auth.enabled
+            && matches!(postgres_connection_info, PostgresConnectionInfo::Disabled)
+        {
+            return Err(ErrorDetails::AppState {
+                message:
+                    "Authentication is enabled (`gateway.auth.enabled = true`) but Postgres is not available. \
+                     Authentication requires Postgres. Set `TENSORZERO_POSTGRES_URL` or disable auth."
+                        .to_string(),
+            }
+            .into());
+        }
+
         let cache_manager = CacheManager::new_from_connections(
             &valkey_cache_connection_info,
             &clickhouse_connection_info,
@@ -659,25 +672,33 @@ async fn create_postgres_connection(
 
 // TODO(#5764): We should test that on startup we issue the correct SQL for write_retention_config,
 // but this is currently structured that's difficult to swap in a Mock.
+#[expect(deprecated)]
 pub async fn setup_postgres(
     config: &Config,
     postgres_url: Option<&str>,
 ) -> Result<PostgresConnectionInfo, Error> {
-    // TODO(#5691): we should stop checking an explicit postgres.enabled config.
+    if config.postgres.enabled.is_some() {
+        crate::utils::deprecation_warning(
+            "`postgres.enabled` is deprecated (2026.3+) and will be removed in a future release. \
+             Postgres connectivity is now determined by the `TENSORZERO_POSTGRES_URL` environment variable. \
+             Remove `postgres.enabled` from your config.",
+        );
+    }
+
     let postgres_connection_info = match (config.postgres.enabled, postgres_url) {
-        // Postgres disabled by config
+        // Postgres disabled by config (deprecated)
         (Some(false), _) => {
             tracing::info!("Disabling Postgres: `postgres.enabled` is set to false in config.");
             PostgresConnectionInfo::Disabled
         }
-        // Postgres enabled but no URL
+        // Postgres enabled but no URL (deprecated)
         (Some(true), None) => {
             return Err(ErrorDetails::AppState {
                 message: "Missing environment variable `TENSORZERO_POSTGRES_URL`.".to_string(),
             }
             .into());
         }
-        // Postgres enabled and URL provided
+        // Postgres enabled and URL provided (deprecated)
         (Some(true), Some(postgres_url)) => {
             create_postgres_connection(
                 postgres_url,
@@ -688,9 +709,7 @@ pub async fn setup_postgres(
         }
         // Postgres default and no URL
         (None, None) => {
-            tracing::debug!(
-                "Disabling Postgres: `postgres.enabled` is not explicitly specified in config and `TENSORZERO_POSTGRES_URL` is not set."
-            );
+            tracing::debug!("Disabling Postgres: `TENSORZERO_POSTGRES_URL` is not set.");
             PostgresConnectionInfo::Disabled
         }
         // Postgres default and URL provided
@@ -1188,6 +1207,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[expect(deprecated)]
     async fn test_setup_postgres_disabled() {
         let logs_contain = crate::utils::testing::capture_logs();
 
@@ -1229,6 +1249,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[expect(deprecated)]
     async fn test_setup_postgres_default_no_url() {
         // Default postgres config (enabled: None) and no URL
         let config = Box::leak(Box::new(Config {
@@ -1247,6 +1268,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[expect(deprecated)]
     async fn test_setup_postgres_enabled_no_url() {
         // Postgres enabled but URL is missing
         let config = Box::leak(Box::new(Config {
@@ -1265,6 +1287,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[expect(deprecated)]
     async fn test_setup_postgres_bad_url() {
         // Postgres enabled with bad URL
         let config = Box::leak(Box::new(Config {
@@ -1408,6 +1431,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[expect(deprecated)]
     async fn test_no_rate_limiting_does_not_require_postgres_or_valkey() {
         // Rate limiting enabled=false should not fail validation (no rules configured)
         let config_no_rules = Arc::new(Config {
@@ -1525,5 +1549,132 @@ mod tests {
         )
         .await
         .expect("Gateway should start when cache.enabled is default (null)");
+    }
+
+    #[tokio::test]
+    #[expect(deprecated)]
+    async fn test_setup_postgres_deprecated_enabled_true_emits_warning() {
+        let logs_contain = crate::utils::testing::capture_logs();
+
+        let config = Box::leak(Box::new(Config {
+            postgres: PostgresConfig {
+                enabled: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        }));
+
+        // Will fail because the URL is bad, but the deprecation warning should still fire
+        let _ = setup_postgres(config, Some("bad_url")).await;
+        assert!(
+            logs_contain("`postgres.enabled` is deprecated"),
+            "should emit deprecation warning when postgres.enabled is explicitly set to true"
+        );
+    }
+
+    #[tokio::test]
+    #[expect(deprecated)]
+    async fn test_setup_postgres_deprecated_enabled_false_emits_warning() {
+        let logs_contain = crate::utils::testing::capture_logs();
+
+        let config = Box::leak(Box::new(Config {
+            postgres: PostgresConfig {
+                enabled: Some(false),
+                ..Default::default()
+            },
+            ..Default::default()
+        }));
+
+        let postgres_connection_info = setup_postgres(config, None).await.unwrap();
+        assert!(
+            matches!(postgres_connection_info, PostgresConnectionInfo::Disabled),
+            "postgres should be disabled when enabled=false"
+        );
+        assert!(
+            logs_contain("`postgres.enabled` is deprecated"),
+            "should emit deprecation warning when postgres.enabled is explicitly set to false"
+        );
+    }
+
+    #[tokio::test]
+    #[expect(deprecated)]
+    async fn test_setup_postgres_default_no_deprecation_warning() {
+        let logs_contain = crate::utils::testing::capture_logs();
+
+        let config = Box::leak(Box::new(Config {
+            postgres: PostgresConfig {
+                enabled: None,
+                ..Default::default()
+            },
+            ..Default::default()
+        }));
+
+        let _ = setup_postgres(config, None).await.unwrap();
+        assert!(
+            !logs_contain("`postgres.enabled` is deprecated"),
+            "should not emit deprecation warning when postgres.enabled is not set"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_auth_enabled_fails_without_postgres() {
+        use crate::config::gateway::AuthConfig;
+
+        let config = Arc::new(Config {
+            gateway: GatewayConfig {
+                auth: AuthConfig {
+                    enabled: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let http_client = TensorzeroHttpClient::new_testing().unwrap();
+        let result = GatewayHandle::new_with_database_and_http_client(
+            config,
+            ClickHouseConnectionInfo::new_disabled(),
+            PostgresConnectionInfo::Disabled,
+            ValkeyConnectionInfo::Disabled,
+            ValkeyConnectionInfo::Disabled,
+            http_client,
+            None,
+            HashSet::new(),
+            HashSet::new(),
+        )
+        .await;
+        let err = result
+            .err()
+            .expect("Gateway should fail when auth is enabled but Postgres is unavailable");
+        assert!(
+            err.to_string().contains("Authentication is enabled")
+                && err.to_string().contains("Postgres"),
+            "error should mention auth and Postgres: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_auth_disabled_starts_without_postgres() {
+        let config = Arc::new(Config {
+            gateway: GatewayConfig {
+                auth: Default::default(), // auth.enabled = false
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let http_client = TensorzeroHttpClient::new_testing().unwrap();
+        let _gateway = GatewayHandle::new_with_database_and_http_client(
+            config,
+            ClickHouseConnectionInfo::new_disabled(),
+            PostgresConnectionInfo::Disabled,
+            ValkeyConnectionInfo::Disabled,
+            ValkeyConnectionInfo::Disabled,
+            http_client,
+            None,
+            HashSet::new(),
+            HashSet::new(),
+        )
+        .await
+        .expect("Gateway should start when auth is disabled even without Postgres");
     }
 }


### PR DESCRIPTION
This removes the postgres.enabled config (and gates postgres entirely on `TENSORZERO_POSTGRES_URL`). See https://www.notion.so/tensorzerodotcom/Postgres-backed-TensorZero-config-changes-3107520bbad3804d802bc8d265bc361f?source=copy_link.

Also fails gateway startup if auth or rate limiting is enabled and the postgres backend is not available.

Step towards #5691.