### PR TITLE
Concurrent metadata+data INSERTs and slow query logging in batch flush

### DIFF
--- a/crates/tensorzero-core/src/db/postgres/batching.rs
+++ b/crates/tensorzero-core/src/db/postgres/batching.rs
@@ -28,6 +28,35 @@ use super::model_inferences::{
 /// Uses bounded channels to provide backpressure: when the write queue is full,
 /// new rows are dropped and logged rather than buffering without limit.
 ///
+/// Each table type (chat, json, model inferences) has its own accumulator task that
+/// collects rows and flushes them when `max_rows` or `flush_interval_ms` is reached.
+/// Within each flush, the metadata and data INSERTs run concurrently via `tokio::join!`.
+///
+/// ## Detecting backpressure
+///
+/// When Postgres INSERT latency exceeds the flush interval, the accumulator blocks
+/// (it can't accept new rows while flushing). This causes the bounded input channel
+/// to fill up, at which point `try_send` fails with `TrySendError::Full` and the
+/// error is logged. Monitor for these log messages:
+///
+///   `"Postgres batch channel full — dropping ... inference record"`
+///
+/// If you see sustained drops, consider:
+/// 1. Increasing `write_queue_capacity` to absorb temporary spikes
+/// 2. Tuning `max_rows` / `flush_interval_ms` to reduce per-flush latency
+/// 3. Scaling up Postgres (connections, IOPS, etc.)
+///
+/// ## Future: concurrent flush worker pool
+///
+/// The current design flushes serially within each accumulator — while an INSERT is
+/// in flight, the accumulator cannot collect new rows. If INSERT latency regularly
+/// exceeds `flush_interval_ms` and the above tuning is insufficient, the next step
+/// would be to decouple accumulation from flushing by introducing a shared pool of
+/// N flush workers. The accumulator would hand off ready batches to the pool and
+/// immediately start collecting the next batch. This adds complexity (shared
+/// `Arc<Mutex<Receiver>>`, boxed futures, two-stage shutdown) but eliminates
+/// accumulator stalls under sustained Postgres latency.
+///
 /// When a `PostgresBatchSender` is dropped, the batch writer will finish
 /// processing all outstanding batches once all senders are dropped.
 #[derive(Debug)]
@@ -151,7 +180,7 @@ impl PostgresBatchWriter {
         let batch_timeout = Duration::from_millis(config.flush_interval_ms);
         let max_rows = config.max_rows_postgres.unwrap_or(config.max_rows);
 
-        // Chat inferences flush task
+        // Chat inferences accumulator
         {
             let pool = pool.clone();
             let channel = self.chat_inferences_rx;
@@ -163,31 +192,7 @@ impl PostgresBatchWriter {
                     move |buffer| {
                         let pool = pool.clone();
                         async move {
-                            // TODO: if this errors, should we retry?
-                            match build_insert_chat_inferences_query(&buffer) {
-                                Ok(mut qb) => {
-                                    if let Err(e) = qb.build().execute(&pool).await {
-                                        tracing::error!(
-                                            "Error writing chat inferences to Postgres: {e}"
-                                        );
-                                    }
-                                }
-                                Err(e) => {
-                                    tracing::error!("Error building chat inferences query: {e}");
-                                }
-                            }
-                            match build_insert_chat_inference_data_query(&buffer) {
-                                Ok(mut qb) => {
-                                    if let Err(e) = qb.build().execute(&pool).await {
-                                        tracing::error!(
-                                            "Error writing chat inference IO to Postgres: {e}"
-                                        );
-                                    }
-                                }
-                                Err(e) => {
-                                    tracing::error!("Error building chat inference IO query: {e}");
-                                }
-                            }
+                            flush_chat_inferences(&pool, &buffer).await;
                             buffer
                         }
                     },
@@ -196,7 +201,7 @@ impl PostgresBatchWriter {
             });
         }
 
-        // JSON inferences flush task
+        // JSON inferences accumulator
         {
             let pool = pool.clone();
             let channel = self.json_inferences_rx;
@@ -208,31 +213,7 @@ impl PostgresBatchWriter {
                     move |buffer| {
                         let pool = pool.clone();
                         async move {
-                            // TODO: if this errors, should we retry?
-                            match build_insert_json_inferences_query(&buffer) {
-                                Ok(mut qb) => {
-                                    if let Err(e) = qb.build().execute(&pool).await {
-                                        tracing::error!(
-                                            "Error writing json inferences to Postgres: {e}"
-                                        );
-                                    }
-                                }
-                                Err(e) => {
-                                    tracing::error!("Error building json inferences query: {e}");
-                                }
-                            }
-                            match build_insert_json_inference_data_query(&buffer) {
-                                Ok(mut qb) => {
-                                    if let Err(e) = qb.build().execute(&pool).await {
-                                        tracing::error!(
-                                            "Error writing json inference IO to Postgres: {e}"
-                                        );
-                                    }
-                                }
-                                Err(e) => {
-                                    tracing::error!("Error building json inference IO query: {e}");
-                                }
-                            }
+                            flush_json_inferences(&pool, &buffer).await;
                             buffer
                         }
                     },
@@ -241,7 +222,7 @@ impl PostgresBatchWriter {
             });
         }
 
-        // Model inferences flush task
+        // Model inferences accumulator
         {
             let channel = self.model_inferences_rx;
             join_set.spawn(async move {
@@ -252,31 +233,7 @@ impl PostgresBatchWriter {
                     move |buffer| {
                         let pool = pool.clone();
                         async move {
-                            // TODO: if this errors, should we retry?
-                            match build_insert_model_inferences_query(&buffer) {
-                                Ok(mut qb) => {
-                                    if let Err(e) = qb.build().execute(&pool).await {
-                                        tracing::error!(
-                                            "Error writing model inferences to Postgres: {e}"
-                                        );
-                                    }
-                                }
-                                Err(e) => {
-                                    tracing::error!("Error building model inferences query: {e}");
-                                }
-                            }
-                            match build_insert_model_inference_data_query(&buffer) {
-                                Ok(mut qb) => {
-                                    if let Err(e) = qb.build().execute(&pool).await {
-                                        tracing::error!(
-                                            "Error writing model inference IO to Postgres: {e}"
-                                        );
-                                    }
-                                }
-                                Err(e) => {
-                                    tracing::error!("Error building model inference IO query: {e}");
-                                }
-                            }
+                            flush_model_inferences(&pool, &buffer).await;
                             buffer
                         }
                     },
@@ -291,4 +248,110 @@ impl PostgresBatchWriter {
             }
         }
     }
+}
+
+/// Execute both chat inference INSERTs (metadata + data) concurrently.
+async fn flush_chat_inferences(pool: &PgPool, buffer: &[ChatInferenceDatabaseInsert]) {
+    let row_count = buffer.len();
+    let metadata_future = async {
+        match build_insert_chat_inferences_query(buffer) {
+            Ok(mut qb) => {
+                if let Err(e) =
+                    super::execute_with_timing(qb.build(), pool, "chat_inferences", row_count).await
+                {
+                    tracing::error!("Error writing chat inferences to Postgres: {e}");
+                }
+            }
+            Err(e) => {
+                tracing::error!("Error building chat inferences query: {e}");
+            }
+        }
+    };
+    let data_future = async {
+        match build_insert_chat_inference_data_query(buffer) {
+            Ok(mut qb) => {
+                if let Err(e) =
+                    super::execute_with_timing(qb.build(), pool, "chat_inference_data", row_count)
+                        .await
+                {
+                    tracing::error!("Error writing chat inference data to Postgres: {e}");
+                }
+            }
+            Err(e) => {
+                tracing::error!("Error building chat inference data query: {e}");
+            }
+        }
+    };
+    tokio::join!(metadata_future, data_future);
+}
+
+/// Execute both JSON inference INSERTs (metadata + data) concurrently.
+async fn flush_json_inferences(pool: &PgPool, buffer: &[JsonInferenceDatabaseInsert]) {
+    let row_count = buffer.len();
+    let metadata_future = async {
+        match build_insert_json_inferences_query(buffer) {
+            Ok(mut qb) => {
+                if let Err(e) =
+                    super::execute_with_timing(qb.build(), pool, "json_inferences", row_count).await
+                {
+                    tracing::error!("Error writing json inferences to Postgres: {e}");
+                }
+            }
+            Err(e) => {
+                tracing::error!("Error building json inferences query: {e}");
+            }
+        }
+    };
+    let data_future = async {
+        match build_insert_json_inference_data_query(buffer) {
+            Ok(mut qb) => {
+                if let Err(e) =
+                    super::execute_with_timing(qb.build(), pool, "json_inference_data", row_count)
+                        .await
+                {
+                    tracing::error!("Error writing json inference data to Postgres: {e}");
+                }
+            }
+            Err(e) => {
+                tracing::error!("Error building json inference data query: {e}");
+            }
+        }
+    };
+    tokio::join!(metadata_future, data_future);
+}
+
+/// Execute both model inference INSERTs (metadata + data) concurrently.
+async fn flush_model_inferences(pool: &PgPool, buffer: &[StoredModelInference]) {
+    let row_count = buffer.len();
+    let metadata_future = async {
+        match build_insert_model_inferences_query(buffer) {
+            Ok(mut qb) => {
+                if let Err(e) =
+                    super::execute_with_timing(qb.build(), pool, "model_inferences", row_count)
+                        .await
+                {
+                    tracing::error!("Error writing model inferences to Postgres: {e}");
+                }
+            }
+            Err(e) => {
+                tracing::error!("Error building model inferences query: {e}");
+            }
+        }
+    };
+    let data_future = async {
+        match build_insert_model_inference_data_query(buffer) {
+            Ok(mut qb) => {
+                if let Err(e) =
+                    super::execute_with_timing(qb.build(), pool, "model_inference_data", row_count)
+                        .await
+                {
+                    tracing::error!("Error writing model inference data to Postgres: {e}");
+                }
+            }
+            Err(e) => {
+                tracing::error!("Error building model inference data query: {e}");
+            }
+        }
+    };
+    tokio::join!(metadata_future, data_future);
 }

--- a/crates/tensorzero-core/src/db/postgres/mod.rs
+++ b/crates/tensorzero-core/src/db/postgres/mod.rs
@@ -38,6 +38,33 @@ pub mod test_helpers;
 
 const RUN_MIGRATIONS_COMMAND: &str = "You likely need to apply migrations to your Postgres database with `--run-postgres-migrations`. Please see our documentation to learn more: https://www.tensorzero.com/docs/deployment/postgres";
 
+/// Slow query threshold for batch INSERT logging (1 second).
+const SLOW_QUERY_THRESHOLD: Duration = Duration::from_secs(1);
+
+/// Execute a built query with timing instrumentation.
+/// Logs a structured warning (table name, row count, elapsed time) for slow queries
+/// without including the full SQL, which can be enormous for bulk INSERTs.
+pub(crate) async fn execute_with_timing<'q>(
+    query: sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>,
+    pool: &PgPool,
+    table_name: &str,
+    row_count: usize,
+) -> Result<(), Error> {
+    let start = std::time::Instant::now();
+    let result = query.execute(pool).await;
+    let elapsed = start.elapsed();
+    if elapsed > SLOW_QUERY_THRESHOLD {
+        tracing::warn!(
+            table = table_name,
+            rows = row_count,
+            elapsed_ms = elapsed.as_millis() as u64,
+            "Slow Postgres write: INSERT into `{table_name}` ({row_count} rows) took {elapsed:.2?}",
+        );
+    }
+    result?;
+    Ok(())
+}
+
 #[derive(Debug, Clone)]
 pub enum PostgresConnectionInfo {
     Enabled {


### PR DESCRIPTION
## Summary

Follow-up to #6903 (bounded channels for Postgres backpressure).

- **Concurrent INSERTs**: Each batch flush now runs the metadata INSERT and data INSERT concurrently via `tokio::join!`, roughly halving per-flush latency. Previously these were sequential (two round trips per flush).
- **Slow query logging**: Adds `execute_with_timing()` that logs a structured warning (table name, row count, elapsed time) when a batch INSERT exceeds 1 second — without dumping the full SQL (which can be enormous for bulk INSERTs with thousands of bind params).
- **Architecture documentation**: Documents the backpressure model, how to detect drops, and when to consider a concurrent flush worker pool.

## Design tradeoffs

### Current architecture (this PR)

Each table type (chat, json, model) has one accumulator task that:
1. Collects rows from a bounded channel
2. Flushes when `max_rows` or `flush_interval_ms` is reached
3. Runs metadata + data INSERTs concurrently (`tokio::join!`)
4. Blocks on flush — cannot accept new rows until both INSERTs complete

This is simple and provides direct backpressure: if Postgres is slow, the channel fills, `try_send` fails with `TrySendError::Full`, and the drop is logged.

### Detecting if this is insufficient

Monitor for sustained occurrences of:
```
Postgres batch channel full — dropping ... inference record.
Increase `write_queue_capacity` or check Postgres performance.
```

If you see drops, try in order:
1. Increase `write_queue_capacity` to absorb temporary spikes
2. Tune `max_rows` / `flush_interval_ms` to reduce per-flush latency
3. Scale up Postgres (connections, IOPS, etc.)

### When to add a flush worker pool (future)

If INSERT latency regularly exceeds `flush_interval_ms` and the above tuning is insufficient, the accumulator stalls because it can't collect new rows while flushing. The fix would be to decouple accumulation from flushing: the accumulator hands off ready batches to a shared pool of N flush workers and immediately starts collecting the next batch. This adds complexity (`Arc<Mutex<Receiver>>`, boxed futures, two-stage shutdown) but eliminates accumulator stalls under sustained Postgres latency.

## Test plan

- [x] All 2269 unit tests pass (`cargo test-unit-fast`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] E2E tests in `pooled_inference_writes.rs` cover flush-on-max-rows, flush-on-timeout, drain-on-close, and overflow scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)