### PR TITLE
Migrate load tests to OpenAI inference

### DIFF
--- a/crates/tensorzero-core/tests/load/simple-streaming/body.json
+++ b/crates/tensorzero-core/tests/load/simple-streaming/body.json
@@ -1,12 +1,10 @@
 {
-  "function_name": "function1",
-  "input": {
-    "messages": [
-      {
-        "role": "user",
-        "content": "Is Santa real?"
-      }
-    ]
-  },
+  "model": "tensorzero::function_name::function1",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Is Santa real?"
+    }
+  ],
   "stream": true
 }

--- a/crates/tensorzero-core/tests/load/simple-streaming/run.sh
+++ b/crates/tensorzero-core/tests/load/simple-streaming/run.sh
@@ -2,7 +2,7 @@
 
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
-echo 'POST http://localhost:3000/inference' \
+echo 'POST http://localhost:3000/openai/v1/chat/completions' \
 | vegeta attack \
     -header="Content-Type: application/json" \
     -body=$SCRIPT_DIR/body.json \

--- a/crates/tensorzero-core/tests/load/simple/body.json
+++ b/crates/tensorzero-core/tests/load/simple/body.json
@@ -1,12 +1,10 @@
 {
-  "function_name": "function1",
-  "input": {
-    "messages": [
-      {
-        "role": "user",
-        "content": "Is Santa real?"
-      }
-    ]
-  },
+  "model": "tensorzero::function_name::function1",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Is Santa real?"
+    }
+  ],
   "stream": false
 }

--- a/crates/tensorzero-core/tests/load/simple/run.sh
+++ b/crates/tensorzero-core/tests/load/simple/run.sh
@@ -2,7 +2,7 @@
 
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
-echo 'POST http://localhost:3000/inference' \
+echo 'POST http://localhost:3000/openai/v1/chat/completions' \
 | vegeta attack \
     -header="Content-Type: application/json" \
     -body=$SCRIPT_DIR/body.json \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to load-test scripts and request payload shapes, with no production code paths modified. Main risk is test breakage if the OpenAI-compatible endpoint or model naming differs in target environments.
> 
> **Overview**
> Updates the `simple` and `simple-streaming` vegeta load tests to hit the OpenAI-compatible `POST /openai/v1/chat/completions` endpoint instead of `POST /inference`.
> 
> Adjusts the JSON request bodies from the legacy `{ function_name, input: { messages } }` shape to OpenAI-style fields (`model` and top-level `messages`) while preserving the existing `stream: true/false` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7b0ce6f23e0680e4510a3fb198aabf52fdfb543. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->