### PR TITLE
Support top-level evaluators in Python sdk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,6 @@
 # Rust
 
+- The Cargo workspace root is `crates/`. Run all `cargo` commands from that directory (e.g. `cd crates && cargo check`).
 - Use `cargo check` for quick verification, restrict further (e.g. `cargo check --package tensorzero-core`) if appropriate. For complex changes, you might want to run `cargo check --all-targets --all-features`. Test suite compilation is slow.
 - If you update Rust types or functions used in TypeScript, regenerate bindings with `pnpm build-bindings` (from root), then rebuild the NAPI bindings with `pnpm --filter=tensorzero-node build`. Run `cargo check` first to catch compilation errors.
 - If you change a signature of a struct, function, and so on, use `grep` to find all instances in the codebase. For example, search for `StructName {` when updating struct fields.

--- a/crates/tensorzero-python/src/lib.rs
+++ b/crates/tensorzero-python/src/lib.rs
@@ -12,7 +12,8 @@
 use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
 
 use evaluations::{
-    ClientInferenceExecutor, EvaluationCoreArgs, EvaluationVariant, run_evaluation_core_streaming,
+    ClientInferenceExecutor, EvaluationCoreArgs, EvaluationFunctionConfig, EvaluationVariant,
+    run_evaluation_core_streaming,
 };
 use futures::StreamExt;
 use pyo3::{
@@ -31,6 +32,7 @@ use python_helpers::{
 use crate::gil_helpers::in_tokio_runtime_no_gil;
 use tensorzero_core::{
     config::{ConfigPyClass, FunctionsConfigPyClass, Namespace, UninitializedVariantInfo},
+    evaluations::EvaluatorConfig,
     function::{FunctionConfigChatPyClass, FunctionConfigJsonPyClass, VariantsConfigPyClass},
     inference::types::{
         ResolvedInput, ResolvedInputMessage,
@@ -572,8 +574,84 @@ impl BaseTensorZeroGateway {
     }
 }
 
+/// Resolved evaluation configuration from either the old or new request path.
+struct ResolvedEvaluationConfig {
+    function_name: String,
+    evaluators: HashMap<String, EvaluatorConfig>,
+    function_config: EvaluationFunctionConfig,
+    /// Evaluation name for metric naming. `None` for standalone evaluators (top-level naming).
+    evaluation_name: Option<String>,
+}
+
 /// Helper function to construct an EvaluationVariant from the optional variant_name and internal_dynamic_variant_config parameters.
 /// Deserializes the internal_dynamic_variant_config if provided and validates that exactly one of the two is provided.
+/// Resolves evaluation configuration from either `evaluation_name` or `function_name` + `evaluator_names`.
+fn resolve_evaluation_config(
+    app_state: &tensorzero_core::utils::gateway::AppStateData,
+    evaluation_name: Option<String>,
+    function_name: Option<String>,
+    evaluator_names: Option<Vec<String>>,
+) -> PyResult<ResolvedEvaluationConfig> {
+    match (evaluation_name, function_name, evaluator_names) {
+        (Some(evaluation_name), None, None) => {
+            let evaluation_config = app_state
+                .config
+                .evaluations
+                .get(&evaluation_name)
+                .ok_or_else(|| {
+                    PyValueError::new_err(format!("evaluation `{evaluation_name}` not found"))
+                })?;
+            let tensorzero_core::evaluations::EvaluationConfig::Inference(
+                ref inference_eval_config,
+            ) = **evaluation_config;
+            let function_name = inference_eval_config.function_name.clone();
+            let evaluators = inference_eval_config.evaluators.clone();
+            let function_config = app_state
+                .config
+                .functions
+                .get(&function_name)
+                .map(|f| tensorzero_core::evaluations::EvaluationFunctionConfig::from(f.as_ref()))
+                .ok_or_else(|| {
+                    PyValueError::new_err(format!("function `{function_name}` not found"))
+                })?;
+            Ok(ResolvedEvaluationConfig {
+                function_name,
+                evaluators,
+                function_config,
+                evaluation_name: Some(evaluation_name),
+            })
+        }
+        (None, Some(function_name), Some(evaluator_names)) => {
+            let function_config = app_state
+                .config
+                .functions
+                .get(&function_name)
+                .map(|f| tensorzero_core::evaluations::EvaluationFunctionConfig::from(f.as_ref()))
+                .ok_or_else(|| {
+                    PyValueError::new_err(format!("function `{function_name}` not found"))
+                })?;
+            let mut evaluators = HashMap::new();
+            for name in &evaluator_names {
+                let evaluator = app_state.config.evaluators.get(name).ok_or_else(|| {
+                    PyValueError::new_err(format!(
+                        "top-level evaluator `{name}` not found in config"
+                    ))
+                })?;
+                evaluators.insert(name.clone(), (**evaluator).clone());
+            }
+            Ok(ResolvedEvaluationConfig {
+                function_name,
+                evaluators,
+                function_config,
+                evaluation_name: None,
+            })
+        }
+        _ => Err(PyValueError::new_err(
+            "Incorrect arguments to identify evaluation: either provide both `function_name` and `evaluator_names`, or provide only `evaluation_name`",
+        )),
+    }
+}
+
 fn construct_evaluation_variant(
     py: Python<'_>,
     internal_dynamic_variant_config: Option<&Bound<'_, PyDict>>,
@@ -1199,7 +1277,9 @@ impl TensorZeroGateway {
     ///
     /// # Arguments
     ///
-    /// * `evaluation_name` - User chosen name of the evaluation.
+    /// * `evaluation_name` - Name of a configured evaluation (mutually exclusive with `function_name`/`evaluator_names`).
+    /// * `function_name` - Name of the function to evaluate (requires `evaluator_names`, mutually exclusive with `evaluation_name`).
+    /// * `evaluator_names` - List of top-level evaluator names (requires `function_name`, mutually exclusive with `evaluation_name`).
     /// * `dataset_name` - The name of the stored dataset to use for variant evaluation
     /// * `variant_name` - Optional name of the variant to evaluate
     /// * `concurrency` - The maximum number of examples to process in parallel
@@ -1214,7 +1294,9 @@ impl TensorZeroGateway {
     ///                         i.e. the width of the larger of the two halves of its confidence interval
     ///                         is <= the precision target.
     #[pyo3(signature = (*,
-                        evaluation_name,
+                        evaluation_name=None,
+                        function_name=None,
+                        evaluator_names=None,
                         dataset_name=None,
                         datapoint_ids=None,
                         variant_name=None,
@@ -1224,12 +1306,14 @@ impl TensorZeroGateway {
                         max_datapoints=None,
                         adaptive_stopping=None
     ),
-    text_signature = "(self, *, evaluation_name, dataset_name=None, datapoint_ids=None, variant_name=None, concurrency=1, inference_cache='on', internal_dynamic_variant_config=None, max_datapoints=None, adaptive_stopping=None)"
+    text_signature = "(self, *, evaluation_name=None, function_name=None, evaluator_names=None, dataset_name=None, datapoint_ids=None, variant_name=None, concurrency=1, inference_cache='on', internal_dynamic_variant_config=None, max_datapoints=None, adaptive_stopping=None)"
     )]
     #[expect(clippy::too_many_arguments)]
     fn experimental_run_evaluation(
         this: PyRef<'_, Self>,
-        evaluation_name: String,
+        evaluation_name: Option<String>,
+        function_name: Option<String>,
+        evaluator_names: Option<Vec<String>>,
         dataset_name: Option<String>,
         datapoint_ids: Option<Vec<String>>,
         variant_name: Option<String>,
@@ -1245,6 +1329,13 @@ impl TensorZeroGateway {
         let app_state = client.get_app_state_data().ok_or_else(|| {
             pyo3::exceptions::PyRuntimeError::new_err("Client is not in EmbeddedGateway mode")
         })?;
+
+        let ResolvedEvaluationConfig {
+            function_name: resolved_function_name,
+            evaluators,
+            function_config,
+            evaluation_name: resolved_evaluation_name,
+        } = resolve_evaluation_config(app_state, evaluation_name, function_name, evaluator_names)?;
 
         let evaluation_run_id = uuid::Uuid::now_v7();
 
@@ -1296,43 +1387,16 @@ impl TensorZeroGateway {
             })
             .transpose()?;
 
-        // Extract evaluation config from app_state
-        let evaluation_config = app_state
-            .config
-            .evaluations
-            .get(&evaluation_name)
-            .ok_or_else(|| {
-                pyo3::exceptions::PyValueError::new_err(format!(
-                    "evaluation '{evaluation_name}' not found"
-                ))
-            })?;
-
-        let tensorzero_core::evaluations::EvaluationConfig::Inference(ref inference_eval_config) =
-            **evaluation_config;
-        let function_name = inference_eval_config.function_name.clone();
-        let evaluators = inference_eval_config.evaluators.clone();
-
-        let function_config = app_state
-            .config
-            .functions
-            .get(&function_name)
-            .map(|f| tensorzero_core::evaluations::EvaluationFunctionConfig::from(f.as_ref()))
-            .ok_or_else(|| {
-                pyo3::exceptions::PyValueError::new_err(format!(
-                    "function `{function_name}` not found"
-                ))
-            })?;
-
         // Wrap the client in ClientInferenceExecutor for use with evaluations
         let inference_executor = Arc::new(ClientInferenceExecutor::new(client.clone()));
 
         let core_args = EvaluationCoreArgs {
             inference_executor,
             db: Arc::new(app_state.get_delegating_database()),
-            function_name,
+            function_name: resolved_function_name,
             function_config,
             evaluators: evaluators.clone(),
-            evaluation_name: Some(evaluation_name),
+            evaluation_name: resolved_evaluation_name,
             evaluation_run_id,
             dataset_name,
             datapoint_ids,
@@ -2260,7 +2324,9 @@ impl AsyncTensorZeroGateway {
     ///
     /// # Arguments
     ///
-    /// * `evaluation_name` - User chosen name of the evaluation.
+    /// * `evaluation_name` - Name of a configured evaluation (mutually exclusive with `function_name`/`evaluator_names`).
+    /// * `function_name` - Name of the function to evaluate (requires `evaluator_names`, mutually exclusive with `evaluation_name`).
+    /// * `evaluator_names` - List of top-level evaluator names (requires `function_name`, mutually exclusive with `evaluation_name`).
     /// * `dataset_name` - The name of the stored dataset to use for variant evaluation
     /// * `variant_name` - Optional name of the variant to evaluate
     /// * `concurrency` - The maximum number of examples to process in parallel
@@ -2275,7 +2341,9 @@ impl AsyncTensorZeroGateway {
     ///                         i.e. the width of the larger of the two halves of its confidence interval
     ///                         is <= the precision target.
     #[pyo3(signature = (*,
-                        evaluation_name,
+                        evaluation_name=None,
+                        function_name=None,
+                        evaluator_names=None,
                         dataset_name=None,
                         datapoint_ids=None,
                         variant_name=None,
@@ -2285,12 +2353,14 @@ impl AsyncTensorZeroGateway {
                         max_datapoints=None,
                         adaptive_stopping=None
     ),
-    text_signature = "(self, *, evaluation_name, dataset_name=None, datapoint_ids=None, variant_name=None, concurrency=1, inference_cache='on', internal_dynamic_variant_config=None, max_datapoints=None, adaptive_stopping=None)"
+    text_signature = "(self, *, evaluation_name=None, function_name=None, evaluator_names=None, dataset_name=None, datapoint_ids=None, variant_name=None, concurrency=1, inference_cache='on', internal_dynamic_variant_config=None, max_datapoints=None, adaptive_stopping=None)"
     )]
     #[expect(clippy::too_many_arguments)]
     fn experimental_run_evaluation<'py>(
         this: PyRef<'py, Self>,
-        evaluation_name: String,
+        evaluation_name: Option<String>,
+        function_name: Option<String>,
+        evaluator_names: Option<Vec<String>>,
         dataset_name: Option<String>,
         datapoint_ids: Option<Vec<String>>,
         variant_name: Option<String>,
@@ -2356,35 +2426,19 @@ impl AsyncTensorZeroGateway {
                 pyo3::exceptions::PyRuntimeError::new_err("Client is not in EmbeddedGateway mode")
             })?;
 
+            let ResolvedEvaluationConfig {
+                function_name: resolved_function_name,
+                evaluators,
+                function_config,
+                evaluation_name: resolved_evaluation_name,
+            } = resolve_evaluation_config(
+                app_state,
+                evaluation_name,
+                function_name,
+                evaluator_names,
+            )?;
+
             let evaluation_run_id = uuid::Uuid::now_v7();
-
-            // Extract evaluation config from app_state
-            let evaluation_config = app_state
-                .config
-                .evaluations
-                .get(&evaluation_name)
-                .ok_or_else(|| {
-                    pyo3::exceptions::PyValueError::new_err(format!(
-                        "evaluation '{evaluation_name}' not found"
-                    ))
-                })?;
-
-            let tensorzero_core::evaluations::EvaluationConfig::Inference(
-                ref inference_eval_config,
-            ) = **evaluation_config;
-            let function_name = inference_eval_config.function_name.clone();
-            let evaluators = inference_eval_config.evaluators.clone();
-
-            let function_config = app_state
-                .config
-                .functions
-                .get(&function_name)
-                .map(|f| tensorzero_core::evaluations::EvaluationFunctionConfig::from(f.as_ref()))
-                .ok_or_else(|| {
-                    pyo3::exceptions::PyValueError::new_err(format!(
-                        "function `{function_name}` not found"
-                    ))
-                })?;
 
             // Wrap the client in ClientInferenceExecutor for use with evaluations
             let inference_executor = Arc::new(ClientInferenceExecutor::new(client.clone()));
@@ -2392,10 +2446,10 @@ impl AsyncTensorZeroGateway {
             let core_args = EvaluationCoreArgs {
                 inference_executor,
                 db: Arc::new(app_state.get_delegating_database()),
-                function_name,
+                function_name: resolved_function_name,
                 function_config,
                 evaluators: evaluators.clone(),
-                evaluation_name: Some(evaluation_name),
+                evaluation_name: resolved_evaluation_name,
                 evaluation_run_id,
                 dataset_name,
                 datapoint_ids,

--- a/crates/tensorzero-python/tensorzero/tensorzero.pyi
+++ b/crates/tensorzero-python/tensorzero/tensorzero.pyi
@@ -869,7 +869,9 @@ class TensorZeroGateway(BaseTensorZeroGateway):
     def experimental_run_evaluation(
         self,
         *,
-        evaluation_name: str,
+        evaluation_name: Optional[str] = None,
+        function_name: Optional[str] = None,
+        evaluator_names: Optional[List[str]] = None,
         dataset_name: Optional[str] = None,
         datapoint_ids: Optional[List[str]] = None,
         variant_name: Optional[str] = None,
@@ -883,7 +885,12 @@ class TensorZeroGateway(BaseTensorZeroGateway):
         Run an evaluation for a specific variant on a dataset or specific datapoints.
         This function is only available in EmbeddedGateway mode.
 
-        :param evaluation_name: The name of the evaluation to run
+        Specify either `evaluation_name` (to use a configured evaluation) or
+        `function_name` + `evaluator_names` (to use top-level evaluators directly).
+
+        :param evaluation_name: The name of a configured evaluation (mutually exclusive with function_name/evaluator_names)
+        :param function_name: The name of the function to evaluate (requires evaluator_names, mutually exclusive with evaluation_name)
+        :param evaluator_names: List of top-level evaluator names to use (requires function_name, mutually exclusive with evaluation_name)
         :param dataset_name: The name of the dataset to use for evaluation (mutually exclusive with datapoint_ids)
         :param datapoint_ids: Specific datapoint IDs to evaluate (mutually exclusive with dataset_name)
         :param variant_name: The name of the variant to evaluate
@@ -1333,7 +1340,9 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
     async def experimental_run_evaluation(
         self,
         *,
-        evaluation_name: str,
+        evaluation_name: Optional[str] = None,
+        function_name: Optional[str] = None,
+        evaluator_names: Optional[List[str]] = None,
         dataset_name: Optional[str] = None,
         datapoint_ids: Optional[List[str]] = None,
         variant_name: Optional[str] = None,
@@ -1347,7 +1356,12 @@ class AsyncTensorZeroGateway(BaseTensorZeroGateway):
         Run an evaluation for a specific variant on a dataset or specific datapoints.
         This function is only available in EmbeddedGateway mode.
 
-        :param evaluation_name: The name of the evaluation to run
+        Specify either `evaluation_name` (to use a configured evaluation) or
+        `function_name` + `evaluator_names` (to use top-level evaluators directly).
+
+        :param evaluation_name: The name of a configured evaluation (mutually exclusive with function_name/evaluator_names)
+        :param function_name: The name of the function to evaluate (requires evaluator_names, mutually exclusive with evaluation_name)
+        :param evaluator_names: List of top-level evaluator names to use (requires function_name, mutually exclusive with evaluation_name)
         :param dataset_name: The name of the dataset to use for evaluation (mutually exclusive with datapoint_ids)
         :param datapoint_ids: Specific datapoint IDs to evaluate (mutually exclusive with dataset_name)
         :param variant_name: The name of the variant to evaluate

--- a/crates/tensorzero-python/tests/test_evaluation.py
+++ b/crates/tensorzero-python/tests/test_evaluation.py
@@ -749,3 +749,138 @@ async def test_async_run_evaluation_datapoint_ids_and_max_datapoints_error(
             inference_cache="on",
             max_datapoints=10,
         )
+
+
+# TESTS FOR function_name + evaluator_names
+
+
+def test_sync_run_evaluation_with_function_name_and_evaluator_names(
+    evaluation_datasets: Dict[str, str],
+    embedded_sync_client: TensorZeroGateway,
+):
+    """Test sync client using function_name + evaluator_names instead of evaluation_name."""
+    job = embedded_sync_client.experimental_run_evaluation(
+        function_name="write_haiku",
+        evaluator_names=["exact_match"],
+        dataset_name=evaluation_datasets["good-haikus-no-output"],
+        variant_name="gpt_4o_mini",
+        concurrency=2,
+        inference_cache="off",
+    )
+
+    run_info: Dict[str, Any] = job.run_info
+    assert "evaluation_run_id" in run_info
+    assert "num_datapoints" in run_info
+    assert run_info["num_datapoints"] > 0
+    # A default evaluation_name is generated when using function_name + evaluator_names
+    assert "evaluation_name" in run_info
+    assert "write_haiku" in run_info["evaluation_name"]
+
+    results: List[Dict[str, Any]] = []
+    for result in job.results():
+        results.append(result)
+        assert result["type"] in ["success", "error"]
+        if result["type"] == "success":
+            assert "exact_match" in result["evaluations"]
+
+    assert len(results) == run_info["num_datapoints"]
+
+    stats: Dict[str, EvaluatorStatsDict] = job.summary_stats()
+    assert "exact_match" in stats
+
+
+@pytest.mark.asyncio
+async def test_async_run_evaluation_with_function_name_and_evaluator_names(
+    evaluation_datasets: Dict[str, str],
+    embedded_async_client: AsyncTensorZeroGateway,
+):
+    """Test async client using function_name + evaluator_names instead of evaluation_name."""
+    job = await embedded_async_client.experimental_run_evaluation(
+        function_name="write_haiku",
+        evaluator_names=["exact_match"],
+        dataset_name=evaluation_datasets["good-haikus-no-output"],
+        variant_name="gpt_4o_mini",
+        concurrency=2,
+        inference_cache="off",
+    )
+
+    run_info: Dict[str, Any] = job.run_info
+    assert "evaluation_run_id" in run_info
+    assert "num_datapoints" in run_info
+    assert run_info["num_datapoints"] > 0
+    # A default evaluation_name is generated when using function_name + evaluator_names
+    assert "evaluation_name" in run_info
+    assert "write_haiku" in run_info["evaluation_name"]
+
+    results: List[Dict[str, Any]] = []
+    async for result in job.results():
+        results.append(result)
+        assert result["type"] in ["success", "error"]
+        if result["type"] == "success":
+            assert "exact_match" in result["evaluations"]
+
+    assert len(results) == run_info["num_datapoints"]
+
+    stats: Dict[str, EvaluatorStatsDict] = await job.summary_stats()
+    assert "exact_match" in stats
+
+
+def test_sync_run_evaluation_no_eval_source_error(
+    embedded_sync_client: TensorZeroGateway,
+):
+    """Test sync client rejects when neither evaluation_name nor function_name is provided."""
+    with pytest.raises(
+        ValueError,
+        match="Incorrect arguments to identify evaluation: either provide both `function_name` and `evaluator_names`, or provide only `evaluation_name`",
+    ):
+        embedded_sync_client.experimental_run_evaluation(
+            dataset_name="some_dataset",
+            variant_name="gpt_4o_mini",
+        )
+
+
+def test_sync_run_evaluation_both_eval_sources_error(
+    embedded_sync_client: TensorZeroGateway,
+):
+    """Test sync client rejects when both evaluation_name and function_name are provided."""
+    with pytest.raises(
+        ValueError,
+        match="Incorrect arguments to identify evaluation: either provide both `function_name` and `evaluator_names`, or provide only `evaluation_name`",
+    ):
+        embedded_sync_client.experimental_run_evaluation(
+            evaluation_name="entity_extraction",
+            function_name="extract_entities",
+            evaluator_names=["exact_match"],
+            dataset_name="some_dataset",
+            variant_name="gpt_4o_mini",
+        )
+
+
+def test_sync_run_evaluation_function_name_without_evaluator_names_error(
+    embedded_sync_client: TensorZeroGateway,
+):
+    """Test sync client rejects function_name without evaluator_names."""
+    with pytest.raises(
+        ValueError,
+        match="Incorrect arguments to identify evaluation: either provide both `function_name` and `evaluator_names`, or provide only `evaluation_name`",
+    ):
+        embedded_sync_client.experimental_run_evaluation(
+            function_name="write_haiku",
+            dataset_name="some_dataset",
+            variant_name="gpt_4o_mini",
+        )
+
+
+def test_sync_run_evaluation_evaluator_names_without_function_name_error(
+    embedded_sync_client: TensorZeroGateway,
+):
+    """Test sync client rejects evaluator_names without function_name."""
+    with pytest.raises(
+        ValueError,
+        match="Incorrect arguments to identify evaluation: either provide both `function_name` and `evaluator_names`, or provide only `evaluation_name`",
+    ):
+        embedded_sync_client.experimental_run_evaluation(
+            evaluator_names=["exact_match"],
+            dataset_name="some_dataset",
+            variant_name="gpt_4o_mini",
+        )


### PR DESCRIPTION
Fixes #6676.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new evaluation execution mode in both the Rust CLI and Python SDK, changing public interfaces and how evaluator configs are resolved/validated. Risk is moderate due to potential argument-handling edge cases and differences in metric/tag naming when `evaluation_name` is omitted.
> 
> **Overview**
> Enables a *new evaluation invocation path* that runs **top-level evaluators directly** by specifying `--function-name` + `--evaluator-names` (or Python `function_name` + `evaluator_names`) instead of requiring a configured `evaluation_name`.
> 
> Updates the Rust `evaluations` CLI/runner to enforce mutual exclusivity/requirements via clap groups, resolve evaluator configs from `config.evaluators`, and propagate `evaluation_name: None` so metric naming/tagging uses top-level evaluator names. Updates Python sync/async `experimental_run_evaluation` signatures + `.pyi` to accept the new arguments, factors shared resolution logic into `resolve_evaluation_config`, and adds CLI + Python tests covering the new mode and error cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc0010fe3296dd7f063d31e255b6b9e0e988067b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->