### PR TITLE
Run clickhouse-tests conditionally

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -25,7 +25,8 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     outputs:
-      clickhouse-tests: ${{ steps.filter.outputs.clickhouse-tests || 'true' }}
+      clickhouse-tests-merge-queue: ${{ steps.filter.outputs.clickhouse-tests-merge-queue || 'true' }}
+      clickhouse-tests-pr: ${{ steps.filter.outputs.clickhouse-tests-pr || 'true' }}
       client-tests: ${{ steps.filter.outputs.client-tests || 'true' }}
       code: ${{ steps.filter.outputs.code || 'true' }}
       docs: ${{ steps.filter.outputs.docs || 'true' }}
@@ -39,13 +40,10 @@ jobs:
         with:
           predicate-quantifier: "every"
           filters: |
-            clickhouse-tests:
-              - '**'
-              - '!**/README.md'
-              - '!docs/**'
-              - '!examples/**'
-              - '!recipes/**'
-              - '!ui/**'
+            clickhouse-tests-merge-queue:
+              - 'crates/**'
+            clickhouse-tests-pr:
+              - 'crates/tensorzero-core/src/db/**'
             client-tests:
               - '**'
               - '!**/README.md'
@@ -846,7 +844,14 @@ jobs:
         build-mock-provider-api-container,
         build-fixtures-container,
       ]
-    if: ${{ needs.detect-changes.outputs.clickhouse-tests == 'true' && (github.event_name == 'merge_group' || (github.event.pull_request.head.repo.full_name == github.repository)) }}
+    if: >-
+      ${{
+        (
+          (github.event_name == 'merge_group' && needs.detect-changes.outputs.clickhouse-tests-merge-queue == 'true') ||
+          (github.event_name != 'merge_group' && needs.detect-changes.outputs.clickhouse-tests-pr == 'true')
+        ) &&
+        (github.event_name == 'merge_group' || (github.event.pull_request.head.repo.full_name == github.repository))
+      }}
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
- PR: only if you touched `crates/tensorzero-core/src/db/**`
- Merge Queue: only if you touched `crates/**`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes to skip `clickhouse-tests` unless specific paths change; misconfigured path filters or event conditionals could inadvertently reduce database test coverage and allow regressions through.
> 
> **Overview**
> Updates the `General Checks` workflow to **run `clickhouse-tests` only when relevant paths change**, splitting change detection into separate filters for *merge queue* (`crates/**`) vs *pull requests* (`crates/tensorzero-core/src/db/**`).
> 
> Adjusts the `clickhouse-tests` job `if` condition to use these new outputs while preserving the existing restriction that the job only runs for merge queue events or PRs from the main repo (not forks).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40da3b4c0d9f015309df1de86d85343b7ac92dfb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->