### PR TITLE
Fix daily batch tests failing due to missing Postgres

### DIFF
--- a/crates/.config/nextest.toml
+++ b/crates/.config/nextest.toml
@@ -40,7 +40,7 @@ not (test(batch) | test(test_dummy_only) | test(clickhouse::) | (test(db::) & !t
 junit.path = "junit.xml"
 
 [profile.live-batch]
-default-filter = 'test(batch) and not test(mock)'
+default-filter = 'test(batch) and not test(mock) and not test(postgres)'
 
 [profile.mock-batch]
 default-filter = 'test(batch) and test(mock)'


### PR DESCRIPTION
## Summary

- The `live-batch` nextest profile matched `test_batch_request_has_snapshot_hash_postgres`, but the `live-batch-tests.yml` workflow doesn't provision Postgres or set `TENSORZERO_POSTGRES_URL`
- This has caused daily test failures for 10+ days with: `Environment variable TENSORZERO_POSTGRES_URL must be set: NotPresent`
- Excludes `postgres` tests from the `live-batch` profile — they're already covered by the dedicated postgres test job in `general.yml`

## Test plan

- [ ] Verify daily tests pass with this change (the postgres batch test should no longer be selected by the `live-batch` profile)
- [ ] Confirm `cargo nextest list --features e2e_tests --profile live-batch` no longer includes `test_batch_request_has_snapshot_hash_postgres`
- [ ] Confirm the postgres batch test still runs in the `general.yml` workflow's postgres job

🤖 Generated with [Claude Code](https://claude.com/claude-code)