### PR TITLE
Bump to 2026.3.2

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -533,7 +533,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot-client"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "chrono",
  "durable-tools-spawn",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-tools"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-worker"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "config-applier"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "pathdiff",
  "schemars 1.2.1",
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools-spawn"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "async-trait",
  "durable",
@@ -2380,7 +2380,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2477,7 +2477,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2723,7 +2723,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "async-stream",
  "autopilot-client",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "googletest-matchers"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "googletest",
  "serde_json",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-utils"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "minijinja",
  "serde",
@@ -4826,7 +4826,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postgres-inference-load-test"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5415,7 +5415,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5750,7 +5750,7 @@ dependencies = [
 
 [[package]]
 name = "reqwest-sse-stream"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "async-stream",
  "futures",
@@ -6860,7 +6860,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "async-trait",
  "clap",
@@ -6884,7 +6884,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "axum",
  "chrono",
@@ -6904,11 +6904,11 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-config-paths"
-version = "2026.3.1"
+version = "2026.3.2"
 
 [[package]]
 name = "tensorzero-core"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -7034,7 +7034,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "config-applier",
  "napi",
@@ -7049,7 +7049,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-optimizers"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -7086,7 +7086,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "evaluations",
  "futures",
@@ -7104,11 +7104,11 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-ts-types"
-version = "2026.3.1"
+version = "2026.3.2"
 
 [[package]]
 name = "tensorzero-types"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "aws-smithy-types",
  "infer",
@@ -7131,7 +7131,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types-providers"
-version = "2026.3.1"
+version = "2026.3.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-unsafe-helpers"
-version = "2026.3.1"
+version = "2026.3.2"
 
 [[package]]
 name = "termcolor"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -32,7 +32,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2026.3.1"
+version = "2026.3.2"
 rust-version = "1.93.0"
 license = "Apache-2.0"
 edition = "2024"

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2026.3.1"
+appVersion: "2026.3.2"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorzero-ui",
-  "version": "2026.3.1",
+  "version": "2026.3.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a coordinated version/appVersion bump with no functional code changes.
> 
> **Overview**
> Updates the project release version to `2026.3.2` across Rust workspace metadata (`crates/Cargo.toml` + `Cargo.lock` entries for internal crates), the Kubernetes Helm `appVersion`, and the UI `package.json` version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b07bfece46ff990610d278508f0443e66496295. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->