### PR TITLE
Migrate integration docs to OpenAI inference

### DIFF
--- a/docs/integrations/model-providers/anthropic.mdx
+++ b/docs/integrations/model-providers/anthropic.mdx
@@ -19,21 +19,19 @@ type = "chat_completion"
 model = "anthropic::claude-haiku-4-5"
 ```
 
-Additionally, you can set `model_name` in the inference request to use a specific Anthropic model, without having to configure a function and variant in TensorZero.
+Additionally, you can set the `model` parameter in the [OpenAI-compatible inference endpoint](/gateway/api-reference/inference-openai-compatible) to use a specific Anthropic model, without having to configure a function and variant in TensorZero.
 
 ```bash {4}
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "anthropic::claude-haiku-4-5",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::model_name::anthropic::claude-haiku-4-5",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 
@@ -115,18 +113,16 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 
@@ -136,21 +132,22 @@ You can enable [Anthropic's prompt caching capability](https://platform.claude.c
 
 For example, to enable caching on your system prompt:
 
-```bash {14-19}
-curl -X POST "http://localhost:3000/inference" \
+```bash {15-20}
+curl -X POST "http://localhost:3000/openai/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "anthropic::claude-haiku-4-5",
-    "input": {
-      "system": "... very long prompt ...",
-      "messages": [
-        {
-          "role": "user",
-          "content": "Write a haiku about TensorZero."
-        }
-      ]
-    },
-    "extra_body": [
+    "model": "tensorzero::model_name::anthropic::claude-haiku-4-5",
+    "messages": [
+      {
+        "role": "system",
+        "content": "... very long prompt ..."
+      },
+      {
+        "role": "user",
+        "content": "Write a haiku about TensorZero."
+      }
+    ],
+    "tensorzero::extra_body": [
         {
             "pointer": "/system/0/cache_control",
             "value": {"type": "ephemeral"}
@@ -161,21 +158,22 @@ curl -X POST "http://localhost:3000/inference" \
 
 Similarly, to enable caching on a message:
 
-```bash {16}
-curl -X POST "http://localhost:3000/inference" \
+```bash {17}
+curl -X POST "http://localhost:3000/openai/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "anthropic::claude-haiku-4-5",
-    "input": {
-      "system": "... very long prompt ...",
-      "messages": [
-        {
-          "role": "user",
-          "content": "Write a haiku about TensorZero."
-        }
-      ]
-    },
-    "extra_body": [
+    "model": "tensorzero::model_name::anthropic::claude-haiku-4-5",
+    "messages": [
+      {
+        "role": "system",
+        "content": "... very long prompt ..."
+      },
+      {
+        "role": "user",
+        "content": "Write a haiku about TensorZero."
+      }
+    ],
+    "tensorzero::extra_body": [
         {
             "pointer": "/messages/0/content/0/cache_control",
             "value": {"type": "ephemeral"}
@@ -186,15 +184,15 @@ curl -X POST "http://localhost:3000/inference" \
 
 <Tip>
 
-You can specify `extra_body` in the [configuration](/gateway/configuration-reference) or at [inference time](/gateway/api-reference/inference).
-If you're using the OpenAI-Compatible Inference API, use `tensorzero::extra_body` instead.
+You can also specify `extra_body` in the [configuration](/gateway/configuration-reference).
+See the [API Reference](/gateway/api-reference/inference-openai-compatible) for more information.
 
 </Tip>
 
 <Tip>
 
-You can retrieve prompt caching usage information with `include_raw_usage`.
-See the [API Reference](/gateway/api-reference/inference) for more information.
+You can retrieve prompt caching usage information with `tensorzero::include_raw_usage`.
+See the [API Reference](/gateway/api-reference/inference-openai-compatible) for more information.
 
 </Tip>
 
@@ -216,19 +214,17 @@ reasoning_effort = "low"  # Accepted values depend on the Anthropic API (e.g. "l
 You can also set `reasoning_effort` at inference time:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    },
-    "params": {
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ],
+    "tensorzero::params": {
       "chat_completion": {
         "reasoning_effort": "low"
       }

--- a/docs/integrations/model-providers/aws-bedrock.mdx
+++ b/docs/integrations/model-providers/aws-bedrock.mdx
@@ -112,18 +112,16 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 
@@ -133,21 +131,22 @@ You can enable [AWS Bedrock's prompt caching capability](https://docs.aws.amazon
 
 For example, to enable caching on your system prompt:
 
-```bash {14-21}
-curl -X POST "http://localhost:3000/inference" \
+```bash {15-22}
+curl -X POST "http://localhost:3000/openai/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "...",
-    "input": {
-      "system": "... very long prompt ...",
-      "messages": [
-        {
-          "role": "user",
-          "content": "Write a haiku about TensorZero."
-        }
-      ]
-    },
-    "extra_body": [
+    "model": "tensorzero::model_name::claude_haiku_4_5",
+    "messages": [
+      {
+        "role": "system",
+        "content": "... very long prompt ..."
+      },
+      {
+        "role": "user",
+        "content": "Write a haiku about TensorZero."
+      }
+    ],
+    "tensorzero::extra_body": [
         {
             "pointer": "/system/-",
             "value": {
@@ -166,21 +165,22 @@ The `/abc/-` notation appends a value to the `abc` array.
 
 Similarly, to enable caching on a message:
 
-```bash {16}
-curl -X POST "http://localhost:3000/inference" \
+```bash {17}
+curl -X POST "http://localhost:3000/openai/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "...",
-    "input": {
-      "system": "... very long prompt ...",
-      "messages": [
-        {
-          "role": "user",
-          "content": "Write a haiku about TensorZero."
-        }
-      ]
-    },
-    "extra_body": [
+    "model": "tensorzero::model_name::claude_haiku_4_5",
+    "messages": [
+      {
+        "role": "system",
+        "content": "... very long prompt ..."
+      },
+      {
+        "role": "user",
+        "content": "Write a haiku about TensorZero."
+      }
+    ],
+    "tensorzero::extra_body": [
         {
             "pointer": "/messages/0/content/-",
             "value": {
@@ -193,15 +193,15 @@ curl -X POST "http://localhost:3000/inference" \
 
 <Tip>
 
-You can specify `extra_body` in the [configuration](/gateway/configuration-reference) or at [inference time](/gateway/api-reference/inference).
-If you're using the OpenAI-Compatible Inference API, use `tensorzero::extra_body` instead.
+You can also specify `extra_body` in the [configuration](/gateway/configuration-reference).
+See the [API Reference](/gateway/api-reference/inference-openai-compatible) for more information.
 
 </Tip>
 
 <Tip>
 
-You can retrieve prompt caching usage information with `include_raw_usage`.
-See the [API Reference](/gateway/api-reference/inference) for more information.
+You can retrieve prompt caching usage information with `tensorzero::include_raw_usage`.
+See the [API Reference](/gateway/api-reference/inference-openai-compatible) for more information.
 
 </Tip>
 

--- a/docs/integrations/model-providers/aws-sagemaker.mdx
+++ b/docs/integrations/model-providers/aws-sagemaker.mdx
@@ -117,17 +117,15 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```

--- a/docs/integrations/model-providers/azure.mdx
+++ b/docs/integrations/model-providers/azure.mdx
@@ -89,18 +89,16 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 

--- a/docs/integrations/model-providers/deepseek.mdx
+++ b/docs/integrations/model-providers/deepseek.mdx
@@ -19,21 +19,19 @@ type = "chat_completion"
 model = "deepseek::deepseek-chat"
 ```
 
-Additionally, you can set `model_name` in the inference request to use a specific DeepSeek model, without having to configure a function and variant in TensorZero.
+Additionally, you can set the `model` parameter in the [OpenAI-compatible inference endpoint](/gateway/api-reference/inference-openai-compatible) to use a specific DeepSeek model, without having to configure a function and variant in TensorZero.
 
 ```bash {4}
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "deepseek::deepseek-chat",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::model_name::deepseek::deepseek-chat",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 
@@ -113,17 +111,15 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```

--- a/docs/integrations/model-providers/fireworks.mdx
+++ b/docs/integrations/model-providers/fireworks.mdx
@@ -19,21 +19,19 @@ type = "chat_completion"
 model = "fireworks::accounts/fireworks/models/llama-v3p3-70b-instruct"
 ```
 
-Additionally, you can set `model_name` in the inference request to use a specific Fireworks model, without having to configure a function and variant in TensorZero.
+Additionally, you can set the `model` parameter in the [OpenAI-compatible inference endpoint](/gateway/api-reference/inference-openai-compatible) to use a specific Fireworks model, without having to configure a function and variant in TensorZero.
 
 ```bash {4}
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "fireworks::accounts/fireworks/models/llama-v3p3-70b-instruct",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::model_name::fireworks::accounts/fireworks/models/llama-v3p3-70b-instruct",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 
@@ -116,17 +114,15 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```

--- a/docs/integrations/model-providers/gcp-vertex-ai-anthropic.mdx
+++ b/docs/integrations/model-providers/gcp-vertex-ai-anthropic.mdx
@@ -99,17 +99,15 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```

--- a/docs/integrations/model-providers/gcp-vertex-ai-gemini.mdx
+++ b/docs/integrations/model-providers/gcp-vertex-ai-gemini.mdx
@@ -99,18 +99,16 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 

--- a/docs/integrations/model-providers/google-ai-studio-gemini.mdx
+++ b/docs/integrations/model-providers/google-ai-studio-gemini.mdx
@@ -19,21 +19,19 @@ type = "chat_completion"
 model = "google_ai_studio_gemini::gemini-2.5-flash-lite"
 ```
 
-Additionally, you can set `model_name` in the inference request to use a specific Google AI Studio (Gemini API) model, without having to configure a function and variant in TensorZero.
+Additionally, you can set the `model` parameter in the [OpenAI-compatible inference endpoint](/gateway/api-reference/inference-openai-compatible) to use a specific Google AI Studio (Gemini API) model, without having to configure a function and variant in TensorZero.
 
 ```bash {4}
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "google_ai_studio_gemini::gemini-2.5-flash-lite",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::model_name::google_ai_studio_gemini::gemini-2.5-flash-lite",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 
@@ -115,18 +113,16 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 

--- a/docs/integrations/model-providers/groq.mdx
+++ b/docs/integrations/model-providers/groq.mdx
@@ -19,21 +19,19 @@ type = "chat_completion"
 model = "groq::meta-llama/llama-4-scout-17b-16e-instruct"
 ```
 
-Additionally, you can set `model_name` in the inference request to use a specific Groq model, without having to configure a function and variant in TensorZero.
+Additionally, you can set the `model` parameter in the [OpenAI-compatible inference endpoint](/gateway/api-reference/inference-openai-compatible) to use a specific Groq model, without having to configure a function and variant in TensorZero.
 
 ```bash {4}
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "groq::meta-llama/llama-4-scout-17b-16e-instruct",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::model_name::groq::meta-llama/llama-4-scout-17b-16e-instruct",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 
@@ -118,17 +116,15 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```

--- a/docs/integrations/model-providers/hyperbolic.mdx
+++ b/docs/integrations/model-providers/hyperbolic.mdx
@@ -19,21 +19,19 @@ type = "chat_completion"
 model = "hyperbolic::openai/gpt-oss-20b"
 ```
 
-Additionally, you can set `model_name` in the inference request to use a specific Hyperbolic model, without having to configure a function and variant in TensorZero.
+Additionally, you can set the `model` parameter in the [OpenAI-compatible inference endpoint](/gateway/api-reference/inference-openai-compatible) to use a specific Hyperbolic model, without having to configure a function and variant in TensorZero.
 
 ```bash {4}
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "hyperbolic::openai/gpt-oss-20b",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::model_name::hyperbolic::openai/gpt-oss-20b",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 
@@ -114,17 +112,15 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```

--- a/docs/integrations/model-providers/mistral.mdx
+++ b/docs/integrations/model-providers/mistral.mdx
@@ -19,21 +19,19 @@ type = "chat_completion"
 model = "mistral::ministral-8b-2410"
 ```
 
-Additionally, you can set `model_name` in the inference request to use a specific Mistral model, without having to configure a function and variant in TensorZero.
+Additionally, you can set the `model` parameter in the [OpenAI-compatible inference endpoint](/gateway/api-reference/inference-openai-compatible) to use a specific Mistral model, without having to configure a function and variant in TensorZero.
 
 ```bash {4}
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "mistral::ministral-8b-2410",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::model_name::mistral::ministral-8b-2410",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 
@@ -131,17 +129,15 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```

--- a/docs/integrations/model-providers/openai-compatible.mdx
+++ b/docs/integrations/model-providers/openai-compatible.mdx
@@ -107,18 +107,16 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 

--- a/docs/integrations/model-providers/openai.mdx
+++ b/docs/integrations/model-providers/openai.mdx
@@ -21,21 +21,19 @@ type = "chat_completion"
 model = "openai::gpt-4o-mini-2024-07-18"
 ```
 
-Additionally, you can set `model_name` in the inference request to use a specific OpenAI model, without having to configure a function and variant in TensorZero.
+Additionally, you can set the `model` parameter in the [OpenAI-compatible inference endpoint](/gateway/api-reference/inference-openai-compatible) to use a specific OpenAI model, without having to configure a function and variant in TensorZero.
 
 ```bash {4}
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "openai::gpt-4o-mini-2024-07-18",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::model_name::openai::gpt-4o-mini-2024-07-18",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 
@@ -49,21 +47,19 @@ type = "chat_completion"
 model = "openai::responses::gpt-5-codex"
 ```
 
-You can also use `model_name` in inference requests:
+You can also use the `model` parameter in OpenAI-compatible inference requests:
 
 ```bash {4}
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "openai::responses::gpt-5-codex",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::model_name::openai::responses::gpt-5-codex",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 
@@ -151,18 +147,16 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 

--- a/docs/integrations/model-providers/openrouter.mdx
+++ b/docs/integrations/model-providers/openrouter.mdx
@@ -19,21 +19,19 @@ type = "chat_completion"
 model = "openrouter::openai/gpt-4.1-mini"
 ```
 
-Additionally, you can set `model_name` in the inference request to use a specific OpenRouter model, without having to configure a function and variant in TensorZero.
+Additionally, you can set the `model` parameter in the [OpenAI-compatible inference endpoint](/gateway/api-reference/inference-openai-compatible) to use a specific OpenRouter model, without having to configure a function and variant in TensorZero.
 
 ```bash {4}
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "openrouter::openai/gpt-4.1-mini",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::model_name::openrouter::openai/gpt-4.1-mini",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 
@@ -115,18 +113,16 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 

--- a/docs/integrations/model-providers/sglang.mdx
+++ b/docs/integrations/model-providers/sglang.mdx
@@ -89,7 +89,7 @@ The `api_key_location` field in your model provider configuration specifies how 
      ```
      The API key can then be passed in the inference request.
 
-See the [Credential Management](/operations/manage-credentials/) guide, the [Configuration Reference](/gateway/configuration-reference/), and the [API reference](/gateway/api-reference/inference/) for more details.
+See the [Credential Management](/operations/manage-credentials/) guide, the [Configuration Reference](/gateway/configuration-reference/), and the [API reference](/gateway/api-reference/inference-openai-compatible/) for more details.
 
 In this example, SGLang is running locally without authentication, so we use `api_key_location = "none"`.
 
@@ -122,17 +122,15 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```

--- a/docs/integrations/model-providers/tgi.mdx
+++ b/docs/integrations/model-providers/tgi.mdx
@@ -89,7 +89,7 @@ The `api_key_location` field in your model provider configuration specifies how 
      ```
      The API key can then be passed in the inference request.
 
-See the [Configuration Reference](/gateway/configuration-reference/) and the [API reference](/gateway/api-reference/inference/) for more details.
+See the [Configuration Reference](/gateway/configuration-reference/) and the [API reference](/gateway/api-reference/inference-openai-compatible/) for more details.
 
 In this example, TGI is running locally without authentication, so we use `api_key_location = "none"`.
 
@@ -122,17 +122,15 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```

--- a/docs/integrations/model-providers/together.mdx
+++ b/docs/integrations/model-providers/together.mdx
@@ -19,21 +19,19 @@ type = "chat_completion"
 model = "together::meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo"
 ```
 
-Additionally, you can set `model_name` in the inference request to use a specific Together AI model, without having to configure a function and variant in TensorZero.
+Additionally, you can set the `model` parameter in the [OpenAI-compatible inference endpoint](/gateway/api-reference/inference-openai-compatible) to use a specific Together AI model, without having to configure a function and variant in TensorZero.
 
 ```bash {4}
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "together::meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::model_name::together::meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 
@@ -118,18 +116,16 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 

--- a/docs/integrations/model-providers/vllm.mdx
+++ b/docs/integrations/model-providers/vllm.mdx
@@ -76,7 +76,7 @@ The `api_key_location` field in your model provider configuration specifies how 
      ```
      The API key can then be passed in the inference request.
 
-See the [Credential Management](/operations/manage-credentials/) guide, the [Configuration Reference](/gateway/configuration-reference/), and the [API reference](/gateway/api-reference/inference/) for more details.
+See the [Credential Management](/operations/manage-credentials/) guide, the [Configuration Reference](/gateway/configuration-reference/), and the [API reference](/gateway/api-reference/inference-openai-compatible/) for more details.
 
 In this example, vLLM is running locally without authentication, so we use `api_key_location = "none"`.
 
@@ -109,17 +109,15 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```

--- a/docs/integrations/model-providers/xai.mdx
+++ b/docs/integrations/model-providers/xai.mdx
@@ -19,21 +19,19 @@ type = "chat_completion"
 model = "xai::grok-4-1-fast-non-reasoning"
 ```
 
-Additionally, you can set `model_name` in the inference request to use a specific xAI model, without having to configure a function and variant in TensorZero.
+Additionally, you can set the `model` parameter in the [OpenAI-compatible inference endpoint](/gateway/api-reference/inference-openai-compatible) to use a specific xAI model, without having to configure a function and variant in TensorZero.
 
 ```bash {4}
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "xai::grok-4-1-fast-non-reasoning",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::model_name::xai::grok-4-1-fast-non-reasoning",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```
 
@@ -115,17 +113,15 @@ You can start the gateway with `docker compose up`.
 Make an inference request to the gateway:
 
 ```bash
-curl -X POST http://localhost:3000/inference \
+curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "function_name": "my_function_name",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "What is the capital of Japan?"
-        }
-      ]
-    }
+    "model": "tensorzero::function_name::my_function_name",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the capital of Japan?"
+      }
+    ]
   }'
 ```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes that update request examples and parameter names; low risk aside from potentially confusing users if any examples are incorrect.
> 
> **Overview**
> Updates the model provider integration guides to use the **OpenAI-compatible inference endpoint** (`/openai/v1/chat/completions`) instead of `/inference`, with examples switching from `function_name`/`input` payloads to `model` + top-level `messages` (e.g. `tensorzero::function_name::...` and `tensorzero::model_name::...`).
> 
> Also aligns advanced examples with the OpenAI-compatible API by renaming inference-time overrides to `tensorzero::extra_body`, `tensorzero::include_raw_usage`, and `tensorzero::params`, and updates documentation links to point at the OpenAI-compatible API reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f73f93f0990a0613cefd62d851dc378b6c9a7f9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->