### PR TITLE
Remove PgPool from SimpleToolContext

### DIFF
--- a/crates/autopilot-tools/tests/config_tools.rs
+++ b/crates/autopilot-tools/tests/config_tools.rs
@@ -6,9 +6,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use autopilot_client::{AutopilotSideInfo, OptimizationWorkflowSideInfo};
-use durable::MIGRATOR;
 use durable_tools::{ErasedSimpleTool, SimpleToolContext, ToolRegistry};
-use sqlx::PgPool;
 use tensorzero::{GetConfigResponse, WriteConfigResponse};
 use uuid::Uuid;
 
@@ -17,8 +15,8 @@ use autopilot_tools::tools::{
 };
 use common::MockTensorZeroClient;
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_get_config_tool_with_hash(pool: PgPool) {
+#[tokio::test]
+async fn test_get_config_tool_with_hash() {
     let response = GetConfigResponse {
         hash: "1234567".to_string(),
         config: serde_json::json!({}),
@@ -49,7 +47,7 @@ async fn test_get_config_tool_with_hash(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -64,8 +62,8 @@ async fn test_get_config_tool_with_hash(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_write_config_tool_sets_autopilot_tags(pool: PgPool) {
+#[tokio::test]
+async fn test_write_config_tool_sets_autopilot_tags() {
     let session_id = Uuid::now_v7();
     let tool_call_event_id = Uuid::now_v7();
 
@@ -116,7 +114,7 @@ async fn test_write_config_tool_sets_autopilot_tags(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(

--- a/crates/autopilot-tools/tests/datapoint_tools.rs
+++ b/crates/autopilot-tools/tests/datapoint_tools.rs
@@ -6,9 +6,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use autopilot_client::{AutopilotSideInfo, OptimizationWorkflowSideInfo};
-use durable::MIGRATOR;
 use durable_tools::{ErasedSimpleTool, SimpleToolContext, TensorZeroClientError, ToolRegistry};
-use sqlx::PgPool;
 use tensorzero::{
     CreateChatDatapointRequest, CreateDatapointRequest, CreateDatapointsFromInferenceRequestParams,
     ListDatapointsRequest, ListDatasetsRequest, UpdateChatDatapointRequest, UpdateDatapointRequest,
@@ -31,8 +29,8 @@ use common::{
 
 // ===== CreateDatapointsTool Tests =====
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_create_datapoints_tool_basic(pool: PgPool) {
+#[tokio::test]
+async fn test_create_datapoints_tool_basic() {
     let datapoint_id = Uuid::now_v7();
     let mock_response = create_mock_create_datapoints_response(vec![datapoint_id]);
 
@@ -70,7 +68,7 @@ async fn test_create_datapoints_tool_basic(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -85,8 +83,8 @@ async fn test_create_datapoints_tool_basic(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_create_datapoints_tool_adds_autopilot_tags(pool: PgPool) {
+#[tokio::test]
+async fn test_create_datapoints_tool_adds_autopilot_tags() {
     let datapoint_id = Uuid::now_v7();
     let mock_response = create_mock_create_datapoints_response(vec![datapoint_id]);
 
@@ -136,7 +134,7 @@ async fn test_create_datapoints_tool_adds_autopilot_tags(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     tool.execute_erased(
         serde_json::to_value(&llm_params).expect("Failed to serialize llm_params"),
@@ -148,8 +146,8 @@ async fn test_create_datapoints_tool_adds_autopilot_tags(pool: PgPool) {
     .expect("CreateDatapointsTool execution should succeed");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_create_datapoints_tool_user_tags_take_precedence(pool: PgPool) {
+#[tokio::test]
+async fn test_create_datapoints_tool_user_tags_take_precedence() {
     let datapoint_id = Uuid::now_v7();
     let mock_response = create_mock_create_datapoints_response(vec![datapoint_id]);
 
@@ -208,7 +206,7 @@ async fn test_create_datapoints_tool_user_tags_take_precedence(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     tool.execute_erased(
         serde_json::to_value(&llm_params).expect("Failed to serialize llm_params"),
@@ -220,8 +218,8 @@ async fn test_create_datapoints_tool_user_tags_take_precedence(pool: PgPool) {
     .expect("CreateDatapointsTool execution should succeed");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_create_datapoints_tool_error(pool: PgPool) {
+#[tokio::test]
+async fn test_create_datapoints_tool_error() {
     let llm_params = CreateDatapointsToolParams {
         dataset_name: "test_dataset".to_string(),
         datapoints: vec![CreateDatapointRequest::Chat(CreateChatDatapointRequest {
@@ -252,7 +250,7 @@ async fn test_create_datapoints_tool_error(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -268,8 +266,8 @@ async fn test_create_datapoints_tool_error(pool: PgPool) {
 
 // ===== GetDatapointsTool Tests =====
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_get_datapoints_tool_with_dataset_name(pool: PgPool) {
+#[tokio::test]
+async fn test_get_datapoints_tool_with_dataset_name() {
     let datapoint_id = Uuid::now_v7();
     let datapoint = create_mock_chat_datapoint(datapoint_id, "test_dataset", "test_function");
     let mock_response = create_mock_get_datapoints_response(vec![datapoint]);
@@ -299,7 +297,7 @@ async fn test_get_datapoints_tool_with_dataset_name(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -314,8 +312,8 @@ async fn test_get_datapoints_tool_with_dataset_name(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_get_datapoints_tool_without_dataset_name(pool: PgPool) {
+#[tokio::test]
+async fn test_get_datapoints_tool_without_dataset_name() {
     let datapoint_id = Uuid::now_v7();
     let datapoint = create_mock_chat_datapoint(datapoint_id, "test_dataset", "test_function");
     let mock_response = create_mock_get_datapoints_response(vec![datapoint]);
@@ -343,7 +341,7 @@ async fn test_get_datapoints_tool_without_dataset_name(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -358,8 +356,8 @@ async fn test_get_datapoints_tool_without_dataset_name(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_get_datapoints_tool_error(pool: PgPool) {
+#[tokio::test]
+async fn test_get_datapoints_tool_error() {
     let llm_params = GetDatapointsToolParams {
         dataset_name: Some("test_dataset".to_string()),
         ids: vec![Uuid::now_v7()],
@@ -382,7 +380,7 @@ async fn test_get_datapoints_tool_error(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -398,8 +396,8 @@ async fn test_get_datapoints_tool_error(pool: PgPool) {
 
 // ===== ListDatapointsTool Tests =====
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_datapoints_tool_basic(pool: PgPool) {
+#[tokio::test]
+async fn test_list_datapoints_tool_basic() {
     let datapoint_id = Uuid::now_v7();
     let datapoint = create_mock_chat_datapoint(datapoint_id, "test_dataset", "test_function");
     let mock_response = create_mock_get_datapoints_response(vec![datapoint]);
@@ -427,7 +425,7 @@ async fn test_list_datapoints_tool_basic(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -442,8 +440,8 @@ async fn test_list_datapoints_tool_basic(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_datapoints_tool_with_filters(pool: PgPool) {
+#[tokio::test]
+async fn test_list_datapoints_tool_with_filters() {
     let mock_response = create_mock_get_datapoints_response(vec![]);
 
     let llm_params = ListDatapointsToolParams {
@@ -479,7 +477,7 @@ async fn test_list_datapoints_tool_with_filters(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -494,8 +492,8 @@ async fn test_list_datapoints_tool_with_filters(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_datapoints_tool_error(pool: PgPool) {
+#[tokio::test]
+async fn test_list_datapoints_tool_error() {
     let llm_params = ListDatapointsToolParams {
         dataset_name: "test_dataset".to_string(),
         request: ListDatapointsRequest::default(),
@@ -518,7 +516,7 @@ async fn test_list_datapoints_tool_error(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -534,8 +532,8 @@ async fn test_list_datapoints_tool_error(pool: PgPool) {
 
 // ===== UpdateDatapointsTool Tests =====
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_update_datapoints_tool_basic(pool: PgPool) {
+#[tokio::test]
+async fn test_update_datapoints_tool_basic() {
     let original_id = Uuid::now_v7();
     let new_id = Uuid::now_v7();
     let mock_response = create_mock_update_datapoints_response(vec![new_id]);
@@ -570,7 +568,7 @@ async fn test_update_datapoints_tool_basic(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -585,8 +583,8 @@ async fn test_update_datapoints_tool_basic(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_update_datapoints_tool_error(pool: PgPool) {
+#[tokio::test]
+async fn test_update_datapoints_tool_error() {
     let llm_params = UpdateDatapointsToolParams {
         dataset_name: "test_dataset".to_string(),
         datapoints: vec![UpdateDatapointRequest::Chat(UpdateChatDatapointRequest {
@@ -616,7 +614,7 @@ async fn test_update_datapoints_tool_error(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -632,8 +630,8 @@ async fn test_update_datapoints_tool_error(pool: PgPool) {
 
 // ===== DeleteDatapointsTool Tests =====
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_delete_datapoints_tool_basic(pool: PgPool) {
+#[tokio::test]
+async fn test_delete_datapoints_tool_basic() {
     let datapoint_id = Uuid::now_v7();
     let mock_response = create_mock_delete_datapoints_response(1);
 
@@ -662,7 +660,7 @@ async fn test_delete_datapoints_tool_basic(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -677,8 +675,8 @@ async fn test_delete_datapoints_tool_basic(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_delete_datapoints_tool_error(pool: PgPool) {
+#[tokio::test]
+async fn test_delete_datapoints_tool_error() {
     let llm_params = DeleteDatapointsToolParams {
         dataset_name: "test_dataset".to_string(),
         ids: vec![Uuid::now_v7()],
@@ -701,7 +699,7 @@ async fn test_delete_datapoints_tool_error(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -717,8 +715,8 @@ async fn test_delete_datapoints_tool_error(pool: PgPool) {
 
 // ===== CreateDatapointsFromInferencesTool Tests =====
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_create_datapoints_from_inferences_tool_with_ids(pool: PgPool) {
+#[tokio::test]
+async fn test_create_datapoints_from_inferences_tool_with_ids() {
     let datapoint_id = Uuid::now_v7();
     let inference_id = Uuid::now_v7();
     let mock_response = create_mock_create_datapoints_response(vec![datapoint_id]);
@@ -758,7 +756,7 @@ async fn test_create_datapoints_from_inferences_tool_with_ids(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -773,8 +771,8 @@ async fn test_create_datapoints_from_inferences_tool_with_ids(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_create_datapoints_from_inferences_tool_error(pool: PgPool) {
+#[tokio::test]
+async fn test_create_datapoints_from_inferences_tool_error() {
     let llm_params = CreateDatapointsFromInferencesToolParams {
         dataset_name: "test_dataset".to_string(),
         params: CreateDatapointsFromInferenceRequestParams::InferenceIds {
@@ -800,7 +798,7 @@ async fn test_create_datapoints_from_inferences_tool_error(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -816,8 +814,8 @@ async fn test_create_datapoints_from_inferences_tool_error(pool: PgPool) {
 
 // ===== ListDatasetsTool Tests =====
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_datasets_tool_basic(pool: PgPool) {
+#[tokio::test]
+async fn test_list_datasets_tool_basic() {
     let dataset1 = create_mock_dataset_metadata("dataset_1", 100, "2024-01-01T00:00:00Z");
     let dataset2 = create_mock_dataset_metadata("dataset_2", 50, "2024-01-02T00:00:00Z");
     let mock_response = create_mock_list_datasets_response(vec![dataset1, dataset2]);
@@ -843,7 +841,7 @@ async fn test_list_datasets_tool_basic(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -865,8 +863,8 @@ async fn test_list_datasets_tool_basic(pool: PgPool) {
     );
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_datasets_tool_with_function_filter(pool: PgPool) {
+#[tokio::test]
+async fn test_list_datasets_tool_with_function_filter() {
     let dataset = create_mock_dataset_metadata("filtered_dataset", 25, "2024-01-03T00:00:00Z");
     let mock_response = create_mock_list_datasets_response(vec![dataset]);
 
@@ -896,7 +894,7 @@ async fn test_list_datasets_tool_with_function_filter(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -911,8 +909,8 @@ async fn test_list_datasets_tool_with_function_filter(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_datasets_tool_with_pagination(pool: PgPool) {
+#[tokio::test]
+async fn test_list_datasets_tool_with_pagination() {
     let mock_response = create_mock_list_datasets_response(vec![]);
 
     let llm_params = ListDatasetsToolParams {
@@ -941,7 +939,7 @@ async fn test_list_datasets_tool_with_pagination(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -956,8 +954,8 @@ async fn test_list_datasets_tool_with_pagination(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_datasets_tool_empty_response(pool: PgPool) {
+#[tokio::test]
+async fn test_list_datasets_tool_empty_response() {
     let mock_response = create_mock_list_datasets_response(vec![]);
 
     let llm_params = ListDatasetsToolParams {
@@ -981,7 +979,7 @@ async fn test_list_datasets_tool_empty_response(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -1001,8 +999,8 @@ async fn test_list_datasets_tool_empty_response(pool: PgPool) {
     );
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_datasets_tool_error(pool: PgPool) {
+#[tokio::test]
+async fn test_list_datasets_tool_error() {
     let llm_params = ListDatasetsToolParams {
         request: ListDatasetsRequest::default(),
     };
@@ -1024,7 +1022,7 @@ async fn test_list_datasets_tool_error(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(

--- a/crates/autopilot-tools/tests/episode_tools.rs
+++ b/crates/autopilot-tools/tests/episode_tools.rs
@@ -5,9 +5,7 @@ mod common;
 use std::sync::Arc;
 
 use autopilot_client::{AutopilotSideInfo, OptimizationWorkflowSideInfo};
-use durable::MIGRATOR;
 use durable_tools::{ErasedSimpleTool, SimpleToolContext, TensorZeroClientError, ToolRegistry};
-use sqlx::PgPool;
 use sqlx::types::chrono::Utc;
 use tensorzero::{BooleanMetricFilter, InferenceFilter};
 use tensorzero_core::db::EpisodeByIdRow;
@@ -18,8 +16,8 @@ use common::{MockTensorZeroClient, create_mock_list_episodes_response};
 
 // ===== ListEpisodesTool Tests =====
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_episodes_tool_basic(pool: PgPool) {
+#[tokio::test]
+async fn test_list_episodes_tool_basic() {
     let episode_id = Uuid::now_v7();
     let inference_id = Uuid::now_v7();
     let now = Utc::now();
@@ -57,7 +55,7 @@ async fn test_list_episodes_tool_basic(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -82,8 +80,8 @@ async fn test_list_episodes_tool_basic(pool: PgPool) {
     );
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_episodes_tool_with_before_pagination(pool: PgPool) {
+#[tokio::test]
+async fn test_list_episodes_tool_with_before_pagination() {
     let mock_response = create_mock_list_episodes_response(vec![]);
     let cursor_id = Uuid::now_v7();
 
@@ -113,7 +111,7 @@ async fn test_list_episodes_tool_with_before_pagination(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -133,8 +131,8 @@ async fn test_list_episodes_tool_with_before_pagination(pool: PgPool) {
     );
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_episodes_tool_with_after_pagination(pool: PgPool) {
+#[tokio::test]
+async fn test_list_episodes_tool_with_after_pagination() {
     let mock_response = create_mock_list_episodes_response(vec![]);
     let cursor_id = Uuid::now_v7();
 
@@ -164,7 +162,7 @@ async fn test_list_episodes_tool_with_after_pagination(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -184,8 +182,8 @@ async fn test_list_episodes_tool_with_after_pagination(pool: PgPool) {
     );
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_episodes_tool_error(pool: PgPool) {
+#[tokio::test]
+async fn test_list_episodes_tool_error() {
     let llm_params = ListEpisodesToolParams {
         limit: 10,
         before: None,
@@ -211,7 +209,7 @@ async fn test_list_episodes_tool_error(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -227,8 +225,8 @@ async fn test_list_episodes_tool_error(pool: PgPool) {
 
 // ===== Filter Tests =====
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_episodes_tool_with_function_name(pool: PgPool) {
+#[tokio::test]
+async fn test_list_episodes_tool_with_function_name() {
     let episode_id = Uuid::now_v7();
     let inference_id = Uuid::now_v7();
     let now = Utc::now();
@@ -266,7 +264,7 @@ async fn test_list_episodes_tool_with_function_name(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -295,8 +293,8 @@ async fn test_list_episodes_tool_with_function_name(pool: PgPool) {
     );
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_episodes_tool_with_boolean_filter(pool: PgPool) {
+#[tokio::test]
+async fn test_list_episodes_tool_with_boolean_filter() {
     let episode_id = Uuid::now_v7();
     let inference_id = Uuid::now_v7();
     let now = Utc::now();
@@ -337,7 +335,7 @@ async fn test_list_episodes_tool_with_boolean_filter(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -369,8 +367,8 @@ async fn test_list_episodes_tool_with_boolean_filter(pool: PgPool) {
     );
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_episodes_tool_with_combined_filters(pool: PgPool) {
+#[tokio::test]
+async fn test_list_episodes_tool_with_combined_filters() {
     let mock_response = create_mock_list_episodes_response(vec![]);
 
     let llm_params = ListEpisodesToolParams {
@@ -404,7 +402,7 @@ async fn test_list_episodes_tool_with_combined_filters(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(

--- a/crates/autopilot-tools/tests/feedback_tools.rs
+++ b/crates/autopilot-tools/tests/feedback_tools.rs
@@ -6,10 +6,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use autopilot_client::{AutopilotSideInfo, OptimizationWorkflowSideInfo};
-use durable::MIGRATOR;
 use durable_tools::{ErasedSimpleTool, SimpleToolContext, TensorZeroClientError, ToolRegistry};
 use serde_json::json;
-use sqlx::PgPool;
 use sqlx::types::chrono::Utc;
 use tensorzero_core::db::feedback::{
     BooleanMetricFeedbackRow, CommentFeedbackRow, CommentTargetType, FeedbackRow,
@@ -31,8 +29,8 @@ use common::{
 
 // ========== FeedbackTool Tests ==========
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_feedback_tool_comment(pool: PgPool) {
+#[tokio::test]
+async fn test_feedback_tool_comment() {
     let feedback_id = Uuid::now_v7();
     let mock_response = create_mock_feedback_response(feedback_id);
 
@@ -74,7 +72,7 @@ async fn test_feedback_tool_comment(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -93,8 +91,8 @@ async fn test_feedback_tool_comment(pool: PgPool) {
     );
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_feedback_tool_float_metric(pool: PgPool) {
+#[tokio::test]
+async fn test_feedback_tool_float_metric() {
     let feedback_id = Uuid::now_v7();
     let mock_response = create_mock_feedback_response(feedback_id);
 
@@ -133,7 +131,7 @@ async fn test_feedback_tool_float_metric(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -148,8 +146,8 @@ async fn test_feedback_tool_float_metric(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_feedback_tool_boolean_metric(pool: PgPool) {
+#[tokio::test]
+async fn test_feedback_tool_boolean_metric() {
     let feedback_id = Uuid::now_v7();
     let mock_response = create_mock_feedback_response(feedback_id);
 
@@ -187,7 +185,7 @@ async fn test_feedback_tool_boolean_metric(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -202,8 +200,8 @@ async fn test_feedback_tool_boolean_metric(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_feedback_tool_error(pool: PgPool) {
+#[tokio::test]
+async fn test_feedback_tool_error() {
     let llm_params = FeedbackToolParams {
         episode_id: None,
         inference_id: Some(Uuid::now_v7()),
@@ -229,7 +227,7 @@ async fn test_feedback_tool_error(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -245,8 +243,8 @@ async fn test_feedback_tool_error(pool: PgPool) {
 
 // ========== GetLatestFeedbackByMetricTool Tests ==========
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_get_latest_feedback_by_metric_tool_success(pool: PgPool) {
+#[tokio::test]
+async fn test_get_latest_feedback_by_metric_tool_success() {
     let target_id = Uuid::now_v7();
     let session_id = Uuid::now_v7();
     let tool_call_event_id = Uuid::now_v7();
@@ -280,7 +278,7 @@ async fn test_get_latest_feedback_by_metric_tool_success(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -299,8 +297,8 @@ async fn test_get_latest_feedback_by_metric_tool_success(pool: PgPool) {
     assert_eq!(feedback_map.len(), 2, "Should have 2 metrics");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_get_latest_feedback_by_metric_tool_empty_result(pool: PgPool) {
+#[tokio::test]
+async fn test_get_latest_feedback_by_metric_tool_empty_result() {
     let target_id = Uuid::now_v7();
     let session_id = Uuid::now_v7();
     let tool_call_event_id = Uuid::now_v7();
@@ -329,7 +327,7 @@ async fn test_get_latest_feedback_by_metric_tool_empty_result(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -348,8 +346,8 @@ async fn test_get_latest_feedback_by_metric_tool_empty_result(pool: PgPool) {
     assert!(feedback_map.is_empty(), "Should have empty feedback map");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_get_latest_feedback_by_metric_tool_error(pool: PgPool) {
+#[tokio::test]
+async fn test_get_latest_feedback_by_metric_tool_error() {
     let llm_params = GetLatestFeedbackByMetricToolParams {
         target_id: Uuid::now_v7(),
     };
@@ -371,7 +369,7 @@ async fn test_get_latest_feedback_by_metric_tool_error(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -387,8 +385,8 @@ async fn test_get_latest_feedback_by_metric_tool_error(pool: PgPool) {
 
 // ========== GetFeedbackByVariantTool Tests ==========
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_get_feedback_by_variant_tool_success(pool: PgPool) {
+#[tokio::test]
+async fn test_get_feedback_by_variant_tool_success() {
     let session_id = Uuid::now_v7();
     let tool_call_event_id = Uuid::now_v7();
 
@@ -423,7 +421,7 @@ async fn test_get_feedback_by_variant_tool_success(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -442,8 +440,8 @@ async fn test_get_feedback_by_variant_tool_success(pool: PgPool) {
     assert_eq!(array[1]["variant_name"], "variant_b");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_get_feedback_by_variant_tool_with_variant_filter(pool: PgPool) {
+#[tokio::test]
+async fn test_get_feedback_by_variant_tool_with_variant_filter() {
     let session_id = Uuid::now_v7();
     let tool_call_event_id = Uuid::now_v7();
 
@@ -477,7 +475,7 @@ async fn test_get_feedback_by_variant_tool_with_variant_filter(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -495,8 +493,8 @@ async fn test_get_feedback_by_variant_tool_with_variant_filter(pool: PgPool) {
     assert_eq!(array[0]["variant_name"], "variant_a");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_get_feedback_by_variant_tool_empty_result(pool: PgPool) {
+#[tokio::test]
+async fn test_get_feedback_by_variant_tool_empty_result() {
     let session_id = Uuid::now_v7();
     let tool_call_event_id = Uuid::now_v7();
 
@@ -523,7 +521,7 @@ async fn test_get_feedback_by_variant_tool_empty_result(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -540,8 +538,8 @@ async fn test_get_feedback_by_variant_tool_empty_result(pool: PgPool) {
     assert!(array.is_empty(), "Should have no variants");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_get_feedback_by_variant_tool_error(pool: PgPool) {
+#[tokio::test]
+async fn test_get_feedback_by_variant_tool_error() {
     let llm_params = GetFeedbackByVariantToolParams {
         metric_name: "accuracy".to_string(),
         function_name: "test_function".to_string(),
@@ -569,7 +567,7 @@ async fn test_get_feedback_by_variant_tool_error(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -585,8 +583,8 @@ async fn test_get_feedback_by_variant_tool_error(pool: PgPool) {
 
 // ========== GetFeedbackByTargetIdTool Tests ==========
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_get_feedback_by_target_id_tool_inference_level(pool: PgPool) {
+#[tokio::test]
+async fn test_get_feedback_by_target_id_tool_inference_level() {
     let inference_id = Uuid::now_v7();
     let session_id = Uuid::now_v7();
     let tool_call_event_id = Uuid::now_v7();
@@ -637,7 +635,7 @@ async fn test_get_feedback_by_target_id_tool_inference_level(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -664,8 +662,8 @@ async fn test_get_feedback_by_target_id_tool_inference_level(pool: PgPool) {
     );
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_get_feedback_by_target_id_tool_episode_level(pool: PgPool) {
+#[tokio::test]
+async fn test_get_feedback_by_target_id_tool_episode_level() {
     let episode_id = Uuid::now_v7();
     let session_id = Uuid::now_v7();
     let tool_call_event_id = Uuid::now_v7();
@@ -716,7 +714,7 @@ async fn test_get_feedback_by_target_id_tool_episode_level(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -743,8 +741,8 @@ async fn test_get_feedback_by_target_id_tool_episode_level(pool: PgPool) {
     );
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_get_feedback_by_target_id_tool_error(pool: PgPool) {
+#[tokio::test]
+async fn test_get_feedback_by_target_id_tool_error() {
     let llm_params = GetFeedbackByTargetIdToolParams {
         target_id: Uuid::now_v7(),
         limit: None,
@@ -767,7 +765,7 @@ async fn test_get_feedback_by_target_id_tool_error(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(

--- a/crates/autopilot-tools/tests/inference_tool.rs
+++ b/crates/autopilot-tools/tests/inference_tool.rs
@@ -5,10 +5,8 @@ mod common;
 use std::sync::Arc;
 
 use autopilot_client::{AutopilotSideInfo, OptimizationWorkflowSideInfo};
-use durable::MIGRATOR;
 use durable_tools::{ActionInput, ActionResponse};
 use durable_tools::{ErasedSimpleTool, SimpleToolContext, TensorZeroClientError, ToolRegistry};
-use sqlx::PgPool;
 use tensorzero::{
     GetInferencesRequest, GetInferencesResponse, InferenceOutputSource, Input, InputMessage,
     InputMessageContent, ListInferencesRequest, Role,
@@ -24,8 +22,8 @@ use common::{MockTensorZeroClient, create_mock_chat_response};
 
 use crate::common::create_mock_stored_chat_inference;
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_inference_tool_with_snapshot_hash(pool: PgPool) {
+#[tokio::test]
+async fn test_inference_tool_with_snapshot_hash() {
     // Create mock response
     let mock_response = create_mock_chat_response("Hello from action!");
 
@@ -90,7 +88,7 @@ async fn test_inference_tool_with_snapshot_hash(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     // Execute the tool
     let result = tool
@@ -109,8 +107,8 @@ async fn test_inference_tool_with_snapshot_hash(pool: PgPool) {
 
 // ===== ListInferencesTool Tests =====
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_inferences_tool_basic(pool: PgPool) {
+#[tokio::test]
+async fn test_list_inferences_tool_basic() {
     let inference_id = Uuid::now_v7();
     let inference =
         create_mock_stored_chat_inference(inference_id, "test_function", "test_variant");
@@ -139,7 +137,7 @@ async fn test_list_inferences_tool_basic(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -154,8 +152,8 @@ async fn test_list_inferences_tool_basic(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_inferences_tool_with_filters(pool: PgPool) {
+#[tokio::test]
+async fn test_list_inferences_tool_with_filters() {
     let mock_response = GetInferencesResponse { inferences: vec![] };
 
     let llm_params = ListInferencesToolParams {
@@ -193,7 +191,7 @@ async fn test_list_inferences_tool_with_filters(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -208,8 +206,8 @@ async fn test_list_inferences_tool_with_filters(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_inferences_tool_with_cursor_pagination(pool: PgPool) {
+#[tokio::test]
+async fn test_list_inferences_tool_with_cursor_pagination() {
     let mock_response = GetInferencesResponse { inferences: vec![] };
     let cursor_id = Uuid::now_v7();
 
@@ -239,7 +237,7 @@ async fn test_list_inferences_tool_with_cursor_pagination(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -254,8 +252,8 @@ async fn test_list_inferences_tool_with_cursor_pagination(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_list_inferences_tool_error(pool: PgPool) {
+#[tokio::test]
+async fn test_list_inferences_tool_error() {
     let llm_params = ListInferencesToolParams {
         request: ListInferencesRequest::default(),
     };
@@ -277,7 +275,7 @@ async fn test_list_inferences_tool_error(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -293,8 +291,8 @@ async fn test_list_inferences_tool_error(pool: PgPool) {
 
 // ===== GetInferencesTool Tests =====
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_get_inferences_tool_basic(pool: PgPool) {
+#[tokio::test]
+async fn test_get_inferences_tool_basic() {
     let inference_id = Uuid::now_v7();
     let inference =
         create_mock_stored_chat_inference(inference_id, "test_function", "test_variant");
@@ -332,7 +330,7 @@ async fn test_get_inferences_tool_basic(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -347,8 +345,8 @@ async fn test_get_inferences_tool_basic(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_get_inferences_tool_with_function_name(pool: PgPool) {
+#[tokio::test]
+async fn test_get_inferences_tool_with_function_name() {
     let inference_id = Uuid::now_v7();
     let inference =
         create_mock_stored_chat_inference(inference_id, "specific_function", "test_variant");
@@ -382,7 +380,7 @@ async fn test_get_inferences_tool_with_function_name(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -397,8 +395,8 @@ async fn test_get_inferences_tool_with_function_name(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_get_inferences_tool_with_output_source(pool: PgPool) {
+#[tokio::test]
+async fn test_get_inferences_tool_with_output_source() {
     let inference_id = Uuid::now_v7();
     let inference =
         create_mock_stored_chat_inference(inference_id, "test_function", "test_variant");
@@ -432,7 +430,7 @@ async fn test_get_inferences_tool_with_output_source(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -447,8 +445,8 @@ async fn test_get_inferences_tool_with_output_source(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_get_inferences_tool_error(pool: PgPool) {
+#[tokio::test]
+async fn test_get_inferences_tool_error() {
     let llm_params = GetInferencesToolParams {
         request: GetInferencesRequest {
             ids: vec![Uuid::now_v7()],
@@ -474,7 +472,7 @@ async fn test_get_inferences_tool_error(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(

--- a/crates/autopilot-tools/tests/run_evaluation_tool.rs
+++ b/crates/autopilot-tools/tests/run_evaluation_tool.rs
@@ -5,12 +5,10 @@ mod common;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use durable::MIGRATOR;
 use durable_tools::{
     ActionInput, ActionResponse, CacheEnabledMode, DatapointResult, ErasedSimpleTool,
     RunEvaluationResponse, SimpleToolContext, ToolRegistry,
 };
-use sqlx::PgPool;
 use uuid::Uuid;
 
 use autopilot_client::{AutopilotSideInfo, OptimizationWorkflowSideInfo};
@@ -40,8 +38,8 @@ fn create_mock_run_evaluation_response() -> RunEvaluationResponse {
 }
 
 /// Test that RunEvaluationTool calls the action endpoint with the correct snapshot hash.
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_run_evaluation_tool_with_snapshot_hash(pool: PgPool) {
+#[tokio::test]
+async fn test_run_evaluation_tool_with_snapshot_hash() {
     // Create mock response
     let mock_response = create_mock_run_evaluation_response();
 
@@ -97,7 +95,7 @@ async fn test_run_evaluation_tool_with_snapshot_hash(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     // Execute the tool
     let result = tool
@@ -114,8 +112,8 @@ async fn test_run_evaluation_tool_with_snapshot_hash(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_run_evaluation_tool_with_dataset_name(pool: PgPool) {
+#[tokio::test]
+async fn test_run_evaluation_tool_with_dataset_name() {
     // Create mock response
     let mock_response = create_mock_run_evaluation_response();
     let expected_response = mock_response.clone();
@@ -176,7 +174,7 @@ async fn test_run_evaluation_tool_with_dataset_name(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     // Execute the tool
     let result = tool
@@ -198,8 +196,8 @@ async fn test_run_evaluation_tool_with_dataset_name(pool: PgPool) {
     assert!(response.stats.contains_key("accuracy"));
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_run_evaluation_tool_with_datapoint_ids(pool: PgPool) {
+#[tokio::test]
+async fn test_run_evaluation_tool_with_datapoint_ids() {
     // Create mock response
     let mock_response = create_mock_run_evaluation_response();
 
@@ -261,7 +259,7 @@ async fn test_run_evaluation_tool_with_datapoint_ids(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     // Execute the tool
     let result = tool
@@ -278,8 +276,8 @@ async fn test_run_evaluation_tool_with_datapoint_ids(pool: PgPool) {
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_run_evaluation_tool_with_precision_targets_and_cache(pool: PgPool) {
+#[tokio::test]
+async fn test_run_evaluation_tool_with_precision_targets_and_cache() {
     // Create mock response
     let mock_response = create_mock_run_evaluation_response();
 
@@ -340,7 +338,7 @@ async fn test_run_evaluation_tool_with_precision_targets_and_cache(pool: PgPool)
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     // Execute the tool
     let result = tool
@@ -357,8 +355,8 @@ async fn test_run_evaluation_tool_with_precision_targets_and_cache(pool: PgPool)
     assert!(result.is_object(), "Result should be a JSON object");
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_run_evaluation_tool_error_handling(pool: PgPool) {
+#[tokio::test]
+async fn test_run_evaluation_tool_error_handling() {
     // Prepare test data
     let session_id = Uuid::now_v7();
     let tool_call_event_id = Uuid::now_v7();
@@ -398,7 +396,7 @@ async fn test_run_evaluation_tool_error_handling(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     // Execute the tool - should fail
     let result = tool
@@ -416,8 +414,8 @@ async fn test_run_evaluation_tool_error_handling(pool: PgPool) {
     );
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_run_evaluation_tool_with_datapoint_results(pool: PgPool) {
+#[tokio::test]
+async fn test_run_evaluation_tool_with_datapoint_results() {
     // Create mock response with per-datapoint results
     let datapoint_id_1 = Uuid::now_v7();
     let datapoint_id_2 = Uuid::now_v7();
@@ -539,7 +537,7 @@ async fn test_run_evaluation_tool_with_datapoint_results(pool: PgPool) {
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     // Execute the tool
     let result = tool
@@ -621,8 +619,8 @@ async fn test_run_evaluation_tool_with_datapoint_results(pool: PgPool) {
     );
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_run_evaluation_tool_rejects_both_evaluation_name_and_evaluator_names(pool: PgPool) {
+#[tokio::test]
+async fn test_run_evaluation_tool_rejects_both_evaluation_name_and_evaluator_names() {
     let llm_params = RunEvaluationToolParams {
         evaluation_name: Some("test_evaluation".to_string()),
         function_name: Some("my_function".to_string()),
@@ -652,7 +650,7 @@ async fn test_run_evaluation_tool_rejects_both_evaluation_name_and_evaluator_nam
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(
@@ -672,8 +670,8 @@ async fn test_run_evaluation_tool_rejects_both_evaluation_name_and_evaluator_nam
     );
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn test_run_evaluation_tool_with_function_name_and_evaluator_names(pool: PgPool) {
+#[tokio::test]
+async fn test_run_evaluation_tool_with_function_name_and_evaluator_names() {
     let mock_response = create_mock_run_evaluation_response();
 
     let session_id = Uuid::now_v7();
@@ -721,7 +719,7 @@ async fn test_run_evaluation_tool_with_function_name_and_evaluator_names(pool: P
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
 
     let result = tool
         .execute_erased(

--- a/crates/autopilot-worker/src/wrapper.rs
+++ b/crates/autopilot-worker/src/wrapper.rs
@@ -343,12 +343,7 @@ async fn execute_simple_tool_step<T: SimpleTool<SideInfo = AutopilotSideInfo>>(
 ) -> anyhow::Result<Result<T::Output, ToolFailure>> {
     let heartbeater = step_state.heartbeater.clone();
     let state = &step_state.state;
-    let simple_ctx = SimpleToolContext::new(
-        state.pool(),
-        state.t0_client(),
-        &heartbeater,
-        state.registry(),
-    );
+    let simple_ctx = SimpleToolContext::new(state.t0_client(), &heartbeater, state.registry());
     let idempotency_key = format!(
         "simple_tool:{}:{}",
         params.tool_name, params.tool_call_event_id

--- a/crates/durable-tools/src/context.rs
+++ b/crates/durable-tools/src/context.rs
@@ -378,12 +378,8 @@ impl<S: Clone + Send + Sync + 'static> ToolContext<S> {
                 let state = &step_state.state;
 
                 // Create SimpleToolContext
-                let simple_ctx = SimpleToolContext::new(
-                    &state.pool,
-                    &state.t0_client,
-                    &heartbeater,
-                    &state.tool_registry,
-                );
+                let simple_ctx =
+                    SimpleToolContext::new(&state.t0_client, &heartbeater, &state.tool_registry);
 
                 // Generate idempotency key using task_id and call_id
                 let idempotency_key = format!("{task_id}:{tool_name}:{call_id}");
@@ -577,12 +573,11 @@ impl<S: Clone + Send + Sync + 'static> ToolContext<S> {
 ///
 /// `SimpleTools` run inside a `TaskTool`'s `step()` checkpoint, so they don't
 /// have access to checkpointing operations themselves. They can access the
-/// database pool for queries and the TensorZero client for inference calls.
+/// TensorZero client for inference calls.
 ///
 /// A heartbeater is available for long-running operations (e.g., evaluations)
 /// that need to extend the task lease to prevent timeout.
 pub struct SimpleToolContext<'a> {
-    pool: &'a PgPool,
     t0_client: &'a Arc<dyn TensorZeroClient>,
     heartbeater: &'a Arc<dyn Heartbeater>,
     tool_registry: &'a ToolRegistry,
@@ -591,22 +586,15 @@ pub struct SimpleToolContext<'a> {
 impl<'a> SimpleToolContext<'a> {
     /// Create a new simple tool context.
     pub fn new(
-        pool: &'a PgPool,
         t0_client: &'a Arc<dyn TensorZeroClient>,
         heartbeater: &'a Arc<dyn Heartbeater>,
         tool_registry: &'a ToolRegistry,
     ) -> Self {
         Self {
-            pool,
             t0_client,
             heartbeater,
             tool_registry,
         }
-    }
-
-    /// Get a reference to the database pool.
-    pub fn pool(&self) -> &PgPool {
-        self.pool
     }
 
     /// Get the TensorZero client for direct access to all client operations.

--- a/crates/durable-tools/tests/integration.rs
+++ b/crates/durable-tools/tests/integration.rs
@@ -392,15 +392,15 @@ impl TaskTool for InferenceTaskTool {
 // Execute Erased Tests
 // ============================================================================
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn execute_erased_deserializes_and_serializes_correctly(pool: PgPool) -> sqlx::Result<()> {
+#[tokio::test]
+async fn execute_erased_deserializes_and_serializes_correctly() {
     let tool = EchoSimpleTool;
 
     let t0_client: Arc<dyn TensorZeroClient> = Arc::new(mock_client_error_on_call());
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
     let llm_params = serde_json::json!({"message": "hello"});
     // Unit type () deserializes from null, not {}
     let side_info = serde_json::json!(null);
@@ -411,18 +411,17 @@ async fn execute_erased_deserializes_and_serializes_correctly(pool: PgPool) -> s
         .unwrap();
 
     assert_eq!(result["echoed"], "hello");
-    Ok(())
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn execute_erased_returns_error_on_invalid_params(pool: PgPool) -> sqlx::Result<()> {
+#[tokio::test]
+async fn execute_erased_returns_error_on_invalid_params() {
     let tool = EchoSimpleTool;
 
     let t0_client: Arc<dyn TensorZeroClient> = Arc::new(mock_client_error_on_call());
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
     // Missing required "message" field
     let llm_params = serde_json::json!({"wrong_field": "hello"});
     let side_info = serde_json::json!(null);
@@ -432,7 +431,6 @@ async fn execute_erased_returns_error_on_invalid_params(pool: PgPool) -> sqlx::R
         .await;
 
     assert!(result.is_err());
-    Ok(())
 }
 
 // ============================================================================
@@ -775,8 +773,8 @@ async fn calling_same_tool_multiple_times_generates_unique_idempotency_keys(
 // Inference Tests
 // ============================================================================
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn simple_tool_calls_inference_successfully(pool: PgPool) -> sqlx::Result<()> {
+#[tokio::test]
+async fn simple_tool_calls_inference_successfully() {
     let mock_response = create_mock_chat_response("Hello from TensorZero!");
     let t0_client: Arc<dyn TensorZeroClient> = Arc::new(mock_client_with_response(mock_response));
 
@@ -784,7 +782,7 @@ async fn simple_tool_calls_inference_successfully(pool: PgPool) -> sqlx::Result<
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
     let llm_params = serde_json::json!({"prompt": "Say hello"});
     let side_info = serde_json::json!(null);
 
@@ -794,11 +792,10 @@ async fn simple_tool_calls_inference_successfully(pool: PgPool) -> sqlx::Result<
         .expect("SimpleTool inference call should succeed");
 
     assert_eq!(result["response"], "Hello from TensorZero!");
-    Ok(())
 }
 
-#[sqlx::test(migrator = "MIGRATOR")]
-async fn simple_tool_propagates_inference_error(pool: PgPool) -> sqlx::Result<()> {
+#[tokio::test]
+async fn simple_tool_propagates_inference_error() {
     // Mock returns error when response is None
     let t0_client: Arc<dyn TensorZeroClient> = Arc::new(mock_client_error_on_call());
 
@@ -806,7 +803,7 @@ async fn simple_tool_propagates_inference_error(pool: PgPool) -> sqlx::Result<()
     let noop_heartbeater: Arc<dyn durable_tools::Heartbeater> =
         Arc::new(durable_tools::NoopHeartbeater);
     let registry = ToolRegistry::new();
-    let ctx = SimpleToolContext::new(&pool, &t0_client, &noop_heartbeater, &registry);
+    let ctx = SimpleToolContext::new(&t0_client, &noop_heartbeater, &registry);
     let llm_params = serde_json::json!({"prompt": "This will fail"});
     let side_info = serde_json::json!(null);
 
@@ -815,7 +812,6 @@ async fn simple_tool_propagates_inference_error(pool: PgPool) -> sqlx::Result<()
         .await;
 
     assert!(result.is_err(), "Expected inference error to propagate");
-    Ok(())
 }
 
 #[sqlx::test(migrator = "MIGRATOR")]


### PR DESCRIPTION
This will allow us to run the MCP server (which invokes SimpleTools) without requiring Postgres.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the `SimpleToolContext` constructor and removes DB access across all simple-tool execution paths, which could break any tools/tests that implicitly relied on `pool()` or sqlx test harness behavior.
> 
> **Overview**
> **Decouples `SimpleTool` execution from Postgres.** `SimpleToolContext` no longer carries a `PgPool` (and the `pool()` accessor is removed), leaving it as a lightweight wrapper around the TensorZero client, heartbeater, and tool registry.
> 
> All call sites are updated to use the new `SimpleToolContext::new(t0_client, heartbeater, registry)` signature, including the autopilot worker’s simple-tool step execution and the durable-tools task execution path. Integration tests for autopilot tools and parts of durable-tools are switched from `#[sqlx::test]` (with migrations/`PgPool` injection) to `#[tokio::test]` and updated accordingly, eliminating the Postgres requirement for these simple-tool tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ab4f4d0eafc777f9987a06b3c2f4f4d41e9e437. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->