### PR TITLE
Fix links

### DIFF
--- a/docs/evaluations/inference-evaluations/cli-reference.mdx
+++ b/docs/evaluations/inference-evaluations/cli-reference.mdx
@@ -39,7 +39,7 @@ docker compose run --rm evaluations \
 
 <Accordion title="Building from Source">
 
-You can build the TensorZero Evaluations CLI from source if necessary. See our [GitHub repository](https://github.com/tensorzero/tensorzero/tree/main/evaluations) for instructions.
+You can build the TensorZero Evaluations CLI from source if necessary. See our [GitHub repository](https://github.com/tensorzero/tensorzero/tree/main/crates/evaluations) for instructions.
 
 </Accordion>
 

--- a/docs/gateway/benchmarks.mdx
+++ b/docs/gateway/benchmarks.mdx
@@ -46,4 +46,4 @@ At 1,000 QPS, LiteLLM fails entirely with the vast majority of requests timing o
 - We configured `observability.enabled = false` (i.e. disabled logging inferences to ClickHouse) in the TensorZero Gateway to make the scenarios comparable. (Even then, the observability features run asynchronously in the background, so they wouldn't materially affect latency given a powerful enough ClickHouse deployment.)
 - The most recent benchmark run was conducted on July 30, 2025. It used TensorZero `2025.5.7` and LiteLLM `1.74.9`.
 
-Read more about the technical details and reproduction instructions [here](https://github.com/tensorzero/tensorzero/tree/main/gateway/benchmarks).
+Read more about the technical details and reproduction instructions [here](https://github.com/tensorzero/tensorzero/tree/main/crates/gateway/benchmarks).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates GitHub URLs; no runtime behavior is affected.
> 
> **Overview**
> Updates documentation links to point to the new GitHub locations under `crates/` for the Evaluations CLI build instructions and the Gateway benchmark reproduction details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e2b04fa4df896951c519e2a967afb2dd8112e41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->