### PR TITLE
Expand visualization events by default in autopilot

### DIFF
--- a/ui/app/components/autopilot/EventStream.tsx
+++ b/ui/app/components/autopilot/EventStream.tsx
@@ -621,7 +621,9 @@ function EventItem({
     (event.payload.type === "tool_result" &&
       (event.payload.outcome.type === "success" ||
         event.payload.outcome.type === "failure"));
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(
+    event.payload.type === "visualization",
+  );
   const shouldShowDetails = !isExpandable || isExpanded;
   const label = <span className="text-sm font-medium">{title}</span>;
 


### PR DESCRIPTION
## Summary

- Visualization events (e.g., TopKEvaluation charts) in the autopilot event stream now start **expanded by default**, so users see rich content immediately without needing to click.

Closes #6308

## Test plan

- [ ] Verify visualization events render expanded on page load
- [ ] Verify other expandable events (tool_call, error, etc.) still start collapsed
- [ ] Verify clicking the collapse button on a visualization event works correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to the initial expanded/collapsed state of `visualization` events in the autopilot event stream.
> 
> **Overview**
> Visualization events in the autopilot `EventStream` now render **expanded by default** by initializing `isExpanded` to `true` when `event.payload.type === "visualization"`. All other expandable event types keep the existing default collapsed behavior and can still be toggled via the expand/collapse control.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcdbf8278e708f6aa9b355083b2c881113ea1a2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->