### PR TITLE
Fix function_name syntax in documentation examples

### DIFF
--- a/docs/experimentation/scope-experiments-with-namespaces.mdx
+++ b/docs/experimentation/scope-experiments-with-namespaces.mdx
@@ -84,7 +84,7 @@ For example:
 
 ```python
 response = client.chat.completions.create(
-    model="tensorzero::function_name=draft_email",
+    model="tensorzero::function_name::draft_email",
     messages=[...],
     extra_body={
         "tensorzero::namespace": "acme_corp",

--- a/docs/gateway/api-reference/inference-openai-compatible.mdx
+++ b/docs/gateway/api-reference/inference-openai-compatible.mdx
@@ -336,7 +336,7 @@ Provide this as an extra body parameter:
 
 ```python
 response = client.chat.completions.create(
-    model="tensorzero::function_name=draft_email",
+    model="tensorzero::function_name::draft_email",
     messages=[...],
     extra_body={
         "tensorzero::namespace": "mobile",


### PR DESCRIPTION
## Summary
Updated documentation examples to use the correct syntax for specifying function names in TensorZero model parameters.

## Changes
- Fixed model parameter syntax from `tensorzero::function_name=draft_email` to `tensorzero::function_name::draft_email` in two documentation files:
  - `docs/experimentation/scope-experiments-with-namespaces.mdx`
  - `docs/gateway/api-reference/inference-openai-compatible.mdx`

## Details
The corrected syntax uses double colons (`::`) as a delimiter between the parameter name and value, which is consistent with TensorZero's parameter naming convention. This ensures that code examples in the documentation are accurate and can be used directly by users without modification.

https://claude.ai/code/session_01MvxCkcDXieKGo13P1ihJnn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates two code snippets; no runtime code or configuration behavior is affected.
> 
> **Overview**
> Updates two docs examples to use the correct model selector delimiter for functions, changing `tensorzero::function_name=draft_email` to `tensorzero::function_name::draft_email` in the namespaces experimentation guide and the OpenAI-compatible inference API reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23d9e7ebaf403f0da52308ea738d6243dfd6a7a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->