### PR TITLE
Sort keys in serialized output in inference evaluation human feedback table in Postgres

### DIFF
--- a/evaluations/src/evaluators/llm_judge/mod.rs
+++ b/evaluations/src/evaluators/llm_judge/mod.rs
@@ -72,7 +72,9 @@ pub async fn run_llm_judge_evaluator(
         external_tags,
     } = params;
     debug!("Checking for existing human feedback");
-    let serialized_output = inference_response.get_serialized_output()?;
+    let serialized_output = clients
+        .db
+        .serialize_output_for_feedback(inference_response)?;
     if let Some(human_feedback) = clients
         .db
         .get_inference_evaluation_human_feedback(

--- a/tensorzero-core/src/db/clickhouse/evaluation_queries.rs
+++ b/tensorzero-core/src/db/clickhouse/evaluation_queries.rs
@@ -17,6 +17,7 @@ use crate::db::evaluation_queries::EvaluationStatisticsRow;
 use crate::db::evaluation_queries::InferenceEvaluationHumanFeedbackRow;
 use crate::db::evaluation_queries::InferenceEvaluationRunInsert;
 use crate::db::evaluation_queries::RawEvaluationResultRow;
+use crate::endpoints::inference::InferenceResponse;
 use crate::error::{Error, ErrorDetails};
 use crate::function::FunctionConfigType;
 use crate::statistics_util::{wald_confint, wilson_confint};
@@ -637,6 +638,21 @@ impl EvaluationQueries for ClickHouseConnectionInfo {
                 FunctionConfigType::Json => row.into_json().map(EvaluationResultRow::Json),
             })
             .collect()
+    }
+
+    fn serialize_output_for_feedback(
+        &self,
+        inference_response: &InferenceResponse,
+    ) -> Result<String, Error> {
+        match inference_response {
+            InferenceResponse::Chat(c) => serde_json::to_string(&c.content),
+            InferenceResponse::Json(j) => serde_json::to_string(&j.output),
+        }
+        .map_err(|e| {
+            Error::new(ErrorDetails::Inference {
+                message: format!("Failed to serialize inference response: {e:?}"),
+            })
+        })
     }
 
     async fn get_inference_evaluation_human_feedback(

--- a/tensorzero-core/src/db/clickhouse/inference_queries.rs
+++ b/tensorzero-core/src/db/clickhouse/inference_queries.rs
@@ -276,7 +276,7 @@ impl InferenceQueries for ClickHouseConnectionInfo {
         Ok(Some(output_schema))
     }
 
-    async fn get_inference_output(
+    async fn get_serialized_inference_output_for_feedback(
         &self,
         function_info: &FunctionInfo,
         inference_id: Uuid,
@@ -2117,7 +2117,7 @@ mod tests {
         }
     }
 
-    mod get_inference_output_tests {
+    mod get_serialized_inference_output_for_feedback_tests {
         use crate::db::clickhouse::clickhouse_client::MockClickHouseClient;
         use crate::db::clickhouse::query_builder::test_util::assert_query_contains;
         use crate::db::clickhouse::{
@@ -2129,7 +2129,7 @@ mod tests {
         use uuid::Uuid;
 
         #[tokio::test]
-        async fn test_get_inference_output_chat_inference_success() {
+        async fn test_get_serialized_inference_output_for_feedback_chat_inference_success() {
             let inference_id = Uuid::now_v7();
             let episode_id = Uuid::now_v7();
             let function_info = FunctionInfo {
@@ -2175,7 +2175,7 @@ mod tests {
 
             let conn = ClickHouseConnectionInfo::new_mock(Arc::new(mock));
             let result = conn
-                .get_inference_output(&function_info, inference_id)
+                .get_serialized_inference_output_for_feedback(&function_info, inference_id)
                 .await
                 .expect("Should succeed");
 
@@ -2191,7 +2191,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_get_inference_output_json_inference_success() {
+        async fn test_get_serialized_inference_output_for_feedback_json_inference_success() {
             let inference_id = Uuid::now_v7();
             let episode_id = Uuid::now_v7();
             let function_info = FunctionInfo {
@@ -2232,7 +2232,7 @@ mod tests {
 
             let conn = ClickHouseConnectionInfo::new_mock(Arc::new(mock));
             let result = conn
-                .get_inference_output(&function_info, inference_id)
+                .get_serialized_inference_output_for_feedback(&function_info, inference_id)
                 .await
                 .expect("Should succeed");
 
@@ -2247,7 +2247,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_get_inference_output_not_found() {
+        async fn test_get_serialized_inference_output_for_feedback_not_found() {
             let inference_id = Uuid::now_v7();
             let episode_id = Uuid::now_v7();
             let function_info = FunctionInfo {
@@ -2270,7 +2270,7 @@ mod tests {
 
             let conn = ClickHouseConnectionInfo::new_mock(Arc::new(mock));
             let result = conn
-                .get_inference_output(&function_info, inference_id)
+                .get_serialized_inference_output_for_feedback(&function_info, inference_id)
                 .await
                 .expect("Should succeed even when not found");
 
@@ -2281,7 +2281,8 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_get_inference_output_uses_all_parameters_for_security() {
+        async fn test_get_serialized_inference_output_for_feedback_uses_all_parameters_for_security()
+         {
             let inference_id = Uuid::now_v7();
             let episode_id = Uuid::now_v7();
             let function_info = FunctionInfo {
@@ -2342,14 +2343,15 @@ mod tests {
 
             let conn = ClickHouseConnectionInfo::new_mock(Arc::new(mock));
             let result = conn
-                .get_inference_output(&function_info, inference_id)
+                .get_serialized_inference_output_for_feedback(&function_info, inference_id)
                 .await;
 
             assert!(result.is_ok(), "Query should execute successfully");
         }
 
         #[tokio::test]
-        async fn test_get_inference_output_table_selection_by_function_type() {
+        async fn test_get_serialized_inference_output_for_feedback_table_selection_by_function_type()
+         {
             // Test Chat function type uses ChatInference table
             let chat_function_info = FunctionInfo {
                 function_name: "chat_func".to_string(),
@@ -2377,7 +2379,7 @@ mod tests {
 
             let conn = ClickHouseConnectionInfo::new_mock(Arc::new(chat_mock));
             let _ = conn
-                .get_inference_output(&chat_function_info, Uuid::now_v7())
+                .get_serialized_inference_output_for_feedback(&chat_function_info, Uuid::now_v7())
                 .await;
 
             // Test Json function type uses JsonInference table
@@ -2407,7 +2409,7 @@ mod tests {
 
             let conn = ClickHouseConnectionInfo::new_mock(Arc::new(json_mock));
             let _ = conn
-                .get_inference_output(&json_function_info, Uuid::now_v7())
+                .get_serialized_inference_output_for_feedback(&json_function_info, Uuid::now_v7())
                 .await;
         }
     }

--- a/tensorzero-core/src/db/clickhouse/mock_clickhouse_connection_info.rs
+++ b/tensorzero-core/src/db/clickhouse/mock_clickhouse_connection_info.rs
@@ -123,13 +123,13 @@ impl InferenceQueries for MockClickHouseConnectionInfo {
             .await
     }
 
-    async fn get_inference_output(
+    async fn get_serialized_inference_output_for_feedback(
         &self,
         function_info: &FunctionInfo,
         inference_id: Uuid,
     ) -> Result<Option<String>, Error> {
         self.inference_queries
-            .get_inference_output(function_info, inference_id)
+            .get_serialized_inference_output_for_feedback(function_info, inference_id)
             .await
     }
 

--- a/tensorzero-core/src/db/delegating_connection.rs
+++ b/tensorzero-core/src/db/delegating_connection.rs
@@ -58,6 +58,7 @@ use crate::db::{
     EpisodeQueries, HowdyFeedbackCounts, HowdyInferenceCounts, HowdyQueries, HowdyTokenUsage,
     ModelLatencyDatapoint, ModelUsageTimePoint, StoredDICLExample, TableBoundsWithCount,
 };
+use crate::endpoints::inference::InferenceResponse;
 use crate::endpoints::stored_inferences::v1::types::InferenceFilter;
 use crate::error::{Error, ErrorDetails};
 use crate::function::{FunctionConfig, FunctionConfigType};
@@ -474,13 +475,13 @@ impl InferenceQueries for DelegatingDatabaseConnection {
             .await
     }
 
-    async fn get_inference_output(
+    async fn get_serialized_inference_output_for_feedback(
         &self,
         function_info: &FunctionInfo,
         inference_id: Uuid,
     ) -> Result<Option<String>, Error> {
         self.get_database()
-            .get_inference_output(function_info, inference_id)
+            .get_serialized_inference_output_for_feedback(function_info, inference_id)
             .await
     }
 
@@ -974,6 +975,14 @@ impl EvaluationQueries for DelegatingDatabaseConnection {
                 offset,
             )
             .await
+    }
+
+    fn serialize_output_for_feedback(
+        &self,
+        inference_response: &InferenceResponse,
+    ) -> Result<String, Error> {
+        self.get_database()
+            .serialize_output_for_feedback(inference_response)
     }
 
     async fn get_inference_evaluation_human_feedback(

--- a/tensorzero-core/src/db/evaluation_queries.rs
+++ b/tensorzero-core/src/db/evaluation_queries.rs
@@ -10,6 +10,7 @@ use mockall::automock;
 use uuid::Uuid;
 
 use crate::config::MetricConfigOptimize;
+use crate::endpoints::inference::InferenceResponse;
 use crate::error::Error;
 use crate::function::FunctionConfigType;
 use crate::inference::types::{ContentBlockChatOutput, Input, JsonInferenceOutput, StoredInput};
@@ -421,19 +422,30 @@ pub trait EvaluationQueries {
         offset: u32,
     ) -> Result<Vec<EvaluationResultRow>, Error>;
 
-    /// Gets existing human feedback for a given inference evaluation if it exists.
+    /// Serializes an inference response's output into a string that is consistent
+    /// with how `get_serialized_inference_output_for_feedback` stored it.
     ///
-    /// This function queries the StaticEvaluationHumanFeedback table to find existing
-    /// human feedback for a specific combination of metric name, datapoint ID, and output.
+    /// ClickHouse preserves the original struct field order, so this is plain
+    /// `serde_json::to_string`. Postgres JSONB does not preserve key order, so
+    /// this sorts keys before serializing.
+    ///
+    /// Call this before `get_inference_evaluation_human_feedback` to produce
+    /// a correctly normalized output string.
+    ///
+    /// TODO(#6664): Make the lookup order-independent instead of requiring a particular
+    /// backend-dependent serialization implementation.
+    fn serialize_output_for_feedback(
+        &self,
+        inference_response: &InferenceResponse,
+    ) -> Result<String, Error>;
+
+    /// Gets existing human feedback for a given inference evaluation if it exists.
     ///
     /// # Arguments
     /// * `metric_name` - The name of the metric being evaluated
     /// * `datapoint_id` - The UUID of the datapoint being evaluated
-    /// * `output` - The serialized inference output to match against
-    ///
-    /// # Returns
-    /// * `Some(InferenceEvaluationHumanFeedbackRow)` - If human feedback exists
-    /// * `None` - If no human feedback exists for this combination
+    /// * `output` - The serialized inference output, produced by
+    ///   [`serialize_output_for_feedback`](Self::serialize_output_for_feedback)
     async fn get_inference_evaluation_human_feedback(
         &self,
         metric_name: &str,

--- a/tensorzero-core/src/db/inferences.rs
+++ b/tensorzero-core/src/db/inferences.rs
@@ -503,13 +503,16 @@ pub trait InferenceQueries {
         inference_id: Uuid,
     ) -> Result<Option<Value>, Error>;
 
-    /// Get the output string from an inference for human feedback context.
+    /// Returns the serialized inference output for storing in the
+    /// `StaticEvaluationHumanFeedback` table and for later exact-match lookup.
     ///
-    /// Returns the serialized output of the inference, which is needed when
-    /// writing static evaluation human feedback records.
+    /// Implementations must ensure that logically identical outputs always produce
+    /// byte-identical strings. ClickHouse stores strings verbatim, so no
+    /// normalization is needed. Postgres JSONB does not preserve key order, so
+    /// the Postgres implementation sorts keys before serializing.
     ///
     /// Returns `None` if the inference doesn't exist.
-    async fn get_inference_output(
+    async fn get_serialized_inference_output_for_feedback(
         &self,
         function_info: &FunctionInfo,
         inference_id: Uuid,

--- a/tensorzero-core/src/db/postgres/evaluation_queries.rs
+++ b/tensorzero-core/src/db/postgres/evaluation_queries.rs
@@ -10,8 +10,10 @@ use crate::db::evaluation_queries::{
     EvaluationRunSearchResult, EvaluationStatisticsRow, InferenceEvaluationHumanFeedbackRow,
     InferenceEvaluationRunInsert, RawEvaluationResultRow,
 };
+use crate::endpoints::inference::InferenceResponse;
 use crate::error::{Error, ErrorDetails};
 use crate::function::FunctionConfigType;
+use crate::serde_util::serialize_with_sorted_keys;
 use crate::statistics_util::{wald_confint, wilson_confint};
 
 use super::PostgresConnectionInfo;
@@ -262,6 +264,25 @@ impl EvaluationQueries for PostgresConnectionInfo {
             .collect()
     }
 
+    fn serialize_output_for_feedback(
+        &self,
+        inference_response: &InferenceResponse,
+    ) -> Result<String, Error> {
+        // Serialize through Value so we can sort keys before producing the final string.
+        // Postgres JSONB does not preserve key order, so the stored output may have
+        // different ordering than direct struct serialization.
+        let output_value = match inference_response {
+            InferenceResponse::Chat(c) => serde_json::to_value(&c.content),
+            InferenceResponse::Json(j) => serde_json::to_value(&j.output),
+        }
+        .map_err(|e| {
+            Error::new(ErrorDetails::Serialization {
+                message: format!("Failed to serialize inference output for feedback lookup: {e}"),
+            })
+        })?;
+        serialize_with_sorted_keys(&output_value)
+    }
+
     async fn get_inference_evaluation_human_feedback(
         &self,
         metric_name: &str,
@@ -277,7 +298,7 @@ impl EvaluationQueries for PostgresConnectionInfo {
             Some(row) => {
                 let value_str: String = row.get("value");
                 let value: serde_json::Value = serde_json::from_str(&value_str).map_err(|e| {
-                    Error::new(crate::error::ErrorDetails::Serialization {
+                    Error::new(ErrorDetails::Serialization {
                         message: format!("Failed to deserialize human feedback value: {e}"),
                     })
                 })?;

--- a/tensorzero-core/src/db/postgres/inference_queries.rs
+++ b/tensorzero-core/src/db/postgres/inference_queries.rs
@@ -40,6 +40,7 @@ use crate::inference::types::stored_input::StoredInput;
 use crate::inference::types::{
     ChatInferenceDatabaseInsert, FunctionType, JsonInferenceDatabaseInsert,
 };
+use crate::serde_util::serialize_with_sorted_keys;
 use crate::stored_inference::{
     StoredChatInferenceDatabase, StoredInferenceDatabase, StoredJsonInference,
 };
@@ -349,7 +350,7 @@ impl InferenceQueries for PostgresConnectionInfo {
     }
 
     // TODO(#5691): Change this to return either a Value or a typed output.
-    async fn get_inference_output(
+    async fn get_serialized_inference_output_for_feedback(
         &self,
         function_info: &FunctionInfo,
         inference_id: Uuid,
@@ -377,8 +378,10 @@ impl InferenceQueries for PostgresConnectionInfo {
                 .fetch_optional(pool)
                 .await?;
 
-                // Convert JSONB to string
-                Ok(result.map(|r| r.output.to_string()))
+                // TODO(#6664): Make the lookup order-independent instead of sorting keys.
+                result
+                    .map(|r| serialize_with_sorted_keys(&r.output))
+                    .transpose()
             }
             FunctionType::Json => {
                 let result = sqlx::query!(
@@ -400,8 +403,10 @@ impl InferenceQueries for PostgresConnectionInfo {
                 .fetch_optional(pool)
                 .await?;
 
-                // Convert JSONB to string
-                Ok(result.map(|r| r.output.to_string()))
+                // TODO(#6664): Make the lookup order-independent instead of sorting keys.
+                result
+                    .map(|r| serialize_with_sorted_keys(&r.output))
+                    .transpose()
             }
         }
     }

--- a/tensorzero-core/src/endpoints/feedback/human_feedback.rs
+++ b/tensorzero-core/src/endpoints/feedback/human_feedback.rs
@@ -40,7 +40,7 @@ pub(super) async fn write_static_evaluation_human_feedback_if_necessary(
         }
     };
     let output = database
-        .get_inference_output(&function_info, target_id)
+        .get_serialized_inference_output_for_feedback(&function_info, target_id)
         .await?
         .ok_or_else(|| {
             Error::new(ErrorDetails::InferenceNotFound {

--- a/tensorzero-core/src/endpoints/inference.rs
+++ b/tensorzero-core/src/endpoints/inference.rs
@@ -1910,33 +1910,6 @@ impl InferenceResponse {
             InferenceResponse::Json(j) => j.episode_id,
         }
     }
-
-    pub fn get_serialized_output(&self) -> Result<String, Error> {
-        match self {
-            InferenceResponse::Chat(c) => c.get_serialized_output(),
-            InferenceResponse::Json(j) => j.get_serialized_output(),
-        }
-    }
-}
-
-impl ChatInferenceResponse {
-    pub fn get_serialized_output(&self) -> Result<String, Error> {
-        serde_json::to_string(&self.content).map_err(|e| {
-            Error::new(ErrorDetails::Inference {
-                message: format!("Failed to serialize chat inference response: {e:?}"),
-            })
-        })
-    }
-}
-
-impl JsonInferenceResponse {
-    pub fn get_serialized_output(&self) -> Result<String, Error> {
-        serde_json::to_string(&self.output).map_err(|e| {
-            Error::new(ErrorDetails::Inference {
-                message: format!("Failed to serialize json inference response: {e:?}"),
-            })
-        })
-    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/tensorzero-core/src/endpoints/internal/evaluations/get_human_feedback.rs
+++ b/tensorzero-core/src/endpoints/internal/evaluations/get_human_feedback.rs
@@ -16,6 +16,11 @@ pub struct GetHumanFeedbackRequest {
     /// The name of the metric being evaluated.
     pub metric_name: String,
     /// The serialized inference output to match against.
+    ///
+    /// Must be produced by `EvaluationQueries::serialize_output_for_feedback` to ensure
+    /// backend-consistent serialization (e.g. sorted keys for Postgres).
+    ///
+    /// TODO(#6664): Make the lookup order-independent instead of sorting keys.
     pub output: String,
 }
 
@@ -54,12 +59,12 @@ pub async fn get_human_feedback_handler(
 
 /// Core business logic for checking human feedback.
 pub async fn get_human_feedback(
-    clickhouse: &impl EvaluationQueries,
+    db: &impl EvaluationQueries,
     metric_name: &str,
     datapoint_id: &Uuid,
     output: &str,
 ) -> Result<GetHumanFeedbackResponse, Error> {
-    let feedback = clickhouse
+    let feedback = db
         .get_inference_evaluation_human_feedback(metric_name, datapoint_id, output)
         .await?;
 

--- a/tensorzero-core/src/serde_util.rs
+++ b/tensorzero-core/src/serde_util.rs
@@ -517,6 +517,41 @@ where
     Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
 }
 
+/// Recursively sorts all object keys in a `serde_json::Value` alphabetically.
+/// This is useful for producing deterministic JSON output from sources like Postgres JSONB
+/// that do not preserve key order.
+pub fn sort_json_keys(value: Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let sorted: serde_json::Map<String, Value> = map
+                .into_iter()
+                .map(|(k, v)| (k, sort_json_keys(v)))
+                .collect::<std::collections::BTreeMap<_, _>>()
+                .into_iter()
+                .collect();
+            Value::Object(sorted)
+        }
+        Value::Array(arr) => Value::Array(arr.into_iter().map(sort_json_keys).collect()),
+        other => other,
+    }
+}
+
+/// Serializes a JSON value with alphabetically sorted keys for deterministic string comparison.
+///
+/// Postgres JSONB does not preserve key order, so we sort keys before serializing
+/// to ensure identical logical outputs always produce byte-identical strings.
+/// Used by Postgres implementations in both the write path
+/// (`get_serialized_inference_output_for_feedback`) and the read path
+/// (`get_inference_evaluation_human_feedback`).
+pub fn serialize_with_sorted_keys(value: &Value) -> Result<String, crate::error::Error> {
+    let sorted = sort_json_keys(value.clone());
+    serde_json::to_string(&sorted).map_err(|e| {
+        crate::error::Error::new(crate::error::ErrorDetails::Serialization {
+            message: format!("Failed to serialize JSON with sorted keys: {e}"),
+        })
+    })
+}
+
 /// Helper for serde `skip_serializing_if` - returns true if the Option is None or contains an empty Vec.
 // Signature dictated by Serde
 #[expect(clippy::ref_option)]
@@ -1040,6 +1075,37 @@ mod tests {
         assert_eq!(
             result.field, "",
             "should return default empty string for absent field"
+        );
+    }
+
+    #[test]
+    fn test_sort_json_keys_nested() {
+        let input: Value = serde_json::json!({
+            "z": 1,
+            "a": {
+                "c": [{"b": 2, "a": 1}],
+                "a": "first"
+            },
+            "m": null
+        });
+        let sorted = sort_json_keys(input);
+        assert_eq!(
+            serde_json::to_string(&sorted).unwrap(),
+            r#"{"a":{"a":"first","c":[{"a":1,"b":2}]},"m":null,"z":1}"#,
+            "keys should be sorted alphabetically at every level"
+        );
+    }
+
+    #[test]
+    fn test_sort_json_keys_primitives_unchanged() {
+        assert_eq!(sort_json_keys(serde_json::json!(42)), serde_json::json!(42));
+        assert_eq!(
+            sort_json_keys(serde_json::json!("hello")),
+            serde_json::json!("hello")
+        );
+        assert_eq!(
+            sort_json_keys(serde_json::json!(null)),
+            serde_json::json!(null)
         );
     }
 }

--- a/tensorzero-core/tests/e2e/db/inference_queries.rs
+++ b/tensorzero-core/tests/e2e/db/inference_queries.rs
@@ -39,7 +39,9 @@ async fn get_e2e_config() -> Config {
 // ===== SHARED TEST IMPLEMENTATIONS =====
 // These tests work with both ClickHouse and Postgres.
 
-async fn test_get_inference_output_chat_inference(conn: impl InferenceQueries) {
+async fn test_get_serialized_inference_output_for_feedback_chat_inference(
+    conn: impl InferenceQueries,
+) {
     // Use a hardcoded inference ID.
     let inference_id = Uuid::parse_str("0196c682-72e0-7c83-a92b-9d1a3c7630f2").expect("Valid UUID");
 
@@ -56,9 +58,9 @@ async fn test_get_inference_output_chat_inference(conn: impl InferenceQueries) {
         "write_haiku should be a Chat function"
     );
 
-    // Now test get_inference_output
+    // Now test get_serialized_inference_output_for_feedback
     let output = conn
-        .get_inference_output(&function_info, inference_id)
+        .get_serialized_inference_output_for_feedback(&function_info, inference_id)
         .await
         .unwrap();
 
@@ -72,9 +74,11 @@ async fn test_get_inference_output_chat_inference(conn: impl InferenceQueries) {
         "Output should not be empty for existing inference"
     );
 }
-make_db_test!(test_get_inference_output_chat_inference);
+make_db_test!(test_get_serialized_inference_output_for_feedback_chat_inference);
 
-async fn test_get_inference_output_json_inference(conn: impl InferenceQueries) {
+async fn test_get_serialized_inference_output_for_feedback_json_inference(
+    conn: impl InferenceQueries,
+) {
     // Use a hardcoded inference ID.
     let inference_id = Uuid::parse_str("0196374c-2c6d-7ce0-b508-e3b24ee4579c").expect("Valid UUID");
 
@@ -91,9 +95,9 @@ async fn test_get_inference_output_json_inference(conn: impl InferenceQueries) {
         "extract_entities should be a Json function"
     );
 
-    // Now test get_inference_output
+    // Now test get_serialized_inference_output_for_feedback
     let output = conn
-        .get_inference_output(&function_info, inference_id)
+        .get_serialized_inference_output_for_feedback(&function_info, inference_id)
         .await
         .unwrap();
 
@@ -107,9 +111,9 @@ async fn test_get_inference_output_json_inference(conn: impl InferenceQueries) {
         "Output should not be empty for existing json inference"
     );
 }
-make_db_test!(test_get_inference_output_json_inference);
+make_db_test!(test_get_serialized_inference_output_for_feedback_json_inference);
 
-async fn test_get_inference_output_not_found(conn: impl InferenceQueries) {
+async fn test_get_serialized_inference_output_for_feedback_not_found(conn: impl InferenceQueries) {
     // Create a fake function_info with a non-existent inference_id
     let fake_function_info = FunctionInfo {
         function_name: "write_haiku".to_string(),
@@ -121,7 +125,10 @@ async fn test_get_inference_output_not_found(conn: impl InferenceQueries) {
     let non_existent_inference_id = Uuid::now_v7();
 
     let output = conn
-        .get_inference_output(&fake_function_info, non_existent_inference_id)
+        .get_serialized_inference_output_for_feedback(
+            &fake_function_info,
+            non_existent_inference_id,
+        )
         .await
         .unwrap();
 
@@ -130,7 +137,7 @@ async fn test_get_inference_output_not_found(conn: impl InferenceQueries) {
         "Should return None for non-existent inference"
     );
 }
-make_db_test!(test_get_inference_output_not_found);
+make_db_test!(test_get_serialized_inference_output_for_feedback_not_found);
 
 async fn test_list_inferences_chat_function(conn: impl InferenceQueries) {
     let config = get_e2e_config().await;

--- a/tensorzero-core/tests/e2e/endpoints/internal/evaluations.rs
+++ b/tensorzero-core/tests/e2e/endpoints/internal/evaluations.rs
@@ -7,7 +7,9 @@ use reqwest::{Client, StatusCode};
 use reqwest_sse_stream::{Event, RequestBuilderExt};
 use serde_json::{Map, Value, json};
 use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
+use tensorzero_core::db::delegating_connection::DelegatingDatabaseConnection;
 use tensorzero_core::db::evaluation_queries::EvaluationResultRow;
+use tensorzero_core::db::inferences::{FunctionInfo, InferenceQueries};
 use tensorzero_core::endpoints::datasets::v1::types::{
     CreateChatDatapointRequest, CreateDatapointRequest, CreateDatapointsRequest,
     CreateDatapointsResponse,
@@ -20,6 +22,7 @@ use tensorzero_core::inference::types::{
     Arguments, ContentBlockChatOutput, Input, InputMessage, InputMessageContent, Role, System, Text,
 };
 use tensorzero_core::tool::DynamicToolParams;
+use tensorzero_types::FunctionType;
 use tokio::time::sleep;
 use uuid::Uuid;
 
@@ -1233,8 +1236,30 @@ async fn test_get_human_feedback_returns_feedback_when_exists() {
     let response_json: Value = response.json().await.unwrap();
     let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
     let inference_id = Uuid::parse_str(inference_id).unwrap();
-    let serialized_inference_output =
-        serde_json::to_string(response_json.get("output").unwrap()).unwrap();
+
+    // Postgres JSONB does not preserve key order, so `get_serialized_inference_output_for_feedback`
+    // sorts keys before serializing. We must use the same serialization here for the lookup to match.
+    // TODO(#6664): make this lookup order-independent.
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
+    let variant_name = response_json
+        .get("variant_name")
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_string();
+    let episode_id =
+        Uuid::parse_str(response_json.get("episode_id").unwrap().as_str().unwrap()).unwrap();
+    let function_info = FunctionInfo {
+        function_name: "json_success".to_string(),
+        function_type: FunctionType::Json,
+        variant_name,
+        episode_id,
+    };
+    let serialized_inference_output = database
+        .get_serialized_inference_output_for_feedback(&function_info, inference_id)
+        .await
+        .expect("should get inference output")
+        .expect("inference output should exist");
 
     // Create datapoint_id and evaluator_inference_id
     let datapoint_id = Uuid::now_v7();
@@ -1366,8 +1391,30 @@ async fn test_get_human_feedback_with_boolean_value() {
     let response_json: Value = response.json().await.unwrap();
     let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
     let inference_id = Uuid::parse_str(inference_id).unwrap();
-    let serialized_inference_output =
-        serde_json::to_string(response_json.get("output").unwrap()).unwrap();
+
+    // Postgres JSONB does not preserve key order, so `get_serialized_inference_output_for_feedback`
+    // sorts keys before serializing. We must use the same serialization here for the lookup to match.
+    // TODO(#6664): make this lookup order-independent.
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
+    let variant_name = response_json
+        .get("variant_name")
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_string();
+    let episode_id =
+        Uuid::parse_str(response_json.get("episode_id").unwrap().as_str().unwrap()).unwrap();
+    let function_info = FunctionInfo {
+        function_name: "json_success".to_string(),
+        function_type: FunctionType::Json,
+        variant_name,
+        episode_id,
+    };
+    let serialized_inference_output = database
+        .get_serialized_inference_output_for_feedback(&function_info, inference_id)
+        .await
+        .expect("should get inference output")
+        .expect("inference output should exist");
 
     // Create datapoint_id and evaluator_inference_id
     let datapoint_id = Uuid::now_v7();
@@ -1454,8 +1501,30 @@ async fn test_get_human_feedback_output_mismatch() {
     let response_json: Value = response.json().await.unwrap();
     let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
     let inference_id = Uuid::parse_str(inference_id).unwrap();
-    let serialized_inference_output =
-        serde_json::to_string(response_json.get("output").unwrap()).unwrap();
+
+    // Postgres JSONB does not preserve key order, so `get_serialized_inference_output_for_feedback`
+    // sorts keys before serializing. We must use the same serialization here for the lookup to match.
+    // TODO(#6664): make this lookup order-independent.
+    let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
+    let variant_name = response_json
+        .get("variant_name")
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_string();
+    let episode_id =
+        Uuid::parse_str(response_json.get("episode_id").unwrap().as_str().unwrap()).unwrap();
+    let function_info = FunctionInfo {
+        function_name: "json_success".to_string(),
+        function_type: FunctionType::Json,
+        variant_name,
+        episode_id,
+    };
+    let serialized_inference_output = database
+        .get_serialized_inference_output_for_feedback(&function_info, inference_id)
+        .await
+        .expect("should get inference output")
+        .expect("inference output should exist");
 
     // Create datapoint_id and evaluator_inference_id
     let datapoint_id = Uuid::now_v7();


### PR DESCRIPTION
See #6664 . Without this change, #6643 fails in Postgres on inference evaluation human feedback lookups. Postgres JSONB columns do not preserve key order, so we need to be deterministic for now since we store the output in inference evaluation tables as a serialized string.

Awful hack, I'm not happy about it, we should rethink the inference evaluation human feedback table at some point, but can't change it today.