### PR TITLE
Make dependabot use /crates directory for Cargo updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,13 +27,11 @@ updates:
       - "recipes/**"
 
   - package-ecosystem: "cargo"
-    directory: "/"
+    directory: "/crates"
     schedule:
       # This schedule does not affect security updates: https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/customizing-dependabot-security-prs#about-customizing-pull-requests-for-security-updates
       interval: "weekly"
     labels: []
-    exclude-paths:
-      - "examples/**/Cargo.lock"
     groups:
       opentelemetry-dependencies:
         patterns:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that only affects where Dependabot looks for Rust manifests/locks and which update PRs it will open.
> 
> **Overview**
> Dependabot’s Cargo configuration is updated to run in `directory: /crates` instead of `/`, aligning Rust dependency update PRs to the workspace layout.
> 
> The previous Cargo `exclude-paths` for `examples/**/Cargo.lock` is removed, since updates are no longer scanned from the repo root.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 994c5c4d3fad412471ee79909d4d25a7c27ffc0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->