### PR TITLE
bumped version to 2026.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot-client"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "chrono",
  "durable-tools-spawn",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-tools"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-worker"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "config-applier"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "pathdiff",
  "schemars 1.2.1",
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2227,7 +2227,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools-spawn"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "async-trait",
  "durable",
@@ -2369,7 +2369,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2463,7 +2463,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "async-stream",
  "autopilot-client",
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-utils"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "minijinja",
  "serde",
@@ -4834,7 +4834,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postgres-inference-load-test"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "reqwest-sse-stream"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "async-stream",
  "futures",
@@ -6890,7 +6890,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "axum",
  "chrono",
@@ -6910,11 +6910,11 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-config-paths"
-version = "2026.2.2"
+version = "2026.3.0"
 
 [[package]]
 name = "tensorzero-core"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -7039,7 +7039,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "config-applier",
  "napi",
@@ -7054,7 +7054,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-optimizers"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -7089,7 +7089,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "evaluations",
  "futures",
@@ -7107,11 +7107,11 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-ts-types"
-version = "2026.2.2"
+version = "2026.3.0"
 
 [[package]]
 name = "tensorzero-types"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "aws-smithy-types",
  "infer",
@@ -7134,7 +7134,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types-providers"
-version = "2026.2.2"
+version = "2026.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7144,7 +7144,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-unsafe-helpers"
-version = "2026.2.2"
+version = "2026.3.0"
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2026.2.2"
+version = "2026.3.0"
 rust-version = "1.93.0"
 license = "Apache-2.0"
 edition = "2024"

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2026.2.2"
+appVersion: "2026.3.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorzero-ui",
-  "version": "2026.2.2",
+  "version": "2026.3.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates version numbers and corresponding lockfile entries, with no functional or behavioral code changes.
> 
> **Overview**
> Bumps the project release version from `2026.2.2` to `2026.3.0` across the Rust workspace (`Cargo.toml` + `Cargo.lock`).
> 
> Updates deployment/UI artifacts to match the new release version, including the Helm chart `appVersion` and the UI `package.json` version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d327cc375fa133248e655be707507aceacc6248. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->