### PR TITLE
Bump durable for ControlFlow::Suspend improvements

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2183,7 +2183,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 [[package]]
 name = "durable"
 version = "0.1.0"
-source = "git+https://github.com/tensorzero/durable?rev=d122e6c175ab9ec3509577ba38b569d892f5daae#d122e6c175ab9ec3509577ba38b569d892f5daae"
+source = "git+https://github.com/tensorzero/durable?rev=2bfe26218458a48d1ab15f22a902536402284cf6#2bfe26218458a48d1ab15f22a902536402284cf6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -117,7 +117,7 @@ schemars = "1.1.0"
 serde_arrow = { version = "0.14", features = ["arrow-58"] }
 blake3 = "1.8.3"
 moka = { version = "0.12.14", features = ["sync"] }
-durable = { git = "https://github.com/tensorzero/durable", rev = "d122e6c175ab9ec3509577ba38b569d892f5daae" }
+durable = { git = "https://github.com/tensorzero/durable", rev = "2bfe26218458a48d1ab15f22a902536402284cf6" }
 durable-tools-spawn = { path = "durable-tools-spawn" }
 tensorzero = { path = "tensorzero-client" }
 tensorzero-core = { path = "tensorzero-core" }

--- a/crates/durable-tools/src/tests.rs
+++ b/crates/durable-tools/src/tests.rs
@@ -664,7 +664,9 @@ mod error_tests {
     use super::*;
     use durable::{ControlFlow, TaskError};
 
-    #[test]
+    // TODO - re-enable this after adding test helpers to `durable`
+    // around `ControlFlow::Suspend`
+    /*#[test]
     fn tool_error_from_task_error_control_flow_suspend() {
         let task_err = TaskError::Control(ControlFlow::Suspend);
         let tool_err: ToolError = task_err.into();
@@ -673,7 +675,7 @@ mod error_tests {
             ToolError::Control(ControlFlow::Suspend) => {}
             _ => panic!("Expected Control(Suspend)"),
         }
-    }
+    }*/
 
     #[test]
     fn tool_error_from_task_error_control_flow_cancelled() {
@@ -702,7 +704,9 @@ mod error_tests {
         }
     }
 
-    #[test]
+    // TODO - re-enable this after adding test helpers to `durable`
+    // around `ControlFlow::Suspend`
+    /*#[test]
     fn task_error_from_tool_error_control_flow() {
         let tool_err = ToolError::Control(ControlFlow::Suspend);
         let task_err: TaskError = tool_err.into();
@@ -711,7 +715,7 @@ mod error_tests {
             TaskError::Control(ControlFlow::Suspend) => {}
             _ => panic!("Expected Control(Suspend)"),
         }
-    }
+    }*/
 
     #[test]
     fn task_error_from_tool_error_tool_not_found() {


### PR DESCRIPTION
I disabled a few error-conversion tests for now, since we can no longer construct a `ControlFlow::Suspend` outside of a durable context

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the pinned `durable` git dependency, which may subtly change task control-flow/error behavior at runtime; additionally reduces test coverage by temporarily disabling `ControlFlow::Suspend` conversion tests.
> 
> **Overview**
> Bumps the workspace `durable` git dependency to a newer revision (and updates `Cargo.lock`) to pick up `ControlFlow::Suspend`-related improvements.
> 
> Temporarily disables two `durable-tools` error-conversion unit tests that relied on constructing `ControlFlow::Suspend` outside a durable runtime, with TODOs to re-enable once upstream adds test helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a8d1016ab913edd9667c7d860480ac88d89785f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->