### PR TITLE
fix: warn when relay mode models lack `skip_relay` setting

### DIFF
--- a/crates/tensorzero-core/src/config/mod.rs
+++ b/crates/tensorzero-core/src/config/mod.rs
@@ -1371,6 +1371,26 @@ impl Config {
         .into_iter()
         .collect::<HashMap<_, _>>();
 
+        if relay_mode && !is_config_snapshot {
+            let models_without_skip_relay: Vec<&Arc<str>> = loaded_models
+                .iter()
+                .filter(|(_, config)| !config.skip_relay)
+                .map(|(name, _)| name)
+                .collect();
+            if !models_without_skip_relay.is_empty() {
+                let names = models_without_skip_relay
+                    .iter()
+                    .map(|n| format!("`{n}`"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                tracing::warn!(
+                    "Relay mode is enabled but the following models do not have `skip_relay` set: {names}. \
+                     Their configured providers will not be used for inference — requests will be relayed instead. \
+                     Set `skip_relay = true` on models that should use their own providers directly."
+                );
+            }
+        }
+
         let loaded_embedding_models =
             try_join_all(embedding_models.into_iter().map(|(name, config)| async {
                 config

--- a/crates/tensorzero-core/src/config/tests.rs
+++ b/crates/tensorzero-core/src/config/tests.rs
@@ -3435,3 +3435,54 @@ async fn test_nested_skip_credential_validation() {
     .await;
     assert!(!skip_credential_validation());
 }
+
+#[tokio::test]
+async fn test_relay_warns_models_without_skip_relay() {
+    let logs_contain = crate::utils::testing::capture_logs();
+    let config_str = r#"
+        [gateway.relay]
+        gateway_url = "http://localhost:9999"
+
+        [models.my-model]
+        routing = ["dummy"]
+
+        [models.my-model.providers.dummy]
+        type = "dummy"
+        model_name = "good"
+    "#;
+
+    let config: toml::Table = toml::from_str(config_str).expect("Failed to parse config");
+    Box::pin(Config::load_from_toml(ConfigInput::Fresh(config)))
+        .await
+        .expect("Config should load successfully");
+    assert!(
+        logs_contain("do not have `skip_relay` set"),
+        "Expected warning about models without `skip_relay` in relay mode"
+    );
+}
+
+#[tokio::test]
+async fn test_relay_no_warn_when_skip_relay_set() {
+    let logs_contain = crate::utils::testing::capture_logs();
+    let config_str = r#"
+        [gateway.relay]
+        gateway_url = "http://localhost:9999"
+
+        [models.my-model]
+        routing = ["dummy"]
+        skip_relay = true
+
+        [models.my-model.providers.dummy]
+        type = "dummy"
+        model_name = "good"
+    "#;
+
+    let config: toml::Table = toml::from_str(config_str).expect("Failed to parse config");
+    Box::pin(Config::load_from_toml(ConfigInput::Fresh(config)))
+        .await
+        .expect("Config should load successfully");
+    assert!(
+        !logs_contain("do not have `skip_relay` set"),
+        "Should not warn when all models have `skip_relay` set"
+    );
+}


### PR DESCRIPTION
## Summary

When relay mode is enabled, models without `skip_relay = true` have their configured providers silently bypassed — all inference requests are relayed instead. This can be confusing when users define models with explicit provider credentials expecting them to be used.

This PR adds a `tracing::warn!` during config loading that lists models whose providers will be ignored due to relay mode. The warning is only emitted for fresh configs (not database snapshots) to avoid spurious noise.

Fixes #6395

## Changes

- Added relay/skip_relay validation warning in `Config::load_from_toml` (`config/mod.rs`)
- Added two unit tests:
  - `test_relay_warns_models_without_skip_relay` — verifies warning is emitted
  - `test_relay_no_warn_when_skip_relay_set` — verifies no warning when `skip_relay = true`

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt` — no changes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Both new tests pass individually (designed for `cargo nextest` process isolation)