### PR TITLE
Disable more provider tests and make sure test embedded clients use correct backend

### DIFF
--- a/clients/rust/src/test_helpers.rs
+++ b/clients/rust/src/test_helpers.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::expect_used, clippy::unwrap_used, clippy::missing_panics_doc)]
 
-use std::collections::HashMap;
+use std::{collections::HashMap, path::Path};
 
 use crate::{Client, ClientBuilder, ClientBuilderMode, PostgresConfig};
 use tempfile::NamedTempFile;
@@ -24,53 +24,26 @@ pub async fn make_http_gateway() -> Client {
 }
 
 pub async fn make_embedded_gateway() -> Client {
-    let postgres_config = if PrimaryDatastore::from_test_env() == PrimaryDatastore::Postgres {
-        let postgres_url = std::env::var("TENSORZERO_POSTGRES_URL")
-            .expect("TENSORZERO_POSTGRES_URL must be set when primary datastore is Postgres");
-        Some(PostgresConfig::Url(postgres_url))
-    } else {
-        None
-    };
-
     let config_path = get_e2e_config_path();
-    ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
-        config_file: Some(config_path),
-        clickhouse_url: Some(CLICKHOUSE_URL.clone()),
-        postgres_config,
-        valkey_url: None,
-        timeout: None,
-        verify_credentials: true,
-        allow_batch_writes: true,
-    })
-    .build()
-    .await
-    .unwrap()
+    make_embedded_gateway_with_config_path(Some(config_path.as_path())).await
 }
 
 pub async fn make_embedded_gateway_no_config() -> Client {
-    let postgres_config = if PrimaryDatastore::from_test_env() == PrimaryDatastore::Postgres {
-        let postgres_url = std::env::var("TENSORZERO_POSTGRES_URL")
-            .expect("TENSORZERO_POSTGRES_URL must be set when primary datastore is Postgres");
-        Some(PostgresConfig::Url(postgres_url))
-    } else {
-        None
-    };
-
-    ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
-        config_file: None,
-        clickhouse_url: Some(CLICKHOUSE_URL.clone()),
-        postgres_config,
-        valkey_url: None,
-        timeout: None,
-        verify_credentials: true,
-        allow_batch_writes: true,
-    })
-    .build()
-    .await
-    .unwrap()
+    make_embedded_gateway_with_config_path(None).await
 }
 
 pub async fn make_embedded_gateway_with_config(config: &str) -> Client {
+    let tmp_config = NamedTempFile::new().unwrap();
+    std::fs::write(tmp_config.path(), config).unwrap();
+    make_embedded_gateway_with_config_path(Some(tmp_config.path())).await
+}
+
+pub async fn make_embedded_gateway_with_config_path(config_path: Option<&Path>) -> Client {
+    let clickhouse_url = if PrimaryDatastore::from_test_env() == PrimaryDatastore::ClickHouse {
+        Some(CLICKHOUSE_URL.clone())
+    } else {
+        None
+    };
     let postgres_config = if PrimaryDatastore::from_test_env() == PrimaryDatastore::Postgres {
         let postgres_url = std::env::var("TENSORZERO_POSTGRES_URL")
             .expect("TENSORZERO_POSTGRES_URL must be set when primary datastore is Postgres");
@@ -79,11 +52,9 @@ pub async fn make_embedded_gateway_with_config(config: &str) -> Client {
         None
     };
 
-    let tmp_config = NamedTempFile::new().unwrap();
-    std::fs::write(tmp_config.path(), config).unwrap();
     ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
-        config_file: Some(tmp_config.path().to_owned()),
-        clickhouse_url: Some(CLICKHOUSE_URL.clone()),
+        config_file: config_path.map(|path| path.to_owned()),
+        clickhouse_url,
         postgres_config,
         valkey_url: None,
         timeout: None,
@@ -96,6 +67,11 @@ pub async fn make_embedded_gateway_with_config(config: &str) -> Client {
 }
 
 pub async fn make_embedded_gateway_with_config_and_postgres(config: &str) -> Client {
+    let clickhouse_url = if PrimaryDatastore::from_test_env() == PrimaryDatastore::ClickHouse {
+        Some(CLICKHOUSE_URL.clone())
+    } else {
+        None
+    };
     let postgres_url = std::env::var("TENSORZERO_POSTGRES_URL")
         .expect("TENSORZERO_POSTGRES_URL must be set for tests that require Postgres");
 
@@ -103,7 +79,7 @@ pub async fn make_embedded_gateway_with_config_and_postgres(config: &str) -> Cli
     std::fs::write(tmp_config.path(), config).unwrap();
     ClientBuilder::new(ClientBuilderMode::EmbeddedGateway {
         config_file: Some(tmp_config.path().to_owned()),
-        clickhouse_url: Some(CLICKHOUSE_URL.clone()),
+        clickhouse_url,
         postgres_config: Some(PostgresConfig::Url(postgres_url)),
         valkey_url: None,
         timeout: None,

--- a/tensorzero-core/tests/e2e/dicl.rs
+++ b/tensorzero-core/tests/e2e/dicl.rs
@@ -1271,6 +1271,7 @@ async fn test_dicl_json_request() {
 /// Test that max_distance filters out all irrelevant examples, falling back to vanilla chat completion
 #[tokio::test]
 pub async fn test_dicl_max_distance_filters_all_examples() {
+    skip_for_postgres!();
     let database = DelegatingDatabaseConnection::new_for_e2e_test().await;
     let episode_id = Uuid::now_v7();
     let variant_name = "dicl_max_distance_strict";

--- a/tensorzero-core/tests/e2e/providers/common.rs
+++ b/tensorzero-core/tests/e2e/providers/common.rs
@@ -1396,6 +1396,7 @@ model = "test-model"
 }
 
 pub async fn test_image_url_inference_with_provider_filesystem(provider: E2ETestProvider) {
+    skip_for_postgres!();
     let temp_dir = tempfile::tempdir().unwrap();
     println!("Temporary image dir: {}", temp_dir.path().to_string_lossy());
     Box::pin(test_url_image_inference_with_provider_and_store(
@@ -1479,6 +1480,7 @@ async fn check_object_fetch_via_gateway(storage_path: &StoragePath, expected_dat
 /// so there's no need to re-test them with PDF inputs.
 /// All of our PDF-capable providers are tested against the filesystem object store.
 pub async fn test_pdf_inference_with_provider_filesystem(provider: E2ETestProvider) {
+    skip_for_postgres!();
     let temp_dir = tempfile::tempdir().unwrap();
     println!("Temporary pdf dir: {}", temp_dir.path().to_string_lossy());
     let (client, storage_path) = Box::pin(test_base64_pdf_inference_with_provider_and_store(
@@ -1519,6 +1521,7 @@ pub async fn test_pdf_inference_with_provider_filesystem(provider: E2ETestProvid
 }
 
 pub async fn test_image_inference_with_provider_filesystem(provider: E2ETestProvider) {
+    skip_for_postgres!();
     let temp_dir = tempfile::tempdir().unwrap();
     println!("Temporary image dir: {}", temp_dir.path().to_string_lossy());
     let (client, storage_path) = Box::pin(test_base64_image_inference_with_provider_and_store(
@@ -1582,6 +1585,7 @@ fn create_s3_object_store(
 }
 
 pub async fn test_image_inference_with_provider_amazon_s3(provider: E2ETestProvider) {
+    skip_for_postgres!();
     let test_bucket = "tensorzero-e2e-test-images";
     let test_bucket_region = "us-east-1";
     let client = create_s3_object_store(

--- a/tensorzero-core/tests/e2e/providers/commonv2/input_audio.rs
+++ b/tensorzero-core/tests/e2e/providers/commonv2/input_audio.rs
@@ -1,4 +1,5 @@
 use crate::providers::common::E2ETestProvider;
+use crate::utils::skip_for_postgres;
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use tensorzero::test_helpers::make_embedded_gateway_with_config;
 use tensorzero::{
@@ -56,6 +57,7 @@ static AUDIO_FILE: &[u8] = include_bytes!("input_audio_barks.mp3");
 const AUDIO_FILE_HASH: &str = "4e497dd5ba1f3761a3d8bdf21da18632d4b919e66cba20af3bb1d07301fc7192";
 
 pub async fn test_audio_inference_with_provider_filesystem(provider: E2ETestProvider) {
+    skip_for_postgres!();
     let temp_dir = tempfile::tempdir().unwrap();
     let (_client, _storage_path) = Box::pin(test_base64_audio_inference_with_provider_and_store(
         provider,

--- a/tensorzero-core/tests/e2e/providers/openai/mod.rs
+++ b/tensorzero-core/tests/e2e/providers/openai/mod.rs
@@ -1520,6 +1520,7 @@ fn cosine_similarity(a: &Embedding, b: &Embedding) -> f32 {
 
 #[tokio::test]
 pub async fn test_image_inference_with_provider_cloudflare_r2() {
+    skip_for_postgres!();
     use crate::providers::common::test_image_inference_with_provider_s3_compatible;
     use object_store::{ObjectStore, aws::AmazonS3Builder};
     use rand::distr::Alphanumeric;
@@ -1715,6 +1716,7 @@ async fn test_content_block_text_field() {
 
 #[tokio::test(flavor = "multi_thread")]
 pub async fn test_image_inference_with_provider_gcp_storage() {
+    skip_for_postgres!();
     use crate::providers::common::IMAGE_FUNCTION_CONFIG;
     use crate::providers::common::test_image_inference_with_provider_s3_compatible;
     use object_store::{ObjectStore, aws::AmazonS3Builder};
@@ -1792,6 +1794,7 @@ pub async fn test_image_inference_with_provider_gcp_storage() {
 
 #[tokio::test]
 pub async fn test_image_inference_with_provider_docker_minio() {
+    skip_for_postgres!();
     use crate::providers::common::test_image_inference_with_provider_s3_compatible;
     use object_store::{ObjectStore, aws::AmazonS3Builder};
     use rand::distr::Alphanumeric;


### PR DESCRIPTION
We create some embedded clients in tests that have custom configs, so some tests still use ClickHouse even though we try to force Postgres.