### PR TITLE
add a way to pass header flags to autopilot API

### DIFF
--- a/ui/app/utils/env.server.ts
+++ b/ui/app/utils/env.server.ts
@@ -20,6 +20,7 @@ interface Env {
   TENSORZERO_API_KEY?: string;
   TENSORZERO_UI_CONFIG_FILE?: string;
   TENSORZERO_AUTOPILOT_BETA_TOOLS?: string;
+  autopilotHeaders: Record<string, string>;
 }
 
 let _env: Env | undefined;
@@ -69,6 +70,18 @@ export function getEnv(): Env {
     hasLoggedClickhouseUrlDeprecation = true;
   }
 
+  // Collect TENSORZERO_HEADER_* env vars as autopilot headers.
+  // e.g. TENSORZERO_HEADER_BETA_TOOLS=value -> tensorzero-beta-tools: value
+  const autopilotHeaders: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key.startsWith("TENSORZERO_HEADER_") && value) {
+      const headerName =
+        "tensorzero-" +
+        key.slice("TENSORZERO_HEADER_".length).toLowerCase().replace(/_/g, "-");
+      autopilotHeaders[headerName] = value;
+    }
+  }
+
   _env = {
     TENSORZERO_POSTGRES_URL: process.env.TENSORZERO_POSTGRES_URL,
     TENSORZERO_UI_READ_ONLY: process.env.TENSORZERO_UI_READ_ONLY === "1",
@@ -77,6 +90,7 @@ export function getEnv(): Env {
     TENSORZERO_UI_CONFIG_FILE: process.env.TENSORZERO_UI_CONFIG_FILE,
     TENSORZERO_AUTOPILOT_BETA_TOOLS:
       process.env.TENSORZERO_AUTOPILOT_BETA_TOOLS,
+    autopilotHeaders,
   };
 
   return _env;

--- a/ui/app/utils/get-autopilot-client.server.ts
+++ b/ui/app/utils/get-autopilot-client.server.ts
@@ -13,6 +13,7 @@ export function getAutopilotClient(): AutopilotClient {
       env.TENSORZERO_GATEWAY_URL,
       env.TENSORZERO_API_KEY,
       env.TENSORZERO_AUTOPILOT_BETA_TOOLS,
+      env.autopilotHeaders,
     );
     return _envClient;
   }
@@ -22,5 +23,6 @@ export function getAutopilotClient(): AutopilotClient {
     env.TENSORZERO_GATEWAY_URL,
     getEffectiveApiKey(),
     env.TENSORZERO_AUTOPILOT_BETA_TOOLS,
+    env.autopilotHeaders,
   );
 }

--- a/ui/app/utils/tensorzero/autopilot-client.ts
+++ b/ui/app/utils/tensorzero/autopilot-client.ts
@@ -22,10 +22,17 @@ import type {
  */
 export class AutopilotClient extends BaseTensorZeroClient {
   private betaTools: string | null;
+  private extraHeaders: Record<string, string>;
 
-  constructor(baseUrl: string, apiKey?: string, betaTools?: string) {
+  constructor(
+    baseUrl: string,
+    apiKey?: string,
+    betaTools?: string,
+    extraHeaders?: Record<string, string>,
+  ) {
     super(baseUrl, apiKey);
     this.betaTools = betaTools ?? null;
+    this.extraHeaders = extraHeaders ?? {};
   }
 
   /**
@@ -94,6 +101,8 @@ export class AutopilotClient extends BaseTensorZeroClient {
     if (this.betaTools) {
       headers["tensorzero-beta-tools"] = this.betaTools;
     }
+    // Extra headers override betaTools on conflict
+    Object.assign(headers, this.extraHeaders);
     const response = await this.fetch(endpoint, {
       method: "POST",
       body: JSON.stringify(request),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds support for injecting arbitrary `tensorzero-*` headers into Autopilot requests, which can change gateway behavior and needs verification to avoid unintended header overrides. Scope is limited to client construction and the `createAutopilotEvent` request path.
> 
> **Overview**
> Enables passing additional header-based flags to Autopilot API calls by collecting `TENSORZERO_HEADER_*` environment variables into `autopilotHeaders` and wiring them through `getAutopilotClient` into `AutopilotClient`.
> 
> `AutopilotClient` now accepts `extraHeaders` and merges them into the headers for `createAutopilotEvent`, with *extra headers taking precedence* over the existing `tensorzero-beta-tools` header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5767b938b9c98a0172148f656b82952ff84500bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->