### PR TITLE
Fix Slack notifications

### DIFF
--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -41,13 +41,12 @@ jobs:
           fi
 
           # Check if user is a member of the organization
-          MEMBER=$((gh api "orgs/tensorzero/members/$ACTOR" && echo 1) || echo 0)
-          if [ "$MEMBER" = "0" ]; then
-            echo "should_skip=false" >> $GITHUB_OUTPUT
-            echo "Sending notification for non-member: $ACTOR"
-          else
+          if gh api "orgs/tensorzero/members/$ACTOR" > /dev/null 2>&1; then
             echo "should_skip=true" >> $GITHUB_OUTPUT
             echo "Skipping notification for organization member: $ACTOR"
+          else
+            echo "should_skip=false" >> $GITHUB_OUTPUT
+            echo "Sending notification for non-member: $ACTOR"
           fi
 
       - name: Build payload for new issue notification


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; it just adjusts the `gh api` membership check logic that gates Slack notifications and could change who gets notified if the previous check was mis-evaluated.
> 
> **Overview**
> Fixes the Slack notification workflow’s skip logic by switching the org-membership check to rely on `gh api`’s exit status (with output suppressed) instead of the previous shell expression.
> 
> As a result, notifications should now reliably be **skipped for organization members** and **sent for non-members**, while still skipping bot actors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ad1be63f0a14afffca6eb4d3a8a81729cede531. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->