### PR TITLE
feat: add require_approval config for autopilot tools

### DIFF
--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -291,11 +291,16 @@ async fn run() -> Result<(), ExitCode> {
         .log_err_pretty("Failed to collect autopilot tool names")?;
 
     // Resolve tool whitelist from config
-    let tool_whitelist: std::collections::HashSet<String> =
+    let mut tool_whitelist: std::collections::HashSet<String> =
         match &unwritten_config.autopilot.tool_whitelist {
             Some(list) => list.iter().cloned().collect(),
             None => autopilot_tools::default_whitelisted_tool_names(),
         };
+
+    // Subtract tools that require approval from the whitelist
+    for tool in &unwritten_config.autopilot.require_approval {
+        tool_whitelist.remove(tool);
+    }
 
     // Initialize GatewayHandle
     let gateway_handle =

--- a/crates/tensorzero-core/src/config/mod.rs
+++ b/crates/tensorzero-core/src/config/mod.rs
@@ -114,6 +114,11 @@ pub struct AutopilotConfig {
     /// If unset, defaults to all nondestructive tools.
     /// If set, replaces the default list entirely.
     pub tool_whitelist: Option<Vec<String>>,
+    /// Tools that require manual approval before execution.
+    /// These tools are subtracted from the whitelist (either default or explicitly configured).
+    /// This allows fine-grained control following the principle of least privilege.
+    #[serde(default)]
+    pub require_approval: Vec<String>,
 }
 
 // Note - the `Default` impl only exists for convenience in tests

--- a/crates/tensorzero-core/src/config/tests.rs
+++ b/crates/tensorzero-core/src/config/tests.rs
@@ -3435,3 +3435,29 @@ async fn test_nested_skip_credential_validation() {
     .await;
     assert!(!skip_credential_validation());
 }
+
+#[test]
+fn test_autopilot_config_require_approval() {
+    // Test with require_approval field
+    let toml_str = r#"
+        tool_whitelist = ["tool1", "tool2", "tool3"]
+        require_approval = ["tool2"]
+    "#;
+    let config: AutopilotConfig = toml::from_str(toml_str).expect("Failed to parse config");
+    assert_eq!(config.tool_whitelist, Some(vec!["tool1".to_string(), "tool2".to_string(), "tool3".to_string()]));
+    assert_eq!(config.require_approval, vec!["tool2".to_string()]);
+
+    // Test without require_approval field (defaults to empty)
+    let toml_str = r#"
+        tool_whitelist = ["tool1", "tool2"]
+    "#;
+    let config: AutopilotConfig = toml::from_str(toml_str).expect("Failed to parse config");
+    assert_eq!(config.tool_whitelist, Some(vec!["tool1".to_string(), "tool2".to_string()]));
+    assert_eq!(config.require_approval, Vec::<String>::new());
+
+    // Test with empty autopilot section (all defaults)
+    let toml_str = r#""#;
+    let config: AutopilotConfig = toml::from_str(toml_str).expect("Failed to parse config");
+    assert_eq!(config.tool_whitelist, None);
+    assert_eq!(config.require_approval, Vec::<String>::new());
+}


### PR DESCRIPTION
## Summary

Fixes #6537

Adds a new `require_approval` field to the `AutopilotConfig` that allows specifying tools that require manual approval before execution. These tools are subtracted from the whitelist (either default or explicitly configured), implementing the principle of least privilege for tool access control.

### Changes

- **`crates/tensorzero-core/src/config/mod.rs`**: Added `require_approval: Vec<String>` field to `AutopilotConfig` with `#[serde(default)]` for backward compatibility
- **`crates/gateway/src/main.rs`**: Updated whitelist resolution to subtract `require_approval` tools from the final whitelist
- **`crates/tensorzero-core/src/config/tests.rs`**: Added unit tests verifying config parsing with and without the new field

### Example Usage

\`\`\`toml
[autopilot]
# Use default whitelist but require approval for specific tools
require_approval = ["write_config", "delete_datapoints"]
\`\`\`

This allows fine-grained control without overriding the entire whitelist, making it easy to apply additional restrictions to sensitive tools.

### Test Plan

- Added `test_autopilot_config_require_approval()` unit test covering:
  - Config with both `tool_whitelist` and `require_approval`
  - Config with only `tool_whitelist` (require_approval defaults to empty)
  - Empty config section (all defaults preserved)

---

> **Transparency note**: This PR was authored with AI assistance (Claude). All code was reviewed for correctness and follows the project's existing patterns.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>