### PR TITLE
fixed the shape of data being written to db in ui autopilot tests

### DIFF
--- a/ui/e2e_tests/autopilot/variant-performance-visualization.spec.ts
+++ b/ui/e2e_tests/autopilot/variant-performance-visualization.spec.ts
@@ -52,6 +52,8 @@ function buildFeedbackByVariantToolEvents(sessionId: string) {
     type: "tool_result" as const,
     tool_call_id: toolCallId,
     tool_call_event_id: toolCallEventId,
+    tool_call_name: "get_feedback_by_variant",
+    tool_call_arguments: toolCallPayload.arguments,
     outcome: {
       type: "success" as const,
       result: JSON.stringify(feedbackData),


### PR DESCRIPTION
This is blocking a merge on autopilot and actually was missing in an earlier PR. 