### PR TITLE
Update inference caching guide with OpenAI-compatible API examples

### DIFF
--- a/docs/gateway/guides/inference-caching.mdx
+++ b/docs/gateway/guides/inference-caching.mdx
@@ -18,7 +18,7 @@ The TensorZero Gateway supports the following cache modes:
 You can also optionally specify a maximum age for cache entries in seconds for inference reads.
 This parameter is ignored for inference writes.
 
-See the [API Reference](/gateway/api-reference/inference-openai-compatible/#tensorzero_cache_options) for more details.
+See the [API Reference](/gateway/api-reference/inference-openai-compatible/#tensorzerocache_options) for more details.
 
 ## Example
 


### PR DESCRIPTION
## Summary
Updated the inference caching documentation to reflect the OpenAI-compatible API approach, replacing the native TensorZero client examples with OpenAI SDK examples in both Python and Node.js.

## Key Changes
- Updated API reference link to point to the OpenAI-compatible endpoint documentation (`inference-openai-compatible/#tensorzero_cache_options`)
- Replaced native TensorZero client example with OpenAI Python client using the gateway's OpenAI-compatible endpoint
- Added Node.js/TypeScript example demonstrating cache options with the OpenAI SDK
- Organized examples in tabbed interface for better readability across multiple languages
- Updated cache options syntax to use `extra_body` with `tensorzero::cache_options` key, matching the OpenAI-compatible API pattern

## Implementation Details
- Examples now use `base_url="http://localhost:3000/openai/v1"` to connect to the gateway's OpenAI-compatible interface
- Model specification follows the pattern: `tensorzero::model_name::openai::gpt-4o-mini`
- Cache configuration is passed via `extra_body` parameter, which is the standard way to pass custom parameters through OpenAI SDK clients

https://claude.ai/code/session_01SSoTmZGAmYQBu5R9qK1YyZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes updating links and code snippets; no runtime behavior or production code is modified.
> 
> **Overview**
> Updates the inference caching guide to reference the OpenAI-compatible inference API and demonstrates cache configuration via the OpenAI Python SDK.
> 
> The example now uses `OpenAI(base_url=.../openai/v1)` and passes cache settings through `extra_body` under `tensorzero::cache_options`, and the docs link is updated to the corresponding OpenAI-compatible API reference section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aab472e38523768f9b7f11c1225733eff2e70873. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->