### PR TITLE
Backfill inference eval runs in clickhouse again

### DIFF
--- a/tensorzero-core/src/db/clickhouse/migration_manager/migration_trait.rs
+++ b/tensorzero-core/src/db/clickhouse/migration_manager/migration_trait.rs
@@ -34,7 +34,11 @@ pub trait Migration {
             })?;
         Ok(id)
     }
+    /// Checks whether the prerequisites for this migration are met (e.g. required tables exist).
+    /// Returns `Ok(())` if the migration can proceed, or an error describing what's missing.
     async fn can_apply(&self) -> Result<(), Error>;
+    /// Checks whether this migration still needs to run. Return `false` to skip it
+    /// (e.g. the table already exists, or the migration manager has already recorded success).
     async fn should_apply(&self) -> Result<bool, Error>;
     async fn apply(&self, clean_start: bool) -> Result<(), Error>;
     /// ClickHouse queries that can be used to rollback the migration.

--- a/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0050.rs
+++ b/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0050.rs
@@ -1,0 +1,208 @@
+use super::check_table_exists;
+use crate::db::clickhouse::ClickHouseConnectionInfo;
+use crate::db::clickhouse::migration_manager::migration_trait::Migration;
+use crate::error::{Error, ErrorDetails};
+use async_trait::async_trait;
+
+/// Fixes `function_type` in `InferenceEvaluationRuns` that was incorrectly backfilled by
+/// migration 0049. The bug: ClickHouse UUID is non-nullable, so a LEFT JOIN on
+/// `ChatInference.id` produces a zero UUID instead of NULL for non-matching rows, causing
+/// `count(ci.id) > 0` to always be true and setting every run's `function_type` to `'chat'`.
+///
+/// This migration re-derives `function_type` by checking `JsonInference` instead and inserts
+/// corrected rows (ReplacingMergeTree deduplicates by `run_id_uint`, keeping the latest
+/// `updated_at`).
+pub struct Migration0050<'a> {
+    pub clickhouse: &'a ClickHouseConnectionInfo,
+}
+
+const MIGRATION_ID: &str = "0050";
+
+#[async_trait]
+impl Migration for Migration0050<'_> {
+    async fn can_apply(&self) -> Result<(), Error> {
+        let tables_to_check = [
+            "InferenceEvaluationRuns",
+            "TagInference",
+            "JsonInference",
+            "BooleanMetricFeedback",
+            "FloatMetricFeedback",
+        ];
+
+        for table_name in tables_to_check {
+            if !check_table_exists(self.clickhouse, table_name, MIGRATION_ID).await? {
+                return Err(Error::new(ErrorDetails::ClickHouseMigration {
+                    id: MIGRATION_ID.to_string(),
+                    message: format!("{table_name} table does not exist"),
+                }));
+            }
+        }
+        Ok(())
+    }
+
+    async fn should_apply(&self) -> Result<bool, Error> {
+        // Check if the migration manager has already recorded this migration as successful.
+        // If so, skip it. Otherwise, run it once so the manager writes the row.
+        let query = format!(
+            "SELECT 1 FROM {}.TensorZeroMigration WHERE migration_id = {MIGRATION_ID} LIMIT 1",
+            self.clickhouse.database()
+        );
+        let response = self
+            .clickhouse
+            .run_query_synchronous_no_params(query)
+            .await?;
+        Ok(response.response.trim() != "1")
+    }
+
+    async fn apply(&self, clean_start: bool) -> Result<(), Error> {
+        if clean_start {
+            // On a clean start, migration 0049 ran with clean_start too (no backfill),
+            // so there is nothing to fix.
+            return Ok(());
+        }
+
+        // Re-derive all InferenceEvaluationRuns from TagInference and feedback tables.
+        // The previous approach read from InferenceEvaluationRuns itself and INNER JOINed
+        // with TagInference, which dropped runs whose inferences had no evaluation tags.
+        // Instead, we re-run the full backfill from source data with corrected function_type
+        // logic: check JsonInference (non-nullable UUID → use countIf with zero-UUID guard).
+        // ReplacingMergeTree deduplicates by run_id_uint, keeping the latest updated_at.
+        //
+        // We LEFT JOIN with existing rows to preserve `source` and `metrics` for runs that
+        // were already written correctly (e.g. by normal evaluation writes between migrations
+        // 0049 and 0050). Only fall back to backfill-derived values for rows that don't exist.
+        self.clickhouse
+            .run_query_synchronous_no_params(
+                r#"
+                INSERT INTO InferenceEvaluationRuns
+                (
+                    run_id_uint,
+                    evaluation_name,
+                    function_name,
+                    function_type,
+                    dataset_name,
+                    variant_names,
+                    metrics,
+                    source,
+                    snapshot_hash,
+                    created_at,
+                    updated_at
+                )
+                WITH
+                evaluation_inferences AS (
+                    SELECT
+                        toUUIDOrNull(maxIf(value, key = 'tensorzero::evaluation_run_id')) AS run_id,
+                        maxIf(value, key = 'tensorzero::evaluation_name') AS evaluation_name,
+                        maxIf(value, key = 'tensorzero::dataset_name') AS dataset_name,
+                        any(function_name) AS function_name,
+                        any(variant_name) AS variant_name,
+                        any(snapshot_hash) AS snapshot_hash,
+                        inference_id,
+                        UUIDv7ToDateTime(inference_id) AS inference_timestamp
+                    FROM TagInference
+                    WHERE key IN ('tensorzero::evaluation_run_id', 'tensorzero::evaluation_name', 'tensorzero::dataset_name')
+                    GROUP BY inference_id
+                    HAVING
+                        run_id IS NOT NULL
+                        AND evaluation_name != ''
+                        AND dataset_name != ''
+                        AND NOT startsWith(function_name, 'tensorzero::')
+                ),
+                metrics_flat AS (
+                    SELECT
+                        ei.run_id AS run_id,
+                        b.metric_name AS metric_name,
+                        'boolean' AS value_type
+                    FROM BooleanMetricFeedback b
+                    INNER JOIN evaluation_inferences ei ON b.target_id = ei.inference_id
+
+                    UNION ALL
+
+                    SELECT
+                        ei.run_id AS run_id,
+                        f.metric_name AS metric_name,
+                        'float' AS value_type
+                    FROM FloatMetricFeedback f
+                    INNER JOIN evaluation_inferences ei ON f.target_id = ei.inference_id
+                ),
+                metrics_by_run AS (
+                    SELECT
+                        run_id,
+                        concat(
+                            '[',
+                            arrayStringConcat(
+                                groupUniqArray(
+                                    concat(
+                                        '{"name":', toJSONString(metric_name),
+                                        ',"evaluator_name":',
+                                        if(
+                                            position(metric_name, '::evaluator_name::') > 0,
+                                            toJSONString(arrayElement(splitByString('::evaluator_name::', metric_name), 2)),
+                                            'null'
+                                        ),
+                                        ',"value_type":', toJSONString(value_type),
+                                        ',"optimize":null}'
+                                    )
+                                ),
+                                ','
+                            ),
+                            ']'
+                        ) AS metrics
+                    FROM metrics_flat
+                    GROUP BY run_id
+                ),
+                run_function_types AS (
+                    SELECT
+                        ei.run_id AS run_id,
+                        if(
+                            countIf(ji.id != toUUID('00000000-0000-0000-0000-000000000000')) > 0,
+                            'json',
+                            'chat'
+                        ) AS function_type
+                    FROM evaluation_inferences ei
+                    LEFT JOIN JsonInference ji ON ji.id = ei.inference_id
+                    GROUP BY ei.run_id
+                ),
+                existing_runs AS (
+                    SELECT
+                        run_id_uint,
+                        argMax(metrics, updated_at) AS metrics,
+                        argMax(source, updated_at) AS source
+                    FROM InferenceEvaluationRuns
+                    GROUP BY run_id_uint
+                )
+                SELECT
+                    toUInt128(ei.run_id) AS run_id_uint,
+                    any(ei.evaluation_name) AS evaluation_name,
+                    any(ei.function_name) AS function_name,
+                    any(rft.function_type) AS function_type,
+                    any(ei.dataset_name) AS dataset_name,
+                    arrayDistinct(groupArray(ei.variant_name)) AS variant_names,
+                    coalesce(nullIf(any(er.metrics), ''), any(mbr.metrics), '[]') AS metrics,
+                    coalesce(nullIf(any(er.source), ''), 'dataset_name') AS source,
+                    if(isNull(any(ei.snapshot_hash)), NULL, lower(hex(any(ei.snapshot_hash)))) AS snapshot_hash,
+                    min(ei.inference_timestamp) AS created_at,
+                    now64(3) AS updated_at
+                FROM evaluation_inferences ei
+                LEFT JOIN metrics_by_run mbr ON ei.run_id = mbr.run_id
+                LEFT JOIN run_function_types rft ON ei.run_id = rft.run_id
+                LEFT JOIN existing_runs er ON toUInt128(ei.run_id) = er.run_id_uint
+                GROUP BY ei.run_id
+                "#
+                .to_string(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    fn rollback_instructions(&self) -> String {
+        // We include 'SELECT 1' so that our test code can run these rollback instructions
+        "SELECT 1;".to_string()
+    }
+
+    async fn has_succeeded(&self) -> Result<bool, Error> {
+        // The table already existed; we just inserted corrected rows.
+        check_table_exists(self.clickhouse, "InferenceEvaluationRuns", MIGRATION_ID).await
+    }
+}

--- a/tensorzero-core/src/db/clickhouse/migration_manager/migrations/mod.rs
+++ b/tensorzero-core/src/db/clickhouse/migration_manager/migrations/mod.rs
@@ -47,6 +47,7 @@ pub mod migration_0046;
 pub mod migration_0047;
 pub mod migration_0048;
 pub mod migration_0049;
+pub mod migration_0050;
 
 /// Returns true if the table exists, false if it does not
 /// Errors if the query fails

--- a/tensorzero-core/src/db/clickhouse/migration_manager/mod.rs
+++ b/tensorzero-core/src/db/clickhouse/migration_manager/mod.rs
@@ -56,11 +56,12 @@ use migrations::migration_0046::Migration0046;
 use migrations::migration_0047::Migration0047;
 use migrations::migration_0048::Migration0048;
 use migrations::migration_0049::Migration0049;
+use migrations::migration_0050::Migration0050;
 use serde::{Deserialize, Serialize};
 
 /// This must match the number of migrations returned by `make_all_migrations` - the tests
 /// will panic if they don't match.
-pub const NUM_MIGRATIONS: usize = 43;
+pub const NUM_MIGRATIONS: usize = 44;
 
 pub const RUN_MIGRATIONS_COMMAND: &str = "Please see our documentation to learn more about deploying ClickHouse: https://www.tensorzero.com/docs/deployment/clickhouse";
 
@@ -131,6 +132,7 @@ pub fn make_all_migrations<'a>(
         Box::new(Migration0047 { clickhouse }),
         Box::new(Migration0048 { clickhouse }),
         Box::new(Migration0049 { clickhouse }),
+        Box::new(Migration0050 { clickhouse }),
     ];
     assert_eq!(
         migrations.len(),

--- a/tensorzero-core/tests/e2e/clickhouse.rs
+++ b/tensorzero-core/tests/e2e/clickhouse.rs
@@ -8,6 +8,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use googletest::expect_that;
+use googletest::gtest;
+use googletest_matchers::{matches_json_literal, partially};
 use paste::paste;
 use rust_decimal::Decimal;
 use secrecy::ExposeSecret;
@@ -453,190 +456,144 @@ async fn run_migration_0020_with_data<R: Future<Output = bool>, F: FnOnce() -> R
     clean_start
 }
 
-async fn run_migration_0049_with_data<R: Future<Output = bool>, F: FnOnce() -> R>(
+/// Tests that migration 0050 correctly fixes `function_type` in `InferenceEvaluationRuns`.
+/// Inserts one chat-based run and one json-based run, then verifies the backfill assigns
+/// the correct function_type to each.
+async fn run_migration_0050_with_data<R: Future<Output = bool>, F: FnOnce() -> R>(
     clickhouse: &ClickHouseConnectionInfo,
     run_migration: F,
 ) -> bool {
     // Insert ChatInference rows with evaluation tags so the materialized view populates TagInference.
-    // Then insert feedback rows targeting those inferences. Migration 0049 should backfill
+    // Then insert feedback rows targeting those inferences. Migration 0050 should backfill
     // InferenceEvaluationRuns from this data.
-    let run_id = Uuid::now_v7();
-    let inference_id1 = Uuid::now_v7();
-    let inference_id2 = Uuid::now_v7();
+    let chat_run_id = Uuid::now_v7();
+    let json_run_id = Uuid::now_v7();
     let episode_id = Uuid::now_v7();
-    let function_name = "test_fn_0049";
-    let variant_name = "test_variant_0049";
-    let evaluation_name = "test_eval_0049";
-    let dataset_name = "test_dataset_0049";
-    let datapoint_id1 = Uuid::now_v7();
-    let datapoint_id2 = Uuid::now_v7();
 
-    // Insert two ChatInference rows with evaluation tags
-    for (inference_id, datapoint_id) in [
-        (inference_id1, datapoint_id1),
-        (inference_id2, datapoint_id2),
-    ] {
-        clickhouse
-            .run_query_synchronous_no_params(format!(
-                "INSERT INTO ChatInference (id, function_name, variant_name, episode_id, input, output, tool_params, inference_params, processing_time_ms, tags) \
-                 VALUES ('{inference_id}', '{function_name}', '{variant_name}', '{episode_id}', '{{}}', '[]', '{{}}', '{{}}', 0, \
-                 {{'tensorzero::evaluation_run_id':'{run_id}', 'tensorzero::evaluation_name':'{evaluation_name}', 'tensorzero::dataset_name':'{dataset_name}', 'tensorzero::datapoint_id':'{datapoint_id}'}})"
-            ))
-            .await
-            .unwrap();
-    }
+    // --- Chat run: insert into ChatInference ---
+    let chat_inference_id = Uuid::now_v7();
+    let chat_datapoint_id = Uuid::now_v7();
+    clickhouse
+        .run_query_synchronous_no_params(format!(
+            "INSERT INTO ChatInference (id, function_name, variant_name, episode_id, input, output, tool_params, inference_params, processing_time_ms, tags) \
+             VALUES ('{chat_inference_id}', 'test_chat_fn_0050', 'test_variant', '{episode_id}', '{{}}', '[]', '{{}}', '{{}}', 0, \
+             {{'tensorzero::evaluation_run_id':'{chat_run_id}', 'tensorzero::evaluation_name':'test_chat_eval', 'tensorzero::dataset_name':'test_ds', 'tensorzero::datapoint_id':'{chat_datapoint_id}'}})"
+        ))
+        .await
+        .unwrap();
 
-    // Insert boolean feedback targeting inference_id1
-    let bool_feedback_id = Uuid::now_v7();
-    let bool_metric_name =
-        format!("tensorzero::evaluation_name::{evaluation_name}::evaluator_name::exact_match");
+    let chat_feedback_id = Uuid::now_v7();
     clickhouse
         .run_query_synchronous_no_params(format!(
             "INSERT INTO BooleanMetricFeedback (id, target_id, metric_name, value) \
-             VALUES ('{bool_feedback_id}', '{inference_id1}', '{bool_metric_name}', true)"
+             VALUES ('{chat_feedback_id}', '{chat_inference_id}', 'tensorzero::evaluation_name::test_chat_eval::evaluator_name::em', true)"
         ))
         .await
         .unwrap();
 
-    // Insert float feedback targeting inference_id2
-    let float_feedback_id = Uuid::now_v7();
-    let float_metric_name =
-        format!("tensorzero::evaluation_name::{evaluation_name}::evaluator_name::llm_judge");
+    // --- JSON run: insert into JsonInference ---
+    let json_inference_id = Uuid::now_v7();
+    let json_datapoint_id = Uuid::now_v7();
+    clickhouse
+        .run_query_synchronous_no_params(format!(
+            "INSERT INTO JsonInference (id, function_name, variant_name, episode_id, input, output, output_schema, inference_params, processing_time_ms, tags) \
+             VALUES ('{json_inference_id}', 'test_json_fn_0050', 'test_variant', '{episode_id}', '{{}}', '{{}}', '{{}}', '{{}}', 0, \
+             {{'tensorzero::evaluation_run_id':'{json_run_id}', 'tensorzero::evaluation_name':'test_json_eval', 'tensorzero::dataset_name':'test_ds', 'tensorzero::datapoint_id':'{json_datapoint_id}'}})"
+        ))
+        .await
+        .unwrap();
+
+    let json_feedback_id = Uuid::now_v7();
     clickhouse
         .run_query_synchronous_no_params(format!(
             "INSERT INTO FloatMetricFeedback (id, target_id, metric_name, value) \
-             VALUES ('{float_feedback_id}', '{inference_id2}', '{float_metric_name}', 0.75)"
+             VALUES ('{json_feedback_id}', '{json_inference_id}', 'tensorzero::evaluation_name::test_json_eval::evaluator_name::score', 0.9)"
         ))
         .await
         .unwrap();
 
-    // Wait for ClickHouse to process inserts and materialized views
+    // Wait for materialized views to populate TagInference
     sleep(Duration::from_millis(1000)).await;
 
     let clean_start = run_migration().await;
 
-    // Verify the backfilled InferenceEvaluationRuns row
-    let response = clickhouse
-        .run_query_synchronous_no_params(format!(
-            "SELECT \
-                uint_to_uuid(run_id_uint) AS run_id, \
-                evaluation_name, \
-                function_name, \
-                function_type, \
-                dataset_name, \
-                variant_names, \
-                metrics, \
-                source \
-             FROM InferenceEvaluationRuns \
-             WHERE run_id_uint = toUInt128(toUUID('{run_id}')) \
-             FORMAT JSONEachRow"
-        ))
-        .await
-        .unwrap();
+    // Helper to query and return the latest row for a given run ID
+    async fn get_run_row(
+        clickhouse: &ClickHouseConnectionInfo,
+        run_id: &Uuid,
+    ) -> serde_json::Value {
+        let response = clickhouse
+            .run_query_synchronous_no_params(format!(
+                "SELECT \
+                    uint_to_uuid(run_id_uint) AS run_id, \
+                    argMax(evaluation_name, updated_at) AS evaluation_name, \
+                    argMax(function_name, updated_at) AS function_name, \
+                    argMax(function_type, updated_at) AS function_type, \
+                    argMax(dataset_name, updated_at) AS dataset_name, \
+                    argMax(metrics, updated_at) AS metrics, \
+                    argMax(source, updated_at) AS source \
+                 FROM InferenceEvaluationRuns \
+                 WHERE run_id_uint = toUInt128(toUUID('{run_id}')) \
+                 GROUP BY run_id_uint \
+                 FORMAT JSONEachRow"
+            ))
+            .await
+            .unwrap();
 
-    assert!(
-        !response.response.trim().is_empty(),
-        "Migration 0049 should have backfilled a row for run_id {run_id}"
-    );
-
-    let row: serde_json::Value =
-        serde_json::from_str(&response.response).expect("Backfilled row should be valid JSON");
-
-    assert_eq!(
-        row["run_id"].as_str().unwrap(),
-        run_id.to_string(),
-        "run_id should match"
-    );
-    assert_eq!(
-        row["evaluation_name"].as_str().unwrap(),
-        evaluation_name,
-        "evaluation_name should match"
-    );
-    assert_eq!(
-        row["function_name"].as_str().unwrap(),
-        function_name,
-        "function_name should match"
-    );
-    assert_eq!(
-        row["function_type"].as_str().unwrap(),
-        "chat",
-        "function_type should be `chat` since we inserted into ChatInference"
-    );
-    assert_eq!(
-        row["dataset_name"].as_str().unwrap(),
-        dataset_name,
-        "dataset_name should match"
-    );
-    assert_eq!(
-        row["source"].as_str().unwrap(),
-        "dataset_name",
-        "source should be `dataset_name` for backfilled rows"
-    );
-
-    // Check variant_names
-    let variant_names = row["variant_names"]
-        .as_array()
-        .expect("variant_names should be an array");
-    assert_eq!(
-        variant_names.len(),
-        1,
-        "Should have exactly 1 variant (both inferences use the same variant)"
-    );
-    assert_eq!(
-        variant_names[0].as_str().unwrap(),
-        variant_name,
-        "variant_name should match"
-    );
-
-    // Check metrics JSON: should contain both boolean and float metrics
-    let metrics_str = row["metrics"].as_str().expect("metrics should be a string");
-    let metrics: Vec<serde_json::Value> =
-        serde_json::from_str(metrics_str).expect("metrics should be valid JSON array");
-    assert_eq!(metrics.len(), 2, "Should have 2 metrics (boolean + float)");
-
-    let metric_names: std::collections::HashSet<&str> = metrics
-        .iter()
-        .map(|m| m["name"].as_str().unwrap())
-        .collect();
-    assert!(
-        metric_names.contains(bool_metric_name.as_str()),
-        "Should contain the boolean metric"
-    );
-    assert!(
-        metric_names.contains(float_metric_name.as_str()),
-        "Should contain the float metric"
-    );
-
-    for metric in &metrics {
-        let name = metric["name"].as_str().unwrap();
-        if name == bool_metric_name {
-            assert_eq!(
-                metric["value_type"].as_str().unwrap(),
-                "boolean",
-                "Boolean metric should have value_type `boolean`"
-            );
-            assert_eq!(
-                metric["evaluator_name"].as_str().unwrap(),
-                "exact_match",
-                "Boolean metric should extract evaluator_name from metric_name"
-            );
-        } else {
-            assert_eq!(
-                metric["value_type"].as_str().unwrap(),
-                "float",
-                "Float metric should have value_type `float`"
-            );
-            assert_eq!(
-                metric["evaluator_name"].as_str().unwrap(),
-                "llm_judge",
-                "Float metric should extract evaluator_name from metric_name"
-            );
-        }
         assert!(
-            metric["optimize"].is_null(),
-            "Historical backfill should set optimize to null"
+            !response.response.trim().is_empty(),
+            "Migration 0050 should have a row for run_id {run_id}"
         );
+        serde_json::from_str(&response.response).expect("Row should be valid JSON")
     }
+
+    let chat_row = get_run_row(clickhouse, &chat_run_id).await;
+    expect_that!(
+        chat_row,
+        partially(matches_json_literal!({
+            "run_id": chat_run_id.to_string(),
+            "evaluation_name": "test_chat_eval",
+            "function_name": "test_chat_fn_0050",
+            "function_type": "chat",
+            "dataset_name": "test_ds",
+            "source": "dataset_name"
+        }))
+    );
+    let chat_metrics: serde_json::Value =
+        serde_json::from_str(chat_row["metrics"].as_str().unwrap()).unwrap();
+    expect_that!(
+        chat_metrics,
+        matches_json_literal!([{
+            "name": "tensorzero::evaluation_name::test_chat_eval::evaluator_name::em",
+            "evaluator_name": "em",
+            "value_type": "boolean",
+            "optimize": null
+        }])
+    );
+
+    let json_row = get_run_row(clickhouse, &json_run_id).await;
+    expect_that!(
+        json_row,
+        partially(matches_json_literal!({
+            "run_id": json_run_id.to_string(),
+            "evaluation_name": "test_json_eval",
+            "function_name": "test_json_fn_0050",
+            "function_type": "json",
+            "dataset_name": "test_ds",
+            "source": "dataset_name"
+        }))
+    );
+    let json_metrics: serde_json::Value =
+        serde_json::from_str(json_row["metrics"].as_str().unwrap()).unwrap();
+    expect_that!(
+        json_metrics,
+        matches_json_literal!([{
+            "name": "tensorzero::evaluation_name::test_json_eval::evaluator_name::score",
+            "evaluator_name": "score",
+            "value_type": "float",
+            "optimize": null
+        }])
+    );
 
     clean_start
 }
@@ -802,7 +759,7 @@ invoke_all_separate_tests!(
     test_rollback_up_to_migration_index_,
     [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-        25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42
+        25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43
     ]
 );
 
@@ -868,6 +825,7 @@ async fn test_rollback_apply_rollback() {
     }
 }
 
+#[gtest]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_clickhouse_migration_manager() {
     let (clickhouse, _cleanup_db) = get_clean_clickhouse(false).await;
@@ -972,12 +930,12 @@ async fn test_clickhouse_migration_manager() {
                     );
                     run_migration_0048_with_data(clickhouse, run_migration).await
                 }
-                "Migration0049" => {
+                "Migration0050" => {
                     assert!(
                         !initial_clean_start.get(),
-                        "Migration0049 should not be run on a clean start"
+                        "Migration0050 should not be run on a clean start"
                     );
-                    run_migration_0049_with_data(clickhouse, run_migration).await
+                    run_migration_0050_with_data(clickhouse, run_migration).await
                 }
                 _ => run_migration().await,
             };
@@ -1140,7 +1098,7 @@ async fn test_clickhouse_migration_manager() {
         .unwrap();
     let episode_count: u64 = response.response.trim().parse().unwrap();
 
-    // 20000000 from fixtures + 2 from run_migration_0049_with_data
+    // 20000000 from fixtures + 1 from run_migration_0049_with_data + 1 from run_migration_0050_with_data
     assert_eq!(episode_count, 20000002);
 
     // Check that the FeedbackByVariantStatistics migration worked

--- a/ui/fixtures/load_fixtures.sh
+++ b/ui/fixtures/load_fixtures.sh
@@ -140,9 +140,13 @@ metrics_by_run AS (
 run_function_types AS (
     SELECT
         ei.run_id AS run_id,
-        if(count(ci.id) > 0, 'chat', 'json') AS function_type
+        if(
+            countIf(ji.id != toUUID('00000000-0000-0000-0000-000000000000')) > 0,
+            'json',
+            'chat'
+        ) AS function_type
     FROM evaluation_inferences ei
-    LEFT JOIN ChatInference ci ON ci.id = ei.inference_id
+    LEFT JOIN JsonInference ji ON ji.id = ei.inference_id
     GROUP BY ei.run_id
 )
 SELECT


### PR DESCRIPTION
ClickHouse UUIDs are not null so the last backfill introduced a bug where all inference runs were marked as chat, whether or not the join with chat_inferences table returned any rows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new ClickHouse backfill migration that rewrites `InferenceEvaluationRuns` rows for all historical runs, which can impact analytics correctness and load on large datasets if the query is slow or mis-scoped. The rest is test/fixture and helper-matcher additions with low operational risk.
> 
> **Overview**
> Adds ClickHouse migration `0050` that **re-backfills `InferenceEvaluationRuns`** from `TagInference` + feedback tables to fix a prior bug where `function_type` was incorrectly set to `chat` for all runs due to ClickHouse non-nullable UUID behavior; it now derives `function_type` by joining `JsonInference` and guarding against the zero UUID.
> 
> Registers the new migration (bumps `NUM_MIGRATIONS`) and updates fixture backfill SQL to match the corrected logic. Updates ClickHouse e2e migration tests to cover a chat run + json run scenario, and introduces a small `googletest-matchers` workspace crate providing JSON matchers used by those tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e41375b19ea09c1ed53e4a03d9436d8cf130ad92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->