### PR TITLE
add an Interrupted type to auth and decision source

### DIFF
--- a/crates/autopilot-client/src/client.rs
+++ b/crates/autopilot-client/src/client.rs
@@ -319,12 +319,16 @@ impl AutopilotClient {
     /// Check if an event should be filtered from responses.
     ///
     /// Returns `true` for:
-    /// - `ToolCallAuthorization` events with `NotAvailable` status
+    /// - `ToolCallAuthorization` events with `NotAvailable` or `Interrupted` status
     /// - `ToolCall` events for unknown tools (not in `available_tools`)
     fn should_filter_event(event: &Event, available_tools: &HashSet<String>) -> bool {
         match &event.payload {
             EventPayload::ToolCallAuthorization(auth)
-                if matches!(auth.status, ToolCallAuthorizationStatus::NotAvailable) =>
+                if matches!(
+                    auth.status,
+                    ToolCallAuthorizationStatus::NotAvailable
+                        | ToolCallAuthorizationStatus::Interrupted
+                ) =>
             {
                 true
             }
@@ -686,9 +690,10 @@ impl AutopilotClient {
         let tool_call_event_id = match &request.payload {
             CreateEventPayload::ToolCallAuthorization(auth) => match auth.status {
                 ToolCallAuthorizationStatus::Approved => Some(auth.tool_call_event_id),
-                // Don't start the tool if rejected or not available
+                // Don't start the tool if rejected, not available, or interrupted
                 ToolCallAuthorizationStatus::Rejected { .. }
-                | ToolCallAuthorizationStatus::NotAvailable => None,
+                | ToolCallAuthorizationStatus::NotAvailable
+                | ToolCallAuthorizationStatus::Interrupted => None,
             },
             _ => None,
         };

--- a/crates/autopilot-client/src/types/mod.rs
+++ b/crates/autopilot-client/src/types/mod.rs
@@ -519,6 +519,8 @@ pub enum ToolCallDecisionSource {
     Ui,
     Automatic,
     Whitelist,
+    /// The session was interrupted before authorization could occur.
+    Interrupted,
 }
 
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
@@ -588,8 +590,12 @@ impl TryFrom<EventPayloadToolCallAuthorization> for GatewayEventPayloadToolCallA
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ToolCallAuthorizationStatus {
     Approved,
-    Rejected { reason: String },
+    Rejected {
+        reason: String,
+    },
     NotAvailable,
+    /// The session was interrupted before authorization could occur.
+    Interrupted,
 }
 
 /// Authorization status for tool calls as seen by gateway consumers.
@@ -617,6 +623,9 @@ impl TryFrom<ToolCallAuthorizationStatus> for GatewayToolCallAuthorizationStatus
             }
             ToolCallAuthorizationStatus::NotAvailable => {
                 Err("NotAvailable status should be filtered before conversion")
+            }
+            ToolCallAuthorizationStatus::Interrupted => {
+                Err("Interrupted status should be filtered before conversion")
             }
         }
     }

--- a/crates/tensorzero-node/lib/bindings/ToolCallAuthorizationStatus.ts
+++ b/crates/tensorzero-node/lib/bindings/ToolCallAuthorizationStatus.ts
@@ -3,4 +3,5 @@
 export type ToolCallAuthorizationStatus =
   | { type: "approved" }
   | { type: "rejected"; reason: string }
-  | { type: "not_available" };
+  | { type: "not_available" }
+  | { type: "interrupted" };

--- a/crates/tensorzero-node/lib/bindings/ToolCallDecisionSource.ts
+++ b/crates/tensorzero-node/lib/bindings/ToolCallDecisionSource.ts
@@ -3,4 +3,5 @@
 export type ToolCallDecisionSource =
   | { type: "ui" }
   | { type: "automatic" }
-  | { type: "whitelist" };
+  | { type: "whitelist" }
+  | { type: "interrupted" };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: additive enum variants plus small client-side filtering/spawn-guard changes; main risk is compatibility if downstream consumers don’t handle the new `interrupted` variant.
> 
> **Overview**
> Adds a new `Interrupted` variant to `ToolCallAuthorizationStatus` and `ToolCallDecisionSource` (and regenerates the corresponding TS bindings) to represent sessions that end before tool authorization occurs.
> 
> Updates the Rust client to **filter out** `ToolCallAuthorization` events with `Interrupted` (same as `NotAvailable`) and to **avoid spawning tools** when an authorization is `Interrupted`, and updates gateway conversion to error if `Interrupted` reaches the consumer layer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f82cbe6e68c8131fc1ea16e94d35226d506bfb27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->