### PR TITLE
Replace fixed sleeps with ViewOffsetDeadline in ClickHouse migrations

### DIFF
--- a/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0009.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0009.rs
@@ -1,9 +1,8 @@
-use std::time::Duration;
-
 use crate::db::clickhouse::migration_manager::migration_trait::Migration;
 use crate::db::clickhouse::{ClickHouseConnectionInfo, GetMaybeReplicatedTableEngineNameArgs};
 use crate::error::{Error, ErrorDetails};
 
+use super::ViewOffsetDeadline;
 use super::check_table_exists;
 use async_trait::async_trait;
 
@@ -58,7 +57,7 @@ impl Migration for Migration0009<'_> {
 
     async fn apply(&self, clean_start: bool) -> Result<(), Error> {
         // Only gets used when we are not doing a clean start
-        let view_offset = Duration::from_secs(15);
+        let view_deadline = ViewOffsetDeadline::new();
         let view_timestamp = (std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_err(|e| {
@@ -67,8 +66,8 @@ impl Migration for Migration0009<'_> {
                     message: e.to_string(),
                 })
             })?
-            + view_offset)
-            .as_secs();
+            + ViewOffsetDeadline::offset())
+        .as_secs();
 
         let table_engine_name = self.clickhouse.get_maybe_replicated_table_engine_name(
             GetMaybeReplicatedTableEngineNameArgs {
@@ -272,8 +271,7 @@ impl Migration for Migration0009<'_> {
 
         // Insert the data from the original tables into the new table (we do this concurrently since it could theoretically take a long time)
         if !clean_start {
-            // Sleep for the duration specified by view_offset to allow the materialized views to catch up
-            tokio::time::sleep(view_offset).await;
+            view_deadline.wait().await;
             let insert_boolean_metric_feedback = async {
                 let query = format!(
                     r"

--- a/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0013.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0013.rs
@@ -1,9 +1,8 @@
-use std::time::Duration;
-
 use crate::db::clickhouse::migration_manager::migration_trait::Migration;
 use crate::db::clickhouse::{ClickHouseConnectionInfo, GetMaybeReplicatedTableEngineNameArgs};
 use crate::error::{Error, ErrorDetails};
 
+use super::ViewOffsetDeadline;
 use super::check_table_exists;
 use async_trait::async_trait;
 
@@ -118,7 +117,7 @@ impl Migration for Migration0013<'_> {
 
     async fn apply(&self, clean_start: bool) -> Result<(), Error> {
         // Only gets used when we are not doing a clean start
-        let view_offset = Duration::from_secs(15);
+        let _view_deadline = ViewOffsetDeadline::new();
         let view_timestamp = (std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_err(|e| {
@@ -127,8 +126,8 @@ impl Migration for Migration0013<'_> {
                     message: e.to_string(),
                 })
             })?
-            + view_offset)
-            .as_secs();
+            + ViewOffsetDeadline::offset())
+        .as_secs();
         let query = "SELECT toUInt32(COUNT())  FROM ChatInference".to_string();
         let chat_count: usize = self
             .clickhouse
@@ -352,8 +351,7 @@ impl Migration for Migration0013<'_> {
 
         /*
         if !self.clean_start {
-            // Sleep for the duration specified by view_offset to allow the materialized views to catch up
-            tokio::time::sleep(view_offset).await;
+            view_deadline.wait().await;
 
             let insert_chat_inference = async {
                 let query = format!(

--- a/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0020.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0020.rs
@@ -1,11 +1,10 @@
 use rand::prelude::*;
-use std::time::Duration;
 
 use crate::db::clickhouse::migration_manager::migration_trait::Migration;
 use crate::db::clickhouse::{ClickHouseConnectionInfo, GetMaybeReplicatedTableEngineNameArgs};
 use crate::error::{Error, ErrorDetails};
 
-use super::{check_table_exists, get_table_engine};
+use super::{ViewOffsetDeadline, check_table_exists, get_table_engine};
 use async_trait::async_trait;
 
 /// This migration reinitializes the `InferenceById` and `InferenceByEpisodeId` tables and
@@ -131,7 +130,7 @@ impl Migration for Migration0020<'_> {
 
     async fn apply(&self, clean_start: bool) -> Result<(), Error> {
         // Only gets used when we are not doing a clean start
-        let view_offset = Duration::from_secs(15);
+        let view_deadline = ViewOffsetDeadline::new();
 
         // Check if the InferenceById table exists
         let inference_by_id_exists =
@@ -256,8 +255,8 @@ impl Migration for Migration0020<'_> {
                     message: e.to_string(),
                 })
             })?
-            + view_offset)
-            .as_secs();
+            + ViewOffsetDeadline::offset())
+        .as_secs();
 
         // If we are not doing a clean start, we need to add a where clause to the view to only include rows that have been created after the view_timestamp
         let view_where_clause = if clean_start {
@@ -353,8 +352,7 @@ impl Migration for Migration0020<'_> {
             .await?;
 
         if !clean_start {
-            // Sleep for the duration specified by view_offset to allow the materialized views to catch up
-            tokio::time::sleep(view_offset).await;
+            view_deadline.wait().await;
 
             // Insert the data from the original tables into the new tables sequentially
             // First, insert data into InferenceById from ChatInference

--- a/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0021.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0021.rs
@@ -1,8 +1,6 @@
-use std::time::Duration;
-
 use async_trait::async_trait;
 
-use super::{check_column_exists, check_table_exists, get_default_expression};
+use super::{ViewOffsetDeadline, check_column_exists, check_table_exists, get_default_expression};
 use crate::db::clickhouse::migration_manager::migration_trait::Migration;
 use crate::db::clickhouse::{ClickHouseConnectionInfo, GetMaybeReplicatedTableEngineNameArgs};
 use crate::error::{Error, ErrorDetails};
@@ -103,7 +101,7 @@ impl Migration for Migration0021<'_> {
 
     async fn apply(&self, clean_start: bool) -> Result<(), Error> {
         // Only gets used when we are not doing a clean start
-        let view_offset = Duration::from_secs(15);
+        let view_deadline = ViewOffsetDeadline::new();
         let view_timestamp = (std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_err(|e| {
@@ -112,8 +110,8 @@ impl Migration for Migration0021<'_> {
                     message: e.to_string(),
                 })
             })?
-            + view_offset)
-            .as_secs();
+            + ViewOffsetDeadline::offset())
+        .as_secs();
         let on_cluster_name = self.clickhouse.get_on_cluster_name();
         let table_engine_name = self.clickhouse.get_maybe_replicated_table_engine_name(
             GetMaybeReplicatedTableEngineNameArgs {
@@ -232,8 +230,7 @@ impl Migration for Migration0021<'_> {
             .await?;
 
         if !clean_start {
-            // Sleep for the duration specified by view_offset to allow the materialized views to catch up
-            tokio::time::sleep(view_offset).await;
+            view_deadline.wait().await;
 
             let insert_chat_inference = async {
                 let query = format!(

--- a/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0028.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0028.rs
@@ -1,11 +1,9 @@
-use std::time::Duration;
-
 use crate::db::clickhouse::migration_manager::migration_trait::Migration;
 use crate::db::clickhouse::{ClickHouseConnectionInfo, GetMaybeReplicatedTableEngineNameArgs};
 use crate::error::{Error, ErrorDetails};
 use async_trait::async_trait;
 
-use super::{check_detached_table_exists, check_table_exists};
+use super::{ViewOffsetDeadline, check_detached_table_exists, check_table_exists};
 
 /// NOTE: This migration supersedes migration_0023.
 /// Migration 0023 was inefficient due to its use of joins.
@@ -110,7 +108,7 @@ impl Migration for Migration0028<'_> {
     }
 
     async fn apply(&self, clean_start: bool) -> Result<(), Error> {
-        let view_offset = Duration::from_secs(10);
+        let view_deadline = ViewOffsetDeadline::new();
         let current_time = std::time::SystemTime::now();
         let view_timestamp = (current_time
             .duration_since(std::time::UNIX_EPOCH)
@@ -120,8 +118,8 @@ impl Migration for Migration0028<'_> {
                     message: e.to_string(),
                 })
             })?
-            + view_offset)
-            .as_secs();
+            + ViewOffsetDeadline::offset())
+        .as_secs();
         let view_timestamp_where_clause = if clean_start {
             String::new()
         } else {
@@ -309,8 +307,7 @@ impl Migration for Migration0028<'_> {
             .await?;
 
         if !clean_start {
-            // Sleep for the duration specified by view_offset to allow the materialized views to catch up
-            tokio::time::sleep(view_offset).await;
+            view_deadline.wait().await;
             let current_timestamp = current_time
                 .duration_since(std::time::UNIX_EPOCH)
                 .map_err(|e| {

--- a/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0034.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0034.rs
@@ -5,7 +5,8 @@ use crate::error::{Error, ErrorDetails};
 use crate::serde_util::deserialize_u64;
 use async_trait::async_trait;
 use serde::Deserialize;
-use std::time::Duration;
+
+use super::ViewOffsetDeadline;
 
 /// This migration adds a `CumulativeUsage` table and `CumulativeUsageView` materialized view
 /// This will allow the sum of tokens in the ModelInference table to be amortized and
@@ -42,7 +43,7 @@ impl Migration for Migration0034<'_> {
     }
 
     async fn apply(&self, clean_start: bool) -> Result<(), Error> {
-        let view_offset = Duration::from_secs(15);
+        let view_deadline = ViewOffsetDeadline::new();
         let view_timestamp_nanos = (std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_err(|e| {
@@ -51,8 +52,8 @@ impl Migration for Migration0034<'_> {
                     message: e.to_string(),
                 })
             })?
-            + view_offset)
-            .as_nanos();
+            + ViewOffsetDeadline::offset())
+        .as_nanos();
         let on_cluster_name = self.clickhouse.get_on_cluster_name();
         let table_engine_name = self.clickhouse.get_maybe_replicated_table_engine_name(
             GetMaybeReplicatedTableEngineNameArgs {
@@ -109,7 +110,7 @@ impl Migration for Migration0034<'_> {
         // NOTE: this migration is subsumed by 0035 so we do not need to run the backfill for this table any more
         // If we are not clean starting, we must backfill this table
         if !clean_start {
-            tokio::time::sleep(view_offset).await;
+            view_deadline.wait().await;
             // Check if the materialized view we wrote is still in the table.
             // If this is the case, we should compute the backfilled sums and add them to the table.
             // Otherwise, we should warn that our view was not written (probably because a concurrent client did this first)

--- a/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0037.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0037.rs
@@ -1,9 +1,9 @@
+use super::ViewOffsetDeadline;
 use super::check_table_exists;
 use crate::db::clickhouse::migration_manager::migration_trait::Migration;
 use crate::db::clickhouse::{ClickHouseConnectionInfo, GetMaybeReplicatedTableEngineNameArgs};
 use crate::error::{Error, ErrorDetails};
 use async_trait::async_trait;
-use std::time::Duration;
 
 pub struct Migration0037<'a> {
     pub clickhouse: &'a ClickHouseConnectionInfo,
@@ -57,7 +57,7 @@ impl Migration for Migration0037<'_> {
     async fn apply(&self, clean_start: bool) -> Result<(), Error> {
         let qs = quantiles_sql_args();
 
-        let view_offset = Duration::from_secs(15);
+        let view_deadline = ViewOffsetDeadline::new();
         let view_timestamp_nanos = (std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_err(|e| {
@@ -66,8 +66,8 @@ impl Migration for Migration0037<'_> {
                     message: e.to_string(),
                 })
             })?
-            + view_offset)
-            .as_nanos();
+            + ViewOffsetDeadline::offset())
+        .as_nanos();
 
         let on_cluster_name = self.clickhouse.get_on_cluster_name();
         let table_engine_name = self.clickhouse.get_maybe_replicated_table_engine_name(
@@ -131,7 +131,7 @@ impl Migration for Migration0037<'_> {
 
         // Backfill if needed
         if !clean_start {
-            tokio::time::sleep(view_offset).await;
+            view_deadline.wait().await;
 
             let create_table = self
                 .clickhouse

--- a/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0038.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0038.rs
@@ -1,10 +1,10 @@
+use super::ViewOffsetDeadline;
 use super::check_table_exists;
 use crate::db::clickhouse::migration_manager::migration_trait::Migration;
 use crate::db::clickhouse::{ClickHouseConnectionInfo, GetMaybeReplicatedTableEngineNameArgs};
 use crate::error::{Error, ErrorDetails};
 use crate::utils::uuid::get_workflow_evaluation_cutoff_uuid;
 use async_trait::async_trait;
-use std::time::Duration;
 
 /*
  * This migration sets up the EpisodeById table.
@@ -52,7 +52,7 @@ impl Migration for Migration0038<'_> {
     }
 
     async fn apply(&self, clean_start: bool) -> Result<(), Error> {
-        let view_offset = Duration::from_secs(15);
+        let view_deadline = ViewOffsetDeadline::new();
         let view_timestamp_nanos = (std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_err(|e| {
@@ -61,8 +61,8 @@ impl Migration for Migration0038<'_> {
                     message: e.to_string(),
                 })
             })?
-            + view_offset)
-            .as_nanos();
+            + ViewOffsetDeadline::offset())
+        .as_nanos();
 
         let on_cluster_name = self.clickhouse.get_on_cluster_name();
         let table_engine_name = self.clickhouse.get_maybe_replicated_table_engine_name(
@@ -139,7 +139,7 @@ impl Migration for Migration0038<'_> {
 
         // Backfill if needed
         if !clean_start {
-            tokio::time::sleep(view_offset).await;
+            view_deadline.wait().await;
 
             let create_chat_table = self
                 .clickhouse

--- a/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0039.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0039.rs
@@ -1,9 +1,9 @@
+use super::ViewOffsetDeadline;
 use super::check_table_exists;
 use crate::db::clickhouse::migration_manager::migration_trait::Migration;
 use crate::db::clickhouse::{ClickHouseConnectionInfo, GetMaybeReplicatedTableEngineNameArgs};
 use crate::error::{Error, ErrorDetails};
 use async_trait::async_trait;
-use std::time::Duration;
 
 /*
  * Introduces a table FeedbackByVariantStatistics which stores aggregated summary statistics
@@ -76,7 +76,7 @@ impl Migration for Migration0039<'_> {
     }
 
     async fn apply(&self, clean_start: bool) -> Result<(), Error> {
-        let view_offset = Duration::from_secs(15);
+        let view_deadline = ViewOffsetDeadline::new();
         let view_timestamp_nanos = (std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_err(|e| {
@@ -85,8 +85,8 @@ impl Migration for Migration0039<'_> {
                     message: e.to_string(),
                 })
             })?
-            + view_offset)
-            .as_nanos();
+            + ViewOffsetDeadline::offset())
+        .as_nanos();
 
         let on_cluster_name = self.clickhouse.get_on_cluster_name();
         let float_table_engine_name = self.clickhouse.get_maybe_replicated_table_engine_name(
@@ -350,7 +350,7 @@ impl Migration for Migration0039<'_> {
 
         // Backfill if needed
         if !clean_start {
-            tokio::time::sleep(view_offset).await;
+            view_deadline.wait().await;
 
             let create_float_feedback_by_variant_view = self
                 .clickhouse

--- a/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0048.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0048.rs
@@ -4,8 +4,8 @@ use crate::db::clickhouse::ClickHouseConnectionInfo;
 use crate::db::clickhouse::migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
 use async_trait::async_trait;
-use std::time::Duration;
 
+use super::ViewOffsetDeadline;
 use super::migration_0037::quantiles_sql_args;
 
 pub struct Migration0048<'a> {
@@ -47,8 +47,8 @@ impl Migration for Migration0048<'_> {
             ))
             .await?;
 
-        // 2. Record timestamp T (now + 15s offset)
-        let view_offset = Duration::from_secs(15);
+        // 2. Record timestamp T (now + offset)
+        let view_deadline = ViewOffsetDeadline::new();
         let view_timestamp_nanos = (std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_err(|e| {
@@ -57,8 +57,8 @@ impl Migration for Migration0048<'_> {
                     message: e.to_string(),
                 })
             })?
-            + view_offset)
-            .as_nanos();
+            + ViewOffsetDeadline::offset())
+        .as_nanos();
 
         // 3. Drop the existing MV
         self.clickhouse
@@ -100,7 +100,7 @@ impl Migration for Migration0048<'_> {
 
         // 5. Backfill if needed
         if !clean_start {
-            tokio::time::sleep(view_offset).await;
+            view_deadline.wait().await;
 
             let create_table = self
                 .clickhouse

--- a/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0051.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0051.rs
@@ -4,8 +4,8 @@ use crate::db::clickhouse::ClickHouseConnectionInfo;
 use crate::db::clickhouse::migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
 use async_trait::async_trait;
-use std::time::Duration;
 
+use super::ViewOffsetDeadline;
 use super::migration_0037::quantiles_sql_args;
 
 /// This migration adds `provider_cache_read_input_tokens` and `provider_cache_write_input_tokens` columns
@@ -97,8 +97,7 @@ impl Migration for Migration0051<'_> {
             ))
             .await?;
 
-        // 3. Record timestamp T (now + 15s offset)
-        let view_offset = Duration::from_secs(15);
+        // 3. Record timestamp T (now + offset)
         let view_timestamp_nanos = (std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_err(|e| {
@@ -107,8 +106,8 @@ impl Migration for Migration0051<'_> {
                     message: e.to_string(),
                 })
             })?
-            + view_offset)
-            .as_nanos();
+            + ViewOffsetDeadline::offset())
+        .as_nanos();
 
         // 4. Drop the existing MV
         self.clickhouse

--- a/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0052.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0052.rs
@@ -4,8 +4,8 @@ use crate::db::clickhouse::ClickHouseConnectionInfo;
 use crate::db::clickhouse::migration_manager::migration_trait::Migration;
 use crate::error::{Error, ErrorDetails};
 use async_trait::async_trait;
-use std::time::Duration;
 
+use super::ViewOffsetDeadline;
 use super::migration_0037::quantiles_sql_args;
 
 /// Adds a dedicated `count_with_cost` column to `ModelProviderStatistics` so that
@@ -54,8 +54,8 @@ impl Migration for Migration0052<'_> {
             ))
             .await?;
 
-        // 2. Record timestamp T (now + 15s offset)
-        let view_offset = Duration::from_secs(15);
+        // 2. Record timestamp T (now + offset)
+        let view_deadline = ViewOffsetDeadline::new();
         let view_timestamp_nanos = (std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_err(|e| {
@@ -64,8 +64,8 @@ impl Migration for Migration0052<'_> {
                     message: e.to_string(),
                 })
             })?
-            + view_offset)
-            .as_nanos();
+            + ViewOffsetDeadline::offset())
+        .as_nanos();
 
         // 3. Drop the existing MV
         self.clickhouse
@@ -110,7 +110,7 @@ impl Migration for Migration0052<'_> {
 
         // 5. Backfill if needed
         if !clean_start {
-            tokio::time::sleep(view_offset).await;
+            view_deadline.wait().await;
 
             let create_table = self
                 .clickhouse

--- a/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/mod.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/mod.rs
@@ -5,6 +5,46 @@ use crate::{
     error::{Error, ErrorDetails},
 };
 
+/// Default offset for materialized view recreation during migrations.
+///
+/// When a migration drops and recreates a MV, there's a window where inserts
+/// are not captured. The MV is created with `WHERE id >= T` (where T = now + offset),
+/// and the backfill covers `WHERE id < T`. We must wait until T has passed before
+/// running the backfill so that no new rows can have `id < T`.
+///
+/// The offset only needs to exceed the time to drop + create the MV (typically < 1s,
+/// up to a few seconds on ClickHouse Cloud with replication).
+const VIEW_OFFSET: Duration = Duration::from_secs(5);
+
+/// Tracks a future deadline for MV backfill operations.
+///
+/// Created before the MV drop/recreate work starts. Call [`wait`](Self::wait)
+/// after the MV is recreated — it only sleeps the remaining time until the
+/// deadline, not the full offset duration.
+pub(crate) struct ViewOffsetDeadline {
+    deadline: tokio::time::Instant,
+}
+
+impl ViewOffsetDeadline {
+    /// Creates a new deadline `VIEW_OFFSET` seconds from now.
+    pub(crate) fn new() -> Self {
+        Self {
+            deadline: tokio::time::Instant::now() + VIEW_OFFSET,
+        }
+    }
+
+    /// Waits until the deadline has passed. If the deadline is already in the
+    /// past (because the MV work took longer than the offset), returns immediately.
+    pub(crate) async fn wait(self) {
+        tokio::time::sleep_until(self.deadline).await;
+    }
+
+    /// Returns the offset duration (for computing the future timestamp).
+    pub(crate) fn offset() -> Duration {
+        VIEW_OFFSET
+    }
+}
+
 pub mod migration_0000;
 pub mod migration_0002;
 pub mod migration_0003;


### PR DESCRIPTION
## Summary
- ClickHouse migrations that drop/recreate MVs need to wait for a future timestamp `T` to pass before running backfill. Previously they slept a full 15s **after** the MV work, even though `T` was computed **before** the work started.
- Adds `ViewOffsetDeadline` helper: records deadline at construction, `wait()` only sleeps the remaining time via `sleep_until`
- Reduces `VIEW_OFFSET` from 15s to 5s (only needs to exceed drop+create MV time, typically <1s)
- Net savings: ~100-130s off the `test_clickhouse_migration_manager` test (which runs ~10 migrations with backfill)

## Test plan
- [x] `test_clickhouse_migration_manager` passes (the main beneficiary)
- [x] No other ClickHouse test regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)