### PR TITLE
Add CI lint for misplaced `use` statements in Rust

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -801,6 +801,9 @@ jobs:
       - name: Check durable dependencies
         run: ./ci/check-durable-deps.sh
 
+      - name: Check Rust use placement
+        run: python3 ci/check_use_placement.py
+
       - name: Run cargo fmt
         working-directory: crates
         run: cargo fmt --all --check

--- a/ci/check_use_placement.py
+++ b/ci/check_use_placement.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Check that private `use` statements are placed correctly:
+1. Not interleaved after function definitions at the same scope level.
+2. Not inside function bodies (should be at module level instead).
+
+This catches common AI coding assistant mistakes where `use` imports are
+appended after existing code or placed inside function bodies rather than
+grouped at the top of the enclosing module/scope.
+
+Conservative: false negatives are acceptable, false positives are not.
+
+Strategy: track brace depth to identify scope boundaries. Within each scope,
+flag private `use` statements that appear after `fn` definitions at the same
+brace depth. Also track function body scopes and flag `use` inside them.
+`pub use` re-exports are excluded since they are commonly placed alongside
+the items they re-export.
+
+Usage:
+    python ci/check_use_placement.py [--warn-fn-body] [paths...]
+
+    If no paths given, checks all .rs files under crates/.
+
+    --warn-fn-body  Also check for `use` inside function bodies (warning only,
+                    does not cause a non-zero exit code).
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# Matches a private `use` statement (NOT `pub use` re-exports)
+PRIVATE_USE_RE = re.compile(r"^\s*use\s+")
+
+# Matches a `pub use` re-export (excluded from checks)
+PUB_USE_RE = re.compile(r"^\s*pub(\s*\(.*?\))?\s+use\s+")
+
+# Matches a `fn` definition (with optional visibility/async/unsafe/const modifiers)
+FN_RE = re.compile(r"^\s*(pub(\s*\(.*?\))?\s+)?(async\s+)?(unsafe\s+)?(const\s+)?fn\s+")
+
+# Files/dirs to skip (generated code, macro expansions)
+SKIP_PATTERNS = [
+    "/target/",
+    "\\target\\",
+    ".expanded.rs",
+    "/bindings/",
+]
+
+
+def count_braces(line: str) -> int:
+    """Count net brace change in a line, skipping strings and comments."""
+    # Strip line comments
+    comment_pos = line.find("//")
+    if comment_pos >= 0:
+        line = line[:comment_pos]
+    depth = 0
+    in_string = False
+    escape = False
+    for ch in line:
+        if escape:
+            escape = False
+            continue
+        if ch == "\\":
+            escape = True
+            continue
+        if in_string:
+            if ch == '"':
+                in_string = False
+        else:
+            if ch == '"':
+                in_string = True
+            elif ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+    return depth
+
+
+def check_source(source: str) -> list[tuple[int, str]]:
+    """Check source code string. Returns list of (line_number, line_text) violations."""
+    lines = source.splitlines()
+    return _check_lines(lines)
+
+
+def check_file(path: Path) -> list[tuple[int, str]]:
+    """Returns list of (line_number, line_text) for misplaced use statements."""
+    try:
+        source = path.read_text()
+    except (OSError, UnicodeDecodeError):
+        return []
+    return check_source(source)
+
+
+def _check_lines(lines: list[str]) -> list[tuple[int, str]]:
+    violations = []
+    brace_depth = 0
+    # Per brace depth: have we seen a fn definition?
+    # Reset when leaving a scope.
+    fn_seen: dict[int, bool] = {}
+    # Set of brace depths that are function body scopes.
+    # When a fn opens a brace, the depth inside is a fn body.
+    fn_body_depths: set[int] = set()
+
+    for i, line in enumerate(lines, 1):
+        stripped = line.lstrip()
+
+        # Skip empty lines and comments
+        if not stripped or stripped.startswith("//") or stripped.startswith("/*") or stripped.startswith("*"):
+            continue
+
+        net = count_braces(stripped)
+
+        # Process closing braces: leaving scope(s), clear state for exited scopes.
+        # When going from depth 2 to 1, clear depth 2+ (the fn body we're leaving),
+        # but preserve depth 1 (the scope we're returning to — fn decl still counts).
+        if net < 0:
+            new_depth = brace_depth + net
+            fn_seen = {k: v for k, v in fn_seen.items() if k <= new_depth}
+            fn_body_depths = {d for d in fn_body_depths if d <= new_depth}
+
+        # Determine the depth for this line's content.
+        # For `}` lines, the content belongs to the outer scope (after closing).
+        # For `fn foo() {` lines, `fn` belongs to current depth before the `{`.
+        # We handle this by checking content at the "minimum" depth:
+        # if net < 0, content is at the new (lower) depth.
+        # if net >= 0, content is at the current depth before opening.
+        if net < 0:
+            content_depth = brace_depth + net
+        else:
+            content_depth = brace_depth
+
+        # Check if we're inside any function body
+        in_fn_body = any(d <= content_depth for d in fn_body_depths)
+
+        # Check content
+        if PUB_USE_RE.match(line):
+            pass  # Skip pub use re-exports
+        elif PRIVATE_USE_RE.match(line):
+            if in_fn_body:
+                violations.append((i, line.rstrip(), "inside_fn"))
+            elif fn_seen.get(content_depth, False):
+                violations.append((i, line.rstrip(), "after_fn"))
+        elif FN_RE.match(line):
+            fn_seen[content_depth] = True
+            if net > 0:
+                # fn opens a brace — the inside is a fn body
+                fn_body_depths.add(brace_depth + net)
+            elif net == 0 and "{" not in stripped:
+                # fn signature without body on this line (brace on next line)
+                fn_body_depths.add(brace_depth + 1)
+
+        # Update depth
+        brace_depth += net
+
+    return violations
+
+
+def should_skip(path: Path) -> bool:
+    s = str(path)
+    return any(pat in s for pat in SKIP_PATTERNS)
+
+
+def main() -> int:
+    warn_fn_body = "--warn-fn-body" in sys.argv
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+
+    if args:
+        paths = [Path(p) for p in args]
+        rs_files = []
+        for p in paths:
+            if p.is_file() and p.suffix == ".rs":
+                rs_files.append(p)
+            elif p.is_dir():
+                rs_files.extend(p.rglob("*.rs"))
+    else:
+        rs_files = list(Path("crates").rglob("*.rs"))
+
+    rs_files = [f for f in rs_files if not should_skip(f)]
+
+    error_count = 0
+    warning_count = 0
+    for path in sorted(rs_files):
+        violations = check_file(path)
+        for violation in violations:
+            line_no, line_text = violation[0], violation[1]
+            reason = violation[2] if len(violation) > 2 else "after_fn"
+            if reason == "inside_fn":
+                if not warn_fn_body:
+                    continue
+                msg = "warning: `use` inside function body (move to module level)"
+                warning_count += 1
+            else:
+                msg = "error: `use` after `fn` at same scope level"
+                error_count += 1
+            print(f"{path}:{line_no}: {msg}")
+            print(f"  {line_text}")
+
+    if error_count > 0:
+        print(f"\nFound {error_count} misplaced `use` statement(s). Move them to the top of their enclosing scope.")
+    if warning_count > 0:
+        print(
+            f"\nFound {warning_count} `use`-inside-function-body warning(s). "
+            "Consider moving them to the top of the enclosing module."
+        )
+    if error_count == 0 and warning_count == 0:
+        print("No misplaced `use` statements found.")
+
+    # Only fail on errors, not warnings
+    return 1 if error_count > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/tests/test_check_use_placement.py
+++ b/ci/tests/test_check_use_placement.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Tests for check_use_placement.py"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from check_use_placement import check_source, count_braces
+
+# ── count_braces ──────────────────────────────────────────────────────
+
+
+def test_count_braces_simple():
+    assert count_braces("fn foo() {") == 1
+    assert count_braces("}") == -1
+    assert count_braces("let x = 5;") == 0
+    assert count_braces("fn foo() {}") == 0
+
+
+def test_count_braces_string_literals():
+    assert count_braces('let s = "hello { world";') == 0
+    assert count_braces('let s = "}{";') == 0
+
+
+def test_count_braces_comments():
+    assert count_braces("foo(); // { not counted") == 0
+    assert count_braces("{ // }") == 1
+
+
+def test_count_braces_escaped_quotes():
+    assert count_braces(r'let s = "hello \"}\"{";') == 0
+
+
+# ── Use after fn (should flag) ───────────────────────────────────────
+
+
+def test_use_after_fn_at_module_level():
+    source = """\
+fn foo() {
+}
+
+use std::io;
+"""
+    violations = check_source(source)
+    assert len(violations) == 1
+    assert violations[0][0] == 4
+    assert "use std::io" in violations[0][1]
+
+
+def test_use_after_fn_in_test_module():
+    source = """\
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_foo() {
+        assert!(true);
+    }
+
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_bar() {
+    }
+}
+"""
+    violations = check_source(source)
+    assert len(violations) == 1
+    assert violations[0][0] == 10
+    assert "HashSet" in violations[0][1]
+
+
+def test_multiple_uses_after_fn():
+    source = """\
+mod tests {
+    use super::*;
+
+    fn helper() {}
+
+    use std::io;
+    use std::fmt;
+}
+"""
+    violations = check_source(source)
+    assert len(violations) == 2
+
+
+def test_use_after_pub_fn():
+    source = """\
+pub fn foo() {}
+
+use std::io;
+"""
+    violations = check_source(source)
+    assert len(violations) == 1
+
+
+def test_use_after_async_fn():
+    source = """\
+async fn foo() {}
+
+use std::io;
+"""
+    violations = check_source(source)
+    assert len(violations) == 1
+
+
+# ── Correct placement (should NOT flag) ──────────────────────────────
+
+
+def test_use_before_fn_at_module_level():
+    source = """\
+use std::io;
+use std::fmt;
+
+fn foo() {}
+fn bar() {}
+"""
+    violations = check_source(source)
+    assert len(violations) == 0
+
+
+def test_use_before_fn_in_test_module():
+    source = """\
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_foo() {
+        assert!(true);
+    }
+
+    #[test]
+    fn test_bar() {
+    }
+}
+"""
+    violations = check_source(source)
+    assert len(violations) == 0
+
+
+def test_pub_use_after_fn_allowed():
+    """pub use re-exports should not be flagged."""
+    source = """\
+pub(crate) fn deprecation_warning(msg: &str) {}
+
+pub use content::{System, Text};
+pub use role::Role;
+"""
+    violations = check_source(source)
+    assert len(violations) == 0
+
+
+def test_pub_crate_use_after_fn_allowed():
+    source = """\
+fn foo() {}
+
+pub(crate) use bar::Baz;
+"""
+    violations = check_source(source)
+    assert len(violations) == 0
+
+
+def test_use_inside_fn_body_flagged():
+    """use inside a function body should be flagged — move to module level."""
+    source = """\
+fn foo() {
+    use std::fmt::Write;
+    let mut s = String::new();
+}
+
+fn bar() {
+    use std::io::Read;
+}
+"""
+    violations = check_source(source)
+    assert len(violations) == 2
+    assert violations[0][0] == 2
+    assert violations[0][2] == "inside_fn"
+    assert violations[1][0] == 7
+    assert violations[1][2] == "inside_fn"
+
+
+def test_impl_block_fns_dont_poison_later_mod():
+    """fns inside impl blocks should not cause false positives in later mod tests."""
+    source = """\
+impl Foo {
+    fn method_a(&self) {}
+    fn method_b(&self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_foo() {}
+}
+"""
+    violations = check_source(source)
+    assert len(violations) == 0
+
+
+def test_nested_mod_resets_scope():
+    """A mod block opens a new scope — fn in outer scope doesn't affect inner."""
+    source = """\
+fn outer_fn() {}
+
+mod inner {
+    use std::io;
+
+    fn inner_fn() {}
+}
+"""
+    violations = check_source(source)
+    assert len(violations) == 0
+
+
+def test_use_in_separate_mod_blocks():
+    source = """\
+mod a {
+    fn foo() {}
+}
+
+mod b {
+    use std::io;
+    fn bar() {}
+}
+"""
+    violations = check_source(source)
+    assert len(violations) == 0
+
+
+def test_fn_after_closing_brace_then_use():
+    """fn at file scope after impl block, then use — should flag."""
+    source = """\
+use std::fmt;
+
+impl Foo {
+    fn method(&self) {}
+}
+
+fn standalone() {}
+
+use std::io;
+"""
+    violations = check_source(source)
+    assert len(violations) == 1
+    assert violations[0][0] == 9
+
+
+def test_empty_file():
+    assert check_source("") == []
+
+
+def test_only_comments():
+    source = """\
+// just a comment
+/* block comment */
+"""
+    assert check_source(source) == []
+
+
+def test_use_after_fn_with_braces_in_string():
+    """fn body containing string with braces should not confuse brace tracking."""
+    source = """\
+mod tests {
+    use super::*;
+
+    fn helper() {
+        let s = "some { string } with braces";
+    }
+
+    use std::io;
+}
+"""
+    violations = check_source(source)
+    assert len(violations) == 1
+    assert violations[0][0] == 8
+
+
+# ── Use inside function body (should flag) ───────────────────────
+
+
+def test_use_inside_test_fn():
+    """use inside a #[test] function body should be flagged."""
+    source = """\
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_foo() {
+        use std::collections::HashMap;
+        let m = HashMap::new();
+    }
+}
+"""
+    violations = check_source(source)
+    assert len(violations) == 1
+    assert violations[0][0] == 7
+    assert violations[0][2] == "inside_fn"
+
+
+def test_use_inside_async_test_fn():
+    """use inside an async test function body should be flagged."""
+    source = """\
+#[tokio::test]
+async fn test_foo() {
+    use reqwest::Client;
+    let c = Client::new();
+}
+"""
+    violations = check_source(source)
+    assert len(violations) == 1
+    assert violations[0][0] == 3
+    assert violations[0][2] == "inside_fn"
+
+
+def test_use_inside_fn_multiline_body():
+    """use inside fn with brace on next line should be flagged."""
+    source = """\
+fn foo()
+{
+    use std::io;
+}
+"""
+    violations = check_source(source)
+    assert len(violations) == 1
+    assert violations[0][0] == 3
+    assert violations[0][2] == "inside_fn"
+
+
+def test_use_inside_fn_not_confused_with_mod():
+    """use at top of mod block should not be flagged as inside fn body."""
+    source = """\
+fn standalone() {}
+
+mod inner {
+    use std::io;
+
+    fn inner_fn() {}
+}
+"""
+    violations = check_source(source)
+    assert len(violations) == 0
+
+
+def test_one_line_fn_body_does_not_poison_scope():
+    """fn foo() {} on one line should not make later use at same scope a fn-body violation."""
+    source = """\
+fn foo() {}
+
+mod tests {
+    use std::io;
+}
+"""
+    violations = check_source(source)
+    assert len(violations) == 0
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/crates/autopilot-client/src/client.rs
+++ b/crates/autopilot-client/src/client.rs
@@ -1196,6 +1196,10 @@ impl AutopilotClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::{
+        AutopilotSideInfo, GatewayEventPayloadToolCall, OptimizationWorkflowSideInfo,
+    };
+
     #[test]
     fn test_is_unknown_tool_with_known_tool() {
         let mut tools = HashSet::new();
@@ -1292,10 +1296,6 @@ mod tests {
     // -------------------------------------------------------------------------
     // requires_approval tests
     // -------------------------------------------------------------------------
-
-    use crate::types::{
-        AutopilotSideInfo, GatewayEventPayloadToolCall, OptimizationWorkflowSideInfo,
-    };
 
     /// Helper to build a minimal `AutopilotSideInfo` for tests.
     fn test_side_info() -> AutopilotSideInfo {

--- a/crates/tensorzero-core/src/db/clickhouse/feedback.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/feedback.rs
@@ -1304,9 +1304,11 @@ mod tests {
 
     use super::*;
     use crate::config::snapshot::SnapshotHash;
+    use crate::config::{MetricConfig, MetricConfigLevel, MetricConfigOptimize, MetricConfigType};
     use crate::db::clickhouse::clickhouse_client::MockClickHouseClient;
     use crate::db::clickhouse::{ClickHouseResponse, ClickHouseResponseMetadata};
     use crate::db::feedback::CommentTargetType;
+    use crate::function::FunctionConfigType;
 
     /// Normalize whitespace and newlines in a query for comparison
     fn normalize_whitespace(s: &str) -> String {
@@ -2298,9 +2300,6 @@ mod tests {
     // =====================================================================
     // Tests for get_variant_performances query building
     // =====================================================================
-
-    use crate::config::{MetricConfig, MetricConfigLevel, MetricConfigOptimize, MetricConfigType};
-    use crate::function::FunctionConfigType;
 
     fn make_inference_level_float_metric() -> MetricConfig {
         MetricConfig {

--- a/crates/tensorzero-core/src/endpoints/functions/internal.rs
+++ b/crates/tensorzero-core/src/endpoints/functions/internal.rs
@@ -189,7 +189,8 @@ pub async fn get_variant_performances(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{Config, ConfigFileGlob};
+    use crate::config::{Config, ConfigFileGlob, MetricConfigLevel, MetricConfigType};
+    use crate::db::feedback::MockFeedbackQueries;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -264,9 +265,6 @@ mod tests {
     // =================================================================
     // Tests for get_variant_performances
     // =================================================================
-
-    use crate::config::{MetricConfigLevel, MetricConfigType};
-    use crate::db::feedback::MockFeedbackQueries;
 
     fn create_config_with_function_and_metric() -> String {
         r#"

--- a/crates/tensorzero-core/tests/e2e/endpoints/internal/inference_count.rs
+++ b/crates/tensorzero-core/tests/e2e/endpoints/internal/inference_count.rs
@@ -8,8 +8,8 @@
 use reqwest::{Client, StatusCode};
 use serde_json::{Value, json};
 use tensorzero_core::endpoints::internal::inference_count::{
-    InferenceCountResponse, InferenceWithFeedbackCountResponse,
-    ListFunctionsWithInferenceCountResponse,
+    GetFunctionThroughputByVariantResponse, InferenceCountResponse,
+    InferenceWithFeedbackCountResponse, ListFunctionsWithInferenceCountResponse,
 };
 use tokio::time::{Duration, sleep};
 use uuid::Uuid;
@@ -699,8 +699,6 @@ pub async fn test_get_inference_count_nonexistent_variant() {
 }
 
 // Tests for function throughput by variant endpoint
-
-use tensorzero_core::endpoints::internal::inference_count::GetFunctionThroughputByVariantResponse;
 
 #[tokio::test(flavor = "multi_thread")]
 pub async fn test_get_function_throughput_by_variant_cumulative() {

--- a/crates/tensorzero-optimizers/src/gepa/analyze.rs
+++ b/crates/tensorzero-optimizers/src/gepa/analyze.rs
@@ -527,6 +527,7 @@ mod tests {
     use evaluations::stats::EvaluationInfo;
     use serde_json::json;
     use std::collections::HashMap;
+    use tensorzero_core::inference::types::{Thought, ThoughtSummaryBlock};
     use tensorzero_core::{
         config::{SchemaData, path::ResolvedTomlPathData},
         db::stored_datapoint::StoredChatInferenceDatapoint,
@@ -1064,8 +1065,6 @@ mod tests {
     // ============================================================================
     // Unit Tests for type-safe thought signature stripping
     // ============================================================================
-
-    use tensorzero_core::inference::types::{Thought, ThoughtSummaryBlock};
 
     #[test]
     fn test_strip_signatures_from_chat_output_removes_signature() {

--- a/crates/tensorzero-types/src/lib.rs
+++ b/crates/tensorzero-types/src/lib.rs
@@ -13,6 +13,10 @@ pub mod storage;
 pub mod tool;
 pub mod tool_failure;
 
+use serde::{Deserialize, Serialize};
+use tensorzero_derive::TensorZeroDeserialize;
+use uuid::Uuid;
+
 pub(crate) fn deprecation_warning(message: &str) {
     tracing::warn!("Deprecation Warning: {message}");
 }
@@ -34,12 +38,9 @@ pub use message::{Input, InputMessage, InputMessageContent, TextKind};
 pub use role::{
     ASSISTANT_TEXT_TEMPLATE_VAR, Role, SYSTEM_TEXT_TEMPLATE_VAR, USER_TEXT_TEMPLATE_VAR,
 };
-use serde::{Deserialize, Serialize};
 pub use storage::{StorageKind, StoragePath};
-use tensorzero_derive::TensorZeroDeserialize;
 pub use tool::{InferenceResponseToolCall, ToolCall, ToolCallWrapper, ToolChoice, ToolResult};
 pub use tool_failure::{NonControlToolError, ToolFailure};
-use uuid::Uuid;
 
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, sqlx::Type)]


### PR DESCRIPTION
## Summary

- Adds `ci/check_use_placement.py` lint script that detects two categories of misplaced `use` statements:
  1. **`use` after `fn` at the same scope level** (error, blocks CI) — a common AI coding assistant mistake where new imports get appended after existing code
  2. **`use` inside function bodies** (warning via `--warn-fn-body`, does not block CI) — per AGENTS.md: "Avoid imports inside functions or tests"
- Wires the lint into CI in `.github/workflows/general.yml` alongside other lint checks
- Fixes all 10 pre-existing `use`-after-`fn` violations across the codebase
- Includes 26 unit tests covering: correct placement, misplaced imports, pub use exclusion, nested scopes, impl blocks, fn body detection, string literals with braces, etc.

Uses brace-depth tracking to correctly handle nested scopes (impl blocks, fn bodies, mod blocks). `pub use` re-exports are excluded. Conservative: false negatives OK, false positives not.

### Why not clippy?

There is no clippy lint that covers our use case:

- **[`clippy::items_after_statements`](https://rust-lang.github.io/rust-clippy/master/index.html#items_after_statements)** — only flags items (including `use`) that appear *after statements* inside a function body. Does NOT flag `use` at the start of a fn body (before any `let`/expression), which is the common pattern (~241 instances).
- **[`clippy::arbitrary_source_item_ordering`](https://rust-lang.github.io/rust-clippy/master/index.html#arbitrary_source_item_ordering)** — enforces full alphabetical ordering of *all* items (struct fields, fns, etc.), not just `use`-before-`fn`. Way too broad (26+ unrelated warnings).
- **[`imports_granularity = "Item"`](https://doc.rust-lang.org/nightly/style-guide/cargo.html)** (rustfmt) — nightly only, not available on stable 1.93.
- **[rust-clippy#259](https://github.com/rust-lang/rust-clippy/issues/259)** — long-standing issue requesting a "`use` anywhere but top of module" lint, never implemented.

## Test plan

- [x] All 26 unit tests pass (`uv run --with pytest python3 -m pytest ci/tests/test_check_use_placement.py`)
- [x] Zero violations on current codebase (`python3 ci/check_use_placement.py`)
- [x] `--warn-fn-body` mode reports 241 warnings but exits 0
- [x] CI step added and should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)