### PR TITLE
Start deprecating patch_openai_client

### DIFF
--- a/clients/python/tensorzero/__init__.py
+++ b/clients/python/tensorzero/__init__.py
@@ -392,6 +392,11 @@ def close_patched_openai_client_gateway(client: t.Any) -> None:
         )
 
 
+@deprecated(
+    "`patch_openai_client` will be removed in a future release (2026.6+). "
+    "Please deploy a standalone TensorZero Gateway and point to it using `base_url`. "
+    "See https://www.tensorzero.com/docs/deployment/tensorzero-gateway for more information."
+)
 def patch_openai_client(
     client: T,
     *,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a metadata/API signaling change that adds a deprecation warning without altering runtime behavior, but it may surface new warnings for existing users/tests calling `patch_openai_client`.
> 
> **Overview**
> `patch_openai_client` is now explicitly annotated with `typing_extensions.deprecated`, warning that it will be removed in `2026.6+` and directing users to run a standalone TensorZero Gateway and configure clients via `base_url` (with docs link).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b26f270f449a9112b79d6bacfc47a225900b899. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->