### PR TITLE
Build and push containers in one step in CI

### DIFF
--- a/.github/workflows/build-fixtures-container.yml
+++ b/.github/workflows/build-fixtures-container.yml
@@ -39,12 +39,9 @@ jobs:
           wait-for-builder: true
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
-      - name: Build `fixtures` container
+      - name: Build and push `fixtures` container
         run: |
-          docker buildx build -f ui/fixtures/Dockerfile . -t tensorzero/fixtures:sha-${{ github.sha }}
-
-      - name: Push `fixtures` container to Docker Hub
-        run: docker push tensorzero/fixtures:sha-${{ github.sha }}
+          docker buildx build -f ui/fixtures/Dockerfile . -t tensorzero/fixtures:sha-${{ github.sha }} --push
 
       - name: Wait for image to be available on Docker Hub
         run: |

--- a/.github/workflows/build-gateway-container.yml
+++ b/.github/workflows/build-gateway-container.yml
@@ -39,12 +39,9 @@ jobs:
           wait-for-builder: true
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
-      - name: Build `gateway` container
+      - name: Build and push `gateway` container
         run: |
-          docker buildx build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 --build-arg PROFILE=dev -f crates/gateway/Dockerfile . -t tensorzero/gateway-dev:sha-${{ github.sha }}
-
-      - name: Push `gateway` container to DockerHub
-        run: docker push tensorzero/gateway-dev:sha-${{ github.sha }}
+          docker buildx build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 --build-arg PROFILE=dev -f crates/gateway/Dockerfile . -t tensorzero/gateway-dev:sha-${{ github.sha }} --push
 
       - name: Wait for image to be available on Docker Hub
         run: |

--- a/.github/workflows/build-gateway-e2e-container.yml
+++ b/.github/workflows/build-gateway-e2e-container.yml
@@ -42,14 +42,11 @@ jobs:
           wait-for-builder: true
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
-      - name: Build `gateway-e2e` container
-        run: |
-          docker buildx build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f crates/gateway/Dockerfile --build-arg PROFILE=dev --build-arg "CARGO_BUILD_FLAGS=--features e2e_tests" --target gateway . -t tensorzero/gateway-e2e:sha-${{ github.sha }}
-
       # Note that this pushes an e2e build of the gateway to 'tensorzero/gateway-e2e'.
       # It does *not* push to the production 'tensorzero/gateway' repo.
-      - name: Push `gateway-e2e` container to DockerHub
-        run: docker push tensorzero/gateway-e2e:sha-${{ github.sha }}
+      - name: Build and push `gateway-e2e` container
+        run: |
+          docker buildx build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f crates/gateway/Dockerfile --build-arg PROFILE=dev --build-arg "CARGO_BUILD_FLAGS=--features e2e_tests" --target gateway . -t tensorzero/gateway-e2e:sha-${{ github.sha }} --push
 
       - name: Wait for image to be available on Docker Hub
         run: |

--- a/.github/workflows/build-live-tests-container.yml
+++ b/.github/workflows/build-live-tests-container.yml
@@ -39,12 +39,9 @@ jobs:
           wait-for-builder: true
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
-      - name: Build `live-tests` container
+      - name: Build and push `live-tests` container
         run: |
-          docker buildx build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f crates/tensorzero-core/tests/e2e/Dockerfile.live . -t tensorzero/live-tests:sha-${{ github.sha }}
-
-      - name: Push `live-tests` container to DockerHub
-        run: docker push tensorzero/live-tests:sha-${{ github.sha }}
+          docker buildx build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f crates/tensorzero-core/tests/e2e/Dockerfile.live . -t tensorzero/live-tests:sha-${{ github.sha }} --push
 
       - name: Wait for image to be available on Docker Hub
         run: |

--- a/.github/workflows/build-mock-provider-api-container.yml
+++ b/.github/workflows/build-mock-provider-api-container.yml
@@ -39,12 +39,9 @@ jobs:
           wait-for-builder: true
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
-      - name: Build `mock-provider-api` container
+      - name: Build and push `mock-provider-api` container
         run: |
-          docker buildx build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f crates/tensorzero-core/tests/mock-provider-api/Dockerfile . -t tensorzero/mock-provider-api:sha-${{ github.sha }}
-
-      - name: Push `mock-provider-api` container to DockerHub
-        run: docker push tensorzero/mock-provider-api:sha-${{ github.sha }}
+          docker buildx build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f crates/tensorzero-core/tests/mock-provider-api/Dockerfile . -t tensorzero/mock-provider-api:sha-${{ github.sha }} --push
 
       - name: Wait for image to be available on Docker Hub
         run: |

--- a/.github/workflows/build-provider-proxy-container.yml
+++ b/.github/workflows/build-provider-proxy-container.yml
@@ -39,12 +39,9 @@ jobs:
           wait-for-builder: true
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
-      - name: Build `provider-proxy` container
+      - name: Build and push `provider-proxy` container
         run: |
-          docker buildx build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f crates/provider-proxy/Dockerfile --target provider-proxy . -t tensorzero/provider-proxy:sha-${{ github.sha }}
-
-      - name: Push `provider-proxy` container to DockerHub
-        run: docker push tensorzero/provider-proxy:sha-${{ github.sha }}
+          docker buildx build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f crates/provider-proxy/Dockerfile --target provider-proxy . -t tensorzero/provider-proxy:sha-${{ github.sha }} --push
 
       - name: Wait for image to be available on Docker Hub
         run: |

--- a/.github/workflows/build-ui-container.yml
+++ b/.github/workflows/build-ui-container.yml
@@ -39,12 +39,9 @@ jobs:
           wait-for-builder: true
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
 
-      - name: Build `ui` container
+      - name: Build and push `ui` container
         run: |
-          docker buildx build --build-arg DEBUG_BUILD=1 --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f ui/Dockerfile . -t tensorzero/ui-dev:sha-${{ github.sha }}
-
-      - name: Push `ui` container to DockerHub
-        run: docker push tensorzero/ui-dev:sha-${{ github.sha }}
+          docker buildx build --build-arg DEBUG_BUILD=1 --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f ui/Dockerfile . -t tensorzero/ui-dev:sha-${{ github.sha }} --push
 
       - name: Wait for image to be available on Docker Hub
         run: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes CI container publishing for multiple images; if `buildx --push` behaves differently than the prior build-then-push flow, images may not be published promptly and downstream jobs could fail.
> 
> **Overview**
> **CI container publish steps are streamlined.** The workflows that build `fixtures`, `gateway(-dev)`, `gateway-e2e`, `live-tests`, `mock-provider-api`, `provider-proxy`, and `ui(-dev)` now combine build+push into one `docker buildx build ... --push` step, removing the separate `docker push` step.
> 
> This reduces job steps while keeping the existing “wait for image availability” check intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be4d869bbc96a2e571d6b0b8ac42c2c780de71ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->