### PR TITLE
Add visit_standalone_task_tool to ToolVisitor

### DIFF
--- a/crates/autopilot-tools/src/visitor.rs
+++ b/crates/autopilot-tools/src/visitor.rs
@@ -51,6 +51,14 @@ pub trait ToolVisitor {
     async fn visit_simple_tool<T>(&self) -> Result<(), Self::Error>
     where
         T: SimpleTool<SideInfo = AutopilotSideInfo> + Default;
+
+    /// Visit a standalone `TaskTool` (no `SideInfo`, no result publishing).
+    ///
+    /// Standalone task tools are registered directly without wrapping.
+    /// They are not visible to the autopilot server.
+    async fn visit_standalone_task_tool<T>(&self, tool: T) -> Result<(), Self::Error>
+    where
+        T: TaskTool<SideInfo = (), ExtraState = ()>;
 }
 
 /// A visitor that collects tool names from `for_each_tool`.
@@ -109,6 +117,14 @@ impl ToolVisitor for ToolNameCollector {
             .lock()
             .map_err(|e| format!("Failed to acquire lock: {e}"))?;
         names.insert(T::default().name().to_string());
+        Ok(())
+    }
+
+    async fn visit_standalone_task_tool<T>(&self, _tool: T) -> Result<(), Self::Error>
+    where
+        T: TaskTool<SideInfo = (), ExtraState = ()>,
+    {
+        // Standalone tools are not visible to the autopilot server
         Ok(())
     }
 }

--- a/crates/autopilot-worker/src/worker.rs
+++ b/crates/autopilot-worker/src/worker.rs
@@ -182,6 +182,15 @@ impl ToolVisitor for LocalToolVisitor<'_> {
             .await?;
         Ok(())
     }
+
+    async fn visit_standalone_task_tool<T>(&self, tool: T) -> Result<(), ToolError>
+    where
+        T: TaskTool<SideInfo = (), ExtraState = ()>,
+    {
+        // Register directly — no ClientTaskToolWrapper, no result publishing
+        self.executor.register_task_tool_instance(tool).await?;
+        Ok(())
+    }
 }
 
 /// Handle to the running autopilot worker.


### PR DESCRIPTION
## Summary
- Add `visit_standalone_task_tool` method to the `ToolVisitor` trait for registering `TaskTool`s that have no `SideInfo` and no result publishing
- Add no-op impl on `ToolNameCollector` (standalone tools aren't visible to the autopilot server)
- Add impl on `LocalToolVisitor` that registers directly via `register_task_tool_instance`

## Test plan
- [x] `cargo check --all-targets --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new required `ToolVisitor` method and a new registration path that bypasses result publishing/wrapping, which could affect tool visibility and execution semantics if misused or if other implementors aren’t updated.
> 
> **Overview**
> Adds a new `ToolVisitor::visit_standalone_task_tool` hook for registering `TaskTool<SideInfo = (), ExtraState = ()>` instances that should run locally *without* autopilot-side wrapping or result publishing.
> 
> Updates `ToolNameCollector` to ignore these standalone tools (so they don’t appear as autopilot-visible tools), and updates the worker’s `LocalToolVisitor` to register them directly via `register_task_tool_instance` rather than `ClientTaskToolWrapper`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c448b7699d581293e8ce5d5ba5c6476932518c53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## PR Stack
```
main (#6713 merged)
 │
 ▼
#6742 Standalone Task Tool  ◄── THIS PR
 │
 ▼
#6734 Durable Task
 │
 ▼
#6812 Progress Polling
 │
 ▼
#6771 Rust Client
 │
 ▼
#6774 Python Client
 │
 ├──────────────────┐
 ▼                  ▼
#6791 Docs &     #6813 Live
Examples         Tests
```