### PR TITLE
Add progress polling to GEPA GET endpoint

### DIFF
--- a/crates/durable-tools-spawn/src/client.rs
+++ b/crates/durable-tools-spawn/src/client.rs
@@ -169,17 +169,19 @@ impl SpawnClient {
     pub async fn get_task_result(&self, task_id: Uuid) -> Result<TaskPollResult, SpawnError> {
         let queue_name = self.queue_name();
 
-        // Query the task table for state and completed_payload
+        // Query the task table for state, completed_payload, and params
         let query = format!(
-            "SELECT state, completed_payload FROM durable.t_{queue_name} WHERE task_id = $1"
+            "SELECT state, completed_payload, params FROM durable.t_{queue_name} WHERE task_id = $1"
         );
 
-        let row: Option<(String, Option<JsonValue>)> = sqlx::query_as(sqlx::AssertSqlSafe(query))
-            .bind(task_id)
-            .fetch_optional(self.pool())
-            .await?;
+        let row: Option<(String, Option<JsonValue>, Option<JsonValue>)> =
+            sqlx::query_as(sqlx::AssertSqlSafe(query))
+                .bind(task_id)
+                .fetch_optional(self.pool())
+                .await?;
 
-        let (state_str, completed_payload) = row.ok_or(SpawnError::TaskNotFound(task_id))?;
+        let (state_str, completed_payload, params) =
+            row.ok_or(SpawnError::TaskNotFound(task_id))?;
 
         let status: TaskStatus = state_str
             .parse()
@@ -206,7 +208,25 @@ impl SpawnClient {
             status,
             result: completed_payload,
             error,
+            params,
         })
+    }
+
+    /// Get the latest checkpoint name for a running task.
+    /// Returns `None` if no checkpoints exist yet.
+    pub async fn get_task_progress(&self, task_id: Uuid) -> Result<Option<String>, SpawnError> {
+        let queue_name = self.queue_name();
+        let query = format!(
+            "SELECT checkpoint_name FROM durable.c_{queue_name} \
+             WHERE task_id = $1 \
+             ORDER BY updated_at DESC \
+             LIMIT 1"
+        );
+        let row: Option<(String,)> = sqlx::query_as(sqlx::AssertSqlSafe(query))
+            .bind(task_id)
+            .fetch_optional(self.pool())
+            .await?;
+        Ok(row.map(|(name,)| name))
     }
 
     /// Interrupt all durable tasks associated with a session ID.

--- a/crates/durable-tools-spawn/src/types.rs
+++ b/crates/durable-tools-spawn/src/types.rs
@@ -62,4 +62,6 @@ pub struct TaskPollResult {
     pub result: Option<JsonValue>,
     /// Error information from the last failed run (only present when status is `Failed`).
     pub error: Option<JsonValue>,
+    /// The task's input params (from the `params` column).
+    pub params: Option<JsonValue>,
 }

--- a/crates/tensorzero-optimizers/src/endpoints.rs
+++ b/crates/tensorzero-optimizers/src/endpoints.rs
@@ -27,7 +27,7 @@ use tensorzero_core::{
     model_table::ProviderTypeDefaultCredentials,
     optimization::{
         OptimizationJobHandle, OptimizationJobInfo, UninitializedOptimizerInfo,
-        gepa::{GepaGetResponse, GepaLaunchRequest, GepaLaunchResponse},
+        gepa::{GepaGetResponse, GepaLaunchRequest, GepaLaunchResponse, GepaProgress},
     },
     stored_inference::RenderedSample,
     utils::gateway::{AppState, AppStateData, StructuredJson},
@@ -475,11 +475,63 @@ pub async fn gepa_get_handler(
             GepaGetResponse::Error { error }
         }
         TaskStatus::Pending | TaskStatus::Running | TaskStatus::Sleeping => {
-            GepaGetResponse::Pending { progress: None }
+            let max_iterations = poll_result
+                .params
+                .as_ref()
+                .and_then(|p| p.get("llm_params"))
+                .and_then(|p| p.get("max_iterations"))
+                .and_then(|v| v.as_u64())
+                .map(|v| v as u32)
+                .unwrap_or(0);
+
+            let progress = match spawn_client.get_task_progress(task_id).await {
+                Ok(Some(checkpoint_name)) => parse_gepa_progress(&checkpoint_name, max_iterations),
+                Ok(None) => None,
+                Err(e) => {
+                    tracing::warn!("Failed to get GEPA progress: {e}");
+                    None
+                }
+            };
+            GepaGetResponse::Pending { progress }
         }
     };
 
     Ok(Json(response).into_response())
+}
+
+fn parse_gepa_progress(checkpoint_name: &str, max_iterations: u32) -> Option<GepaProgress> {
+    match checkpoint_name {
+        "setup" => {
+            return Some(GepaProgress {
+                current_iteration: 0,
+                max_iterations,
+                current_step: "setup".to_string(),
+            });
+        }
+        "init_eval" => {
+            return Some(GepaProgress {
+                current_iteration: 0,
+                max_iterations,
+                current_step: "init_eval".to_string(),
+            });
+        }
+        _ => {}
+    }
+
+    // Iteration steps: "iter_{n}_{step}" where step can contain underscores
+    // e.g. "iter_3_eval_analyze_mutate" → iteration 3, step "eval_analyze_mutate"
+    if let Some(rest) = checkpoint_name.strip_prefix("iter_")
+        && let Some((n_str, step)) = rest.split_once('_')
+        && let Ok(iteration) = n_str.parse::<u32>()
+    {
+        return Some(GepaProgress {
+            current_iteration: iteration,
+            max_iterations,
+            current_step: step.to_string(),
+        });
+    }
+
+    None
 }
 
 /// Randomly split examples into train and val sets.


### PR DESCRIPTION
## Summary
- Query the durable checkpoint table for the latest checkpoint name when polling a pending/running GEPA task
- Parse checkpoint names (`setup`, `init_eval`, `iter_{n}_{step}`) into `GepaProgress` with `current_iteration`, `max_iterations`, and `current_step`
- Extend `TaskPollResult` and `get_task_result()` to also return task params so `max_iterations` can be extracted
## Test plan
- [x] `cargo check --all-targets --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test-unit-fast` (2612 passed)
- [ ] Manual: launch a GEPA task, poll repeatedly, verify progress updates from `None` → `setup` → `init_eval` → iteration steps → `completed`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new DB queries and response fields to the GEPA polling path; incorrect checkpoint parsing or missing `params`/checkpoint rows could lead to misleading progress or extra load, but changes are scoped to optimizer polling.
> 
> **Overview**
> GEPA task polling now returns *structured progress* while a job is `pending/running/sleeping` by querying the durable checkpoint table for the latest `checkpoint_name` and translating it into `GepaProgress` (`setup`, `init_eval`, or `iter_{n}_{step}`).
> 
> To support this, `durable-tools-spawn` extends `TaskPollResult`/`get_task_result()` to also fetch the task `params` (used to extract `max_iterations`) and adds `SpawnClient::get_task_progress()` for retrieving the most recent checkpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cc6f7ba2742015bf8b9fcf2b01d10190faa9ed1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## PR Stack
```
main (#6713, #6742, #6734 merged)
 │
 ▼
#6812 Progress Polling  ◄── THIS PR
 │
 ▼
#6771 Rust Client
 │
 ▼
#6774 Python Client
 │
 ├──────────────────┐
 ▼                  ▼
#6791 Docs &     #6813 Live
Examples         Tests
```

