### PR TITLE
Require 'autopilot-e2e' job to pass again

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1337,10 +1337,9 @@ jobs:
   check-all-general-jobs-passed:
     permissions: {}
     if: always() && github.repository == 'tensorzero/tensorzero'
-    # NOTE: autopilot-e2e is intentionally excluded — it runs but doesn't block merging
-    # TODO: Add autopilot-e2e back once autopilot e2e tests are stable
     needs:
       [
+        autopilot-e2e,
         build-gateway-container,
         build-gateway-e2e-container,
         build-live-tests-container,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Makes `autopilot-e2e` a merge-blocking dependency for the `check-all-general-jobs-passed` gate, which can increase merge-queue latency or block merges if those E2E tests are flaky.
> 
> **Overview**
> Updates the GitHub Actions `general.yml` workflow so the merge gate job `check-all-general-jobs-passed` now **requires** the `autopilot-e2e` job to complete successfully (previously it was intentionally excluded from blocking merges).
> 
> This effectively makes Autopilot E2E runs merge-blocking in the merge queue (while remaining skipped/non-blocking on regular PR runs due to the job’s `merge_group`-only condition).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b7dba87bc7befba935315cd152b38ebb584b412. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->