### PR TITLE
Fix nightly clippy lint

### DIFF
--- a/tensorzero-core/src/providers/anthropic.rs
+++ b/tensorzero-core/src/providers/anthropic.rs
@@ -973,10 +973,10 @@ impl<'a> AnthropicRequestBody<'a> {
         };
         // We use the content block form rather than string so people can use
         // extra_body for cache control.
-        let system = match request.system.as_deref() {
-            Some(text) => Some(vec![AnthropicSystemBlock::Text { text }]),
-            None => None,
-        };
+        let system = request
+            .system
+            .as_deref()
+            .map(|text| vec![AnthropicSystemBlock::Text { text }]);
         let messages: Vec<AnthropicMessage> =
             try_join_all(request.messages.iter().map(|m| {
                 AnthropicMessage::from_request_message(m, messages_config, PROVIDER_TYPE)

--- a/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
+++ b/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
@@ -574,10 +574,10 @@ impl<'a> GCPVertexAnthropicRequestBody<'a> {
         };
         // We use the content block form rather than string so people can use
         // extra_body for cache control.
-        let system = match request.system.as_deref() {
-            Some(text) => Some(vec![AnthropicSystemBlock::Text { text }]),
-            None => None,
-        };
+        let system = request
+            .system
+            .as_deref()
+            .map(|text| vec![AnthropicSystemBlock::Text { text }]);
         let mut messages: Vec<AnthropicMessage> =
             try_join_all(request.messages.iter().map(|m| {
                 AnthropicMessage::from_request_message(m, messages_config, PROVIDER_TYPE)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a small refactor from a `match` to `Option::map` when building the `system` field, with no intended behavioral change.
> 
> **Overview**
> Fixes a nightly clippy lint by refactoring the `system` field construction in both `anthropic.rs` and `gcp_vertex_anthropic.rs` from a `match` to an `Option::map`, keeping the serialized request shape the same (still emitting `Some([Text{...}])` or `None`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa68a93d001a43e61e7eb6eb1ff1c4f142216ee9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->