### PR TITLE
Add deprecation warning for sequential GEPA optimization workflow

### DIFF
--- a/crates/tensorzero-optimizers/src/gepa/sequential/mod.rs
+++ b/crates/tensorzero-optimizers/src/gepa/sequential/mod.rs
@@ -49,6 +49,14 @@ impl Optimizer for GEPAConfig {
         db: &Arc<dyn DelegatingDatabaseQueries + Send + Sync>,
         config: std::sync::Arc<Config>,
     ) -> Result<Self::Handle, Error> {
+        tracing::warn!(
+            "The optimization workflow API for GEPA is deprecated. \
+             Please use the dedicated GEPA API instead: \
+             HTTP: `POST /v1/optimization/gepa` (launch) and `GET /v1/optimization/gepa/{{task_id}}` (poll), \
+             Python: `client.optimization.gepa.launch(...)` and `client.optimization.gepa.get(task_id=...)`, \
+             Rust: `client.gepa_launch(...)` and `client.gepa_get(...)`"
+        );
+
         // Validate configuration and examples, get the FunctionContext (function_config, static_tools, and evaluation_config)
         let function_context = validate_gepa_config(self, &config)?;
 


### PR DESCRIPTION
## Summary
- Adds a `tracing::warn!` deprecation message when GEPA is launched through the old optimization workflow (`launch_optimization` / `experimental_launch_optimization`)
- Directs users to the dedicated GEPA API (HTTP, Python, and Rust clients)

## Test plan
- [x] `cargo check --all-targets --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Pre-commit hooks pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a `tracing::warn!` message and does not change GEPA optimization behavior or data flow.
> 
> **Overview**
> Adds a `tracing::warn!` deprecation warning when launching sequential GEPA via the legacy optimization workflow API, directing users to the dedicated GEPA endpoints and client methods (HTTP/Python/Rust).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdbe7ee5eaf6fee60212dd29bed17381d5423605. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->