### PR TITLE
Add TENSORZERO_AUTOPILOT_BETA_TOOLS env var to the ui

### DIFF
--- a/ui/app/utils/env.server.ts
+++ b/ui/app/utils/env.server.ts
@@ -19,6 +19,7 @@ interface Env {
   TENSORZERO_GATEWAY_URL: string;
   TENSORZERO_API_KEY?: string;
   TENSORZERO_UI_CONFIG_FILE?: string;
+  TENSORZERO_AUTOPILOT_BETA_TOOLS?: string;
 }
 
 let _env: Env | undefined;
@@ -74,6 +75,8 @@ export function getEnv(): Env {
     TENSORZERO_GATEWAY_URL,
     TENSORZERO_API_KEY: process.env.TENSORZERO_API_KEY,
     TENSORZERO_UI_CONFIG_FILE: process.env.TENSORZERO_UI_CONFIG_FILE,
+    TENSORZERO_AUTOPILOT_BETA_TOOLS:
+      process.env.TENSORZERO_AUTOPILOT_BETA_TOOLS,
   };
 
   return _env;

--- a/ui/app/utils/get-autopilot-client.server.ts
+++ b/ui/app/utils/get-autopilot-client.server.ts
@@ -11,6 +11,7 @@ export function getAutopilotClient(): AutopilotClient {
   _autopilotClient = new AutopilotClient(
     env.TENSORZERO_GATEWAY_URL,
     env.TENSORZERO_API_KEY,
+    env.TENSORZERO_AUTOPILOT_BETA_TOOLS,
   );
   return _autopilotClient;
 }

--- a/ui/app/utils/tensorzero/autopilot-client.ts
+++ b/ui/app/utils/tensorzero/autopilot-client.ts
@@ -21,6 +21,13 @@ import type {
  * A client for calling TensorZero Autopilot API endpoints.
  */
 export class AutopilotClient extends BaseTensorZeroClient {
+  private betaTools: string | null;
+
+  constructor(baseUrl: string, apiKey?: string, betaTools?: string) {
+    super(baseUrl, apiKey);
+    this.betaTools = betaTools ?? null;
+  }
+
   /**
    * Lists autopilot sessions with optional pagination.
    */
@@ -83,9 +90,14 @@ export class AutopilotClient extends BaseTensorZeroClient {
     request: CreateEventGatewayRequest,
   ): Promise<CreateEventResponse> {
     const endpoint = `/internal/autopilot/v1/sessions/${encodeURIComponent(sessionId)}/events`;
+    const headers: Record<string, string> = {};
+    if (this.betaTools) {
+      headers["tensorzero-beta-tools"] = this.betaTools;
+    }
     const response = await this.fetch(endpoint, {
       method: "POST",
       body: JSON.stringify(request),
+      headers,
     });
     if (!response.ok) {
       const message = await this.getErrorText(response);


### PR DESCRIPTION
This will be useful for turtles

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional env var plumbed through the UI to send a new header on Autopilot event creation, with no behavior change unless configured.
> 
> **Overview**
> Adds support for a new optional `TENSORZERO_AUTOPILOT_BETA_TOOLS` environment variable in the UI and wires it into `getAutopilotClient`.
> 
> `AutopilotClient` now accepts this value and, when set, includes a `tensorzero-beta-tools` header on `createAutopilotEvent` requests to the gateway.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3881662168eb31310c9eff60d99a05120eb6a3e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->