### PR TITLE
Bump to 2026.3.4

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -533,7 +533,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot-client"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "chrono",
  "durable-tools-spawn",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-tools"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-worker"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "config-applier"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "pathdiff",
  "schemars 1.2.1",
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2239,7 +2239,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools-spawn"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "async-trait",
  "durable",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2480,7 +2480,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "async-stream",
  "autopilot-client",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "googletest-matchers"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "googletest",
  "serde_json",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-utils"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "minijinja",
  "serde",
@@ -4830,7 +4830,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postgres-inference-load-test"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5419,7 +5419,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5754,7 +5754,7 @@ dependencies = [
 
 [[package]]
 name = "reqwest-sse-stream"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "async-stream",
  "futures",
@@ -6864,7 +6864,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "async-trait",
  "clap",
@@ -6891,7 +6891,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "axum",
  "chrono",
@@ -6911,11 +6911,11 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-config-paths"
-version = "2026.3.3"
+version = "2026.3.4"
 
 [[package]]
 name = "tensorzero-core"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -7042,7 +7042,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-error"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "autopilot-client",
  "axum",
@@ -7065,7 +7065,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "config-applier",
  "napi",
@@ -7080,7 +7080,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-optimizers"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -7117,7 +7117,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "evaluations",
  "futures",
@@ -7135,11 +7135,11 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-ts-types"
-version = "2026.3.3"
+version = "2026.3.4"
 
 [[package]]
 name = "tensorzero-types"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "aws-smithy-types",
  "blake3",
@@ -7167,7 +7167,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types-providers"
-version = "2026.3.3"
+version = "2026.3.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -7177,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-unsafe-helpers"
-version = "2026.3.3"
+version = "2026.3.4"
 
 [[package]]
 name = "termcolor"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2026.3.3"
+version = "2026.3.4"
 rust-version = "1.93.0"
 license = "Apache-2.0"
 edition = "2024"

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2026.3.3"
+appVersion: "2026.3.4"

--- a/examples/production-deployment-k8s-helm/tests/__snapshot__/snapshots_test.yaml.snap
+++ b/examples/production-deployment-k8s-helm/tests/__snapshot__/snapshots_test.yaml.snap
@@ -19,7 +19,7 @@ should match snapshot with all features enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.3
+        app.kubernetes.io/version: 2026.3.4
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero
   2: |
@@ -33,7 +33,7 @@ should match snapshot with all features enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.3
+        app.kubernetes.io/version: 2026.3.4
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-gateway
     spec:
@@ -58,7 +58,7 @@ should match snapshot with all features enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.3
+        app.kubernetes.io/version: 2026.3.4
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-gateway
     spec:
@@ -81,7 +81,7 @@ should match snapshot with all features enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.3
+        app.kubernetes.io/version: 2026.3.4
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-gateway
     spec:
@@ -121,7 +121,7 @@ should match snapshot with all features enabled:
                     secretKeyRef:
                       key: OPENAI_API_KEY
                       name: tensorzero-secret
-              image: tensorzero/gateway:2026.3.3
+              image: tensorzero/gateway:2026.3.4
               imagePullPolicy: IfNotPresent
               name: tensorzero
               ports:
@@ -159,7 +159,7 @@ should match snapshot with all features enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.3
+        app.kubernetes.io/version: 2026.3.4
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-storage
     spec:
@@ -178,7 +178,7 @@ should match snapshot with all features enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.3
+        app.kubernetes.io/version: 2026.3.4
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-ui
     spec:
@@ -203,7 +203,7 @@ should match snapshot with all features enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.3
+        app.kubernetes.io/version: 2026.3.4
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-ui
     spec:
@@ -226,7 +226,7 @@ should match snapshot with all features enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.3
+        app.kubernetes.io/version: 2026.3.4
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-ui
     spec:
@@ -252,7 +252,7 @@ should match snapshot with all features enabled:
                     secretKeyRef:
                       key: TENSORZERO_GATEWAY_URL
                       name: tensorzero-secret
-              image: tensorzero/ui:2026.3.3
+              image: tensorzero/ui:2026.3.4
               imagePullPolicy: IfNotPresent
               name: ui
               ports:
@@ -297,7 +297,7 @@ should match snapshot with default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.3
+        app.kubernetes.io/version: 2026.3.4
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero
   2: |
@@ -309,7 +309,7 @@ should match snapshot with default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.3
+        app.kubernetes.io/version: 2026.3.4
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-gateway
     spec:
@@ -333,7 +333,7 @@ should match snapshot with default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.3
+        app.kubernetes.io/version: 2026.3.4
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-gateway
     spec:
@@ -356,7 +356,7 @@ should match snapshot with default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.3
+        app.kubernetes.io/version: 2026.3.4
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-gateway
     spec:
@@ -396,7 +396,7 @@ should match snapshot with default values:
                     secretKeyRef:
                       key: OPENAI_API_KEY
                       name: tensorzero-secret
-              image: tensorzero/gateway:2026.3.3
+              image: tensorzero/gateway:2026.3.4
               imagePullPolicy: IfNotPresent
               name: tensorzero
               ports:
@@ -428,7 +428,7 @@ should match snapshot with default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.3
+        app.kubernetes.io/version: 2026.3.4
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-ui
     spec:
@@ -452,7 +452,7 @@ should match snapshot with default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.3
+        app.kubernetes.io/version: 2026.3.4
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-ui
     spec:
@@ -475,7 +475,7 @@ should match snapshot with default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.3
+        app.kubernetes.io/version: 2026.3.4
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-ui
     spec:
@@ -501,7 +501,7 @@ should match snapshot with default values:
                     secretKeyRef:
                       key: TENSORZERO_GATEWAY_URL
                       name: tensorzero-secret
-              image: tensorzero/ui:2026.3.3
+              image: tensorzero/ui:2026.3.4
               imagePullPolicy: IfNotPresent
               name: ui
               ports:
@@ -545,7 +545,7 @@ should match snapshot with minimal config (no UI, no ingress, no persistence):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.3
+        app.kubernetes.io/version: 2026.3.4
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero
   2: |
@@ -557,7 +557,7 @@ should match snapshot with minimal config (no UI, no ingress, no persistence):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.3
+        app.kubernetes.io/version: 2026.3.4
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-gateway
     spec:
@@ -580,7 +580,7 @@ should match snapshot with minimal config (no UI, no ingress, no persistence):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.3
+        app.kubernetes.io/version: 2026.3.4
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-gateway
     spec:
@@ -620,7 +620,7 @@ should match snapshot with minimal config (no UI, no ingress, no persistence):
                     secretKeyRef:
                       key: OPENAI_API_KEY
                       name: tensorzero-secret
-              image: tensorzero/gateway:2026.3.3
+              image: tensorzero/gateway:2026.3.4
               imagePullPolicy: IfNotPresent
               name: tensorzero
               ports:

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorzero-ui",
-  "version": "2026.3.3",
+  "version": "2026.3.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates version strings and deployment image tags, without changing runtime logic.
> 
> **Overview**
> Bumps the workspace and crate versions from `2026.3.3` to `2026.3.4` (including `Cargo.lock`).
> 
> Updates the Helm production deployment examples/snapshots and UI package metadata to reference `2026.3.4` images and `appVersion`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03d704e58705cd15fb7c2834c36bafec459ede27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->