### PR TITLE
Allow `env::...` for `object_storage.endpoint`

### DIFF
--- a/crates/tensorzero-core/src/config/mod.rs
+++ b/crates/tensorzero-core/src/config/mod.rs
@@ -250,9 +250,15 @@ pub struct ObjectStoreInfo {
 
 impl ObjectStoreInfo {
     pub fn new(config: Option<StorageKind>) -> Result<Option<Self>, Error> {
-        let Some(config) = config else {
+        let Some(mut config) = config else {
             return Ok(None);
         };
+
+        if let StorageKind::S3Compatible { endpoint, .. } = &mut config
+            && let Some(endpoint_value) = endpoint.take()
+        {
+            *endpoint = Some(resolve_object_storage_endpoint(&endpoint_value)?);
+        }
 
         let object_store: Option<Arc<dyn ObjectStore>> = match &config {
             StorageKind::Filesystem { path } => {
@@ -395,6 +401,32 @@ impl ObjectStoreInfo {
 // We are attempting to find this error: `https://github.com/seanmonstar/reqwest/blob/c4a9fb060fb518f0053b98f78c7583071a760cf4/src/error.rs#L340`
 fn contains_bad_scheme_err(e: &impl StdError) -> bool {
     format!("{e:?}").contains("BadScheme")
+}
+
+fn resolve_object_storage_endpoint(endpoint: &str) -> Result<String, Error> {
+    if let Some(env_var) = endpoint.strip_prefix("env::") {
+        return std::env::var(env_var).map_err(|_| {
+            Error::new(ErrorDetails::Config {
+                message: format!(
+                    "Environment variable `{env_var}` not found. Your configuration for `[object_storage]` requires this variable for `endpoint`."
+                ),
+            })
+        });
+    }
+
+    if endpoint.starts_with("dynamic::")
+        || endpoint.starts_with("path::")
+        || endpoint.starts_with("path_from_env::")
+        || matches!(endpoint, "sdk" | "none")
+    {
+        return Err(Error::new(ErrorDetails::Config {
+            message: format!(
+                "Invalid `[object_storage].endpoint`: `{endpoint}`. Use `env::ENVIRONMENT_VARIABLE` or a literal endpoint value."
+            ),
+        }));
+    }
+
+    Ok(endpoint.to_string())
 }
 
 /// Selects the primary datastore used for observability writes (inferences, feedback).

--- a/crates/tensorzero-core/src/config/tests.rs
+++ b/crates/tensorzero-core/src/config/tests.rs
@@ -4,7 +4,11 @@ use std::{io::Write, path::PathBuf};
 use tempfile::NamedTempFile;
 use toml::de::DeTable;
 
-use crate::{embeddings::EmbeddingProviderConfig, inference::types::Role, variant::JsonMode};
+use crate::{
+    embeddings::EmbeddingProviderConfig,
+    inference::types::{Role, storage::StorageKind},
+    variant::JsonMode,
+};
 
 /// Ensure that the sample valid config can be parsed without panicking
 #[tokio::test]
@@ -2074,6 +2078,93 @@ async fn test_config_load_invalid_s3_creds() {
         "Unexpected error message: {err}"
     );
 }
+
+#[tokio::test]
+async fn test_config_object_storage_endpoint_env_var_resolves() {
+    tensorzero_unsafe_helpers::set_env_var_tests_only(
+        "TENSORZERO_TEST_S3_ENDPOINT",
+        "https://storage.example.com",
+    );
+
+    let config_str = r#"
+            [object_storage]
+            type = "s3_compatible"
+            bucket_name = "tensorzero-fake-bucket"
+            region = "us-east-1"
+            endpoint = "env::TENSORZERO_TEST_S3_ENDPOINT"
+
+            [functions]"#;
+    let config = toml::from_str(config_str).expect("Failed to parse sample config");
+
+    let config = Box::pin(Config::load_from_toml(ConfigInput::Fresh(config)))
+        .await
+        .expect("Env-backed object storage endpoint should be valid config");
+    let object_store_info = config
+        .object_store_info
+        .as_ref()
+        .expect("Object store info should be initialized");
+
+    let StorageKind::S3Compatible { endpoint, .. } = &object_store_info.kind else {
+        panic!("Expected an S3-compatible object store");
+    };
+
+    assert_eq!(
+        endpoint.as_deref(),
+        Some("https://storage.example.com"),
+        "The resolved endpoint should be stored in the object store kind"
+    );
+}
+
+#[tokio::test]
+async fn test_config_object_storage_endpoint_env_var_missing_errors() {
+    let config_str = r#"
+            [object_storage]
+            type = "s3_compatible"
+            bucket_name = "tensorzero-fake-bucket"
+            region = "us-east-1"
+            endpoint = "env::TENSORZERO_TEST_NONEXISTENT_S3_ENDPOINT_VAR"
+
+            [functions]"#;
+    let config = toml::from_str(config_str).expect("Failed to parse sample config");
+
+    let err = Box::pin(Config::load_from_toml(ConfigInput::Fresh(config)))
+        .await
+        .expect_err("Should error when the object storage endpoint env var is missing");
+    let err_msg = err.to_string();
+
+    assert!(
+        err_msg.contains("TENSORZERO_TEST_NONEXISTENT_S3_ENDPOINT_VAR"),
+        "Error should mention the missing env var: {err_msg}"
+    );
+}
+
+#[tokio::test]
+async fn test_config_object_storage_endpoint_dynamic_rejected() {
+    let config_str = r#"
+            [object_storage]
+            type = "s3_compatible"
+            bucket_name = "tensorzero-fake-bucket"
+            region = "us-east-1"
+            endpoint = "dynamic::s3_endpoint"
+
+            [functions]"#;
+    let config = toml::from_str(config_str).expect("Failed to parse sample config");
+
+    let err = Box::pin(Config::load_from_toml(ConfigInput::Fresh(config)))
+        .await
+        .expect_err("Dynamic object storage endpoints should be rejected");
+    let err_msg = err.to_string();
+
+    assert!(
+        err_msg.contains("Invalid `[object_storage].endpoint`"),
+        "Error should point to the invalid object storage endpoint: {err_msg}"
+    );
+    assert!(
+        err_msg.contains("Use `env::ENVIRONMENT_VARIABLE` or a literal endpoint value"),
+        "Error should explain the supported endpoint forms: {err_msg}"
+    );
+}
+
 #[tokio::test]
 async fn test_config_blocked_s3_http_endpoint_default() {
     let logs_contain = crate::utils::testing::capture_logs();

--- a/docs/gateway/configuration-reference.mdx
+++ b/docs/gateway/configuration-reference.mdx
@@ -4856,6 +4856,7 @@ If you set `type = "s3_compatible"`, the following fields are available.
 
 Defines the endpoint of the object storage service.
 You can use this field to specify a custom endpoint for the object storage service (e.g. GCP Cloud Storage, Cloudflare R2, and many more).
+You can also set it to `env::YOUR_ENVIRONMENT_VARIABLE` to read from the environment variable `YOUR_ENVIRONMENT_VARIABLE` on startup.
 
 ##### `bucket_name`
 


### PR DESCRIPTION
Closes #6948

## Summary
- allow `[object_storage].endpoint` to use `env::ENVIRONMENT_VARIABLE` or a literal value
- resolve env-backed endpoint during config loading and persist the concrete value in normalized config
- reject unsupported source forms (`dynamic::`, `path::`, `path_from_env::`, `sdk`, `none`)
- add focused config tests and update docs

## Testing
- `cargo +1.93.0 nextest run --lib -p tensorzero-core test_config_object_storage_endpoint_env_var_resolves test_config_object_storage_endpoint_env_var_missing_errors test_config_object_storage_endpoint_dynamic_rejected`
- `cargo +1.93.0 clippy -p tensorzero-core --lib -- -D warnings`

## Notes
I also verified that the resolved endpoint is stored in `object_store_info.kind` , so downstream uses of `StorageKind` see the concrete endpoint value rather than the original `env::...` placeholder.