### PR TITLE
Only run 'autopilot-e2e' job when we have code changes

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1396,11 +1396,10 @@ jobs:
     secrets: inherit
 
   autopilot-e2e:
-    needs: [detect-changes]
     permissions:
       contents: read
     if: needs.detect-changes.outputs.code == 'true' && github.repository == 'tensorzero/tensorzero' && github.event_name == 'merge_group'
-    needs: [build-gateway-e2e-container, build-ui-container]
+    needs: [detect-changes, build-gateway-e2e-container, build-ui-container]
     uses: ./.github/workflows/dispatch-autopilot-e2e.yml
     secrets:
       AUTOPILOT_DISPATCH_APP_ID: ${{ secrets.AUTOPILOT_DISPATCH_APP_ID }}


### PR DESCRIPTION
This unbreaks docs-only prs, since they don't build the containers needed by autopilot dispatch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only change that just tightens job conditions and dependencies; main risk is accidentally skipping `autopilot-e2e` when it should run due to paths-filter configuration.
> 
> **Overview**
> In `general.yml`, the `autopilot-e2e` merge-queue job is now **gated on** `needs.detect-changes.outputs.code == 'true'` and explicitly **depends on** `detect-changes`.
> 
> This prevents docs-only changes from attempting to dispatch `autopilot-e2e` (and requiring containers that weren’t built).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e48d5343c5b576f936bb028fdca1e601776926cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->