### PR TITLE
Cache config snapshot metrics in GEPA setup step

### DIFF
--- a/crates/autopilot-tools/src/tools/prod/gepa.rs
+++ b/crates/autopilot-tools/src/tools/prod/gepa.rs
@@ -354,6 +354,7 @@ async fn execute_gepa(
                     gepa_config: setup.gepa_config.clone(),
                     iteration: iteration as u32,
                     max_concurrency: setup.gepa_config.max_concurrency,
+                    metrics: setup.metrics.clone(),
                 },
                 eval_analyze_mutate_step,
             )
@@ -742,6 +743,7 @@ async fn setup_step(
         run_id,
         gepa_config: resolved_config,
         rng_seed,
+        metrics: uninitialized_config.metrics,
     })
 }
 
@@ -914,21 +916,9 @@ async fn eval_analyze_mutate_step(
     // ── 2. Reconstruct GEPAConfig and FunctionContext ────────────
     let gepa_config = reconstruct_gepa_config(&params.gepa_config);
 
-    let config_response = client
-        .get_config_snapshot(None)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to get config: {e}"))?;
-
-    let uninitialized_config: UninitializedConfig =
-        serde_json::from_value(config_response.config.clone())
-            .map_err(|e| anyhow::anyhow!("Failed to deserialize config snapshot: {e}"))?;
-
     let function_context = params
         .function_context
-        .load(
-            &params.gepa_config.function_name,
-            &uninitialized_config.metrics,
-        )
+        .load(&params.gepa_config.function_name, &params.metrics)
         .map_err(|e| anyhow::anyhow!("Failed to load function context: {e}"))?;
 
     // ── 3. Analyze inferences ───────────────────────────────────

--- a/crates/tensorzero-optimizers/src/gepa/durable/types.rs
+++ b/crates/tensorzero-optimizers/src/gepa/durable/types.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use tensorzero_core::config::MetricConfig;
 use tensorzero_core::evaluations::EvaluatorConfig;
 use tensorzero_core::optimization::gepa::GepaEvaluatorStats;
 use tensorzero_core::variant::chat_completion::UninitializedChatCompletionConfig;
@@ -100,6 +101,9 @@ pub struct SetupResult {
     /// Generated from the user's seed or OS randomness, then checkpointed
     /// so that task resumption produces identical RNG state.
     pub rng_seed: u64,
+    /// Cached metric configs from the config snapshot at setup time.
+    /// Avoids re-fetching the full config snapshot on every GEPA iteration.
+    pub metrics: HashMap<String, MetricConfig>,
 }
 
 /// Resolved GEPA config fields (extracted from GepaToolParams with defaults applied).
@@ -161,6 +165,8 @@ pub struct EvalAnalyzeMutateStepParams {
     pub gepa_config: ResolvedGEPAConfig,
     pub iteration: u32,
     pub max_concurrency: u32,
+    /// Cached metric configs from setup, avoids re-fetching config snapshot per iteration.
+    pub metrics: HashMap<String, MetricConfig>,
 }
 
 // ── Step result types ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Cache the `metrics` HashMap from the config snapshot in `SetupResult` during the GEPA setup step
- Thread cached metrics through `EvalAnalyzeMutateStepParams` to subsequent iterations
- Remove the redundant `get_config_snapshot` + deserialization call from `eval_analyze_mutate_step`, eliminating one DB round-trip per GEPA iteration

## Test plan
- [x] `cargo check --package autopilot-tools` passes
- [ ] Existing GEPA integration tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)