### PR TITLE
Use non-default user for postgres-dev image

### DIFF
--- a/crates/tensorzero-core/tests/e2e/Dockerfile.postgres
+++ b/crates/tensorzero-core/tests/e2e/Dockerfile.postgres
@@ -7,3 +7,6 @@ RUN apt-get update \
 
 # Configure postgresql.conf to load pg_cron
 RUN echo "shared_preload_libraries = 'pg_cron'" >> /usr/share/postgresql/postgresql.conf.sample
+
+# The base postgres image creates a `postgres` user (UID 999)
+USER postgres


### PR DESCRIPTION
Set USER postgres in Dockerfile.postgres so the container runs as the non-root postgres user (UID 999) instead of root.

Closes #6846