### PR TITLE
Clean up observability example

### DIFF
--- a/examples/docs/guides/observability/query-historical-inferences/curl.sh
+++ b/examples/docs/guides/observability/query-historical-inferences/curl.sh
@@ -2,17 +2,15 @@
 
 # 1. Make an inference with a tag
 echo "1. Making an inference with tag \`my_tag=my_value\`"
-INFERENCE_RESPONSE=$(curl -s -X POST http://localhost:3000/inference \
+INFERENCE_RESPONSE=$(curl -s -X POST http://localhost:3000/openai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "openai::gpt-5-mini",
-    "input": {
-      "messages": [{"role": "user", "content": "Write a haiku about TensorZero."}]
-    },
-    "tags": {"my_tag": "my_value"}
+    "model": "tensorzero::model_name::openai::gpt-5-mini",
+    "messages": [{"role": "user", "content": "Write a haiku about TensorZero."}],
+    "tensorzero::tags": {"my_tag": "my_value"}
   }')
 
-INFERENCE_ID=$(echo "$INFERENCE_RESPONSE" | jq -r '.inference_id')
+INFERENCE_ID=$(echo "$INFERENCE_RESPONSE" | jq -r '.id')
 echo "Completed Inference: $INFERENCE_ID"
 echo
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation/example-script change only; no production logic is modified.
> 
> **Overview**
> Updates the observability guide `curl.sh` example to create the tagged inference via the OpenAI-compatible `POST /openai/v1/chat/completions` endpoint instead of `POST /inference`.
> 
> The payload is adjusted to use `model`, top-level `messages`, and `tensorzero::tags`, and the script now reads the inference identifier from `.id` (rather than `.inference_id`) for subsequent historical queries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b53b4d1e4d4973e412816e098dc2ed8025b2bf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->