### PR TITLE
Clean up OTel guides/examples

### DIFF
--- a/docs/operations/export-opentelemetry-traces.mdx
+++ b/docs/operations/export-opentelemetry-traces.mdx
@@ -125,7 +125,7 @@ from openai import OpenAI
 client = OpenAI(api_key="not-used", base_url="http://localhost:3000/openai/v1")
 
 result = client.chat.completions.create(
-    model="tensorzero::function_name::your_function",
+    model="tensorzero::model_name::openai::gpt-4o-mini",
     messages=[
         {
             "role": "user",
@@ -158,7 +158,7 @@ const client = new OpenAI({
 
 const result = await client.chat.completions.create(
   {
-    model: "tensorzero::function_name::your_function",
+    model: "tensorzero::model_name::openai::gpt-4o-mini",
     messages: [
       {
         role: "user",
@@ -189,7 +189,7 @@ curl -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "tensorzero-otlp-traces-extra-header-user-id: user-123" \
   -H "tensorzero-otlp-traces-extra-header-request-source: mobile-app" \
   -d '{
-    "model": "tensorzero::function_name::your_function_name",
+    "model": "tensorzero::model_name::openai::gpt-4o-mini",
     "messages": [
       {
         "role": "user",
@@ -223,7 +223,7 @@ from openai import OpenAI
 client = OpenAI(api_key="not-used", base_url="http://localhost:3000/openai/v1")
 
 result = client.chat.completions.create(
-    model="tensorzero::function_name::your_function_name",
+    model="tensorzero::model_name::openai::gpt-4o-mini",
     messages=[
         {
             "role": "user",
@@ -271,7 +271,7 @@ from openai import OpenAI
 client = OpenAI(api_key="not-used", base_url="http://localhost:3000/openai/v1")
 
 result = client.chat.completions.create(
-    model="tensorzero::function_name::your_function_name",
+    model="tensorzero::model_name::openai::gpt-4o-mini",
     messages=[
         {
             "role": "user",

--- a/examples/guides/opentelemetry-otlp/README.md
+++ b/examples/guides/opentelemetry-otlp/README.md
@@ -18,18 +18,16 @@ Here, we'll export traces to a local instance of Jaeger.
 First, let's make an inference request to the gateway.
 
 ```bash
-curl -X POST "http://localhost:3000/inference" \
+curl -X POST "http://localhost:3000/openai/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "openai::gpt-4o-mini",
-    "input": {
-      "messages": [
-        {
-          "role": "user",
-          "content": "Write a haiku about TensorZero."
-        }
-      ]
-    }
+    "model": "tensorzero::model_name::openai::gpt-4o-mini",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Write a haiku about TensorZero."
+      }
+    ]
   }'
 ```
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that adjust example requests and model identifiers; no runtime behavior is modified.
> 
> **Overview**
> Updates the OTLP trace export guide and runnable Jaeger example to use the OpenAI-compatible `POST /openai/v1/chat/completions` flow and the `tensorzero::model_name::openai::gpt-4o-mini` model selector in all Python/Node/HTTP snippets.
> 
> Removes the older `/inference` example payload shape (`model_name` + `input.messages`) in favor of standard OpenAI `model` + `messages` request bodies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c96e81ac5790a2307ea2dbba13b897c590a1b490. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->