### PR TITLE
test(python): add fast PyO3 sanity check to validate-python CI

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -425,6 +425,11 @@ jobs:
         run: |
           uv run stubtest tensorzero.tensorzero
 
+      - name: "Python: PyO3 Client: Sanity check"
+        working-directory: clients/python
+        run: |
+          uv run pytest tests/test_pyo3_sanity.py
+
       - name: "Python: Recipes: Install dependencies"
         working-directory: recipes
         run: |

--- a/clients/python/tests/test_pyo3_sanity.py
+++ b/clients/python/tests/test_pyo3_sanity.py
@@ -1,0 +1,65 @@
+import os
+import tempfile
+from typing import Generator
+
+import pytest
+from tensorzero import TensorZeroGateway
+
+DUMMY_CONFIG = """
+[gateway]
+bind_address = "127.0.0.1:3000"
+
+[gateway.observability]
+enabled = false
+
+[models.dummy_model]
+routing = ["my_dummy_provider"]
+
+[models.dummy_model.providers.my_dummy_provider]
+type = "openai"
+model_name = "gpt-4o-mini"
+
+[functions.sanity_check]
+type = "chat"
+
+[functions.sanity_check.variants.default]
+type = "chat_completion"
+model = "dummy_model"
+"""
+
+
+@pytest.fixture
+def dummy_config_path() -> Generator[str, None, None]:
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".toml") as f:
+        f.write(DUMMY_CONFIG)
+        config_path = f.name
+
+    yield config_path
+
+    os.remove(config_path)
+
+
+def test_pyo3_dummy_sanity(dummy_config_path: str) -> None:
+    """
+    Ensures the PyO3 bindings compile and execute correctly without requiring external databases.
+    This provides a fast CI signal before a PR enters the merge queue.
+    """
+
+    os.environ["OPENAI_API_KEY"] = "dummy-key"
+
+    with TensorZeroGateway.build_embedded(config_file=dummy_config_path) as client:
+        
+        with pytest.raises(Exception):
+            client.inference(
+                function_name="sanity_check",
+                input={
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": "Hello from Python!"}
+                            ]
+                        }
+                    ]
+                }
+            )


### PR DESCRIPTION
Resolves #5652

### Context
As outlined in the issue, a lightweight sanity check for the PyO3 bindings is needed before PRs enter the heavy merge queue. This allows the CI to catch segfaults or basic Rust-to-Python initialization errors early.

### Changes
* **Added `test_pyo3_sanity.py`:** Uses a minimal embedded gateway config (with observability disabled) and the `openai` provider. It injects a dummy API key and expects a standard `Exception`. Catching this exception proves the Rust core successfully loaded the config and the PyO3 boundary is passing errors back safely without crashing the process.
* **Updated `general.yml`:** Hooked the new pytest into the `validate-python` CI job so it runs automatically on all PRs right after the Python wheels are built.