### PR TITLE
Update aws-lc-rs to fix cargo-deny advisories

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
## Summary
- Updates `aws-lc-rs` 1.16.1 → 1.16.2 (`aws-lc-sys` 0.38.0 → 0.39.0)
- Fixes RUSTSEC-2026-0044 (X.509 Name Constraints Bypass) and RUSTSEC-2026-0048 (CRL Distribution Point Logic Error)
- Unblocks `cargo-deny` CI failures on all branches

## Test plan
- [ ] `cargo-deny` check passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)