### PR TITLE
Fix ClickHouse migration flakiness for MATERIALIZE INDEX

### DIFF
--- a/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0027.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0027.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use super::{check_index_exists, check_table_exists};
+use super::{check_index_exists, check_table_exists, materialize_index};
 use crate::db::clickhouse::ClickHouseConnectionInfo;
 use crate::db::clickhouse::migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
@@ -76,82 +76,42 @@ impl Migration for Migration0027<'_> {
         let create_index_query = r"
             ALTER TABLE TagInference ADD INDEX IF NOT EXISTS inference_id_index inference_id TYPE bloom_filter GRANULARITY 1;
         ";
-        let _ = self
-            .clickhouse
+        self.clickhouse
             .run_query_synchronous_no_params(create_index_query.to_string())
             .await?;
-
-        let materialize_index_query = r"
-            ALTER TABLE TagInference MATERIALIZE INDEX inference_id_index;
-        ";
-        let _ = self
-            .clickhouse
-            .run_query_synchronous_no_params(materialize_index_query.to_string())
-            .await?;
+        materialize_index(self.clickhouse, "TagInference", "inference_id_index").await?;
 
         let create_index_query = r"
             ALTER TABLE ChatInference ADD INDEX IF NOT EXISTS inference_id_index id TYPE bloom_filter GRANULARITY 1;
         ";
-        let _ = self
-            .clickhouse
+        self.clickhouse
             .run_query_synchronous_no_params(create_index_query.to_string())
             .await?;
-
-        let materialize_index_query = r"
-            ALTER TABLE ChatInference MATERIALIZE INDEX inference_id_index;
-        ";
-        let _ = self
-            .clickhouse
-            .run_query_synchronous_no_params(materialize_index_query.to_string())
-            .await?;
+        materialize_index(self.clickhouse, "ChatInference", "inference_id_index").await?;
 
         let create_index_query = r"
             ALTER TABLE JsonInference ADD INDEX IF NOT EXISTS inference_id_index id TYPE bloom_filter GRANULARITY 1;
         ";
-        let _ = self
-            .clickhouse
+        self.clickhouse
             .run_query_synchronous_no_params(create_index_query.to_string())
             .await?;
-
-        let materialize_index_query = r"
-            ALTER TABLE JsonInference MATERIALIZE INDEX inference_id_index;
-        ";
-        let _ = self
-            .clickhouse
-            .run_query_synchronous_no_params(materialize_index_query.to_string())
-            .await?;
+        materialize_index(self.clickhouse, "JsonInference", "inference_id_index").await?;
 
         let create_index_query = r"
             ALTER TABLE ChatInferenceDatapoint ADD INDEX IF NOT EXISTS id_index id TYPE bloom_filter GRANULARITY 1;
         ";
-        let _ = self
-            .clickhouse
+        self.clickhouse
             .run_query_synchronous_no_params(create_index_query.to_string())
             .await?;
-
-        let materialize_index_query = r"
-            ALTER TABLE ChatInferenceDatapoint MATERIALIZE INDEX id_index;
-        ";
-        let _ = self
-            .clickhouse
-            .run_query_synchronous_no_params(materialize_index_query.to_string())
-            .await?;
+        materialize_index(self.clickhouse, "ChatInferenceDatapoint", "id_index").await?;
 
         let create_index_query = r"
             ALTER TABLE JsonInferenceDatapoint ADD INDEX IF NOT EXISTS id_index id TYPE bloom_filter GRANULARITY 1;
         ";
-        let _ = self
-            .clickhouse
+        self.clickhouse
             .run_query_synchronous_no_params(create_index_query.to_string())
             .await?;
-
-        let materialize_index_query = r"
-            ALTER TABLE JsonInferenceDatapoint MATERIALIZE INDEX id_index;
-        ";
-        let _ = self
-            .clickhouse
-            .run_query_synchronous_no_params(materialize_index_query.to_string())
-            .await?;
+        materialize_index(self.clickhouse, "JsonInferenceDatapoint", "id_index").await?;
 
         Ok(())
     }

--- a/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0046.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0046.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 
 use super::check_index_exists;
 use super::check_table_exists;
+use super::materialize_index;
 use crate::db::clickhouse::ClickHouseConnectionInfo;
 use crate::db::clickhouse::migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
@@ -50,17 +51,11 @@ impl Migration for Migration0046<'_> {
             let create_index_query = format!(
                 "ALTER TABLE {table} ADD INDEX IF NOT EXISTS id_index id TYPE bloom_filter GRANULARITY 1;"
             );
-            let _ = self
-                .clickhouse
+            self.clickhouse
                 .run_query_synchronous_no_params(create_index_query)
                 .await?;
 
-            let materialize_index_query =
-                format!("ALTER TABLE {table} MATERIALIZE INDEX id_index;");
-            let _ = self
-                .clickhouse
-                .run_query_synchronous_no_params(materialize_index_query)
-                .await?;
+            materialize_index(self.clickhouse, table, "id_index").await?;
         }
 
         Ok(())

--- a/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/mod.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/mod.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::{
     db::clickhouse::ClickHouseConnectionInfo,
     error::{Error, ErrorDetails},
@@ -232,4 +234,58 @@ async fn check_index_exists(
     );
     let result = clickhouse.run_query_synchronous_no_params(query).await?;
     Ok(result.response.trim() == "1")
+}
+
+/// Submits a `MATERIALIZE INDEX` mutation asynchronously (with `mutations_sync=0` to override
+/// the connection-level `mutations_sync=2`), then polls `system.mutations` until the table
+/// has no pending mutations.
+///
+/// This avoids holding a blocking HTTP connection for the entire duration of the mutation,
+/// which can cause timeouts and lock contention when multiple gateway instances start concurrently.
+pub async fn materialize_index(
+    clickhouse: &ClickHouseConnectionInfo,
+    table: &str,
+    index: &str,
+) -> Result<(), Error> {
+    // Submit the mutation asynchronously by overriding mutations_sync at the query level.
+    // The connection-level mutations_sync=2 is overridden by the SETTINGS clause.
+    let query =
+        format!("ALTER TABLE {table} MATERIALIZE INDEX {index} SETTINGS mutations_sync = 0");
+    clickhouse.run_query_synchronous_no_params(query).await?;
+
+    // Poll system.mutations until no pending mutations remain for this table.
+    let poll_interval = Duration::from_millis(100);
+    let timeout = Duration::from_secs(300);
+    let start = std::time::Instant::now();
+
+    loop {
+        let query = format!(
+            "SELECT count() FROM system.mutations WHERE database = currentDatabase() AND table = '{table}' AND is_done = 0 FORMAT CSV"
+        );
+        let result = clickhouse.run_query_synchronous_no_params(query).await?;
+
+        let pending: i64 = result.response.trim().parse().map_err(|e| {
+            Error::new(ErrorDetails::ClickHouseMigration {
+                id: "materialize_index".to_string(),
+                message: format!("Failed to parse pending mutation count for table `{table}`: {e}"),
+            })
+        })?;
+
+        if pending == 0 {
+            return Ok(());
+        }
+
+        if start.elapsed() > timeout {
+            return Err(ErrorDetails::ClickHouseMigration {
+                id: "materialize_index".to_string(),
+                message: format!(
+                    "Timed out waiting for MATERIALIZE INDEX `{index}` on table `{table}` to complete ({pending} mutations still pending after {}s)",
+                    timeout.as_secs()
+                ),
+            }
+            .into());
+        }
+
+        tokio::time::sleep(poll_interval).await;
+    }
 }


### PR DESCRIPTION
## Summary

Fixes flaky ClickHouse migrations by making `MATERIALIZE INDEX` non-blocking.

## Problem

Migrations 0027 and 0046 create bloom filter indices on several tables (10 total across both migrations). Each index creation involves two steps:

1. `ALTER TABLE ... ADD INDEX IF NOT EXISTS ...` — fast metadata-only operation
2. `ALTER TABLE ... MATERIALIZE INDEX ...` — rewrites existing data parts to build the bloom filter

The problem is that **all queries** go through `run_query_synchronous`, which sets `mutations_sync=2` and `alter_sync=2` at the connection level. This means `MATERIALIZE INDEX` blocks the HTTP connection until the mutation completes **on all replicas**.

This causes flakiness because:
- The HTTP connection is held open for the entire duration of the mutation (can be long on large tables)
- If multiple gateway instances start concurrently (e.g. in tests or rolling deploys), they all submit `MATERIALIZE INDEX` mutations on the same tables, creating lock contention on part-level locks
- Mutations on the same table are executed sequentially in ClickHouse, so queued mutations compound the wait time

## Fix

We now submit `MATERIALIZE INDEX` with an inline `SETTINGS mutations_sync = 0` clause, which **overrides** the connection-level `mutations_sync=2`. This makes the mutation submission return immediately.

We then poll `system.mutations` to wait for all pending mutations on the table to complete:

```sql
SELECT count() FROM system.mutations
WHERE database = currentDatabase() AND table = '{table}' AND is_done = 0
```

This approach:
- **Avoids holding a blocking HTTP connection** for the entire mutation duration
- **Handles concurrent submissions gracefully** — if another process already submitted the same mutation, we just wait for all mutations to finish
- **Has a 5-minute timeout** with 100ms polling interval
- **Requires no changes to the ClickHouse client trait** — the fix is self-contained in the migration helpers

The new `materialize_index` helper in `migrations/mod.rs` encapsulates this pattern and is used by both migration 0027 and 0046.

## Test plan
- [x] Unit tests pass (2279/2279)
- [x] E2E tests with ClickHouse (CI)
- [x] Verify migrations 0027 and 0046 apply successfully on a fresh ClickHouse instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)