### PR TITLE
run all the autopilot ui tests in one go again

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -15,8 +15,7 @@
     "test": "vitest",
     "test-e2e-fast": "playwright test --grep-invert @slow",
     "test-e2e": "playwright test",
-    "test-e2e-autopilot": "TENSORZERO_PLAYWRIGHT_INCLUDE_AUTOPILOT=1 playwright test e2e_tests/autopilot/autopilot.spec.ts e2e_tests/autopilot/user-questions.spec.ts e2e_tests/autopilot/topk-visualization.spec.ts",
-    "test-e2e-autopilot-config-apply": "TENSORZERO_PLAYWRIGHT_INCLUDE_AUTOPILOT=1 playwright test e2e_tests/autopilot/config-apply.spec.ts",
+    "test-e2e-autopilot": "TENSORZERO_PLAYWRIGHT_INCLUDE_AUTOPILOT=1 playwright test e2e_tests/autopilot/",
     "test-e2e-base-path": "playwright test --grep @base-path",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes an npm script for running Playwright E2E tests, with no production code impact. Main risk is CI/local test selection/coverage changing due to different test discovery.
> 
> **Overview**
> Replaces the `test-e2e-autopilot` script in `ui/package.json` from a hard-coded list of spec files to running `playwright test e2e_tests/autopilot/` with `TENSORZERO_PLAYWRIGHT_INCLUDE_AUTOPILOT=1`.
> 
> Removes the separate `test-e2e-autopilot-config-apply` script, consolidating autopilot E2E execution into a single entry point.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ae86baf926edd30ced5b49a39354949883e2a00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->