### PR TITLE
Fix bulk-add-to-dataset for function-level evaluators

### DIFF
--- a/ui/app/routes/evaluations/bulkAddToDataset.server.ts
+++ b/ui/app/routes/evaluations/bulkAddToDataset.server.ts
@@ -1,5 +1,4 @@
 import { data } from "react-router";
-import { getConfig } from "~/utils/config/index.server";
 import { handleAddToDatasetAction } from "~/utils/dataset.server";
 import { logger } from "~/utils/logger";
 
@@ -12,23 +11,8 @@ export interface SelectedItemData {
 export async function handleBulkAddToDataset(
   dataset: string,
   selectedItems: SelectedItemData[],
-  evaluation_name: string,
+  function_name: string,
 ) {
-  const config = await getConfig();
-  const evaluation_config = config.evaluations[evaluation_name];
-
-  if (!evaluation_config) {
-    return data(
-      {
-        error: `Evaluation config not found for ${evaluation_name}`,
-        success: false,
-      },
-      { status: 404 },
-    );
-  }
-
-  const function_name = evaluation_config.function_name;
-
   // Process all selected items in parallel
   const results = await Promise.allSettled(
     selectedItems.map((item) => {

--- a/ui/app/routes/evaluations/runs.tsx
+++ b/ui/app/routes/evaluations/runs.tsx
@@ -289,9 +289,9 @@ export async function action({ request }: Route.ActionArgs) {
     case "addMultipleToDataset": {
       const dataset = formData.get("dataset");
       const selectedItemsJson = formData.get("selectedItems");
-      const evaluation_name = formData.get("evaluation_name");
+      const function_name = formData.get("function_name");
 
-      if (!dataset || !selectedItemsJson || !evaluation_name) {
+      if (!dataset || !selectedItemsJson || !function_name) {
         return data(
           { error: "Missing required fields", success: false },
           { status: 400 },
@@ -303,7 +303,7 @@ export async function action({ request }: Route.ActionArgs) {
         return await handleBulkAddToDataset(
           dataset.toString(),
           selectedItems,
-          evaluation_name.toString(),
+          function_name.toString(),
         );
       } catch (error) {
         logger.error("Error processing bulk add to dataset:", error);
@@ -529,7 +529,7 @@ export default function EvaluationRunsPage({
     const formData = new FormData();
     formData.append("_action", "addMultipleToDataset");
     formData.append("dataset", dataset);
-    formData.append("evaluation_name", evaluation_name);
+    formData.append("function_name", function_name);
     formData.append("selectedItems", JSON.stringify(selectedData));
 
     fetcher.submit(formData, { method: "post" });


### PR DESCRIPTION
Derive function_name from run metadata instead of config.evaluations lookup, so bulk-add-to-dataset works for function-level evaluators that don't have a top-level evaluation config entry.