### PR TITLE
Make ClickHouse tests faster

### DIFF
--- a/.github/workflows/clickhouse-tests.yml
+++ b/.github/workflows/clickhouse-tests.yml
@@ -82,6 +82,11 @@ jobs:
         with:
           tool: cargo-nextest
 
+      # Start building the tests in the background while we download conatiners, fixtures, etc.
+      # The subsequent cargo command will wait for this to complete.
+      - name: Start building tests in the background
+        run: cargo test-clickhouse --no-run &
+
       - name: Set ClickHouse replicated cluster name
         if: matrix.replicated == true
         run: echo "TENSORZERO_CLICKHOUSE_CLUSTER_NAME=tensorzero_e2e_tests_cluster" >> $GITHUB_ENV


### PR DESCRIPTION
Saves 2min

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change; the main risk is hiding build failures until the later `cargo test-clickhouse` step or introducing flakiness due to background compilation.
> 
> **Overview**
> Speeds up the ClickHouse CI workflow by starting a background `cargo test-clickhouse --no-run` build while containers/fixtures are being downloaded, so compilation overlaps with environment setup and the later test run can reuse the completed build.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fd74c6e5e6cf93600a1ec663cc5575f2317dba7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->