### PR TITLE
Remove unused 'OpenSSL' license allowance

### DIFF
--- a/crates/deny.toml
+++ b/crates/deny.toml
@@ -39,7 +39,6 @@ allow = [
     "BSD-3-Clause",
     "Zlib",
     "MIT-0",
-    "OpenSSL",
     "BSD-2-Clause",
 ]
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change that just tightens license allowlisting; it may cause `cargo deny` to fail if any dependency is actually licensed under OpenSSL.
> 
> **Overview**
> Removes `OpenSSL` from the `cargo-deny` license allowlist in `crates/deny.toml`, tightening license compliance checks so dependencies using that license will now be flagged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bc2e2ab47f04e2f672ecc970693cbcdf98e1c4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->