### PR TITLE
Tool call rendering logic

### DIFF
--- a/ui/app/components/autopilot/EventStream.tsx
+++ b/ui/app/components/autopilot/EventStream.tsx
@@ -371,19 +371,6 @@ function renderEventTitle(event: GatewayEvent) {
         </span>
       );
     case "tool_call_authorization":
-      return (
-        <span className="inline-flex items-center gap-2">
-          Tool Call
-          {payload.tool_call_name && (
-            <>
-              <DotSeparator />
-              <span className="font-mono font-medium">
-                {payload.tool_call_name}
-              </span>
-            </>
-          )}
-        </span>
-      );
     case "tool_result":
       return (
         <span className="inline-flex items-center gap-2">


### PR DESCRIPTION
Combine `tool_call_authorization` and `tool_result` switch cases to remove duplicated rendering logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only refactor that consolidates duplicated JSX in a `switch` without changing underlying data flow; potential risk is minor visual/title regression for `tool_call_authorization` vs `tool_result` events.
> 
> **Overview**
> Simplifies `EventStream` event title rendering by merging the `tool_call_authorization` and `tool_result` `switch` cases into a single shared JSX path, removing duplicated logic for displaying tool call names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c63ffc74b4abfe5d644c3204a8a7bfb55e2bd4a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->