### PR TITLE
Use 16 retries for azure tests

### DIFF
--- a/crates/.config/nextest.toml
+++ b/crates/.config/nextest.toml
@@ -142,7 +142,7 @@ retries = { backoff = "exponential", count = 8, delay = "5s", jitter = true, max
 [[profile.default.overrides]]
 filter = 'binary(e2e) and test(providers::azure::)'
 # We have a low rate limit on Azure, so we often need to retry several times
-retries = { backoff = "exponential", count = 8, delay = "5s", jitter = true, max-delay = "120s" }
+retries = { backoff = "exponential", count = 16, delay = "5s", jitter = true, max-delay = "120s" }
 
 [[profile.default.overrides]]
 filter = 'test(test_clickhouse_migration_manager)'


### PR DESCRIPTION
We keep getting rate-limited in the daily provider-proxy regen job, so let's use even more retries

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that may increase CI runtime but should reduce flakiness from Azure rate limiting.
> 
> **Overview**
> In `crates/.config/nextest.toml`, increases the `cargo nextest` retry count for Azure provider E2E tests (`binary(e2e) and test(providers::azure::)`) from 8 to 16 to better tolerate rate limiting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f73f55c67e66efd221786812d7a0083cf93d1b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->