### PR TITLE
Change GetConfigResponse.config to be untyped

### DIFF
--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -1,7 +1,9 @@
 #![recursion_limit = "256"]
 
 use std::{collections::HashMap, sync::Arc};
+use tensorzero_core::config::UninitializedConfig;
 use tensorzero_core::config::snapshot::ConfigSnapshot;
+use tensorzero_core::db::ConfigQueries;
 use tensorzero_core::db::HealthCheckable;
 use tensorzero_core::db::delegating_connection::DelegatingDatabaseQueries;
 use tensorzero_core::endpoints::stored_inferences::render_samples;
@@ -1273,7 +1275,6 @@ impl ClientExt for Client {
             }
             ClientMode::EmbeddedGateway { gateway, timeout } => {
                 with_embedded_timeout(*timeout, async {
-                    use tensorzero_core::db::ConfigQueries;
                     let snapshot_hash = match hash {
                         Some(h) => h.parse().map_err(|_| {
                             err_to_http(Error::new(ErrorDetails::ConfigSnapshotNotFound {
@@ -1289,13 +1290,20 @@ impl ClientExt for Client {
                         .get_config_snapshot(snapshot_hash)
                         .await
                         .map_err(err_to_http)?;
-                    Ok(GetConfigResponse {
-                        hash: snapshot.hash.to_string(),
-                        config: snapshot.config.try_into().map_err(|e: &'static str| {
+                    let uninitialized: UninitializedConfig =
+                        snapshot.config.try_into().map_err(|e: &'static str| {
                             err_to_http(Error::new(ErrorDetails::Config {
                                 message: e.to_string(),
                             }))
-                        })?,
+                        })?;
+                    let config = serde_json::to_value(&uninitialized).map_err(|e| {
+                        err_to_http(Error::new(ErrorDetails::Config {
+                            message: format!("Failed to serialize config: {e}"),
+                        }))
+                    })?;
+                    Ok(GetConfigResponse {
+                        hash: snapshot.hash.to_string(),
+                        config,
                         extra_templates: snapshot.extra_templates,
                         tags: snapshot.tags,
                     })

--- a/internal/autopilot-tools/tests/config_tools.rs
+++ b/internal/autopilot-tools/tests/config_tools.rs
@@ -10,7 +10,6 @@ use durable::MIGRATOR;
 use durable_tools::{ErasedSimpleTool, SimpleToolContext};
 use sqlx::PgPool;
 use tensorzero::{GetConfigResponse, WriteConfigResponse};
-use tensorzero_core::config::UninitializedConfig;
 use uuid::Uuid;
 
 use autopilot_tools::tools::{
@@ -20,12 +19,9 @@ use common::MockTensorZeroClient;
 
 #[sqlx::test(migrator = "MIGRATOR")]
 async fn test_get_config_tool_with_hash(pool: PgPool) {
-    let config: UninitializedConfig =
-        serde_json::from_value(serde_json::json!({})).expect("Config should deserialize");
-
     let response = GetConfigResponse {
         hash: "1234567".to_string(),
-        config,
+        config: serde_json::json!({}),
         extra_templates: HashMap::new(),
         tags: HashMap::new(),
     };

--- a/internal/durable-tools/src/tensorzero_client/embedded.rs
+++ b/internal/durable-tools/src/tensorzero_client/embedded.rs
@@ -15,6 +15,7 @@ use tensorzero::{
     TensorZeroError, UpdateDatapointRequest, UpdateDatapointsResponse, WriteConfigRequest,
     WriteConfigResponse,
 };
+use tensorzero_core::config::UninitializedConfig;
 use tensorzero_core::config::snapshot::{ConfigSnapshot, SnapshotHash};
 use tensorzero_core::db::ConfigQueries;
 use tensorzero_core::db::delegating_connection::DelegatingDatabaseQueries;
@@ -68,11 +69,9 @@ impl TensorZeroClient for EmbeddedClient {
         &self,
         params: ClientInferenceParams,
     ) -> Result<InferenceResponse, TensorZeroClientError> {
-        let internal_params = params
-            .try_into()
-            .map_err(|e: tensorzero_core::error::Error| {
-                TensorZeroClientError::TensorZero(TensorZeroError::Other { source: e.into() })
-            })?;
+        let internal_params = params.try_into().map_err(|e: Error| {
+            TensorZeroClientError::TensorZero(TensorZeroError::Other { source: e.into() })
+        })?;
 
         let result = Box::pin(inference(
             self.app_state.config.clone(),
@@ -263,18 +262,26 @@ impl TensorZeroClient for EmbeddedClient {
                 TensorZeroClientError::TensorZero(TensorZeroError::Other { source: e.into() })
             })?;
 
-        Ok(GetConfigResponse {
-            hash: snapshot.hash.to_string(),
-            config: snapshot.config.try_into().map_err(|e: &'static str| {
+        let uninitialized: UninitializedConfig =
+            snapshot.config.try_into().map_err(|e: &'static str| {
                 TensorZeroClientError::TensorZero(TensorZeroError::Other {
-                    source: tensorzero_core::error::Error::new(
-                        tensorzero_core::error::ErrorDetails::Config {
-                            message: e.to_string(),
-                        },
-                    )
+                    source: Error::new(ErrorDetails::Config {
+                        message: e.to_string(),
+                    })
                     .into(),
                 })
-            })?,
+            })?;
+        let config = serde_json::to_value(&uninitialized).map_err(|e| {
+            TensorZeroClientError::TensorZero(TensorZeroError::Other {
+                source: Error::new(ErrorDetails::Config {
+                    message: format!("Failed to serialize config: {e}"),
+                })
+                .into(),
+            })
+        })?;
+        Ok(GetConfigResponse {
+            hash: snapshot.hash.to_string(),
+            config,
             extra_templates: snapshot.extra_templates,
             tags: snapshot.tags,
         })

--- a/tensorzero-core/src/endpoints/internal/config.rs
+++ b/tensorzero-core/src/endpoints/internal/config.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use axum::Json;
 use axum::extract::{Path, State};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use tracing::instrument;
 
 use crate::config::UninitializedConfig;
@@ -19,8 +20,10 @@ use crate::utils::gateway::{AppState, AppStateData, StructuredJson};
 /// Response containing a config snapshot.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetConfigResponse {
-    /// The config in a form suitable for serialization.
-    pub config: UninitializedConfig,
+    /// The config as a JSON value.
+    /// Important: This should not be a strongly typed UninitializedConfig.
+    /// Nothing outside of the gateway should attempt to deserialize it into UninitializedConfig.
+    pub config: Value,
     /// The hash identifying this config version.
     pub hash: String,
     /// Templates that were loaded from the filesystem.
@@ -31,13 +34,20 @@ pub struct GetConfigResponse {
 
 impl GetConfigResponse {
     fn from_snapshot(snapshot: ConfigSnapshot) -> Result<Self, Error> {
-        Ok(Self {
-            hash: snapshot.hash.to_string(),
-            config: snapshot.config.try_into().map_err(|e: &'static str| {
+        let uninitialized: UninitializedConfig =
+            snapshot.config.try_into().map_err(|e: &'static str| {
                 Error::new(ErrorDetails::Config {
                     message: e.to_string(),
                 })
-            })?,
+            })?;
+        let config = serde_json::to_value(&uninitialized).map_err(|e| {
+            Error::new(ErrorDetails::Config {
+                message: format!("Failed to serialize config: {e}"),
+            })
+        })?;
+        Ok(Self {
+            hash: snapshot.hash.to_string(),
+            config,
             extra_templates: snapshot.extra_templates,
             tags: snapshot.tags,
         })


### PR DESCRIPTION
This is breaking config type changes again because autopilot tries to deserialize into a strongly typed config.