### PR TITLE
Add CODEOWNERS entry for /docs directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,3 +9,5 @@
 /crates/tensorzero-core/src/db/clickhouse/migration_manager @virajmehta @Aaron1011
 /crates/tensorzero-core/src/db/postgres/migrations @virajmehta @Aaron1011
 /crates/tensorzero-auth/src/postgres/migrations @virajmehta @Aaron1011
+
+/docs @GabrielBianconi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates repository ownership rules in `CODEOWNERS` with no runtime or build impact.
> 
> **Overview**
> Adds a `CODEOWNERS` rule for the `/docs` directory, assigning review ownership to `@GabrielBianconi`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 434649a071c68271d9f6796968f7cd79afeab57e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->