### PR TITLE
Add `gepa` to default whitelisted tool names

### DIFF
--- a/crates/autopilot-tools/src/lib.rs
+++ b/crates/autopilot-tools/src/lib.rs
@@ -94,6 +94,7 @@ pub fn default_whitelisted_tool_names() -> HashSet<String> {
         "get_inferences",
         "upload_dataset",
         "list_episodes",
+        "gepa",
     ]
     .into_iter()
     .map(String::from)


### PR DESCRIPTION
## Summary
- Add `gepa` to `default_whitelisted_tool_names()` so autopilot durable tasks don't hang waiting for approval when `gepa` is called.

## Test plan
- [x] `cargo check --all-targets --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test-unit-fast` (2699 tests pass)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the set of automatically approved tools by adding `gepa`, which changes approval/guardrail behavior for optimization runs. Low code complexity, but it affects operational safety controls around tool execution.
> 
> **Overview**
> Adds `gepa` to `default_whitelisted_tool_names()` in `autopilot-tools`, allowing GEPA runs to proceed without manual approval in durable task execution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45318b1fdef877ba32e2b3f19a1f8fa0bf41f21f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->