### PR TITLE
Bump version to 2026.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot-client"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "chrono",
  "durable-tools-spawn",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-tools"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-worker"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "config-applier"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "pathdiff",
  "schemars 1.2.1",
@@ -2203,7 +2203,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2237,7 +2237,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools-spawn"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "async-trait",
  "durable",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "async-stream",
  "autopilot-client",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "googletest-matchers"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "googletest",
  "serde_json",
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-utils"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "minijinja",
  "serde",
@@ -4859,7 +4859,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postgres-inference-load-test"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5448,7 +5448,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "reqwest-sse-stream"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "async-stream",
  "futures",
@@ -6918,7 +6918,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "axum",
  "chrono",
@@ -6938,11 +6938,11 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-config-paths"
-version = "2026.3.0"
+version = "2026.3.1"
 
 [[package]]
 name = "tensorzero-core"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "config-applier",
  "napi",
@@ -7083,7 +7083,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-optimizers"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -7118,7 +7118,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "evaluations",
  "futures",
@@ -7136,11 +7136,11 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-ts-types"
-version = "2026.3.0"
+version = "2026.3.1"
 
 [[package]]
 name = "tensorzero-types"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "aws-smithy-types",
  "infer",
@@ -7163,7 +7163,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types-providers"
-version = "2026.3.0"
+version = "2026.3.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -7173,7 +7173,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-unsafe-helpers"
-version = "2026.3.0"
+version = "2026.3.1"
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2026.3.0"
+version = "2026.3.1"
 rust-version = "1.93.0"
 license = "Apache-2.0"
 edition = "2024"

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2026.3.0"
+appVersion: "2026.3.1"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorzero-ui",
-  "version": "2026.3.0",
+  "version": "2026.3.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a coordinated version/appVersion bump with no functional code changes. Main risk is accidental mismatch between published artifacts if any version references were missed.
> 
> **Overview**
> Updates the release version to `2026.3.1` across the Rust workspace (`Cargo.toml`/`Cargo.lock`), the Helm chart `appVersion`, and the UI `package.json` version to keep all artifacts in sync for the next release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 473f8e2cae14f0c5dd5ad3b8061d9676f3c99b77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->