### PR TITLE
Evaluator config dropping

### DIFF
--- a/crates/tensorzero-core/src/evaluations/mod.rs
+++ b/crates/tensorzero-core/src/evaluations/mod.rs
@@ -134,6 +134,24 @@ impl EvaluatorConfig {
             }
         }
     }
+
+    /// Converts this loaded evaluator config back to its uninitialized form.
+    /// Note: For LLMJudge evaluators, variant information cannot be reconstructed
+    /// as it's stored separately in the function table, so an empty variants map is used.
+    pub fn as_uninitialized(&self) -> UninitializedEvaluatorConfig {
+        match self {
+            EvaluatorConfig::ExactMatch(config) => {
+                UninitializedEvaluatorConfig::ExactMatch(config.clone())
+            }
+            EvaluatorConfig::LLMJudge(config) => {
+                UninitializedEvaluatorConfig::LLMJudge(config.as_uninitialized())
+            }
+            EvaluatorConfig::ToolUse(config) => {
+                UninitializedEvaluatorConfig::ToolUse(config.clone())
+            }
+            EvaluatorConfig::Regex(config) => UninitializedEvaluatorConfig::Regex(config.clone()),
+        }
+    }
 }
 
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
@@ -212,6 +230,24 @@ pub struct LLMJudgeConfig {
     pub cutoff: Option<f32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+}
+
+impl LLMJudgeConfig {
+    /// Converts this loaded LLM judge config back to its uninitialized form.
+    /// Note: Variant information cannot be reconstructed as it's stored separately
+    /// in the function table during loading, so an empty variants map is used.
+    #[expect(deprecated)]
+    pub fn as_uninitialized(&self) -> UninitializedLLMJudgeConfig {
+        UninitializedLLMJudgeConfig {
+            input_format: self.input_format.clone(),
+            variants: HashMap::new(),
+            output_type: self.output_type,
+            optimize: self.optimize,
+            include: self.include.clone(),
+            cutoff: self.cutoff,
+            description: self.description.clone(),
+        }
+    }
 }
 
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]

--- a/crates/tensorzero-core/src/function/function_config.rs
+++ b/crates/tensorzero-core/src/function/function_config.rs
@@ -228,7 +228,11 @@ impl FunctionConfigChat {
             parallel_tool_calls: self.parallel_tool_calls,
             description: self.description.clone(),
             experimentation: None,
-            evaluators: HashMap::new(),
+            evaluators: self
+                .evaluators
+                .iter()
+                .map(|(k, v)| (k.clone(), v.as_uninitialized()))
+                .collect(),
         }
     }
 }
@@ -251,7 +255,11 @@ impl FunctionConfigJson {
             )),
             description: self.description.clone(),
             experimentation: None,
-            evaluators: HashMap::new(),
+            evaluators: self
+                .evaluators
+                .iter()
+                .map(|(k, v)| (k.clone(), v.as_uninitialized()))
+                .collect(),
         }
     }
 }


### PR DESCRIPTION
Fixes evaluators being silently dropped in `as_uninitialized` round-trip methods.

The `as_uninitialized` methods for `FunctionConfigChat` and `FunctionConfigJson` were incorrectly hardcoding empty HashMaps for evaluators, leading to silent data loss during serialization when converting `EvaluatorConfig` to `UninitializedEvaluatorConfig`. This PR introduces an `as_uninitialized` method for `EvaluatorConfig` and uses it to correctly convert evaluators, preventing data loss.