### PR TITLE
Fix cargo chef

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -20,6 +20,7 @@ ARG PROFILE
 WORKDIR /tensorzero
 ENV CARGO_INCREMENTAL=0
 RUN apt-get update && apt-get install -y clang libc++-dev && rm -rf /var/lib/apt/lists/*
+COPY rust-toolchain.toml .
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --profile ${PROFILE} -p gateway ${CARGO_BUILD_FLAGS}
 COPY . /tensorzero


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk Docker build change that only affects dependency caching/build reproducibility; runtime behavior is unchanged. Main risk is potential cache invalidation or build failures if `rust-toolchain.toml` differs from the image toolchain.
> 
> **Overview**
> Fixes the `gateway` Docker build with `cargo-chef` by copying `rust-toolchain.toml` into the `builder` stage before running `cargo chef cook`, ensuring the correct toolchain is available during dependency compilation and caching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53a26aa40246bbee0d6fb483609f3ff744473155. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->