### PR TITLE
Loosen floating point tolerance for L2 norm test

### DIFF
--- a/crates/tensorzero-core/tests/e2e/providers/openai/mod.rs
+++ b/crates/tensorzero-core/tests/e2e/providers/openai/mod.rs
@@ -1336,7 +1336,7 @@ async fn test_embedding_request() {
 
     // Assert that the norm is approximately 1 (allowing for small floating-point errors)
     assert!(
-        (norm - 1.0).abs() < 1e-6,
+        (norm - 1.0).abs() < 1e-3,
         "The L2 norm of the embedding should be 1, but it is {norm}"
     );
     // Check that the timestamp in created is within 1 second of the current time


### PR DESCRIPTION
- Fixes test `test_embedding_request` which is suddenly flaky, probably due to a change on OpenAI's end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that relaxes a floating-point assertion to avoid flaky failures from minor embedding normalization drift.
> 
> **Overview**
> Relaxes the `test_embedding_request` assertion on OpenAI embedding L2 norm from `1e-6` to `1e-3`, making the e2e test less sensitive to small floating-point/producer-side variation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8800dc088a5b318b41839ffd40a1c2ea8a8f21d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->