### PR TITLE
Add get_feedback_by_target_id to default whitelisted tool names

### DIFF
--- a/crates/autopilot-tools/src/lib.rs
+++ b/crates/autopilot-tools/src/lib.rs
@@ -95,6 +95,7 @@ pub fn default_whitelisted_tool_names() -> HashSet<String> {
         "upload_dataset",
         "list_episodes",
         "gepa",
+        "get_feedback_by_target_id",
     ]
     .into_iter()
     .map(String::from)


### PR DESCRIPTION
## Summary
- Add `get_feedback_by_target_id` to `default_whitelisted_tool_names()` so the autopilot client gateway auto-approves calls to this tool
- The tool is already implemented and registered in `for_each_tool()` but was missing from the whitelist

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only expands the default auto-approved tool whitelist to include an already-implemented, non-destructive read tool.
> 
> **Overview**
> Adds `get_feedback_by_target_id` to `default_whitelisted_tool_names()` so autopilot can automatically approve calls to this existing feedback query tool (it was registered in `for_each_tool()` but not whitelisted).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3d7b7b141f9c0370a260049f298bc29b1defab6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->