### PR TITLE
Reduce peak memory usage when streaming autopilot events

### DIFF
--- a/crates/autopilot-client/src/client.rs
+++ b/crates/autopilot-client/src/client.rs
@@ -859,6 +859,8 @@ impl AutopilotClient {
                         if sse.event.as_str() == "event" {
                             match serde_json::from_str::<StreamUpdate>(&sse.data) {
                                 Ok(update) => {
+                                    // Reduce peak memory usage by dropping the SSE event as soon as possible
+                                    drop(sse);
                                     // Cache tool calls for later lookup
                                     if let EventPayload::ToolCall(tool_call) = &update.event.payload
                                     {

--- a/crates/tensorzero-core/src/endpoints/internal/autopilot.rs
+++ b/crates/tensorzero-core/src/endpoints/internal/autopilot.rs
@@ -475,18 +475,19 @@ pub async fn stream_events_handler(
     // Convert the autopilot event stream to SSE events
     let sse_stream = stream.map(
         |result: Result<GatewayStreamUpdate, autopilot_client::AutopilotError>| match result {
-            Ok(event) => match serde_json::to_string(&event) {
-                Ok(data) => Ok(SseEvent::default().event("event").data(data)),
-                Err(e) => {
+            Ok(event) => SseEvent::default()
+                .event("event")
+                .json_data(event)
+                .map_err(|e| {
                     tracing::error!(
                         "Failed to serialize autopilot event: {}",
                         DisplayOrDebugGateway::new(&e)
                     );
-                    Err(Error::new(ErrorDetails::Serialization {
+                    Error::new(ErrorDetails::Serialization {
                         message: e.to_string(),
-                    }))
-                }
-            },
+                    })
+                }),
+
             Err(e) => {
                 tracing::error!("Autopilot stream error: {}", DisplayOrDebugGateway::new(&e));
                 Err(Error::from(e))


### PR DESCRIPTION
This is the low-hanging fruit - there's further room for improvement here, but it will require more invasive refactors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are localized to SSE event streaming and serialization; main risk is subtle behavior differences in how streaming payloads are serialized or errors are surfaced.
> 
> **Overview**
> Reduces peak memory during Autopilot SSE streaming by explicitly dropping each incoming SSE message immediately after parsing in `AutopilotClient::stream_events`.
> 
> Simplifies gateway SSE emission in `stream_events_handler` by switching from manual `serde_json::to_string` + `.data()` to `SseEvent::json_data`, preserving existing error logging while reducing intermediate allocations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cb29a85ceab0cd59a2bdeab23807ba8b3781765. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->