### PR TITLE
pull config appliction tests into a separate suite

### DIFF
--- a/ui/e2e_tests/autopilot/config-apply.spec.ts
+++ b/ui/e2e_tests/autopilot/config-apply.spec.ts
@@ -103,17 +103,15 @@ test.describe("Config applying", () => {
 
     const variantName = deterministicTestAndAttempt(testInfo, "variant");
 
-    // Build the variant JSON with the correct ResolvedTomlPathData format
-    // for system_template so the set_variant tool accepts it.
-    // The path is arbitrary since the config writing crate canonicalizes paths.
+    // Build the variant JSON with the simplified format expected by set_variant.
+    // Templates are plain strings (name → content), not ResolvedTomlPathData objects.
     const templateContent =
       "Extract all named entities (people, organizations, locations) from the given text and return them as JSON.";
     const variantJson = JSON.stringify({
       type: "chat_completion",
       model: "gpt-4o-mini-2024-07-18",
-      system_template: {
-        __tensorzero_remapped_path: "dummy",
-        __data: templateContent,
+      templates: {
+        system: templateContent,
       },
       temperature: 0,
       json_mode: "strict",
@@ -193,15 +191,20 @@ test.describe("Config applying", () => {
 
     // 9. Verify template file was created
     // The config writer canonicalizes paths, so read it from the TOML.
-    const writtenSystemTemplate = variant.system_template as string | undefined;
+    // With simplified types, templates are written under `templates.system.path`.
+    const templates = variant.templates as
+      | Record<string, Record<string, string>>
+      | undefined;
+    expect(templates, "Variant should have a templates section").toBeDefined();
+    const systemTemplatePath = templates?.system?.path;
     expect(
-      writtenSystemTemplate,
-      "Variant should have a system_template path",
+      systemTemplatePath,
+      "Variant should have a templates.system.path",
     ).toBeDefined();
 
     const fullTemplatePath = path.join(
       AUTOPILOT_CONFIG_DIR,
-      writtenSystemTemplate!,
+      systemTemplatePath!,
     );
     expect(
       fs.existsSync(fullTemplatePath),
@@ -304,10 +307,7 @@ test.describe("Config applying", () => {
           type: "chat_completion",
           model: "gpt-4o-mini-2024-07-18",
           json_mode: "off",
-          system_instructions: {
-            __tensorzero_remapped_path: "dummy",
-            __data: instructionsContent,
-          },
+          system_instructions: instructionsContent,
         },
       },
     });
@@ -431,9 +431,8 @@ test.describe("Config applying", () => {
     const variantJson = JSON.stringify({
       type: "chat_completion",
       model: "gpt-4o-mini-2024-07-18",
-      system_template: {
-        __tensorzero_remapped_path: "dummy",
-        __data: templateContent,
+      templates: {
+        system: templateContent,
       },
       temperature: 0,
       json_mode: "strict",
@@ -512,15 +511,20 @@ test.describe("Config applying", () => {
     ).toBe("gpt-4o-mini-2024-07-18");
 
     // 9. Verify template file was created
-    const writtenSystemTemplate = variant.system_template as string | undefined;
+    // With simplified types, templates are written under `templates.system.path`.
+    const templates = variant.templates as
+      | Record<string, Record<string, string>>
+      | undefined;
+    expect(templates, "Variant should have a templates section").toBeDefined();
+    const systemTemplatePath = templates?.system?.path;
     expect(
-      writtenSystemTemplate,
-      "Variant should have a system_template path",
+      systemTemplatePath,
+      "Variant should have a templates.system.path",
     ).toBeDefined();
 
     const fullTemplatePath = path.join(
       AUTOPILOT_CONFIG_DIR,
-      writtenSystemTemplate!,
+      systemTemplatePath!,
     );
     expect(
       fs.existsSync(fullTemplatePath),

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,7 +15,8 @@
     "test": "vitest",
     "test-e2e-fast": "playwright test --grep-invert @slow",
     "test-e2e": "playwright test",
-    "test-e2e-autopilot": "TENSORZERO_PLAYWRIGHT_INCLUDE_AUTOPILOT=1 playwright test e2e_tests/autopilot",
+    "test-e2e-autopilot": "TENSORZERO_PLAYWRIGHT_INCLUDE_AUTOPILOT=1 playwright test e2e_tests/autopilot/autopilot.spec.ts e2e_tests/autopilot/user-questions.spec.ts e2e_tests/autopilot/topk-visualization.spec.ts",
+    "test-e2e-autopilot-config-apply": "TENSORZERO_PLAYWRIGHT_INCLUDE_AUTOPILOT=1 playwright test e2e_tests/autopilot/config-apply.spec.ts",
     "test-e2e-base-path": "playwright test --grep @base-path",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"


### PR DESCRIPTION
This PR sets up tests for simplified config writing in the autopilot. Since the PR https://github.com/tensorzero/autopilot/pull/666 breaks these tests we'll temporarily disable them, make that change, and then re-enable them. This is not a breaking API change, but rather will result in file system writes and config writes in general exclusively using our newer `templates.foo` format as desired. 
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes Playwright autopilot test data formats and the npm scripts that select which specs run, which could cause the wrong tests to run or fail if CI relies on the previous script behavior.
> 
> **Overview**
> Updates the autopilot config-apply Playwright spec to use the newer simplified tool payload format (plain `templates.system` / `system_instructions` strings) and to assert template paths via `templates.system.path` in the written TOML.
> 
> Adjusts UI npm scripts to *exclude* `config-apply.spec.ts` from the default `test-e2e-autopilot` run and adds a dedicated `test-e2e-autopilot-config-apply` script to run that suite separately.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdd9736abbb97e5a718788cabd4b5d008abec806. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->