### PR TITLE
Skip Dependabot on docs, examples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,8 @@ updates:
       # This schedule does not affect security updates: https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/customizing-dependabot-security-prs#about-customizing-pull-requests-for-security-updates
       interval: "weekly"
     labels: []
+    exclude-paths:
+      - "examples/**/Cargo.lock"
     groups:
       opentelemetry-dependencies:
         patterns:

--- a/examples/integrations/cursor/feedback/Cargo.lock
+++ b/examples/integrations/cursor/feedback/Cargo.lock
@@ -4727,6 +4727,7 @@ dependencies = [
  "dashmap",
  "derive_builder 0.20.2",
  "durable",
+ "durable-tools-spawn",
  "enum-map",
  "futures",
  "futures-core",


### PR DESCRIPTION
Docs: The `mint` tool is for dev only; Mintlify handles deployments.

Examples: often are stale / connect to third-party deps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration change limited to Dependabot update scope, plus a lockfile-only dependency addition in an example project.
> 
> **Overview**
> Reduces Dependabot noise by excluding `docs/pnpm-lock.yaml` from npm updates and `examples/**/Cargo.lock` from cargo updates (while keeping security-update behavior unchanged).
> 
> Updates the `examples/integrations/cursor/feedback` `Cargo.lock` to include `durable-tools-spawn`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dba40f93bd3ae257235151776a3c876a1aa02ae0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->