### PR TITLE
Handle DB replication lag in batch inference polling

### DIFF
--- a/crates/tensorzero-core/src/endpoints/batch_inference.rs
+++ b/crates/tensorzero-core/src/endpoints/batch_inference.rs
@@ -880,8 +880,20 @@ pub async fn write_poll_batch_inference(
             {
                 Ok(inferences) => inferences,
                 Err(e) => {
-                    // If we fail to process a completed batch (e.g. all JSONL rows failed
-                    // to parse), mark the batch as Failed so we don't retry indefinitely.
+                    // Transient errors (e.g. DB replication lag — provider returned valid
+                    // results but BatchModelInference rows aren't visible yet) should keep
+                    // the batch as Pending so the next poll can retry.
+                    if e.is_retryable_batch_error() {
+                        tracing::warn!(
+                            batch_id = %batch_request.batch_id,
+                            "Transient error processing completed batch: {e}. \
+                             Keeping batch as Pending for retry on next poll."
+                        );
+                        // No status write needed — the batch is already Pending.
+                        return Ok(PollInferenceResponse::Pending);
+                    }
+                    // Permanent errors (e.g. all JSONL rows failed to parse) should mark
+                    // the batch as Failed so we don't retry indefinitely.
                     tracing::error!(
                         batch_id = %batch_request.batch_id,
                         "Failed to process completed batch inference: {e}. Marking batch as failed."
@@ -1040,7 +1052,17 @@ pub async fn write_completed_batch_inference<'a>(
     let function_name = &batch_model_inferences
         .first()
         .ok_or_else(|| {
-            Error::new(ErrorDetails::MissingBatchInferenceResponse { inference_id: None })
+            if inference_ids.is_empty() {
+                // Provider returned no elements — permanent failure (e.g. all JSONL rows skipped)
+                Error::new(ErrorDetails::MissingBatchInferenceResponse { inference_id: None })
+            } else {
+                // Provider returned valid elements but DB has no matching rows —
+                // likely a transient issue (e.g. replication lag)
+                Error::new(ErrorDetails::BatchInferenceNotYetVisible {
+                    batch_id: batch_request.batch_id,
+                    expected_count: inference_ids.len(),
+                })
+            }
         })?
         .function_name
         .clone();

--- a/crates/tensorzero-core/src/error/mod.rs
+++ b/crates/tensorzero-core/src/error/mod.rs
@@ -192,6 +192,16 @@ impl Error {
         &self.details
     }
 
+    /// Returns true if this is a `BatchInferenceNotYetVisible` error, indicating the
+    /// provider completed but DB rows aren't visible yet (likely replication lag).
+    /// The batch should stay `Pending` so the next poll can retry.
+    pub fn is_retryable_batch_error(&self) -> bool {
+        matches!(
+            *self.details,
+            ErrorDetails::BatchInferenceNotYetVisible { .. }
+        )
+    }
+
     /// Ensures that the OpenTelemetry span corresponding to `span` is marked as an error.
     /// If our level is `ERROR`, then we'll do nothing, since logging an error automatically marks the span as an error.
     /// If our level is anything else, then we explicitly mark the span as an error using our own messages
@@ -421,6 +431,13 @@ pub enum ErrorDetails {
     },
     BatchNotFound {
         id: Uuid,
+    },
+    /// Provider returned valid completed results but the corresponding
+    /// `BatchModelInference` rows are not yet visible in the database.
+    /// This is typically caused by database replication lag and is transient.
+    BatchInferenceNotYetVisible {
+        batch_id: Uuid,
+        expected_count: usize,
     },
     BadFileFetch {
         url: Url,
@@ -850,6 +867,7 @@ impl ErrorDetails {
             ErrorDetails::UnsupportedContentBlockType { .. } => tracing::Level::WARN,
             ErrorDetails::BatchInputValidation { .. } => tracing::Level::WARN,
             ErrorDetails::BatchNotFound { .. } => tracing::Level::WARN,
+            ErrorDetails::BatchInferenceNotYetVisible { .. } => tracing::Level::WARN,
             ErrorDetails::Cache { .. } => tracing::Level::WARN,
             ErrorDetails::ChannelWrite { .. } => tracing::Level::ERROR,
             ErrorDetails::ClickHouseConnection { .. } => tracing::Level::ERROR,
@@ -1016,6 +1034,7 @@ impl ErrorDetails {
             ErrorDetails::BadCredentialsPreInference { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::BatchInputValidation { .. } => StatusCode::BAD_REQUEST,
             ErrorDetails::BatchNotFound { .. } => StatusCode::NOT_FOUND,
+            ErrorDetails::BatchInferenceNotYetVisible { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::Cache { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::ChannelWrite { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::ClickHouseConfiguration { .. } => StatusCode::INTERNAL_SERVER_ERROR,
@@ -1398,6 +1417,16 @@ impl std::fmt::Display for ErrorDetails {
             }
             ErrorDetails::BatchNotFound { id } => {
                 write!(f, "Batch request not found for id: {id}")
+            }
+            ErrorDetails::BatchInferenceNotYetVisible {
+                batch_id,
+                expected_count,
+            } => {
+                write!(
+                    f,
+                    "Batch {batch_id}: provider returned {expected_count} completed inferences \
+                     but no matching BatchModelInference rows found in database (possible replication lag)"
+                )
             }
             ErrorDetails::Cache { message } => {
                 write!(f, "Error in cache: {message}")
@@ -2334,6 +2363,44 @@ mod tests {
         assert_eq!(
             error_with_id.status_code(),
             StatusCode::INTERNAL_SERVER_ERROR,
+        );
+    }
+
+    #[test]
+    fn test_is_retryable_batch_error() {
+        // BatchInferenceNotYetVisible is retryable (replication lag)
+        let error = Error::new(ErrorDetails::BatchInferenceNotYetVisible {
+            batch_id: Uuid::now_v7(),
+            expected_count: 30,
+        });
+        assert!(
+            error.is_retryable_batch_error(),
+            "BatchInferenceNotYetVisible should be retryable"
+        );
+
+        // MissingBatchInferenceResponse is NOT retryable (permanent failure)
+        let error_no_id =
+            Error::new(ErrorDetails::MissingBatchInferenceResponse { inference_id: None });
+        assert!(
+            !error_no_id.is_retryable_batch_error(),
+            "MissingBatchInferenceResponse should not be retryable"
+        );
+
+        let error_with_id = Error::new(ErrorDetails::MissingBatchInferenceResponse {
+            inference_id: Some(Uuid::now_v7()),
+        });
+        assert!(
+            !error_with_id.is_retryable_batch_error(),
+            "MissingBatchInferenceResponse with inference_id should not be retryable"
+        );
+
+        // Other errors are not retryable
+        let other_error = Error::new(ErrorDetails::Config {
+            message: "some error".to_string(),
+        });
+        assert!(
+            !other_error.is_retryable_batch_error(),
+            "Non-batch errors should not be retryable"
         );
     }
 

--- a/crates/tensorzero-core/tests/e2e/db/batch_inference_endpoint_internals.rs
+++ b/crates/tensorzero-core/tests/e2e/db/batch_inference_endpoint_internals.rs
@@ -30,8 +30,8 @@ use tensorzero_core::inference::types::{
     ContentBlockChatOutput, ContentBlockOutput, FinishReason, JsonInferenceOutput, StoredInput,
     Usage,
 };
-use tensorzero_types::Text;
 use tensorzero_core::jsonschema_util::JSONSchema;
+use tensorzero_types::Text;
 use uuid::Uuid;
 
 use crate::db::get_test_postgres;
@@ -1212,11 +1212,8 @@ make_db_test!(test_write_poll_completed_batch_with_empty_elements_marks_failed);
 /// Tests the DB replication lag scenario:
 /// Provider reports Completed with valid elements (non-empty), but the
 /// `BatchModelInference` rows are not yet visible in the database (simulated
-/// by not writing them at all). Current behavior marks the batch as Failed
-/// permanently — but this is a transient issue that should allow retry.
-///
-/// This test documents the current (broken) behavior: the batch is permanently
-/// marked as Failed even though the data will eventually be available.
+/// by not writing them at all). The batch should stay Pending so the next
+/// poll can retry once the rows become visible.
 async fn test_replication_lag_completed_batch_stays_pending_for_retry(
     database: impl BatchInferenceQueries
     + ConfigQueries
@@ -1310,16 +1307,12 @@ async fn test_replication_lag_completed_batch_stays_pending_for_retry(
             // This is the desired behavior after the fix
         }
         Ok(other) => {
-            panic!(
-                "Expected Pending response for replication lag scenario, got: {other:?}"
-            );
+            panic!("Expected Pending response for replication lag scenario, got: {other:?}");
         }
         Err(e) => {
             // Current (broken) behavior: returns an error and marks batch as Failed.
             // After the fix, this path should not be taken.
-            panic!(
-                "Replication lag scenario should return Pending, not error: {e}"
-            );
+            panic!("Replication lag scenario should return Pending, not error: {e}");
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes a bug where `GET /batch_inference/{batch_id}` permanently marks a batch as `Failed` when the provider reports completion but `BatchModelInference` rows aren't yet visible in the database (replication lag). This is a follow-up to #6957 which fixed JSONL parse failures but didn't cover the replication lag case (as noted in the review).

### Root cause

When a provider (e.g. GCP Vertex) reports `JOB_STATE_SUCCEEDED`:
1. `write_completed_batch_inference` extracts inference IDs from the provider response
2. Queries `BatchModelInference` for those IDs — returns empty due to replication lag
3. `batch_model_inferences.first()` returns `None` → `MissingBatchInferenceResponse` error
4. #6957's error handler marks the batch as `Failed` permanently
5. The data becomes visible moments later, but the batch is already dead

### Fix

- New `BatchInferenceNotYetVisible` error variant distinguishes "provider returned valid elements but DB has no rows" (transient) from "provider returned empty elements" (permanent JSONL failure)
- `is_retryable_batch_error()` on `Error` identifies the transient case
- `write_poll_batch_inference` returns `Ok(Pending)` for retryable errors instead of marking as `Failed` — the next client poll will retry and find the rows

### What's NOT in this PR (follow-up)

- **Retry cap**: if rows truly never appear (data loss, not just lag), the batch retries forever. A follow-up should count retries and escalate to `Failed` after N attempts.

## Test plan

- [x] New E2E test `test_replication_lag_completed_batch_stays_pending_for_retry` — simulates provider completing with valid elements but no DB rows
- [x] New unit test `test_is_retryable_batch_error` — verifies `BatchInferenceNotYetVisible` is retryable, `MissingBatchInferenceResponse` and other errors are not
- [x] Existing test `test_write_poll_completed_batch_with_empty_elements_marks_failed` still passes (empty elements → permanent `Failed`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test-unit-fast` passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)