### PR TITLE
Extract EventItemContent from EventItem for maintainability

### DIFF
--- a/ui/app/components/autopilot/EventStream.tsx
+++ b/ui/app/components/autopilot/EventStream.tsx
@@ -42,6 +42,7 @@ import { cn } from "~/utils/common";
 import { ApplyConfigChangeButton } from "~/components/autopilot/ApplyConfigChangeButton";
 import EventVisualization, {
   detectEventVisualization,
+  type EventVisualizationData,
 } from "./EventVisualization";
 
 /**
@@ -550,6 +551,79 @@ function UserQuestionsAnswersContent({
 const uuidRemarkPlugins = [remarkUuidLinks];
 const uuidComponents = { [UUID_LINK_ELEMENT]: UuidLink };
 
+interface EventItemContentProps {
+  event: GatewayEvent;
+  description?: string;
+  visualizationData: EventVisualizationData | null;
+  questionsMap?: Map<string, EventPayloadUserQuestion[]>;
+}
+
+function EventItemContent({
+  event,
+  description,
+  visualizationData,
+  questionsMap,
+}: EventItemContentProps) {
+  if (visualizationData) {
+    return <EventVisualization data={visualizationData} />;
+  }
+
+  if (event.payload.type === "user_questions") {
+    return <UserQuestionsContent questions={event.payload.questions} />;
+  }
+
+  if (event.payload.type === "user_questions_answers") {
+    return (
+      <UserQuestionsAnswersContent
+        responses={event.payload.responses}
+        questions={
+          questionsMap?.get(event.payload.user_questions_event_id) ?? []
+        }
+      />
+    );
+  }
+
+  if (!description) return null;
+
+  switch (event.payload.type) {
+    case "message":
+      return (
+        <Markdown remarkPlugins={uuidRemarkPlugins} components={uuidComponents}>
+          {description}
+        </Markdown>
+      );
+
+    case "tool_call":
+      return <ReadOnlyCodeBlock code={description} language="json" />;
+
+    case "tool_result":
+    case "error":
+      return (
+        <p
+          className="text-fg-secondary overflow-y-auto text-sm whitespace-pre-wrap font-mono"
+          style={{ maxHeight: TOOL_CONTENT_MAX_HEIGHT }}
+        >
+          {description}
+        </p>
+      );
+
+    case "status_update":
+    case "tool_call_authorization":
+    case "visualization":
+    case "unknown":
+      return (
+        <p className="text-fg-secondary text-sm whitespace-pre-wrap">
+          {description}
+        </p>
+      );
+
+    default: {
+      const _exhaustiveCheck: never = event.payload;
+      return _exhaustiveCheck;
+    }
+  }
+}
+
 type EventItemProps = {
   event: GatewayEvent;
   questionsMap?: Map<string, EventPayloadUserQuestion[]>;
@@ -638,51 +712,12 @@ function EventItem({
         </div>
       </div>
       {shouldShowDetails && (
-        <>
-          {summary.description && !visualizationData && (
-            <>
-              {event.payload.type === "message" ? (
-                <Markdown
-                  remarkPlugins={uuidRemarkPlugins}
-                  components={uuidComponents}
-                >
-                  {summary.description}
-                </Markdown>
-              ) : event.payload.type === "tool_call" ? (
-                <ReadOnlyCodeBlock code={summary.description} language="json" />
-              ) : (
-                <p
-                  className={cn(
-                    "text-fg-secondary text-sm whitespace-pre-wrap",
-                    (event.payload.type === "tool_result" ||
-                      event.payload.type === "error") &&
-                      "overflow-y-auto font-mono",
-                  )}
-                  style={
-                    event.payload.type === "tool_result" ||
-                    event.payload.type === "error"
-                      ? { maxHeight: TOOL_CONTENT_MAX_HEIGHT }
-                      : undefined
-                  }
-                >
-                  {summary.description}
-                </p>
-              )}
-            </>
-          )}
-          {visualizationData && <EventVisualization data={visualizationData} />}
-          {event.payload.type === "user_questions" && (
-            <UserQuestionsContent questions={event.payload.questions} />
-          )}
-          {event.payload.type === "user_questions_answers" && (
-            <UserQuestionsAnswersContent
-              responses={event.payload.responses}
-              questions={
-                questionsMap?.get(event.payload.user_questions_event_id) ?? []
-              }
-            />
-          )}
-        </>
+        <EventItemContent
+          event={event}
+          description={summary.description}
+          visualizationData={visualizationData}
+          questionsMap={questionsMap}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- Extract `EventItemContent` component from `EventItem` in `EventStream.tsx`
- Replace nested ternary content rendering with a clean `switch` dispatch on `event.payload.type`
- Each payload type gets explicit rendering logic instead of cascading conditionals
- Exhaustive `never` check ensures new payload types are handled at compile time

Stacked on #6631. Fast follow addressing #6763 (Viraj's maintainability concern).

## Test plan

- [ ] Verify autopilot e2e tests pass (variant performance visualization)
- [ ] Visual check that all event types render correctly in session view

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to Autopilot event UI rendering, but could introduce subtle regressions in how specific event payload types (especially tool results/errors/visualizations) are displayed.
> 
> **Overview**
> Refactors `EventStream` by extracting the per-event detail rendering logic into a new `EventItemContent` component, replacing nested conditional/ternary JSX with a clearer dispatch that handles each `event.payload.type` explicitly.
> 
> Rendering now prioritizes detected `EventVisualization` output, then user question/answer blocks, and otherwise renders the summarized `description` via a `switch` with an exhaustive `never` check to force new payload types to be handled at compile time.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3ab2c81ef3ca2a942006b38c685811d55da4661. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->