### PR TITLE
Fix cargo deny

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -5985,9 +5985,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk lockfile-only change that bumps a single TLS-related dependency; risk is limited to potential downstream build/compatibility differences from the patch update.
> 
> **Overview**
> Updates the Rust dependency lockfile to bump `rustls-webpki` from `0.103.9` to `0.103.10` (with the corresponding checksum change), likely to satisfy dependency policy checks (e.g., `cargo-deny`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00097506b4026585a34a6c6dcbd4aef1970c7eb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->