### PR TITLE
Fix input validation triggering on page load in SFT UI

### DIFF
--- a/ui/app/routes/optimization/supervised-fine-tuning/SFTForm.tsx
+++ b/ui/app/routes/optimization/supervised-fine-tuning/SFTForm.tsx
@@ -95,7 +95,7 @@ export function SFTForm({
 
   // Reset variant when function changes since variants are function-specific
   useEffect(() => {
-    form.setValue("variant", "", { shouldValidate: true });
+    form.setValue("variant", "");
   }, [functionName, form]);
 
   // Form submission using formFetcher


### PR DESCRIPTION
## Summary

- Removes `shouldValidate: true` from the variant field's `setValue` call in the `useEffect` that resets the variant when the function changes
- This prevented the Zod `nonempty()` validation from firing on mount (when `functionName` starts as `""`)

## Root cause

`SFTForm.tsx` line 98 had:
```tsx
form.setValue("variant", "", { shouldValidate: true });
```
This `useEffect` runs on mount because `functionName` starts as `""`. With `shouldValidate: true`, it immediately triggers validation against `z.string().nonempty()`, producing the "String must contain at least 1 character(s)" error before the user has interacted with the form.

## Before

![before](https://raw.githubusercontent.com/tensorzero/tensorzero/simeonlee/assets/6913/before.gif)

## After

![after](https://raw.githubusercontent.com/tensorzero/tensorzero/simeonlee/assets/6913/after.gif)

## Test plan

- [x] Verified the "Prompt" field no longer shows validation error on page load
- [x] Verified form submission still validates correctly (empty variant still blocked by Zod on submit)
- [x] Existing SFT e2e tests pass (6/6 non-mock tests pass; mock tests timeout on pre-existing Metric combobox issue)

Closes #6913

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts `react-hook-form` behavior to avoid showing a validation error before user interaction.
> 
> **Overview**
> Removes `shouldValidate: true` from the `variant` field reset in `SFTForm.tsx`, so changing/initializing the selected function no longer triggers immediate `variant` validation.
> 
> Validation still occurs through normal form interactions/submission, but the form won’t display an error on initial page load due solely to the reset effect.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5766186f6403731e7580a8fc80b6d85db45b7ba3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->