### PR TITLE
Read evaluation run metadata from DB instead of config

### DIFF
--- a/tensorzero-core/src/db/clickhouse/episode_queries.rs
+++ b/tensorzero-core/src/db/clickhouse/episode_queries.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::config::Config;
@@ -8,7 +7,6 @@ use crate::db::clickhouse::query_builder::{ClickhouseType, JoinRegistry, QueryPa
 use crate::db::{EpisodeByIdRow, EpisodeQueries, TableBoundsWithCount};
 use crate::endpoints::stored_inferences::v1::types::InferenceFilter;
 use crate::error::{Error, ErrorDetails};
-use crate::serde_util::deserialize_u64;
 
 use super::ClickHouseConnectionInfo;
 
@@ -373,42 +371,4 @@ pub(crate) fn build_pagination_clause(
         ),
         _ => (String::new(), vec![]),
     }
-}
-
-pub(crate) fn parse_json_rows<T: serde::de::DeserializeOwned>(
-    response: &str,
-) -> Result<Vec<T>, Error> {
-    response
-        .lines()
-        .filter(|line| !line.trim().is_empty())
-        .map(|row| {
-            serde_json::from_str(row).map_err(|e| {
-                Error::new(ErrorDetails::ClickHouseDeserialization {
-                    message: format!("Failed to deserialize row: {e}"),
-                })
-            })
-        })
-        .collect()
-}
-
-pub(crate) fn parse_count(response: &str) -> Result<u64, Error> {
-    #[derive(Deserialize)]
-    struct CountResult {
-        #[serde(deserialize_with = "deserialize_u64")]
-        count: u64,
-    }
-
-    let line = response.trim().lines().next().ok_or_else(|| {
-        Error::new(ErrorDetails::ClickHouseDeserialization {
-            message: "No count result returned from database".to_string(),
-        })
-    })?;
-
-    let result: CountResult = serde_json::from_str(line).map_err(|e| {
-        Error::new(ErrorDetails::ClickHouseDeserialization {
-            message: format!("Failed to deserialize count: {e}"),
-        })
-    })?;
-
-    Ok(result.count)
 }

--- a/tensorzero-core/src/db/clickhouse/evaluation_queries.rs
+++ b/tensorzero-core/src/db/clickhouse/evaluation_queries.rs
@@ -5,9 +5,9 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use serde::Deserialize;
 
-use super::ClickHouseConnectionInfo;
-use super::episode_queries::{parse_count, parse_json_rows};
-use super::escape_string_for_clickhouse_literal;
+use super::{
+    ClickHouseConnectionInfo, escape_string_for_clickhouse_literal, parse_count, parse_json_rows,
+};
 use crate::db::evaluation_queries::EvaluationQueries;
 use crate::db::evaluation_queries::EvaluationResultRow;
 use crate::db::evaluation_queries::EvaluationRunInfoByIdRow;
@@ -16,6 +16,8 @@ use crate::db::evaluation_queries::EvaluationRunSearchResult;
 use crate::db::evaluation_queries::EvaluationStatisticsRow;
 use crate::db::evaluation_queries::InferenceEvaluationHumanFeedbackRow;
 use crate::db::evaluation_queries::InferenceEvaluationRunInsert;
+use crate::db::evaluation_queries::InferenceEvaluationRunMetadata;
+use crate::db::evaluation_queries::InferenceEvaluationRunMetricMetadata;
 use crate::db::evaluation_queries::RawEvaluationResultRow;
 use crate::endpoints::inference::InferenceResponse;
 use crate::error::{Error, ErrorDetails};
@@ -126,6 +128,84 @@ fn get_evaluation_result_datapoint_id_subquery(
 
 #[async_trait]
 impl EvaluationQueries for ClickHouseConnectionInfo {
+    async fn get_inference_evaluation_run_metadata(
+        &self,
+        evaluation_run_ids: &[uuid::Uuid],
+    ) -> Result<Vec<(uuid::Uuid, InferenceEvaluationRunMetadata)>, Error> {
+        if evaluation_run_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let run_ids_strs: Vec<String> = evaluation_run_ids
+            .iter()
+            .map(|id| format!("'{id}'"))
+            .collect();
+        let run_ids_formatted = format!("[{}]", run_ids_strs.join(","));
+
+        let query = r"
+            SELECT
+                toString(uint_to_uuid(run_id_uint)) AS run_id,
+                argMax(evaluation_name, updated_at) AS evaluation_name,
+                argMax(function_name, updated_at) AS function_name,
+                argMax(function_type, updated_at) AS function_type,
+                argMax(metrics, updated_at) AS metrics
+            FROM InferenceEvaluationRuns
+            WHERE run_id_uint IN (
+                SELECT arrayJoin(arrayMap(x -> toUInt128(toUUID(x)), {run_ids:Array(String)}))
+            )
+            GROUP BY run_id_uint
+            FORMAT JSONEachRow
+        "
+        .to_string();
+
+        let mut params = HashMap::new();
+        params.insert("run_ids", run_ids_formatted.as_str());
+
+        let response = self.run_query_synchronous(query, &params).await?;
+
+        if response.response.trim().is_empty() {
+            return Ok(Vec::new());
+        }
+
+        #[derive(Debug, Deserialize)]
+        struct RawRow {
+            run_id: String,
+            evaluation_name: String,
+            function_name: String,
+            function_type: FunctionConfigType,
+            metrics: String,
+        }
+
+        let rows: Vec<RawRow> = parse_json_rows(&response.response)?;
+        let mut results = Vec::with_capacity(rows.len());
+
+        for row in rows {
+            let run_id: uuid::Uuid = row.run_id.parse().map_err(|e| {
+                Error::new(ErrorDetails::Serialization {
+                    message: format!("Failed to parse run_id UUID: {e}"),
+                })
+            })?;
+            let metrics: Vec<InferenceEvaluationRunMetricMetadata> =
+                serde_json::from_str(&row.metrics).map_err(|e| {
+                    Error::new(ErrorDetails::Serialization {
+                        message: format!("Failed to deserialize metrics: {e}"),
+                    })
+                })?;
+
+            results.push((
+                run_id,
+                InferenceEvaluationRunMetadata {
+                    evaluation_name: row.evaluation_name,
+                    function_name: row.function_name,
+                    function_type: row.function_type,
+                    metrics,
+                },
+            ));
+        }
+
+        Ok(results)
+    }
+
     async fn insert_inference_evaluation_run(
         &self,
         run: &InferenceEvaluationRunInsert,

--- a/tensorzero-core/src/db/clickhouse/feedback.rs
+++ b/tensorzero-core/src/db/clickhouse/feedback.rs
@@ -23,9 +23,8 @@ use crate::{
 };
 
 use super::{
-    ClickHouseConnectionInfo,
-    episode_queries::{build_pagination_clause, parse_count, parse_json_rows},
-    escape_string_for_clickhouse_literal,
+    ClickHouseConnectionInfo, episode_queries::build_pagination_clause,
+    escape_string_for_clickhouse_literal, parse_count, parse_json_rows,
 };
 
 /// Raw database result for metrics with feedback (without metric_type)

--- a/tensorzero-core/src/db/clickhouse/inference_queries.rs
+++ b/tensorzero-core/src/db/clickhouse/inference_queries.rs
@@ -8,7 +8,7 @@ use crate::config::{
     Config, MetricConfig, MetricConfigLevel, MetricConfigOptimize, MetricConfigType,
 };
 use crate::db::TimeWindow;
-use crate::db::clickhouse::episode_queries::parse_count;
+use crate::db::clickhouse::parse_count;
 use crate::db::clickhouse::query_builder::parameters::add_parameter;
 use crate::db::clickhouse::query_builder::{
     ClickhouseType, JoinRegistry, OrderByTerm, OrderDirection, QueryParameter,

--- a/tensorzero-core/src/db/clickhouse/mod.rs
+++ b/tensorzero-core/src/db/clickhouse/mod.rs
@@ -16,6 +16,7 @@ use crate::db::clickhouse::clickhouse_client::DisabledClickHouseClient;
 use crate::db::clickhouse::clickhouse_client::ProductionClickHouseClient;
 use crate::error::DelayedError;
 use crate::error::{Error, ErrorDetails};
+use crate::serde_util::deserialize_u64;
 
 // Re-export for backwards compatibility.
 pub use crate::db::BatchWriterHandle;
@@ -490,6 +491,44 @@ where
 {
     let s = String::deserialize(deserializer)?;
     s.parse::<u64>().map_err(serde::de::Error::custom)
+}
+
+pub(crate) fn parse_json_rows<T: serde::de::DeserializeOwned>(
+    response: &str,
+) -> Result<Vec<T>, Error> {
+    response
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|row| {
+            serde_json::from_str(row).map_err(|e| {
+                Error::new(ErrorDetails::ClickHouseDeserialization {
+                    message: format!("Failed to deserialize row: {e}"),
+                })
+            })
+        })
+        .collect()
+}
+
+pub(crate) fn parse_count(response: &str) -> Result<u64, Error> {
+    #[derive(Deserialize)]
+    struct CountResult {
+        #[serde(deserialize_with = "deserialize_u64")]
+        count: u64,
+    }
+
+    let line = response.trim().lines().next().ok_or_else(|| {
+        Error::new(ErrorDetails::ClickHouseDeserialization {
+            message: "No count result returned from database".to_string(),
+        })
+    })?;
+
+    let result: CountResult = serde_json::from_str(line).map_err(|e| {
+        Error::new(ErrorDetails::ClickHouseDeserialization {
+            message: format!("Failed to deserialize count: {e}"),
+        })
+    })?;
+
+    Ok(result.count)
 }
 
 #[cfg(test)]

--- a/tensorzero-core/src/db/clickhouse/workflow_evaluation_queries.rs
+++ b/tensorzero-core/src/db/clickhouse/workflow_evaluation_queries.rs
@@ -5,8 +5,9 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use uuid::Uuid;
 
-use super::episode_queries::{parse_count, parse_json_rows};
-use super::{ClickHouseConnectionInfo, escape_string_for_clickhouse_literal};
+use super::{
+    ClickHouseConnectionInfo, escape_string_for_clickhouse_literal, parse_count, parse_json_rows,
+};
 use crate::config::snapshot::SnapshotHash;
 use crate::db::workflow_evaluation_queries::{
     GroupedWorkflowEvaluationRunEpisodeWithFeedbackRow, WorkflowEvaluationProjectRow,

--- a/tensorzero-core/src/db/delegating_connection.rs
+++ b/tensorzero-core/src/db/delegating_connection.rs
@@ -28,7 +28,7 @@ use crate::db::datasets::{
 use crate::db::evaluation_queries::{
     EvaluationQueries, EvaluationResultRow, EvaluationRunInfoByIdRow, EvaluationRunInfoRow,
     EvaluationRunSearchResult, EvaluationStatisticsRow, InferenceEvaluationHumanFeedbackRow,
-    InferenceEvaluationRunInsert,
+    InferenceEvaluationRunInsert, InferenceEvaluationRunMetadata,
 };
 use crate::db::feedback::{
     BooleanMetricFeedbackInsert, CommentFeedbackInsert, CumulativeFeedbackTimeSeriesPoint,
@@ -871,6 +871,15 @@ impl WorkflowEvaluationQueries for DelegatingDatabaseConnection {
 
 #[async_trait]
 impl EvaluationQueries for DelegatingDatabaseConnection {
+    async fn get_inference_evaluation_run_metadata(
+        &self,
+        evaluation_run_ids: &[Uuid],
+    ) -> Result<Vec<(Uuid, InferenceEvaluationRunMetadata)>, Error> {
+        self.get_database()
+            .get_inference_evaluation_run_metadata(evaluation_run_ids)
+            .await
+    }
+
     async fn insert_inference_evaluation_run(
         &self,
         run: &InferenceEvaluationRunInsert,

--- a/tensorzero-core/src/db/evaluation_queries.rs
+++ b/tensorzero-core/src/db/evaluation_queries.rs
@@ -68,6 +68,7 @@ impl std::fmt::Display for InferenceEvaluationRunSource {
 #[derive(Debug, Clone, PartialEq)]
 pub struct InferenceEvaluationRunInsert {
     pub run_id: Uuid,
+    /// A human-readable evaluation name.
     pub evaluation_name: String,
     pub function_name: String,
     pub function_type: FunctionConfigType,
@@ -85,6 +86,16 @@ pub struct EvaluationRunInfoByIdRow {
     pub evaluation_run_id: Uuid,
     pub variant_name: String,
     pub created_at: DateTime<Utc>,
+}
+
+/// Metadata from an inference evaluation run, used to resolve function_name and metrics
+/// from the database instead of requiring the evaluation config.
+#[derive(Debug, Clone)]
+pub struct InferenceEvaluationRunMetadata {
+    pub evaluation_name: String,
+    pub function_name: String,
+    pub function_type: FunctionConfigType,
+    pub metrics: Vec<InferenceEvaluationRunMetricMetadata>,
 }
 
 /// Database struct for deserializing evaluation statistics from ClickHouse.
@@ -337,6 +348,13 @@ impl RawEvaluationResultRow {
 #[async_trait]
 #[cfg_attr(test, automock)]
 pub trait EvaluationQueries {
+    /// Fetches metadata (function_name, function_type, metrics) for one or more inference evaluation runs.
+    /// Returns a Vec of (run_id, metadata) pairs for each found run.
+    async fn get_inference_evaluation_run_metadata(
+        &self,
+        evaluation_run_ids: &[Uuid],
+    ) -> Result<Vec<(Uuid, InferenceEvaluationRunMetadata)>, Error>;
+
     /// Inserts or updates run-level metadata for an inference evaluation run.
     async fn insert_inference_evaluation_run(
         &self,

--- a/tensorzero-core/src/db/postgres/evaluation_queries.rs
+++ b/tensorzero-core/src/db/postgres/evaluation_queries.rs
@@ -8,7 +8,8 @@ use uuid::Uuid;
 use crate::db::evaluation_queries::{
     EvaluationQueries, EvaluationResultRow, EvaluationRunInfoByIdRow, EvaluationRunInfoRow,
     EvaluationRunSearchResult, EvaluationStatisticsRow, InferenceEvaluationHumanFeedbackRow,
-    InferenceEvaluationRunInsert, RawEvaluationResultRow,
+    InferenceEvaluationRunInsert, InferenceEvaluationRunMetadata,
+    InferenceEvaluationRunMetricMetadata, RawEvaluationResultRow,
 };
 use crate::endpoints::inference::InferenceResponse;
 use crate::error::{Error, ErrorDetails};
@@ -60,6 +61,51 @@ impl RawEvaluationStatisticsRow {
 
 #[async_trait]
 impl EvaluationQueries for PostgresConnectionInfo {
+    async fn get_inference_evaluation_run_metadata(
+        &self,
+        evaluation_run_ids: &[Uuid],
+    ) -> Result<Vec<(Uuid, InferenceEvaluationRunMetadata)>, Error> {
+        if evaluation_run_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let pool = self.get_pool_result()?;
+
+        #[derive(sqlx::FromRow)]
+        struct InferenceEvaluationRunMetadataRow {
+            run_id: Uuid,
+            evaluation_name: String,
+            function_name: String,
+            function_type: FunctionConfigType,
+            metrics: sqlx::types::Json<Vec<InferenceEvaluationRunMetricMetadata>>,
+        }
+        let rows: Vec<InferenceEvaluationRunMetadataRow> = sqlx::query_as(
+            r"
+            SELECT run_id, evaluation_name, function_name, function_type, metrics
+            FROM tensorzero.inference_evaluation_runs
+            WHERE run_id = ANY($1)
+            ",
+        )
+        .bind(evaluation_run_ids)
+        .fetch_all(pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| {
+                (
+                    row.run_id,
+                    InferenceEvaluationRunMetadata {
+                        evaluation_name: row.evaluation_name,
+                        function_name: row.function_name,
+                        function_type: row.function_type,
+                        metrics: row.metrics.0,
+                    },
+                )
+            })
+            .collect())
+    }
+
     async fn insert_inference_evaluation_run(
         &self,
         run: &InferenceEvaluationRunInsert,

--- a/tensorzero-core/src/endpoints/internal/evaluations/get_evaluation_results.rs
+++ b/tensorzero-core/src/endpoints/internal/evaluations/get_evaluation_results.rs
@@ -10,13 +10,14 @@ use crate::config::Config;
 use crate::db::evaluation_queries::{EvaluationQueries, EvaluationResultRow};
 use crate::error::{Error, ErrorDetails};
 use crate::evaluations::EvaluationConfig;
+use crate::function::FunctionConfigType;
 use crate::utils::gateway::{AppState, AppStateData};
 
 /// Query parameters for getting evaluation results.
 #[derive(Debug, Deserialize)]
 pub struct GetEvaluationResultsParams {
     /// The name of the evaluation (e.g., "haiku", "entity_extraction")
-    pub evaluation_name: String,
+    pub evaluation_name: Option<String>,
     /// Comma-separated list of evaluation run UUIDs
     pub evaluation_run_ids: String,
     /// Optional datapoint ID to filter results to a specific datapoint
@@ -65,7 +66,7 @@ pub async fn get_evaluation_results_handler(
     let response = get_evaluation_results(
         &app_state.config,
         &database,
-        &params.evaluation_name,
+        params.evaluation_name.as_deref(),
         &evaluation_run_ids,
         params.datapoint_id.as_ref(),
         limit,
@@ -76,24 +77,63 @@ pub async fn get_evaluation_results_handler(
     Ok(Json(response))
 }
 
-/// Core business logic for getting paginated evaluation results.
-pub async fn get_evaluation_results(
+/// Resolved metadata needed to query evaluation results.
+struct ResolvedEvaluationMetadata {
+    function_name: String,
+    function_type: FunctionConfigType,
+    metric_names: Vec<String>,
+}
+
+/// Resolves evaluation metadata by first checking the `inference_evaluation_runs` table,
+/// then falling back to the evaluation config.
+async fn resolve_evaluation_metadata(
     config: &Config,
-    clickhouse: &impl EvaluationQueries,
-    evaluation_name: &str,
+    db: &impl EvaluationQueries,
+    evaluation_name: Option<&str>,
     evaluation_run_ids: &[Uuid],
-    datapoint_id: Option<&Uuid>,
-    limit: u32,
-    offset: u32,
-) -> Result<GetEvaluationResultsResponse, Error> {
-    // Look up the evaluation config
+) -> Result<ResolvedEvaluationMetadata, Error> {
+    // Try to read metadata from the database for all requested runs
+    if !evaluation_run_ids.is_empty() {
+        let results = db
+            .get_inference_evaluation_run_metadata(evaluation_run_ids)
+            .await?;
+        if let Some((_, first_metadata)) = results.first() {
+            let function_name = first_metadata.function_name.clone();
+            let function_type = first_metadata.function_type;
+
+            // Collect metric names from all runs (deduplicated, preserving insertion order)
+            let mut seen = std::collections::HashSet::new();
+            let mut metric_names = Vec::new();
+            for (_, metadata) in &results {
+                for m in &metadata.metrics {
+                    if seen.insert(&m.name) {
+                        metric_names.push(m.name.clone());
+                    }
+                }
+            }
+
+            return Ok(ResolvedEvaluationMetadata {
+                function_name,
+                function_type,
+                metric_names,
+            });
+        }
+    }
+
+    // Fall back to reading from config (legacy path)
+    let Some(evaluation_name) = evaluation_name else {
+        return Err(Error::new(ErrorDetails::InvalidRequest {
+            message: "Did not provide an evaluation name when resolving evaluation metadata, and run metadata is not stored."
+                .to_string(),
+        }));
+    };
+
     let evaluation_config = config.evaluations.get(evaluation_name).ok_or_else(|| {
         Error::new(ErrorDetails::InvalidRequest {
-            message: format!("Evaluation '{evaluation_name}' not found in config"),
+            message: format!("Evaluation `{evaluation_name}` not found in config"),
         })
     })?;
 
-    // Extract function_name and evaluators from the config
     let (function_name, evaluators) = match evaluation_config.as_ref() {
         EvaluationConfig::Inference(inference_config) => (
             &inference_config.function_name,
@@ -101,19 +141,13 @@ pub async fn get_evaluation_results(
         ),
     };
 
-    // Get the function config to determine the function type
     let function_config = config.functions.get(function_name).ok_or_else(|| {
         Error::new(ErrorDetails::InvalidRequest {
-            message: format!("Function '{function_name}' not found in config"),
+            message: format!("Function `{function_name}` not found in config"),
         })
     })?;
 
-    // Get function type
-    let function_type = function_config.config_type();
-
-    // Build metric names from evaluator names
-    // Format: tensorzero::evaluation_name::{evaluation_name}::evaluator_name::{evaluator_name}
-    let metric_names: Vec<String> = evaluators
+    let metric_names = evaluators
         .keys()
         .map(|evaluator_name| {
             format!(
@@ -122,13 +156,35 @@ pub async fn get_evaluation_results(
         })
         .collect();
 
-    // Query the database
-    let results = clickhouse
+    Ok(ResolvedEvaluationMetadata {
+        function_name: function_name.clone(),
+        function_type: function_config.config_type(),
+        metric_names,
+    })
+}
+
+/// Core business logic for getting paginated evaluation results.
+///
+/// Tries to read function_name and metric_names from the `inference_evaluation_runs` table first.
+/// Falls back to the evaluation config if the run metadata is not found in the database.
+pub async fn get_evaluation_results(
+    config: &Config,
+    db: &impl EvaluationQueries,
+    evaluation_name: Option<&str>,
+    evaluation_run_ids: &[Uuid],
+    datapoint_id: Option<&Uuid>,
+    limit: u32,
+    offset: u32,
+) -> Result<GetEvaluationResultsResponse, Error> {
+    let metadata =
+        resolve_evaluation_metadata(config, db, evaluation_name, evaluation_run_ids).await?;
+
+    let results = db
         .get_evaluation_results(
-            function_name,
+            &metadata.function_name,
             evaluation_run_ids,
-            function_type,
-            &metric_names,
+            metadata.function_type,
+            &metadata.metric_names,
             datapoint_id,
             limit,
             offset,
@@ -141,7 +197,10 @@ pub async fn get_evaluation_results(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::evaluation_queries::{ChatEvaluationResultRow, MockEvaluationQueries};
+    use crate::db::evaluation_queries::{
+        ChatEvaluationResultRow, InferenceEvaluationRunMetadata,
+        InferenceEvaluationRunMetricMetadata, MockEvaluationQueries,
+    };
     use crate::evaluations::{EvaluatorConfig, ExactMatchConfig, InferenceEvaluationConfig};
     use crate::function::{
         FunctionConfig, FunctionConfigChat, FunctionConfigJson, FunctionConfigType,
@@ -211,13 +270,155 @@ mod tests {
         }
     }
 
+    /// Helper to set up the mock to return empty metadata, triggering the config fallback.
+    fn mock_no_db_metadata(mock: &mut MockEvaluationQueries) {
+        mock.expect_get_inference_evaluation_run_metadata()
+            .returning(|_| Box::pin(async { Ok(Vec::new()) }));
+    }
+
+    #[tokio::test]
+    async fn test_get_evaluation_results_from_db_metadata() {
+        let config = Config::default();
+        let evaluation_run_id = Uuid::now_v7();
+
+        let mut mock_db = MockEvaluationQueries::new();
+        mock_db
+            .expect_get_inference_evaluation_run_metadata()
+            .withf(move |ids| ids == [evaluation_run_id])
+            .times(1)
+            .returning(move |ids| {
+                let run_id = ids[0];
+                Box::pin(async move {
+                    Ok(vec![(
+                        run_id,
+                        InferenceEvaluationRunMetadata {
+                            evaluation_name: "db_eval".to_string(),
+                            function_name: "db_function".to_string(),
+                            function_type: FunctionConfigType::Chat,
+                            metrics: vec![InferenceEvaluationRunMetricMetadata {
+                                name: "metric_from_db".to_string(),
+                                evaluator_name: Some("my_evaluator".to_string()),
+                                value_type: "boolean".to_string(),
+                                optimize: None,
+                            }],
+                        },
+                    )])
+                })
+            });
+        mock_db
+            .expect_get_evaluation_results()
+            .withf(
+                move |fn_name, _run_ids, fn_type, metrics, _dp_id, _limit, _offset| {
+                    fn_name == "db_function"
+                        && *fn_type == FunctionConfigType::Chat
+                        && metrics == ["metric_from_db"]
+                },
+            )
+            .times(1)
+            .returning(|_, _, _, _, _, _, _| Box::pin(async { Ok(vec![]) }));
+
+        let result =
+            get_evaluation_results(&config, &mock_db, None, &[evaluation_run_id], None, 100, 0)
+                .await
+                .unwrap();
+
+        assert_eq!(result.results.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_get_evaluation_results_merges_metrics_across_runs() {
+        let config = Config::default();
+        let run_id_1 = Uuid::now_v7();
+        let run_id_2 = Uuid::now_v7();
+
+        let mut mock_db = MockEvaluationQueries::new();
+        mock_db
+            .expect_get_inference_evaluation_run_metadata()
+            .withf(move |ids| ids.len() == 2 && ids.contains(&run_id_1) && ids.contains(&run_id_2))
+            .times(1)
+            .returning(move |_| {
+                Box::pin(async move {
+                    Ok(vec![
+                        (
+                            run_id_1,
+                            InferenceEvaluationRunMetadata {
+                                evaluation_name: "eval".to_string(),
+                                function_name: "my_function".to_string(),
+                                function_type: FunctionConfigType::Chat,
+                                metrics: vec![
+                                    InferenceEvaluationRunMetricMetadata {
+                                        name: "metric_a".to_string(),
+                                        evaluator_name: Some("eval_a".to_string()),
+                                        value_type: "boolean".to_string(),
+                                        optimize: None,
+                                    },
+                                    InferenceEvaluationRunMetricMetadata {
+                                        name: "metric_shared".to_string(),
+                                        evaluator_name: Some("eval_shared".to_string()),
+                                        value_type: "float".to_string(),
+                                        optimize: None,
+                                    },
+                                ],
+                            },
+                        ),
+                        (
+                            run_id_2,
+                            InferenceEvaluationRunMetadata {
+                                evaluation_name: "eval".to_string(),
+                                function_name: "my_function".to_string(),
+                                function_type: FunctionConfigType::Chat,
+                                metrics: vec![
+                                    InferenceEvaluationRunMetricMetadata {
+                                        name: "metric_shared".to_string(),
+                                        evaluator_name: Some("eval_shared".to_string()),
+                                        value_type: "float".to_string(),
+                                        optimize: None,
+                                    },
+                                    InferenceEvaluationRunMetricMetadata {
+                                        name: "metric_b".to_string(),
+                                        evaluator_name: Some("eval_b".to_string()),
+                                        value_type: "boolean".to_string(),
+                                        optimize: None,
+                                    },
+                                ],
+                            },
+                        ),
+                    ])
+                })
+            });
+        mock_db
+            .expect_get_evaluation_results()
+            .withf(
+                move |fn_name, run_ids, fn_type, metrics, _dp_id, _limit, _offset| {
+                    fn_name == "my_function"
+                    && run_ids.len() == 2
+                    && *fn_type == FunctionConfigType::Chat
+                    // All three unique metrics should be present (deduplicated)
+                    && metrics.len() == 3
+                    && metrics.contains(&"metric_a".to_string())
+                    && metrics.contains(&"metric_shared".to_string())
+                    && metrics.contains(&"metric_b".to_string())
+                },
+            )
+            .times(1)
+            .returning(|_, _, _, _, _, _, _| Box::pin(async { Ok(vec![]) }));
+
+        let result =
+            get_evaluation_results(&config, &mock_db, None, &[run_id_1, run_id_2], None, 100, 0)
+                .await
+                .unwrap();
+
+        assert_eq!(result.results.len(), 0);
+    }
+
     #[tokio::test]
     async fn test_get_evaluation_results_chat_function() {
         let config = create_test_config_with_chat_function();
         let evaluation_run_id = Uuid::now_v7();
 
-        let mut mock_clickhouse = MockEvaluationQueries::new();
-        mock_clickhouse
+        let mut mock_db = MockEvaluationQueries::new();
+        mock_no_db_metadata(&mut mock_db);
+        mock_db
             .expect_get_evaluation_results()
             .withf(
                 move |fn_name, run_ids, fn_type, metrics, dp_id, limit, offset| {
@@ -263,8 +464,8 @@ mod tests {
 
         let result = get_evaluation_results(
             &config,
-            &mock_clickhouse,
-            "test_eval",
+            &mock_db,
+            Some("test_eval"),
             &[evaluation_run_id],
             None,
             100,
@@ -287,8 +488,9 @@ mod tests {
         let config = create_test_config_with_json_function();
         let evaluation_run_id = Uuid::now_v7();
 
-        let mut mock_clickhouse = MockEvaluationQueries::new();
-        mock_clickhouse
+        let mut mock_db = MockEvaluationQueries::new();
+        mock_no_db_metadata(&mut mock_db);
+        mock_db
             .expect_get_evaluation_results()
             .withf(
                 |_fn_name, _run_ids, fn_type, _metrics, _dp_id, _limit, _offset| {
@@ -300,8 +502,8 @@ mod tests {
 
         let result = get_evaluation_results(
             &config,
-            &mock_clickhouse,
-            "test_eval",
+            &mock_db,
+            Some("test_eval"),
             &[evaluation_run_id],
             None,
             100,
@@ -316,12 +518,13 @@ mod tests {
     #[tokio::test]
     async fn test_get_evaluation_results_evaluation_not_found() {
         let config = create_test_config_with_chat_function();
-        let mock_clickhouse = MockEvaluationQueries::new();
+        let mut mock_db = MockEvaluationQueries::new();
+        mock_no_db_metadata(&mut mock_db);
 
         let result = get_evaluation_results(
             &config,
-            &mock_clickhouse,
-            "nonexistent_eval",
+            &mock_db,
+            Some("nonexistent_eval"),
             &[Uuid::now_v7()],
             None,
             100,
@@ -357,12 +560,13 @@ mod tests {
             ..Default::default()
         };
 
-        let mock_clickhouse = MockEvaluationQueries::new();
+        let mut mock_db = MockEvaluationQueries::new();
+        mock_no_db_metadata(&mut mock_db);
 
         let result = get_evaluation_results(
             &config,
-            &mock_clickhouse,
-            "test_eval",
+            &mock_db,
+            Some("test_eval"),
             &[Uuid::now_v7()],
             None,
             100,
@@ -381,8 +585,9 @@ mod tests {
         let config = create_test_config_with_chat_function();
         let evaluation_run_id = Uuid::now_v7();
 
-        let mut mock_clickhouse = MockEvaluationQueries::new();
-        mock_clickhouse
+        let mut mock_db = MockEvaluationQueries::new();
+        mock_no_db_metadata(&mut mock_db);
+        mock_db
             .expect_get_evaluation_results()
             .withf(
                 |_fn_name, _run_ids, _fn_type, _metrics, _dp_id, limit, offset| {
@@ -394,8 +599,8 @@ mod tests {
 
         let result = get_evaluation_results(
             &config,
-            &mock_clickhouse,
-            "test_eval",
+            &mock_db,
+            Some("test_eval"),
             &[evaluation_run_id],
             None,
             50,
@@ -439,8 +644,9 @@ mod tests {
             ..Default::default()
         };
 
-        let mut mock_clickhouse = MockEvaluationQueries::new();
-        mock_clickhouse
+        let mut mock_db = MockEvaluationQueries::new();
+        mock_no_db_metadata(&mut mock_db);
+        mock_db
             .expect_get_evaluation_results()
             .withf(
                 |_fn_name, _run_ids, _fn_type, metrics, _dp_id, _limit, _offset| {
@@ -453,8 +659,8 @@ mod tests {
 
         let result = get_evaluation_results(
             &config,
-            &mock_clickhouse,
-            "test_eval",
+            &mock_db,
+            Some("test_eval"),
             &[Uuid::now_v7()],
             None,
             100,
@@ -472,8 +678,9 @@ mod tests {
         let evaluation_run_id = Uuid::now_v7();
         let datapoint_id = Uuid::now_v7();
 
-        let mut mock_clickhouse = MockEvaluationQueries::new();
-        mock_clickhouse
+        let mut mock_db = MockEvaluationQueries::new();
+        mock_no_db_metadata(&mut mock_db);
+        mock_db
             .expect_get_evaluation_results()
             .withf(
                 move |_fn_name, _run_ids, _fn_type, _metrics, dp_id, _limit, _offset| {
@@ -509,8 +716,8 @@ mod tests {
 
         let result = get_evaluation_results(
             &config,
-            &mock_clickhouse,
-            "test_eval",
+            &mock_db,
+            Some("test_eval"),
             &[evaluation_run_id],
             Some(&datapoint_id),
             u32::MAX,

--- a/tensorzero-core/src/function/function_config.rs
+++ b/tensorzero-core/src/function/function_config.rs
@@ -22,7 +22,7 @@ use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::{PyKeyError, PyValueError};
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
@@ -85,7 +85,9 @@ impl std::fmt::Display for FunctionConfigJsonPyClass {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Deserialize, sqlx::Type)]
+#[serde(rename_all = "snake_case")]
+#[sqlx(type_name = "text", rename_all = "snake_case")]
 #[cfg_attr(feature = "pyo3", pyclass)]
 pub enum FunctionConfigType {
     Chat,

--- a/tensorzero-core/tests/e2e/db/evaluation_queries.rs
+++ b/tensorzero-core/tests/e2e/db/evaluation_queries.rs
@@ -96,6 +96,70 @@ async fn test_insert_inference_evaluation_run(conn: impl EvaluationQueries + Tes
 make_db_test!(test_insert_inference_evaluation_run);
 
 // ============================================================================
+// get_inference_evaluation_run_metadata tests
+// ============================================================================
+
+/// Test that `get_inference_evaluation_run_metadata` returns the correct metadata
+/// after inserting a run.
+async fn test_get_inference_evaluation_run_metadata(
+    conn: impl EvaluationQueries + TestDatabaseHelpers,
+) {
+    let run = make_test_inference_evaluation_run(Uuid::now_v7());
+
+    conn.insert_inference_evaluation_run(&run)
+        .await
+        .expect("insert should succeed");
+    conn.sleep_for_writes_to_be_visible().await;
+
+    let results = conn
+        .get_inference_evaluation_run_metadata(&[run.run_id])
+        .await
+        .expect("get_inference_evaluation_run_metadata should succeed");
+    assert_eq!(results.len(), 1, "should return one result");
+    let (returned_run_id, metadata) = &results[0];
+    assert_eq!(*returned_run_id, run.run_id, "run_id should match");
+
+    assert_eq!(
+        metadata.evaluation_name, run.evaluation_name,
+        "evaluation_name should match"
+    );
+    assert_eq!(
+        metadata.function_name, run.function_name,
+        "function_name should match"
+    );
+    assert_eq!(
+        metadata.function_type,
+        FunctionConfigType::Chat,
+        "function_type should match"
+    );
+    assert_eq!(metadata.metrics.len(), 2, "should have two metric entries");
+
+    // Verify full metric details (order may differ, so sort by name)
+    let mut actual_metrics = metadata.metrics.clone();
+    actual_metrics.sort_by(|a, b| a.name.cmp(&b.name));
+    let mut expected_metrics = run.metrics.clone();
+    expected_metrics.sort_by(|a, b| a.name.cmp(&b.name));
+    assert_eq!(actual_metrics, expected_metrics, "metrics should match");
+}
+make_db_test!(test_get_inference_evaluation_run_metadata);
+
+/// Test that `get_inference_evaluation_run_metadata` returns empty for a nonexistent run.
+async fn test_get_inference_evaluation_run_metadata_not_found(
+    conn: impl EvaluationQueries + TestDatabaseHelpers,
+) {
+    let results = conn
+        .get_inference_evaluation_run_metadata(&[Uuid::now_v7()])
+        .await
+        .expect("query should succeed even for nonexistent run");
+
+    assert!(
+        results.is_empty(),
+        "should return empty for nonexistent run"
+    );
+}
+make_db_test!(test_get_inference_evaluation_run_metadata_not_found);
+
+// ============================================================================
 // get_evaluation_run_infos tests
 // ============================================================================
 

--- a/tensorzero-core/tests/e2e/endpoints/internal/evaluations.rs
+++ b/tensorzero-core/tests/e2e/endpoints/internal/evaluations.rs
@@ -642,7 +642,10 @@ async fn test_get_evaluation_results_pagination() {
 async fn test_get_evaluation_results_evaluation_not_found() {
     let http_client = Client::new();
 
-    let evaluation_run_id = "01963691-9d3c-7793-a8be-3937ebb849c1";
+    // Use a run ID that does NOT exist in InferenceEvaluationRuns so that
+    // resolve_evaluation_metadata falls back to the config path (where the
+    // nonexistent evaluation name triggers an error).
+    let evaluation_run_id = "00000000-0000-0000-0000-000000000000";
 
     let url = get_gateway_endpoint("/internal/evaluations/results").to_string()
         + &format!(


### PR DESCRIPTION
A step towards support running evaluations without a named evaluation in the config. (#6557 and #6676)

Since the 2026.3.0 release we start writing evaluation run metadata into the database. This starts to consume it when we try to render evaluation runs.

Look up function_name, function_type, and metric_names from the inference_evaluation_runs table when loading evaluation results. Falls back to reading from the evaluation config if the run metadata is not found in the database (but ideally at some point we backfill and remove the config path).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the metadata source for evaluation result queries (preferring DB-stored run metadata over config), which can alter which function/metrics are queried and may surface differences when run records are missing or inconsistent. Also adds new cross-DB query methods and ClickHouse parsing utilities, affecting multiple backends.
> 
> **Overview**
> Evaluation results fetching now **prefers run metadata stored in the DB** (function name/type and metric list) via a new `EvaluationQueries::get_inference_evaluation_run_metadata` method implemented for both ClickHouse and Postgres, and plumbed through `DelegatingDatabaseConnection`.
> 
> The `/internal/evaluations/results` endpoint makes `evaluation_name` optional and introduces a resolver that merges/dedupes metric names across requested runs; it falls back to config lookup only when DB metadata is absent (erroring if no name is provided). ClickHouse helpers `parse_json_rows`/`parse_count` were centralized in `db/clickhouse/mod.rs`, and `FunctionConfigType` was updated to support DB deserialization (`Deserialize`/`sqlx::Type`), with unit/e2e tests updated to cover the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b04163e656fb8ea5f81163955ebd36b40298b03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->