### PR TITLE
Switch ClickHouse batch writer to bounded channels

### DIFF
--- a/crates/tensorzero-core/src/db/batching.rs
+++ b/crates/tensorzero-core/src/db/batching.rs
@@ -1,24 +1,23 @@
 use std::future::Future;
 use std::time::Duration;
 
-use tokio::sync::mpsc::{Receiver, UnboundedReceiver};
+use tokio::sync::mpsc::Receiver;
 
 /// Shared channel flushing logic for batch writers (used by both ClickHouse and Postgres).
 ///
-/// Buffers items from `channel` and calls `flush` when the buffer reaches
+/// Buffers items from a bounded `channel` and calls `flush` when the buffer reaches
 /// `max_rows` or `flush_interval` elapses, whichever comes first.
 /// Drains all remaining items when the channel closes.
 ///
 /// The `flush` callback takes ownership of the buffer and returns it, so we can
 /// avoid reallocating between batches while keeping the callback `Send`.
-pub(crate) async fn process_channel_with_capacity_and_timeout<T, F, Fut>(
-    mut channel: UnboundedReceiver<T>,
+pub(crate) async fn process_bounded_channel_with_capacity_and_timeout<T, F, Fut>(
+    mut channel: Receiver<T>,
     max_rows: usize,
     flush_interval: Duration,
     mut flush: F,
 ) where
     T: Send + 'static,
-    // TODO: try making this F: FnMut(&mut Vec<T>)
     F: FnMut(Vec<T>) -> Fut + Send + 'static,
     Fut: Future<Output = Vec<T>> + Send + 'static,
 {
@@ -44,43 +43,6 @@ pub(crate) async fn process_channel_with_capacity_and_timeout<T, F, Fut>(
                 Err(elapsed) => {
                     // Compile-time assertion that this is actually an Elapsed error.
                     // We hit our deadline, so we should submit our current batch
-                    let _: tokio::time::error::Elapsed = elapsed;
-                    break;
-                }
-            }
-        }
-        if !buffer.is_empty() {
-            buffer = flush(buffer).await;
-            buffer.clear();
-        }
-    }
-}
-
-/// Same as [`process_channel_with_capacity_and_timeout`] but for bounded channels.
-///
-/// Used by the Postgres batch writer to provide backpressure: when a bounded channel
-/// fills up, senders get `TrySendError::Full` and can drop + log instead of buffering
-/// without limit.
-pub(crate) async fn process_bounded_channel_with_capacity_and_timeout<T, F, Fut>(
-    mut channel: Receiver<T>,
-    max_rows: usize,
-    flush_interval: Duration,
-    mut flush: F,
-) where
-    T: Send + 'static,
-    F: FnMut(Vec<T>) -> Fut + Send + 'static,
-    Fut: Future<Output = Vec<T>> + Send + 'static,
-{
-    let mut buffer = Vec::with_capacity(max_rows);
-    while !channel.is_closed() || !channel.is_empty() {
-        let deadline = tokio::time::Instant::now() + flush_interval;
-        while buffer.len() < max_rows {
-            let remaining = max_rows - buffer.len();
-            match tokio::time::timeout_at(deadline, channel.recv_many(&mut buffer, remaining)).await
-            {
-                Ok(0) => break,
-                Ok(_) => {}
-                Err(elapsed) => {
                     let _: tokio::time::error::Elapsed = elapsed;
                     break;
                 }

--- a/crates/tensorzero-core/src/db/clickhouse/batching.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/batching.rs
@@ -6,25 +6,29 @@ use crate::error::IMPOSSIBLE_ERROR_MESSAGE;
 use enum_map::EnumMap;
 use futures::{FutureExt, TryFutureExt};
 use tokio::runtime::{Handle, RuntimeFlavor};
-use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{self, Sender, error::TrySendError};
 use tokio::task::JoinSet;
 
-use crate::db::batching::process_channel_with_capacity_and_timeout;
+use crate::db::batching::process_bounded_channel_with_capacity_and_timeout;
 use crate::db::clickhouse::{ClickHouseConnectionInfo, Rows, TableName};
 use crate::error::{Error, ErrorDetails};
 
 /// A `BatchSender` is used to submit entries to the batch writer, which aggregates
 /// and submits them to ClickHouse on a schedule defined by a `BatchWritesConfig`.
+///
+/// Uses bounded channels to provide backpressure: when the write queue is full,
+/// new rows are dropped and logged rather than buffering without limit.
+///
 /// When a `BatchSender` is dropped, it blocks until the batch writer finishes
 /// processing all outstanding batches.
 #[derive(Debug)]
 pub struct BatchSender {
     // This needs to be an `Option`, so that we can drop it
-    // (in particular, the `UnboundedSender`) from our `Drop` impl.
+    // (in particular, the `Sender`) from our `Drop` impl.
     // This signals to the writer tasks that the channel is closed,
     // and that they should exit after they finish processing all messages
-    // currently in the channell.
-    channels: Option<EnumMap<TableName, UnboundedSender<String>>>,
+    // currently in the channel.
+    channels: Option<EnumMap<TableName, Sender<String>>>,
     pub writer_handle: BatchWriterHandle,
 }
 
@@ -42,9 +46,10 @@ impl BatchSender {
                     .to_string(),
             }));
         }
+        let channel_capacity = config.write_queue_capacity;
         let mut channels: EnumMap<TableName, _> = enum_map::enum_map! {
             _ => {
-                let (tx, rx) = mpsc::unbounded_channel();
+                let (tx, rx) = mpsc::channel(channel_capacity);
                 (Some(tx), Some(rx))
             }
         };
@@ -92,10 +97,21 @@ impl BatchSender {
         };
         let channel = &channels[table_name];
         for row in rows {
-            if let Err(e) = channel.send(row) {
-                tracing::error!(
-                    "Error sending row to batch channel: {e}. {IMPOSSIBLE_ERROR_MESSAGE}"
-                );
+            match channel.try_send(row) {
+                Ok(()) => {}
+                Err(TrySendError::Full(_)) => {
+                    tracing::error!(
+                        table = ?table_name,
+                        "ClickHouse batch channel full — dropping row. \
+                         Increase `write_queue_capacity` or check ClickHouse performance."
+                    );
+                }
+                Err(TrySendError::Closed(_)) => {
+                    tracing::error!(
+                        table = ?table_name,
+                        "ClickHouse batch writer has shut down — dropping row."
+                    );
+                }
             }
         }
         Ok(())
@@ -103,7 +119,7 @@ impl BatchSender {
 }
 
 pub struct BatchWriter {
-    channels: EnumMap<TableName, UnboundedReceiver<String>>,
+    channels: EnumMap<TableName, tokio::sync::mpsc::Receiver<String>>,
 }
 
 impl BatchWriter {
@@ -113,7 +129,7 @@ impl BatchWriter {
         for (table_name, channel) in self.channels {
             let clickhouse = clickhouse.clone();
             join_set.spawn(async move {
-                process_channel_with_capacity_and_timeout(
+                process_bounded_channel_with_capacity_and_timeout(
                     channel,
                     config.max_rows,
                     batch_timeout,


### PR DESCRIPTION
## Summary

Mirrors the Postgres bounded channel work from PR #6903 for ClickHouse.

- **Bounded channels**: Replaces `UnboundedSender`/`UnboundedReceiver` with bounded `Sender`/`Receiver` using the existing `write_queue_capacity` config (default: 10,000). When the channel is full, rows are dropped with structured log messages instead of buffering without limit.
- **`try_send` with Full/Closed discrimination**: Distinguishes between a full channel (backpressure — tune `write_queue_capacity` or check ClickHouse performance) and a closed channel (writer shut down).
- **Removes dead code**: The unbounded `process_channel_with_capacity_and_timeout` in `db/batching.rs` is no longer used by any caller, so it's removed. Only the bounded variant remains.

## Note on capacity

ClickHouse deployments typically handle higher QPS than Postgres, so the shared `write_queue_capacity` default of 10,000 may need tuning. If we see ClickHouse-specific drops in production, we can add a separate `write_queue_capacity_clickhouse` override (similar to `max_rows_postgres`). For now the shared default is a reasonable starting point.

## Test plan

- [x] All 2269 unit tests pass (`cargo test-unit-fast`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] E2E tests with ClickHouse batch writes enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)