### PR TITLE
fix tests to account for migration

### DIFF
--- a/ui/e2e_tests/autopilot/helpers/db.ts
+++ b/ui/e2e_tests/autopilot/helpers/db.ts
@@ -40,13 +40,23 @@ export function insertEvent(
     SELECT '${eventId}', $json$${payloadJson}$json$::jsonb, '${sessionId}', workspace_lock.monotonic_message_id
     FROM workspace_lock`;
   const sqlOld = `INSERT INTO autopilot.events (id, payload, session_id) VALUES ('${eventId}', $json$${payloadJson}$json$::jsonb, '${sessionId}')`;
+  let useOld = false;
   try {
-    execSync(`${PSQL_PREFIX} -q`, {
+    const result = execSync(`${PSQL_PREFIX}`, {
       input: sqlNew,
       timeout: 5000,
+      encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
     });
+    // psql prints "INSERT 0 N" where N is the number of rows inserted.
+    // If the CTE matched zero workspace rows, N will be 0 and the event was silently not inserted.
+    if (!result.includes("INSERT 0 1")) {
+      useOld = true;
+    }
   } catch {
+    useOld = true;
+  }
+  if (useOld) {
     execSync(`${PSQL_PREFIX} -q`, {
       input: sqlOld,
       timeout: 5000,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk test-only change that updates the DB helper to support a schema migration; main risk is flaky e2e tests if the new insert/CTE behaves unexpectedly for some sessions.
> 
> **Overview**
> Updates the autopilot e2e DB helper `insertEvent` to support the migrated `autopilot.events` schema by allocating and inserting `monotonic_message_id` via a workspace counter.
> 
> If the new CTE insert fails or inserts zero rows, it automatically falls back to the legacy `INSERT` without `monotonic_message_id`, improving compatibility across old/new test DB schemas.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b1015b9eb36d5a8332f68b58834c57ab85b4d58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->