### PR TITLE
fix: only show enabled backends in /health response

### DIFF
--- a/crates/tensorzero-core/src/endpoints/status.rs
+++ b/crates/tensorzero-core/src/endpoints/status.rs
@@ -1,13 +1,15 @@
 use crate::{
     db::HealthCheckable,
+    db::clickhouse::{ClickHouseConnectionInfo, clickhouse_client::ClickHouseClientType},
+    db::postgres::PostgresConnectionInfo,
+    db::valkey::ValkeyConnectionInfo,
     utils::gateway::{AppState, AppStateData},
 };
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::Json;
-use futures::join;
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 
 pub const TENSORZERO_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -49,74 +51,126 @@ pub async fn health_handler(
     .await
 }
 
+fn is_clickhouse_enabled(info: &ClickHouseConnectionInfo) -> bool {
+    info.client_type() != ClickHouseClientType::Disabled
+}
+
+fn is_postgres_enabled(info: &PostgresConnectionInfo) -> bool {
+    !matches!(info, PostgresConnectionInfo::Disabled)
+}
+
+fn is_valkey_enabled(info: &ValkeyConnectionInfo) -> bool {
+    !matches!(info, ValkeyConnectionInfo::Disabled)
+}
+
 async fn health_check_inner(
-    clickhouse_connection_info: &(dyn HealthCheckable + Sync),
-    postgres_connection_info: &(dyn HealthCheckable + Sync),
-    valkey_connection_info: &(dyn HealthCheckable + Sync),
-    valkey_cache_connection_info: &(dyn HealthCheckable + Sync),
+    clickhouse_connection_info: &ClickHouseConnectionInfo,
+    postgres_connection_info: &PostgresConnectionInfo,
+    valkey_connection_info: &ValkeyConnectionInfo,
+    valkey_cache_connection_info: &ValkeyConnectionInfo,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    let (clickhouse_result, postgres_result, valkey_result, valkey_cache_result) = join!(
+    let clickhouse_enabled = is_clickhouse_enabled(clickhouse_connection_info);
+    let postgres_enabled = is_postgres_enabled(postgres_connection_info);
+    let valkey_enabled = is_valkey_enabled(valkey_connection_info);
+    let valkey_cache_enabled = is_valkey_enabled(valkey_cache_connection_info);
+
+    let (clickhouse_result, postgres_result, valkey_result, valkey_cache_result) = tokio::join!(
         clickhouse_connection_info.health(),
         postgres_connection_info.health(),
         valkey_connection_info.health(),
         valkey_cache_connection_info.health(),
     );
 
-    if clickhouse_result.is_ok()
+    let all_ok = clickhouse_result.is_ok()
         && postgres_result.is_ok()
         && valkey_result.is_ok()
-        && valkey_cache_result.is_ok()
-    {
-        return Ok(Json(json!({
-            "gateway": "ok",
-            "clickhouse": "ok",
-            "postgres": "ok",
-            "valkey": "ok",
-            "valkey_cache": "ok",
-        })));
+        && valkey_cache_result.is_ok();
+
+    let mut response = Map::new();
+    response.insert("gateway".to_string(), json!("ok"));
+
+    if clickhouse_enabled {
+        response.insert(
+            "clickhouse".to_string(),
+            json!(if clickhouse_result.is_ok() {
+                "ok"
+            } else {
+                "error"
+            }),
+        );
+    }
+    if postgres_enabled {
+        response.insert(
+            "postgres".to_string(),
+            json!(if postgres_result.is_ok() {
+                "ok"
+            } else {
+                "error"
+            }),
+        );
+    }
+    if valkey_enabled {
+        response.insert(
+            "valkey".to_string(),
+            json!(if valkey_result.is_ok() { "ok" } else { "error" }),
+        );
+    }
+    if valkey_cache_enabled {
+        response.insert(
+            "valkey_cache".to_string(),
+            json!(if valkey_cache_result.is_ok() {
+                "ok"
+            } else {
+                "error"
+            }),
+        );
     }
 
-    Err((
-        StatusCode::SERVICE_UNAVAILABLE,
-        Json(json!({
-            "gateway": "ok",
-            "clickhouse": if clickhouse_result.is_ok() { "ok" } else { "error" },
-            "postgres": if postgres_result.is_ok() { "ok" } else { "error" },
-            "valkey": if valkey_result.is_ok() { "ok" } else { "error" },
-            "valkey_cache": if valkey_cache_result.is_ok() { "ok" } else { "error" },
-        })),
-    ))
+    if all_ok {
+        Ok(Json(Value::Object(response)))
+    } else {
+        Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(Value::Object(response)),
+        ))
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::db::MockHealthCheckable;
+    use std::sync::Arc;
+
+    use crate::db::clickhouse::clickhouse_client::MockClickHouseClient;
     use crate::error::{Error, ErrorDetails};
 
     use super::*;
 
-    fn mock_healthy() -> MockHealthCheckable {
-        let mut mock = MockHealthCheckable::new();
+    fn mock_healthy_clickhouse() -> ClickHouseConnectionInfo {
+        let mut mock = MockClickHouseClient::new();
         mock.expect_health().returning(|| Ok(()));
-        mock
+        mock.expect_client_type()
+            .returning(|| ClickHouseClientType::Production);
+        ClickHouseConnectionInfo::new_mock(Arc::new(mock))
     }
 
-    fn mock_unhealthy() -> MockHealthCheckable {
-        let mut mock = MockHealthCheckable::new();
+    fn mock_unhealthy_clickhouse() -> ClickHouseConnectionInfo {
+        let mut mock = MockClickHouseClient::new();
         mock.expect_health().returning(|| {
             Err(Error::new(ErrorDetails::InternalError {
                 message: "unhealthy".to_string(),
             }))
         });
-        mock
+        mock.expect_client_type()
+            .returning(|| ClickHouseClientType::Production);
+        ClickHouseConnectionInfo::new_mock(Arc::new(mock))
     }
 
     #[tokio::test]
-    async fn test_health_handler() {
-        let clickhouse = mock_healthy();
-        let postgres = mock_healthy();
-        let valkey = mock_healthy();
-        let valkey_cache = mock_healthy();
+    async fn test_health_handler_all_enabled_and_healthy() {
+        let clickhouse = mock_healthy_clickhouse();
+        let postgres = PostgresConnectionInfo::new_mock(true);
+        let valkey = ValkeyConnectionInfo::Disabled;
+        let valkey_cache = ValkeyConnectionInfo::Disabled;
 
         let response = health_check_inner(&clickhouse, &postgres, &valkey, &valkey_cache).await;
         assert!(response.is_ok(), "health check should pass");
@@ -124,16 +178,51 @@ mod tests {
         assert_eq!(response_value.get("gateway").unwrap(), "ok");
         assert_eq!(response_value.get("clickhouse").unwrap(), "ok");
         assert_eq!(response_value.get("postgres").unwrap(), "ok");
-        assert_eq!(response_value.get("valkey").unwrap(), "ok");
-        assert_eq!(response_value.get("valkey_cache").unwrap(), "ok");
+        assert!(
+            response_value.get("valkey").is_none(),
+            "disabled valkey should not appear"
+        );
+        assert!(
+            response_value.get("valkey_cache").is_none(),
+            "disabled valkey_cache should not appear"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_health_handler_all_disabled() {
+        let clickhouse = ClickHouseConnectionInfo::new_disabled();
+        let postgres = PostgresConnectionInfo::Disabled;
+        let valkey = ValkeyConnectionInfo::Disabled;
+        let valkey_cache = ValkeyConnectionInfo::Disabled;
+
+        let response = health_check_inner(&clickhouse, &postgres, &valkey, &valkey_cache).await;
+        assert!(response.is_ok(), "health check should pass");
+        let response_value = response.unwrap();
+        assert_eq!(response_value.get("gateway").unwrap(), "ok");
+        assert!(
+            response_value.get("clickhouse").is_none(),
+            "disabled clickhouse should not appear"
+        );
+        assert!(
+            response_value.get("postgres").is_none(),
+            "disabled postgres should not appear"
+        );
+        assert!(
+            response_value.get("valkey").is_none(),
+            "disabled valkey should not appear"
+        );
+        assert!(
+            response_value.get("valkey_cache").is_none(),
+            "disabled valkey_cache should not appear"
+        );
     }
 
     #[tokio::test]
     async fn should_report_error_for_unhealthy_clickhouse() {
-        let clickhouse = mock_unhealthy();
-        let postgres = mock_healthy();
-        let valkey = mock_healthy();
-        let valkey_cache = mock_healthy();
+        let clickhouse = mock_unhealthy_clickhouse();
+        let postgres = PostgresConnectionInfo::new_mock(true);
+        let valkey = ValkeyConnectionInfo::Disabled;
+        let valkey_cache = ValkeyConnectionInfo::Disabled;
 
         let response = health_check_inner(&clickhouse, &postgres, &valkey, &valkey_cache).await;
         assert!(response.is_err());
@@ -145,10 +234,10 @@ mod tests {
 
     #[tokio::test]
     async fn should_report_error_for_unhealthy_postgres() {
-        let clickhouse = mock_healthy();
-        let postgres = mock_unhealthy();
-        let valkey = mock_healthy();
-        let valkey_cache = mock_healthy();
+        let clickhouse = mock_healthy_clickhouse();
+        let postgres = PostgresConnectionInfo::new_mock(false);
+        let valkey = ValkeyConnectionInfo::Disabled;
+        let valkey_cache = ValkeyConnectionInfo::Disabled;
 
         let response = health_check_inner(&clickhouse, &postgres, &valkey, &valkey_cache).await;
         assert!(response.is_err());


### PR DESCRIPTION
## Summary

Resolves #6750. The `/health` endpoint previously always included all backends (ClickHouse, Postgres, Valkey, Valkey cache) in its response, even when they were disabled. This made the response noisy and potentially confusing for operators.

**Changes:**
- Added `is_clickhouse_enabled()`, `is_postgres_enabled()`, `is_valkey_enabled()` helpers that check concrete connection types
- Changed `health_check_inner()` to accept concrete types instead of `dyn HealthCheckable`, enabling compile-time backend state inspection
- Only includes a backend in the JSON response when it is actually configured
- Replaced `futures::join!` with `tokio::join!` (removes an unnecessary dependency)

**Before:**
```json
{"gateway": "ok", "clickhouse": "ok", "postgres": "ok", "valkey": "ok", "valkey_cache": "ok"}
```

**After** (e.g., only ClickHouse + Postgres configured):
```json
{"gateway": "ok", "clickhouse": "ok", "postgres": "ok"}
```

## Test plan

- [x] Updated existing tests to use concrete types instead of mocks
- [x] Added `test_health_handler_all_disabled` — verifies only "gateway" appears when all backends are disabled
- [x] `cargo check -p tensorzero-core` passes