### PR TITLE
Don't rebuild containers in daily-tests workflow

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -9,69 +9,7 @@ on:
     - cron: "0 0 * * *" # Runs at 00:00 UTC every day
 
 jobs:
-  build-gateway-e2e-container:
-    if: github.repository == 'tensorzero/tensorzero'
-    uses: ./.github/workflows/build-gateway-e2e-container.yml
-    permissions:
-      contents: read
-      id-token: write
-    secrets:
-      DOCKERHUB_LIMITED_TOKEN: ${{ secrets.DOCKERHUB_LIMITED_TOKEN }}
-
-  build-gateway-container:
-    if: github.repository == 'tensorzero/tensorzero'
-    uses: ./.github/workflows/build-gateway-container.yml
-    permissions:
-      contents: read
-      id-token: write
-    secrets:
-      DOCKERHUB_LIMITED_TOKEN: ${{ secrets.DOCKERHUB_LIMITED_TOKEN }}
-
-  build-mock-provider-api-container:
-    if: github.repository == 'tensorzero/tensorzero'
-    uses: ./.github/workflows/build-mock-provider-api-container.yml
-    permissions:
-      contents: read
-      id-token: write
-    secrets:
-      DOCKERHUB_LIMITED_TOKEN: ${{ secrets.DOCKERHUB_LIMITED_TOKEN }}
-
-  build-fixtures-container:
-    if: github.repository == 'tensorzero/tensorzero'
-    uses: ./.github/workflows/build-fixtures-container.yml
-    permissions:
-      contents: read
-      id-token: write
-    secrets:
-      DOCKERHUB_LIMITED_TOKEN: ${{ secrets.DOCKERHUB_LIMITED_TOKEN }}
-
-  build-provider-proxy-container:
-    if: github.repository == 'tensorzero/tensorzero'
-    uses: ./.github/workflows/build-provider-proxy-container.yml
-    permissions:
-      contents: read
-      id-token: write
-    secrets:
-      DOCKERHUB_LIMITED_TOKEN: ${{ secrets.DOCKERHUB_LIMITED_TOKEN }}
-
-  build-live-tests-container:
-    if: github.repository == 'tensorzero/tensorzero'
-    uses: ./.github/workflows/build-live-tests-container.yml
-    permissions:
-      contents: read
-      id-token: write
-    secrets:
-      DOCKERHUB_LIMITED_TOKEN: ${{ secrets.DOCKERHUB_LIMITED_TOKEN }}
-
   live-tests:
-    needs:
-      [
-        build-gateway-e2e-container,
-        build-gateway-container,
-        build-fixtures-container,
-        build-provider-proxy-container,
-        build-live-tests-container,
-      ]
     permissions:
       contents: read
       actions: read
@@ -79,14 +17,6 @@ jobs:
     secrets: inherit
 
   client-tests:
-    needs:
-      [
-        build-gateway-e2e-container,
-        build-gateway-container,
-        build-mock-provider-api-container,
-        build-fixtures-container,
-        build-provider-proxy-container,
-      ]
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
These containers are already built in the merge queue for anything that gets puehd to main. This workflow started failing when we enabled tag immutability on Docker Hub.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only changes GitHub Actions orchestration; the main impact is whether daily test jobs still have the required images available without the removed build steps.
> 
> **Overview**
> The `daily-tests` workflow no longer rebuilds/pushes the gateway, fixtures, provider-proxy, and test containers before running daily checks.
> 
> `live-tests` and `client-tests` now run directly without `needs` dependencies on the removed build jobs, relying on images built elsewhere; `live-batch-tests` remains gated to the main repo and the scheduled-run Slack failure notification stays in place.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 239ca0e68338c24cd125c9c87ad7a84fd0c417a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->