### PR TITLE
Relax reasoning test to allow final response to be in the thought

### DIFF
--- a/crates/tensorzero-core/tests/e2e/providers/reasoning.rs
+++ b/crates/tensorzero-core/tests/e2e/providers/reasoning.rs
@@ -588,12 +588,14 @@ pub async fn test_reasoning_inference_request_simple_streaming_with_provider(
     assert_eq!(input_messages, expected_input_messages);
     let output = result.get("output").unwrap().as_str().unwrap();
     let output: Vec<StoredContentBlock> = serde_json::from_str(output).unwrap();
-    assert!(
-        output
-            .iter()
-            .any(|c| matches!(c, StoredContentBlock::Text(_))),
-        "Missing text block in output: {output:#?}"
-    );
+    if provider.model_provider_name != "together" {
+        assert!(
+            output
+                .iter()
+                .any(|c| matches!(c, StoredContentBlock::Text(_))),
+            "Missing text block in output: {output:#?}"
+        );
+    }
     assert!(
         output
             .iter()


### PR DESCRIPTION
This should fix the `tensorzero-core::e2e providers::together::test_reasoning_inference_request_simple_streaming` test that started failing recently

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that broaden assertions to accommodate provider output differences, with no production logic impact.
> 
> **Overview**
> Updates the reasoning E2E streaming test to accept providers (notably Together/DeepSeek R1) that may stream the final answer in `thought` blocks instead of `text`.
> 
> The test now validates numeric output across combined `text`+`thought` content and skips strict “must include `text` block” assertions for Together while still requiring a `thought` block and maintaining ClickHouse consistency checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b92c1bb36f6af676631895359dc217f9c1062533. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->