### PR TITLE
Add FMA read-only API client methods to autopilot-client

### DIFF
--- a/crates/autopilot-client/src/client.rs
+++ b/crates/autopilot-client/src/client.rs
@@ -1046,6 +1046,133 @@ impl AutopilotClient {
     }
 
     // -------------------------------------------------------------------------
+    // Failure Mode Analysis Endpoints
+    // -------------------------------------------------------------------------
+
+    /// Lists active failure modes for a deployment/function.
+    pub async fn list_failure_modes(
+        &self,
+        deployment_id: &str,
+        function_name: &str,
+        params: crate::types::FmaCursorPaginationParams,
+    ) -> Result<crate::types::ListFailureModesResponse, AutopilotError> {
+        let url = self.base_url.join(&format!(
+            "/v1/deployments/{deployment_id}/functions/{function_name}/failure-modes"
+        ))?;
+        let response = self
+            .http_client
+            .get(url)
+            .headers(self.auth_headers())
+            .query(&params)
+            .send()
+            .await?;
+        let response = self.check_response(response).await?;
+        Ok(response.json().await?)
+    }
+
+    /// Gets a single failure mode by ID.
+    pub async fn get_failure_mode(
+        &self,
+        deployment_id: &str,
+        function_name: &str,
+        failure_mode_id: Uuid,
+    ) -> Result<crate::types::FailureModeResponse, AutopilotError> {
+        let url = self.base_url.join(&format!(
+            "/v1/deployments/{deployment_id}/functions/{function_name}/failure-modes/{failure_mode_id}"
+        ))?;
+        let response = self
+            .http_client
+            .get(url)
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        let response = self.check_response(response).await?;
+        Ok(response.json().await?)
+    }
+
+    /// Lists active failures for a deployment/function.
+    pub async fn list_failures(
+        &self,
+        deployment_id: &str,
+        function_name: &str,
+        params: crate::types::ListFailuresParams,
+    ) -> Result<crate::types::ListFailuresResponse, AutopilotError> {
+        let url = self.base_url.join(&format!(
+            "/v1/deployments/{deployment_id}/functions/{function_name}/failures"
+        ))?;
+        let response = self
+            .http_client
+            .get(url)
+            .headers(self.auth_headers())
+            .query(&params)
+            .send()
+            .await?;
+        let response = self.check_response(response).await?;
+        Ok(response.json().await?)
+    }
+
+    /// Gets a single failure by ID.
+    pub async fn get_failure(
+        &self,
+        deployment_id: &str,
+        function_name: &str,
+        failure_id: Uuid,
+    ) -> Result<crate::types::FailureResponse, AutopilotError> {
+        let url = self.base_url.join(&format!(
+            "/v1/deployments/{deployment_id}/functions/{function_name}/failures/{failure_id}"
+        ))?;
+        let response = self
+            .http_client
+            .get(url)
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        let response = self.check_response(response).await?;
+        Ok(response.json().await?)
+    }
+
+    /// Lists analyses for a deployment/function.
+    pub async fn list_analyses(
+        &self,
+        deployment_id: &str,
+        function_name: &str,
+        params: crate::types::FmaCursorPaginationParams,
+    ) -> Result<crate::types::ListAnalysesResponse, AutopilotError> {
+        let url = self.base_url.join(&format!(
+            "/v1/deployments/{deployment_id}/functions/{function_name}/failure-mode-analyses"
+        ))?;
+        let response = self
+            .http_client
+            .get(url)
+            .headers(self.auth_headers())
+            .query(&params)
+            .send()
+            .await?;
+        let response = self.check_response(response).await?;
+        Ok(response.json().await?)
+    }
+
+    /// Gets a single analysis by ID.
+    pub async fn get_analysis(
+        &self,
+        deployment_id: &str,
+        function_name: &str,
+        analysis_id: Uuid,
+    ) -> Result<crate::types::AnalysisResponse, AutopilotError> {
+        let url = self.base_url.join(&format!(
+            "/v1/deployments/{deployment_id}/functions/{function_name}/failure-mode-analyses/{analysis_id}"
+        ))?;
+        let response = self
+            .http_client
+            .get(url)
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        let response = self.check_response(response).await?;
+        Ok(response.json().await?)
+    }
+
+    // -------------------------------------------------------------------------
     // Tool Whitelist Auto-Approval
     // -------------------------------------------------------------------------
 

--- a/crates/autopilot-client/src/types/mod.rs
+++ b/crates/autopilot-client/src/types/mod.rs
@@ -1042,6 +1042,98 @@ pub struct S3UploadResponse {
 }
 
 // =============================================================================
+// Failure Mode Analysis Types
+// =============================================================================
+
+/// Query parameters for cursor-based pagination on FMA endpoints.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FmaCursorPaginationParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+}
+
+/// Query parameters for listing failures.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ListFailuresParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_mode_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unclassified: Option<bool>,
+}
+
+/// A failure mode returned by the FMA API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailureModeResponse {
+    pub id: Uuid,
+    pub analysis_id: Uuid,
+    pub name: String,
+    pub description: String,
+    pub failure_count: i64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// A failure returned by the FMA API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailureResponse {
+    pub id: Uuid,
+    pub analysis_id: Uuid,
+    pub failure_mode_id: Option<Uuid>,
+    pub episode_id: Uuid,
+    pub inference_id: Option<Uuid>,
+    pub characterization: String,
+    pub pinned: bool,
+    pub failure_mode_id_is_user_provided: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// An analysis returned by the FMA API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnalysisResponse {
+    pub id: Uuid,
+    pub deployment_id: String,
+    pub function_name: String,
+    pub tool_name: String,
+    pub session_id: Option<Uuid>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instruction: Option<String>,
+    pub filters: Option<serde_json::Value>,
+    pub max_failures: Option<i32>,
+    pub fit_score: Option<f64>,
+    pub failure_mode_count: i64,
+    pub failure_count: i64,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Response from listing failure modes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListFailureModesResponse {
+    pub failure_modes: Vec<FailureModeResponse>,
+    pub next_cursor: Option<Uuid>,
+}
+
+/// Response from listing failures.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListFailuresResponse {
+    pub failures: Vec<FailureResponse>,
+    pub next_cursor: Option<Uuid>,
+}
+
+/// Response from listing analyses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListAnalysesResponse {
+    pub analyses: Vec<AnalysisResponse>,
+    pub next_cursor: Option<Uuid>,
+}
+
+// =============================================================================
 // Error Types
 // =============================================================================
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, additive client methods/types for new read-only Failure Mode Analysis endpoints; primary risk is mismatched request/response shapes with the server API.
> 
> **Overview**
> Adds read-only Failure Mode Analysis (FMA) support to `autopilot-client`.
> 
> The client now exposes new GET helpers to list/fetch `failure-modes`, `failures` (with optional filtering), and `failure-mode-analyses` for a deployment/function, and introduces the corresponding request/response wire types (cursor pagination params and FMA response structs) in `types/mod.rs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ceeb3e54c0f835ee9b32b3de3a5ed1d6d6d7b20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->