### PR TITLE
Add SBOM and provenance attestations to CI Docker builds

### DIFF
--- a/.github/workflows/build-fixtures-container.yml
+++ b/.github/workflows/build-fixtures-container.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build and push `fixtures` container
         run: |
-          docker buildx build -f ui/fixtures/Dockerfile . -t tensorzero/fixtures:sha-${{ github.sha }} --push
+          docker buildx build --sbom=true --provenance=true -f ui/fixtures/Dockerfile . -t tensorzero/fixtures:sha-${{ github.sha }} --push
 
       - name: Wait for image to be available on Docker Hub
         run: |

--- a/.github/workflows/build-gateway-container.yml
+++ b/.github/workflows/build-gateway-container.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build and push `gateway` container
         run: |
-          docker buildx build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 --build-arg PROFILE=dev -f crates/gateway/Dockerfile . -t tensorzero/gateway-dev:sha-${{ github.sha }} --push
+          docker buildx build --sbom=true --provenance=true --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 --build-arg PROFILE=dev -f crates/gateway/Dockerfile . -t tensorzero/gateway-dev:sha-${{ github.sha }} --push
 
       - name: Wait for image to be available on Docker Hub
         run: |

--- a/.github/workflows/build-gateway-e2e-container.yml
+++ b/.github/workflows/build-gateway-e2e-container.yml
@@ -46,7 +46,7 @@ jobs:
       # It does *not* push to the production 'tensorzero/gateway' repo.
       - name: Build and push `gateway-e2e` container
         run: |
-          docker buildx build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f crates/gateway/Dockerfile --build-arg PROFILE=dev --build-arg "CARGO_BUILD_FLAGS=--features e2e_tests" --target gateway . -t tensorzero/gateway-e2e:sha-${{ github.sha }} --push
+          docker buildx build --sbom=true --provenance=true --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f crates/gateway/Dockerfile --build-arg PROFILE=dev --build-arg "CARGO_BUILD_FLAGS=--features e2e_tests" --target gateway . -t tensorzero/gateway-e2e:sha-${{ github.sha }} --push
 
       - name: Wait for image to be available on Docker Hub
         run: |

--- a/.github/workflows/build-live-tests-container.yml
+++ b/.github/workflows/build-live-tests-container.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build and push `live-tests` container
         run: |
-          docker buildx build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f crates/tensorzero-core/tests/e2e/Dockerfile.live . -t tensorzero/live-tests:sha-${{ github.sha }} --push
+          docker buildx build --sbom=true --provenance=true --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f crates/tensorzero-core/tests/e2e/Dockerfile.live . -t tensorzero/live-tests:sha-${{ github.sha }} --push
 
       - name: Wait for image to be available on Docker Hub
         run: |

--- a/.github/workflows/build-mock-provider-api-container.yml
+++ b/.github/workflows/build-mock-provider-api-container.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build and push `mock-provider-api` container
         run: |
-          docker buildx build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f crates/tensorzero-core/tests/mock-provider-api/Dockerfile . -t tensorzero/mock-provider-api:sha-${{ github.sha }} --push
+          docker buildx build --sbom=true --provenance=true --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f crates/tensorzero-core/tests/mock-provider-api/Dockerfile . -t tensorzero/mock-provider-api:sha-${{ github.sha }} --push
 
       - name: Wait for image to be available on Docker Hub
         run: |

--- a/.github/workflows/build-provider-proxy-container.yml
+++ b/.github/workflows/build-provider-proxy-container.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build and push `provider-proxy` container
         run: |
-          docker buildx build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f crates/provider-proxy/Dockerfile --target provider-proxy . -t tensorzero/provider-proxy:sha-${{ github.sha }} --push
+          docker buildx build --sbom=true --provenance=true --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f crates/provider-proxy/Dockerfile --target provider-proxy . -t tensorzero/provider-proxy:sha-${{ github.sha }} --push
 
       - name: Wait for image to be available on Docker Hub
         run: |

--- a/.github/workflows/build-ui-container.yml
+++ b/.github/workflows/build-ui-container.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build and push `ui` container
         run: |
-          docker buildx build --build-arg DEBUG_BUILD=1 --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f ui/Dockerfile . -t tensorzero/ui-dev:sha-${{ github.sha }} --push
+          docker buildx build --sbom=true --provenance=true --build-arg DEBUG_BUILD=1 --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -f ui/Dockerfile . -t tensorzero/ui-dev:sha-${{ github.sha }} --push
 
       - name: Wait for image to be available on Docker Hub
         run: |


### PR DESCRIPTION
## Summary
- Adds `--sbom=true --provenance=true` to all 7 CI `docker buildx build` commands
- The publish workflow (`docker-hub-publish.yml`) already had `sbom: true` and `provenance: mode=max` — this brings the CI build workflows to parity
- Embeds full dependency manifests so Docker Scout can detect Rust/Cargo-level vulnerabilities in minimal (distroless) images that only ship a compiled binary
- No Dockerfiles strip binaries (verified), so embedded metadata is preserved

**Workflows updated:**
- `build-provider-proxy-container.yml`
- `build-ui-container.yml`
- `build-live-tests-container.yml`
- `build-fixtures-container.yml`
- `build-gateway-container.yml`
- `build-mock-provider-api-container.yml`
- `build-gateway-e2e-container.yml`

## Test plan
- [ ] CI passes (all container builds succeed with the new flags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)