### PR TITLE
Add AutopilotToolResult.into_value

### DIFF
--- a/crates/autopilot-client/src/types.rs
+++ b/crates/autopilot-client/src/types.rs
@@ -485,6 +485,15 @@ impl AutopilotToolResult {
             Self::Legacy { result } => serde_json::from_str(result),
         }
     }
+
+    /// Like `value`, but avoids a clone
+    #[expect(deprecated)]
+    pub fn into_value(self) -> Result<JsonValue, serde_json::Error> {
+        match self {
+            Self::Typed { result_value, .. } => Ok(result_value),
+            Self::Legacy { result } => serde_json::from_str(&result),
+        }
+    }
 }
 
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]


### PR DESCRIPTION
This will help reduce peak memory usage when processing large values

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new helper method without changing serialization formats or existing behavior; impact is limited to callers opting into the new API.
> 
> **Overview**
> Adds `AutopilotToolResult::into_value(self)` as an ownership-taking alternative to `value(&self)`, returning the JSON result without cloning for the typed variant while still parsing the legacy string fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25d53c5139cf38199b4eb1beeae9354aeed85990. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->