### PR TITLE
Support cutoff in python client

### DIFF
--- a/clients/python/src/evaluation_handlers.rs
+++ b/clients/python/src/evaluation_handlers.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use evaluations::{
-    OutputFormat, RunInfo,
+    OutputFormat, RunInfo, check_evaluator_cutoffs, format_cutoff_failures,
+    resolve_effective_cutoffs,
     stats::{EvaluationError, EvaluationInfo, EvaluationStats, EvaluationUpdate},
 };
 use pyo3::{
@@ -48,6 +50,54 @@ fn compute_evaluation_stats(
     serialize_to_dict(py, &computed_stats)
 }
 
+/// Shared implementation for checking cutoffs on evaluation results.
+///
+/// This mirrors the CLI's cutoff checking logic:
+/// 1. Compute stats from collected evaluation results
+/// 2. Resolve effective cutoffs (merging provided cutoffs with any config-level cutoffs)
+/// 3. Check if stats meet the cutoff thresholds
+fn check_cutoffs_impl(
+    _py: Python<'_>,
+    evaluation_infos: &Arc<Mutex<Vec<EvaluationInfo>>>,
+    evaluation_errors: &Arc<Mutex<Vec<EvaluationError>>>,
+    evaluation_config: &Arc<EvaluationConfig>,
+    cutoffs: &HashMap<String, f32>,
+) -> PyResult<()> {
+    if cutoffs.is_empty() {
+        return Ok(());
+    }
+
+    let infos = evaluation_infos.blocking_lock().clone();
+    let errors = evaluation_errors.blocking_lock().clone();
+
+    let EvaluationConfig::Inference(inference_config) = &**evaluation_config;
+
+    let stats_obj = EvaluationStats {
+        output_format: OutputFormat::Jsonl,
+        evaluation_infos: infos,
+        evaluation_errors: errors,
+        progress_bar: None,
+    };
+    let stats = stats_obj.compute_stats(&inference_config.evaluators);
+
+    let effective_cutoffs = resolve_effective_cutoffs(&inference_config.evaluators, cutoffs)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid cutoffs: {e}")))?;
+
+    let failures =
+        check_evaluator_cutoffs(&stats, &inference_config.evaluators, &effective_cutoffs).map_err(
+            |e| pyo3::exceptions::PyRuntimeError::new_err(format!("Error checking cutoffs: {e}")),
+        )?;
+
+    if !failures.is_empty() {
+        let failure_messages = format_cutoff_failures(&failures);
+        return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+            "Failed cutoffs for evaluators:\n{failure_messages}"
+        )));
+    }
+
+    Ok(())
+}
+
 /// Job handler for streaming evaluation results (synchronous)
 #[pyclass(frozen, str)]
 pub struct EvaluationJobHandler {
@@ -56,6 +106,7 @@ pub struct EvaluationJobHandler {
     pub(crate) evaluation_config: Arc<EvaluationConfig>,
     pub(crate) evaluation_infos: Arc<Mutex<Vec<EvaluationInfo>>>,
     pub(crate) evaluation_errors: Arc<Mutex<Vec<EvaluationError>>>,
+    pub(crate) cutoffs: HashMap<String, f32>,
 }
 
 #[pymethods]
@@ -121,6 +172,20 @@ impl EvaluationJobHandler {
         })
     }
 
+    /// Check if evaluator results meet the cutoff thresholds.
+    ///
+    /// Must be called after consuming all results (via iteration).
+    /// Raises `RuntimeError` if any evaluator fails its cutoff threshold.
+    fn check_cutoffs(&self, py: Python<'_>) -> PyResult<()> {
+        check_cutoffs_impl(
+            py,
+            &self.evaluation_infos,
+            &self.evaluation_errors,
+            &self.evaluation_config,
+            &self.cutoffs,
+        )
+    }
+
     fn __repr__(&self) -> PyResult<String> {
         serde_json::to_string_pretty(&self.run_info).map_err(|e| {
             pyo3::exceptions::PyRuntimeError::new_err(format!("Serialization error: {e}"))
@@ -143,6 +208,7 @@ pub struct AsyncEvaluationJobHandler {
     pub(crate) evaluation_config: Arc<EvaluationConfig>,
     pub(crate) evaluation_infos: Arc<Mutex<Vec<EvaluationInfo>>>,
     pub(crate) evaluation_errors: Arc<Mutex<Vec<EvaluationError>>>,
+    pub(crate) cutoffs: HashMap<String, f32>,
 }
 
 #[pymethods]
@@ -203,6 +269,30 @@ impl AsyncEvaluationJobHandler {
             let infos = evaluation_infos.lock().await.clone();
             let errors = evaluation_errors.lock().await.clone();
             Python::attach(|py| compute_evaluation_stats(py, infos, errors, evaluation_config))
+        })
+    }
+
+    /// Check if evaluator results meet the cutoff thresholds.
+    ///
+    /// Must be called after consuming all results (via iteration).
+    /// Raises `RuntimeError` if any evaluator fails its cutoff threshold.
+    fn check_cutoffs<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let evaluation_infos = self.evaluation_infos.clone();
+        let evaluation_errors = self.evaluation_errors.clone();
+        let evaluation_config = self.evaluation_config.clone();
+        let cutoffs = self.cutoffs.clone();
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            Python::attach(|py| {
+                check_cutoffs_impl(
+                    py,
+                    &evaluation_infos,
+                    &evaluation_errors,
+                    &evaluation_config,
+                    &cutoffs,
+                )
+                .map(|()| py.None())
+            })
         })
     }
 

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -576,6 +576,28 @@ impl BaseTensorZeroGateway {
     }
 }
 
+/// Parse an optional Python `Dict[str, float]` into a `HashMap<String, f32>`.
+fn parse_float_dict(
+    _py: Python<'_>,
+    dict: Option<&Bound<'_, PyDict>>,
+) -> PyResult<HashMap<String, f32>> {
+    let Some(dict) = dict else {
+        return Ok(HashMap::new());
+    };
+    let mut map = HashMap::new();
+    for (key, value) in dict.iter() {
+        let key_str: String = key.extract()?;
+        let value_f64: f64 = value.extract()?;
+        if value_f64 < 0.0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "Cutoff value for `{key_str}` must be non-negative, got {value_f64}"
+            )));
+        }
+        map.insert(key_str, value_f64 as f32);
+    }
+    Ok(map)
+}
+
 /// Helper function to construct an EvaluationVariant from the optional variant_name and internal_dynamic_variant_config parameters.
 /// Deserializes the internal_dynamic_variant_config if provided and validates that exactly one of the two is provided.
 fn construct_evaluation_variant(
@@ -1269,6 +1291,9 @@ impl TensorZeroGateway {
     ///                         Evaluation for a given evaluator stops when it achieves its precision target,
     ///                         i.e. the width of the larger of the two halves of its confidence interval
     ///                         is <= the precision target.
+    /// * `cutoffs` - Optional per-evaluator cutoff thresholds for pass/fail.
+    ///               Example: `{"exact_match": 0.95, "llm_judge": 0.8}`
+    ///               After consuming all results, call `handler.check_cutoffs()` to verify.
     #[pyo3(signature = (*,
                         evaluation_name,
                         dataset_name=None,
@@ -1278,9 +1303,10 @@ impl TensorZeroGateway {
                         inference_cache="on".to_string(),
                         internal_dynamic_variant_config=None,
                         max_datapoints=None,
-                        adaptive_stopping=None
+                        adaptive_stopping=None,
+                        cutoffs=None
     ),
-    text_signature = "(self, *, evaluation_name, dataset_name=None, datapoint_ids=None, variant_name=None, concurrency=1, inference_cache='on', internal_dynamic_variant_config=None, max_datapoints=None, adaptive_stopping=None)"
+    text_signature = "(self, *, evaluation_name, dataset_name=None, datapoint_ids=None, variant_name=None, concurrency=1, inference_cache='on', internal_dynamic_variant_config=None, max_datapoints=None, adaptive_stopping=None, cutoffs=None)"
     )]
     #[expect(clippy::too_many_arguments)]
     fn experimental_run_evaluation(
@@ -1294,6 +1320,7 @@ impl TensorZeroGateway {
         internal_dynamic_variant_config: Option<&Bound<'_, PyDict>>,
         max_datapoints: Option<u32>,
         adaptive_stopping: Option<&Bound<'_, PyDict>>,
+        cutoffs: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<EvaluationJobHandler> {
         let client = this.as_super().client.clone();
 
@@ -1336,6 +1363,9 @@ impl TensorZeroGateway {
         } else {
             HashMap::new()
         };
+
+        // Parse cutoffs from Python dict
+        let cutoffs_map = parse_float_dict(this.py(), cutoffs)?;
 
         // Parse datapoint_ids from strings to UUIDs (keeping as Option)
         let datapoint_ids: Option<Vec<Uuid>> = datapoint_ids
@@ -1405,6 +1435,7 @@ impl TensorZeroGateway {
             evaluation_config: result.evaluation_config,
             evaluation_infos: Arc::new(Mutex::new(Vec::new())),
             evaluation_errors: Arc::new(Mutex::new(Vec::new())),
+            cutoffs: cutoffs_map,
         })
     }
 
@@ -2447,6 +2478,9 @@ impl AsyncTensorZeroGateway {
     ///                         Evaluation for a given evaluator stops when it achieves its precision target,
     ///                         i.e. the width of the larger of the two halves of its confidence interval
     ///                         is <= the precision target.
+    /// * `cutoffs` - Optional per-evaluator cutoff thresholds for pass/fail.
+    ///               Example: `{"exact_match": 0.95, "llm_judge": 0.8}`
+    ///               After consuming all results, call `handler.check_cutoffs()` to verify.
     #[pyo3(signature = (*,
                         evaluation_name,
                         dataset_name=None,
@@ -2456,9 +2490,10 @@ impl AsyncTensorZeroGateway {
                         inference_cache="on".to_string(),
                         internal_dynamic_variant_config=None,
                         max_datapoints=None,
-                        adaptive_stopping=None
+                        adaptive_stopping=None,
+                        cutoffs=None
     ),
-    text_signature = "(self, *, evaluation_name, dataset_name=None, datapoint_ids=None, variant_name=None, concurrency=1, inference_cache='on', internal_dynamic_variant_config=None, max_datapoints=None, adaptive_stopping=None)"
+    text_signature = "(self, *, evaluation_name, dataset_name=None, datapoint_ids=None, variant_name=None, concurrency=1, inference_cache='on', internal_dynamic_variant_config=None, max_datapoints=None, adaptive_stopping=None, cutoffs=None)"
     )]
     #[expect(clippy::too_many_arguments)]
     fn experimental_run_evaluation<'py>(
@@ -2472,6 +2507,7 @@ impl AsyncTensorZeroGateway {
         internal_dynamic_variant_config: Option<&Bound<'py, PyDict>>,
         max_datapoints: Option<u32>,
         adaptive_stopping: Option<&Bound<'py, PyDict>>,
+        cutoffs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = this.as_super().client.clone();
 
@@ -2507,6 +2543,9 @@ impl AsyncTensorZeroGateway {
         } else {
             HashMap::new()
         };
+
+        // Parse cutoffs from Python dict
+        let cutoffs_map = parse_float_dict(this.py(), cutoffs)?;
 
         // Parse datapoint_ids from strings to UUIDs
         let datapoint_ids: Option<Vec<Uuid>> = datapoint_ids
@@ -2584,6 +2623,7 @@ impl AsyncTensorZeroGateway {
                     evaluation_config: result.evaluation_config,
                     evaluation_infos: Arc::new(Mutex::new(Vec::new())),
                     evaluation_errors: Arc::new(Mutex::new(Vec::new())),
+                    cutoffs: cutoffs_map,
                 };
                 Py::new(py, handler).map(Py::into_any)
             })

--- a/clients/python/tensorzero/tensorzero.pyi
+++ b/clients/python/tensorzero/tensorzero.pyi
@@ -112,6 +112,16 @@ class EvaluationJobHandler:
         """
         ...
 
+    def check_cutoffs(self) -> None:
+        """
+        Check if evaluator results meet the cutoff thresholds.
+
+        Must be called after consuming all results (via iteration).
+        Raises RuntimeError if any evaluator fails its cutoff threshold.
+        Only meaningful if cutoffs were provided to experimental_run_evaluation().
+        """
+        ...
+
     def __repr__(self) -> str: ...
 
 @final
@@ -153,6 +163,16 @@ class AsyncEvaluationJobHandler:
         Uses cached results collected during iteration.
         Returns dict mapping evaluator names to
         {"mean": float, "stderr": float, "count": int}.
+        """
+        ...
+
+    async def check_cutoffs(self) -> None:
+        """
+        Check if evaluator results meet the cutoff thresholds.
+
+        Must be called after consuming all results (via iteration).
+        Raises RuntimeError if any evaluator fails its cutoff threshold.
+        Only meaningful if cutoffs were provided to experimental_run_evaluation().
         """
         ...
 
@@ -935,6 +955,7 @@ class TensorZeroGateway(BaseTensorZeroGateway):
         internal_dynamic_variant_config: Optional[Dict[str, Any]] = None,
         max_datapoints: Optional[int] = None,
         adaptive_stopping: Optional[Dict[str, Dict[str, float]]] = None,
+        cutoffs: Optional[Dict[str, float]] = None,
     ) -> EvaluationJobHandler:
         """
         Run an evaluation for a specific variant on a dataset or specific datapoints.
@@ -949,6 +970,7 @@ class TensorZeroGateway(BaseTensorZeroGateway):
         :param internal_dynamic_variant_config: Optional dynamic variant configuration [INTERNAL: This field is unstable and may change without notice.]
         :param max_datapoints: Maximum number of datapoints to evaluate from the dataset
         :param adaptive_stopping: Optional dict configuring adaptive stopping behavior. Example: {"precision": {"exact_match": 0.2, "llm_judge": 0.15}}. The "precision" field maps evaluator names to CI half-width thresholds.
+        :param cutoffs: Optional per-evaluator cutoff thresholds for pass/fail. Example: {"exact_match": 0.95, "llm_judge": 0.8}. After consuming all results, call handler.check_cutoffs() to verify.
         :return: An EvaluationJobHandler for iterating over evaluation results
         """
         ...
@@ -1454,6 +1476,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         internal_dynamic_variant_config: Optional[Dict[str, Any]] = None,
         max_datapoints: Optional[int] = None,
         adaptive_stopping: Optional[Dict[str, Dict[str, float]]] = None,
+        cutoffs: Optional[Dict[str, float]] = None,
     ) -> AsyncEvaluationJobHandler:
         """
         Run an evaluation for a specific variant on a dataset or specific datapoints.
@@ -1468,6 +1491,7 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         :param internal_dynamic_variant_config: Optional dynamic variant configuration [INTERNAL: This field is unstable and may change without notice.]
         :param max_datapoints: Maximum number of datapoints to evaluate from the dataset
         :param adaptive_stopping: Optional dict configuring adaptive stopping behavior. Example: {"precision": {"exact_match": 0.2, "llm_judge": 0.15}}. The "precision" field maps evaluator names to CI half-width thresholds.
+        :param cutoffs: Optional per-evaluator cutoff thresholds for pass/fail. Example: {"exact_match": 0.95, "llm_judge": 0.8}. After consuming all results, call handler.check_cutoffs() to verify.
         :return: An AsyncEvaluationJobHandler for iterating over evaluation results
         """
         ...

--- a/clients/python/tests/test_evaluation.py
+++ b/clients/python/tests/test_evaluation.py
@@ -720,6 +720,176 @@ async def test_async_run_evaluation_neither_dataset_nor_datapoint_ids_error(
         )
 
 
+# TESTS FOR CUTOFFS PARAMETER
+
+
+def test_sync_cutoffs_negative_value_error(
+    embedded_sync_client: TensorZeroGateway,
+    evaluation_datasets: Dict[str, str],
+):
+    """Test that negative cutoff values are rejected at parse time."""
+    with pytest.raises(ValueError, match="non-negative"):
+        embedded_sync_client.experimental_run_evaluation(
+            evaluation_name="entity_extraction",
+            dataset_name=evaluation_datasets["extract_entities_0.8"],
+            variant_name="gpt_4o_mini",
+            concurrency=1,
+            inference_cache="on",
+            cutoffs={"exact_match": -0.5},
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_cutoffs_negative_value_error(
+    embedded_async_client: AsyncTensorZeroGateway,
+    evaluation_datasets: Dict[str, str],
+):
+    """Test that negative cutoff values are rejected at parse time (async)."""
+    with pytest.raises(ValueError, match="non-negative"):
+        await embedded_async_client.experimental_run_evaluation(
+            evaluation_name="entity_extraction",
+            dataset_name=evaluation_datasets["extract_entities_0.8"],
+            variant_name="gpt_4o_mini",
+            concurrency=1,
+            inference_cache="on",
+            cutoffs={"exact_match": -0.5},
+        )
+
+
+def test_sync_cutoffs_unknown_evaluator_error(
+    embedded_sync_client: TensorZeroGateway,
+    evaluation_datasets: Dict[str, str],
+):
+    """Test that check_cutoffs raises for unknown evaluator names."""
+    job = embedded_sync_client.experimental_run_evaluation(
+        evaluation_name="entity_extraction",
+        dataset_name=evaluation_datasets["extract_entities_0.8"],
+        variant_name="gpt_4o_mini",
+        concurrency=1,
+        inference_cache="on",
+        cutoffs={"nonexistent_evaluator": 0.5},
+    )
+
+    # Consume all results
+    for _ in job.results():
+        pass
+
+    with pytest.raises(ValueError, match="nonexistent_evaluator"):
+        job.check_cutoffs()
+
+
+@pytest.mark.asyncio
+async def test_async_cutoffs_unknown_evaluator_error(
+    embedded_async_client: AsyncTensorZeroGateway,
+    evaluation_datasets: Dict[str, str],
+):
+    """Test that check_cutoffs raises for unknown evaluator names (async)."""
+    job = await embedded_async_client.experimental_run_evaluation(
+        evaluation_name="entity_extraction",
+        dataset_name=evaluation_datasets["extract_entities_0.8"],
+        variant_name="gpt_4o_mini",
+        concurrency=1,
+        inference_cache="on",
+        cutoffs={"nonexistent_evaluator": 0.5},
+    )
+
+    # Consume all results
+    async for _ in job.results():
+        pass
+
+    with pytest.raises(ValueError, match="nonexistent_evaluator"):
+        await job.check_cutoffs()
+
+
+def test_sync_cutoffs_passing(
+    embedded_sync_client: TensorZeroGateway,
+    evaluation_datasets: Dict[str, str],
+):
+    """Test that check_cutoffs succeeds when the evaluator meets the threshold.
+
+    count_sports mean is ~0.50, so a cutoff of 0.01 should pass.
+    """
+    job = embedded_sync_client.experimental_run_evaluation(
+        evaluation_name="entity_extraction",
+        dataset_name=evaluation_datasets["extract_entities_0.8"],
+        variant_name="gpt_4o_mini",
+        concurrency=1,
+        inference_cache="on",
+        cutoffs={"count_sports": 0.01},
+    )
+
+    for _ in job.results():
+        pass
+
+    # Should not raise
+    job.check_cutoffs()
+
+
+def test_sync_cutoffs_failing(
+    embedded_sync_client: TensorZeroGateway,
+    evaluation_datasets: Dict[str, str],
+):
+    """Test that check_cutoffs raises when the evaluator fails the threshold.
+
+    count_sports mean is ~0.50, so a cutoff of 0.99 should fail.
+    """
+    job = embedded_sync_client.experimental_run_evaluation(
+        evaluation_name="entity_extraction",
+        dataset_name=evaluation_datasets["extract_entities_0.8"],
+        variant_name="gpt_4o_mini",
+        concurrency=1,
+        inference_cache="on",
+        cutoffs={"count_sports": 0.99},
+    )
+
+    for _ in job.results():
+        pass
+
+    with pytest.raises(RuntimeError, match="Failed cutoffs"):
+        job.check_cutoffs()
+
+
+def test_sync_cutoffs_empty_dict_is_noop(
+    embedded_sync_client: TensorZeroGateway,
+    evaluation_datasets: Dict[str, str],
+):
+    """Test that passing an empty cutoffs dict is a no-op."""
+    job = embedded_sync_client.experimental_run_evaluation(
+        evaluation_name="entity_extraction",
+        dataset_name=evaluation_datasets["extract_entities_0.8"],
+        variant_name="gpt_4o_mini",
+        concurrency=1,
+        inference_cache="on",
+        cutoffs={},
+    )
+
+    for _ in job.results():
+        pass
+
+    # Should not raise
+    job.check_cutoffs()
+
+
+def test_sync_cutoffs_none_is_noop(
+    embedded_sync_client: TensorZeroGateway,
+    evaluation_datasets: Dict[str, str],
+):
+    """Test that check_cutoffs is a no-op when cutoffs is None."""
+    job = embedded_sync_client.experimental_run_evaluation(
+        evaluation_name="entity_extraction",
+        dataset_name=evaluation_datasets["extract_entities_0.8"],
+        variant_name="gpt_4o_mini",
+        concurrency=1,
+        inference_cache="on",
+    )
+
+    for _ in job.results():
+        pass
+
+    # Should not raise
+    job.check_cutoffs()
+
+
 def test_sync_run_evaluation_datapoint_ids_and_max_datapoints_error(
     embedded_sync_client: TensorZeroGateway,
 ):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new pass/fail cutoff plumbing to the Python evaluation API, including new Rust-side stats/cutoff computation and error mapping that could affect runtime behavior when used. Uses blocking access to shared result buffers, so misuse (e.g., calling before iteration completes) could lead to confusing failures or stalls.
> 
> **Overview**
> Adds optional per-evaluator `cutoffs` to Python `experimental_run_evaluation(...)` (sync + async) and stores them on the returned job handler.
> 
> Introduces `check_cutoffs()` on `EvaluationJobHandler`/`AsyncEvaluationJobHandler`, which computes final evaluator stats from cached results, resolves effective cutoffs (including config-level defaults), and raises if any evaluator misses its threshold (with formatted failure details). Negative cutoff values are rejected up front, and new tests + `.pyi` typings/documentation cover passing, failing, unknown-evaluator, and no-op cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a88ac46efd4f82149e61bb10dcbc366fcae3d4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->