### PR TITLE
Support function-only searchEvaluationRuns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 ## Rust Testing
 
 - Run tests with `cargo nextest`.
+- Use `googletest` for new Rust tests.
 - Annotate new tests with `#[gtest]` (googletest crate).
 - Include descriptive messages: use `.expect("why")` over `.unwrap()`, and add custom messages to key assertions.
 - Prefer `expect_that!` to collect all failure messages; use `assert_that!` when subsequent code depends on the assertion.

--- a/crates/tensorzero-core/src/db/clickhouse/evaluation_queries.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/evaluation_queries.rs
@@ -345,43 +345,81 @@ impl EvaluationQueries for ClickHouseConnectionInfo {
 
     async fn search_evaluation_runs(
         &self,
-        evaluation_name: &str,
+        evaluation_name: Option<&str>,
         function_name: Option<&str>,
         query: &str,
         limit: u32,
         offset: u32,
     ) -> Result<Vec<EvaluationRunSearchResult>, Error> {
-        let function_name_clause = if function_name.is_some() {
-            "AND argMax(function_name, updated_at) = {function_name:String}"
+        let raw_evaluation_name_clause = if evaluation_name.is_some() {
+            "AND evaluation_name = {evaluation_name:String}"
         } else {
             ""
+        };
+        let raw_function_name_clause = if function_name.is_some() {
+            "AND function_name = {function_name:String}"
+        } else {
+            ""
+        };
+        let evaluation_name_clause = if evaluation_name.is_some() {
+            "AND latest_evaluation_name = {evaluation_name:String}"
+        } else {
+            ""
+        };
+        let function_name_clause = if function_name.is_some() {
+            "AND latest_function_name = {function_name:String}"
+        } else {
+            ""
+        };
+        let query_clause = if query.is_empty() {
+            ""
+        } else {
+            r"
+                AND (
+                    positionCaseInsensitive(toString(uint_to_uuid(run_id_uint)), {query:String}) > 0
+                    OR positionCaseInsensitive(latest_evaluation_name, {query:String}) > 0
+                    OR positionCaseInsensitive(latest_dataset_name, {query:String}) > 0
+                    OR positionCaseInsensitive(
+                        if(
+                            length(latest_variant_names) > 0,
+                            latest_variant_names[1],
+                            ''
+                        ),
+                        {query:String}
+                    ) > 0
+                )"
         };
 
         let sql_query = format!(
             r"
             SELECT
                 uint_to_uuid(run_id_uint) AS evaluation_run_id,
+                latest_evaluation_name AS evaluation_name,
+                latest_dataset_name AS dataset_name,
                 if(
-                    length(argMax(variant_names, updated_at)) > 0,
-                    argMax(variant_names, updated_at)[1],
+                    length(latest_variant_names) > 0,
+                    latest_variant_names[1],
                     ''
                 ) AS variant_name
-            FROM InferenceEvaluationRuns
-            GROUP BY run_id_uint
-            HAVING
-                argMax(evaluation_name, updated_at) = {{evaluation_name:String}}
+            FROM (
+                SELECT
+                    run_id_uint,
+                    argMax(evaluation_name, updated_at) AS latest_evaluation_name,
+                    argMax(function_name, updated_at) AS latest_function_name,
+                    argMax(dataset_name, updated_at) AS latest_dataset_name,
+                    argMax(variant_names, updated_at) AS latest_variant_names
+                FROM InferenceEvaluationRuns
+                WHERE
+                    1 = 1
+                    {raw_evaluation_name_clause}
+                    {raw_function_name_clause}
+                GROUP BY run_id_uint
+            )
+            WHERE
+                1 = 1
+                {evaluation_name_clause}
                 {function_name_clause}
-                AND (
-                    positionCaseInsensitive(toString(uint_to_uuid(run_id_uint)), {{query:String}}) > 0
-                    OR positionCaseInsensitive(
-                        if(
-                            length(argMax(variant_names, updated_at)) > 0,
-                            argMax(variant_names, updated_at)[1],
-                            ''
-                        ),
-                        {{query:String}}
-                    ) > 0
-                )
+                {query_clause}
             ORDER BY run_id_uint DESC
             LIMIT {{limit:UInt32}}
             OFFSET {{offset:UInt32}}
@@ -389,17 +427,21 @@ impl EvaluationQueries for ClickHouseConnectionInfo {
         "
         );
 
-        let evaluation_name_str = evaluation_name.to_string();
         let query_str = query.to_string();
         let limit_str = limit.to_string();
         let offset_str = offset.to_string();
 
         let mut params = HashMap::new();
-        params.insert("evaluation_name", evaluation_name_str.as_str());
+        let evaluation_name_str = evaluation_name.map(ToOwned::to_owned);
+        if let Some(evaluation_name) = evaluation_name_str.as_deref() {
+            params.insert("evaluation_name", evaluation_name);
+        }
         if let Some(function_name) = function_name {
             params.insert("function_name", function_name);
         }
-        params.insert("query", query_str.as_str());
+        if !query.is_empty() {
+            params.insert("query", query_str.as_str());
+        }
         params.insert("limit", limit_str.as_str());
         params.insert("offset", offset_str.as_str());
 
@@ -1079,17 +1121,46 @@ mod tests {
             .expect_run_query_synchronous()
             .withf(|query, params| {
                 assert_query_contains(query, "FROM InferenceEvaluationRuns");
-                assert_query_contains(query, "HAVING");
-                assert_query_contains(query, "argMax(evaluation_name, updated_at) = {evaluation_name:String}");
-                assert_query_contains(query, "argMax(function_name, updated_at) = {function_name:String}");
+                assert_query_contains(
+                    query,
+                    "argMax(evaluation_name, updated_at) AS latest_evaluation_name",
+                );
+                assert_query_contains(
+                    query,
+                    "argMax(function_name, updated_at) AS latest_function_name",
+                );
+                assert_query_contains(
+                    query,
+                    "argMax(dataset_name, updated_at) AS latest_dataset_name",
+                );
+                assert_query_contains(
+                    query,
+                    "argMax(variant_names, updated_at) AS latest_variant_names",
+                );
+                assert_query_contains(query, "WHERE");
+                assert_query_contains(query, "AND evaluation_name = {evaluation_name:String}");
+                assert_query_contains(query, "AND function_name = {function_name:String}");
+                assert_query_contains(
+                    query,
+                    "AND latest_evaluation_name = {evaluation_name:String}",
+                );
+                assert_query_contains(query, "AND latest_function_name = {function_name:String}");
+                assert_query_contains(
+                    query,
+                    "OR positionCaseInsensitive(latest_evaluation_name, {query:String}) > 0",
+                );
+                assert_query_contains(
+                    query,
+                    "OR positionCaseInsensitive(latest_dataset_name, {query:String}) > 0",
+                );
                 assert_query_contains(query, "positionCaseInsensitive(toString(uint_to_uuid(run_id_uint)), {query:String}) > 0");
                 assert_query_contains(query, "ORDER BY run_id_uint DESC");
                 assert_query_contains(
                     query,
                     "positionCaseInsensitive(
                     if(
-                        length(argMax(variant_names, updated_at)) > 0,
-                        argMax(variant_names, updated_at)[1],
+                        length(latest_variant_names) > 0,
+                        latest_variant_names[1],
                         ''
                     ),
                     {query:String}
@@ -1110,8 +1181,8 @@ mod tests {
             })
             .returning(|_, _| {
                 Ok(ClickHouseResponse {
-                    response: r#"{"evaluation_run_id":"0196ee9c-d808-74f3-8000-02ec7409b95d","variant_name":"variant1"}
-{"evaluation_run_id":"0196ee9c-d808-74f3-8000-02ec7409b95e","variant_name":"variant2"}"#.to_string(),
+                    response: r#"{"evaluation_run_id":"0196ee9c-d808-74f3-8000-02ec7409b95d","evaluation_name":"test_eval","dataset_name":"dataset_1","variant_name":"variant1"}
+{"evaluation_run_id":"0196ee9c-d808-74f3-8000-02ec7409b95e","evaluation_name":"test_eval","dataset_name":"dataset_2","variant_name":"variant2"}"#.to_string(),
                     metadata: ClickHouseResponseMetadata {
                         read_rows: 2,
                         written_rows: 0,
@@ -1121,11 +1192,13 @@ mod tests {
 
         let conn = ClickHouseConnectionInfo::new_mock(Arc::new(mock_clickhouse_client));
         let result = conn
-            .search_evaluation_runs("test_eval", Some("test_func"), "variant", 100, 0)
+            .search_evaluation_runs(Some("test_eval"), Some("test_func"), "variant", 100, 0)
             .await
             .unwrap();
 
         assert_eq!(result.len(), 2);
+        assert_eq!(result[0].evaluation_name, "test_eval");
+        assert_eq!(result[0].dataset_name, "dataset_1");
         assert_eq!(result[0].variant_name, "variant1");
         assert_eq!(result[1].variant_name, "variant2");
     }
@@ -1148,11 +1221,62 @@ mod tests {
 
         let conn = ClickHouseConnectionInfo::new_mock(Arc::new(mock_clickhouse_client));
         let result = conn
-            .search_evaluation_runs("test_eval", Some("test_func"), "nonexistent", 100, 0)
+            .search_evaluation_runs(Some("test_eval"), Some("test_func"), "nonexistent", 100, 0)
             .await
             .unwrap();
 
         assert_eq!(result.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_search_evaluation_runs_function_only_empty_query() {
+        let mut mock_clickhouse_client = MockClickHouseClient::new();
+
+        mock_clickhouse_client
+            .expect_run_query_synchronous()
+            .withf(|query, params| {
+                assert_query_contains(query, "FROM InferenceEvaluationRuns");
+                assert_query_contains(
+                    query,
+                    "argMax(function_name, updated_at) AS latest_function_name",
+                );
+                assert_query_contains(query, "WHERE");
+                assert_query_contains(query, "AND function_name = {function_name:String}");
+                assert_query_contains(query, "AND latest_function_name = {function_name:String}");
+                assert!(
+                    !query.contains("{evaluation_name:String}"),
+                    "Query should not require evaluation_name when omitted"
+                );
+                assert!(
+                    !query.contains("{query:String}"),
+                    "Empty search should not add text matching clauses"
+                );
+                assert_eq!(params.get("function_name"), Some(&"test_func"));
+                assert_eq!(params.get("limit"), Some(&"100"));
+                assert_eq!(params.get("offset"), Some(&"0"));
+                assert_eq!(params.get("evaluation_name"), None);
+                assert_eq!(params.get("query"), None);
+                true
+            })
+            .returning(|_, _| {
+                Ok(ClickHouseResponse {
+                    response: r#"{"evaluation_run_id":"0196ee9c-d808-74f3-8000-02ec7409b95d","evaluation_name":"generated_eval","dataset_name":"dataset_1","variant_name":"variant1"}"#.to_string(),
+                    metadata: ClickHouseResponseMetadata {
+                        read_rows: 1,
+                        written_rows: 0,
+                    },
+                })
+            });
+
+        let conn = ClickHouseConnectionInfo::new_mock(Arc::new(mock_clickhouse_client));
+        let result = conn
+            .search_evaluation_runs(None, Some("test_func"), "", 100, 0)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].evaluation_name, "generated_eval");
+        assert_eq!(result[0].dataset_name, "dataset_1");
     }
 
     #[tokio::test]

--- a/crates/tensorzero-core/src/db/delegating_connection.rs
+++ b/crates/tensorzero-core/src/db/delegating_connection.rs
@@ -914,7 +914,7 @@ impl EvaluationQueries for DelegatingDatabaseConnection {
 
     async fn search_evaluation_runs(
         &self,
-        evaluation_name: &str,
+        evaluation_name: Option<&str>,
         function_name: Option<&str>,
         query: &str,
         limit: u32,

--- a/crates/tensorzero-core/src/db/evaluation_queries.rs
+++ b/crates/tensorzero-core/src/db/evaluation_queries.rs
@@ -33,6 +33,8 @@ pub struct EvaluationRunInfoRow {
 #[derive(Debug, Deserialize, sqlx::FromRow)]
 pub struct EvaluationRunSearchResult {
     pub evaluation_run_id: Uuid,
+    pub evaluation_name: String,
+    pub dataset_name: String,
     pub variant_name: String,
 }
 
@@ -381,7 +383,7 @@ pub trait EvaluationQueries {
     /// Searches evaluation runs by ID or variant name.
     async fn search_evaluation_runs(
         &self,
-        evaluation_name: &str,
+        evaluation_name: Option<&str>,
         function_name: Option<&str>,
         query: &str,
         limit: u32,

--- a/crates/tensorzero-core/src/db/postgres/evaluation_queries.rs
+++ b/crates/tensorzero-core/src/db/postgres/evaluation_queries.rs
@@ -203,7 +203,7 @@ impl EvaluationQueries for PostgresConnectionInfo {
 
     async fn search_evaluation_runs(
         &self,
-        evaluation_name: &str,
+        evaluation_name: Option<&str>,
         function_name: Option<&str>,
         query: &str,
         limit: u32,
@@ -431,7 +431,7 @@ fn build_count_datapoints_for_evaluation_query(
 }
 
 fn build_search_evaluation_runs_query(
-    evaluation_name: &str,
+    evaluation_name: Option<&str>,
     function_name: Option<&str>,
     query: &str,
     limit: u32,
@@ -441,23 +441,34 @@ fn build_search_evaluation_runs_query(
         r"
         SELECT
             run_id AS evaluation_run_id,
+            evaluation_name,
+            dataset_name,
             COALESCE(variant_names->>0, '') AS variant_name
         FROM tensorzero.inference_evaluation_runs
-        WHERE evaluation_name = ",
+        WHERE TRUE",
     );
-    qb.push_bind(evaluation_name.to_string());
+    if let Some(evaluation_name) = evaluation_name {
+        qb.push(" AND evaluation_name = ");
+        qb.push_bind(evaluation_name.to_string());
+    }
     if let Some(fn_name) = function_name {
         qb.push(" AND function_name = ");
         qb.push_bind(fn_name.to_string());
     }
-    qb.push(
-        r"
+    if !query.is_empty() {
+        qb.push(
+            r"
         AND (run_id::TEXT ILIKE ",
-    );
-    qb.push_bind(format!("%{query}%"));
-    qb.push(" OR COALESCE(variant_names->>0, '') ILIKE ");
-    qb.push_bind(format!("%{query}%"));
-    qb.push(")");
+        );
+        qb.push_bind(format!("%{query}%"));
+        qb.push(" OR evaluation_name ILIKE ");
+        qb.push_bind(format!("%{query}%"));
+        qb.push(" OR dataset_name ILIKE ");
+        qb.push_bind(format!("%{query}%"));
+        qb.push(" OR COALESCE(variant_names->>0, '') ILIKE ");
+        qb.push_bind(format!("%{query}%"));
+        qb.push(")");
+    }
     qb.push(
         r"
         ORDER BY run_id DESC
@@ -812,7 +823,7 @@ mod tests {
     #[test]
     fn test_build_search_evaluation_runs_query() {
         let qb = build_search_evaluation_runs_query(
-            "test_eval",
+            Some("test_eval"),
             Some("test_func"),
             "search_term",
             50,
@@ -826,19 +837,21 @@ mod tests {
             r"
             SELECT
                 run_id AS evaluation_run_id,
+                evaluation_name,
+                dataset_name,
                 COALESCE(variant_names->>0, '') AS variant_name
             FROM tensorzero.inference_evaluation_runs
-            WHERE evaluation_name = $1 AND function_name = $2
-            AND (run_id::TEXT ILIKE $3 OR COALESCE(variant_names->>0, '') ILIKE $4)
+            WHERE TRUE AND evaluation_name = $1 AND function_name = $2
+            AND (run_id::TEXT ILIKE $3 OR evaluation_name ILIKE $4 OR dataset_name ILIKE $5 OR COALESCE(variant_names->>0, '') ILIKE $6)
             ORDER BY run_id DESC
-            LIMIT $5 OFFSET $6
+            LIMIT $7 OFFSET $8
             ",
         );
     }
 
     #[test]
     fn test_build_search_evaluation_runs_query_no_function_name() {
-        let qb = build_search_evaluation_runs_query("test_eval", None, "search_term", 50, 10);
+        let qb = build_search_evaluation_runs_query(Some("test_eval"), None, "search_term", 50, 10);
         let sql = qb.sql();
         let sql = sql.as_str();
 
@@ -847,12 +860,36 @@ mod tests {
             r"
             SELECT
                 run_id AS evaluation_run_id,
+                evaluation_name,
+                dataset_name,
                 COALESCE(variant_names->>0, '') AS variant_name
             FROM tensorzero.inference_evaluation_runs
-            WHERE evaluation_name = $1
-            AND (run_id::TEXT ILIKE $2 OR COALESCE(variant_names->>0, '') ILIKE $3)
+            WHERE TRUE AND evaluation_name = $1
+            AND (run_id::TEXT ILIKE $2 OR evaluation_name ILIKE $3 OR dataset_name ILIKE $4 OR COALESCE(variant_names->>0, '') ILIKE $5)
             ORDER BY run_id DESC
-            LIMIT $4 OFFSET $5
+            LIMIT $6 OFFSET $7
+            ",
+        );
+    }
+
+    #[test]
+    fn test_build_search_evaluation_runs_query_function_only_empty_search() {
+        let qb = build_search_evaluation_runs_query(None, Some("test_func"), "", 50, 10);
+        let sql = qb.sql();
+        let sql = sql.as_str();
+
+        assert_query_equals(
+            sql,
+            r"
+            SELECT
+                run_id AS evaluation_run_id,
+                evaluation_name,
+                dataset_name,
+                COALESCE(variant_names->>0, '') AS variant_name
+            FROM tensorzero.inference_evaluation_runs
+            WHERE TRUE AND function_name = $1
+            ORDER BY run_id DESC
+            LIMIT $2 OFFSET $3
             ",
         );
     }

--- a/crates/tensorzero-core/src/endpoints/internal/evaluations/search_runs.rs
+++ b/crates/tensorzero-core/src/endpoints/internal/evaluations/search_runs.rs
@@ -6,7 +6,7 @@ use super::types::{
     SearchEvaluationRunResult, SearchEvaluationRunsParams, SearchEvaluationRunsResponse,
 };
 use crate::db::evaluation_queries::EvaluationQueries;
-use crate::error::Error;
+use crate::error::{Error, ErrorDetails};
 use crate::utils::gateway::{AppState, AppStateData};
 
 /// Handler for `GET /internal/evaluations/runs/search`
@@ -34,15 +34,22 @@ pub async fn search_evaluation_runs_handler(
 /// Internal function for searching evaluation runs, testable with mock ClickHouse.
 async fn search_evaluation_runs_internal(
     clickhouse: &impl EvaluationQueries,
-    evaluation_name: String,
+    evaluation_name: Option<String>,
     function_name: Option<String>,
     query: String,
     limit: u32,
     offset: u32,
 ) -> Result<SearchEvaluationRunsResponse, Error> {
+    if evaluation_name.is_none() && function_name.is_none() {
+        return Err(Error::new(ErrorDetails::InvalidRequest {
+            message: "At least one of `evaluation_name` or `function_name` must be provided"
+                .to_string(),
+        }));
+    }
+
     let db_results = clickhouse
         .search_evaluation_runs(
-            &evaluation_name,
+            evaluation_name.as_deref(),
             function_name.as_deref(),
             &query,
             limit,
@@ -55,6 +62,8 @@ async fn search_evaluation_runs_internal(
         .into_iter()
         .map(|row| SearchEvaluationRunResult {
             evaluation_run_id: row.evaluation_run_id,
+            evaluation_name: row.evaluation_name,
+            dataset_name: row.dataset_name,
             variant_name: row.variant_name,
         })
         .collect();
@@ -66,8 +75,10 @@ async fn search_evaluation_runs_internal(
 mod tests {
     use super::*;
     use crate::db::evaluation_queries::{EvaluationRunSearchResult, MockEvaluationQueries};
+    use googletest::prelude::*;
     use uuid::Uuid;
 
+    #[gtest]
     #[tokio::test]
     async fn test_search_evaluation_runs_basic() {
         let mut mock_clickhouse = MockEvaluationQueries::new();
@@ -76,7 +87,7 @@ mod tests {
         mock_clickhouse
             .expect_search_evaluation_runs()
             .withf(|eval_name, fn_name, query, limit, offset| {
-                assert_eq!(eval_name, "test_eval");
+                assert_eq!(eval_name, &Some("test_eval"));
                 assert_eq!(
                     fn_name,
                     &Some("test_function"),
@@ -92,6 +103,8 @@ mod tests {
                 Box::pin(async move {
                     Ok(vec![EvaluationRunSearchResult {
                         evaluation_run_id: run_id,
+                        evaluation_name: "test_eval".to_string(),
+                        dataset_name: "test_dataset".to_string(),
                         variant_name: "variant_1".to_string(),
                     }])
                 })
@@ -99,20 +112,27 @@ mod tests {
 
         let result = search_evaluation_runs_internal(
             &mock_clickhouse,
-            "test_eval".to_string(),
+            Some("test_eval".to_string()),
             Some("test_function".to_string()),
             "test-query".to_string(),
             100,
             0,
         )
         .await
-        .unwrap();
+        .expect("search should succeed");
 
-        assert_eq!(result.results.len(), 1);
-        assert_eq!(result.results[0].evaluation_run_id, run_id);
-        assert_eq!(result.results[0].variant_name, "variant_1");
+        expect_that!(
+            &result.results,
+            elements_are![matches_pattern!(SearchEvaluationRunResult {
+                evaluation_run_id: eq(&run_id),
+                evaluation_name: eq("test_eval"),
+                dataset_name: eq("test_dataset"),
+                variant_name: eq("variant_1"),
+            })]
+        );
     }
 
+    #[gtest]
     #[tokio::test]
     async fn test_search_evaluation_runs_empty() {
         let mut mock_clickhouse = MockEvaluationQueries::new();
@@ -123,18 +143,19 @@ mod tests {
 
         let result = search_evaluation_runs_internal(
             &mock_clickhouse,
-            "test_eval".to_string(),
+            Some("test_eval".to_string()),
             Some("test_function".to_string()),
             "no-results".to_string(),
             100,
             0,
         )
         .await
-        .unwrap();
+        .expect("search should succeed");
 
-        assert_eq!(result.results.len(), 0);
+        expect_that!(result.results, is_empty());
     }
 
+    #[gtest]
     #[tokio::test]
     async fn test_search_evaluation_runs_multiple_results() {
         let mut mock_clickhouse = MockEvaluationQueries::new();
@@ -148,10 +169,14 @@ mod tests {
                     Ok(vec![
                         EvaluationRunSearchResult {
                             evaluation_run_id: run_id1,
+                            evaluation_name: "test_eval".to_string(),
+                            dataset_name: "dataset_1".to_string(),
                             variant_name: "variant_1".to_string(),
                         },
                         EvaluationRunSearchResult {
                             evaluation_run_id: run_id2,
+                            evaluation_name: "test_eval".to_string(),
+                            dataset_name: "dataset_2".to_string(),
                             variant_name: "variant_2".to_string(),
                         },
                     ])
@@ -160,22 +185,35 @@ mod tests {
 
         let result = search_evaluation_runs_internal(
             &mock_clickhouse,
-            "test_eval".to_string(),
+            Some("test_eval".to_string()),
             Some("test_function".to_string()),
             "variant".to_string(),
             100,
             0,
         )
         .await
-        .unwrap();
+        .expect("search should succeed");
 
-        assert_eq!(result.results.len(), 2);
-        assert_eq!(result.results[0].evaluation_run_id, run_id1);
-        assert_eq!(result.results[0].variant_name, "variant_1");
-        assert_eq!(result.results[1].evaluation_run_id, run_id2);
-        assert_eq!(result.results[1].variant_name, "variant_2");
+        expect_that!(
+            &result.results,
+            elements_are![
+                matches_pattern!(SearchEvaluationRunResult {
+                    evaluation_run_id: eq(&run_id1),
+                    evaluation_name: eq("test_eval"),
+                    dataset_name: eq("dataset_1"),
+                    variant_name: eq("variant_1"),
+                }),
+                matches_pattern!(SearchEvaluationRunResult {
+                    evaluation_run_id: eq(&run_id2),
+                    evaluation_name: eq("test_eval"),
+                    dataset_name: eq("dataset_2"),
+                    variant_name: eq("variant_2"),
+                })
+            ]
+        );
     }
 
+    #[gtest]
     #[tokio::test]
     async fn test_search_evaluation_runs_with_pagination() {
         let mut mock_clickhouse = MockEvaluationQueries::new();
@@ -193,6 +231,8 @@ mod tests {
                 Box::pin(async move {
                     Ok(vec![EvaluationRunSearchResult {
                         evaluation_run_id: run_id,
+                        evaluation_name: "test_eval".to_string(),
+                        dataset_name: "test_dataset".to_string(),
                         variant_name: "variant_3".to_string(),
                     }])
                 })
@@ -200,18 +240,27 @@ mod tests {
 
         let result = search_evaluation_runs_internal(
             &mock_clickhouse,
-            "test_eval".to_string(),
+            Some("test_eval".to_string()),
             Some("test_function".to_string()),
             "query".to_string(),
             50,
             100,
         )
         .await
-        .unwrap();
+        .expect("search should succeed");
 
-        assert_eq!(result.results.len(), 1);
+        expect_that!(
+            &result.results,
+            elements_are![matches_pattern!(SearchEvaluationRunResult {
+                evaluation_run_id: eq(&run_id),
+                evaluation_name: eq("test_eval"),
+                dataset_name: eq("test_dataset"),
+                variant_name: eq("variant_3"),
+            })]
+        );
     }
 
+    #[gtest]
     #[tokio::test]
     async fn test_search_evaluation_runs_error_handling() {
         let mut mock_clickhouse = MockEvaluationQueries::new();
@@ -228,7 +277,7 @@ mod tests {
 
         let result = search_evaluation_runs_internal(
             &mock_clickhouse,
-            "test_eval".to_string(),
+            Some("test_eval".to_string()),
             Some("test_function".to_string()),
             "query".to_string(),
             100,
@@ -236,9 +285,10 @@ mod tests {
         )
         .await;
 
-        assert!(result.is_err());
+        expect_that!(result, err(anything()));
     }
 
+    #[gtest]
     #[tokio::test]
     async fn test_search_evaluation_runs_no_function_name() {
         let mut mock_clickhouse = MockEvaluationQueries::new();
@@ -247,7 +297,7 @@ mod tests {
         mock_clickhouse
             .expect_search_evaluation_runs()
             .withf(|eval_name, fn_name, query, limit, offset| {
-                assert_eq!(eval_name, "test_eval");
+                assert_eq!(eval_name, &Some("test_eval"));
                 assert_eq!(fn_name, &None, "function_name should be None");
                 assert_eq!(query, "test-query");
                 assert_eq!(*limit, 100);
@@ -259,6 +309,8 @@ mod tests {
                 Box::pin(async move {
                     Ok(vec![EvaluationRunSearchResult {
                         evaluation_run_id: run_id,
+                        evaluation_name: "test_eval".to_string(),
+                        dataset_name: "test_dataset".to_string(),
                         variant_name: "variant_1".to_string(),
                     }])
                 })
@@ -266,17 +318,89 @@ mod tests {
 
         let result = search_evaluation_runs_internal(
             &mock_clickhouse,
-            "test_eval".to_string(),
+            Some("test_eval".to_string()),
             None,
             "test-query".to_string(),
             100,
             0,
         )
         .await
-        .unwrap();
+        .expect("search should succeed");
 
-        assert_eq!(result.results.len(), 1, "Should return 1 result");
-        assert_eq!(result.results[0].evaluation_run_id, run_id);
-        assert_eq!(result.results[0].variant_name, "variant_1");
+        expect_that!(
+            &result.results,
+            elements_are![matches_pattern!(SearchEvaluationRunResult {
+                evaluation_run_id: eq(&run_id),
+                evaluation_name: eq("test_eval"),
+                dataset_name: eq("test_dataset"),
+                variant_name: eq("variant_1"),
+            })]
+        );
+    }
+
+    #[gtest]
+    #[tokio::test]
+    async fn test_search_evaluation_runs_function_only() {
+        let mut mock_clickhouse = MockEvaluationQueries::new();
+        let run_id = Uuid::now_v7();
+
+        mock_clickhouse
+            .expect_search_evaluation_runs()
+            .withf(|eval_name, fn_name, query, limit, offset| {
+                assert_that!(eval_name, eq(&None));
+                assert_that!(fn_name, eq(&Some("test_function")));
+                assert_that!(query, eq("dataset"));
+                assert_that!(*limit, eq(100));
+                assert_that!(*offset, eq(0));
+                true
+            })
+            .times(1)
+            .returning(move |_, _, _, _, _| {
+                Box::pin(async move {
+                    Ok(vec![EvaluationRunSearchResult {
+                        evaluation_run_id: run_id,
+                        evaluation_name: "generated_eval".to_string(),
+                        dataset_name: "test_dataset".to_string(),
+                        variant_name: "variant_1".to_string(),
+                    }])
+                })
+            });
+
+        let result = search_evaluation_runs_internal(
+            &mock_clickhouse,
+            None,
+            Some("test_function".to_string()),
+            "dataset".to_string(),
+            100,
+            0,
+        )
+        .await
+        .expect("search should succeed");
+
+        expect_that!(
+            &result.results,
+            elements_are![matches_pattern!(SearchEvaluationRunResult {
+                evaluation_run_id: eq(&run_id),
+                evaluation_name: eq("generated_eval"),
+                dataset_name: eq("test_dataset"),
+                variant_name: eq("variant_1"),
+            })]
+        );
+    }
+
+    #[gtest]
+    #[tokio::test]
+    async fn test_search_evaluation_runs_requires_scope() {
+        let mock_clickhouse = MockEvaluationQueries::new();
+
+        let result =
+            search_evaluation_runs_internal(&mock_clickhouse, None, None, String::new(), 100, 0)
+                .await;
+
+        expect_that!(
+            result,
+            err(anything()),
+            "Expected missing scope to return an error"
+        );
     }
 }

--- a/crates/tensorzero-core/src/endpoints/internal/evaluations/types.rs
+++ b/crates/tensorzero-core/src/endpoints/internal/evaluations/types.rs
@@ -84,7 +84,9 @@ pub struct DatapointStatsResponse {
 /// Query parameters for searching evaluation runs.
 #[derive(Debug, Deserialize)]
 pub struct SearchEvaluationRunsParams {
-    pub evaluation_name: String,
+    #[serde(default)]
+    pub evaluation_name: Option<String>,
+    #[serde(default)]
     pub function_name: Option<String>,
     pub query: String,
     #[serde(default = "default_limit")]
@@ -107,6 +109,8 @@ pub struct SearchEvaluationRunsResponse {
 #[cfg_attr(feature = "ts-bindings", ts(export))]
 pub struct SearchEvaluationRunResult {
     pub evaluation_run_id: Uuid,
+    pub evaluation_name: String,
+    pub dataset_name: String,
     pub variant_name: String,
 }
 

--- a/crates/tensorzero-core/tests/e2e/db/evaluation_queries.rs
+++ b/crates/tensorzero-core/tests/e2e/db/evaluation_queries.rs
@@ -47,7 +47,13 @@ async fn test_insert_inference_evaluation_run(conn: impl EvaluationQueries + Tes
 
     // Verify via search_evaluation_runs (queries the runs table by evaluation_name)
     let search_results = conn
-        .search_evaluation_runs(&run.evaluation_name, Some(&run.function_name), "", 10, 0)
+        .search_evaluation_runs(
+            Some(&run.evaluation_name),
+            Some(&run.function_name),
+            "",
+            10,
+            0,
+        )
         .await
         .expect("search_evaluation_runs should succeed");
     assert_eq!(
@@ -58,6 +64,14 @@ async fn test_insert_inference_evaluation_run(conn: impl EvaluationQueries + Tes
     assert_eq!(
         search_results[0].evaluation_run_id, run.run_id,
         "search result run_id should match inserted value"
+    );
+    assert_eq!(
+        search_results[0].evaluation_name, run.evaluation_name,
+        "search result evaluation_name should match inserted value"
+    );
+    assert_eq!(
+        search_results[0].dataset_name, run.dataset_name,
+        "search result dataset_name should match inserted value"
     );
     assert_eq!(
         search_results[0].variant_name, "variant_a",
@@ -1126,7 +1140,13 @@ make_db_test!(test_get_evaluation_results_json_datapoint_details);
 /// Test that search_evaluation_runs returns all runs for an evaluation with an empty query.
 async fn test_search_evaluation_runs_empty_query(conn: impl EvaluationQueries) {
     let results = conn
-        .search_evaluation_runs("entity_extraction", Some("extract_entities"), "", 100, 0)
+        .search_evaluation_runs(
+            Some("entity_extraction"),
+            Some("extract_entities"),
+            "",
+            100,
+            0,
+        )
         .await
         .unwrap();
 
@@ -1143,7 +1163,7 @@ async fn test_search_evaluation_runs_by_variant_name(conn: impl EvaluationQuerie
     // "mini" should only match the gpt4o_mini_initial_prompt variant
     let results = conn
         .search_evaluation_runs(
-            "entity_extraction",
+            Some("entity_extraction"),
             Some("extract_entities"),
             "mini",
             100,
@@ -1165,7 +1185,7 @@ async fn test_search_evaluation_runs_common_variant_substring(conn: impl Evaluat
     // "gpt4o" should match both variants
     let results = conn
         .search_evaluation_runs(
-            "entity_extraction",
+            Some("entity_extraction"),
             Some("extract_entities"),
             "gpt4o",
             100,
@@ -1185,7 +1205,7 @@ make_db_test!(test_search_evaluation_runs_common_variant_substring);
 async fn test_search_evaluation_runs_case_insensitive(conn: impl EvaluationQueries) {
     let results = conn
         .search_evaluation_runs(
-            "entity_extraction",
+            Some("entity_extraction"),
             Some("extract_entities"),
             "GPT4O_MINI",
             100,
@@ -1207,7 +1227,7 @@ async fn test_search_evaluation_runs_by_run_id(conn: impl EvaluationQueries) {
     // "19bd" is a substring of "0196368f-19bd-7082-a677-1c0bf346ff24" but not of the other run ID
     let results = conn
         .search_evaluation_runs(
-            "entity_extraction",
+            Some("entity_extraction"),
             Some("extract_entities"),
             "19bd",
             100,
@@ -1232,7 +1252,7 @@ make_db_test!(test_search_evaluation_runs_by_run_id);
 async fn test_search_evaluation_runs_no_match(conn: impl EvaluationQueries) {
     let results = conn
         .search_evaluation_runs(
-            "entity_extraction",
+            Some("entity_extraction"),
             Some("extract_entities"),
             "zzz_nonexistent_zzz",
             100,
@@ -1253,7 +1273,7 @@ make_db_test!(test_search_evaluation_runs_no_match);
 async fn test_search_evaluation_runs_wrong_evaluation_name(conn: impl EvaluationQueries) {
     let results = conn
         .search_evaluation_runs(
-            "nonexistent_evaluation",
+            Some("nonexistent_evaluation"),
             Some("extract_entities"),
             "",
             100,
@@ -1274,7 +1294,7 @@ make_db_test!(test_search_evaluation_runs_wrong_evaluation_name);
 async fn test_search_evaluation_runs_wrong_function_name(conn: impl EvaluationQueries) {
     let results = conn
         .search_evaluation_runs(
-            "entity_extraction",
+            Some("entity_extraction"),
             Some("nonexistent_function"),
             "",
             100,
@@ -1294,7 +1314,7 @@ make_db_test!(test_search_evaluation_runs_wrong_function_name);
 /// Test that search_evaluation_runs works without a function_name filter.
 async fn test_search_evaluation_runs_no_function_name(conn: impl EvaluationQueries) {
     let results = conn
-        .search_evaluation_runs("entity_extraction", None, "", 100, 0)
+        .search_evaluation_runs(Some("entity_extraction"), None, "", 100, 0)
         .await
         .unwrap();
 
@@ -1309,10 +1329,58 @@ async fn test_search_evaluation_runs_no_function_name(conn: impl EvaluationQueri
 }
 make_db_test!(test_search_evaluation_runs_no_function_name);
 
+/// Test that search_evaluation_runs works with only a function_name filter.
+async fn test_search_evaluation_runs_function_only(conn: impl EvaluationQueries) {
+    let results = conn
+        .search_evaluation_runs(None, Some("extract_entities"), "", 100, 0)
+        .await
+        .unwrap();
+
+    assert!(
+        results.len() > 1,
+        "Should return results when filtering only by function_name"
+    );
+    assert!(
+        results
+            .iter()
+            .all(|result| !result.evaluation_name.is_empty()),
+        "Stored runs should always have a human-readable evaluation_name"
+    );
+}
+make_db_test!(test_search_evaluation_runs_function_only);
+
+/// Test that search_evaluation_runs can match evaluation_name and dataset_name substrings.
+async fn test_search_evaluation_runs_by_evaluation_or_dataset_name(conn: impl EvaluationQueries) {
+    let evaluation_name_results = conn
+        .search_evaluation_runs(None, Some("extract_entities"), "entity_extraction", 100, 0)
+        .await
+        .unwrap();
+    let dataset_name_results = conn
+        .search_evaluation_runs(None, Some("extract_entities"), "entity_extraction", 100, 0)
+        .await
+        .unwrap();
+
+    assert!(
+        !evaluation_name_results.is_empty(),
+        "Expected evaluation_name substring search to return results"
+    );
+    assert!(
+        !dataset_name_results.is_empty(),
+        "Expected dataset_name substring search to return results"
+    );
+}
+make_db_test!(test_search_evaluation_runs_by_evaluation_or_dataset_name);
+
 /// Test that search_evaluation_runs respects the limit parameter.
 async fn test_search_evaluation_runs_with_limit(conn: impl EvaluationQueries) {
     let results = conn
-        .search_evaluation_runs("entity_extraction", Some("extract_entities"), "", 1, 0)
+        .search_evaluation_runs(
+            Some("entity_extraction"),
+            Some("extract_entities"),
+            "",
+            1,
+            0,
+        )
         .await
         .unwrap();
 
@@ -1323,7 +1391,13 @@ make_db_test!(test_search_evaluation_runs_with_limit);
 /// Test that search_evaluation_runs respects the offset parameter.
 async fn test_search_evaluation_runs_with_offset(conn: impl EvaluationQueries) {
     let results = conn
-        .search_evaluation_runs("entity_extraction", Some("extract_entities"), "", 100, 1)
+        .search_evaluation_runs(
+            Some("entity_extraction"),
+            Some("extract_entities"),
+            "",
+            100,
+            1,
+        )
         .await
         .unwrap();
 
@@ -1337,7 +1411,13 @@ make_db_test!(test_search_evaluation_runs_with_offset);
 /// Test that search_evaluation_runs returns empty when offset is beyond all results.
 async fn test_search_evaluation_runs_offset_beyond_results(conn: impl EvaluationQueries) {
     let results = conn
-        .search_evaluation_runs("entity_extraction", Some("extract_entities"), "", 100, 100)
+        .search_evaluation_runs(
+            Some("entity_extraction"),
+            Some("extract_entities"),
+            "",
+            100,
+            100,
+        )
         .await
         .unwrap();
 

--- a/crates/tensorzero-core/tests/e2e/endpoints/internal/evaluations/mod.rs
+++ b/crates/tensorzero-core/tests/e2e/endpoints/internal/evaluations/mod.rs
@@ -5,6 +5,7 @@ mod get_run_metadata;
 use std::time::Duration;
 
 use futures::StreamExt;
+use googletest::prelude::*;
 use reqwest::{Client, StatusCode};
 use reqwest_sse_stream::{Event, RequestBuilderExt};
 use serde_json::{Map, Value, json};
@@ -15,7 +16,9 @@ use tensorzero_core::endpoints::datasets::v1::types::{
     CreateChatDatapointRequest, CreateDatapointRequest, CreateDatapointsRequest,
     CreateDatapointsResponse,
 };
-use tensorzero_core::endpoints::internal::evaluations::types::GetEvaluationStatisticsResponse;
+use tensorzero_core::endpoints::internal::evaluations::types::{
+    GetEvaluationStatisticsResponse, SearchEvaluationRunResult, SearchEvaluationRunsResponse,
+};
 use tensorzero_core::endpoints::internal::evaluations::{
     GetEvaluationResultsResponse, GetEvaluationRunInfosResponse,
 };
@@ -28,6 +31,9 @@ use tokio::time::sleep;
 use uuid::Uuid;
 
 use crate::common::get_gateway_endpoint;
+
+const ENTITY_EXTRACTION_RUN_ID_GPT4O_MINI: &str = "0196368f-19bd-7082-a677-1c0bf346ff24";
+const ENTITY_EXTRACTION_RUN_ID_GPT4O: &str = "0196368e-53a8-7e82-a88d-db7086926d81";
 
 /// Test the count evaluation runs endpoint.
 /// This tests GET /internal/evaluations/runs/count
@@ -57,6 +63,137 @@ async fn test_count_evaluation_runs() {
     assert!(
         count > 0,
         "Expected at least one evaluation run in the test database"
+    );
+}
+
+#[gtest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_search_evaluation_runs_function_name_only() {
+    let http_client = Client::new();
+    let url = get_gateway_endpoint(
+        "/internal/evaluations/runs/search?function_name=extract_entities&query=",
+    );
+
+    let resp = http_client
+        .get(url)
+        .send()
+        .await
+        .expect("search_evaluation_runs function-only request failed");
+    expect_that!(resp.status(), eq(StatusCode::OK));
+
+    let response: SearchEvaluationRunsResponse = resp
+        .json()
+        .await
+        .expect("Failed to parse function-only search response");
+
+    expect_that!(
+        response.results.len(),
+        ge(2),
+        "Expected at least 2 evaluation runs for function-only search"
+    );
+    expect_that!(
+        &response.results,
+        contains_each![
+            matches_pattern!(SearchEvaluationRunResult {
+                evaluation_run_id: eq(
+                    &Uuid::parse_str(ENTITY_EXTRACTION_RUN_ID_GPT4O_MINI).expect("Valid UUID")
+                ),
+                evaluation_name: eq("entity_extraction"),
+                ..
+            }),
+            matches_pattern!(SearchEvaluationRunResult {
+                evaluation_run_id: eq(
+                    &Uuid::parse_str(ENTITY_EXTRACTION_RUN_ID_GPT4O).expect("Valid UUID")
+                ),
+                evaluation_name: eq("entity_extraction"),
+                ..
+            })
+        ]
+    );
+}
+
+#[gtest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_search_evaluation_runs_evaluation_name_only() {
+    let http_client = Client::new();
+    let url = get_gateway_endpoint(
+        "/internal/evaluations/runs/search?evaluation_name=entity_extraction&query=",
+    );
+
+    let resp = http_client
+        .get(url)
+        .send()
+        .await
+        .expect("search_evaluation_runs evaluation-only request failed");
+    let status = resp.status();
+    let body = resp
+        .text()
+        .await
+        .expect("Failed to read evaluation-only search response body");
+    expect_that!(status, eq(StatusCode::OK), "response body: {body}");
+
+    let response: SearchEvaluationRunsResponse =
+        serde_json::from_str(&body).expect("Failed to parse evaluation-only search response");
+
+    expect_that!(
+        response.results,
+        len(ge(2)),
+        "Expected at least 2 evaluation runs for evaluation-only search"
+    );
+    expect_that!(
+        response.results,
+        each(matches_pattern!(SearchEvaluationRunResult {
+            evaluation_name: eq("entity_extraction"),
+            ..
+        }))
+    );
+}
+
+#[gtest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_search_evaluation_runs_missing_scope_returns_error() {
+    let http_client = Client::new();
+    let url = get_gateway_endpoint("/internal/evaluations/runs/search?query=");
+
+    let resp = http_client
+        .get(url)
+        .send()
+        .await
+        .expect("search_evaluation_runs missing-scope request failed");
+    expect_that!(resp.status(), eq(StatusCode::BAD_REQUEST));
+}
+
+#[gtest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_search_evaluation_runs_query_returns_correct_runs() {
+    let http_client = Client::new();
+    let url = get_gateway_endpoint(
+        "/internal/evaluations/runs/search?evaluation_name=entity_extraction&query=mini",
+    );
+
+    let resp = http_client
+        .get(url)
+        .send()
+        .await
+        .expect("search_evaluation_runs query request failed");
+    expect_that!(resp.status(), eq(StatusCode::OK));
+
+    let response: SearchEvaluationRunsResponse = resp
+        .json()
+        .await
+        .expect("Failed to parse query search response");
+
+    expect_that!(
+        &response.results,
+        contains(matches_pattern!(SearchEvaluationRunResult {
+            evaluation_run_id: eq(
+                &Uuid::parse_str(ENTITY_EXTRACTION_RUN_ID_GPT4O_MINI).expect("Valid UUID")
+            ),
+            evaluation_name: eq("entity_extraction"),
+            variant_name: eq("gpt4o_mini_initial_prompt"),
+            ..
+        })),
+        "Expected search results for query `mini` to include the fixture run"
     );
 }
 

--- a/crates/tensorzero-node/lib/bindings/SearchEvaluationRunResult.ts
+++ b/crates/tensorzero-node/lib/bindings/SearchEvaluationRunResult.ts
@@ -5,5 +5,7 @@
  */
 export type SearchEvaluationRunResult = {
   evaluation_run_id: string;
+  evaluation_name: string;
+  dataset_name: string;
   variant_name: string;
 };

--- a/ui/app/components/evaluations/EvalRunSelector.tsx
+++ b/ui/app/components/evaluations/EvalRunSelector.tsx
@@ -25,14 +25,14 @@ import { getLastUuidSegment } from "~/components/evaluations/EvaluationRunBadge"
 import EvaluationRunBadge from "~/components/evaluations/EvaluationRunBadge";
 
 interface EvalRunSelectorProps {
-  evaluationName: string;
+  functionName: string;
   selectedRunIdInfos: EvaluationRunInfo[];
   allowedRunInfos?: EvaluationRunInfo[]; // To be used if only a subset of runs are available,
   // for example if we're filtering by datapoint_id
 }
 
 export function EvalRunSelector({
-  evaluationName,
+  functionName,
   selectedRunIdInfos,
   allowedRunInfos,
 }: EvalRunSelectorProps) {
@@ -74,12 +74,9 @@ export function EvalRunSelector({
     : []; // If data itself is null/undefined, use an empty array
 
   // Update the URL with the selected run IDs
-  const updateSelectedRunIds = (runIdInfos: SearchEvaluationRunResult[]) => {
+  const updateSelectedRunIds = (runIds: string[]) => {
     const newParams = new URLSearchParams(searchParams);
-    newParams.set(
-      "evaluation_run_ids",
-      runIdInfos.map((info) => info.evaluation_run_id).join(","),
-    );
+    newParams.set("evaluation_run_ids", runIds.join(","));
     navigate(`?${newParams.toString()}`, { replace: true });
   };
 
@@ -92,13 +89,13 @@ export function EvalRunSelector({
 
     if (selectedRunIds.includes(runId)) {
       // Remove the run
-      const newSelectedRunIdInfos = selectedRunIdInfos.filter(
-        (info) => info.evaluation_run_id !== runId,
+      const newSelectedRunIds = selectedRunIds.filter(
+        (selectedRunId) => selectedRunId !== runId,
       );
-      updateSelectedRunIds(newSelectedRunIdInfos);
+      updateSelectedRunIds(newSelectedRunIds);
     } else if (canAddMore) {
       // Add the run only if we haven't reached the limit
-      updateSelectedRunIds([...selectedRunIdInfos, runInfo]);
+      updateSelectedRunIds([...selectedRunIds, runInfo.evaluation_run_id]);
     }
   };
 
@@ -113,7 +110,9 @@ export function EvalRunSelector({
       updateSelectedRunIds([]);
     } else {
       // Select all, but respect the maximum limit
-      const runsToSelect = availableRunInfos.slice(0, MAX_SELECTIONS);
+      const runsToSelect = availableRunInfos
+        .slice(0, MAX_SELECTIONS)
+        .map((info) => info.evaluation_run_id);
       updateSelectedRunIds(runsToSelect);
     }
   };
@@ -123,27 +122,25 @@ export function EvalRunSelector({
     // Stop the tooltip from triggering
     e.stopPropagation();
 
-    const newSelectedRunIdInfos = selectedRunIdInfos.filter(
-      (info) => info.evaluation_run_id !== runId,
+    const newSelectedRunIds = selectedRunIds.filter(
+      (selectedRunId) => selectedRunId !== runId,
     );
-    updateSelectedRunIds(newSelectedRunIdInfos);
+    updateSelectedRunIds(newSelectedRunIds);
   };
 
   const hasInitializedRuns = useRef(false);
   function loadRuns(query: string | null, args?: { debounce?: boolean }) {
-    if (evaluationName) {
-      const searchParams = new URLSearchParams();
-      searchParams.set("evaluation_name", evaluationName);
+    if (functionName) {
+      const nextSearchParams = new URLSearchParams();
+      nextSearchParams.set("function_name", functionName);
       if (query) {
-        searchParams.set("q", query);
+        nextSearchParams.set("q", query);
       }
       if (args?.debounce) {
-        searchParams.set("debounce", "");
+        nextSearchParams.set("debounce", "");
       }
       hasInitializedRuns.current = true;
-      loadRunsFetcher(
-        `/api/evaluations/search_runs/${evaluationName}?${searchParams}`,
-      );
+      loadRunsFetcher(`/api/evaluations/search_runs?${nextSearchParams}`);
     }
   }
 
@@ -174,7 +171,7 @@ export function EvalRunSelector({
           <PopoverContent className="w-96 p-0">
             <Command>
               <CommandInput
-                placeholder="Search by variant name or evaluation run ID..."
+                placeholder="Search by evaluation, variant, dataset, or run ID..."
                 value={searchValue}
                 onValueChange={(value) => {
                   setSearchValue(value);
@@ -206,13 +203,14 @@ export function EvalRunSelector({
                         const runIdSegment = getLastUuidSegment(
                           info.evaluation_run_id,
                         );
+                        const runLabel = `${info.variant_name} (${info.evaluation_name})`;
                         const isDisabled =
                           (!isSelected && !canAddMore) || isLoading;
 
                         return (
                           <CommandItem
                             key={info.evaluation_run_id}
-                            value={`${info.variant_name} ${info.evaluation_run_id}`}
+                            value={`${info.evaluation_name} ${info.variant_name} ${info.dataset_name} ${info.evaluation_run_id}`}
                             onSelect={() => toggleRun(info.evaluation_run_id)}
                             className={`flex items-center gap-2 ${
                               isDisabled ? "cursor-not-allowed opacity-50" : ""
@@ -222,9 +220,7 @@ export function EvalRunSelector({
                             <div
                               className={`${variantColor} h-3 w-3 rounded-full`}
                             />
-                            <span className="flex-1 truncate">
-                              {info.variant_name}
-                            </span>
+                            <span className="flex-1 truncate">{runLabel}</span>
                             <span className="text-muted-foreground text-xs">
                               {runIdSegment}
                             </span>

--- a/ui/app/components/evaluations/EvaluationRunBadge.tsx
+++ b/ui/app/components/evaluations/EvaluationRunBadge.tsx
@@ -1,12 +1,18 @@
-import type { SearchEvaluationRunResult } from "~/types/tensorzero";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { Badge } from "../ui/badge";
 import { X } from "lucide-react";
 import { formatDate } from "~/utils/date";
 import { cn } from "~/utils/common";
 
+export interface EvaluationRunBadgeInfo {
+  evaluation_run_id: string;
+  variant_name: string;
+  evaluation_name?: string;
+  dataset_name?: string;
+}
+
 interface EvaluationRunBadgeProps {
-  runInfo: SearchEvaluationRunResult;
+  runInfo: EvaluationRunBadgeInfo;
   getColor: (runId: string) => string;
   createdAt?: Date;
   onRemove?: (e: React.MouseEvent) => void;

--- a/ui/app/routes.ts
+++ b/ui/app/routes.ts
@@ -27,10 +27,9 @@ export default [
       "workflow_evaluations/search_runs",
       "routes/api/workflow_evaluations/search_runs/route.ts",
     ),
-
     route(
-      "evaluations/search_runs/:evaluation_name",
-      "routes/api/evaluations/search_runs/$evaluation_name/route.ts",
+      "evaluations/search_runs",
+      "routes/api/evaluations/search_runs/route.ts",
     ),
 
     route("evaluations/cancel", "routes/api/evaluations/cancel.route.ts"),

--- a/ui/app/routes/api/evaluations/search_runs/route.ts
+++ b/ui/app/routes/api/evaluations/search_runs/route.ts
@@ -1,27 +1,27 @@
 import type { Route } from "./+types/route";
 import { abortableTimeout } from "~/utils/common";
-import { getConfig } from "~/utils/config/index.server";
 import { getTensorZeroClient } from "~/utils/tensorzero.server";
 
 export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url);
-  const evaluationName = url.searchParams.get("evaluation_name");
-  if (!evaluationName) {
-    return new Response("Missing evaluation_name parameter", { status: 400 });
+  const functionName = url.searchParams.get("function_name");
+  if (!functionName) {
+    return new Response("Missing function_name parameter", { status: 400 });
   }
+
+  const evaluationName = url.searchParams.get("evaluation_name") || undefined;
   const query = url.searchParams.get("q") || "";
-  const config = await getConfig();
-  const function_name = config.evaluations[evaluationName]?.function_name;
 
   const runs = await getTensorZeroClient()
     .searchEvaluationRuns(
-      evaluationName,
       query,
-      function_name,
-      /*limit=*/ 100,
-      /*offset=*/ 0,
+      functionName,
+      evaluationName,
+      /* limit= */ 100,
+      /* offset= */ 0,
     )
     .then((response) => response.results);
+
   return new Response(JSON.stringify(runs), {
     headers: {
       "Content-Type": "application/json",

--- a/ui/app/routes/evaluations/EvaluationTable.tsx
+++ b/ui/app/routes/evaluations/EvaluationTable.tsx
@@ -212,6 +212,7 @@ interface EvaluationTableProps {
   evaluation_statistics: EvaluationStatistics[];
   metric_names: string[];
   evaluation_name: string;
+  function_name: string;
   metricsConfig: Record<string, RunMetricMetadata>;
   /** Maps full metric_name → short evaluator_name. */
   evaluatorMetricNames: Record<string, string>;
@@ -243,6 +244,7 @@ export function EvaluationTable({
   evaluation_statistics,
   metric_names,
   evaluation_name,
+  function_name,
   metricsConfig,
   evaluatorMetricNames,
   selectedRows,
@@ -376,7 +378,7 @@ export function EvaluationTable({
       <div>
         {/* Eval run selector */}
         <EvalRunSelector
-          evaluationName={evaluation_name}
+          functionName={function_name}
           selectedRunIdInfos={selected_evaluation_run_infos}
         />
 

--- a/ui/app/routes/evaluations/results/route.tsx
+++ b/ui/app/routes/evaluations/results/route.tsx
@@ -401,14 +401,14 @@ function MainContent({
 
 function EvalRunSelectorWithData({
   data,
-  evaluationName,
+  functionName,
 }: {
   data: RunInfoData;
-  evaluationName: string;
+  functionName: string;
 }) {
   return (
     <EvalRunSelector
-      evaluationName={evaluationName}
+      functionName={functionName}
       selectedRunIdInfos={data.selected_evaluation_run_infos}
       allowedRunInfos={data.allowedEvaluationRunInfos}
     />
@@ -494,7 +494,7 @@ export default function EvaluationDatapointPage({
             {(infoData) => (
               <EvalRunSelectorWithData
                 data={infoData}
-                evaluationName={evaluation_name}
+                functionName={functionName}
               />
             )}
           </Await>

--- a/ui/app/routes/evaluations/runs.tsx
+++ b/ui/app/routes/evaluations/runs.tsx
@@ -353,6 +353,7 @@ function ResultsError() {
 
 function ResultsContent({
   evaluation_name,
+  function_name,
   metricsConfig,
   evaluatorMetricNames,
   data,
@@ -367,6 +368,7 @@ function ResultsContent({
   isCancelling,
 }: {
   evaluation_name: string;
+  function_name: string;
   metricsConfig: Record<string, RunMetricMetadata>;
   evaluatorMetricNames: Record<string, string>;
   data: EvaluationData;
@@ -433,6 +435,7 @@ function ResultsContent({
       </div>
       <EvaluationTable
         evaluation_name={evaluation_name}
+        function_name={function_name}
         metricsConfig={metricsConfig}
         evaluatorMetricNames={evaluatorMetricNames}
         selected_evaluation_run_infos={selected_evaluation_run_infos}
@@ -579,6 +582,7 @@ export default function EvaluationRunsPage({
                 return (
                   <ResultsContent
                     evaluation_name={evaluation_name}
+                    function_name={function_name}
                     metricsConfig={metricsConfig}
                     evaluatorMetricNames={evaluatorMetricNames}
                     data={resolvedData}

--- a/ui/app/utils/tensorzero/tensorzero.ts
+++ b/ui/app/utils/tensorzero/tensorzero.ts
@@ -1398,26 +1398,26 @@ export class TensorZeroClient extends BaseTensorZeroClient {
   }
 
   /**
-   * Searches evaluation runs by ID or variant name.
-   * @param evaluationName - The name of the evaluation
+   * Searches evaluation runs by run ID, evaluation name, dataset name, or variant name.
    * @param query - The search query (case-insensitive)
-   * @param functionName - Optional function name filter
+   * @param functionName - Function name filter
+   * @param evaluationName - Optional evaluation name filter
    * @param limit - Maximum number of results to return (default: 100)
    * @param offset - Number of results to skip (default: 0)
    * @returns A promise that resolves with the search results
    * @throws Error if the request fails
    */
   async searchEvaluationRuns(
-    evaluationName: string,
     query: string,
-    functionName?: string,
+    functionName: string,
+    evaluationName?: string,
     limit: number = 100,
     offset: number = 0,
   ): Promise<SearchEvaluationRunsResponse> {
     const searchParams = new URLSearchParams();
-    searchParams.append("evaluation_name", evaluationName);
-    if (functionName) {
-      searchParams.append("function_name", functionName);
+    searchParams.append("function_name", functionName);
+    if (evaluationName) {
+      searchParams.append("evaluation_name", evaluationName);
     }
     searchParams.append("query", query);
     searchParams.append("limit", limit.toString());


### PR DESCRIPTION
Fixes #6859

This suppports searching evaluations without providing an evaluation name to support showing a reasonable EvalRunSelector in the UI for the new (function_name, evaluator_names) style of evaluation runs. We also adapt the EvalRunSelector to use the new path that doesn't require an evaluation name.

![image.png](https://app.graphite.com/user-attachments/assets/6fc71272-5551-4194-b31d-04600673e810.png)

The two exact_match evaluator/metric output differ because one is nested and one uses the top-level evaluator format:

![image.png](https://app.graphite.com/user-attachments/assets/5ad8d79e-45f7-4ae5-83e1-d18dc80b1ba9.png)

![image.png](https://app.graphite.com/user-attachments/assets/d7b0e3c7-f257-4f3d-b073-96ccfff89b15.png)



