### PR TITLE
Add a postgres-only toml config for ui e2e docker config

### DIFF
--- a/ui/fixtures/config/postgres.gateway.toml
+++ b/ui/fixtures/config/postgres.gateway.toml
@@ -1,0 +1,6 @@
+# Override file for Postgres-as-primary-datastore tests.
+# Include this alongside the tensorzero.*.toml files via a glob like:
+#   {tensorzero,postgres}.*.toml
+
+[gateway.observability]
+backend = "postgres"

--- a/ui/fixtures/docker-compose.yml
+++ b/ui/fixtures/docker-compose.yml
@@ -52,9 +52,17 @@ services:
         condition: service_healthy
       gateway-postgres-migrations:
         condition: service_healthy
-    command: [ "--config-file", "/app/config/tensorzero.toml" ]
+    command: --config-file ${TENSORZERO_GATEWAY_CONFIG:-'/app/config/tensorzero.toml'}
     healthcheck:
-      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/health" ]
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:3000/health",
+        ]
       start_period: 30s
       start_interval: 1s
       timeout: 1s
@@ -83,9 +91,9 @@ services:
         condition: service_healthy
       gateway-postgres-migrations:
         condition: service_healthy
-    command: [ "bash", "-c", "cd /fixtures && ./load_fixtures.sh" ]
+    command: ["bash", "-c", "cd /fixtures && ./load_fixtures.sh"]
     healthcheck:
-      test: [ "CMD", "test", "-f", "/load_complete.marker" ]
+      test: ["CMD", "test", "-f", "/load_complete.marker"]
       interval: 5s
       timeout: 1s
       retries: 72 # Retry for up to 6 minutes


### PR DESCRIPTION
UI fixtures docker compose uses a different set of configs from backend e2e compose files.