### PR TITLE
Warn when ignoring unknown tool call

### DIFF
--- a/internal/autopilot-client/src/client.rs
+++ b/internal/autopilot-client/src/client.rs
@@ -329,7 +329,10 @@ impl AutopilotClient {
                 true
             }
             EventPayload::ToolCall(tool_call) if !available_tools.contains(&tool_call.name) => {
-                tracing::warn!("Ignoring autopilot tool call of unknown tool `{}`", tool_call.name);
+                tracing::warn!(
+                    "Ignoring autopilot tool call of unknown tool `{}`",
+                    tool_call.name
+                );
                 true
             }
             _ => false,


### PR DESCRIPTION
This will help when debugging broken tests, as well as when running an outdated gateway against production autopilot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds a `tracing::warn!` log when filtering unknown tool calls, with no behavioral change beyond potential log volume/noise.
> 
> **Overview**
> Adds a warning log when the client filters out `ToolCall` events for tools not present in `available_tools`, making it easier to spot mismatches between gateway/tool configuration and upstream Autopilot tool calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdab054f5b5c1bf3c0cb19241e5d74c50c2fd529. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->