### PR TITLE
Migrate mixture_of_n

### DIFF
--- a/tensorzero-core/tests/e2e/mixture_of_n.rs
+++ b/tensorzero-core/tests/e2e/mixture_of_n.rs
@@ -1,31 +1,35 @@
 use futures::StreamExt;
+use googletest::prelude::*;
 use reqwest::{Client, StatusCode};
 use reqwest_sse_stream::{Event, RequestBuilderExt};
+use rust_decimal::Decimal;
 use serde_json::{Value, json};
+use tensorzero_core::db::delegating_connection::DelegatingDatabaseConnection;
+use tensorzero_core::db::inferences::{InferenceQueries, ListInferencesParams};
+use tensorzero_core::db::model_inferences::ModelInferenceQueries;
+use tensorzero_core::db::test_helpers::TestDatabaseHelpers;
 use tensorzero_core::inference::types::{
-    Role, StoredContentBlock, StoredRequestMessage, Text, Unknown, Usage,
+    ContentBlockChatOutput, ContentBlockOutput, FinishReason, Role, StoredContentBlock,
+    StoredModelInference, StoredRequestMessage, Text, Unknown, Usage,
 };
+use tensorzero_core::stored_inference::StoredInferenceDatabase;
+use tensorzero_core::test_helpers::get_e2e_config;
 use uuid::Uuid;
 
 use crate::common::get_gateway_endpoint;
-use crate::utils::skip_for_postgres;
-use tensorzero_core::db::clickhouse::test_helpers::{
-    get_clickhouse, select_chat_inference_clickhouse, select_json_inference_clickhouse,
-    select_model_inferences_clickhouse,
-};
 
+#[gtest]
 #[tokio::test]
 async fn test_mixture_of_n_dummy_candidates_dummy_judge_non_stream() {
-    skip_for_postgres!();
     // Include randomness in put to make sure that the first request is a cache miss
     let random_input = Uuid::now_v7();
     test_mixture_of_n_dummy_candidates_dummy_judge_inner(random_input, false, false).await;
     test_mixture_of_n_dummy_candidates_dummy_judge_inner(random_input, true, false).await;
 }
 
+#[gtest]
 #[tokio::test]
 async fn test_mixture_of_n_dummy_candidates_dummy_judge_streaming() {
-    skip_for_postgres!();
     // Include randomness in put to make sure that the first request is a cache miss
     let random_input = Uuid::now_v7();
     test_mixture_of_n_dummy_candidates_dummy_judge_inner(random_input, false, true).await;
@@ -37,7 +41,6 @@ async fn test_mixture_of_n_dummy_candidates_dummy_judge_inner(
     should_be_cached: bool,
     stream: bool,
 ) {
-    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -116,19 +119,28 @@ async fn test_mixture_of_n_dummy_candidates_dummy_judge_inner(
         )
     };
 
-    // Sleep for 1 second to allow time for data to be inserted into ClickHouse (trailing writes from API)
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    let conn = DelegatingDatabaseConnection::new_for_e2e_test().await;
+    conn.flush_pending_writes().await;
+    conn.sleep_for_writes_to_be_visible().await;
 
-    // Check ClickHouse
-    let clickhouse = get_clickhouse().await;
-    let result = select_json_inference_clickhouse(&clickhouse, inference_id)
+    let config = get_e2e_config().await;
+    let inferences = conn
+        .list_inferences(
+            &config,
+            &ListInferencesParams {
+                ids: Some(&[inference_id]),
+                ..Default::default()
+            },
+        )
         .await
         .unwrap();
-    let id = result.get("id").unwrap().as_str().unwrap();
-    let id_uuid = Uuid::parse_str(id).unwrap();
-    assert_eq!(id_uuid, inference_id);
-    let input: Value =
-        serde_json::from_str(result.get("input").unwrap().as_str().unwrap()).unwrap();
+    assert_eq!(inferences.len(), 1);
+    let json_inf = match &inferences[0] {
+        StoredInferenceDatabase::Json(j) => j,
+        StoredInferenceDatabase::Chat(_) => panic!("Expected json inference"),
+    };
+    assert_eq!(json_inf.inference_id, inference_id);
+    let input = serde_json::to_value(&json_inf.input).unwrap();
     let correct_input: Value = json!(
         {
             "system": {
@@ -147,10 +159,11 @@ async fn test_mixture_of_n_dummy_candidates_dummy_judge_inner(
     assert_eq!(input, correct_input);
 
     // Check the ModelInference Table
-    let results: Vec<Value> = select_model_inferences_clickhouse(&clickhouse, inference_id)
+    let model_inferences = conn
+        .get_model_inferences_by_inference_id(inference_id)
         .await
         .unwrap();
-    assert_eq!(results.len(), 4);
+    assert_eq!(model_inferences.len(), 4);
 
     // Collect model names
     let mut model_names = std::collections::HashSet::new();
@@ -162,41 +175,33 @@ async fn test_mixture_of_n_dummy_candidates_dummy_judge_inner(
         cost: None,
     };
 
-    for result in results {
-        let id = result.get("id").unwrap().as_str().unwrap();
-        let _ = Uuid::parse_str(id).unwrap();
-        let inference_id_result = result.get("inference_id").unwrap().as_str().unwrap();
-        let inference_id_result = Uuid::parse_str(inference_id_result).unwrap();
-        assert_eq!(inference_id_result, inference_id);
+    for mi in &model_inferences {
+        assert_eq!(mi.inference_id, inference_id);
 
         // Collect model_name
-        let model_name = result.get("model_name").unwrap().as_str().unwrap();
-        model_names.insert(model_name.to_string());
+        model_names.insert(mi.model_name.clone());
 
         // Check that all expected fields are present
-        assert!(result.get("model_provider_name").is_some());
-        assert!(result.get("raw_request").is_some());
-        assert!(result.get("raw_response").is_some());
-        assert!(result.get("input_tokens").is_some());
-        assert!(result.get("output_tokens").is_some());
-        assert!(result.get("response_time_ms").is_some());
-        assert!(result.get("ttft_ms").is_some());
+        assert!(!mi.model_provider_name.is_empty());
+        assert!(mi.raw_request.is_some());
+        assert!(mi.raw_response.is_some());
+        assert!(mi.input_tokens.is_some());
+        assert!(mi.output_tokens.is_some());
+        assert!(mi.response_time_ms.is_some());
 
-        let input_tokens = result.get("input_tokens").unwrap().as_u64().unwrap() as u32;
-        let output_tokens = result.get("output_tokens").unwrap().as_u64().unwrap() as u32;
+        let input_tokens = mi.input_tokens.unwrap();
+        let output_tokens = mi.output_tokens.unwrap();
         usage_sum.input_tokens = Some(usage_sum.input_tokens.unwrap() + input_tokens);
         usage_sum.output_tokens = Some(usage_sum.output_tokens.unwrap() + output_tokens);
 
         // We just check the output here, since we already have several tests covering the other fields
         // for mixture_of_n
-        if model_name == "dummy::random_answer" {
-            let cached = result.get("cached").unwrap().as_bool().unwrap();
-            assert_eq!(cached, should_be_cached);
-            let output = result.get("output").unwrap().as_str().unwrap();
-            let output: Vec<StoredContentBlock> = serde_json::from_str(output).unwrap();
+        if mi.model_name == "dummy::random_answer" {
+            assert_eq!(mi.cached, should_be_cached);
+            let output = mi.output.as_ref().unwrap();
             assert_eq!(output.len(), 1);
             match &output[0] {
-                StoredContentBlock::Text(text) => {
+                ContentBlockOutput::Text(text) => {
                     let parsed: Value = serde_json::from_str(&text.text).unwrap();
                     let uuid = parsed.get("answer").unwrap().as_str().unwrap();
                     dummy_uuids.push(uuid.to_string());
@@ -258,15 +263,15 @@ async fn test_mixture_of_n_dummy_candidates_dummy_judge_inner(
     assert_ne!(dummy_uuids[0], dummy_uuids[1]);
 }
 
+#[gtest]
 #[tokio::test]
 async fn test_mixture_of_n_dummy_candidates_real_judge_non_stream() {
-    skip_for_postgres!();
     test_mixture_of_n_dummy_candidates_real_judge_inner(false).await;
 }
 
+#[gtest]
 #[tokio::test]
 async fn test_mixture_of_n_dummy_candidates_real_judge_streaming() {
-    skip_for_postgres!();
     test_mixture_of_n_dummy_candidates_real_judge_inner(true).await;
 }
 
@@ -275,7 +280,6 @@ async fn test_mixture_of_n_dummy_candidates_real_judge_streaming() {
 /// Besides checking that the response is well-formed and everything is stored correctly,
 /// we also check that the input to GPT4o-mini is correct (as this is the most critical part).
 async fn test_mixture_of_n_dummy_candidates_real_judge_inner(stream: bool) {
-    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -356,19 +360,28 @@ async fn test_mixture_of_n_dummy_candidates_real_judge_inner(stream: bool) {
         (Some(content.to_string()), inference_id)
     };
 
-    // Sleep for 1 second to allow time for data to be inserted into ClickHouse (trailing writes from API)
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    let conn = DelegatingDatabaseConnection::new_for_e2e_test().await;
+    conn.flush_pending_writes().await;
+    conn.sleep_for_writes_to_be_visible().await;
 
-    // Check ClickHouse
-    let clickhouse = get_clickhouse().await;
-    let result = select_chat_inference_clickhouse(&clickhouse, inference_id)
+    let config = get_e2e_config().await;
+    let inferences = conn
+        .list_inferences(
+            &config,
+            &ListInferencesParams {
+                ids: Some(&[inference_id]),
+                ..Default::default()
+            },
+        )
         .await
         .unwrap();
-    let id = result.get("id").unwrap().as_str().unwrap();
-    let id_uuid = Uuid::parse_str(id).unwrap();
-    assert_eq!(id_uuid, inference_id);
-    let input: Value =
-        serde_json::from_str(result.get("input").unwrap().as_str().unwrap()).unwrap();
+    assert_eq!(inferences.len(), 1);
+    let chat = match &inferences[0] {
+        StoredInferenceDatabase::Chat(c) => c,
+        StoredInferenceDatabase::Json(_) => panic!("Expected chat inference"),
+    };
+    assert_eq!(chat.inference_id, inference_id);
+    let input = serde_json::to_value(&chat.input).unwrap();
     let correct_input: Value = json!(
         {
             "system": {
@@ -387,57 +400,48 @@ async fn test_mixture_of_n_dummy_candidates_real_judge_inner(stream: bool) {
     );
     assert_eq!(input, correct_input);
     // Check that content blocks are correct
-    let content_blocks = result.get("output").unwrap().as_str().unwrap();
-    let content_blocks: Vec<Value> = serde_json::from_str(content_blocks).unwrap();
-    assert_eq!(content_blocks.len(), 1);
-    let content_block = content_blocks.first().unwrap();
-    let content_block_type = content_block.get("type").unwrap().as_str().unwrap();
-    assert_eq!(content_block_type, "text");
-    let db_content = content_block.get("text").unwrap().as_str().unwrap();
+    let output = chat.output.as_ref().unwrap();
+    assert_eq!(output.len(), 1);
+    let db_content = match &output[0] {
+        ContentBlockChatOutput::Text(text) => &text.text,
+        _ => panic!("Expected a text block, got {:?}", output[0]),
+    };
     if let Some(content) = content {
-        assert_eq!(db_content, content);
+        assert_eq!(db_content, &content);
     }
     // Check that episode_id is here and correct
-    let retrieved_episode_id = result.get("episode_id").unwrap().as_str().unwrap();
-    let retrieved_episode_id = Uuid::parse_str(retrieved_episode_id).unwrap();
-    assert_eq!(retrieved_episode_id, episode_id);
+    assert_eq!(chat.episode_id, episode_id);
     // Check the variant name
-    let variant_name = result.get("variant_name").unwrap().as_str().unwrap();
-    assert_eq!(variant_name, "mixture_of_n_variant");
+    assert_eq!(chat.variant_name, "mixture_of_n_variant");
 
     // Check the ModelInference Table
-    let results = select_model_inferences_clickhouse(&clickhouse, inference_id)
+    let model_inferences = conn
+        .get_model_inferences_by_inference_id(inference_id)
         .await
         .unwrap();
-    assert_eq!(results.len(), 3);
+    assert_eq!(model_inferences.len(), 3);
 
     // Collect model names
     let mut model_names = std::collections::HashSet::new();
 
-    for result in results {
-        let id = result.get("id").unwrap().as_str().unwrap();
-        let _ = Uuid::parse_str(id).unwrap();
-        let inference_id_result = result.get("inference_id").unwrap().as_str().unwrap();
-        let inference_id_result = Uuid::parse_str(inference_id_result).unwrap();
-        assert_eq!(inference_id_result, inference_id);
+    for mi in &model_inferences {
+        assert_eq!(mi.inference_id, inference_id);
 
         // Collect model_name
-        let model_name = result.get("model_name").unwrap().as_str().unwrap();
-        model_names.insert(model_name.to_string());
+        model_names.insert(mi.model_name.clone());
 
         // Check that all expected fields are present
-        assert!(result.get("model_provider_name").is_some());
-        assert!(result.get("raw_request").is_some());
-        assert!(result.get("raw_response").is_some());
-        assert!(result.get("input_tokens").is_some());
-        assert!(result.get("output_tokens").is_some());
-        assert!(result.get("response_time_ms").is_some());
-        assert!(result.get("ttft_ms").is_some());
+        assert!(!mi.model_provider_name.is_empty());
+        assert!(mi.raw_request.is_some());
+        assert!(mi.raw_response.is_some());
+        assert!(mi.input_tokens.is_some());
+        assert!(mi.output_tokens.is_some());
+        assert!(mi.response_time_ms.is_some());
 
         // For the judge model we want to check that the `raw_request` is correct
-        if model_name == "gpt-4o-mini-2024-07-18" {
-            let raw_request = result.get("raw_request").unwrap().as_str().unwrap();
-            let raw_request: Value = serde_json::from_str(raw_request).unwrap();
+        if mi.model_name == "gpt-4o-mini-2024-07-18" {
+            let raw_request: Value =
+                serde_json::from_str(mi.raw_request.as_deref().unwrap()).unwrap();
             let mut expected_request = json!({
               "messages": [
                 {
@@ -462,14 +466,11 @@ async fn test_mixture_of_n_dummy_candidates_real_judge_inner(stream: bool) {
                 });
             }
             assert_eq!(raw_request, expected_request);
-            let system = result.get("system").unwrap().as_str().unwrap();
             assert_eq!(
-                system,
+                mi.system.as_deref().unwrap(),
                 "You have been provided with a set of responses from various models to the following problem:\n------\nYou are a helpful and friendly assistant named AskJeeves\n------\nYour task is to synthesize these responses into a single, high-quality response. It is crucial to critically evaluate the information provided in these responses, recognizing that some of it may be biased or incorrect. Your response should not simply replicate the given answers but should offer a refined, accurate, and comprehensive reply to the instruction and take the best from all the responses. Ensure your response is well-structured, coherent, and adheres to the highest standards of accuracy and reliability.  Below will be: first, any messages leading up to this point, and then, a final message containing the set of candidate responses."
             );
-            let input_messages = result.get("input_messages").unwrap().as_str().unwrap();
-            let input_messages: Vec<StoredRequestMessage> =
-                serde_json::from_str(input_messages).unwrap();
+            let input_messages = mi.input_messages.as_ref().unwrap();
             assert_eq!(input_messages.len(), 2);
             assert_eq!(
                 input_messages[0],
@@ -487,21 +488,18 @@ async fn test_mixture_of_n_dummy_candidates_real_judge_inner(stream: bool) {
                     StoredContentBlock::Text(Text { text: "Here are the candidate answers (with the index and a row of ------ separating):\n0:\n[{\"type\":\"text\",\"text\":\"Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake.\"}]\n------\n1:\n[{\"type\":\"text\",\"text\":\"Megumin chanted her spell, but instead of an explosion, a gentle rain began to fall.\"}]\n------".to_string() })
                 ],
             });
-            let output = result.get("output").unwrap().as_str().unwrap();
-            let output: Vec<StoredContentBlock> = serde_json::from_str(output).unwrap();
+            let output = mi.output.as_ref().unwrap();
             assert_eq!(output.len(), 1);
             match &output[0] {
-                StoredContentBlock::Text(_) => {
+                ContentBlockOutput::Text(_) => {
                     // We don't need to check the exact content since this is a fuser model
                 }
                 _ => {
                     panic!("Expected a text block, got {:?}", output[0]);
                 }
             }
-        } else if model_name == "test" {
-            let input_messages = result.get("input_messages").unwrap().as_str().unwrap();
-            let input_messages: Vec<StoredRequestMessage> =
-                serde_json::from_str(input_messages).unwrap();
+        } else if mi.model_name == "test" {
+            let input_messages = mi.input_messages.as_ref().unwrap();
             assert_eq!(input_messages.len(), 1);
             assert_eq!(
                 input_messages[0],
@@ -520,10 +518,8 @@ async fn test_mixture_of_n_dummy_candidates_real_judge_inner(stream: bool) {
                     ],
                 }
             );
-        } else if model_name == "alternate" {
-            let input_messages = result.get("input_messages").unwrap().as_str().unwrap();
-            let input_messages: Vec<StoredRequestMessage> =
-                serde_json::from_str(input_messages).unwrap();
+        } else if mi.model_name == "alternate" {
+            let input_messages = mi.input_messages.as_ref().unwrap();
             assert_eq!(input_messages.len(), 1);
             assert_eq!(
                 input_messages[0],
@@ -537,26 +533,19 @@ async fn test_mixture_of_n_dummy_candidates_real_judge_inner(stream: bool) {
             );
         }
 
-        let input_tokens = result.get("input_tokens").unwrap().as_u64().unwrap();
-        assert!(input_tokens > 0);
-        let output_tokens = result.get("output_tokens").unwrap().as_u64().unwrap();
-        assert!(output_tokens > 0);
-        let response_time_ms = result.get("response_time_ms").unwrap().as_u64().unwrap();
-        assert!(response_time_ms > 0);
+        assert!(mi.input_tokens.unwrap() > 0);
+        assert!(mi.output_tokens.unwrap() > 0);
+        assert!(mi.response_time_ms.unwrap() > 0);
 
         // In streaming mode, only the judge model should have a ttft_ms
         // (all of the other models should have received non-streaming requests,
         // since their responses need to be concatenated into the judge input).
-        if stream && model_name == "gpt-4o-mini-2024-07-18" {
-            println!("ttft_ms: {:?}", result.get("ttft_ms"));
-            let ttft_ms = result
-                .get("ttft_ms")
-                .expect("Missing ttft_ms")
-                .as_u64()
-                .expect("ttft_ms is not a u64");
+        if stream && mi.model_name == "gpt-4o-mini-2024-07-18" {
+            println!("ttft_ms: {:?}", mi.ttft_ms);
+            let ttft_ms = mi.ttft_ms.expect("Missing ttft_ms");
             assert!(ttft_ms > 0);
         } else {
-            assert!(result.get("ttft_ms").unwrap().is_null());
+            assert!(mi.ttft_ms.is_none());
         }
     }
 
@@ -574,9 +563,9 @@ async fn test_mixture_of_n_dummy_candidates_real_judge_inner(stream: bool) {
 /// and one that gives an incorrect but well-formed JSON response.
 /// We check that the good response is selected and that the other responses are not
 /// but they get stored to the ModelInference table.
+#[gtest]
 #[tokio::test]
 async fn test_mixture_of_n_json_real_judge() {
-    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -600,7 +589,7 @@ async fn test_mixture_of_n_json_real_judge() {
         .await
         .unwrap();
     // Check Response is OK, then fields in order
-    assert_eq!(response.status(), StatusCode::OK);
+    expect_that!(response.status(), eq(StatusCode::OK));
     let response_json = response.json::<Value>().await.unwrap();
     // Check that inference_id is here
     let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
@@ -609,31 +598,40 @@ async fn test_mixture_of_n_json_real_judge() {
     let output = response_json.get("output").unwrap();
     let parsed_output = output.get("parsed").unwrap();
     let names = parsed_output.get("names").unwrap().as_array().unwrap();
-    assert_eq!(names.len(), 4);
-    assert!(names.contains(&"John".into()));
-    assert!(names.contains(&"Paul".into()));
-    assert!(names.contains(&"Ringo".into()));
-    assert!(names.contains(&"George".into()));
+    expect_that!(names.len(), eq(4));
+    expect_that!(names.contains(&"John".into()), eq(true));
+    expect_that!(names.contains(&"Paul".into()), eq(true));
+    expect_that!(names.contains(&"Ringo".into()), eq(true));
+    expect_that!(names.contains(&"George".into()), eq(true));
     // Check that usage is correct
     let usage = response_json.get("usage").unwrap();
     let usage = usage.as_object().unwrap();
     let input_tokens = usage.get("input_tokens").unwrap().as_u64().unwrap();
     let output_tokens = usage.get("output_tokens").unwrap().as_u64().unwrap();
-    assert!(input_tokens > 100);
-    assert!(output_tokens > 10, "output_tokens: {output_tokens}");
-    // Sleep for 1 second to allow time for data to be inserted into ClickHouse (trailing writes from API)
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    expect_that!(input_tokens, gt(100));
+    expect_that!(output_tokens, gt(10), "output_tokens: {output_tokens}");
+    let conn = DelegatingDatabaseConnection::new_for_e2e_test().await;
+    conn.flush_pending_writes().await;
+    conn.sleep_for_writes_to_be_visible().await;
 
-    // Check ClickHouse
-    let clickhouse = get_clickhouse().await;
-    let result = select_json_inference_clickhouse(&clickhouse, inference_id)
+    let config = get_e2e_config().await;
+    let inferences = conn
+        .list_inferences(
+            &config,
+            &ListInferencesParams {
+                ids: Some(&[inference_id]),
+                ..Default::default()
+            },
+        )
         .await
         .unwrap();
-    let id = result.get("id").unwrap().as_str().unwrap();
-    let id_uuid = Uuid::parse_str(id).unwrap();
-    assert_eq!(id_uuid, inference_id);
-    let input: Value =
-        serde_json::from_str(result.get("input").unwrap().as_str().unwrap()).unwrap();
+    assert_that!(inferences.len(), eq(1));
+    let json_inf = match &inferences[0] {
+        StoredInferenceDatabase::Json(j) => j,
+        StoredInferenceDatabase::Chat(_) => panic!("Expected json inference"),
+    };
+    expect_that!(json_inf.inference_id, eq(inference_id));
+    let input = serde_json::to_value(&json_inf.input).unwrap();
     let correct_input: Value = json!(
         {
             "system": {
@@ -647,57 +645,48 @@ async fn test_mixture_of_n_json_real_judge() {
             ]
         }
     );
-    assert_eq!(input, correct_input);
+    expect_that!(input, eq(&correct_input));
     // Check that json parsed output is correct
-    let output = result.get("output").unwrap().as_str().unwrap();
-    let output: Value = serde_json::from_str(output).unwrap();
-    let parsed_output = output.get("parsed").unwrap();
+    let output = json_inf.output.as_ref().unwrap();
+    let parsed_output = output.parsed.as_ref().unwrap();
     let names = parsed_output.get("names").unwrap().as_array().unwrap();
-    assert_eq!(names.len(), 4);
-    assert!(names.contains(&"John".into()));
-    assert!(names.contains(&"Paul".into()));
-    assert!(names.contains(&"Ringo".into()));
-    assert!(names.contains(&"George".into()));
+    expect_that!(names.len(), eq(4));
+    expect_that!(names.contains(&"John".into()), eq(true));
+    expect_that!(names.contains(&"Paul".into()), eq(true));
+    expect_that!(names.contains(&"Ringo".into()), eq(true));
+    expect_that!(names.contains(&"George".into()), eq(true));
     // Check that episode_id is here and correct
-    let retrieved_episode_id = result.get("episode_id").unwrap().as_str().unwrap();
-    let retrieved_episode_id = Uuid::parse_str(retrieved_episode_id).unwrap();
-    assert_eq!(retrieved_episode_id, episode_id);
+    expect_that!(json_inf.episode_id, eq(episode_id));
     // Check the variant name
-    let variant_name = result.get("variant_name").unwrap().as_str().unwrap();
-    assert_eq!(variant_name, "mixture_of_n_variant");
+    expect_that!(&json_inf.variant_name, eq("mixture_of_n_variant"));
 
     // Check the ModelInference Table
-    let results = select_model_inferences_clickhouse(&clickhouse, inference_id)
+    let model_inferences = conn
+        .get_model_inferences_by_inference_id(inference_id)
         .await
         .unwrap();
-    assert_eq!(results.len(), 3);
+    expect_that!(model_inferences.len(), eq(3));
 
     // Collect model names
     let mut model_names = std::collections::HashSet::new();
 
-    for result in results {
-        let id = result.get("id").unwrap().as_str().unwrap();
-        let _ = Uuid::parse_str(id).unwrap();
-        let inference_id_result = result.get("inference_id").unwrap().as_str().unwrap();
-        let inference_id_result = Uuid::parse_str(inference_id_result).unwrap();
-        assert_eq!(inference_id_result, inference_id);
+    for mi in &model_inferences {
+        expect_that!(mi.inference_id, eq(inference_id));
 
         // Collect model_name
-        let model_name = result.get("model_name").unwrap().as_str().unwrap();
-        model_names.insert(model_name.to_string());
+        model_names.insert(mi.model_name.clone());
 
         // Check that all expected fields are present
-        assert!(result.get("model_provider_name").is_some());
-        assert!(result.get("raw_request").is_some());
-        assert!(result.get("raw_response").is_some());
-        assert!(result.get("input_tokens").is_some());
-        assert!(result.get("output_tokens").is_some());
-        assert!(result.get("response_time_ms").is_some());
-        assert!(result.get("ttft_ms").is_some());
+        expect_that!(mi.model_provider_name.is_empty(), eq(false));
+        expect_that!(&mi.raw_request, some(anything()));
+        expect_that!(&mi.raw_response, some(anything()));
+        expect_that!(mi.input_tokens, some(anything()));
+        expect_that!(mi.output_tokens, some(anything()));
+        expect_that!(mi.response_time_ms, some(anything()));
         // For the judge model we want to check that the `raw_request` is correct
-        if model_name == "gpt-4o-mini-2024-07-18" {
-            let raw_request = result.get("raw_request").unwrap().as_str().unwrap();
-            let raw_request: Value = serde_json::from_str(raw_request).unwrap();
+        if mi.model_name == "gpt-4o-mini-2024-07-18" {
+            let raw_request: Value =
+                serde_json::from_str(mi.raw_request.as_deref().unwrap()).unwrap();
             let expected_request = json!({
               "messages": [
                 {
@@ -739,36 +728,34 @@ async fn test_mixture_of_n_json_real_judge() {
                 }
               }
             });
-            assert_eq!(raw_request, expected_request);
-            let system = result.get("system").unwrap().as_str().unwrap();
-            assert_eq!(
-                system,
-                "You have been provided with a set of responses from various models to the following problem:\n------\nYou are a helpful and friendly assistant named AskJeeves\n------\nYour task is to synthesize these responses into a single, high-quality response. It is crucial to critically evaluate the information provided in these responses, recognizing that some of it may be biased or incorrect. Your response should not simply replicate the given answers but should offer a refined, accurate, and comprehensive reply to the instruction and take the best from all the responses. Ensure your response is well-structured, coherent, and adheres to the highest standards of accuracy and reliability.  Below will be: first, any messages leading up to this point, and then, a final message containing the set of candidate responses."
+            expect_that!(raw_request, eq(&expected_request));
+            expect_that!(
+                mi.system.as_deref().unwrap(),
+                eq(
+                    "You have been provided with a set of responses from various models to the following problem:\n------\nYou are a helpful and friendly assistant named AskJeeves\n------\nYour task is to synthesize these responses into a single, high-quality response. It is crucial to critically evaluate the information provided in these responses, recognizing that some of it may be biased or incorrect. Your response should not simply replicate the given answers but should offer a refined, accurate, and comprehensive reply to the instruction and take the best from all the responses. Ensure your response is well-structured, coherent, and adheres to the highest standards of accuracy and reliability.  Below will be: first, any messages leading up to this point, and then, a final message containing the set of candidate responses."
+                )
             );
-            let input_messages = result.get("input_messages").unwrap().as_str().unwrap();
-            let input_messages: Vec<StoredRequestMessage> =
-                serde_json::from_str(input_messages).unwrap();
-            assert_eq!(input_messages.len(), 2);
-            assert_eq!(
-                input_messages[0],
-                StoredRequestMessage {
+            let input_messages = mi.input_messages.as_ref().unwrap();
+            assert_that!(input_messages.len(), eq(2));
+            expect_that!(
+                &input_messages[0],
+                eq(&StoredRequestMessage {
                     role: Role::User,
                     content: vec![
                         StoredContentBlock::Text(Text { text: "What are the first names of the Beatles? Respond in the format {\"names\": List[str]}".to_string() })
                     ],
-                }
+                })
             );
-            assert_eq!(input_messages[1], StoredRequestMessage {
+            expect_that!(&input_messages[1], eq(&StoredRequestMessage {
                 role: Role::User,
                 content: vec![
                     StoredContentBlock::Text(Text { text: "Here are the candidate answers (with the index and a row of ------ separating):\n0:\n{\"names\":[\"John\", \"George\"]}\n------\n1:\n{\"names\":[\"Paul\", \"Ringo\"]}\n------".to_string() })
                 ],
-            });
-            let output = result.get("output").unwrap().as_str().unwrap();
-            let output: Vec<StoredContentBlock> = serde_json::from_str(output).unwrap();
-            assert_eq!(output.len(), 1);
+            }));
+            let output = mi.output.as_ref().unwrap();
+            assert_that!(output.len(), eq(1));
             match &output[0] {
-                StoredContentBlock::Text(_) => {
+                ContentBlockOutput::Text(_) => {
                     // We don't need to check the exact content since this is a fuser model
                 }
                 _ => {
@@ -777,13 +764,10 @@ async fn test_mixture_of_n_json_real_judge() {
             }
         }
 
-        let input_tokens = result.get("input_tokens").unwrap().as_u64().unwrap();
-        assert!(input_tokens > 0);
-        let output_tokens = result.get("output_tokens").unwrap().as_u64().unwrap();
-        assert!(output_tokens > 0);
-        let response_time_ms = result.get("response_time_ms").unwrap().as_u64().unwrap();
-        assert!(response_time_ms > 0);
-        assert!(result.get("ttft_ms").unwrap().is_null());
+        expect_that!(mi.input_tokens.unwrap(), gt(0));
+        expect_that!(mi.output_tokens.unwrap(), gt(0));
+        expect_that!(mi.response_time_ms.unwrap(), gt(0));
+        expect_that!(mi.ttft_ms, none());
     }
 
     // Check that all expected model names are present
@@ -792,12 +776,12 @@ async fn test_mixture_of_n_json_real_judge() {
             .iter()
             .map(std::string::ToString::to_string)
             .collect();
-    assert_eq!(model_names, expected_model_names);
+    expect_that!(model_names, eq(&expected_model_names));
 }
 
+#[gtest]
 #[tokio::test]
 async fn test_mixture_of_n_extra_body() {
-    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
 
     let payload = json!({
@@ -821,50 +805,43 @@ async fn test_mixture_of_n_extra_body() {
         .await
         .unwrap();
     // Check Response is OK, then fields in order
-    assert_eq!(response.status(), StatusCode::OK);
+    expect_that!(response.status(), eq(StatusCode::OK));
     let response_json = response.json::<Value>().await.unwrap();
     // Check that inference_id is here
     let inference_id = response_json.get("inference_id").unwrap().as_str().unwrap();
     let inference_id = Uuid::parse_str(inference_id).unwrap();
-    // Sleep for 1 second to allow time for data to be inserted into ClickHouse (trailing writes from API)
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-
-    // Check ClickHouse
-    let clickhouse = get_clickhouse().await;
+    let conn = DelegatingDatabaseConnection::new_for_e2e_test().await;
+    conn.flush_pending_writes().await;
+    conn.sleep_for_writes_to_be_visible().await;
 
     // Check the ModelInference Table
-    let results = select_model_inferences_clickhouse(&clickhouse, inference_id)
+    let model_inferences = conn
+        .get_model_inferences_by_inference_id(inference_id)
         .await
         .unwrap();
-    assert_eq!(results.len(), 3);
+    expect_that!(model_inferences.len(), eq(3));
 
     // Collect model names
     let mut model_names = std::collections::HashSet::new();
 
-    for result in results {
-        let id = result.get("id").unwrap().as_str().unwrap();
-        let _ = Uuid::parse_str(id).unwrap();
-        let inference_id_result = result.get("inference_id").unwrap().as_str().unwrap();
-        let inference_id_result = Uuid::parse_str(inference_id_result).unwrap();
-        assert_eq!(inference_id_result, inference_id);
+    for mi in &model_inferences {
+        expect_that!(mi.inference_id, eq(inference_id));
 
         // Collect model_name
-        let model_name = result.get("model_name").unwrap().as_str().unwrap();
-        model_names.insert(model_name.to_string());
+        model_names.insert(mi.model_name.clone());
 
         // Check that all expected fields are present
-        assert!(result.get("model_provider_name").is_some());
-        assert!(result.get("raw_request").is_some());
-        assert!(result.get("raw_response").is_some());
-        assert!(result.get("input_tokens").is_some());
-        assert!(result.get("output_tokens").is_some());
-        assert!(result.get("response_time_ms").is_some());
-        assert!(result.get("ttft_ms").is_some());
+        expect_that!(mi.model_provider_name.is_empty(), eq(false));
+        expect_that!(&mi.raw_request, some(anything()));
+        expect_that!(&mi.raw_response, some(anything()));
+        expect_that!(mi.input_tokens, some(anything()));
+        expect_that!(mi.output_tokens, some(anything()));
+        expect_that!(mi.response_time_ms, some(anything()));
 
         // Check that the judge model gets 'temperature' injected from 'fuser.extra_body'
-        if model_name == "gpt-4o-mini-2024-07-18" {
-            let raw_request = result.get("raw_request").unwrap().as_str().unwrap();
-            let mut raw_request: Value = serde_json::from_str(raw_request).unwrap();
+        if mi.model_name == "gpt-4o-mini-2024-07-18" {
+            let mut raw_request: Value =
+                serde_json::from_str(mi.raw_request.as_deref().unwrap()).unwrap();
 
             // This message depends on the particular output of the candidate model, so just check that
             // it has the expected prefix.
@@ -875,13 +852,14 @@ async fn test_mixture_of_n_extra_body() {
                 .unwrap()
                 .pop()
                 .unwrap();
-            assert!(
+            expect_that!(
                 candidate_msg
                     .get("content")
                     .unwrap()
                     .as_str()
                     .unwrap()
                     .contains("Here are the candidate answers"),
+                eq(true),
                 "Unexpected candidate msg: {candidate_msg:?}"
             );
 
@@ -900,11 +878,11 @@ async fn test_mixture_of_n_extra_body() {
               "stream": false,
               "temperature": 0.123
             });
-            assert_eq!(raw_request, expected_request);
+            expect_that!(raw_request, eq(&expected_request));
         // Check that the other model does not get 'temperature' injected from 'fuser.extra_body'
-        } else if model_name == "o1-2024-12-17" {
-            let raw_request = result.get("raw_request").unwrap().as_str().unwrap();
-            let raw_request: Value = serde_json::from_str(raw_request).unwrap();
+        } else if mi.model_name == "o1-2024-12-17" {
+            let raw_request: Value =
+                serde_json::from_str(mi.raw_request.as_deref().unwrap()).unwrap();
             let expected_request = json!({
               "messages": [
                 {
@@ -919,7 +897,7 @@ async fn test_mixture_of_n_extra_body() {
               "model": "o1-2024-12-17",
               "stream": false,
             });
-            assert_eq!(raw_request, expected_request);
+            expect_that!(raw_request, eq(&expected_request));
         }
     }
     // Check that all expected model names are present
@@ -928,12 +906,12 @@ async fn test_mixture_of_n_extra_body() {
             .iter()
             .map(std::string::ToString::to_string)
             .collect();
-    assert_eq!(model_names, expected_model_names);
+    expect_that!(model_names, eq(&expected_model_names));
 }
 
+#[gtest]
 #[tokio::test]
 async fn test_mixture_of_n_bad_fuser_streaming() {
-    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     let payload = json!({
         "function_name": "mixture_of_n",
@@ -977,46 +955,51 @@ async fn test_mixture_of_n_bad_fuser_streaming() {
         }
         chunk_data.push(chunk_json);
     }
-    assert_eq!(chunk_data.len(), 2);
+    assert_that!(chunk_data.len(), eq(2));
     // First chunk contains content only (usage/finish_reason are in the final chunk)
-    assert_eq!(
-        chunk_data[0],
-        serde_json::json!({
-            "inference_id": first_inference_id.unwrap().to_string(),
-            "episode_id": episode_id.to_string(),
-            "variant_name":"mixture_of_n_variant_bad_fuser",
-            "content":[{"type": "text", "id": "0", "text": "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."}],
-        })
-    );
+    let expected_chunk_0 = serde_json::json!({
+        "inference_id": first_inference_id.unwrap().to_string(),
+        "episode_id": episode_id.to_string(),
+        "variant_name":"mixture_of_n_variant_bad_fuser",
+        "content":[{"type": "text", "id": "0", "text": "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake."}],
+    });
+    expect_that!(chunk_data[0], eq(&expected_chunk_0));
     // Final chunk contains usage (accumulated from all candidates) and finish_reason
-    assert_eq!(
-        chunk_data[1],
-        serde_json::json!({
-            "inference_id": first_inference_id.unwrap().to_string(),
-            "episode_id": episode_id.to_string(),
-            "variant_name":"mixture_of_n_variant_bad_fuser",
-            "content":[],
-            // Usage is accumulated from all 2 candidates (10+10 input tokens, 1+1 output tokens)
-            "usage":{"input_tokens":20,"output_tokens":2,"cost":0.00036},
-            "finish_reason": "stop"
-        }),
-    );
+    let expected_chunk_1 = serde_json::json!({
+        "inference_id": first_inference_id.unwrap().to_string(),
+        "episode_id": episode_id.to_string(),
+        "variant_name":"mixture_of_n_variant_bad_fuser",
+        "content":[],
+        // Usage is accumulated from all 2 candidates (10+10 input tokens, 1+1 output tokens)
+        "usage":{"input_tokens":20,"output_tokens":2,"cost":0.00036},
+        "finish_reason": "stop"
+    });
+    expect_that!(chunk_data[1], eq(&expected_chunk_1));
 
     let inference_id = first_inference_id.unwrap();
 
-    // Sleep for 1 second to allow time for data to be inserted into ClickHouse (trailing writes from API)
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    let conn = DelegatingDatabaseConnection::new_for_e2e_test().await;
+    conn.flush_pending_writes().await;
+    conn.sleep_for_writes_to_be_visible().await;
 
-    // Check ClickHouse
-    let clickhouse = get_clickhouse().await;
-    let result = select_chat_inference_clickhouse(&clickhouse, inference_id)
+    let config = get_e2e_config().await;
+    let inferences = conn
+        .list_inferences(
+            &config,
+            &ListInferencesParams {
+                ids: Some(&[inference_id]),
+                ..Default::default()
+            },
+        )
         .await
         .unwrap();
-    let id = result.get("id").unwrap().as_str().unwrap();
-    let id_uuid = Uuid::parse_str(id).unwrap();
-    assert_eq!(id_uuid, inference_id);
-    let input: Value =
-        serde_json::from_str(result.get("input").unwrap().as_str().unwrap()).unwrap();
+    assert_that!(inferences.len(), eq(1));
+    let chat = match &inferences[0] {
+        StoredInferenceDatabase::Chat(c) => c,
+        StoredInferenceDatabase::Json(_) => panic!("Expected chat inference"),
+    };
+    expect_that!(chat.inference_id, eq(inference_id));
+    let input = serde_json::to_value(&chat.input).unwrap();
     let correct_input: Value = json!(
         {
             "system": {
@@ -1032,83 +1015,69 @@ async fn test_mixture_of_n_bad_fuser_streaming() {
             ]
         }
     );
-    assert_eq!(input, correct_input);
+    expect_that!(input, eq(&correct_input));
 
     // Check the ModelInference Table
-    let results: Vec<Value> = select_model_inferences_clickhouse(&clickhouse, inference_id)
+    let model_inferences = conn
+        .get_model_inferences_by_inference_id(inference_id)
         .await
         .unwrap();
     // Both candidates should be present (but not the fuser, since it failed)
-    println!("results: {results:#?}");
-    assert_eq!(results.len(), 2);
-    let mut first_result = results[0].clone();
-    // Pop the snapshot hash because it's not easy to assert on
-    let snapshot_hash = first_result
-        .as_object_mut()
-        .unwrap()
-        .remove("snapshot_hash")
-        .unwrap();
-    assert!(snapshot_hash.is_string());
+    println!("model_inferences: {model_inferences:#?}");
+    assert_that!(model_inferences.len(), eq(2));
 
-    // Each model inference should have its INDIVIDUAL usage, not aggregated
-    assert_eq!(
-        first_result,
-        serde_json::json!({
-          "id": results[0].get("id").unwrap().as_str().unwrap(),
-          "inference_id": inference_id.to_string(),
-          "raw_request": "raw request",
-          "raw_response": "",
-          "raw_response": "{\n  \"id\": \"id\",\n  \"object\": \"text.completion\",\n  \"created\": 1618870400,\n  \"model\": \"text-davinci-002\",\n  \"choices\": [\n    {\n      \"text\": \"Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake.\",\n      \"index\": 0,\n      \"logprobs\": null,\n      \"finish_reason\": null\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 10,\n    \"completion_tokens\": 10,\n    \"total_tokens\": 20\n  }\n}",
-          "model_name": "test",
-          "model_provider_name": "good",
-          "input_tokens": 10,
-          "output_tokens": 1,
-          "response_time_ms": 100,
-          "ttft_ms": 100,
-          "system": "You are a helpful and friendly assistant named AskJeeves",
-          "input_messages": "[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Please write me a sentence about Megumin making an explosion\"}]}]",
-          "output": "[{\"type\":\"text\",\"text\":\"Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake.\"}]",
-          "cached": false,
-          "finish_reason": "stop",
-          "cost": 0.00018,
-        })
-    );
+    let expected_raw_response = "{\n  \"id\": \"id\",\n  \"object\": \"text.completion\",\n  \"created\": 1618870400,\n  \"model\": \"text-davinci-002\",\n  \"choices\": [\n    {\n      \"text\": \"Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake.\",\n      \"index\": 0,\n      \"logprobs\": null,\n      \"finish_reason\": null\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 10,\n    \"completion_tokens\": 10,\n    \"total_tokens\": 20\n  }\n}";
+    let expected_input_messages = vec![StoredRequestMessage {
+        role: Role::User,
+        content: vec![StoredContentBlock::Text(Text {
+            text: "Please write me a sentence about Megumin making an explosion".to_string(),
+        })],
+    }];
+    let expected_output = vec![ContentBlockOutput::Text(Text {
+        text: "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake.".to_string(),
+    })];
 
-    let mut second_result = results[1].clone();
-    // Pop the snapshot hash because it's not easy to assert on
-    let snapshot_hash = second_result
-        .as_object_mut()
-        .unwrap()
-        .remove("snapshot_hash")
-        .unwrap();
-    assert!(snapshot_hash.is_string());
+    // Each model inference should have its INDIVIDUAL usage, not aggregated.
+    // Row order is not guaranteed, so check common fields in a loop
+    // and use unordered_elements_are! for the distinguishing field (ttft_ms).
+    let inference_cost = Decimal::from(18) / Decimal::from(100_000);
+    for mi in &model_inferences {
+        expect_that!(
+            mi,
+            matches_pattern!(StoredModelInference {
+                snapshot_hash: some(anything()),
+                inference_id: eq(&inference_id),
+                raw_request: some(eq("raw request")),
+                raw_response: some(eq(expected_raw_response)),
+                model_name: eq("test"),
+                model_provider_name: eq("good"),
+                input_tokens: some(eq(&10)),
+                output_tokens: some(eq(&1)),
+                response_time_ms: some(eq(&100)),
+                system: some(eq(
+                    "You are a helpful and friendly assistant named AskJeeves"
+                )),
+                input_messages: some(eq(&expected_input_messages)),
+                output: some(eq(&expected_output)),
+                cached: eq(&false),
+                finish_reason: some(eq(&FinishReason::Stop)),
+                cost: some(eq(&inference_cost)),
+                ..
+            })
+        );
+    }
 
-    assert_eq!(
-        second_result,
-        serde_json::json!({
-          "id": results[1].get("id").unwrap().as_str().unwrap(),
-          "inference_id": inference_id.to_string(),
-          "raw_request": "raw request",
-          "raw_response": "{\n  \"id\": \"id\",\n  \"object\": \"text.completion\",\n  \"created\": 1618870400,\n  \"model\": \"text-davinci-002\",\n  \"choices\": [\n    {\n      \"text\": \"Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake.\",\n      \"index\": 0,\n      \"logprobs\": null,\n      \"finish_reason\": null\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 10,\n    \"completion_tokens\": 10,\n    \"total_tokens\": 20\n  }\n}",
-          "model_name": "test",
-          "model_provider_name": "good",
-          "input_tokens": 10,
-          "output_tokens": 1,
-          "response_time_ms": 100,
-          "ttft_ms": null,
-          "system": "You are a helpful and friendly assistant named AskJeeves",
-          "input_messages": "[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Please write me a sentence about Megumin making an explosion\"}]}]",
-          "output": "[{\"type\":\"text\",\"text\":\"Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake.\"}]",
-          "cached": false,
-          "finish_reason": "stop",
-          "cost": 0.00018,
-        })
+    // One candidate should have ttft_ms (the first streamed response) and the other should not.
+    let ttft_values: Vec<_> = model_inferences.iter().map(|mi| mi.ttft_ms).collect();
+    expect_that!(
+        ttft_values,
+        unordered_elements_are![none(), some(eq(&100u32))],
     );
 }
 
+#[gtest]
 #[tokio::test]
 async fn test_mixture_of_n_single_candidate_streaming() {
-    skip_for_postgres!();
     let episode_id = Uuid::now_v7();
     test_mixture_of_n_single_candidate_inner(true, episode_id, json!({
         "function_name": "mixture_of_n_single_candidate",
@@ -1129,7 +1098,6 @@ async fn test_mixture_of_n_single_candidate_streaming() {
 }
 
 async fn test_mixture_of_n_single_candidate_inner(stream: bool, episode_id: Uuid, payload: Value) {
-    skip_for_postgres!();
     let builder = Client::new()
         .post(get_gateway_endpoint("/inference"))
         .json(&payload);
@@ -1190,19 +1158,28 @@ async fn test_mixture_of_n_single_candidate_inner(stream: bool, episode_id: Uuid
         Uuid::parse_str(inference_id).unwrap()
     };
 
-    // Sleep for 1 second to allow time for data to be inserted into ClickHouse (trailing writes from API)
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    let conn = DelegatingDatabaseConnection::new_for_e2e_test().await;
+    conn.flush_pending_writes().await;
+    conn.sleep_for_writes_to_be_visible().await;
 
-    // Check ClickHouse
-    let clickhouse = get_clickhouse().await;
-    let result = select_chat_inference_clickhouse(&clickhouse, inference_id)
+    let config = get_e2e_config().await;
+    let inferences = conn
+        .list_inferences(
+            &config,
+            &ListInferencesParams {
+                ids: Some(&[inference_id]),
+                ..Default::default()
+            },
+        )
         .await
         .unwrap();
-    let id = result.get("id").unwrap().as_str().unwrap();
-    let id_uuid = Uuid::parse_str(id).unwrap();
-    assert_eq!(id_uuid, inference_id);
-    let input: Value =
-        serde_json::from_str(result.get("input").unwrap().as_str().unwrap()).unwrap();
+    assert_eq!(inferences.len(), 1);
+    let chat = match &inferences[0] {
+        StoredInferenceDatabase::Chat(c) => c,
+        StoredInferenceDatabase::Json(_) => panic!("Expected chat inference"),
+    };
+    assert_eq!(chat.inference_id, inference_id);
+    let input = serde_json::to_value(&chat.input).unwrap();
     let correct_input: Value = json!(
         {
             "system": {
@@ -1221,43 +1198,47 @@ async fn test_mixture_of_n_single_candidate_inner(stream: bool, episode_id: Uuid
     assert_eq!(input, correct_input);
 
     // Check the ModelInference Table
-    let results: Vec<Value> = select_model_inferences_clickhouse(&clickhouse, inference_id)
+    let model_inferences = conn
+        .get_model_inferences_by_inference_id(inference_id)
         .await
         .unwrap();
     // With only a single candidate, the fuser should not be used
-    println!("results: {results:#?}");
-    assert_eq!(results.len(), 1);
+    println!("model_inferences: {model_inferences:#?}");
+    assert_eq!(model_inferences.len(), 1);
 
-    let mut result = results[0].clone();
-
-    println!("result: {result}");
-    // Pop the snapshot hash because it's not easy to assert on
-    let snapshot_hash = result
-        .as_object_mut()
-        .unwrap()
-        .remove("snapshot_hash")
-        .unwrap();
-    assert!(snapshot_hash.is_string());
-
+    let mi = &model_inferences[0];
+    println!("mi: {mi:#?}");
+    assert!(mi.snapshot_hash.is_some());
+    assert_eq!(mi.inference_id, inference_id);
+    assert_eq!(mi.raw_request.as_deref().unwrap(), "raw request");
     assert_eq!(
-        result,
-        serde_json::json!({
-          "id": result.get("id").unwrap().as_str().unwrap(),
-          "inference_id": inference_id.to_string(),
-          "raw_request": "raw request",
-          "raw_response": "{\n  \"id\": \"id\",\n  \"object\": \"text.completion\",\n  \"created\": 1618870400,\n  \"model\": \"text-davinci-002\",\n  \"choices\": [\n    {\n      \"text\": \"Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake.\",\n      \"index\": 0,\n      \"logprobs\": null,\n      \"finish_reason\": null\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 10,\n    \"completion_tokens\": 10,\n    \"total_tokens\": 20\n  }\n}",
-          "model_name": "test",
-          "model_provider_name": "good",
-          "input_tokens": 10,
-          "output_tokens": 1,
-          "response_time_ms": 100,
-          "ttft_ms": 100,
-          "system": "You are a helpful and friendly assistant named AskJeeves",
-          "input_messages": "[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Please write me a sentence about Megumin making an explosion\"}]}]",
-          "output": "[{\"type\":\"text\",\"text\":\"Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake.\"}]",
-          "cached": false,
-          "finish_reason": "stop",
-          "cost": 0.00018,
-        })
+        mi.raw_response.as_deref().unwrap(),
+        "{\n  \"id\": \"id\",\n  \"object\": \"text.completion\",\n  \"created\": 1618870400,\n  \"model\": \"text-davinci-002\",\n  \"choices\": [\n    {\n      \"text\": \"Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake.\",\n      \"index\": 0,\n      \"logprobs\": null,\n      \"finish_reason\": null\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 10,\n    \"completion_tokens\": 10,\n    \"total_tokens\": 20\n  }\n}"
     );
+    assert_eq!(mi.model_name, "test");
+    assert_eq!(mi.model_provider_name, "good");
+    assert_eq!(mi.input_tokens, Some(10));
+    assert_eq!(mi.output_tokens, Some(1));
+    assert_eq!(mi.response_time_ms, Some(100));
+    assert_eq!(mi.ttft_ms, Some(100));
+    assert_eq!(
+        mi.system.as_deref().unwrap(),
+        "You are a helpful and friendly assistant named AskJeeves"
+    );
+    assert_eq!(
+        mi.input_messages.as_ref().unwrap(),
+        &vec![StoredRequestMessage {
+            role: Role::User,
+            content: vec![StoredContentBlock::Text(Text {
+                text: "Please write me a sentence about Megumin making an explosion".to_string(),
+            })],
+        }]
+    );
+    assert_eq!(
+        mi.output.as_ref().unwrap(),
+        &vec![ContentBlockOutput::Text(Text {
+            text: "Megumin gleefully chanted her spell, unleashing a thunderous explosion that lit up the sky and left a massive crater in its wake.".to_string(),
+        })]
+    );
+    assert!(!mi.cached);
 }


### PR DESCRIPTION
https://github.com/tensorzero/tensorzero/issues/6718

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches only e2e tests, but changes how persistence is asserted (new DB query paths, removal of `skip_for_postgres!()`), which could cause CI failures or mask real storage regressions if assumptions don’t match the new abstractions.
> 
> **Overview**
> Updates the `mixture_of_n` e2e suite to stop querying ClickHouse directly and instead validate persisted results via `DelegatingDatabaseConnection` (`list_inferences` + `get_model_inferences_by_inference_id`) after explicit `flush_pending_writes()`/`sleep_for_writes_to_be_visible()`.
> 
> Assertions are migrated to typed stored structures (`StoredInferenceDatabase`, `StoredModelInference`, `ContentBlock*Output`, `FinishReason`) and `googletest` matchers (including unordered/partial matching), adding stricter checks around caching behavior, TTFT presence, and per-model cost/usage accounting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0214c5ee1035ab31722f37836738e5a1eb5249e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->