### PR TITLE
Start test compilation on buildkite before polling clickhouse-cloud

### DIFF
--- a/ci/buildkite/test-clickhouse-cloud.sh
+++ b/ci/buildkite/test-clickhouse-cloud.sh
@@ -117,6 +117,13 @@ SQLX_OFFLINE=1 cargo build-e2e
 cargo run --bin gateway --features e2e_tests -- --run-postgres-migrations
 
 cargo run-e2e > e2e_logs.txt 2>&1 &
+
+# Start test compilation in background immediately - it doesn't need the gateway,
+# so we overlap it with the gateway health check wait (~2 min on ClickHouse Cloud)
+echo "Starting background test compilation..."
+SQLX_OFFLINE=1 cargo test-clickhouse --no-run &
+TEST_BUILD_PID=$!
+
     count=0
     max_attempts=180
     while ! curl -s -f http://localhost:3000/health >/dev/null 2>&1; do
@@ -130,11 +137,6 @@ cargo run-e2e > e2e_logs.txt 2>&1 &
         fi
     done
     export GATEWAY_PID=$!
-
-# Start test compilation in background while we load fixtures
-echo "Starting background test compilation..."
-SQLX_OFFLINE=1 cargo test-clickhouse --no-run &
-TEST_BUILD_PID=$!
 
 export CLICKHOUSE_USER=$(buildkite-agent secret get CLICKHOUSE_CLOUD_INSERT_USERNAME)
 export CLICKHOUSE_PASSWORD=$(buildkite-agent secret get CLICKHOUSE_CLOUD_INSERT_PASSWORD)


### PR DESCRIPTION
This should slightly speed up the job

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that reorders steps to run compilation earlier; main risk is timing-related failures if later steps implicitly relied on the previous ordering.
> 
> **Overview**
> Speeds up the ClickHouse Cloud Buildkite job by starting background `cargo test-clickhouse --no-run` immediately after launching the gateway, overlapping compilation with the gateway `/health` polling period.
> 
> Removes the later background compilation step (previously started around fixture loading) while keeping the existing `wait $TEST_BUILD_PID` before running `cargo test-clickhouse`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d614b00f0b82762ef34080d4da5c1d3192cb0dbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->