### PR TITLE
Print observability with postgres

### DIFF
--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -3720,4 +3720,4 @@ def test_capfd_captured_warnings(capfd: CaptureFixture[str]):
     assert client is not None
     captured = capfd.readouterr()
     assert captured.err == ""
-    assert "Disabling observability:" in captured.out
+    assert "No config file provided" in captured.out

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -20,6 +20,7 @@ use durable_tools::{EmbeddedClient, WorkerOptions};
 use tensorzero_auth::constants::{DEFAULT_ORGANIZATION, DEFAULT_WORKSPACE};
 use tensorzero_core::config::{Config, ConfigFileGlob};
 use tensorzero_core::db::clickhouse::migration_manager::manual_run_clickhouse_migrations;
+use tensorzero_core::db::delegating_connection::PrimaryDatastore;
 use tensorzero_core::db::postgres::{PostgresConnectionInfo, manual_run_postgres_migrations};
 use tensorzero_core::db::valkey::ValkeyConnectionInfo;
 use tensorzero_core::endpoints::status::TENSORZERO_VERSION;
@@ -391,9 +392,15 @@ async fn run() -> Result<(), ExitCode> {
     // Print the configuration being used
     print_configuration_info(glob.as_ref());
 
-    // Print whether observability is enabled
+    // Print observability backend and ClickHouse status
+    let observability_backend = match gateway_handle.app_state.primary_datastore {
+        PrimaryDatastore::ClickHouse => "ClickHouse",
+        PrimaryDatastore::Postgres => "Postgres",
+        PrimaryDatastore::Disabled => "disabled",
+    };
+    tracing::info!("├ Observability Backend: {observability_backend}");
     tracing::info!(
-        "├ Observability (ClickHouse): {}",
+        "├ ClickHouse: {}",
         gateway_handle.app_state.clickhouse_connection_info
     );
     if config.gateway.observability.batch_writes.enabled {

--- a/tensorzero-core/src/client/mod.rs
+++ b/tensorzero-core/src/client/mod.rs
@@ -1521,7 +1521,7 @@ mod tests {
             "Missing environment variable TENSORZERO_CLICKHOUSE_URL"
         ));
         assert!(logs_contain(
-            "Disabling observability: `gateway.observability.enabled` is not explicitly specified in config and `clickhouse_url` was not provided."
+            "`gateway.observability.enabled` is not explicitly specified in config and `clickhouse_url` was not provided."
         ));
     }
 
@@ -1547,7 +1547,7 @@ mod tests {
             "No config file provided, so only default functions will be available. Set `config_file` to specify your `tensorzero.toml`"
         ));
         assert!(logs_contain(
-            "Disabling observability: `gateway.observability.enabled` is not explicitly specified in config and `clickhouse_url` was not provided."
+            "`gateway.observability.enabled` is not explicitly specified in config and `clickhouse_url` was not provided."
         ));
     }
 

--- a/tensorzero-core/src/howdy.rs
+++ b/tensorzero-core/src/howdy.rs
@@ -61,9 +61,7 @@ pub fn setup_howdy(
         return;
     }
 
-    // TODO(#5691): Support reading deployment ID when ClickHouse is disabled.
-    let clickhouse_disabled = clickhouse.client_type() == ClickHouseClientType::Disabled;
-    if clickhouse_disabled {
+    if primary_datastore == PrimaryDatastore::Disabled {
         return;
     }
     spawn_ignoring_shutdown(howdy_loop(clickhouse, postgres, primary_datastore, token));

--- a/tensorzero-core/src/utils/gateway.rs
+++ b/tensorzero-core/src/utils/gateway.rs
@@ -31,7 +31,7 @@ use crate::db::valkey::ValkeyConnectionInfo;
 use crate::endpoints;
 use crate::endpoints::openai_compatible::RouterExt;
 use crate::error::{Error, ErrorDetails};
-use crate::howdy::setup_howdy;
+use crate::howdy::{get_deployment_id, setup_howdy};
 use crate::http::TensorzeroHttpClient;
 use crate::rate_limiting::{RateLimitingConfig, RateLimitingManager};
 use autopilot_client::AutopilotClient;
@@ -370,14 +370,18 @@ impl GatewayHandle {
             cancel_token.clone(),
         );
 
-        // Fetch the deployment ID
-        let deployment_id = crate::howdy::get_deployment_id(
-            &clickhouse_connection_info,
-            &postgres_connection_info,
-            primary_datastore,
-        )
-        .await
-        .ok();
+        // Fetch the deployment ID (skip when observability is disabled since there's no datastore to query)
+        let deployment_id = if primary_datastore == PrimaryDatastore::Disabled {
+            None
+        } else {
+            get_deployment_id(
+                &clickhouse_connection_info,
+                &postgres_connection_info,
+                primary_datastore,
+            )
+            .await
+            .ok()
+        };
 
         let db = Arc::new(DelegatingDatabaseConnection::new(
             clickhouse_connection_info.clone(),
@@ -590,7 +594,7 @@ pub async fn setup_clickhouse(
         (Some(false), _) => {
             // Observability disabled by config
             tracing::info!(
-                "Disabling observability: `gateway.observability.enabled` is set to false in config."
+                "Disabling ClickHouse: `gateway.observability.enabled` is set to false in config."
             );
             ClickHouseConnectionInfo::new_disabled()
         }
@@ -616,7 +620,7 @@ pub async fn setup_clickhouse(
                 "`TENSORZERO_CLICKHOUSE_URL` is not set."
             };
             tracing::warn!(
-                "Disabling observability: `gateway.observability.enabled` is not explicitly specified in config and {msg_suffix}"
+                "Disabling ClickHouse: `gateway.observability.enabled` is not explicitly specified in config and {msg_suffix}"
             );
             ClickHouseConnectionInfo::new_disabled()
         }
@@ -1078,7 +1082,7 @@ mod tests {
             "Missing environment variable `TENSORZERO_CLICKHOUSE_URL`"
         ));
         assert!(logs_contain(
-            "Disabling observability: `gateway.observability.enabled` is not explicitly specified in config and `TENSORZERO_CLICKHOUSE_URL` is not set."
+            "`gateway.observability.enabled` is not explicitly specified in config and `TENSORZERO_CLICKHOUSE_URL` is not set."
         ));
 
         // We do not test the case where a ClickHouse URL is provided but observability is default,


### PR DESCRIPTION
This was misleadingly always printing ClickHouse before, even when Postgres is the primary.

Also stops fetching deployment ID when observability is disabled (no primary database). 

Fixes https://github.com/tensorzero/tensorzero/issues/6685.