### PR TITLE
Fix best-of-n evaluator ignoring ToolCall when Text block precedes it

### DIFF
--- a/crates/tensorzero-core/src/variant/best_of_n_sampling.rs
+++ b/crates/tensorzero-core/src/variant/best_of_n_sampling.rs
@@ -593,13 +593,24 @@ async fn inner_select_best_candidate<'a>(
         model_inference_response,
         evaluator.inner.model().clone(),
     );
+    // Prefer `ToolCall` over `Text`: when `json_mode="tool"`, the model responds via a tool call
+    // but may also emit a conversational `Text` block before it. We must read the `ToolCall`
+    // arguments (which contain the actual JSON) rather than the preamble text.
     let raw = match model_inference_result
         .output
         .iter()
         .find_map(|block| match block {
-            ContentBlockOutput::Text(text) => Some(&text.text),
             ContentBlockOutput::ToolCall(tool_call) => Some(&tool_call.arguments),
-            ContentBlockOutput::Thought(_) | ContentBlockOutput::Unknown(_) => None,
+            _ => None,
+        })
+        .or_else(|| {
+            model_inference_result
+                .output
+                .iter()
+                .find_map(|block| match block {
+                    ContentBlockOutput::Text(text) => Some(&text.text),
+                    _ => None,
+                })
         }) {
         Some(text) => text,
         None => {


### PR DESCRIPTION
## Summary

- Fixes a flaky test (`test_best_of_n_json_real_judge_implicit_tool`) caused by the best-of-n evaluator's output parsing ignoring the actual `ToolCall` response when the model also emits a `Text` preamble block.

## Problem

When `json_mode="tool"`, the best-of-n evaluator asks the judge model (Claude Haiku 4.5) to respond via a tool call containing `{"thinking": "...", "answer_choice": N}`.

However, the Anthropic API can return **both** a `Text` content block (conversational preamble like "I'll analyze these candidates...") **and** a `ToolCall` content block. The existing code used `find_map` which matched `Text` before `ToolCall`:

```rust
.find_map(|block| match block {
    ContentBlockOutput::Text(text) => Some(&text.text),      // ← matched first
    ContentBlockOutput::ToolCall(tool_call) => Some(&tool_call.arguments),
    ...
})
```

The preamble text is not valid JSON with `answer_choice`, so parsing failed, and the code silently fell back to **random candidate selection** — giving a 50/50 chance of picking the wrong answer despite the LLM correctly choosing the right one via the tool call.

## Fix

Prefer `ToolCall` over `Text` by searching for a `ToolCall` first, then falling back to `Text` only if no tool call is found.

## Test plan

- [ ] Existing `test_best_of_n_json_real_judge_implicit_tool` e2e test should pass reliably
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes evaluator output parsing that determines which candidate response is selected; incorrect handling could affect routing/quality, but the change is small and scoped to `json_mode="tool"` responses.
> 
> **Overview**
> Fixes a best-of-n evaluator bug where a judge model returning both a conversational `Text` preamble and a `ToolCall` would be parsed as text first, causing JSON parsing to fail and selection to fall back to a random candidate.
> 
> The evaluator now **searches for a `ContentBlockOutput::ToolCall` first** (using its `arguments` as the JSON payload), and only falls back to `Text` if no tool call exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94b87d77a6e22f25467dd21a37f42e141a2522eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->