### PR TITLE
Add GEPA route scaffolding with 501 stubs

### DIFF
--- a/crates/gateway/src/routes/external.rs
+++ b/crates/gateway/src/routes/external.rs
@@ -54,6 +54,7 @@ pub fn build_non_otel_enabled_routes(metrics_handle: PrometheusHandle) -> Router
         .merge(build_observability_routes())
         .merge(build_datasets_routes())
         .merge(build_optimization_routes())
+        .merge(build_gepa_routes())
         .merge(build_evaluations_routes())
         .merge(build_meta_observability_routes(metrics_handle))
 }
@@ -123,6 +124,21 @@ fn build_optimization_routes() -> Router<AppStateData> {
         .route(
             "/experimental_optimization/{job_handle}",
             get(tensorzero_optimizers::endpoints::poll_optimization_handler),
+        )
+}
+
+/// This function builds the public routes for GEPA optimization.
+///
+/// IMPORTANT: Add internal routes to `internal.rs` instead.
+fn build_gepa_routes() -> Router<AppStateData> {
+    Router::new()
+        .route(
+            "/v1/optimization/gepa",
+            post(tensorzero_optimizers::endpoints::gepa_launch_handler),
+        )
+        .route(
+            "/v1/optimization/gepa/{task_id}",
+            get(tensorzero_optimizers::endpoints::gepa_get_handler),
         )
 }
 

--- a/crates/tensorzero-core/src/optimization/gepa.rs
+++ b/crates/tensorzero-core/src/optimization/gepa.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
@@ -326,4 +327,136 @@ impl GEPAJobHandle {
     fn __repr__(&self) -> String {
         format!("{self}")
     }
+}
+
+// ── GEPA HTTP API types ──────────────────────────────────────────────
+
+/// The dataset config is either a single dataset (auto-split 50/50)
+/// or explicit train/val datasets.
+#[derive(Debug)]
+pub enum GepaDatasetConfig {
+    Single {
+        dataset_name: String,
+    },
+    Split {
+        train_dataset_name: String,
+        val_dataset_name: String,
+    },
+}
+
+/// The evaluation config is either a reference to a named evaluation
+/// or an inline list of evaluator names (top-level evaluators).
+#[derive(Debug)]
+pub enum GepaEvaluationConfig {
+    Named { evaluation_name: String },
+    Inline { evaluators: Vec<String> },
+}
+
+/// Raw launch request as deserialized from JSON.
+///
+/// Dataset fields (`dataset_name` vs `train_dataset_name`/`val_dataset_name`)
+/// and evaluation fields (`evaluation_name` vs `evaluators`) are represented as
+/// flat optional fields to avoid serde's flatten+untagged incompatibility.
+/// Use [`GepaLaunchRequest::dataset`] and [`GepaLaunchRequest::evaluation`] to
+/// resolve them into their typed enum forms.
+#[derive(Debug, Deserialize)]
+pub struct GepaLaunchRequest {
+    pub function_name: String,
+    /// Single dataset name (auto-split 50/50). Mutually exclusive with
+    /// `train_dataset_name`/`val_dataset_name`.
+    pub dataset_name: Option<String>,
+    /// Training dataset name. Must be paired with `val_dataset_name`.
+    pub train_dataset_name: Option<String>,
+    /// Validation dataset name. Must be paired with `train_dataset_name`.
+    pub val_dataset_name: Option<String>,
+    /// Named evaluation. Mutually exclusive with `evaluators`.
+    pub evaluation_name: Option<String>,
+    /// Inline list of evaluator names. Mutually exclusive with `evaluation_name`.
+    pub evaluators: Option<Vec<String>>,
+    pub analysis_model: String,
+    pub mutation_model: String,
+    pub initial_variants: Option<Vec<String>>,
+    pub max_iterations: u32,
+    pub variant_prefix: Option<String>,
+    pub batch_size: Option<usize>,
+    pub seed: Option<u32>,
+    pub include_inference_for_mutation: Option<bool>,
+}
+
+impl GepaLaunchRequest {
+    /// Resolve the flat dataset fields into a typed enum.
+    pub fn dataset(&self) -> Result<GepaDatasetConfig, &'static str> {
+        match (
+            &self.dataset_name,
+            &self.train_dataset_name,
+            &self.val_dataset_name,
+        ) {
+            (Some(name), None, None) => Ok(GepaDatasetConfig::Single {
+                dataset_name: name.clone(),
+            }),
+            (None, Some(train), Some(val)) => Ok(GepaDatasetConfig::Split {
+                train_dataset_name: train.clone(),
+                val_dataset_name: val.clone(),
+            }),
+            _ => Err(
+                "Provide either `dataset_name` or both `train_dataset_name` and `val_dataset_name`",
+            ),
+        }
+    }
+
+    /// Resolve the flat evaluation fields into a typed enum.
+    pub fn evaluation(&self) -> Result<GepaEvaluationConfig, &'static str> {
+        match (&self.evaluation_name, &self.evaluators) {
+            (Some(name), None) => Ok(GepaEvaluationConfig::Named {
+                evaluation_name: name.clone(),
+            }),
+            (None, Some(evals)) => Ok(GepaEvaluationConfig::Inline {
+                evaluators: evals.clone(),
+            }),
+            (Some(_), Some(_)) => Err("Provide either `evaluation_name` or `evaluators`, not both"),
+            (None, None) => Err("Provide either `evaluation_name` or `evaluators`"),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "pyo3", pyclass)]
+pub struct GepaLaunchResponse {
+    pub task_id: String,
+}
+
+/// GET response is a tagged enum on `status`.
+/// Serializes as: `{"status": "pending"}` | `{"status": "error", ...}` | `{"status": "completed", ...}`
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum GepaGetResponse {
+    Pending {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        progress: Option<GepaProgress>,
+    },
+    Error {
+        error: String,
+    },
+    Completed {
+        /// Map of variant_name to its configuration
+        variants: HashMap<String, UninitializedChatCompletionConfig>,
+        /// Map of variant_name to { evaluator_name to stats }
+        statistics: HashMap<String, HashMap<String, GepaEvaluatorStats>>,
+    },
+}
+
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "pyo3", pyclass)]
+pub struct GepaProgress {
+    pub current_iteration: u32,
+    pub max_iterations: u32,
+    pub current_step: String,
+}
+
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "pyo3", pyclass)]
+pub struct GepaEvaluatorStats {
+    pub mean: f64,
+    pub stdev: f64,
+    pub count: usize,
 }

--- a/crates/tensorzero-optimizers/src/endpoints.rs
+++ b/crates/tensorzero-optimizers/src/endpoints.rs
@@ -25,7 +25,10 @@ use tensorzero_core::{
     error::{Error, ErrorDetails},
     http::TensorzeroHttpClient,
     model_table::ProviderTypeDefaultCredentials,
-    optimization::{OptimizationJobHandle, OptimizationJobInfo, UninitializedOptimizerInfo},
+    optimization::{
+        OptimizationJobHandle, OptimizationJobInfo, UninitializedOptimizerInfo,
+        gepa::GepaLaunchRequest,
+    },
     stored_inference::RenderedSample,
     utils::gateway::{AppState, AppStateData, StructuredJson},
 };
@@ -340,6 +343,26 @@ pub async fn poll_optimization(
             provider_types,
         )
         .await
+}
+
+#[expect(clippy::unused_async, reason = "axum handler must be async")]
+pub async fn gepa_launch_handler(
+    State(_app_state): AppState,
+    StructuredJson(_req): StructuredJson<GepaLaunchRequest>,
+) -> Result<Response<Body>, Error> {
+    Err(Error::new(ErrorDetails::NotImplemented {
+        message: "GEPA launch endpoint is not yet implemented".to_string(),
+    }))
+}
+
+#[expect(clippy::unused_async, reason = "axum handler must be async")]
+pub async fn gepa_get_handler(
+    State(_app_state): AppState,
+    Path(_task_id): Path<String>,
+) -> Result<Response<Body>, Error> {
+    Err(Error::new(ErrorDetails::NotImplemented {
+        message: "GEPA get endpoint is not yet implemented".to_string(),
+    }))
 }
 
 /// Randomly split examples into train and val sets.


### PR DESCRIPTION
## Summary
- Add `POST /v1/optimization/gepa` and `GET /v1/optimization/gepa/{task_id}` routes
- Add request/response types: `GepaLaunchRequest`, `GepaLaunchResponse`, `GepaGetResponse`, `GepaProgress`, `GepaEvaluatorStats`, plus `GepaDatasetConfig` and `GepaEvaluationConfig` untagged enums
- Handlers return 501 Not Implemented — real durable execution implementation comes later

## Test plan
- [x] `cargo check` passes for modified packages
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] All pre-commit hooks pass
- [x] Unit tests pass (2379 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new public routes and request/response types but handlers currently return `NotImplemented` and do not change existing optimization behavior.
> 
> **Overview**
> Adds new external GEPA optimization endpoints `POST /v1/optimization/gepa` and `GET /v1/optimization/gepa/{task_id}`, wired into the gateway router.
> 
> Introduces GEPA HTTP API request/response types in `tensorzero-core` (including validation helpers for mutually exclusive dataset/evaluation fields), and adds corresponding `axum` handlers in `tensorzero-optimizers` that currently return `501 Not Implemented`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf223986f93e738dc934b74b11ff72a893cb3e39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## PR Stack
```
main
 │
 ▼
#6713 Route Scaffolding  ◄── THIS PR
 │
 ▼
#6742 Standalone Task Tool
 │
 ▼
#6734 Durable Task
 │
 ▼
#6812 Progress Polling
 │
 ▼
#6771 Rust Client
 │
 ▼
#6774 Python Client
 │
 ├──────────────────┐
 ▼                  ▼
#6791 Docs &     #6813 Live
Examples         Tests
```