### PR TITLE
Add TaskTool.execute_with_owned_ctx

### DIFF
--- a/internal/durable-tools/src/task_tool.rs
+++ b/internal/durable-tools/src/task_tool.rs
@@ -153,12 +153,12 @@ pub trait TaskTool: ToolMetadata {
         llm_params: <Self as ToolMetadata>::LlmParams,
         side_info: <Self as ToolMetadata>::SideInfo,
         mut ctx: ToolContext<Self::ExtraState>,
-    ) -> (
-        ToolExecResult<<Self as ToolMetadata>::Output>,
+    ) -> ToolExecResult<(
+        <Self as ToolMetadata>::Output,
         ToolContext<Self::ExtraState>,
-    ) {
-        let res = self.execute(llm_params, side_info, &mut ctx).await;
-        (res, ctx)
+    )> {
+        let res = self.execute(llm_params, side_info, &mut ctx).await?;
+        Ok((res, ctx))
     }
 
     /// Execute the tool logic.
@@ -211,10 +211,10 @@ impl<T: TaskTool> Task<ToolAppState<T::ExtraState>> for TaskToolAdapter<T> {
         app_ctx: ToolAppState<T::ExtraState>,
     ) -> TaskResult<Self::Output> {
         let tool_ctx = ToolContext::new(task_ctx, app_ctx, wrapped.episode_id);
-        self.0
-            .execute_with_owned_ctx(wrapped.llm_params, wrapped.side_info, tool_ctx)
-            .await
+        Ok(self
             .0
-            .map_err(Into::into)
+            .execute_with_owned_ctx(wrapped.llm_params, wrapped.side_info, tool_ctx)
+            .await?
+            .0)
     }
 }


### PR DESCRIPTION
This has a default implementation which delegates to the existing 'execute', so it doesn't break any existing tools.

We're going to implement 'execute_with_owned_ctx' in RLM-based tools in order to have an owned value to use with `deno_core`, which is significantly easier to work with.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core `TaskTool` execution path by adding an owned-`ToolContext` execution variant and routing the durable adapter through it; mistakes could affect all task tool invocations even though a delegating default reduces breakage risk.
> 
> **Overview**
> Adds `TaskTool::execute_with_owned_ctx`, a new async execution entrypoint that takes an owned `ToolContext` and returns it alongside the tool output, with a default implementation that delegates to the existing `execute`.
> 
> Updates `TaskToolAdapter::run` to call `execute_with_owned_ctx` (instead of `execute` with `&mut ToolContext`), enabling tools that require ownership of the context while keeping existing tools working via the default delegation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b78b8107a9b6dd6aa012b205fe07576a13f3c8b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->