### PR TITLE
Remove lifetime parameters from ToolContext

### DIFF
--- a/internal/autopilot-tools/src/tools/prod/auto_reject_tool_call.rs
+++ b/internal/autopilot-tools/src/tools/prod/auto_reject_tool_call.rs
@@ -85,7 +85,7 @@ impl TaskTool for AutoRejectToolCallTool {
         &self,
         _llm_params: <Self as ToolMetadata>::LlmParams,
         side_info: <Self as ToolMetadata>::SideInfo,
-        ctx: &mut ToolContext<'_>,
+        ctx: &mut ToolContext,
     ) -> ToolResult<<Self as ToolMetadata>::Output> {
         // Send ToolCallAuthorization::NotAvailable to autopilot API
         ctx.client()

--- a/internal/autopilot-tools/src/tools/prod/launch_optimization_workflow.rs
+++ b/internal/autopilot-tools/src/tools/prod/launch_optimization_workflow.rs
@@ -437,7 +437,7 @@ impl TaskTool for LaunchOptimizationWorkflowTool {
         &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         side_info: <Self as ToolMetadata>::SideInfo,
-        ctx: &mut ToolContext<'_>,
+        ctx: &mut ToolContext,
     ) -> ToolResult<<Self as ToolMetadata>::Output> {
         // Step 1: Launch the optimization workflow
         let job_handle: OptimizationJobHandle = ctx

--- a/internal/autopilot-tools/src/tools/prod/upload_dataset.rs
+++ b/internal/autopilot-tools/src/tools/prod/upload_dataset.rs
@@ -223,7 +223,7 @@ impl TaskTool for UploadDatasetTool {
         &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         side_info: <Self as ToolMetadata>::SideInfo,
-        ctx: &mut ToolContext<'_>,
+        ctx: &mut ToolContext,
     ) -> ToolResult<<Self as ToolMetadata>::Output> {
         // Step 1: Get S3 credentials
         let credentials: S3UploadResponse = ctx

--- a/internal/autopilot-tools/src/tools/test/echo.rs
+++ b/internal/autopilot-tools/src/tools/test/echo.rs
@@ -50,7 +50,7 @@ impl TaskTool for EchoTool {
         &self,
         llm_params: Self::LlmParams,
         _side_info: Self::SideInfo,
-        ctx: &mut ToolContext<'_>,
+        ctx: &mut ToolContext,
     ) -> ToolResult<Self::Output> {
         Ok(EchoOutput {
             echoed: llm_params.message,

--- a/internal/autopilot-tools/src/tools/test/failing.rs
+++ b/internal/autopilot-tools/src/tools/test/failing.rs
@@ -46,7 +46,7 @@ impl TaskTool for FailingTool {
         &self,
         llm_params: Self::LlmParams,
         _side_info: Self::SideInfo,
-        _ctx: &mut ToolContext<'_>,
+        _ctx: &mut ToolContext,
     ) -> ToolResult<Self::Output> {
         Err(AutopilotToolError::test_error(llm_params.error_message).into())
     }

--- a/internal/autopilot-tools/src/tools/test/flaky.rs
+++ b/internal/autopilot-tools/src/tools/test/flaky.rs
@@ -64,7 +64,7 @@ impl TaskTool for FlakyTool {
         &self,
         llm_params: Self::LlmParams,
         _side_info: Self::SideInfo,
-        _ctx: &mut ToolContext<'_>,
+        _ctx: &mut ToolContext,
     ) -> ToolResult<Self::Output> {
         if llm_params.fail_on_attempt > 0
             && llm_params.attempt_number % llm_params.fail_on_attempt == 0

--- a/internal/autopilot-tools/src/tools/test/panic.rs
+++ b/internal/autopilot-tools/src/tools/test/panic.rs
@@ -46,7 +46,7 @@ impl TaskTool for PanicTool {
         &self,
         llm_params: Self::LlmParams,
         _side_info: Self::SideInfo,
-        _ctx: &mut ToolContext<'_>,
+        _ctx: &mut ToolContext,
     ) -> ToolResult<Self::Output> {
         std::panic::panic_any(llm_params.panic_message);
     }

--- a/internal/autopilot-tools/src/tools/test/slow.rs
+++ b/internal/autopilot-tools/src/tools/test/slow.rs
@@ -62,7 +62,7 @@ impl TaskTool for SlowTool {
         &self,
         llm_params: Self::LlmParams,
         _side_info: Self::SideInfo,
-        _ctx: &mut ToolContext<'_>,
+        _ctx: &mut ToolContext,
     ) -> ToolResult<Self::Output> {
         let start = Instant::now();
         tokio::time::sleep(tokio::time::Duration::from_millis(llm_params.delay_ms)).await;

--- a/internal/autopilot-worker/src/wrapper.rs
+++ b/internal/autopilot-worker/src/wrapper.rs
@@ -90,7 +90,7 @@ where
         &self,
         llm_params: Self::LlmParams,
         side_info: Self::SideInfo,
-        ctx: &mut ToolContext<'_>,
+        ctx: &mut ToolContext,
     ) -> DurableToolResult<Self::Output> {
         let session_id = side_info.session_id;
         let tool_call_event_id = side_info.tool_call_event_id;
@@ -226,7 +226,7 @@ impl<T: SimpleTool<SideInfo = AutopilotSideInfo>> TaskTool for ClientSimpleToolW
         &self,
         llm_params: Self::LlmParams,
         side_info: Self::SideInfo,
-        ctx: &mut ToolContext<'_>,
+        ctx: &mut ToolContext,
     ) -> DurableToolResult<Self::Output> {
         let tool_name = self.inner.name().to_string();
         let tool_call_event_id = side_info.tool_call_event_id;
@@ -563,7 +563,7 @@ mod tests {
             &self,
             llm_params: Self::LlmParams,
             _side_info: Self::SideInfo,
-            _ctx: &mut ToolContext<'_>,
+            _ctx: &mut ToolContext,
         ) -> DurableToolResult<Self::Output> {
             Ok(TestTaskToolOutput {
                 result: format!("Processed: {}", llm_params.message),

--- a/internal/durable-tools/README.md
+++ b/internal/durable-tools/README.md
@@ -43,7 +43,7 @@ pub trait TaskTool: ToolMetadata {
     async fn execute(
         llm_params: <Self as ToolMetadata>::LlmParams,
         side_info: <Self as ToolMetadata>::SideInfo,
-        ctx: &mut ToolContext<'_>,
+        ctx: &mut ToolContext,
     ) -> ToolResult<<Self as ToolMetadata>::Output>;
 }
 ```
@@ -214,7 +214,7 @@ impl TaskTool for ResearchTool {
     async fn execute(
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: <Self as ToolMetadata>::SideInfo,
-        ctx: &mut ToolContext<'_>,
+        ctx: &mut ToolContext,
     ) -> ToolResult<<Self as ToolMetadata>::Output> {
         // Call another tool
         let _search = ctx

--- a/internal/durable-tools/src/context.rs
+++ b/internal/durable-tools/src/context.rs
@@ -82,19 +82,19 @@ impl<S> ToolAppState<S> {
 ///
 /// Wraps durable's `TaskContext` and provides access to the application context
 /// along with helper methods for calling other tools and checkpointing operations.
-pub struct ToolContext<'a, S: Clone + Send + Sync + 'static = ()> {
-    task_ctx: &'a mut TaskContext<ToolAppState<S>>,
-    app_state: &'a ToolAppState<S>,
+pub struct ToolContext<S: Clone + Send + Sync + 'static = ()> {
+    task_ctx: TaskContext<ToolAppState<S>>,
+    app_state: ToolAppState<S>,
     episode_id: Uuid,
     /// Counter for generating unique tool call identifiers.
     tool_call_counter: u32,
 }
 
-impl<'a, S: Clone + Send + Sync + 'static> ToolContext<'a, S> {
+impl<S: Clone + Send + Sync + 'static> ToolContext<S> {
     /// Create a new tool context.
     pub fn new(
-        task_ctx: &'a mut TaskContext<ToolAppState<S>>,
-        app_ctx: &'a ToolAppState<S>,
+        task_ctx: TaskContext<ToolAppState<S>>,
+        app_ctx: ToolAppState<S>,
         episode_id: Uuid,
     ) -> Self {
         Self {
@@ -172,7 +172,7 @@ impl<'a, S: Clone + Send + Sync + 'static> ToolContext<'a, S> {
     ///
     /// Use this for advanced operations not exposed by `ToolContext`.
     pub fn task_ctx(&mut self) -> &mut TaskContext<ToolAppState<S>> {
-        self.task_ctx
+        &mut self.task_ctx
     }
 
     /// Execute a checkpointed step.

--- a/internal/durable-tools/src/lib.rs
+++ b/internal/durable-tools/src/lib.rs
@@ -113,7 +113,7 @@
 //!     async fn execute(
 //!         llm_params: <Self as ToolMetadata>::LlmParams,
 //!         _side_info: <Self as ToolMetadata>::SideInfo,
-//!         ctx: &mut ToolContext<'_>,
+//!         ctx: &mut ToolContext,
 //!     ) -> ToolResult<<Self as ToolMetadata>::Output> {
 //!         // Call the search tool
 //!         let _search = ctx

--- a/internal/durable-tools/src/task_tool.rs
+++ b/internal/durable-tools/src/task_tool.rs
@@ -67,7 +67,7 @@ use crate::tool_metadata::ToolMetadata;
 ///         &self,
 ///         llm_params: <Self as ToolMetadata>::LlmParams,
 ///         _side_info: <Self as ToolMetadata>::SideInfo,
-///         ctx: &mut ToolContext<'_>,
+///         ctx: &mut ToolContext,
 ///     ) -> ToolResult<<Self as ToolMetadata>::Output> {
 ///         // Call other tools
 ///         let search = ctx.call_tool("search", serde_json::json!({"query": llm_params.topic}), serde_json::json!(null)).await?;
@@ -129,7 +129,7 @@ use crate::tool_metadata::ToolMetadata;
 ///         &self,
 ///         llm_params: <Self as ToolMetadata>::LlmParams,
 ///         side_info: <Self as ToolMetadata>::SideInfo,
-///         ctx: &mut ToolContext<'_>,
+///         ctx: &mut ToolContext,
 ///     ) -> ToolResult<<Self as ToolMetadata>::Output> {
 ///         // Use llm_params.query (from LLM)
 ///         // Use side_info.api_token (hidden from LLM)
@@ -155,7 +155,7 @@ pub trait TaskTool: ToolMetadata {
         &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         side_info: <Self as ToolMetadata>::SideInfo,
-        ctx: &mut ToolContext<'_, Self::ExtraState>,
+        ctx: &mut ToolContext<Self::ExtraState>,
     ) -> ToolExecResult<<Self as ToolMetadata>::Output>;
 }
 
@@ -186,10 +186,10 @@ impl<T: TaskTool> Task<ToolAppState<T::ExtraState>> for TaskToolAdapter<T> {
     async fn run(
         &self,
         wrapped: Self::Params,
-        mut task_ctx: TaskContext<ToolAppState<T::ExtraState>>,
+        task_ctx: TaskContext<ToolAppState<T::ExtraState>>,
         app_ctx: ToolAppState<T::ExtraState>,
     ) -> TaskResult<Self::Output> {
-        let mut tool_ctx = ToolContext::new(&mut task_ctx, &app_ctx, wrapped.episode_id);
+        let mut tool_ctx = ToolContext::new(task_ctx, app_ctx, wrapped.episode_id);
         self.0
             .execute(wrapped.llm_params, wrapped.side_info, &mut tool_ctx)
             .await

--- a/internal/durable-tools/src/tests.rs
+++ b/internal/durable-tools/src/tests.rs
@@ -98,7 +98,7 @@ impl TaskTool for EchoTaskTool {
         &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: Self::SideInfo,
-        _ctx: &mut ToolContext<'_>,
+        _ctx: &mut ToolContext,
     ) -> ToolResult<Self::Output> {
         Ok(EchoOutput {
             echoed: llm_params.message,
@@ -132,7 +132,7 @@ impl TaskTool for DefaultTimeoutTaskTool {
         &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: Self::SideInfo,
-        _ctx: &mut ToolContext<'_>,
+        _ctx: &mut ToolContext,
     ) -> ToolResult<Self::Output> {
         Ok(EchoOutput {
             echoed: llm_params.message,

--- a/internal/durable-tools/tests/integration.rs
+++ b/internal/durable-tools/tests/integration.rs
@@ -157,7 +157,7 @@ impl TaskTool for EchoTaskTool {
         &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: Self::SideInfo,
-        _ctx: &mut ToolContext<'_>,
+        _ctx: &mut ToolContext,
     ) -> ToolResult<Self::Output> {
         Ok(EchoOutput {
             echoed: llm_params.message,
@@ -281,7 +281,7 @@ impl TaskTool for InferenceTaskTool {
         &self,
         llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: Self::SideInfo,
-        ctx: &mut ToolContext<'_>,
+        ctx: &mut ToolContext,
     ) -> ToolResult<Self::Output> {
         let input = Input {
             system: None,
@@ -545,7 +545,7 @@ impl TaskTool for MultiCallTaskTool {
         &self,
         _llm_params: <Self as ToolMetadata>::LlmParams,
         _side_info: Self::SideInfo,
-        ctx: &mut ToolContext<'_>,
+        ctx: &mut ToolContext,
     ) -> ToolResult<Self::Output> {
         // Call the same SimpleTool three times with different params
         ctx.call_tool(


### PR DESCRIPTION
This will make it easier to use in RLM code in autopilot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core `ToolContext`/`TaskTool` execution API used across durable tools and autopilot wrappers; while largely mechanical, ownership/lifetime changes could surface subtle behavior or borrowing issues at runtime.
> 
> **Overview**
> Refactors `ToolContext` to **own** its `TaskContext` and `ToolAppState` instead of borrowing them, removing the lifetime parameter from the type.
> 
> Updates the `TaskTool::execute` signature and all call sites (autopilot tools, autopilot worker wrappers, docs, and tests) to use `&mut ToolContext` / `&mut ToolContext<ExtraState>`, and adjusts `TaskToolAdapter` to construct the new owned context from moved `task_ctx`/`app_ctx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 150828b7ae94ce7543bed783c39aa5121ff46e0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->