### PR TITLE
Increase test threads to 12 for buildkite clickhouse cloud

### DIFF
--- a/ci/buildkite/test-clickhouse-cloud.sh
+++ b/ci/buildkite/test-clickhouse-cloud.sh
@@ -160,5 +160,5 @@ sleep 2
 echo "Waiting for test compilation to complete..."
 wait $TEST_BUILD_PID
 
-cargo test-clickhouse --no-fail-fast -- --skip test_concurrent_clickhouse_migrations
+cargo test-clickhouse -j 12 --no-fail-fast -- --skip test_concurrent_clickhouse_migrations
 cat e2e_logs.txt


### PR DESCRIPTION
Let's see if we can run more tests in parallel without overloading Clickhoues Cloud.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI test execution parallelism against ClickHouse Cloud, which could increase load and introduce flaky failures or resource contention.
> 
> **Overview**
> Buildkite’s ClickHouse Cloud E2E runner now executes `cargo test-clickhouse` with `-j 12`, increasing test parallelism while still skipping `test_concurrent_clickhouse_migrations`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56a3318349d6c2360c35b6d76ae9559443e01fd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->