### PR TITLE
Add tests for stored config parsing

### DIFF
--- a/tensorzero-core/src/config/stored/AGENTS.md
+++ b/tensorzero-core/src/config/stored/AGENTS.md
@@ -1,3 +1,9 @@
 # Stored Config Types
 
 `Stored*Config` types represent configuration that is persisted in the database. They must **not** use `#[serde(deny_unknown_fields)]`, because the database may contain fields added by newer versions of the application after a rollback. Rejecting unknown fields would cause deserialization failures when rolling back to an older version.
+
+## Historical snapshot tests
+
+Whenever a config shape changes (fields added, removed, renamed, or restructured), add a test in `mod.rs` that parses the **previous** version of the config TOML and asserts it deserializes into `StoredConfig` and converts to `UninitializedConfig` with the correct values. See the existing `test_historical_*` tests for examples. This ensures that snapshots already persisted in databases remain loadable after the change.
+
+Do not add round-trip tests (e.g. serialize then deserialize and compare). They don't catch real bugs and add noise.

--- a/tensorzero-core/src/config/stored/embedding_model_config.rs
+++ b/tensorzero-core/src/config/stored/embedding_model_config.rs
@@ -129,3 +129,116 @@ impl From<UninitializedEmbeddingProviderConfig> for StoredEmbeddingProviderConfi
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Old snapshot with deprecated `timeouts` on embedding model should parse
+    /// and migrate the value to `timeout_ms`.
+    #[test]
+    fn test_deprecated_timeouts_migrates() {
+        let toml_str = r#"
+            routing = ["provider1"]
+
+            [timeouts.non_streaming]
+            total_ms = 5000
+
+            [providers.provider1]
+            model_name = "text-embedding-ada-002"
+            type = "openai"
+        "#;
+
+        let stored: StoredEmbeddingModelConfig =
+            toml::from_str(toml_str).expect("should parse deprecated timeouts field");
+        assert!(
+            stored.timeout_ms.is_none(),
+            "new field should not be set when only deprecated field is present"
+        );
+        assert_eq!(stored.timeouts.non_streaming.total_ms, Some(5000));
+
+        let uninit: UninitializedEmbeddingModelConfig = stored.into();
+        assert_eq!(
+            uninit.timeout_ms,
+            Some(5000),
+            "deprecated timeouts.non_streaming.total_ms should migrate to timeout_ms"
+        );
+    }
+
+    /// Old snapshot with deprecated `timeouts` on embedding provider should parse
+    /// and migrate the value to the provider's `timeout_ms`.
+    #[test]
+    fn test_provider_deprecated_timeouts_migrates() {
+        let toml_str = r#"
+            routing = ["provider1"]
+
+            [providers.provider1]
+            model_name = "text-embedding-ada-002"
+            type = "openai"
+
+            [providers.provider1.timeouts.non_streaming]
+            total_ms = 7000
+        "#;
+
+        let stored: StoredEmbeddingModelConfig =
+            toml::from_str(toml_str).expect("should parse deprecated provider timeouts");
+        let provider = stored.providers.get("provider1").unwrap();
+        assert_eq!(provider.timeouts.non_streaming.total_ms, Some(7000));
+
+        let uninit: UninitializedEmbeddingModelConfig = stored.into();
+        let provider = uninit.providers.get("provider1").unwrap();
+        assert_eq!(
+            provider.timeout_ms,
+            Some(7000),
+            "deprecated provider timeouts should migrate to provider timeout_ms"
+        );
+    }
+
+    /// New snapshot with `timeout_ms` on embedding model should parse correctly.
+    #[test]
+    fn test_new_timeout_ms() {
+        let toml_str = r#"
+            routing = ["provider1"]
+            timeout_ms = 3000
+
+            [providers.provider1]
+            model_name = "text-embedding-ada-002"
+            type = "openai"
+            timeout_ms = 2000
+        "#;
+
+        let stored: StoredEmbeddingModelConfig =
+            toml::from_str(toml_str).expect("should parse new timeout_ms field");
+        assert_eq!(stored.timeout_ms, Some(3000));
+
+        let uninit: UninitializedEmbeddingModelConfig = stored.into();
+        assert_eq!(uninit.timeout_ms, Some(3000));
+        let (_, provider) = uninit.providers.into_iter().next().unwrap();
+        assert_eq!(provider.timeout_ms, Some(2000));
+    }
+
+    /// When both `timeout_ms` and deprecated `timeouts` are set, `timeout_ms` wins.
+    #[test]
+    fn test_new_field_takes_precedence() {
+        let toml_str = r#"
+            routing = ["provider1"]
+            timeout_ms = 1000
+
+            [timeouts.non_streaming]
+            total_ms = 9999
+
+            [providers.provider1]
+            model_name = "text-embedding-ada-002"
+            type = "openai"
+        "#;
+
+        let stored: StoredEmbeddingModelConfig =
+            toml::from_str(toml_str).expect("should parse both fields");
+        let uninit: UninitializedEmbeddingModelConfig = stored.into();
+        assert_eq!(
+            uninit.timeout_ms,
+            Some(1000),
+            "new timeout_ms should take precedence over deprecated timeouts"
+        );
+    }
+}

--- a/tensorzero-core/src/config/stored/observability_config.rs
+++ b/tensorzero-core/src/config/stored/observability_config.rs
@@ -60,3 +60,27 @@ impl From<StoredObservabilityConfig> for ObservabilityConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Historical: `disable_automatic_migrations` was an observability field before
+    /// being migrated to a top-level `[clickhouse]` section. Stored snapshots from
+    /// that era must still parse.
+    #[test]
+    fn test_disable_automatic_migrations_parses() {
+        let toml_str = r"
+            enabled = true
+            async_writes = true
+            disable_automatic_migrations = true
+        ";
+
+        let stored: StoredObservabilityConfig =
+            toml::from_str(toml_str).expect("should parse deprecated field");
+        assert!(
+            stored.disable_automatic_migrations,
+            "deprecated field should be preserved"
+        );
+    }
+}


### PR DESCRIPTION
This sets up structure to make sure we can parse all versions of historical snapshots and translate them correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that reorganize and expand coverage around backwards-compatible config deserialization/migration; minimal runtime risk aside from potential CI failures if assumptions are wrong.
> 
> **Overview**
> Adds guidance in `AGENTS.md` to write *historical snapshot* parsing/migration tests (and to avoid round-trip tests).
> 
> Moves embedding model/provider timeout migration coverage out of `stored/mod.rs` into `embedding_model_config.rs`, and adds assertions for deprecated `timeouts` handling, new `timeout_ms` parsing, and precedence when both are present.
> 
> Adds a dedicated `StoredObservabilityConfig` test to ensure the deprecated `disable_automatic_migrations` field continues to parse, and removes several broad forward-compat/round-trip tests from `stored/mod.rs` to reduce noise.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf1bf082ea60fa5e21b179b0775b7f7fcf938f7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->