### PR TITLE
feat: Add Novita AI as a new LLM provider

### DIFF
--- a/crates/tensorzero-core/src/config/provider_types.rs
+++ b/crates/tensorzero-core/src/config/provider_types.rs
@@ -25,6 +25,8 @@ pub struct ProviderTypesConfig {
     #[serde(default)]
     pub mistral: MistralProviderTypeConfig,
     #[serde(default)]
+    pub novita: NovitaProviderTypeConfig,
+    #[serde(default)]
     pub openai: OpenAIProviderTypeConfig,
     #[serde(default)]
     pub openrouter: OpenRouterProviderTypeConfig,
@@ -453,6 +455,29 @@ impl Default for VLLMDefaults {
         Self {
             api_key_location: CredentialLocationWithFallback::Single(CredentialLocation::Env(
                 "VLLM_API_KEY".to_string(),
+            )),
+        }
+    }
+}
+
+// Novita
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct NovitaProviderTypeConfig {
+    #[serde(default)]
+    pub defaults: NovitaDefaults,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct NovitaDefaults {
+    pub api_key_location: CredentialLocationWithFallback,
+}
+
+impl Default for NovitaDefaults {
+    fn default() -> Self {
+        Self {
+            api_key_location: CredentialLocationWithFallback::Single(CredentialLocation::Env(
+                "NOVITA_API_KEY".to_string(),
             )),
         }
     }

--- a/crates/tensorzero-core/src/embeddings.rs
+++ b/crates/tensorzero-core/src/embeddings.rs
@@ -19,8 +19,9 @@ use crate::inference::types::extra_headers::ExtraHeadersConfig;
 use crate::inference::types::{ContentBlock, Text};
 use crate::model::{ModelProviderRequestInfo, UninitializedProviderConfig};
 use crate::model_table::{BaseModelTable, ProviderKind, ProviderTypeDefaultCredentials};
-use crate::model_table::{OpenAIKind, OpenRouterKind, ShorthandModelConfig};
+use crate::model_table::{NovitaKind, OpenAIKind, OpenRouterKind, ShorthandModelConfig};
 use crate::providers::azure::AzureProvider;
+use crate::providers::novita::NovitaProvider;
 use crate::providers::openrouter::OpenRouterProvider;
 use crate::rate_limiting::{
     EstimatedRateLimitResourceUsage, RateLimitResource, RateLimitResourceUsage,
@@ -51,7 +52,7 @@ use crate::providers::dummy::DummyProvider;
 pub type EmbeddingModelTable = BaseModelTable<EmbeddingModelConfig>;
 
 impl ShorthandModelConfig for EmbeddingModelConfig {
-    const SHORTHAND_MODEL_PREFIXES: &[&str] = &["openai::", "openrouter::"];
+    const SHORTHAND_MODEL_PREFIXES: &[&str] = &["openai::", "openrouter::", "novita::"];
     const MODEL_TYPE: &str = "Embedding model";
     async fn from_shorthand(
         provider_type: &str,
@@ -74,6 +75,12 @@ impl ShorthandModelConfig for EmbeddingModelConfig {
             "openrouter" => EmbeddingProviderConfig::OpenRouter(OpenRouterProvider::new(
                 model_name,
                 OpenRouterKind
+                    .get_defaulted_credential(None, default_credentials)
+                    .await?,
+            )),
+            "novita" => EmbeddingProviderConfig::Novita(NovitaProvider::new(
+                model_name,
+                NovitaKind
                     .get_defaulted_credential(None, default_credentials)
                     .await?,
             )),
@@ -618,6 +625,7 @@ pub enum EmbeddingProviderConfig {
     OpenAI(OpenAIProvider),
     Azure(AzureProvider),
     OpenRouter(OpenRouterProvider),
+    Novita(NovitaProvider),
     #[cfg(any(test, feature = "e2e_tests"))]
     Dummy(DummyProvider),
 }
@@ -628,6 +636,7 @@ impl EmbeddingProviderConfig {
             EmbeddingProviderConfig::OpenAI(_) => crate::providers::openai::PROVIDER_TYPE,
             EmbeddingProviderConfig::Azure(_) => crate::providers::azure::PROVIDER_TYPE,
             EmbeddingProviderConfig::OpenRouter(_) => crate::providers::openrouter::PROVIDER_TYPE,
+            EmbeddingProviderConfig::Novita(_) => crate::providers::novita::PROVIDER_TYPE,
             #[cfg(any(test, feature = "e2e_tests"))]
             EmbeddingProviderConfig::Dummy(_) => crate::providers::dummy::PROVIDER_TYPE,
         }
@@ -790,6 +799,14 @@ impl UninitializedEmbeddingProviderConfig {
                 extra_headers,
                 cost,
             },
+            ProviderConfig::Novita(provider) => EmbeddingProviderInfo {
+                inner: EmbeddingProviderConfig::Novita(provider),
+                timeout_ms,
+                provider_name,
+                extra_body,
+                extra_headers,
+                cost,
+            },
             #[cfg(any(test, feature = "e2e_tests"))]
             ProviderConfig::Dummy(provider) => EmbeddingProviderInfo {
                 inner: EmbeddingProviderConfig::Dummy(provider),
@@ -830,6 +847,11 @@ impl EmbeddingProvider for EmbeddingProviderConfig {
                     .await
             }
             EmbeddingProviderConfig::OpenRouter(provider) => {
+                provider
+                    .embed(request, client, dynamic_api_keys, model_provider_data)
+                    .await
+            }
+            EmbeddingProviderConfig::Novita(provider) => {
                 provider
                     .embed(request, client, dynamic_api_keys, model_provider_data)
                     .await

--- a/crates/tensorzero-core/src/model.rs
+++ b/crates/tensorzero-core/src/model.rs
@@ -54,12 +54,13 @@ use crate::inference::types::{
 };
 use crate::model_table::{
     AnthropicKind, AzureKind, BaseModelTable, DeepSeekKind, FireworksKind,
-    GoogleAIStudioGeminiKind, GroqKind, HyperbolicKind, MistralKind, OpenAIKind, OpenRouterKind,
-    ProviderTypeDefaultCredentials, SGLangKind, ShorthandModelConfig, TGIKind, TogetherKind,
-    VLLMKind, XAIKind,
+    GoogleAIStudioGeminiKind, GroqKind, HyperbolicKind, MistralKind, NovitaKind, OpenAIKind,
+    OpenRouterKind, ProviderTypeDefaultCredentials, SGLangKind, ShorthandModelConfig, TGIKind,
+    TogetherKind, VLLMKind, XAIKind,
 };
 use crate::providers::helpers::peek_first_chunk;
 use crate::providers::hyperbolic::HyperbolicProvider;
+use crate::providers::novita::NovitaProvider;
 use crate::providers::openai::OpenAIAPIType;
 use crate::providers::sglang::SGLangProvider;
 use crate::providers::tgi::TGIProvider;
@@ -1075,6 +1076,7 @@ impl ModelProvider {
             ProviderConfig::Groq(_) => crate::providers::groq::PROVIDER_TYPE,
             ProviderConfig::Hyperbolic(_) => crate::providers::hyperbolic::PROVIDER_TYPE,
             ProviderConfig::Mistral(_) => crate::providers::mistral::PROVIDER_TYPE,
+            ProviderConfig::Novita(_) => crate::providers::novita::PROVIDER_TYPE,
             ProviderConfig::OpenAI(_) => crate::providers::openai::PROVIDER_TYPE,
             ProviderConfig::OpenRouter(_) => crate::providers::openrouter::PROVIDER_TYPE,
             ProviderConfig::Together(_) => crate::providers::together::PROVIDER_TYPE,
@@ -1112,6 +1114,7 @@ impl ModelProvider {
             ProviderConfig::Groq(provider) => Some(provider.model_name()),
             ProviderConfig::Hyperbolic(provider) => Some(provider.model_name()),
             ProviderConfig::Mistral(provider) => Some(provider.model_name()),
+            ProviderConfig::Novita(provider) => Some(provider.model_name()),
             ProviderConfig::OpenAI(provider) => Some(provider.model_name()),
             ProviderConfig::OpenRouter(provider) => Some(provider.model_name()),
             ProviderConfig::Together(provider) => Some(provider.model_name()),
@@ -1167,6 +1170,7 @@ pub enum ProviderConfig {
     Groq(GroqProvider),
     Hyperbolic(HyperbolicProvider),
     Mistral(MistralProvider),
+    Novita(NovitaProvider),
     OpenAI(OpenAIProvider),
     OpenRouter(OpenRouterProvider),
     #[serde(rename = "sglang")]
@@ -1219,6 +1223,7 @@ impl ProviderConfig {
                 Cow::Borrowed(crate::providers::hyperbolic::PROVIDER_TYPE)
             }
             ProviderConfig::Mistral(_) => Cow::Borrowed(crate::providers::mistral::PROVIDER_TYPE),
+            ProviderConfig::Novita(_) => Cow::Borrowed(crate::providers::novita::PROVIDER_TYPE),
             ProviderConfig::OpenAI(_) => Cow::Borrowed(crate::providers::openai::PROVIDER_TYPE),
             ProviderConfig::OpenRouter(_) => {
                 Cow::Borrowed(crate::providers::openrouter::PROVIDER_TYPE)
@@ -1262,6 +1267,7 @@ impl ProviderConfig {
             ProviderConfig::Groq(_) => false,
             ProviderConfig::Hyperbolic(_) => false,
             ProviderConfig::Mistral(_) => false,
+            ProviderConfig::Novita(_) => false,
             ProviderConfig::OpenRouter(_) => false,
             ProviderConfig::SGLang(_) => false,
             ProviderConfig::TGI(_) => false,
@@ -1408,6 +1414,11 @@ pub enum UninitializedProviderConfig {
         #[cfg_attr(feature = "ts-bindings", ts(type = "string | null"))]
         api_key_location: Option<CredentialLocationWithFallback>,
         prompt_mode: Option<String>,
+    },
+    Novita {
+        model_name: String,
+        #[cfg_attr(feature = "ts-bindings", ts(type = "string | null"))]
+        api_key_location: Option<CredentialLocationWithFallback>,
     },
     OpenAI {
         model_name: String,
@@ -1712,6 +1723,18 @@ impl UninitializedProviderConfig {
                     )
                     .await?,
                 prompt_mode,
+            )),
+            UninitializedProviderConfig::Novita {
+                model_name,
+                api_key_location,
+            } => ProviderConfig::Novita(NovitaProvider::new(
+                model_name,
+                NovitaKind
+                    .get_defaulted_credential(
+                        api_key_location.as_ref(),
+                        provider_type_default_credentials,
+                    )
+                    .await?,
             )),
             UninitializedProviderConfig::OpenAI {
                 model_name,
@@ -2038,6 +2061,11 @@ impl ModelProvider {
                     .infer(request, &clients.http_client, &clients.credentials, self)
                     .await
             }
+            ProviderConfig::Novita(provider) => {
+                provider
+                    .infer(request, &clients.http_client, &clients.credentials, self)
+                    .await
+            }
             ProviderConfig::OpenAI(provider) => {
                 provider
                     .infer(request, &clients.http_client, &clients.credentials, self)
@@ -2172,6 +2200,11 @@ impl ModelProvider {
                     .infer_stream(request, &clients.http_client, &clients.credentials, self)
                     .await
             }
+            ProviderConfig::Novita(provider) => {
+                provider
+                    .infer_stream(request, &clients.http_client, &clients.credentials, self)
+                    .await
+            }
             ProviderConfig::OpenAI(provider) => {
                 provider
                     .infer_stream(request, &clients.http_client, &clients.credentials, self)
@@ -2293,6 +2326,11 @@ impl ModelProvider {
                     .start_batch_inference(requests, client, api_keys)
                     .await
             }
+            ProviderConfig::Novita(provider) => {
+                provider
+                    .start_batch_inference(requests, client, api_keys)
+                    .await
+            }
             ProviderConfig::OpenAI(provider) => {
                 provider
                     .start_batch_inference(requests, client, api_keys)
@@ -2400,6 +2438,11 @@ impl ModelProvider {
                     .await
             }
             ProviderConfig::Mistral(provider) => {
+                provider
+                    .poll_batch_inference(batch_request, http_client, dynamic_api_keys)
+                    .await
+            }
+            ProviderConfig::Novita(provider) => {
                 provider
                     .poll_batch_inference(batch_request, http_client, dynamic_api_keys)
                     .await
@@ -2750,6 +2793,7 @@ pub const SHORTHAND_MODEL_PREFIXES: &[&str] = &[
     "hyperbolic::",
     "groq::",
     "mistral::",
+    "novita::",
     "openai::",
     "openrouter::",
     "together::",
@@ -2868,6 +2912,12 @@ impl ShorthandModelConfig for ModelConfig {
             "together" => ProviderConfig::Together(TogetherProvider::new(
                 model_name,
                 TogetherKind
+                    .get_defaulted_credential(None, default_credentials)
+                    .await?,
+            )),
+            "novita" => ProviderConfig::Novita(NovitaProvider::new(
+                model_name,
+                NovitaKind
                     .get_defaulted_credential(None, default_credentials)
                     .await?,
             )),

--- a/crates/tensorzero-core/src/model_table.rs
+++ b/crates/tensorzero-core/src/model_table.rs
@@ -27,6 +27,7 @@ use crate::{
         groq::GroqCredentials,
         hyperbolic::HyperbolicCredentials,
         mistral::MistralCredentials,
+        novita::NovitaCredentials,
         openai::OpenAICredentials,
         openrouter::OpenRouterCredentials,
         sglang::SGLangCredentials,
@@ -96,6 +97,7 @@ pub enum ProviderType {
     Groq,
     Hyperbolic,
     Mistral,
+    Novita,
     OpenAI,
     OpenRouter,
     SGLang,
@@ -119,6 +121,7 @@ impl Display for ProviderType {
             ProviderType::Groq => write!(f, "Groq"),
             ProviderType::Hyperbolic => write!(f, "Hyperbolic"),
             ProviderType::Mistral => write!(f, "Mistral"),
+            ProviderType::Novita => write!(f, "Novita"),
             ProviderType::OpenAI => write!(f, "OpenAI"),
             ProviderType::OpenRouter => write!(f, "OpenRouter"),
             ProviderType::SGLang => write!(f, "SGLang"),
@@ -381,6 +384,7 @@ pub struct ProviderTypeDefaultCredentials {
     groq: LazyCredential<GroqCredentials>,
     hyperbolic: LazyCredential<HyperbolicCredentials>,
     mistral: LazyCredential<MistralCredentials>,
+    novita: LazyCredential<NovitaCredentials>,
     openai: LazyCredential<OpenAICredentials>,
     openrouter: LazyCredential<OpenRouterCredentials>,
     sglang: LazyCredential<SGLangCredentials>,
@@ -435,6 +439,11 @@ impl ProviderTypeDefaultCredentials {
             .clone();
         let mistral_location = provider_types_config
             .mistral
+            .defaults
+            .api_key_location
+            .clone();
+        let novita_location = provider_types_config
+            .novita
             .defaults
             .api_key_location
             .clone();
@@ -509,6 +518,9 @@ impl ProviderTypeDefaultCredentials {
             }),
             mistral: LazyCredential::new(move || {
                 load_credential_with_fallback(&mistral_location, ProviderType::Mistral)?.try_into()
+            }),
+            novita: LazyCredential::new(move || {
+                load_credential_with_fallback(&novita_location, ProviderType::Novita)?.try_into()
             }),
             openai: LazyCredential::new(move || {
                 load_credential_with_fallback(&openai_location, ProviderType::OpenAI)?.try_into()
@@ -941,6 +953,22 @@ impl ProviderKind for MistralKind {
         default_credentials: &ProviderTypeDefaultCredentials,
     ) -> Result<Self::Credential, Error> {
         default_credentials.mistral.get_cloned()
+    }
+}
+
+pub struct NovitaKind;
+
+impl ProviderKind for NovitaKind {
+    type Credential = NovitaCredentials;
+    fn get_provider_type(&self) -> ProviderType {
+        ProviderType::Novita
+    }
+
+    async fn get_credential_field(
+        &self,
+        default_credentials: &ProviderTypeDefaultCredentials,
+    ) -> Result<Self::Credential, Error> {
+        default_credentials.novita.get_cloned()
     }
 }
 

--- a/crates/tensorzero-core/src/providers/mod.rs
+++ b/crates/tensorzero-core/src/providers/mod.rs
@@ -16,6 +16,7 @@ pub mod helpers;
 pub mod helpers_thinking_block;
 pub mod hyperbolic;
 pub mod mistral;
+pub mod novita;
 pub mod openai;
 pub mod openrouter;
 pub mod sglang;

--- a/crates/tensorzero-core/src/providers/novita.rs
+++ b/crates/tensorzero-core/src/providers/novita.rs
@@ -1,0 +1,960 @@
+use std::borrow::Cow;
+
+use crate::cache::ModelProviderRequest;
+use crate::embeddings::{
+    Embedding, EmbeddingEncodingFormat, EmbeddingInput, EmbeddingProvider,
+    EmbeddingProviderRequestInfo, EmbeddingProviderResponse, EmbeddingRequest,
+};
+use crate::endpoints::inference::InferenceCredentials;
+use crate::error::{DelayedError, DisplayOrDebugGateway, Error, ErrorDetails};
+use crate::http::TensorzeroHttpClient;
+use crate::inference::types::batch::{BatchRequestRow, PollBatchInferenceResponse};
+use crate::inference::types::chat_completion_inference_params::{
+    ChatCompletionInferenceParamsV2, warn_inference_parameter_not_supported,
+};
+use crate::inference::types::extra_body::FullExtraBodyConfig;
+use crate::inference::types::usage::raw_usage_entries_from_value;
+use crate::inference::types::{ApiType, ContentBlockOutput, ProviderInferenceResponseArgs};
+use crate::inference::types::{
+    Latency, ModelInferenceRequest, PeekableProviderInferenceResponseStream,
+    ProviderInferenceResponse, batch::StartBatchProviderInferenceResponse,
+};
+use crate::model::{Credential, ModelProvider};
+use crate::providers::helpers::{
+    inject_extra_request_data_and_send, inject_extra_request_data_and_send_eventsource,
+};
+use crate::providers::openai::OpenAIMessagesConfig;
+use futures::{StreamExt, TryStreamExt};
+use lazy_static::lazy_static;
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::time::Instant;
+use url::Url;
+use uuid::Uuid;
+
+use super::openai::{
+    OpenAIRequestMessage, OpenAIResponse, OpenAIResponseChoice, SystemOrDeveloper, get_chat_url,
+    handle_openai_error, openai_response_tool_call_to_tensorzero_tool_call,
+    prepare_openai_messages, stream_openai,
+};
+use crate::inference::{InferenceProvider, TensorZeroEventError};
+
+lazy_static! {
+    static ref NOVITA_DEFAULT_BASE_URL: Url = {
+        #[expect(clippy::expect_used)]
+        Url::parse("https://api.novita.ai/openai/v1/")
+            .expect("Failed to parse NOVITA_DEFAULT_BASE_URL")
+    };
+}
+
+const PROVIDER_NAME: &str = "Novita";
+pub const PROVIDER_TYPE: &str = "novita";
+
+#[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "ts-bindings", ts(export))]
+pub struct NovitaProvider {
+    model_name: String,
+    #[serde(skip)]
+    credentials: NovitaCredentials,
+}
+
+impl NovitaProvider {
+    pub fn new(model_name: String, credentials: NovitaCredentials) -> Self {
+        NovitaProvider {
+            model_name,
+            credentials,
+        }
+    }
+
+    pub fn model_name(&self) -> &str {
+        &self.model_name
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum NovitaCredentials {
+    Static(SecretString),
+    Dynamic(String),
+    None,
+    WithFallback {
+        default: Box<NovitaCredentials>,
+        fallback: Box<NovitaCredentials>,
+    },
+}
+
+impl TryFrom<Credential> for NovitaCredentials {
+    type Error = Error;
+
+    fn try_from(credentials: Credential) -> Result<Self, Error> {
+        match credentials {
+            Credential::Static(key) => Ok(NovitaCredentials::Static(key)),
+            Credential::Dynamic(key_name) => Ok(NovitaCredentials::Dynamic(key_name)),
+            Credential::Missing => Ok(NovitaCredentials::None),
+            Credential::WithFallback { default, fallback } => Ok(NovitaCredentials::WithFallback {
+                default: Box::new((*default).try_into()?),
+                fallback: Box::new((*fallback).try_into()?),
+            }),
+            _ => Err(Error::new(ErrorDetails::Config {
+                message: "Invalid api_key_location for Novita provider".to_string(),
+            })),
+        }
+    }
+}
+
+impl NovitaCredentials {
+    fn get_api_key<'a>(
+        &'a self,
+        dynamic_api_keys: &'a InferenceCredentials,
+    ) -> Result<&'a SecretString, DelayedError> {
+        match self {
+            NovitaCredentials::Static(api_key) => Ok(api_key),
+            NovitaCredentials::Dynamic(key_name) => {
+                dynamic_api_keys.get(key_name).ok_or_else(|| {
+                    DelayedError::new(ErrorDetails::ApiKeyMissing {
+                        provider_name: PROVIDER_NAME.to_string(),
+                        message: format!("Dynamic api key `{key_name}` is missing"),
+                    })
+                })
+            }
+            NovitaCredentials::WithFallback { default, fallback } => {
+                match default.get_api_key(dynamic_api_keys) {
+                    Ok(key) => Ok(key),
+                    Err(e) => {
+                        e.log_at_level(
+                            "Using fallback credential, as default credential is unavailable: ",
+                            tracing::Level::WARN,
+                        );
+                        fallback.get_api_key(dynamic_api_keys)
+                    }
+                }
+            }
+            NovitaCredentials::None => Err(DelayedError::new(ErrorDetails::ApiKeyMissing {
+                provider_name: PROVIDER_NAME.to_string(),
+                message: "No credentials are set".to_string(),
+            })),
+        }
+    }
+}
+
+impl InferenceProvider for NovitaProvider {
+    async fn infer<'a>(
+        &'a self,
+        ModelProviderRequest {
+            request,
+            provider_name: _,
+            model_name,
+            otlp_config: _,
+            model_inference_id,
+        }: ModelProviderRequest<'a>,
+        http_client: &'a TensorzeroHttpClient,
+        dynamic_api_keys: &'a InferenceCredentials,
+        model_provider: &'a ModelProvider,
+    ) -> Result<ProviderInferenceResponse, Error> {
+        let request_body = serde_json::to_value(
+            NovitaRequest::new(&self.model_name, request).await?,
+        )
+        .map_err(|e| {
+            Error::new(ErrorDetails::Serialization {
+                message: format!(
+                    "Error serializing Novita request: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
+            })
+        })?;
+        let request_url = get_chat_url(&NOVITA_DEFAULT_BASE_URL)?;
+        let api_key = self
+            .credentials
+            .get_api_key(dynamic_api_keys)
+            .map_err(|e| e.log())?;
+        let start_time = Instant::now();
+        let request_builder = http_client
+            .post(request_url)
+            .bearer_auth(api_key.expose_secret());
+
+        let (res, raw_request) = inject_extra_request_data_and_send(
+            PROVIDER_TYPE,
+            ApiType::ChatCompletions,
+            &request.extra_body,
+            &request.extra_headers,
+            model_provider,
+            model_name,
+            request_body,
+            request_builder,
+        )
+        .await?;
+
+        if res.status().is_success() {
+            let raw_response = res.text().await.map_err(|e| {
+                Error::new(ErrorDetails::InferenceServer {
+                    message: format!(
+                        "Error parsing text response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
+                    raw_request: Some(raw_request.clone()),
+                    raw_response: None,
+                    provider_type: PROVIDER_TYPE.to_string(),
+                    api_type: ApiType::ChatCompletions,
+                })
+            })?;
+
+            let response = serde_json::from_str(&raw_response).map_err(|e| {
+                Error::new(ErrorDetails::InferenceServer {
+                    message: format!(
+                        "Error parsing JSON response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
+                    provider_type: PROVIDER_TYPE.to_string(),
+                    raw_request: Some(raw_request.clone()),
+                    raw_response: Some(raw_response.clone()),
+                    api_type: ApiType::ChatCompletions,
+                })
+            })?;
+
+            let latency = Latency::NonStreaming {
+                response_time: start_time.elapsed(),
+            };
+            Ok(NovitaResponseWithMetadata {
+                response,
+                latency,
+                raw_response,
+                raw_request,
+                generic_request: request,
+                model_inference_id,
+            }
+            .try_into()?)
+        } else {
+            Err(handle_openai_error(
+                &raw_request,
+                res.status(),
+                &res.text().await.map_err(|e| {
+                    Error::new(ErrorDetails::InferenceServer {
+                        message: format!(
+                            "Error parsing error response: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
+                        raw_request: Some(raw_request.clone()),
+                        raw_response: None,
+                        provider_type: PROVIDER_TYPE.to_string(),
+                        api_type: ApiType::ChatCompletions,
+                    })
+                })?,
+                PROVIDER_TYPE,
+                None,
+                ApiType::ChatCompletions,
+            ))
+        }
+    }
+
+    async fn infer_stream<'a>(
+        &'a self,
+        ModelProviderRequest {
+            request,
+            provider_name: _,
+            model_name,
+            otlp_config: _,
+            model_inference_id,
+        }: ModelProviderRequest<'a>,
+        http_client: &'a TensorzeroHttpClient,
+        dynamic_api_keys: &'a InferenceCredentials,
+        model_provider: &'a ModelProvider,
+    ) -> Result<(PeekableProviderInferenceResponseStream, String), Error> {
+        let request_body = serde_json::to_value(
+            NovitaRequest::new(&self.model_name, request).await?,
+        )
+        .map_err(|e| {
+            Error::new(ErrorDetails::Serialization {
+                message: format!(
+                    "Error serializing Novita request: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
+            })
+        })?;
+        let request_url = get_chat_url(&NOVITA_DEFAULT_BASE_URL)?;
+        let api_key = self
+            .credentials
+            .get_api_key(dynamic_api_keys)
+            .map_err(|e| e.log())?;
+        let start_time = Instant::now();
+        let request_builder = http_client
+            .post(request_url)
+            .bearer_auth(api_key.expose_secret());
+
+        let (event_source, raw_request) = inject_extra_request_data_and_send_eventsource(
+            PROVIDER_TYPE,
+            ApiType::ChatCompletions,
+            &request.extra_body,
+            &request.extra_headers,
+            model_provider,
+            model_name,
+            request_body,
+            request_builder,
+        )
+        .await?;
+
+        let stream = stream_openai(
+            PROVIDER_TYPE.to_string(),
+            model_inference_id,
+            event_source.map_err(TensorZeroEventError::EventSource),
+            start_time,
+            None,
+            &raw_request,
+        )
+        .peekable();
+        Ok((stream, raw_request))
+    }
+
+    async fn start_batch_inference<'a>(
+        &'a self,
+        _requests: &'a [ModelInferenceRequest<'_>],
+        _client: &'a TensorzeroHttpClient,
+        _dynamic_api_keys: &'a InferenceCredentials,
+    ) -> Result<StartBatchProviderInferenceResponse, Error> {
+        Err(ErrorDetails::UnsupportedModelProviderForBatchInference {
+            provider_type: PROVIDER_TYPE.to_string(),
+        }
+        .into())
+    }
+
+    async fn poll_batch_inference<'a>(
+        &'a self,
+        _batch_request: &'a BatchRequestRow<'a>,
+        _http_client: &'a TensorzeroHttpClient,
+        _dynamic_api_keys: &'a InferenceCredentials,
+    ) -> Result<PollBatchInferenceResponse, Error> {
+        Err(ErrorDetails::UnsupportedModelProviderForBatchInference {
+            provider_type: PROVIDER_TYPE.to_string(),
+        }
+        .into())
+    }
+}
+
+impl EmbeddingProvider for NovitaProvider {
+    async fn embed(
+        &self,
+        request: &EmbeddingRequest,
+        client: &TensorzeroHttpClient,
+        dynamic_api_keys: &InferenceCredentials,
+        model_provider_data: &EmbeddingProviderRequestInfo,
+    ) -> Result<EmbeddingProviderResponse, Error> {
+        let api_key = self
+            .credentials
+            .get_api_key(dynamic_api_keys)
+            .map_err(|e| e.log())?;
+        let request_body = NovitaEmbeddingRequest::new(
+            &self.model_name,
+            &request.input,
+            request.dimensions,
+            request.encoding_format,
+        );
+        let request_url = get_embedding_url(&NOVITA_DEFAULT_BASE_URL)?;
+        let start_time = Instant::now();
+        let request_builder = client
+            .post(request_url)
+            .bearer_auth(api_key.expose_secret());
+
+        let request_body_value = serde_json::to_value(&request_body).map_err(|e| {
+            Error::new(ErrorDetails::Serialization {
+                message: format!(
+                    "Error serializing Novita embedding request: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
+            })
+        })?;
+
+        let (res, raw_request) = inject_extra_request_data_and_send(
+            PROVIDER_TYPE,
+            ApiType::Embeddings,
+            &FullExtraBodyConfig::default(),
+            &Default::default(),
+            model_provider_data,
+            &self.model_name,
+            request_body_value,
+            request_builder,
+        )
+        .await?;
+        if res.status().is_success() {
+            let raw_response = res.text().await.map_err(|e| {
+                Error::new(ErrorDetails::InferenceServer {
+                    message: format!(
+                        "Error parsing text response: {}",
+                        DisplayOrDebugGateway::new(e)
+                    ),
+                    raw_request: Some(raw_request.clone()),
+                    raw_response: None,
+                    provider_type: PROVIDER_TYPE.to_string(),
+                    api_type: ApiType::Embeddings,
+                })
+            })?;
+
+            let response: NovitaEmbeddingResponse =
+                serde_json::from_str(&raw_response).map_err(|e| {
+                    Error::new(ErrorDetails::InferenceServer {
+                        message: format!(
+                            "Error parsing JSON response: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
+                        raw_request: Some(raw_request.clone()),
+                        raw_response: Some(raw_response.clone()),
+                        provider_type: PROVIDER_TYPE.to_string(),
+                        api_type: ApiType::Embeddings,
+                    })
+                })?;
+            let latency = Latency::NonStreaming {
+                response_time: start_time.elapsed(),
+            };
+
+            Ok(NovitaEmbeddingResponseWithMetadata {
+                response,
+                latency,
+                request: request_body,
+                raw_response,
+            }
+            .try_into()?)
+        } else {
+            Err(handle_openai_error(
+                &raw_request,
+                res.status(),
+                &res.text().await.map_err(|e| {
+                    Error::new(ErrorDetails::InferenceServer {
+                        message: format!(
+                            "Error parsing error response: {}",
+                            DisplayOrDebugGateway::new(e)
+                        ),
+                        raw_request: Some(raw_request.clone()),
+                        raw_response: None,
+                        provider_type: PROVIDER_TYPE.to_string(),
+                        api_type: ApiType::Embeddings,
+                    })
+                })?,
+                PROVIDER_TYPE,
+                None,
+                ApiType::Embeddings,
+            ))
+        }
+    }
+}
+
+fn get_embedding_url(base_url: &Url) -> Result<Url, Error> {
+    let mut url = base_url.clone();
+    if !url.path().ends_with('/') {
+        url.set_path(&format!("{}/", url.path()));
+    }
+    url.join("embeddings").map_err(|e| {
+        Error::new(ErrorDetails::InvalidBaseUrl {
+            message: e.to_string(),
+        })
+    })
+}
+
+#[derive(Debug, Serialize)]
+struct NovitaEmbeddingRequest<'a> {
+    model: &'a str,
+    input: &'a EmbeddingInput,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dimensions: Option<u32>,
+    encoding_format: EmbeddingEncodingFormat,
+}
+
+impl<'a> NovitaEmbeddingRequest<'a> {
+    fn new(
+        model: &'a str,
+        input: &'a EmbeddingInput,
+        dimensions: Option<u32>,
+        encoding_format: EmbeddingEncodingFormat,
+    ) -> Self {
+        Self {
+            model,
+            input,
+            dimensions,
+            encoding_format,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct NovitaEmbeddingResponse {
+    data: Vec<NovitaEmbeddingData>,
+    usage: Option<NovitaEmbeddingUsage>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct NovitaEmbeddingData {
+    embedding: Embedding,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct NovitaEmbeddingUsage {
+    prompt_tokens: Option<u32>,
+    total_tokens: Option<u32>,
+}
+
+impl From<NovitaEmbeddingUsage> for crate::inference::types::Usage {
+    fn from(usage: NovitaEmbeddingUsage) -> Self {
+        Self {
+            input_tokens: usage.prompt_tokens,
+            output_tokens: None,
+            cost: None,
+        }
+    }
+}
+
+struct NovitaEmbeddingResponseWithMetadata<'a> {
+    response: NovitaEmbeddingResponse,
+    latency: Latency,
+    request: NovitaEmbeddingRequest<'a>,
+    raw_response: String,
+}
+
+impl<'a> TryFrom<NovitaEmbeddingResponseWithMetadata<'a>> for EmbeddingProviderResponse {
+    type Error = Error;
+    fn try_from(response: NovitaEmbeddingResponseWithMetadata<'a>) -> Result<Self, Self::Error> {
+        let NovitaEmbeddingResponseWithMetadata {
+            response,
+            latency,
+            request,
+            raw_response,
+        } = response;
+        let raw_request = serde_json::to_string(&request).map_err(|e| {
+            Error::new(ErrorDetails::InferenceServer {
+                message: format!(
+                    "Error serializing request body as JSON: {}",
+                    DisplayOrDebugGateway::new(e)
+                ),
+                raw_request: Some(serde_json::to_string(&request).unwrap_or_default()),
+                raw_response: None,
+                provider_type: PROVIDER_TYPE.to_string(),
+                api_type: ApiType::Embeddings,
+            })
+        })?;
+
+        let embeddings = response
+            .data
+            .into_iter()
+            .map(|embedding| embedding.embedding)
+            .collect();
+        let provider_usage = response.usage;
+        let usage = provider_usage.clone().map(Into::into).unwrap_or_default();
+        let raw_usage_value = novita_usage_from_raw_response(&raw_response);
+        let mut embedding_response = EmbeddingProviderResponse::new(
+            embeddings,
+            request.input.clone(),
+            raw_request,
+            raw_response,
+            usage,
+            latency,
+            None,
+        );
+        embedding_response.raw_usage = raw_usage_value.map(|usage| {
+            raw_usage_entries_from_value(
+                embedding_response.id,
+                PROVIDER_TYPE,
+                ApiType::Embeddings,
+                usage,
+            )
+        });
+        Ok(embedding_response)
+    }
+}
+
+/// This struct defines the supported parameters for the Novita AI text generation API
+/// See the [API documentation](https://novita.ai/docs/api-reference/llm-openai-compatible)
+/// for more details.
+#[derive(Debug, Serialize)]
+struct NovitaRequest<'a> {
+    messages: Vec<OpenAIRequestMessage<'a>>,
+    model: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    frequency_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    presence_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    seed: Option<u32>,
+    stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stop: Option<Cow<'a, [String]>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning_effort: Option<String>,
+}
+
+fn apply_inference_params(
+    request: &mut NovitaRequest,
+    inference_params: &ChatCompletionInferenceParamsV2,
+) {
+    let ChatCompletionInferenceParamsV2 {
+        reasoning_effort,
+        service_tier,
+        thinking_budget_tokens,
+        verbosity,
+    } = inference_params;
+
+    if reasoning_effort.is_some() {
+        request.reasoning_effort.clone_from(reasoning_effort);
+    }
+
+    if service_tier.is_some() {
+        warn_inference_parameter_not_supported(PROVIDER_NAME, "service_tier", None);
+    }
+
+    if thinking_budget_tokens.is_some() {
+        warn_inference_parameter_not_supported(
+            PROVIDER_NAME,
+            "thinking_budget_tokens",
+            Some("Tip: You might want to use `reasoning_effort` for this provider."),
+        );
+    }
+
+    if verbosity.is_some() {
+        warn_inference_parameter_not_supported(PROVIDER_NAME, "verbosity", None);
+    }
+}
+
+impl<'a> NovitaRequest<'a> {
+    pub async fn new(
+        model: &'a str,
+        request: &'a ModelInferenceRequest<'_>,
+    ) -> Result<NovitaRequest<'a>, Error> {
+        let ModelInferenceRequest {
+            temperature,
+            max_tokens,
+            seed,
+            top_p,
+            presence_penalty,
+            frequency_penalty,
+            stream,
+            stop_sequences,
+            ..
+        } = request;
+
+        let messages = prepare_openai_messages(
+            request
+                .system
+                .as_deref()
+                .map(|m| SystemOrDeveloper::System(Cow::Borrowed(m))),
+            &request.messages,
+            OpenAIMessagesConfig {
+                json_mode: Some(&request.json_mode),
+                provider_type: PROVIDER_TYPE,
+                fetch_and_encode_input_files_before_inference: request
+                    .fetch_and_encode_input_files_before_inference,
+            },
+        )
+        .await?;
+        let mut novita_request = NovitaRequest {
+            messages,
+            model,
+            frequency_penalty: *frequency_penalty,
+            max_tokens: *max_tokens,
+            presence_penalty: *presence_penalty,
+            seed: *seed,
+            stream: *stream,
+            temperature: *temperature,
+            top_p: *top_p,
+            stop: stop_sequences.clone(),
+            reasoning_effort: None,
+        };
+
+        apply_inference_params(&mut novita_request, &request.inference_params_v2);
+
+        Ok(novita_request)
+    }
+}
+
+struct NovitaResponseWithMetadata<'a> {
+    response: OpenAIResponse,
+    raw_response: String,
+    latency: Latency,
+    raw_request: String,
+    generic_request: &'a ModelInferenceRequest<'a>,
+    model_inference_id: Uuid,
+}
+
+impl<'a> TryFrom<NovitaResponseWithMetadata<'a>> for ProviderInferenceResponse {
+    type Error = Error;
+    fn try_from(value: NovitaResponseWithMetadata<'a>) -> Result<Self, Self::Error> {
+        let NovitaResponseWithMetadata {
+            mut response,
+            latency,
+            raw_response,
+            raw_request,
+            generic_request,
+            model_inference_id,
+        } = value;
+
+        if response.choices.len() != 1 {
+            return Err(ErrorDetails::InferenceServer {
+                message: format!(
+                    "Response has invalid number of choices {}, Expected 1",
+                    response.choices.len()
+                ),
+                raw_request: Some(raw_request.clone()),
+                raw_response: Some(raw_response.clone()),
+                provider_type: PROVIDER_TYPE.to_string(),
+                api_type: ApiType::ChatCompletions,
+            }
+            .into());
+        }
+
+        let OpenAIResponseChoice {
+            message,
+            finish_reason,
+            ..
+        } = response
+            .choices
+            .pop()
+            .ok_or_else(|| Error::new(ErrorDetails::InferenceServer {
+                message: "Response has no choices (this should never happen). Please file a bug report: https://github.com/tensorzero/tensorzero/issues/new".to_string(),
+                provider_type: PROVIDER_TYPE.to_string(),
+                raw_request: Some(raw_request.clone()),
+                raw_response: Some(raw_response.clone()),
+                api_type: ApiType::ChatCompletions,
+            }))?;
+        let mut content: Vec<ContentBlockOutput> = Vec::new();
+        if let Some(text) = message.content {
+            content.push(text.into());
+        }
+        if let Some(tool_calls) = message.tool_calls {
+            for tool_call in tool_calls {
+                content.push(ContentBlockOutput::ToolCall(
+                    openai_response_tool_call_to_tensorzero_tool_call(tool_call),
+                ));
+            }
+        }
+
+        let raw_usage = novita_usage_from_raw_response(&raw_response).map(|usage| {
+            raw_usage_entries_from_value(
+                model_inference_id,
+                PROVIDER_TYPE,
+                ApiType::ChatCompletions,
+                usage,
+            )
+        });
+        let usage = response.usage.into();
+        let system = generic_request.system.clone();
+        let input_messages = generic_request.messages.clone();
+        Ok(ProviderInferenceResponse::new(
+            ProviderInferenceResponseArgs {
+                output: content,
+                system,
+                input_messages,
+                raw_request,
+                raw_response: raw_response.clone(),
+                usage,
+                raw_usage,
+                relay_raw_response: None,
+                provider_latency: latency,
+                finish_reason: Some(finish_reason.into()),
+                id: model_inference_id,
+            },
+        ))
+    }
+}
+
+fn novita_usage_from_raw_response(raw_response: &str) -> Option<Value> {
+    serde_json::from_str::<Value>(raw_response)
+        .ok()
+        .and_then(|value| value.get("usage").filter(|v| !v.is_null()).cloned())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+    use std::time::Duration;
+
+    use uuid::Uuid;
+
+    use super::*;
+
+    use crate::inference::types::{
+        FunctionType, ModelInferenceRequestJsonMode, RequestMessage, Role,
+    };
+    use crate::providers::openai::{
+        OpenAIFinishReason, OpenAIResponseChoice, OpenAIResponseMessage, OpenAIUsage,
+    };
+    use crate::providers::test_helpers::WEATHER_TOOL_CONFIG;
+
+    #[tokio::test]
+    async fn test_novita_request_new() {
+        let request_with_tools = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
+            messages: vec![RequestMessage {
+                role: Role::User,
+                content: vec!["What's the weather?".to_string().into()],
+            }],
+            system: None,
+            temperature: Some(0.5),
+            top_p: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            max_tokens: Some(100),
+            stream: false,
+            seed: Some(69),
+            json_mode: ModelInferenceRequestJsonMode::Off,
+            tool_config: Some(Cow::Borrowed(&WEATHER_TOOL_CONFIG)),
+            function_type: FunctionType::Chat,
+            output_schema: None,
+            extra_body: Default::default(),
+            ..Default::default()
+        };
+
+        let novita_request = NovitaRequest::new("moonshotai/kimi-k2.5", &request_with_tools)
+            .await
+            .expect("failed to create Novita Request during test");
+
+        assert_eq!(novita_request.messages.len(), 1);
+        assert_eq!(novita_request.temperature, Some(0.5));
+        assert_eq!(novita_request.max_tokens, Some(100));
+        assert!(!novita_request.stream);
+        assert_eq!(novita_request.seed, Some(69));
+    }
+
+    #[test]
+    fn test_novita_api_base() {
+        assert_eq!(
+            NOVITA_DEFAULT_BASE_URL.as_str(),
+            "https://api.novita.ai/openai/v1/"
+        );
+    }
+
+    #[test]
+    fn test_credential_to_novita_credentials() {
+        // Test Static credential
+        let generic = Credential::Static(SecretString::from("test_key"));
+        let creds = NovitaCredentials::try_from(generic).unwrap();
+        assert!(matches!(creds, NovitaCredentials::Static(_)));
+
+        // Test Dynamic credential
+        let generic = Credential::Dynamic("key_name".to_string());
+        let creds = NovitaCredentials::try_from(generic).unwrap();
+        assert!(matches!(creds, NovitaCredentials::Dynamic(_)));
+
+        // Test Missing credential
+        let generic = Credential::Missing;
+        let creds = NovitaCredentials::try_from(generic).unwrap();
+        assert!(matches!(creds, NovitaCredentials::None));
+
+        // Test invalid type
+        let generic = Credential::FileContents(SecretString::from("test"));
+        let result = NovitaCredentials::try_from(generic);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err().get_details(),
+            ErrorDetails::Config { message } if message.contains("Invalid api_key_location")
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_novita_response_with_metadata_try_into() {
+        let valid_response = OpenAIResponse {
+            choices: vec![OpenAIResponseChoice {
+                index: 0,
+                finish_reason: OpenAIFinishReason::Stop,
+                message: OpenAIResponseMessage {
+                    content: Some("Hello, world!".to_string()),
+                    reasoning_content: None,
+                    tool_calls: None,
+                },
+            }],
+            usage: Some(OpenAIUsage {
+                prompt_tokens: Some(10),
+                completion_tokens: Some(20),
+            }),
+        };
+        let generic_request = ModelInferenceRequest {
+            inference_id: Uuid::now_v7(),
+            messages: vec![RequestMessage {
+                role: Role::User,
+                content: vec!["test_user".to_string().into()],
+            }],
+            system: None,
+            temperature: Some(0.5),
+            top_p: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            max_tokens: Some(100),
+            stream: false,
+            seed: Some(69),
+            json_mode: ModelInferenceRequestJsonMode::Off,
+            tool_config: None,
+            function_type: FunctionType::Chat,
+            output_schema: None,
+            extra_body: Default::default(),
+            ..Default::default()
+        };
+        let novita_response_with_metadata = NovitaResponseWithMetadata {
+            response: valid_response,
+            raw_response: "test_response".to_string(),
+            latency: Latency::NonStreaming {
+                response_time: Duration::from_secs(0),
+            },
+            raw_request: serde_json::to_string(
+                &NovitaRequest::new("test-model", &generic_request)
+                    .await
+                    .unwrap(),
+            )
+            .unwrap(),
+            generic_request: &generic_request,
+            model_inference_id: Uuid::now_v7(),
+        };
+        let inference_response: ProviderInferenceResponse =
+            novita_response_with_metadata.try_into().unwrap();
+
+        assert_eq!(inference_response.output.len(), 1);
+        assert_eq!(
+            inference_response.output[0],
+            "Hello, world!".to_string().into()
+        );
+        assert_eq!(inference_response.raw_response, "test_response");
+        assert_eq!(inference_response.usage.input_tokens, Some(10));
+        assert_eq!(inference_response.usage.output_tokens, Some(20));
+        assert_eq!(
+            inference_response.provider_latency,
+            Latency::NonStreaming {
+                response_time: Duration::from_secs(0)
+            }
+        );
+    }
+
+    #[test]
+    fn test_novita_apply_inference_params_called() {
+        let logs_contain = crate::utils::testing::capture_logs();
+        let inference_params = ChatCompletionInferenceParamsV2 {
+            reasoning_effort: Some("high".to_string()),
+            service_tier: None,
+            thinking_budget_tokens: Some(1024),
+            verbosity: Some("low".to_string()),
+        };
+        let mut request = NovitaRequest {
+            messages: vec![],
+            model: "test-model",
+            frequency_penalty: None,
+            max_tokens: None,
+            presence_penalty: None,
+            seed: None,
+            stream: false,
+            temperature: None,
+            top_p: None,
+            stop: None,
+            reasoning_effort: None,
+        };
+
+        apply_inference_params(&mut request, &inference_params);
+
+        assert_eq!(request.reasoning_effort, Some("high".to_string()));
+
+        assert!(logs_contain(
+            "Novita does not support the inference parameter `thinking_budget_tokens`, so it will be ignored. Tip: You might want to use `reasoning_effort` for this provider."
+        ));
+
+        assert!(logs_contain(
+            "Novita does not support the inference parameter `verbosity`"
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds [Novita AI](https://novita.ai) as a new OpenAI-compatible inference provider via `https://api.novita.ai/openai/v1/`
- Follows the same integration pattern as the Hyperbolic provider
- Supports shorthand model syntax (`novita::moonshotai/kimi-k2.5`) and explicit config

## Changes

- **New file**: `crates/tensorzero-core/src/providers/novita.rs` — provider struct, credentials, request/response types, `InferenceProvider` impl (reuses OpenAI helpers)
- **`providers/mod.rs`**: `pub mod novita`
- **`config/provider_types.rs`**: `NovitaProviderTypeConfig` / `NovitaDefaults` (default env var: `NOVITA_API_KEY`)
- **`model_table.rs`**: `ProviderType::Novita`, `NovitaKind`, `ProviderTypeDefaultCredentials.novita`
- **`model.rs`**: `ProviderConfig::Novita`, `UninitializedProviderConfig::Novita`, all dispatch match arms, shorthand prefix `novita::`

## Usage

**Explicit config** (`tensorzero.toml`):
```toml
[models."moonshotai/kimi-k2.5"]
routing = ["novita"]

[models."moonshotai/kimi-k2.5".providers.novita]
type = "novita"
model_name = "moonshotai/kimi-k2.5"
```

**Shorthand**: `model = "novita::moonshotai/kimi-k2.5"`

**Env var**: `NOVITA_API_KEY=<your-key>`

## Supported Models

| Model | Context | Notes |
|-------|---------|-------|
| `moonshotai/kimi-k2.5` | 262k | Default; supports reasoning, vision |
| `zai-org/glm-5` | 202k | Supports reasoning |
| `minimax/minimax-m2.5` | 204k | Supports reasoning |

## Test Plan

- [x] `cargo build -p tensorzero-core` passes with no warnings
- [ ] Set `NOVITA_API_KEY` and run a basic inference against `novita::moonshotai/kimi-k2.5`