### PR TITLE
made other struct fields public

### DIFF
--- a/crates/autopilot-client/src/types/autoevals.rs
+++ b/crates/autopilot-client/src/types/autoevals.rs
@@ -77,15 +77,15 @@ pub enum AutoEvalExampleSource {
 #[cfg_attr(feature = "ts-bindings", ts(export))]
 pub struct AutoEvalExampleSourceInference {
     /// The inference ID of the historical datapoint for auto evals
-    id: Uuid,
+    pub id: Uuid,
 }
 
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "ts-bindings", ts(export))]
 pub struct AutoEvalExampleSourceSynthetic {
-    full_prompt: Option<AutoEvalContentBlock>,
-    full_response: AutoEvalContentBlock,
+    pub full_prompt: Option<AutoEvalContentBlock>,
+    pub full_response: AutoEvalContentBlock,
 }
 
 /// A multiple-choice labeling question within an autoeval example.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a visibility/API-surface change only, with no behavioral or data-handling logic changes.
> 
> **Overview**
> Makes previously private fields on autoeval source types public: `AutoEvalExampleSourceInference.id` and `AutoEvalExampleSourceSynthetic.full_prompt`/`full_response`, enabling external crates (and generated TS bindings) to access these values directly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8de1842985e04f565d65116c710b4474017d13a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->