### PR TITLE
Add full e2e tests for ask_user_questions

### DIFF
--- a/ui/e2e_tests/autopilot/user-questions.spec.ts
+++ b/ui/e2e_tests/autopilot/user-questions.spec.ts
@@ -499,8 +499,6 @@ test.describe("User questions (full e2e)", () => {
       `Use the ask_user_questions tool to ask me exactly one multiple choice question. Use header "Auth", question "Which auth method?", type "multiple_choice", multi_select false, and two options: label "JWT" description "JSON Web Tokens" and label "OAuth" description "OAuth 2.0 flow". Call the tool directly without using any other tools first. ${v7()}`,
     );
 
-    // Wait for the question card's Submit button (unique to question cards —
-    // the user message also contains "JWT" so we can't use getByText("JWT"))
     const submitButton = page.getByRole("button", { name: /submit/i });
     await expect(submitButton).toBeVisible({ timeout: 90000 });
 
@@ -511,11 +509,6 @@ test.describe("User questions (full e2e)", () => {
     // Verify "Answered" event appears
     await expect(page.getByText("Answered")).toBeVisible({ timeout: 15000 });
 
-    // Wait for session to return to idle after the tool unblocks and the
-    // LLM produces a follow-up response. Note: ask_user_questions is a
-    // direct TaskTool (not wrapped in ClientToolTaskAdapter), so no
-    // ToolCall/ToolResult events are written — we verify completion by
-    // checking the session returns to "Ready" (idle).
     await expect(page.getByText("Ready")).toBeVisible({ timeout: 60000 });
 
     // Verify the answer was persisted correctly in the database
@@ -546,7 +539,6 @@ test.describe("User questions (full e2e)", () => {
 
     await expect(page.getByText("Answered")).toBeVisible({ timeout: 15000 });
 
-    // Wait for session to return to idle (see comment in multiple choice test)
     await expect(page.getByText("Ready")).toBeVisible({ timeout: 60000 });
 
     // Verify the answer was persisted correctly in the database


### PR DESCRIPTION
## Summary
- Adds 2 full e2e Playwright tests for the `ask_user_questions` tool that exercise the complete autopilot backend flow
- Unlike existing tests that inject events via direct DB insertion (`insertEvent`), these go through the live worker: send message → LLM calls `ask_user_questions` → worker writes `UserQuestions` event → UI renders question card → user submits → session returns to idle
- Test cases: multiple choice selection and free response
- Uses `page.getByText("Ready")` to verify session completion — `ask_user_questions` is a direct TaskTool (not a ClientTool), so no `ToolCall`/`ToolResult` events are written to the DB

Companion to https://github.com/tensorzero/autopilot/pull/596 which adds the Rust-side tool implementation and Rust e2e tests.

## Test plan
- [ ] Run with autopilot backend: `TENSORZERO_PLAYWRIGHT_INCLUDE_AUTOPILOT=1 pnpm exec playwright test e2e_tests/autopilot/user-questions.spec.ts`
- [ ] Verify existing DB-injection tests still pass
- [ ] Verify new full e2e tests pass with live backend

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Test-only changes, but the new "full e2e" specs depend on the live autopilot backend/LLM timing and longer timeouts, which can increase CI runtime and flakiness.
> 
> **Overview**
> Adds a new **"full e2e" Playwright suite** for `ask_user_questions` that runs through the live autopilot backend (send message → questions rendered → submit → session returns to `Ready`) for both *multiple choice* and *free response* flows, and verifies persisted `user_questions_answers` in the DB.
> 
> Refactors `createSession` to accept an optional custom message and uses the `Page` type import, and removes a UI-style-based assertion in the back-navigation test in favor of DB-based verification.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7393085b2b8d42b21125728b5d5dd6eafb18fddd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->