### PR TITLE
Fix Option<Decimal> serde round-trip through serde_json::Value

### DIFF
--- a/crates/tensorzero-core/src/inference/types/usage.rs
+++ b/crates/tensorzero-core/src/inference/types/usage.rs
@@ -61,40 +61,9 @@ pub struct RawResponseEntry {
 pub struct Usage {
     pub input_tokens: Option<u32>,
     pub output_tokens: Option<u32>,
-    #[serde(default, with = "decimal_float_option")]
+    #[serde(default, with = "tensorzero_types::serde_utils::decimal_float_option")]
     #[cfg_attr(feature = "ts-bindings", ts(type = "number | null"))]
     pub cost: Option<Decimal>,
-}
-
-/// Custom serde module for `Option<Decimal>` as float.
-///
-/// Serializes identically to `rust_decimal::serde::float_option`.
-/// Deserializes via `Option<f64>` instead of `deserialize_option` so that
-/// serde's untagged-enum `ContentDeserializer` (which maps JSON `null` to
-/// `Content::Unit` → `visit_unit`) is handled correctly.  The upstream
-/// `OptionDecimalVisitor` only implements `visit_none`, not `visit_unit`,
-/// which causes failures inside `#[serde(untagged)]` enums.
-mod decimal_float_option {
-    use rust_decimal::Decimal;
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    // Signature is required by serde's `with` attribute.
-    #[expect(clippy::ref_option)]
-    pub fn serialize<S>(value: &Option<Decimal>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        rust_decimal::serde::float_option::serialize(value, serializer)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Decimal>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Option::<f64>::deserialize(deserializer)?
-            .map(|f| Decimal::try_from(f).map_err(serde::de::Error::custom))
-            .transpose()
-    }
 }
 
 impl Usage {

--- a/crates/tensorzero-types/src/cost.rs
+++ b/crates/tensorzero-types/src/cost.rs
@@ -18,9 +18,9 @@ pub struct UninitializedCostConfigEntry<P = CostPointerConfig> {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UninitializedCostRate {
-    #[serde(default, with = "rust_decimal::serde::float_option")]
+    #[serde(default, with = "crate::serde_utils::decimal_float_option")]
     pub cost_per_million: Option<Decimal>,
-    #[serde(default, with = "rust_decimal::serde::float_option")]
+    #[serde(default, with = "crate::serde_utils::decimal_float_option")]
     pub cost_per_unit: Option<Decimal>,
 }
 

--- a/crates/tensorzero-types/src/lib.rs
+++ b/crates/tensorzero-types/src/lib.rs
@@ -9,6 +9,7 @@ pub mod error;
 pub mod file;
 pub mod message;
 pub mod role;
+pub mod serde_utils;
 pub mod storage;
 pub mod tool;
 pub mod tool_failure;

--- a/crates/tensorzero-types/src/serde_utils.rs
+++ b/crates/tensorzero-types/src/serde_utils.rs
@@ -1,0 +1,29 @@
+/// Custom serde module for `Option<Decimal>` as float.
+///
+/// Serializes identically to `rust_decimal::serde::float_option`.
+/// Deserializes via `Option<f64>` instead of `deserialize_option` so that
+/// serde's untagged-enum `ContentDeserializer` (which maps JSON `null` to
+/// `Content::Unit` → `visit_unit`) is handled correctly.  The upstream
+/// `OptionDecimalVisitor` only implements `visit_none`, not `visit_unit`,
+/// which causes failures inside `#[serde(flatten)]` and `#[serde(untagged)]`.
+pub mod decimal_float_option {
+    use rust_decimal::Decimal;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    // Signature is required by serde's `with` attribute.
+    pub fn serialize<S>(value: &Option<Decimal>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        rust_decimal::serde::float_option::serialize(value, serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Decimal>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<f64>::deserialize(deserializer)?
+            .map(|f| Decimal::try_from(f).map_err(serde::de::Error::custom))
+            .transpose()
+    }
+}


### PR DESCRIPTION
## Summary
- Extract shared `decimal_float_option` serde module into `tensorzero-types::serde_utils`
- Use it in `UninitializedCostRate` (`cost.rs`) to fix deserialization failure when `#[serde(flatten)]` causes `null` to go through `visit_unit()` instead of `visit_none()`
- Remove duplicate local copy from `usage.rs` in favor of the shared module



## PR Stack
```
main
 │
 ▼
#6950 Fix Option<Decimal> serde  ◄── THIS PR
 │
 ▼
#6813 Live Tests
```

## Test plan
- [x] `cargo check --all-targets --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt`
- [x] `cargo test-unit-fast` (2684 tests pass)
- [x] Verify durable GEPA config snapshot round-trip in e2e tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches serialization/deserialization for cost-related fields, which can affect config/API wire compatibility if the new helper behaves differently. Scope is small and limited to `Option<Decimal>` handling, but failures would surface at runtime when parsing JSON.
> 
> **Overview**
> Fixes `Option<Decimal>` JSON round-tripping by introducing a shared `tensorzero-types::serde_utils::decimal_float_option` serde helper that properly deserializes `null` in `#[serde(flatten)]`/`#[serde(untagged)]` contexts.
> 
> Updates `UninitializedCostRate` and core `Usage.cost` to use this helper and removes the previous local `decimal_float_option` implementation from `usage.rs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28071f4140a51a4ec4466ba124ac544d3f8b318e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->