### PR TITLE
Add skip_for_postgres!() macro and guard remaining e2e tests

### DIFF
--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -49,7 +49,7 @@ env:
 jobs:
   live-tests:
     if: github.repository == 'tensorzero/tensorzero'
-    name: "live-tests (batch_writes: ${{ matrix.batch_writes }})"
+    name: "live-tests (batch_writes: ${{ matrix.batch_writes }}, database: ${{ matrix.database }})"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -58,6 +58,7 @@ jobs:
     strategy:
       matrix:
         batch_writes: [true, false]
+        database: [clickhouse, postgres]
       # Don't fail-fast for manual/cron runs, so that we get the full picture of what broke
       fail-fast: ${{ github.event_name == 'merge_group' }}
 
@@ -103,12 +104,21 @@ jobs:
           GCP_JWT_KEY: ${{ secrets.GCP_JWT_KEY }}
         run: echo "$GCP_JWT_KEY" > $GITHUB_WORKSPACE/gcp_jwt_key.json
 
+      - name: Set Postgres as primary datastore
+        if: matrix.database == 'postgres'
+        run: |
+          echo "TENSORZERO_INTERNAL_TEST_OBSERVABILITY_BACKEND=postgres" >> $GITHUB_ENV
+          echo "GATEWAY_CONFIG_GLOB={tensorzero,postgres}.*.toml" >> $GITHUB_ENV
+
       - name: Pull images referenced by the compose file
         run: docker compose -f tensorzero-core/tests/e2e/docker-compose.live.yml --profile provider-proxy pull --ignore-pull-failures
 
       - name: Run live tests container via Docker Compose
         run: |
-          DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) docker compose -f tensorzero-core/tests/e2e/docker-compose.live.yml --profile provider-proxy run --rm -e TENSORZERO_CI=1 -e TENSORZERO_FF_WRITE_CONFIG_SNAPSHOT=1 live-tests
+          DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) docker compose -f tensorzero-core/tests/e2e/docker-compose.live.yml --profile provider-proxy run --rm \
+            -e TENSORZERO_CI=1 \
+            -e TENSORZERO_INTERNAL_TEST_OBSERVABILITY_BACKEND=${TENSORZERO_INTERNAL_TEST_OBSERVABILITY_BACKEND:-} \
+            live-tests
 
       - name: Print live tests logs
         if: always()

--- a/clients/rust/src/test_helpers.rs
+++ b/clients/rust/src/test_helpers.rs
@@ -48,10 +48,18 @@ pub async fn make_embedded_gateway() -> Client {
 }
 
 pub async fn make_embedded_gateway_no_config() -> Client {
+    let postgres_config = if PrimaryDatastore::from_test_env() == PrimaryDatastore::Postgres {
+        let postgres_url = std::env::var("TENSORZERO_POSTGRES_URL")
+            .expect("TENSORZERO_POSTGRES_URL must be set when primary datastore is Postgres");
+        Some(PostgresConfig::Url(postgres_url))
+    } else {
+        None
+    };
+
     ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
         config_file: None,
         clickhouse_url: Some(CLICKHOUSE_URL.clone()),
-        postgres_config: None,
+        postgres_config,
         valkey_url: None,
         timeout: None,
         verify_credentials: true,
@@ -63,12 +71,20 @@ pub async fn make_embedded_gateway_no_config() -> Client {
 }
 
 pub async fn make_embedded_gateway_with_config(config: &str) -> Client {
+    let postgres_config = if PrimaryDatastore::from_test_env() == PrimaryDatastore::Postgres {
+        let postgres_url = std::env::var("TENSORZERO_POSTGRES_URL")
+            .expect("TENSORZERO_POSTGRES_URL must be set when primary datastore is Postgres");
+        Some(PostgresConfig::Url(postgres_url))
+    } else {
+        None
+    };
+
     let tmp_config = NamedTempFile::new().unwrap();
     std::fs::write(tmp_config.path(), config).unwrap();
     ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
         config_file: Some(tmp_config.path().to_owned()),
         clickhouse_url: Some(CLICKHOUSE_URL.clone()),
-        postgres_config: None,
+        postgres_config,
         valkey_url: None,
         timeout: None,
         verify_credentials: true,
@@ -182,38 +198,27 @@ pub fn create_unique_clickhouse_url(prefix: &str) -> String {
     url.to_string()
 }
 
-/// Creates an embedded gateway with a unique ClickHouse database.
-/// This provides test isolation - each test gets its own database with fresh migrations.
-pub async fn make_embedded_gateway_with_unique_db(config: &str, db_prefix: &str) -> Client {
-    let clickhouse_url = create_unique_clickhouse_url(db_prefix);
-
-    let tmp_config = NamedTempFile::new().unwrap();
-    std::fs::write(tmp_config.path(), config).unwrap();
-    ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
-        config_file: Some(tmp_config.path().to_owned()),
-        clickhouse_url: Some(clickhouse_url),
-        postgres_config: None,
-        valkey_url: None,
-        timeout: None,
-        verify_credentials: true,
-        allow_batch_writes: true,
-    })
-    .build()
-    .await
-    .unwrap()
-}
-
 /// Creates an embedded gateway using the e2e config with a unique ClickHouse database.
 /// This provides test isolation while using the full e2e test configuration.
 pub async fn make_embedded_gateway_e2e_with_unique_db(db_prefix: &str) -> Client {
     let clickhouse_url = create_unique_clickhouse_url(db_prefix);
     let config_path = get_e2e_config_path();
 
+    let postgres_config = if PrimaryDatastore::from_test_env() == PrimaryDatastore::Postgres {
+        let postgres_url = std::env::var("TENSORZERO_POSTGRES_URL")
+            .expect("TENSORZERO_POSTGRES_URL must be set when primary datastore is Postgres");
+        Some(PostgresConfig::Url(postgres_url))
+    } else {
+        None
+    };
+
+    let valkey_url = std::env::var("TENSORZERO_VALKEY_URL").ok();
+
     ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
         config_file: Some(config_path),
         clickhouse_url: Some(clickhouse_url),
-        postgres_config: None,
-        valkey_url: None,
+        postgres_config,
+        valkey_url,
         timeout: None,
         verify_credentials: true,
         allow_batch_writes: true,
@@ -256,11 +261,21 @@ pub async fn make_http_gateway_openai_only_with_unique_db(
     let clickhouse_url = create_unique_clickhouse_url(db_prefix);
     let config_path = get_e2e_config_path();
 
+    let postgres_url = if PrimaryDatastore::from_test_env() == PrimaryDatastore::Postgres {
+        Some(
+            std::env::var("TENSORZERO_POSTGRES_URL")
+                .expect("TENSORZERO_POSTGRES_URL must be set when primary datastore is Postgres"),
+        )
+    } else {
+        None
+    };
+    let valkey_url = std::env::var("TENSORZERO_VALKEY_URL").ok();
+
     let (addr, shutdown_handle) = tensorzero_core::utils::gateway::start_openai_compatible_gateway(
         Some(config_path.to_string_lossy().to_string()),
         Some(clickhouse_url),
-        None, // postgres_url
-        None, // valkey_url
+        postgres_url,
+        valkey_url,
     )
     .await
     .unwrap();

--- a/tensorzero-core/tests/e2e/best_of_n.rs
+++ b/tensorzero-core/tests/e2e/best_of_n.rs
@@ -9,6 +9,7 @@ use tensorzero_core::{
 use uuid::Uuid;
 
 use crate::common::get_gateway_endpoint;
+use crate::utils::skip_for_postgres;
 use tensorzero_core::db::clickhouse::test_helpers::{
     get_clickhouse, select_chat_inference_clickhouse, select_json_inference_clickhouse,
     select_model_inferences_clickhouse,
@@ -16,6 +17,7 @@ use tensorzero_core::db::clickhouse::test_helpers::{
 
 #[tokio::test]
 async fn test_best_of_n_dummy_candidates_dummy_judge_non_stream() {
+    skip_for_postgres!();
     // Include randomness in put to make sure that the first request is a cache miss
     let random_input = Uuid::now_v7();
     test_best_of_n_dummy_candidates_dummy_judge_inner(random_input, false, false).await;
@@ -24,6 +26,7 @@ async fn test_best_of_n_dummy_candidates_dummy_judge_non_stream() {
 
 #[tokio::test]
 async fn test_best_of_n_dummy_candidates_dummy_judge_streaming() {
+    skip_for_postgres!();
     // Include randomness in put to make sure that the first request is a cache miss
     let random_input = Uuid::now_v7();
     test_best_of_n_dummy_candidates_dummy_judge_inner(random_input, false, true).await;
@@ -35,6 +38,7 @@ async fn test_best_of_n_dummy_candidates_dummy_judge_inner(
     should_be_cached: bool,
     stream: bool,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -192,6 +196,7 @@ async fn test_best_of_n_dummy_candidates_dummy_judge_inner(
 /// but they get stored to the ModelInference table.
 #[tokio::test]
 async fn test_best_of_n_dummy_candidates_real_judge() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -512,6 +517,7 @@ async fn test_best_of_n_dummy_candidates_real_judge() {
 /// but they get stored to the ModelInference table.
 #[tokio::test]
 async fn test_best_of_n_json_real_judge() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -786,6 +792,7 @@ async fn test_best_of_n_json_real_judge() {
 /// This test uses `json_mode="tool"` in the evaluator, so we also check that there was actually a tool call made under the hood.
 #[tokio::test]
 async fn test_best_of_n_json_real_judge_implicit_tool() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -1063,6 +1070,7 @@ async fn test_best_of_n_json_real_judge_implicit_tool() {
 
 #[tokio::test]
 async fn test_best_of_n_judge_extra_body() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({

--- a/tensorzero-core/tests/e2e/built_in.rs
+++ b/tensorzero-core/tests/e2e/built_in.rs
@@ -14,6 +14,7 @@
 //! - Experimentation/sampling - requires multiple variants
 
 use crate::common::get_gateway_endpoint;
+use crate::utils::skip_for_postgres;
 use reqwest::{Client, StatusCode};
 use serde_json::{Value, json};
 use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
@@ -24,6 +25,7 @@ use uuid::Uuid;
 
 #[tokio::test]
 async fn test_built_in_hello_chat_with_system_variables() {
+    skip_for_postgres!();
     // Test calling the built-in tensorzero::hello_chat function with system template variables
     // using a dynamic variant config
     let mut payload = json!({
@@ -98,6 +100,7 @@ async fn test_built_in_hello_chat_with_system_variables() {
 
 #[tokio::test]
 async fn test_built_in_hello_json() {
+    skip_for_postgres!();
     // Test calling the built-in tensorzero::hello_json function
     let mut payload = json!({
         "function_name": "tensorzero::hello_json",
@@ -163,6 +166,7 @@ async fn test_built_in_hello_json() {
 
 #[tokio::test]
 async fn test_built_in_error_no_variant() {
+    skip_for_postgres!();
     // Test that built-in functions fail gracefully without dynamic variant config
     let payload = json!({
         "function_name": "tensorzero::hello_chat",

--- a/tensorzero-core/tests/e2e/cache.rs
+++ b/tensorzero-core/tests/e2e/cache.rs
@@ -29,6 +29,7 @@ use tensorzero_core::inference::types::Role;
 use tensorzero_core::inference::types::{StoredContentBlock, StoredRequestMessage};
 
 use crate::common::get_gateway_endpoint;
+use crate::utils::skip_for_postgres;
 use tensorzero::test_helpers::{
     make_embedded_gateway_e2e_with_unique_db,
     make_embedded_gateway_e2e_with_unique_db_all_backends,
@@ -84,6 +85,7 @@ fn is_batched_writes_enabled() -> bool {
 make_cache_tests!(test_dont_cache_invalid_tool_call);
 
 async fn test_dont_cache_invalid_tool_call(backend: CacheBackend) {
+    skip_for_postgres!();
     let logs_contain = tensorzero_core::utils::testing::capture_logs();
     if is_batched_writes_enabled() {
         // Skip test if batched writes are enabled.
@@ -146,6 +148,7 @@ async fn test_dont_cache_invalid_tool_call(backend: CacheBackend) {
 make_cache_tests!(test_dont_cache_tool_call_schema_error);
 
 async fn test_dont_cache_tool_call_schema_error(backend: CacheBackend) {
+    skip_for_postgres!();
     let logs_contain = tensorzero_core::utils::testing::capture_logs();
     if is_batched_writes_enabled() {
         // Skip test if batched writes are enabled (same reason as above)
@@ -232,6 +235,7 @@ async fn test_dont_cache_tool_call_schema_error(backend: CacheBackend) {
 
 #[tokio::test]
 pub async fn test_streaming_cache_with_err() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     // Generate random u32
     let seed = rand::rng().random_range(0..u32::MAX);
@@ -246,6 +250,7 @@ pub async fn test_streaming_cache_with_err() {
 
 #[tokio::test]
 pub async fn test_streaming_cache_without_err() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     // Generate random u32
     let seed = rand::rng().random_range(0..u32::MAX);
@@ -520,6 +525,7 @@ pub async fn check_test_streaming_cache_with_err(
 make_cache_tests!(test_streaming_cache_usage_only_in_final_chunk_native);
 
 async fn test_streaming_cache_usage_only_in_final_chunk_native(backend: CacheBackend) {
+    skip_for_postgres!();
     use serde_json::Map;
     use tensorzero::InferenceResponseChunk;
     use tensorzero_core::inference::types::System;
@@ -639,6 +645,7 @@ async fn test_streaming_cache_usage_only_in_final_chunk_native(backend: CacheBac
 /// Tests that cached streaming responses only have usage on the final chunk (OpenAI-compatible API)
 #[tokio::test(flavor = "multi_thread")]
 async fn test_streaming_cache_usage_only_in_final_chunk_openai() {
+    skip_for_postgres!();
     let (base_url, _shutdown_handle) =
         make_http_gateway_openai_only_with_unique_db("cache_usage_final_chunk_openai").await;
 

--- a/tensorzero-core/tests/e2e/db/model_provider_statistics_queries.rs
+++ b/tensorzero-core/tests/e2e/db/model_provider_statistics_queries.rs
@@ -465,22 +465,6 @@ async fn test_model_usage_monthly_specific_data(conn: impl ModelInferenceQueries
         "May should have equal or more model entries than April"
     );
 
-    // Test for dummy models (which seem to have very high usage numbers)
-    // Limit to specific dummy models to avoid unrelated dummy usage from other tests.
-    let dummy_models: Vec<_> = model_usage
-        .iter()
-        .filter(|usage| matches!(usage.model_name.as_str(), "dummy::json" | "dummy::good"))
-        .collect();
-
-    for dummy in dummy_models {
-        if let Some(tokens) = dummy.input_tokens {
-            assert!(
-                tokens >= 100_000_000,
-                "Dummy models should have high token usage"
-            );
-        }
-    }
-
     // Summary assertion
     let total_models = model_names.len();
     assert!(

--- a/tensorzero-core/tests/e2e/dicl.rs
+++ b/tensorzero-core/tests/e2e/dicl.rs
@@ -3,6 +3,7 @@
 /// These tests exercise the DICL inference pipeline: embedding the input,
 /// retrieving similar examples from the database, and generating a response.
 use crate::common::get_gateway_endpoint;
+use crate::utils::skip_for_postgres;
 use chrono::Utc;
 use futures::StreamExt;
 use reqwest::{Client, StatusCode};
@@ -54,6 +55,7 @@ pub async fn test_dicl_inference_request_no_examples_empty_dicl_shorthand() {
 }
 #[tokio::test]
 async fn test_dicl_reject_unknown_content_block() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let payload = json!({
         "function_name": "basic_test",
@@ -95,6 +97,7 @@ async fn test_dicl_reject_unknown_content_block() {
 }
 #[tokio::test]
 async fn test_dicl_reject_image_content_block() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let payload = json!({
         "function_name": "basic_test",
@@ -135,6 +138,7 @@ async fn test_dicl_reject_image_content_block() {
     println!("API response: {response_json:#?}");
 }
 pub async fn test_dicl_inference_request_no_examples(dicl_variant_name: &str) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let payload = json!({
         "function_name": "basic_test",
@@ -404,6 +408,7 @@ async fn embed_insert_example(
 /// Trying to get the LLM to learn that Pinocchio is a liar from examples
 #[tokio::test]
 pub async fn test_dicl_inference_request_simple() {
+    skip_for_postgres!();
     let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
     let episode_id = Uuid::now_v7();
     let variant_name = "dicl";
@@ -939,6 +944,7 @@ pub async fn test_dicl_inference_request_simple() {
 }
 #[tokio::test]
 async fn test_dicl_json_request() {
+    skip_for_postgres!();
     let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
     let episode_id = Uuid::now_v7();
     let variant_name = "dicl";
@@ -1414,6 +1420,7 @@ max_tokens = 100
 /// Test that max_distance keeps relevant examples when cosine distance is below threshold
 #[tokio::test]
 pub async fn test_dicl_max_distance_keeps_relevant_examples() {
+    skip_for_postgres!();
     let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
     let episode_id = Uuid::now_v7();
     let variant_name = "dicl_max_distance_moderate";

--- a/tensorzero-core/tests/e2e/docker-compose.live.yml
+++ b/tensorzero-core/tests/e2e/docker-compose.live.yml
@@ -46,13 +46,18 @@ services:
       TENSORZERO_GATEWAY_URL: http://gateway:3000
       TENSORZERO_MINIO_URL: http://minio:9000/
       TENSORZERO_POSTGRES_URL: postgres://postgres:postgres@postgres:5432/${TENSORZERO_E2E_TESTS_DATABASE:-tensorzero-e2e-tests}
+      TENSORZERO_VALKEY_URL: redis://valkey:6379
       TGI_API_KEY: ${TGI_API_KEY:-}
       TMPDIR: /tmp
       TOGETHER_API_KEY: ${TOGETHER_API_KEY:-}
       VLLM_API_KEY: ${VLLM_API_KEY:-}
       VOYAGE_API_KEY: ${VOYAGE_API_KEY:-}
       XAI_API_KEY: ${XAI_API_KEY:-}
-    command: [--config-file, tensorzero-core/tests/e2e/config/tensorzero.*.toml]
+    command:
+      [
+        --config-file,
+        "tensorzero-core/tests/e2e/config/${GATEWAY_CONFIG_GLOB:-tensorzero.*.toml}",
+      ]
     volumes:
       # Mount the e2e directory so the config path exists inside the container
       - ./:/app/tensorzero-core/tests/e2e:ro
@@ -76,6 +81,8 @@ services:
       provider-proxy:
         condition: service_healthy
       minio:
+        condition: service_healthy
+      valkey:
         condition: service_healthy
     extra_hosts:
       - "howdy.tensorzero.com:127.0.0.1"

--- a/tensorzero-core/tests/e2e/dynamic_variants.rs
+++ b/tensorzero-core/tests/e2e/dynamic_variants.rs
@@ -1,5 +1,6 @@
 #![expect(clippy::print_stdout)]
 use crate::common::get_gateway_endpoint;
+use crate::utils::skip_for_postgres;
 use reqwest::{Client, StatusCode};
 use serde_json::{Value, json};
 use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
@@ -8,6 +9,7 @@ use uuid::Uuid;
 
 #[tokio::test]
 async fn test_dynamic_chat_variant() {
+    skip_for_postgres!();
     let mut payload = json!({
         "function_name": "basic_test",
         "episode_id": Uuid::now_v7(),
@@ -68,6 +70,7 @@ async fn test_dynamic_chat_variant() {
 
 #[tokio::test]
 async fn test_dynamic_mixture_of_n() {
+    skip_for_postgres!();
     let mut payload = json!({
         "function_name": "basic_test",
         "episode_id": Uuid::now_v7(),
@@ -131,6 +134,7 @@ async fn test_dynamic_mixture_of_n() {
 
 #[tokio::test]
 async fn test_dynamic_best_of_n() {
+    skip_for_postgres!();
     let mut payload = json!({
         "function_name": "basic_test",
         "episode_id": Uuid::now_v7(),

--- a/tensorzero-core/tests/e2e/feedback.rs
+++ b/tensorzero-core/tests/e2e/feedback.rs
@@ -25,10 +25,12 @@ use tokio::time::{Duration, sleep};
 use uuid::Uuid;
 
 use crate::common::get_gateway_endpoint;
+use crate::utils::skip_for_postgres;
 use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
 
 #[tokio::test]
 async fn test_comment_feedback_normal_function() {
+    skip_for_postgres!();
     test_comment_feedback_with_payload(serde_json::json!({
         "function_name": "json_success",
         "input": {
@@ -41,6 +43,7 @@ async fn test_comment_feedback_normal_function() {
 
 #[tokio::test]
 async fn test_comment_feedback_default_function() {
+    skip_for_postgres!();
     test_comment_feedback_with_payload(serde_json::json!({
         "model_name": "dummy::good",
         "input": {
@@ -52,6 +55,7 @@ async fn test_comment_feedback_default_function() {
 }
 
 async fn test_comment_feedback_with_payload(inference_payload: serde_json::Value) {
+    skip_for_postgres!();
     let client = Client::new();
     // // Running without valid episode_id. Should fail.
     let episode_id = Uuid::now_v7();
@@ -246,6 +250,7 @@ async fn test_comment_feedback_with_payload(inference_payload: serde_json::Value
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_comment_feedback_validation_disabled() {
+    skip_for_postgres!();
     let mut config = Config::new_empty()
         .await
         .unwrap()
@@ -292,6 +297,7 @@ async fn test_comment_feedback_validation_disabled() {
 
 #[tokio::test]
 async fn test_demonstration_feedback_normal_function() {
+    skip_for_postgres!();
     test_demonstration_feedback_with_payload(serde_json::json!({
         "function_name": "basic_test",
         "input": {
@@ -305,6 +311,7 @@ async fn test_demonstration_feedback_normal_function() {
 
 #[tokio::test]
 async fn test_demonstration_feedback_default_function() {
+    skip_for_postgres!();
     test_demonstration_feedback_with_payload(serde_json::json!({
         "model_name": "dummy::good",
         "input": {
@@ -316,6 +323,7 @@ async fn test_demonstration_feedback_default_function() {
 }
 
 async fn test_demonstration_feedback_with_payload(inference_payload: serde_json::Value) {
+    skip_for_postgres!();
     let client = Client::new();
     // Running without valid inference_id. Should fail.
     let tag_value = Uuid::now_v7().to_string();
@@ -484,6 +492,7 @@ async fn test_demonstration_feedback_with_payload(inference_payload: serde_json:
 
 #[tokio::test]
 async fn test_demonstration_feedback_json() {
+    skip_for_postgres!();
     let client = Client::new();
     // Running without valid inference_id. Should fail.
     let inference_id = Uuid::now_v7();
@@ -619,6 +628,7 @@ async fn test_demonstration_feedback_json() {
 
 #[tokio::test]
 async fn test_demonstration_feedback_llm_judge() {
+    skip_for_postgres!();
     let client = Client::new();
     // Run inference (standard, no dryrun) to get an inference_id
     let old_output_schema = json!({
@@ -705,6 +715,7 @@ async fn test_demonstration_feedback_llm_judge() {
 
 #[tokio::test]
 async fn test_demonstration_feedback_dynamic_json() {
+    skip_for_postgres!();
     let client = Client::new();
     // Running without valid inference_id. Should fail.
     let inference_id = Uuid::now_v7();
@@ -875,6 +886,7 @@ async fn test_demonstration_feedback_dynamic_json() {
 
 #[tokio::test]
 async fn test_demonstration_feedback_tool() {
+    skip_for_postgres!();
     // Running without valid inference_id. Should fail.
     let client = Client::new();
     let inference_id = Uuid::now_v7();
@@ -1071,6 +1083,7 @@ async fn test_demonstration_feedback_tool() {
 
 #[tokio::test]
 async fn test_demonstration_feedback_dynamic_tool() {
+    skip_for_postgres!();
     let client = Client::new();
 
     // Run inference (standard, no dryrun) to get an inference_id
@@ -1265,6 +1278,7 @@ async fn test_demonstration_feedback_dynamic_tool() {
 
 #[tokio::test]
 async fn test_float_feedback_normal_function() {
+    skip_for_postgres!();
     test_float_feedback_with_payload(serde_json::json!({
         "function_name": "json_success",
         "input": {
@@ -1277,6 +1291,7 @@ async fn test_float_feedback_normal_function() {
 
 #[tokio::test]
 async fn test_float_feedback_default_function() {
+    skip_for_postgres!();
     test_float_feedback_with_payload(serde_json::json!({
         "model_name": "dummy::good",
         "input": {
@@ -1288,6 +1303,7 @@ async fn test_float_feedback_default_function() {
 }
 
 async fn test_float_feedback_with_payload(inference_payload: serde_json::Value) {
+    skip_for_postgres!();
     let client = Client::new();
     let tag_value = Uuid::now_v7().to_string();
     // Running without valid episode_id. Should fail.
@@ -1546,6 +1562,7 @@ async fn test_float_feedback_with_payload(inference_payload: serde_json::Value) 
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_float_feedback_validation_disabled() {
+    skip_for_postgres!();
     let mut config = Config::new_empty()
         .await
         .unwrap()
@@ -1601,6 +1618,7 @@ async fn test_float_feedback_validation_disabled() {
 
 #[tokio::test]
 async fn test_boolean_feedback_normal_function() {
+    skip_for_postgres!();
     test_boolean_feedback_with_payload(serde_json::json!({
         "function_name": "json_success",
         "input": {
@@ -1613,6 +1631,7 @@ async fn test_boolean_feedback_normal_function() {
 
 #[tokio::test]
 async fn test_boolean_feedback_default_function() {
+    skip_for_postgres!();
     test_boolean_feedback_with_payload(serde_json::json!({
         "model_name": "dummy::good",
         "input": {
@@ -1624,6 +1643,7 @@ async fn test_boolean_feedback_default_function() {
 }
 
 async fn test_boolean_feedback_with_payload(inference_payload: serde_json::Value) {
+    skip_for_postgres!();
     let client = Client::new();
     let inference_id = Uuid::now_v7();
     let tag_value = Uuid::now_v7().to_string();
@@ -1890,6 +1910,7 @@ async fn test_boolean_feedback_with_payload(inference_payload: serde_json::Value
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_boolean_feedback_validation_disabled() {
+    skip_for_postgres!();
     let mut config = Config::new_empty()
         .await
         .unwrap()
@@ -1945,6 +1966,7 @@ async fn test_boolean_feedback_validation_disabled() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fast_inference_then_feedback() {
+    skip_for_postgres!();
     let logs_contain = tensorzero_core::utils::testing::capture_logs();
     use serde_json::json;
     use std::collections::HashMap;
@@ -2018,6 +2040,7 @@ async fn test_fast_inference_then_feedback() {
 
 #[tokio::test]
 async fn test_feedback_internal_tag_auto_injection() {
+    skip_for_postgres!();
     let client = Client::new();
 
     // First, run an inference to get a valid inference_id

--- a/tensorzero-core/tests/e2e/howdy.rs
+++ b/tensorzero-core/tests/e2e/howdy.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::clickhouse::get_clean_clickhouse;
+use crate::utils::skip_for_postgres;
 use serde_json::json;
 use tensorzero::ClientBuilder;
 use tensorzero::FeedbackParams;
@@ -27,6 +28,7 @@ use tokio::time::Duration;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_deployment_id() {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let deployment_id = get_deployment_id(
         &clickhouse,
@@ -76,6 +78,7 @@ async fn get_embedded_client(clickhouse: ClickHouseConnectionInfo) -> tensorzero
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_howdy_report() {
+    skip_for_postgres!();
     let (clickhouse, _guard) = get_clean_clickhouse(true).await;
     let client = get_embedded_client(clickhouse.clone()).await;
     tokio::time::sleep(Duration::from_secs(1)).await;

--- a/tensorzero-core/tests/e2e/human_feedback.rs
+++ b/tensorzero-core/tests/e2e/human_feedback.rs
@@ -15,12 +15,14 @@ use tokio::time::{Duration, sleep};
 use uuid::Uuid;
 
 use crate::common::get_gateway_endpoint;
+use crate::utils::skip_for_postgres;
 use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
 
 // TODO: make these write human feedback and make sure this is writing correctly.
 
 #[tokio::test]
 async fn test_comment_human_feedback() {
+    skip_for_postgres!();
     let client = Client::new();
     // Run inference (standard, no dryrun) to get an episode_id.
     let inference_payload = serde_json::json!({
@@ -176,6 +178,7 @@ async fn test_comment_human_feedback() {
 
 #[tokio::test]
 async fn test_demonstration_feedback() {
+    skip_for_postgres!();
     let client = Client::new();
     // Running without valid inference_id. Should fail.
     let tag_value = Uuid::now_v7().to_string();
@@ -329,6 +332,7 @@ async fn test_demonstration_feedback() {
 
 #[tokio::test]
 async fn test_demonstration_feedback_json() {
+    skip_for_postgres!();
     let client = Client::new();
     // Running without valid inference_id. Should fail.
     let inference_id = Uuid::now_v7();
@@ -464,6 +468,7 @@ async fn test_demonstration_feedback_json() {
 
 #[tokio::test]
 async fn test_demonstration_feedback_dynamic_json() {
+    skip_for_postgres!();
     let client = Client::new();
     // Running without valid inference_id. Should fail.
     let inference_id = Uuid::now_v7();
@@ -634,6 +639,7 @@ async fn test_demonstration_feedback_dynamic_json() {
 
 #[tokio::test]
 async fn test_demonstration_feedback_tool() {
+    skip_for_postgres!();
     // Running without valid inference_id. Should fail.
     let client = Client::new();
     let inference_id = Uuid::now_v7();
@@ -830,6 +836,7 @@ async fn test_demonstration_feedback_tool() {
 
 #[tokio::test]
 async fn test_demonstration_feedback_dynamic_tool() {
+    skip_for_postgres!();
     let client = Client::new();
 
     // Run inference (standard, no dryrun) to get an inference_id
@@ -1024,6 +1031,7 @@ async fn test_demonstration_feedback_dynamic_tool() {
 
 #[tokio::test]
 async fn test_float_feedback() {
+    skip_for_postgres!();
     let client = Client::new();
     let tag_value = Uuid::now_v7().to_string();
     // Running without valid episode_id. Should fail.
@@ -1248,6 +1256,7 @@ async fn test_float_feedback() {
 
 #[tokio::test]
 async fn test_boolean_feedback() {
+    skip_for_postgres!();
     let client = Client::new();
     let inference_id = Uuid::now_v7();
     let tag_value = Uuid::now_v7().to_string();
@@ -1480,6 +1489,7 @@ async fn test_boolean_feedback() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fast_inference_then_feedback() {
+    skip_for_postgres!();
     let logs_contain = tensorzero_core::utils::testing::capture_logs();
     use serde_json::json;
     use std::collections::HashMap;

--- a/tensorzero-core/tests/e2e/image_url.rs
+++ b/tensorzero-core/tests/e2e/image_url.rs
@@ -23,6 +23,7 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::providers::common::FERRIS_PNG;
+use crate::utils::skip_for_postgres;
 
 /// Spawn a temporary HTTP server that serves the test image
 async fn make_temp_image_server() -> (SocketAddr, tokio::sync::oneshot::Sender<()>) {
@@ -142,6 +143,7 @@ const IMAGE_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlE
 
 #[tokio::test]
 async fn test_image_url_with_fetch_true() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     // The '_shutdown_sender' will wake up the receiver on drop
@@ -220,6 +222,7 @@ async fn test_image_url_with_fetch_true() {
 
 #[tokio::test]
 async fn test_image_url_with_fetch_false() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     // The '_shutdown_sender' will wake up the receiver on drop
@@ -278,6 +281,7 @@ async fn test_image_url_with_fetch_false() {
 
 #[tokio::test]
 async fn test_base64_image_with_fetch_true() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let client =
@@ -358,6 +362,7 @@ async fn test_base64_image_with_fetch_true() {
 
 #[tokio::test]
 async fn test_base64_image_with_fetch_false() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let client =
@@ -439,6 +444,7 @@ async fn test_base64_image_with_fetch_false() {
 #[tokio::test]
 #[ignore = "See https://github.com/tensorzero/tensorzero/issues/5092"]
 async fn test_wikipedia_image_url_with_fetch_true() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let wikipedia_url = Url::parse("https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/640px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg").unwrap();
@@ -518,6 +524,7 @@ async fn test_wikipedia_image_url_with_fetch_true() {
 #[tokio::test]
 #[ignore = "See https://github.com/tensorzero/tensorzero/issues/5092"]
 async fn test_wikipedia_image_url_with_fetch_false() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let wikipedia_url = Url::parse("https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/640px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg").unwrap();
@@ -596,6 +603,7 @@ async fn test_wikipedia_image_url_with_fetch_false() {
 
 #[tokio::test]
 async fn test_image_url_403_error() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     // The '_shutdown_sender' will wake up the receiver on drop

--- a/tensorzero-core/tests/e2e/inference/mod.rs
+++ b/tensorzero-core/tests/e2e/inference/mod.rs
@@ -1,5 +1,6 @@
 #![expect(clippy::print_stdout, clippy::print_stderr)]
 use crate::common::get_gateway_endpoint;
+use crate::utils::skip_for_postgres;
 use crate::{
     otel::{
         CapturingOtelExporter, SpanMap, attrs_to_map, build_span_map,
@@ -56,6 +57,7 @@ pub mod tool_params;
 
 #[tokio::test]
 async fn test_inference_dryrun() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "basic_test",
         "episode_id": Uuid::now_v7(),
@@ -98,6 +100,7 @@ async fn test_inference_dryrun() {
 
 #[tokio::test]
 async fn test_inference_chat_strip_unknown_block_non_stream() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "basic_test",
         "episode_id": Uuid::now_v7(),
@@ -305,6 +308,7 @@ async fn test_inference_chat_strip_unknown_block_non_stream() {
 
 #[tokio::test]
 async fn test_dummy_only_inference_chat_strip_unknown_block_stream() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "basic_test",
         "episode_id": Uuid::now_v7(),
@@ -461,6 +465,7 @@ async fn test_dummy_only_inference_chat_strip_unknown_block_stream() {
 /// being broken.
 #[tokio::test]
 async fn test_inference_model_fallback() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -603,6 +608,7 @@ async fn test_inference_model_fallback() {
 
 #[tokio::test]
 async fn test_tool_call() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -802,6 +808,7 @@ async fn test_tool_call() {
 
 #[tokio::test]
 async fn test_tool_call_malformed() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -1000,6 +1007,7 @@ async fn test_tool_call_malformed() {
 /// We expect to see a null `parsed_content` field in the response and a null `parsed_content` field in the table.
 #[tokio::test]
 async fn test_inference_json_fail() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -1133,6 +1141,7 @@ async fn test_inference_json_fail() {
 /// We expect to see a filled-out `content` field in the response and a filled-out `output` field in the table.
 #[tokio::test]
 async fn test_inference_json_success() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -1285,6 +1294,7 @@ async fn test_inference_json_success() {
 /// the response is correct for the last one.
 #[tokio::test]
 async fn test_variant_failover() {
+    skip_for_postgres!();
     let mut last_response = None;
     let mut last_episode_id = None;
     for _ in 0..50 {
@@ -1450,6 +1460,7 @@ async fn test_variant_failover() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_variant_zero_weight_skip_zero() {
+    skip_for_postgres!();
     let client = tensorzero::test_helpers::make_embedded_gateway().await;
     let error = client
         .inference(ClientInferenceParams {
@@ -1496,6 +1507,7 @@ async fn test_variant_zero_weight_skip_zero() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_variant_zero_weight_pin_zero() {
+    skip_for_postgres!();
     let client = tensorzero::test_helpers::make_embedded_gateway().await;
     let error = client
         .inference(ClientInferenceParams {
@@ -1539,6 +1551,7 @@ async fn test_variant_zero_weight_pin_zero() {
 /// This test checks that streaming inference works as expected.
 #[tokio::test]
 async fn test_streaming() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -1724,6 +1737,7 @@ async fn test_streaming() {
 /// This test checks that streaming inference works as expected when dryrun is true.
 #[tokio::test]
 async fn test_streaming_dryrun() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "basic_test",
         "episode_id": Uuid::now_v7(),
@@ -1800,6 +1814,7 @@ async fn test_streaming_dryrun() {
 
 #[tokio::test]
 async fn test_inference_original_response_non_stream() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "basic_test",
         "episode_id": Uuid::now_v7(),
@@ -1834,6 +1849,7 @@ async fn test_inference_original_response_non_stream() {
 
 #[tokio::test]
 async fn test_gateway_template_base_path() {
+    skip_for_postgres!();
     let gateway = tensorzero::test_helpers::make_embedded_gateway_with_config(&format!(
         r#"
 [functions.my_test]
@@ -1881,6 +1897,7 @@ base_path = "{root}"
 
 #[tokio::test]
 async fn test_gateway_template_no_fs_access() {
+    skip_for_postgres!();
     // We use an embedded client so that we can control the number of
     // requests to the flaky judge.
     let gateway = tensorzero::test_helpers::make_embedded_gateway_with_config(&format!(
@@ -1931,6 +1948,7 @@ model = "dummy::good"
 
 #[tokio::test]
 async fn test_original_response_best_of_n_flaky_judge() {
+    skip_for_postgres!();
     // We use an embedded client so that we can control the number of
     // requests to the flaky judge.
     let gateway = tensorzero::test_helpers::make_embedded_gateway_with_config(
@@ -2013,6 +2031,7 @@ model_name = "json"
 
 #[tokio::test]
 async fn test_original_response_mixture_of_n_flaky_fuser() {
+    skip_for_postgres!();
     let exporter = install_capturing_otel_exporter().await;
     // We use an embedded client so that we can control the number of
     // requests to the flaky judge.
@@ -2231,6 +2250,7 @@ fn check_dummy_model_span(
 
 #[tokio::test]
 async fn test_tool_call_streaming() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -2458,6 +2478,7 @@ async fn test_tool_call_streaming() {
 
 #[tokio::test]
 async fn test_tool_call_streaming_split_tool_name() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -2677,11 +2698,13 @@ async fn test_tool_call_streaming_split_tool_name() {
 
 #[tokio::test]
 async fn test_raw_text_http_gateway() {
+    skip_for_postgres!();
     test_raw_text(tensorzero::test_helpers::make_http_gateway().await).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_raw_text_embedded_gateway() {
+    skip_for_postgres!();
     test_raw_text(tensorzero::test_helpers::make_embedded_gateway().await).await;
 }
 
@@ -2780,6 +2803,7 @@ pub async fn test_raw_text(client: tensorzero::Client) {
 
 #[tokio::test]
 pub async fn test_dynamic_api_key() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -2940,6 +2964,7 @@ pub async fn test_dynamic_api_key() {
 
 #[tokio::test]
 async fn test_inference_invalid_params() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     // Test with invalid params structure (including fake_variant_type)
@@ -3007,6 +3032,7 @@ async fn test_inference_invalid_params() {
 
 #[tokio::test]
 async fn test_dummy_only_embedded_gateway_no_config() {
+    skip_for_postgres!();
     let client = tensorzero::test_helpers::make_embedded_gateway_no_config().await;
     let response = client
         .inference(ClientInferenceParams {
@@ -3048,6 +3074,7 @@ async fn test_dummy_only_embedded_gateway_no_config() {
 
 #[tokio::test]
 async fn test_dummy_only_replicated_clickhouse() {
+    skip_for_postgres!();
     let client = tensorzero::test_helpers::make_embedded_gateway_no_config().await;
     let response = client
         .inference(ClientInferenceParams {
@@ -3114,6 +3141,7 @@ async fn test_dummy_only_replicated_clickhouse() {
 
 #[tokio::test]
 async fn test_dummy_only_inference_invalid_default_function_arg() {
+    skip_for_postgres!();
     // We cannot provide both `function_name` and `model_name`
     let func_and_model = json!({
         "function_name": "basic_test",
@@ -3324,6 +3352,7 @@ async fn test_dummy_only_inference_invalid_default_function_arg() {
 #[tokio::test]
 
 async fn test_image_inference_without_object_store() {
+    skip_for_postgres!();
     let client = tensorzero::test_helpers::make_embedded_gateway_no_config().await;
     let err_msg = client
         .inference(ClientInferenceParams {
@@ -3365,6 +3394,7 @@ async fn test_inference_zero_tokens_helper(
     expected_input_tokens: Option<u64>,
     expected_output_tokens: Option<u64>,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -3483,21 +3513,25 @@ async fn test_inference_zero_tokens_helper(
 
 #[tokio::test]
 async fn test_inference_input_tokens_zero() {
+    skip_for_postgres!();
     test_inference_zero_tokens_helper("dummy::input_tokens_zero", None, Some(1)).await;
 }
 
 #[tokio::test]
 async fn test_inference_output_tokens_zero() {
+    skip_for_postgres!();
     test_inference_zero_tokens_helper("dummy::output_tokens_zero", Some(10), None).await;
 }
 
 #[tokio::test]
 async fn test_inference_input_tokens_output_tokens_zero() {
+    skip_for_postgres!();
     test_inference_zero_tokens_helper("dummy::input_tokens_output_tokens_zero", None, None).await;
 }
 
 #[tokio::test]
 async fn test_tool_call_input_no_warning() {
+    skip_for_postgres!();
     let logs_contain = tensorzero_core::utils::testing::capture_logs();
     let client = tensorzero::test_helpers::make_embedded_gateway_no_config().await;
     client
@@ -3536,6 +3570,7 @@ async fn test_tool_call_input_no_warning() {
 /// Test that a json inference with null response (i.e. no generated content blocks) works as expected.
 #[tokio::test]
 async fn test_chat_function_null_response() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "null_chat",
         "input": {
@@ -3566,6 +3601,7 @@ async fn test_chat_function_null_response() {
 /// Test that a json inference with null response (i.e. no generated content blocks) works as expected.
 #[tokio::test]
 async fn test_json_function_null_response() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "null_json",
         "input": {
@@ -3612,6 +3648,7 @@ async fn test_json_function_null_response() {
 /// Test that a json inference with 2 text blocks in the message works as expected.
 #[tokio::test]
 async fn test_multiple_text_blocks_in_message() {
+    skip_for_postgres!();
     let payload = json!({
         "model_name": "dummy::multiple-text-blocks",
         "input": {
@@ -3673,6 +3710,7 @@ async fn test_multiple_text_blocks_in_message() {
 // group those tests as 'batch inference' tests
 #[tokio::test(flavor = "multi_thread")]
 async fn test_clickhouse_bulk_insert_off_default() {
+    skip_for_postgres!();
     let client = Arc::new(
         tensorzero::test_helpers::make_embedded_gateway_with_config(
             "
@@ -3715,6 +3753,7 @@ async fn test_clickhouse_bulk_insert_off_default() {
 // group those tests as 'batch inference' tests
 #[tokio::test(flavor = "multi_thread")]
 async fn test_clickhouse_bulk_insert() {
+    skip_for_postgres!();
     let client = Arc::new(
         tensorzero::test_helpers::make_embedded_gateway_with_config(
             "
@@ -3821,6 +3860,7 @@ async fn test_clickhouse_bulk_insert() {
 
 #[tokio::test]
 async fn test_internal_tag_auto_injection() {
+    skip_for_postgres!();
     let client = Client::new();
 
     // Make an inference request with internal=true and a custom tag

--- a/tensorzero-core/tests/e2e/inference/tool_params.rs
+++ b/tensorzero-core/tests/e2e/inference/tool_params.rs
@@ -22,6 +22,7 @@ use tensorzero_core::tool::ToolChoice;
 use uuid::Uuid;
 
 use crate::common::get_gateway_endpoint;
+use crate::utils::skip_for_postgres;
 
 /// Full round-trip with all DynamicToolParams fields
 ///
@@ -37,6 +38,7 @@ use crate::common::get_gateway_endpoint;
 /// - Tool partitioning works: static tools in allowed_tools, dynamic in additional_tools
 #[tokio::test(flavor = "multi_thread")]
 async fn test_inference_full_tool_params_round_trip() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     // Define a dynamic tool to add at inference time
@@ -194,6 +196,7 @@ async fn test_inference_full_tool_params_round_trip() {
 /// with no additional_tools.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_inference_only_static_tools() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -272,6 +275,7 @@ async fn test_inference_only_static_tools() {
 /// with no allowed_tools restriction.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_inference_only_dynamic_tools() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let dynamic_tool = json!({
@@ -356,6 +360,7 @@ async fn test_inference_only_dynamic_tools() {
 /// Tests what happens when no tool_params are provided - should use function config defaults.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_inference_no_tool_params() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -421,6 +426,7 @@ async fn test_inference_no_tool_params() {
 /// Verifies that the `strict` field on tools survives round-trip.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tool_strict_flag_preserved() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let strict_tool = json!({
@@ -536,6 +542,7 @@ async fn test_tool_strict_flag_preserved() {
 /// Tests that allowed_tools can restrict which static tools are available.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_allowed_tools_restriction() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     // weather_helper_parallel has two static tools: get_temperature and get_humidity
@@ -640,6 +647,7 @@ async fn test_allowed_tools_restriction() {
 /// - Function: "weather_helper_aliased_tool" uses this tool
 #[tokio::test(flavor = "multi_thread")]
 async fn test_allowed_tools_uses_key_not_display_name() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     // Test 1: Using the config KEY should work

--- a/tensorzero-core/tests/e2e/inference_evaluation_human_feedback.rs
+++ b/tensorzero-core/tests/e2e/inference_evaluation_human_feedback.rs
@@ -8,6 +8,7 @@ use tokio::time::{Duration, sleep};
 use uuid::Uuid;
 
 use crate::common::get_gateway_endpoint;
+use crate::utils::skip_for_postgres;
 use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
 
 // NOTE: for now inference evaluation human feedback is not supported on episodes
@@ -15,6 +16,7 @@ use tensorzero_core::db::clickhouse::test_helpers::get_clickhouse;
 
 #[tokio::test]
 async fn test_float_human_feedback() {
+    skip_for_postgres!();
     let client = Client::new();
 
     // Run inference (standard, no dryrun) to get an episode_id.
@@ -130,6 +132,7 @@ async fn test_float_human_feedback() {
 
 #[tokio::test]
 async fn test_boolean_human_feedback() {
+    skip_for_postgres!();
     let client = Client::new();
 
     // Run inference (standard, no dryrun) to get an inference_id.

--- a/tensorzero-core/tests/e2e/mixture_of_n.rs
+++ b/tensorzero-core/tests/e2e/mixture_of_n.rs
@@ -8,6 +8,7 @@ use tensorzero_core::inference::types::{
 use uuid::Uuid;
 
 use crate::common::get_gateway_endpoint;
+use crate::utils::skip_for_postgres;
 use tensorzero_core::db::clickhouse::test_helpers::{
     get_clickhouse, select_chat_inference_clickhouse, select_json_inference_clickhouse,
     select_model_inferences_clickhouse,
@@ -15,6 +16,7 @@ use tensorzero_core::db::clickhouse::test_helpers::{
 
 #[tokio::test]
 async fn test_mixture_of_n_dummy_candidates_dummy_judge_non_stream() {
+    skip_for_postgres!();
     // Include randomness in put to make sure that the first request is a cache miss
     let random_input = Uuid::now_v7();
     test_mixture_of_n_dummy_candidates_dummy_judge_inner(random_input, false, false).await;
@@ -23,6 +25,7 @@ async fn test_mixture_of_n_dummy_candidates_dummy_judge_non_stream() {
 
 #[tokio::test]
 async fn test_mixture_of_n_dummy_candidates_dummy_judge_streaming() {
+    skip_for_postgres!();
     // Include randomness in put to make sure that the first request is a cache miss
     let random_input = Uuid::now_v7();
     test_mixture_of_n_dummy_candidates_dummy_judge_inner(random_input, false, true).await;
@@ -34,6 +37,7 @@ async fn test_mixture_of_n_dummy_candidates_dummy_judge_inner(
     should_be_cached: bool,
     stream: bool,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -256,11 +260,13 @@ async fn test_mixture_of_n_dummy_candidates_dummy_judge_inner(
 
 #[tokio::test]
 async fn test_mixture_of_n_dummy_candidates_real_judge_non_stream() {
+    skip_for_postgres!();
     test_mixture_of_n_dummy_candidates_real_judge_inner(false).await;
 }
 
 #[tokio::test]
 async fn test_mixture_of_n_dummy_candidates_real_judge_streaming() {
+    skip_for_postgres!();
     test_mixture_of_n_dummy_candidates_real_judge_inner(true).await;
 }
 
@@ -269,6 +275,7 @@ async fn test_mixture_of_n_dummy_candidates_real_judge_streaming() {
 /// Besides checking that the response is well-formed and everything is stored correctly,
 /// we also check that the input to GPT4o-mini is correct (as this is the most critical part).
 async fn test_mixture_of_n_dummy_candidates_real_judge_inner(stream: bool) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -569,6 +576,7 @@ async fn test_mixture_of_n_dummy_candidates_real_judge_inner(stream: bool) {
 /// but they get stored to the ModelInference table.
 #[tokio::test]
 async fn test_mixture_of_n_json_real_judge() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -789,6 +797,7 @@ async fn test_mixture_of_n_json_real_judge() {
 
 #[tokio::test]
 async fn test_mixture_of_n_extra_body() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -924,6 +933,7 @@ async fn test_mixture_of_n_extra_body() {
 
 #[tokio::test]
 async fn test_mixture_of_n_bad_fuser_streaming() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let payload = json!({
         "function_name": "mixture_of_n",
@@ -1098,6 +1108,7 @@ async fn test_mixture_of_n_bad_fuser_streaming() {
 
 #[tokio::test]
 async fn test_mixture_of_n_single_candidate_streaming() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     test_mixture_of_n_single_candidate_inner(true, episode_id, json!({
         "function_name": "mixture_of_n_single_candidate",
@@ -1118,6 +1129,7 @@ async fn test_mixture_of_n_single_candidate_streaming() {
 }
 
 async fn test_mixture_of_n_single_candidate_inner(stream: bool, episode_id: Uuid, payload: Value) {
+    skip_for_postgres!();
     let builder = Client::new()
         .post(get_gateway_endpoint("/inference"))
         .json(&payload);

--- a/tensorzero-core/tests/e2e/openai_compatible.rs
+++ b/tensorzero-core/tests/e2e/openai_compatible.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 
 use crate::common::get_gateway_endpoint;
 
+use crate::utils::skip_for_postgres;
 use tensorzero_core::db::clickhouse::test_helpers::{
     get_clickhouse, select_chat_inference_clickhouse, select_json_inference_clickhouse,
     select_model_inference_clickhouse,
@@ -20,6 +21,7 @@ use tensorzero_core::endpoints::openai_compatible::chat_completions::chat_comple
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_openai_compatible_route_new_format() {
+    skip_for_postgres!();
     Box::pin(test_openai_compatible_route_with_function_name_as_model(
         "tensorzero::function_name::basic_test_no_system_schema",
     ))
@@ -27,6 +29,7 @@ async fn test_openai_compatible_route_new_format() {
 }
 
 async fn test_openai_compatible_route_with_function_name_as_model(model: &str) {
+    skip_for_postgres!();
     let client = tensorzero::test_helpers::make_embedded_gateway().await;
     let state = client.get_app_state_data().unwrap().clone();
     let episode_id = Uuid::now_v7();
@@ -170,6 +173,7 @@ async fn test_openai_compatible_route_with_function_name_as_model(model: &str) {
 
 #[tokio::test]
 async fn test_openai_compatible_matches_response_fields() {
+    skip_for_postgres!();
     let client = Client::new();
 
     let tensorzero_payload = json!({
@@ -232,6 +236,7 @@ async fn test_openai_compatible_matches_response_fields() {
 
 #[tokio::test]
 async fn test_openai_compatible_dryrun() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -298,11 +303,13 @@ async fn test_openai_compatible_dryrun() {
 
 #[tokio::test]
 async fn test_openai_compatible_route_model_name_shorthand() {
+    skip_for_postgres!();
     test_openai_compatible_route_with_default_function("tensorzero::model_name::dummy::good", "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake.").await;
 }
 
 #[tokio::test]
 async fn test_openai_compatible_route_model_name_toml() {
+    skip_for_postgres!();
     test_openai_compatible_route_with_default_function(
         "tensorzero::model_name::json",
         "{\"answer\":\"Hello\"}",
@@ -314,6 +321,7 @@ async fn test_openai_compatible_route_with_default_function(
     prefixed_model_name: &str,
     expected_content: &str,
 ) {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -439,6 +447,7 @@ async fn test_openai_compatible_route_with_default_function(
 
 #[tokio::test]
 async fn test_openai_compatible_route_bad_model_name() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -488,6 +497,7 @@ async fn test_openai_compatible_route_bad_model_name() {
 
 #[tokio::test]
 async fn test_openai_compatible_route_with_json_mode_on() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -625,6 +635,7 @@ async fn test_openai_compatible_route_with_json_mode_on() {
 
 #[tokio::test]
 async fn test_openai_compatible_route_with_json_schema() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -765,6 +776,7 @@ async fn test_openai_compatible_route_with_json_schema() {
 
 #[tokio::test]
 async fn test_openai_compatible_streaming_tool_call() {
+    skip_for_postgres!();
     use futures::StreamExt;
     use reqwest_sse_stream::{Event, RequestBuilderExt};
 
@@ -883,6 +895,7 @@ async fn test_openai_compatible_streaming_tool_call() {
 
 #[tokio::test]
 async fn test_openai_compatible_warn_unknown_fields() {
+    skip_for_postgres!();
     let logs_contain = tensorzero_core::utils::testing::capture_logs();
     let client = tensorzero::test_helpers::make_embedded_gateway_no_config().await;
     let state = client.get_app_state_data().unwrap().clone();
@@ -908,6 +921,7 @@ async fn test_openai_compatible_warn_unknown_fields() {
 
 #[tokio::test]
 async fn test_openai_compatible_deny_unknown_fields() {
+    skip_for_postgres!();
     let client = tensorzero::test_helpers::make_embedded_gateway_no_config().await;
     let state = client.get_app_state_data().unwrap().clone();
     let err = chat_completions_handler(
@@ -934,6 +948,7 @@ async fn test_openai_compatible_deny_unknown_fields() {
 
 #[tokio::test]
 async fn test_openai_compatible_streaming() {
+    skip_for_postgres!();
     use futures::StreamExt;
     use reqwest_sse_stream::{Event, RequestBuilderExt};
 
@@ -1019,6 +1034,7 @@ async fn test_openai_compatible_streaming() {
 // Test using 'stop' parameter in the openai-compatible endpoint
 #[tokio::test]
 async fn test_openai_compatible_stop_sequence() {
+    skip_for_postgres!();
     let client = Client::new();
 
     let payload = json!({
@@ -1061,6 +1077,7 @@ async fn test_openai_compatible_stop_sequence() {
 
 #[tokio::test]
 async fn test_openai_compatible_file_with_custom_filename() {
+    skip_for_postgres!();
     let client = tensorzero::test_helpers::make_embedded_gateway().await;
     let state = client.get_app_state_data().unwrap().clone();
     let episode_id = Uuid::now_v7();
@@ -1142,6 +1159,7 @@ async fn test_openai_compatible_file_with_custom_filename() {
 
 #[tokio::test]
 async fn test_openai_compatible_parallel_tool_calls_multi_turn() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 

--- a/tensorzero-core/tests/e2e/provider_tools/anthropic.rs
+++ b/tensorzero-core/tests/e2e/provider_tools/anthropic.rs
@@ -17,6 +17,8 @@ use tensorzero_core::inference::types::{ContentBlockChatOutput, Text};
 use tensorzero_core::tool::{ProviderTool, ProviderToolScope, ProviderToolScopeModelProvider};
 use uuid::Uuid;
 
+use crate::utils::skip_for_postgres;
+
 // =============================================================================
 // Static Provider Tools Tests (configured in model config)
 // =============================================================================
@@ -184,6 +186,7 @@ provider_tools = [{type = "web_search_20250305", name = "web_search", max_uses =
 /// Test Anthropic provider tools with web_search (streaming, multi-turn)
 #[tokio::test(flavor = "multi_thread")]
 pub async fn test_anthropic_provider_tools_web_search_streaming() {
+    skip_for_postgres!();
     let config = r#"
 gateway.debug = true
 

--- a/tensorzero-core/tests/e2e/provider_tools/gcp_vertex_anthropic.rs
+++ b/tensorzero-core/tests/e2e/provider_tools/gcp_vertex_anthropic.rs
@@ -17,6 +17,8 @@ use tensorzero_core::inference::types::{ContentBlockChatOutput, Text};
 use tensorzero_core::tool::{ProviderTool, ProviderToolScope, ProviderToolScopeModelProvider};
 use uuid::Uuid;
 
+use crate::utils::skip_for_postgres;
+
 // =============================================================================
 // Static Provider Tools Tests (configured in model config)
 // =============================================================================
@@ -186,6 +188,7 @@ provider_tools = [{type = "web_search_20250305", name = "web_search", max_uses =
 /// Test GCP Vertex Anthropic provider tools with web_search (streaming, multi-turn)
 #[tokio::test(flavor = "multi_thread")]
 pub async fn test_gcp_vertex_anthropic_provider_tools_web_search_streaming() {
+    skip_for_postgres!();
     let config = r#"
 gateway.debug = true
 

--- a/tensorzero-core/tests/e2e/provider_tools/openai_responses.rs
+++ b/tensorzero-core/tests/e2e/provider_tools/openai_responses.rs
@@ -19,6 +19,8 @@ use tensorzero_core::inference::types::{
 use tensorzero_core::tool::{ProviderTool, ProviderToolScope, ProviderToolScopeModelProvider};
 use uuid::Uuid;
 
+use crate::utils::skip_for_postgres;
+
 // =============================================================================
 // Static Provider Tools Tests (configured in model config)
 // =============================================================================
@@ -202,6 +204,7 @@ api_type = "responses"
 /// Test OpenAI provider tools with web_search (streaming)
 #[tokio::test(flavor = "multi_thread")]
 pub async fn test_openai_provider_tools_web_search_streaming() {
+    skip_for_postgres!();
     let config = r#"
 gateway.debug = true
 

--- a/tensorzero-core/tests/e2e/providers/anthropic.rs
+++ b/tensorzero-core/tests/e2e/providers/anthropic.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
 use crate::{
     common::get_gateway_endpoint,
     providers::common::{DEEPSEEK_PAPER_PDF, E2ETestProvider, E2ETestProviders, FERRIS_PNG},
+    utils::skip_for_postgres,
 };
 use tensorzero_core::{
     db::clickhouse::test_helpers::{
@@ -245,6 +246,7 @@ async fn test_thinking_rejected_128k() {
 
 #[tokio::test]
 async fn test_empty_chunks_success() {
+    skip_for_postgres!();
     let payload = json!({
         "model_name": "anthropic::claude-sonnet-4-5",
         "input":{
@@ -328,6 +330,7 @@ pub async fn test_thinking_signature_helper(
     model_name: &str,
     model_provider_name: &str,
 ) {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -515,6 +518,7 @@ pub async fn test_redacted_thinking_helper(
     model_provider_name: &str,
     provider_type: &str,
 ) {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -719,6 +723,7 @@ async fn test_beta_structured_outputs_json_non_streaming() {
 }
 
 async fn test_beta_structured_outputs_json_helper(stream: bool) {
+    skip_for_postgres!();
     let client = Client::new();
     let payload = json!({
         "function_name": "anthropic_beta_structured_outputs_json",
@@ -821,6 +826,7 @@ async fn test_beta_structured_outputs_strict_tool_non_streaming() {
 }
 
 async fn test_beta_structured_outputs_strict_tool_helper(stream: bool) {
+    skip_for_postgres!();
     let client = Client::new();
     let payload = json!({
         "function_name": "anthropic_beta_structured_outputs_chat",
@@ -919,6 +925,7 @@ async fn test_streaming_thinking() {
 }
 
 pub async fn test_streaming_thinking_helper(model_name: &str, provider_type: &str) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -1202,6 +1209,7 @@ pub async fn test_streaming_thinking_helper(model_name: &str, provider_type: &st
 
 #[tokio::test]
 async fn test_forward_image_url() {
+    skip_for_postgres!();
     let temp_dir = tempfile::tempdir().unwrap();
     let config = format!(
         r#"
@@ -1284,6 +1292,7 @@ async fn test_forward_image_url() {
 
 #[tokio::test]
 async fn test_forward_file_url() {
+    skip_for_postgres!();
     let temp_dir = tempfile::tempdir().unwrap();
     let config = format!(
         r#"

--- a/tensorzero-core/tests/e2e/providers/aws_bedrock.rs
+++ b/tensorzero-core/tests/e2e/providers/aws_bedrock.rs
@@ -14,6 +14,8 @@ use tensorzero_core::db::clickhouse::test_helpers::{
     get_clickhouse, select_chat_inference_clickhouse, select_model_inference_clickhouse,
 };
 
+use crate::utils::skip_for_postgres;
+
 crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 
@@ -152,6 +154,7 @@ async fn get_providers() -> E2ETestProviders {
 
 #[tokio::test]
 async fn test_inference_with_explicit_region() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -341,6 +344,7 @@ async fn test_inference_with_empty_system() {
 
 #[tokio::test]
 async fn test_inference_with_thinking_budget_tokens() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 

--- a/tensorzero-core/tests/e2e/providers/batch.rs
+++ b/tensorzero-core/tests/e2e/providers/batch.rs
@@ -42,6 +42,7 @@ use crate::providers::common::{
     check_tool_use_tool_choice_required_inference_response,
     check_tool_use_tool_choice_specific_inference_response,
 };
+use crate::utils::skip_for_postgres;
 use crate::{
     common::get_gateway_endpoint,
     providers::common::{check_inference_params_response, check_simple_image_inference_response},
@@ -646,6 +647,7 @@ async fn insert_fake_pending_batch_inference_data(
 pub async fn test_start_simple_image_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -827,6 +829,7 @@ pub async fn test_start_simple_image_batch_inference_request_with_provider(
 pub async fn test_poll_existing_simple_image_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let function_name = "basic_test";
     let latest_pending_batch_inference = get_latest_batch_inference(
@@ -910,6 +913,7 @@ pub async fn test_poll_existing_simple_image_batch_inference_request_with_provid
 pub async fn test_poll_completed_simple_image_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let function_name = "basic_test";
     let latest_pending_batch_inference = insert_fake_pending_batch_inference_data(
@@ -935,6 +939,7 @@ pub async fn test_poll_completed_simple_image_batch_inference_request_with_provi
     provider: E2ETestProvider,
     ids: InsertedFakeDataIds,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     // Poll by inference_id
     let url = get_poll_batch_inference_url(PollPathParams {
@@ -994,6 +999,7 @@ pub async fn test_poll_completed_simple_image_batch_inference_request_with_provi
 pub async fn test_start_inference_params_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -1182,6 +1188,7 @@ pub async fn test_start_inference_params_batch_inference_request_with_provider(
 pub async fn test_poll_existing_inference_params_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let function_name = "basic_test";
     let latest_pending_batch_inference = get_latest_batch_inference(
@@ -1263,6 +1270,7 @@ pub async fn test_poll_existing_inference_params_batch_inference_request_with_pr
 pub async fn test_poll_completed_inference_params_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let function_name = "basic_test";
     let latest_pending_batch_inference = insert_fake_pending_batch_inference_data(
@@ -1290,6 +1298,7 @@ pub async fn test_poll_completed_inference_params_batch_inference_request_with_p
     provider: E2ETestProvider,
     ids: InsertedFakeDataIds,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     // Poll by inference_id
     let url = get_poll_batch_inference_url(PollPathParams {
@@ -1346,6 +1355,7 @@ pub async fn test_poll_completed_inference_params_batch_inference_request_with_p
 /// Tests that the tool use works as expected in a batch inference request.
 /// Each element is a different test case from the e2e test suite for the synchronous API.
 pub async fn test_tool_use_batch_inference_request_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     let mut episode_ids = Vec::new();
     for _ in 0..5 {
         episode_ids.push(Uuid::now_v7());
@@ -1870,6 +1880,7 @@ async fn get_tags_for_batch_inferences(
 pub async fn test_poll_existing_tool_choice_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let function_name = "weather_helper";
     let latest_pending_batch_inference = get_latest_batch_inference(
@@ -1989,6 +2000,7 @@ pub async fn test_poll_existing_tool_choice_batch_inference_request_with_provide
 pub async fn test_poll_completed_tool_use_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let function_name = "weather_helper";
     let latest_pending_batch_inference = insert_fake_pending_batch_inference_data(
@@ -2013,6 +2025,7 @@ pub async fn test_poll_completed_tool_use_batch_inference_request_with_provider_
     provider: E2ETestProvider,
     ids: InsertedFakeDataIds,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let batch_id = ids.batch_id;
     let inference_tags = get_tags_for_batch_inferences(&clickhouse, batch_id)
@@ -2113,6 +2126,7 @@ pub async fn test_poll_completed_tool_use_batch_inference_request_with_provider_
 }
 
 pub async fn test_allowed_tools_batch_inference_request_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -2290,6 +2304,7 @@ pub async fn test_allowed_tools_batch_inference_request_with_provider(provider: 
 pub async fn test_poll_existing_allowed_tools_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let function_name = "basic_test";
     let latest_pending_batch_inference = get_latest_batch_inference(
@@ -2382,6 +2397,7 @@ pub async fn test_poll_existing_allowed_tools_batch_inference_request_with_provi
 pub async fn test_poll_completed_allowed_tools_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let function_name = "basic_test";
     let latest_pending_batch_inference = insert_fake_pending_batch_inference_data(
@@ -2407,6 +2423,7 @@ pub async fn test_poll_completed_allowed_tools_batch_inference_request_with_prov
     provider: E2ETestProvider,
     ids: InsertedFakeDataIds,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     // Poll by inference_id
     let url = get_poll_batch_inference_url(PollPathParams {
@@ -2476,6 +2493,7 @@ pub async fn test_poll_completed_allowed_tools_batch_inference_request_with_prov
 pub async fn test_multi_turn_parallel_tool_use_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!(
@@ -2739,6 +2757,7 @@ pub async fn test_multi_turn_parallel_tool_use_batch_inference_request_with_prov
 }
 
 pub async fn test_tool_multi_turn_batch_inference_request_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -2948,6 +2967,7 @@ pub async fn test_tool_multi_turn_batch_inference_request_with_provider(provider
 pub async fn test_poll_existing_multi_turn_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let function_name = "weather_helper";
     let latest_pending_batch_inference = get_latest_batch_inference(
@@ -3022,6 +3042,7 @@ pub async fn test_poll_existing_multi_turn_batch_inference_request_with_provider
 pub async fn test_poll_existing_multi_turn_parallel_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let function_name = "weather_helper_parallel";
     let latest_pending_batch_inference = get_latest_batch_inference(
@@ -3106,6 +3127,7 @@ pub async fn test_poll_existing_multi_turn_parallel_batch_inference_request_with
 pub async fn test_poll_completed_multi_turn_parallel_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let function_name = "weather_helper_parallel";
     let latest_pending_batch_inference = insert_fake_pending_batch_inference_data(
@@ -3133,6 +3155,7 @@ pub async fn test_poll_completed_multi_turn_parallel_batch_inference_request_wit
     provider: E2ETestProvider,
     ids: InsertedFakeDataIds,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     // Poll by inference_id
     let url = get_poll_batch_inference_url(PollPathParams {
@@ -3210,6 +3233,7 @@ pub async fn test_poll_completed_multi_turn_parallel_batch_inference_request_wit
 pub async fn test_poll_completed_multi_turn_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let function_name = "weather_helper";
     let latest_pending_batch_inference = insert_fake_pending_batch_inference_data(
@@ -3235,6 +3259,7 @@ pub async fn test_poll_completed_multi_turn_batch_inference_request_with_provide
     provider: E2ETestProvider,
     ids: InsertedFakeDataIds,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     // Poll by inference_id
     let url = get_poll_batch_inference_url(PollPathParams {
@@ -3294,6 +3319,7 @@ pub async fn test_poll_completed_multi_turn_batch_inference_request_with_provide
 pub async fn test_dynamic_tool_use_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -3496,6 +3522,7 @@ pub async fn test_dynamic_tool_use_batch_inference_request_with_provider(
 pub async fn test_poll_existing_dynamic_tool_use_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let function_name = "basic_test";
     let latest_pending_batch_inference = get_latest_batch_inference(
@@ -3578,6 +3605,7 @@ pub async fn test_poll_existing_dynamic_tool_use_batch_inference_request_with_pr
 pub async fn test_poll_completed_dynamic_tool_use_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let function_name = "basic_test";
     let latest_pending_batch_inference = insert_fake_pending_batch_inference_data(
@@ -3605,6 +3633,7 @@ pub async fn test_poll_completed_dynamic_tool_use_batch_inference_request_with_p
     provider: E2ETestProvider,
     ids: InsertedFakeDataIds,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     // Poll by inference_id
     let url = get_poll_batch_inference_url(PollPathParams {
@@ -3664,6 +3693,7 @@ pub async fn test_poll_completed_dynamic_tool_use_batch_inference_request_with_p
 pub async fn test_parallel_tool_use_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -3858,6 +3888,7 @@ pub async fn test_parallel_tool_use_batch_inference_request_with_provider(
 pub async fn test_poll_existing_parallel_tool_use_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let function_name = "weather_helper_parallel";
     let latest_pending_batch_inference = get_latest_batch_inference(
@@ -3953,6 +3984,7 @@ pub async fn test_poll_existing_parallel_tool_use_batch_inference_request_with_p
 pub async fn test_poll_completed_parallel_tool_use_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let function_name = "weather_helper_parallel";
     let latest_pending_batch_inference = insert_fake_pending_batch_inference_data(
@@ -3980,6 +4012,7 @@ pub async fn test_poll_completed_parallel_tool_use_batch_inference_request_with_
     provider: E2ETestProvider,
     ids: InsertedFakeDataIds,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     // Poll by inference_id
     let url = get_poll_batch_inference_url(PollPathParams {
@@ -4049,6 +4082,7 @@ pub async fn test_poll_completed_parallel_tool_use_batch_inference_request_with_
 }
 
 pub async fn test_json_mode_batch_inference_request_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     if provider.variant_name.ends_with("cot") {
         // Don't test chain of thought variants with batch mode
         return;
@@ -4216,6 +4250,7 @@ pub async fn test_json_mode_batch_inference_request_with_provider(provider: E2ET
 pub async fn test_poll_existing_json_mode_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     if provider.variant_name.ends_with("cot") {
         // Don't test chain of thought variants with batch mode
         return;
@@ -4301,6 +4336,7 @@ pub async fn test_poll_existing_json_mode_batch_inference_request_with_provider(
 pub async fn test_poll_completed_json_mode_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     if provider.variant_name.ends_with("cot") {
         // Don't test chain of thought variants with batch mode
         return;
@@ -4331,6 +4367,7 @@ pub async fn test_poll_completed_json_mode_batch_inference_request_with_provider
     provider: E2ETestProvider,
     ids: InsertedFakeDataIds,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     // Poll by inference_id
     let url = get_poll_batch_inference_url(PollPathParams {
@@ -4387,6 +4424,7 @@ pub async fn test_poll_completed_json_mode_batch_inference_request_with_provider
 pub async fn test_dynamic_json_mode_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     if provider.variant_name.ends_with("cot") {
         // Don't test chain of thought variants with batch mode
         return;
@@ -4565,6 +4603,7 @@ pub async fn test_dynamic_json_mode_batch_inference_request_with_provider(
 pub async fn test_poll_existing_dynamic_json_mode_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     if provider.variant_name.ends_with("cot") {
         // Don't test chain of thought variants with batch mode
         return;
@@ -4664,6 +4703,7 @@ pub async fn test_poll_existing_dynamic_json_mode_batch_inference_request_with_p
 pub async fn test_poll_completed_dynamic_json_mode_batch_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     if provider.variant_name.ends_with("cot") {
         // Don't test chain of thought variants with batch mode
         return;
@@ -4696,6 +4736,7 @@ pub async fn test_poll_completed_dynamic_json_mode_batch_inference_request_with_
     provider: E2ETestProvider,
     ids: InsertedFakeDataIds,
 ) {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     // Poll by inference_id
     let url = get_poll_batch_inference_url(PollPathParams {

--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -55,6 +55,7 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::common::get_gateway_endpoint;
+use crate::utils::skip_for_postgres;
 // use tensorzero_core::config::provider_types::*;
 use tensorzero_core::db::clickhouse::test_helpers::{
     get_clickhouse, select_chat_inference_clickhouse, select_inference_tags_clickhouse,
@@ -1010,6 +1011,7 @@ fn uses_credential_location(provider_type: &str) -> bool {
 /// 4. Configures the gateway to use the custom location via provider_types config
 /// 5. Verifies inference works
 pub async fn test_provider_type_default_credentials_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     // Get the default credential location for this provider
     let default_location = get_default_credential_location(&provider.model_provider_name);
 
@@ -1126,6 +1128,7 @@ model = "test-model"
 pub async fn test_provider_type_default_credentials_shorthand_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // Get the default credential location for this provider
     let default_location = get_default_credential_location(&provider.model_provider_name);
 
@@ -1233,6 +1236,7 @@ pub async fn test_provider_type_fallback_credentials_with_provider(
     supports_dynamic_credentials_test: bool,
     logs_contain: &impl Fn(&str) -> bool,
 ) {
+    skip_for_postgres!();
     reset_capture_logs();
     // Get the default credential location for this provider
     let default_location = get_default_credential_location(&provider.provider_type);
@@ -1963,6 +1967,7 @@ pub async fn test_base64_image_inference_with_provider_and_store(
 }
 
 pub async fn test_extra_body_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     test_extra_body_with_provider_and_stream(&provider, false).await;
     test_extra_body_with_provider_and_stream(&provider, true).await;
 }
@@ -2103,6 +2108,7 @@ pub async fn test_extra_body_with_provider_and_stream(provider: &E2ETestProvider
 }
 
 pub async fn test_inference_extra_body_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     test_inference_extra_body_with_provider_and_stream(&provider, false).await;
     test_inference_extra_body_with_provider_and_stream(&provider, true).await;
 }
@@ -2361,6 +2367,7 @@ pub async fn test_inference_extra_body_with_provider_and_stream(
 }
 
 pub async fn test_bad_auth_extra_headers_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     test_bad_auth_extra_headers_with_provider_and_stream(&provider, false).await;
     test_bad_auth_extra_headers_with_provider_and_stream(&provider, true).await;
 }
@@ -2561,6 +2568,7 @@ pub async fn test_warn_ignored_thought_block_with_provider(
     provider: E2ETestProvider,
     logs_contain: &impl Fn(&str) -> bool,
 ) {
+    skip_for_postgres!();
     reset_capture_logs();
     // Bedrock rejects input thoughts for these models
     if provider.model_name == "claude-haiku-4-5-aws-bedrock"
@@ -2658,6 +2666,7 @@ pub async fn test_warn_ignored_thought_block_with_provider(
 }
 
 pub async fn test_assistant_prefill_inference_request_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     // * Mistral doesn't support assistant prefill
     // * Our TGI deployment on sagemaker is OOMing when we try to use prefill
     // * Some AWS Bedrock models error when the last message is an assistant message
@@ -2734,6 +2743,7 @@ pub async fn test_assistant_prefill_inference_request_with_provider(provider: E2
 }
 
 pub async fn test_empty_message_content_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let extra_headers = if provider.is_modal_provider() {
         get_modal_extra_headers()
@@ -2779,6 +2789,7 @@ pub async fn test_empty_message_content_with_provider(provider: E2ETestProvider)
 }
 
 pub async fn test_simple_inference_request_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let extra_headers = if provider.is_modal_provider() {
         get_modal_extra_headers()
@@ -3722,6 +3733,7 @@ pub async fn check_simple_image_inference_response(
 }
 
 pub async fn test_streaming_invalid_request_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     // This test is very flaky on Fireworks for some reason
     if provider.model_provider_name == "fireworks" || provider.model_provider_name == "together" {
         return;
@@ -3798,6 +3810,7 @@ pub async fn test_streaming_invalid_request_with_provider(provider: E2ETestProvi
 }
 
 pub async fn test_simple_streaming_inference_request_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     // We use a serverless Sagemaker endpoint, which doesn't support streaming
     if provider.variant_name == "aws-sagemaker-tgi" {
         return;
@@ -3828,6 +3841,7 @@ pub async fn test_simple_streaming_inference_request_with_provider(provider: E2E
 }
 
 pub async fn test_streaming_include_original_response_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     // We use a serverless Sagemaker endpoint, which doesn't support streaming
     if provider.variant_name == "aws-sagemaker-tgi" {
         return;
@@ -4154,6 +4168,7 @@ pub async fn test_simple_streaming_inference_request_with_provider_cache(
 pub async fn test_inference_params_dynamic_credentials_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // Gemini 2.5 models don't support penalty parameters
     if provider.model_name.contains("gemini-2.5") {
         return;
@@ -4459,6 +4474,7 @@ pub async fn check_inference_params_response(
 pub async fn test_inference_params_dynamic_credentials_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // Gemini 2.5 models don't support penalty parameters
     if provider.model_name.contains("gemini-2.5") {
         return;
@@ -4769,6 +4785,7 @@ pub async fn test_inference_params_dynamic_credentials_streaming_inference_reque
 pub async fn test_tool_use_tool_choice_auto_used_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let extra_headers = if provider.is_modal_provider() {
         get_modal_extra_headers()
@@ -5150,6 +5167,7 @@ pub async fn check_tool_use_tool_choice_auto_used_inference_response(
 pub async fn test_tool_use_tool_choice_auto_used_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // Together doesn't correctly produce streaming tool call chunks (it produces text chunks with the raw tool call).
     if provider.model_provider_name == "together" {
         return;
@@ -5508,6 +5526,7 @@ pub async fn test_tool_use_tool_choice_auto_used_streaming_inference_request_wit
 pub async fn test_tool_use_tool_choice_auto_unused_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let extra_headers = if provider.is_modal_provider() {
         get_modal_extra_headers()
@@ -5769,6 +5788,7 @@ pub async fn check_tool_use_tool_choice_auto_unused_inference_response(
 pub async fn test_tool_use_tool_choice_auto_unused_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // Together doesn't correctly produce streaming tool call chunks (it produces text chunks with the raw tool call).
     if provider.model_provider_name == "together" {
         return;
@@ -6064,6 +6084,7 @@ pub async fn test_tool_use_tool_choice_auto_unused_streaming_inference_request_w
 pub async fn test_tool_use_tool_choice_required_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // Azure, Together, and SGLang don't support `tool_choice: "required"`
     // Groq says they support it, but it doesn't return the required tool as expected
     if provider.model_provider_name == "azure"
@@ -6365,6 +6386,7 @@ pub async fn check_tool_use_tool_choice_required_inference_response(
 pub async fn test_tool_use_tool_choice_required_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // Azure, Together, and SGLang don't support `tool_choice: "required"`
     // Groq says they support it, but it doesn't return the required tool as expected
     // Fireworks returns trash.
@@ -6714,6 +6736,7 @@ pub async fn test_tool_use_tool_choice_required_streaming_inference_request_with
 pub async fn test_tool_use_tool_choice_none_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // NOTE: The xAI API occasionally returns mangled output most of the time when this test runs.
     // The bug has been reported to the xAI team.
     //
@@ -6984,6 +7007,7 @@ pub async fn check_tool_use_tool_choice_none_inference_response(
 pub async fn test_tool_use_tool_choice_none_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // Gemini 2.5 produces unexpected behavior for this test (empty content or 'executableCode' blocks)
     // We don't support 'executableCode' in streaming mode (since we don't have "unknown" streaming chunks)
     if provider.model_name.contains("gemini-2.5") {
@@ -7290,6 +7314,7 @@ pub async fn test_tool_use_tool_choice_none_streaming_inference_request_with_pro
 pub async fn test_tool_use_tool_choice_specific_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // GCP Vertex AI, Groq, Mistral, Together, and Fireworks don't support ToolChoice::Specific.
     // (Together AI claims to support it, but we can't get it to behave strictly.)
     // In those cases, we use ToolChoice::Any with a single tool under the hood.
@@ -7635,6 +7660,7 @@ pub async fn check_tool_use_tool_choice_specific_inference_response(
 pub async fn test_tool_use_tool_choice_specific_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // - GCP Vertex AI, Mistral, Together, Groq, and Fireworks don't support ToolChoice::Specific.
     // (Together AI claims to support it, but we can't get it to behave strictly.)
     // In those cases, we use ToolChoice::Any with a single tool under the hood.
@@ -8048,6 +8074,7 @@ pub async fn test_tool_use_tool_choice_specific_streaming_inference_request_with
 pub async fn test_tool_use_allowed_tools_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // Groq isn't respecting allowed_tools and will call brave_search instead of get_humidity, for example
     if provider.model_provider_name == "groq" {
         return;
@@ -8325,6 +8352,7 @@ pub async fn check_tool_use_tool_choice_allowed_tools_inference_response(
 pub async fn test_tool_use_allowed_tools_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // Together doesn't correctly produce streaming tool call chunks (it produces text chunks with the raw tool call).
     if provider.model_provider_name == "together" {
         return;
@@ -8691,6 +8719,7 @@ pub async fn test_tool_use_allowed_tools_streaming_inference_request_with_provid
 }
 
 pub async fn test_tool_multi_turn_inference_request_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     // NOTE: The xAI API returns an error for multi-turn tool use when the assistant message only has tool_calls but no content.
     // The xAI team has acknowledged the issue and is working on a fix.
     // We skip this test for xAI until the fix is deployed.
@@ -8992,6 +9021,7 @@ pub async fn check_tool_use_multi_turn_inference_response(
 pub async fn test_tool_multi_turn_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // Together doesn't correctly produce streaming tool call chunks (it produces text chunks with the raw tool call).
     if provider.model_provider_name == "together" {
         return;
@@ -9315,6 +9345,7 @@ pub async fn test_stop_sequences_inference_request_with_provider(
     provider: E2ETestProvider,
     client: &tensorzero::Client,
 ) {
+    skip_for_postgres!();
     // OpenAI Responses doesn't support stop sequences
     // Azure reasoning models don't support stop sequences
     if provider.variant_name == "openai-responses" || provider.variant_name.contains("azure") {
@@ -9455,6 +9486,7 @@ pub async fn test_dynamic_tool_use_inference_request_with_provider(
     provider: E2ETestProvider,
     client: &tensorzero::Client,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let response = client.inference(tensorzero::ClientInferenceParams {
@@ -9770,6 +9802,7 @@ pub async fn test_dynamic_tool_use_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
     client: &tensorzero::Client,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let input_function_name = "basic_test";
@@ -10129,6 +10162,7 @@ pub async fn test_dynamic_tool_use_streaming_inference_request_with_provider(
 }
 
 pub async fn test_parallel_tool_use_inference_request_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -10500,6 +10534,7 @@ pub async fn check_parallel_tool_use_inference_response(
 pub async fn test_parallel_tool_use_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // Together doesn't correctly produce streaming tool call chunks (it produces text chunks with the raw tool call).
     // Groq also doesn't seem to produce the correct tool call chunks, but not sure what's happening there yet.
     if provider.model_provider_name == "together" || provider.model_provider_name == "groq" {
@@ -10921,6 +10956,7 @@ pub async fn test_parallel_tool_use_streaming_inference_request_with_provider(
 }
 
 pub async fn test_json_mode_inference_request_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let extra_headers = if provider.is_modal_provider() {
         get_modal_extra_headers()
@@ -11173,6 +11209,7 @@ pub async fn check_json_mode_inference_response(
 }
 
 pub async fn test_dynamic_json_mode_inference_request_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let extra_headers = if provider.is_modal_provider() {
         get_modal_extra_headers()
@@ -11442,6 +11479,7 @@ pub async fn check_dynamic_json_mode_inference_response(
 }
 
 pub async fn test_json_mode_streaming_inference_request_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     if provider.variant_name.contains("tgi")
         || provider.variant_name.contains("cot")
         || provider.model_provider_name == "groq"
@@ -11720,6 +11758,7 @@ pub async fn test_json_mode_streaming_inference_request_with_provider(provider: 
 
 /// Test the behavior of model providers when the model tries to output a lot more than `max_tokens`.
 pub async fn test_short_inference_request_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     // We currently host ollama on sagemaker, and use a wrapped 'openai' provider
     // in our tensorzero.toml. ollama doesn't support 'max_completion_tokens', so this test
     // currently fails. It's fine to skip it, since we really care about testing the sagemaker
@@ -11971,6 +12010,7 @@ async fn check_short_inference_response(
 pub async fn test_multi_turn_parallel_tool_use_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // Together's model is too dumb to figure out multi-turn tool + parallel tool calls... It keeps calling the same tool over and over.
     if provider.model_provider_name == "together" {
         return;
@@ -12274,6 +12314,7 @@ pub async fn check_multi_turn_parallel_tool_use_inference_response(
 pub async fn test_multi_turn_parallel_tool_use_streaming_inference_request_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // Together's model is too dumb to figure out multi-turn tool + parallel tool calls... It keeps calling the same tool over and over.
     if provider.model_provider_name == "together" {
         return;
@@ -12615,6 +12656,7 @@ pub async fn test_multi_turn_parallel_tool_use_streaming_inference_request_with_
 }
 
 pub async fn test_json_mode_off_inference_request_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let extra_headers = if provider.is_modal_provider() {
         get_modal_extra_headers()
@@ -12782,6 +12824,7 @@ pub async fn test_json_mode_off_inference_request_with_provider(provider: E2ETes
 }
 
 pub async fn test_multiple_text_blocks_in_message_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let extra_headers = if provider.is_modal_provider() {
         get_modal_extra_headers()
@@ -12854,6 +12897,7 @@ pub async fn test_multiple_text_blocks_in_message_with_provider(provider: E2ETes
 pub async fn test_reasoning_multi_turn_thought_non_streaming_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     if provider.variant_name == "together-deepseek-r1" {
         // This produces invalid tool calls within text blocks (e.g 🛠\u{fe0f}\n\n```json\n{\n  \"too)
         return;
@@ -13022,6 +13066,7 @@ pub async fn test_reasoning_multi_turn_thought_non_streaming_with_provider(
 }
 
 pub async fn test_reasoning_multi_turn_thought_streaming_with_provider(provider: E2ETestProvider) {
+    skip_for_postgres!();
     if provider.variant_name == "fireworks-kimi-k2p5-reasoning" {
         // This either times out or returns "Internal Server Error"
         return;

--- a/tensorzero-core/tests/e2e/providers/gcp_vertex_gemini.rs
+++ b/tensorzero-core/tests/e2e/providers/gcp_vertex_gemini.rs
@@ -12,6 +12,8 @@ use crate::{
 
 use super::common::ModelTestProvider;
 
+use crate::utils::skip_for_postgres;
+
 crate::generate_provider_tests!(get_providers);
 crate::generate_batch_inference_tests!(get_providers);
 crate::generate_unified_mock_batch_tests!(get_providers);
@@ -386,6 +388,7 @@ async fn test_gcp_vertex_multi_turn_thought_non_streaming() {
 /// the model is forced to use tools (because internally we set mode to Any).
 #[tokio::test]
 async fn test_gcp_vertex_gemini_tool_choice_auto_with_allowed_tools() {
+    skip_for_postgres!();
     use tensorzero_core::db::clickhouse::test_helpers::{
         get_clickhouse, select_chat_inference_clickhouse,
     };

--- a/tensorzero-core/tests/e2e/providers/google_ai_studio_gemini.rs
+++ b/tensorzero-core/tests/e2e/providers/google_ai_studio_gemini.rs
@@ -7,6 +7,8 @@ use tensorzero_core::db::clickhouse::test_helpers::{
 };
 use uuid::Uuid;
 
+use crate::utils::skip_for_postgres;
+
 use crate::{
     common::get_gateway_endpoint,
     providers::common::{E2ETestProvider, E2ETestProviders},
@@ -348,6 +350,7 @@ async fn test_gemini_double_thought() {
 /// the model is forced to use tools (because internally we set mode to Any).
 #[tokio::test]
 async fn test_google_ai_studio_gemini_tool_choice_auto_with_allowed_tools() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({

--- a/tensorzero-core/tests/e2e/providers/mock_batch.rs
+++ b/tensorzero-core/tests/e2e/providers/mock_batch.rs
@@ -44,6 +44,7 @@ use crate::{
             check_tool_use_tool_choice_specific_inference_response,
         },
     },
+    utils::skip_for_postgres,
 };
 
 /// Poll for batch completion with retries
@@ -285,6 +286,7 @@ pub async fn test_simple_image_unified_mock_batch_with_provider(
     provider: &E2ETestProvider,
     function_name: &str,
 ) {
+    skip_for_postgres!();
     // Use unique episode_id for test isolation
     let episode_id = Uuid::now_v7();
     let test_id = Uuid::now_v7();
@@ -369,6 +371,7 @@ pub async fn test_json_mode_unified_mock_batch_with_provider(
     provider: &E2ETestProvider,
     function_name: &str,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let test_id = Uuid::now_v7();
 
@@ -437,6 +440,7 @@ pub async fn test_tool_use_unified_mock_batch_with_provider(
     provider: &E2ETestProvider,
     function_name: &str,
 ) {
+    skip_for_postgres!();
     let mut episode_ids = Vec::new();
     for _ in 0..5 {
         episode_ids.push(Uuid::now_v7());
@@ -608,6 +612,7 @@ pub async fn test_parallel_tool_use_unified_mock_batch_with_provider(
     provider: &E2ETestProvider,
     function_name: &str,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let test_id = Uuid::now_v7();
 
@@ -692,6 +697,7 @@ pub async fn test_inference_params_unified_mock_batch_with_provider(
     provider: &E2ETestProvider,
     function_name: &str,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let test_id = Uuid::now_v7();
 
@@ -772,6 +778,7 @@ pub async fn test_multi_turn_tool_use_unified_mock_batch_with_provider(
     provider: &E2ETestProvider,
     function_name: &str,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let test_id = Uuid::now_v7();
 
@@ -859,6 +866,7 @@ pub async fn test_multi_turn_parallel_tool_use_unified_mock_batch_with_provider(
     provider: &E2ETestProvider,
     function_name: &str,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let test_id = Uuid::now_v7();
 
@@ -967,6 +975,7 @@ pub async fn test_dynamic_tool_use_unified_mock_batch_with_provider(
     provider: &E2ETestProvider,
     function_name: &str,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let test_id = Uuid::now_v7();
 
@@ -1055,6 +1064,7 @@ pub async fn test_dynamic_json_mode_unified_mock_batch_with_provider(
     provider: &E2ETestProvider,
     function_name: &str,
 ) {
+    skip_for_postgres!();
     // Skip chain of thought variants with batch mode
     if provider.variant_name.ends_with("cot") {
         println!(
@@ -1148,6 +1158,7 @@ pub async fn test_allowed_tools_unified_mock_batch_with_provider(
     provider: &E2ETestProvider,
     function_name: &str,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let test_id = Uuid::now_v7();
 

--- a/tensorzero-core/tests/e2e/providers/openai/custom_tools.rs
+++ b/tensorzero-core/tests/e2e/providers/openai/custom_tools.rs
@@ -5,6 +5,7 @@ use serde_json::{Value, json};
 use uuid::Uuid;
 
 use crate::common::get_gateway_endpoint;
+use crate::utils::skip_for_postgres;
 use tensorzero_core::db::clickhouse::test_helpers::{
     get_clickhouse, select_chat_inference_clickhouse, select_model_inference_clickhouse,
 };
@@ -12,6 +13,7 @@ use tensorzero_core::db::clickhouse::test_helpers::{
 /// Test that OpenAI Responses API accepts and uses a custom tool with text format
 #[tokio::test(flavor = "multi_thread")]
 async fn test_responses_api_custom_tool_text_format() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -135,6 +137,7 @@ async fn test_responses_api_custom_tool_text_format() {
 /// Test that OpenAI accepts and uses a custom tool with text format
 #[tokio::test(flavor = "multi_thread")]
 async fn test_openai_custom_tool_text_format() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -275,6 +278,7 @@ async fn test_openai_custom_tool_text_format() {
 /// Test that OpenAI accepts and uses a custom tool with Lark grammar format
 #[tokio::test(flavor = "multi_thread")]
 async fn test_openai_custom_tool_grammar_lark() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -449,6 +453,7 @@ NUMBER: /\d+(\.\d+)?/
 /// Test that OpenAI accepts and uses a custom tool with Regex grammar format
 #[tokio::test(flavor = "multi_thread")]
 async fn test_openai_custom_tool_grammar_regex() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -602,6 +607,7 @@ async fn test_openai_custom_tool_grammar_regex() {
 /// Test that standard function tools and custom tools can be used together
 #[tokio::test(flavor = "multi_thread")]
 async fn test_openai_mixed_function_and_custom_tools() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -762,6 +768,7 @@ async fn test_openai_mixed_function_and_custom_tools() {
 /// Test that OpenAI Responses API accepts and uses a custom tool with Lark grammar format
 #[tokio::test(flavor = "multi_thread")]
 async fn test_responses_api_custom_tool_grammar_lark() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -919,6 +926,7 @@ NUMBER: /\d+(\.\d+)?/
 /// Test that OpenAI Responses API accepts and uses a custom tool with Regex grammar format
 #[tokio::test(flavor = "multi_thread")]
 async fn test_responses_api_custom_tool_grammar_regex() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -1055,6 +1063,7 @@ async fn test_responses_api_custom_tool_grammar_regex() {
 /// Test that standard function tools and custom tools can be used together with Responses API
 #[tokio::test(flavor = "multi_thread")]
 async fn test_responses_api_mixed_function_and_custom_tools() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 

--- a/tensorzero-core/tests/e2e/providers/openai/mod.rs
+++ b/tensorzero-core/tests/e2e/providers/openai/mod.rs
@@ -32,6 +32,7 @@ use crate::providers::common::{
     DEEPSEEK_PAPER_PDF, E2ETestProvider, E2ETestProviders, EmbeddingTestProvider, FERRIS_PNG,
     ModelTestProvider,
 };
+use crate::utils::skip_for_postgres;
 use tensorzero_core::db::clickhouse::test_helpers::{
     get_clickhouse, select_batch_model_inference_clickhouse, select_chat_inference_clickhouse,
     select_model_inference_clickhouse,
@@ -309,6 +310,7 @@ async fn get_providers() -> E2ETestProviders {
 
 #[tokio::test]
 pub async fn test_provider_config_extra_body() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -406,6 +408,7 @@ pub async fn test_provider_config_extra_body() {
 
 #[tokio::test]
 async fn test_default_function_default_tool_choice() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -484,6 +487,7 @@ async fn test_default_function_default_tool_choice() {
 
 #[tokio::test]
 async fn test_default_function_model_name_shorthand() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -598,6 +602,7 @@ async fn test_default_function_model_name_shorthand() {
 
 #[tokio::test]
 async fn test_default_function_model_name_non_shorthand() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -842,6 +847,7 @@ async fn test_chat_function_json_override_with_mode_strict() {
 }
 
 async fn test_chat_function_json_override_with_mode(json_mode: ModelInferenceRequestJsonMode) {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
     let mode = serde_json::to_value(json_mode).unwrap();
@@ -999,6 +1005,7 @@ async fn test_chat_function_json_override_with_mode(json_mode: ModelInferenceReq
 
 #[tokio::test]
 async fn test_o4_mini_inference() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -1112,6 +1119,7 @@ async fn test_o4_mini_inference() {
 
 #[tokio::test]
 async fn test_o3_mini_inference_with_reasoning_effort() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -1236,6 +1244,7 @@ async fn test_o3_mini_inference_with_reasoning_effort() {
 
 #[tokio::test]
 async fn test_embedding_request() {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let provider_config_serialized = r#"
     type = "openai"
@@ -1386,6 +1395,7 @@ async fn test_embedding_request() {
 
 #[tokio::test]
 async fn test_embedding_sanity_check() {
+    skip_for_postgres!();
     let clickhouse = get_clickhouse().await;
     let provider_config_serialized = r#"
     type = "openai"
@@ -1589,6 +1599,7 @@ pub async fn test_image_inference_with_provider_cloudflare_r2() {
 // Tests using `{"type": "text", "text": "Some string"}` as input
 #[tokio::test]
 async fn test_content_block_text_field() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -1861,6 +1872,7 @@ pub async fn test_image_inference_with_provider_docker_minio() {
 
 #[tokio::test]
 pub async fn test_parallel_tool_use_default_true_inference_request() {
+    skip_for_postgres!();
     use crate::providers::common::check_parallel_tool_use_inference_response;
 
     let episode_id = Uuid::now_v7();
@@ -2015,6 +2027,7 @@ pub async fn test_embedding_extra_headers() {
 // (and we never read things back from the object in batch inference handling)
 #[tokio::test]
 pub async fn test_start_batch_inference_write_file() {
+    skip_for_postgres!();
     let temp_dir = tempfile::tempdir().unwrap();
     let config = format!(
         r#"
@@ -2132,6 +2145,7 @@ pub async fn test_start_batch_inference_write_file() {
 
 #[tokio::test]
 async fn test_forward_image_url() {
+    skip_for_postgres!();
     let temp_dir = tempfile::tempdir().unwrap();
     let config = format!(
         r#"
@@ -2214,6 +2228,7 @@ async fn test_forward_image_url() {
 
 #[tokio::test]
 async fn test_forward_file_url() {
+    skip_for_postgres!();
     let temp_dir = tempfile::tempdir().unwrap();
     let config = format!(
         r#"
@@ -2478,6 +2493,7 @@ async fn test_responses_api_invalid_thought() {
 /// both the provider (openai) and the API type (responses).
 #[tokio::test]
 async fn test_responses_api_shorthand() {
+    skip_for_postgres!();
     let client = Client::new();
     let episode_id = Uuid::now_v7();
 
@@ -2602,6 +2618,7 @@ async fn test_responses_api_shorthand() {
 
 #[tokio::test]
 async fn test_file_custom_filename_sent_to_openai() {
+    skip_for_postgres!();
     // Test that custom filename is sent to OpenAI API
     let temp_dir = tempfile::tempdir().unwrap();
     let config = format!(
@@ -2670,6 +2687,7 @@ async fn test_file_custom_filename_sent_to_openai() {
 
 #[tokio::test]
 async fn test_file_fallback_filename_sent_to_openai() {
+    skip_for_postgres!();
     // Test that fallback filename "input.pdf" is used when no custom filename provided
     let temp_dir = tempfile::tempdir().unwrap();
     let config = format!(

--- a/tensorzero-core/tests/e2e/providers/reasoning.rs
+++ b/tensorzero-core/tests/e2e/providers/reasoning.rs
@@ -19,9 +19,12 @@ use tensorzero_core::inference::types::extra_headers::UnfilteredInferenceExtraHe
 use tensorzero_core::inference::types::{StoredContentBlock, StoredRequestMessage, Text};
 use uuid::Uuid;
 
+use crate::utils::skip_for_postgres;
+
 pub async fn test_reasoning_inference_request_simple_nonstreaming_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let extra_headers = if provider.is_modal_provider() {
         get_modal_extra_headers()
@@ -289,6 +292,7 @@ pub async fn test_reasoning_inference_request_simple_nonstreaming_with_provider(
 pub async fn test_reasoning_inference_request_simple_streaming_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     use reqwest_sse_stream::{Event, RequestBuilderExt};
     use serde_json::Value;
 
@@ -608,6 +612,7 @@ pub async fn test_reasoning_inference_request_simple_streaming_with_provider(
 pub async fn test_reasoning_inference_request_json_mode_nonstreaming_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // Direct Anthropic uses output_format for json_mode=strict
     // AWS Bedrock and GCP Vertex Anthropic use json_mode=off (prompt-based JSON) to avoid prefill conflicts
 
@@ -842,6 +847,7 @@ pub async fn test_reasoning_inference_request_json_mode_nonstreaming_with_provid
 pub async fn test_reasoning_inference_request_json_mode_streaming_with_provider(
     provider: E2ETestProvider,
 ) {
+    skip_for_postgres!();
     // OpenAI O1 doesn't support streaming responses
     if provider.model_provider_name.contains("openai") && provider.model_name.starts_with("o1") {
         return;

--- a/tensorzero-core/tests/e2e/raw_response/retries.rs
+++ b/tensorzero-core/tests/e2e/raw_response/retries.rs
@@ -12,6 +12,7 @@ use uuid::Uuid;
 use super::assert_raw_response_entry;
 use super::error::assert_error_raw_response_entry;
 use crate::common::get_gateway_endpoint;
+use crate::utils::skip_for_postgres;
 
 // =============================================================================
 // Flaky model retry tests (fail then succeed)
@@ -52,6 +53,7 @@ async fn warmup_flaky_retries() {
 /// Expects `raw_response` to have error entry from failed attempt + success entry from retry.
 #[tokio::test]
 async fn test_retries_fail_then_succeed_non_streaming() {
+    skip_for_postgres!();
     // Warm up to advance counter to 1
     warmup_flaky_retries().await;
 
@@ -125,6 +127,7 @@ async fn test_retries_fail_then_succeed_non_streaming() {
 /// Expects failed retry entries in `raw_response` chunk, then `raw_chunk` from successful streaming.
 #[tokio::test]
 async fn test_retries_fail_then_succeed_streaming() {
+    skip_for_postgres!();
     // Warm up to advance counter to 1 (odd = success).
     // Both infer and infer_stream share the same FLAKY_COUNTERS,
     // so a non-streaming warmup works for the streaming test.
@@ -212,6 +215,7 @@ async fn test_retries_fail_then_succeed_streaming() {
 /// With 2 retries = 3 total attempts, expects error response with `raw_response` from all 3 attempts.
 #[tokio::test]
 async fn test_retries_all_fail_non_streaming() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let payload = json!({
         "function_name": "raw_response_retries_all_fail",
@@ -269,6 +273,7 @@ async fn test_retries_all_fail_non_streaming() {
 /// Expects error response body (not SSE) with `raw_response` from all 3 attempts.
 #[tokio::test]
 async fn test_retries_all_fail_streaming() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let payload = json!({
         "function_name": "raw_response_retries_all_fail",
@@ -331,6 +336,7 @@ async fn test_retries_all_fail_streaming() {
 /// Expects both the failed provider entry + success entry in `raw_response`.
 #[tokio::test]
 async fn test_retries_with_provider_fallback_non_streaming() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let payload = json!({
         "function_name": "raw_response_retries_with_provider_fallback",
@@ -401,6 +407,7 @@ async fn test_retries_with_provider_fallback_non_streaming() {
 /// Expects failed provider entries in `raw_response` chunk, then `raw_chunk` from good provider.
 #[tokio::test]
 async fn test_retries_with_provider_fallback_streaming() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let payload = json!({
         "function_name": "raw_response_retries_with_provider_fallback",

--- a/tensorzero-core/tests/e2e/retries.rs
+++ b/tensorzero-core/tests/e2e/retries.rs
@@ -12,6 +12,7 @@ use tensorzero_core::{
 use uuid::Uuid;
 
 use crate::common::get_gateway_endpoint;
+use crate::utils::skip_for_postgres;
 use tensorzero_core::db::clickhouse::test_helpers::{
     get_clickhouse, select_chat_inference_clickhouse, select_model_inference_clickhouse,
     select_model_inferences_clickhouse,
@@ -20,6 +21,7 @@ use tensorzero_core::db::clickhouse::test_helpers::{
 /// This test calls a function which calls a model where the provider is flaky but with retries.
 #[tokio::test]
 async fn test_inference_flaky() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -163,6 +165,7 @@ async fn test_inference_flaky() {
 /// This test checks that streaming inference works as expected with a flaky provider and retries.
 #[tokio::test]
 async fn test_streaming_flaky() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -357,6 +360,7 @@ async fn test_streaming_flaky() {
 /// but they get stored to the ModelInference table.
 #[tokio::test]
 async fn test_best_of_n_dummy_candidates_flaky_judge() {
+    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({

--- a/tensorzero-core/tests/e2e/template.rs
+++ b/tensorzero-core/tests/e2e/template.rs
@@ -12,9 +12,11 @@ use tensorzero_core::{
 use uuid::Uuid;
 
 use crate::common::get_gateway_endpoint;
+use crate::utils::skip_for_postgres;
 
 #[tokio::test]
 async fn test_template_no_schema() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "basic_test_template_no_schema",
         "variant_name": "test",
@@ -124,6 +126,7 @@ async fn test_template_no_schema() {
 
 #[tokio::test]
 async fn test_mixture_of_n_template_no_schema() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "basic_test_template_no_schema",
         "variant_name": "mixture_of_n",
@@ -206,6 +209,7 @@ async fn test_mixture_of_n_template_no_schema() {
 
 #[tokio::test]
 async fn test_best_of_n_template_no_schema() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "basic_test_template_no_schema",
         "variant_name": "best_of_n",
@@ -349,6 +353,7 @@ async fn test_best_of_n_template_no_schema() {
 
 #[tokio::test]
 async fn test_invalid_system_input_template_no_schema() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "basic_test_template_no_schema",
         "input":{
@@ -392,6 +397,7 @@ async fn test_invalid_system_input_template_no_schema() {
 
 #[tokio::test]
 async fn test_invalid_json_user_input_template_no_schema() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "null_json",
         "input":{
@@ -427,6 +433,7 @@ async fn test_invalid_json_user_input_template_no_schema() {
 
 #[tokio::test]
 async fn test_invalid_user_input_template_no_schema() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "basic_test_template_no_schema",
         "input":{
@@ -462,6 +469,7 @@ async fn test_invalid_user_input_template_no_schema() {
 
 #[tokio::test]
 async fn test_invalid_assistant_input_template_no_schema() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "basic_test_template_no_schema",
         "variant_name": "test",
@@ -497,6 +505,7 @@ async fn test_invalid_assistant_input_template_no_schema() {
 
 #[tokio::test]
 async fn test_invalid_json_assistant_input_template_no_schema() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "null_json",
         "input":{
@@ -531,6 +540,7 @@ async fn test_invalid_json_assistant_input_template_no_schema() {
 
 #[tokio::test]
 async fn test_named_system_template_no_schema() {
+    skip_for_postgres!();
     let config_dir = tempfile::tempdir().unwrap();
     let config_path = config_dir.path().join("tensorzero.toml");
     let config = r#"
@@ -591,6 +601,7 @@ async fn test_named_system_template_no_schema() {
 
 #[tokio::test]
 async fn test_named_system_template_with_schema() {
+    skip_for_postgres!();
     let config_dir = tempfile::tempdir().unwrap();
     let config_path = config_dir.path().join("tensorzero.toml");
     let config = r#"

--- a/tensorzero-core/tests/e2e/timeouts.rs
+++ b/tensorzero-core/tests/e2e/timeouts.rs
@@ -16,11 +16,13 @@ use tokio_stream::StreamExt;
 use uuid::Uuid;
 
 use crate::common::get_gateway_endpoint;
+use crate::utils::skip_for_postgres;
 
 // Variant timeout tests
 
 #[tokio::test]
 async fn test_variant_timeout_non_streaming() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "basic_test_variant_timeout",
         "variant_name": "slow_timeout",
@@ -63,6 +65,7 @@ async fn test_variant_timeout_non_streaming() {
 
 #[tokio::test]
 async fn test_variant_timeout_streaming() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "basic_test_variant_timeout",
         "variant_name": "slow_timeout",
@@ -108,6 +111,7 @@ async fn test_variant_timeout_streaming() {
 
 #[tokio::test]
 async fn test_variant_timeout_slow_second_chunk_streaming() {
+    skip_for_postgres!();
     slow_second_chunk_streaming(json!({
         "function_name": "basic_test_variant_timeout",
         "variant_name": "slow_second_chunk",
@@ -127,6 +131,7 @@ async fn test_variant_timeout_slow_second_chunk_streaming() {
 
 #[tokio::test]
 async fn test_variant_total_timeout_streaming() {
+    skip_for_postgres!();
     streaming_total_timeout(json!({
         "function_name": "basic_test_variant_timeout",
         "variant_name": "slow_second_chunk_total_timeout",
@@ -146,6 +151,7 @@ async fn test_variant_total_timeout_streaming() {
 
 #[tokio::test]
 async fn test_chat_inference_ttft_ms() {
+    skip_for_postgres!();
     test_inference_ttft_ms(
         json!({
             "function_name": "inference_ttft_chat",
@@ -166,6 +172,7 @@ async fn test_chat_inference_ttft_ms() {
 }
 #[tokio::test]
 async fn test_json_inference_ttft_ms() {
+    skip_for_postgres!();
     test_inference_ttft_ms(
         json!({
             "function_name": "inference_ttft_json",
@@ -186,6 +193,7 @@ async fn test_json_inference_ttft_ms() {
 }
 
 async fn test_inference_ttft_ms(payload: Value, json: bool) {
+    skip_for_postgres!();
     let mut response = Client::new()
         .post(get_gateway_endpoint("/inference"))
         .json(&payload)
@@ -250,6 +258,7 @@ async fn test_inference_ttft_ms(payload: Value, json: bool) {
 // Test that if a candidate times out, the evaluator can still see the other candidates
 #[tokio::test]
 async fn test_variant_timeout_best_of_n_other_candidate() {
+    skip_for_postgres!();
     best_of_n_other_candidate(json!({
         "function_name": "basic_test_variant_timeout",
         "variant_name": "best_of_n",
@@ -270,6 +279,7 @@ async fn test_variant_timeout_best_of_n_other_candidate() {
 
 #[tokio::test]
 async fn test_model_provider_timeout_non_streaming() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "basic_test_timeout",
         "variant_name": "timeout",
@@ -318,6 +328,7 @@ async fn test_model_provider_timeout_non_streaming() {
 
 #[tokio::test]
 async fn test_model_provider_timeout_streaming() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "basic_test_timeout",
         "variant_name": "timeout",
@@ -369,6 +380,7 @@ async fn test_model_provider_timeout_streaming() {
 
 #[tokio::test]
 async fn test_model_provider_timeout_slow_second_chunk_streaming() {
+    skip_for_postgres!();
     slow_second_chunk_streaming(json!({
         "function_name": "basic_test_timeout",
         "variant_name": "slow_second_chunk",
@@ -388,6 +400,7 @@ async fn test_model_provider_timeout_slow_second_chunk_streaming() {
 
 #[tokio::test]
 async fn test_model_provider_total_timeout_streaming() {
+    skip_for_postgres!();
     streaming_total_timeout(json!({
         "function_name": "basic_test_timeout",
         "variant_name": "slow_second_chunk_total_timeout",
@@ -408,6 +421,7 @@ async fn test_model_provider_total_timeout_streaming() {
 // Test that if a candidate times out, the evaluator can still see the other candidates
 #[tokio::test]
 async fn test_model_provider_timeout_best_of_n_other_candidate() {
+    skip_for_postgres!();
     best_of_n_other_candidate(json!({
         "function_name": "basic_test_timeout",
         "variant_name": "best_of_n",
@@ -487,6 +501,7 @@ async fn best_of_n_other_candidate(payload: Value) {
 
 #[tokio::test]
 async fn test_model_provider_timeout_best_of_n_judge_timeout() {
+    skip_for_postgres!();
     best_of_n_judge_timeout(json!({
         "function_name": "basic_test_timeout",
         "variant_name": "best_of_n_judge_timeout",
@@ -659,6 +674,7 @@ async fn streaming_total_timeout(payload: Value) {
 // Test timeouts that occur at both the model and model-provider level
 #[tokio::test]
 async fn test_double_model_timeout() {
+    skip_for_postgres!();
     let logs_contain = tensorzero_core::utils::testing::capture_logs();
     let config = r#"
 [functions.double_timeout]
@@ -724,6 +740,7 @@ timeouts = { non_streaming = { total_ms = 500 }, streaming = { ttft_ms = 500 } }
 
 #[tokio::test]
 async fn test_model_timeout_non_streaming() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "basic_test_model_timeout",
         "variant_name": "slow_variant",
@@ -766,6 +783,7 @@ async fn test_model_timeout_non_streaming() {
 
 #[tokio::test]
 async fn test_model_timeout_streaming() {
+    skip_for_postgres!();
     let payload = json!({
         "function_name": "basic_test_model_timeout",
         "variant_name": "slow_variant",
@@ -811,6 +829,7 @@ async fn test_model_timeout_streaming() {
 
 #[tokio::test]
 async fn test_model_timeout_slow_second_chunk_streaming() {
+    skip_for_postgres!();
     slow_second_chunk_streaming(json!({
         "function_name": "basic_test_model_timeout",
         "variant_name": "slow_second_chunk",
@@ -830,6 +849,7 @@ async fn test_model_timeout_slow_second_chunk_streaming() {
 
 #[tokio::test]
 async fn test_model_total_timeout_streaming() {
+    skip_for_postgres!();
     streaming_total_timeout(json!({
         "function_name": "basic_test_model_timeout",
         "variant_name": "slow_second_chunk_total_timeout",

--- a/tensorzero-core/tests/e2e/utils/mod.rs
+++ b/tensorzero-core/tests/e2e/utils/mod.rs
@@ -1,1 +1,16 @@
 pub mod poll_for_result;
+
+/// Skips the current test if the observability backend is not ClickHouse.
+///
+/// Usage: `skip_for_postgres!();`
+macro_rules! skip_for_postgres {
+    () => {
+        if tensorzero_core::db::delegating_connection::PrimaryDatastore::from_test_env()
+            != tensorzero_core::db::delegating_connection::PrimaryDatastore::ClickHouse
+        {
+            return;
+        }
+    };
+}
+
+pub(crate) use skip_for_postgres;

--- a/tensorzero-core/tests/e2e/workflow_evaluations.rs
+++ b/tensorzero-core/tests/e2e/workflow_evaluations.rs
@@ -3,6 +3,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use crate::utils::skip_for_postgres;
 use serde_json::json;
 use tensorzero::{
     ClientExt, ClientInferenceParams, FeedbackParams, InferenceOutput, Input, InputMessage,
@@ -21,6 +22,7 @@ use uuid::{Timestamp, Uuid};
 
 #[tokio::test]
 async fn test_workflow_evaluation() {
+    skip_for_postgres!();
     let client = tensorzero::test_helpers::make_http_gateway().await;
     let params = WorkflowEvaluationRunParams {
         internal: false,
@@ -257,6 +259,7 @@ async fn test_workflow_evaluation() {
 
 #[tokio::test]
 async fn test_workflow_evaluation_nonexistent_function() {
+    skip_for_postgres!();
     let client = tensorzero::test_helpers::make_http_gateway().await;
     let params = WorkflowEvaluationRunParams {
         variants: HashMap::from([("nonexistent_function".to_string(), "test2".to_string())]),
@@ -278,6 +281,7 @@ async fn test_workflow_evaluation_nonexistent_function() {
 /// But the tags are applied
 #[tokio::test(flavor = "multi_thread")]
 async fn test_workflow_evaluation_other_function() {
+    skip_for_postgres!();
     let client = tensorzero::test_helpers::make_embedded_gateway().await;
     let params = WorkflowEvaluationRunParams {
         variants: HashMap::from([("dynamic_json".to_string(), "gcp-vertex-haiku".to_string())]),
@@ -351,6 +355,7 @@ async fn test_workflow_evaluation_other_function() {
 /// This should error
 #[tokio::test(flavor = "multi_thread")]
 async fn test_workflow_evaluation_variant_error() {
+    skip_for_postgres!();
     let client = tensorzero::test_helpers::make_embedded_gateway().await;
     let params = WorkflowEvaluationRunParams {
         variants: HashMap::from([("basic_test".to_string(), "error".to_string())]),
@@ -407,6 +412,7 @@ async fn test_workflow_evaluation_variant_error() {
 /// But the tags are applied
 #[tokio::test(flavor = "multi_thread")]
 async fn test_workflow_evaluation_override_variant_tags() {
+    skip_for_postgres!();
     let client = tensorzero::test_helpers::make_embedded_gateway().await;
     let params = WorkflowEvaluationRunParams {
         internal: false,
@@ -481,6 +487,7 @@ async fn test_workflow_evaluation_override_variant_tags() {
 
 #[tokio::test]
 async fn test_bad_workflow_evaluation_run() {
+    skip_for_postgres!();
     let client = tensorzero::test_helpers::make_http_gateway().await;
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -522,6 +529,7 @@ async fn test_bad_workflow_evaluation_run() {
 
 #[tokio::test]
 async fn test_workflow_evaluation_tag_validation() {
+    skip_for_postgres!();
     let client = tensorzero::test_helpers::make_http_gateway().await;
     let params = WorkflowEvaluationRunParams {
         internal: false,


### PR DESCRIPTION
The PR that migrated all of them was too big, so we're doing it step by step. This sets up all live tests to run against both ClickHouse and Postgres. We'll remove the guard one file at a time.

Some of these already pass as-is in the follow-up PR that migrates them, but in the interest of setting up the CI pipeline we'll keep them gated and remove the gating shortly.

https://github.com/tensorzero/tensorzero/issues/6718
https://github.com/tensorzero/tensorzero/issues/6717