### PR TITLE
set virajmehta as codeowner for autopilot wire types

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 /crates/evaluations/src/cli.rs @GabrielBianconi
 /crates/gateway/src/cli.rs @GabrielBianconi
 /crates/gateway/src/routes/external.rs @GabrielBianconi
+/crates/autopilot-client/src/types.rs @virajmehta
 
 /crates/tensorzero-core/src/db/clickhouse/migration_manager @virajmehta @Aaron1011
 /crates/tensorzero-core/src/db/postgres/migrations @virajmehta @Aaron1011


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: updates `CODEOWNERS` only, with no runtime or build logic changes.
> 
> **Overview**
> Assigns ownership of the autopilot wire types by adding `@virajmehta` as the `CODEOWNERS` entry for `crates/autopilot-client/src/types.rs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96e50098e531fd77fca9119cbd0cbf9e9bd340f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->