### PR TITLE
Show full metric and evaluator names in tooltip

### DIFF
--- a/ui/app/routes/evaluations/EvaluationTable.tsx
+++ b/ui/app/routes/evaluations/EvaluationTable.tsx
@@ -689,6 +689,16 @@ const EvaluatorHeader = ({
       <TooltipContent side="top" className="p-3">
         <div className="space-y-1 text-left text-xs">
           <div>
+            <span className="font-medium">Metric:</span>
+            <span className="ml-2 font-medium">{metric_name}</span>
+          </div>
+          {evaluator_name !== metric_name && (
+            <div>
+              <span className="font-medium">Evaluator:</span>
+              <span className="ml-2 font-medium">{evaluator_name}</span>
+            </div>
+          )}
+          <div>
             <span className="font-medium">Type:</span>
             <span className="ml-2 font-medium">
               {metricProperties.value_type}


### PR DESCRIPTION
This helps us distinguish metric output from old (nested) and new (flat) evaluators:

<img width="995" height="543" alt="image" src="https://github.com/user-attachments/assets/e1cae521-9936-4b48-b5dc-ffa72956e8ac" />

<img width="836" height="464" alt="image" src="https://github.com/user-attachments/assets/a7a2fbc8-34f9-47ad-8790-ef2af800a869" />
