### PR TITLE
Add tools and evaluations types for config-in-database

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1621,8 +1621,8 @@ dependencies = [
  "tensorzero-derive",
  "thiserror 2.0.18",
  "tokio",
- "toml 1.1.0+spec-1.1.0",
- "toml_edit 0.25.8+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
+ "toml_edit 0.25.10+spec-1.1.0",
  "ts-rs",
 ]
 
@@ -2616,9 +2616,12 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "fs_extra"
@@ -3239,9 +3242,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "typenum",
 ]
@@ -3348,12 +3351,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -3361,9 +3365,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -3374,9 +3378,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -3388,15 +3392,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -3408,15 +3412,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -3606,9 +3610,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -3643,6 +3647,47 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jni"
@@ -3700,9 +3745,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3856,9 +3901,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -3935,9 +3980,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -4898,6 +4943,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "postgres-inference-load-test"
 version = "2026.4.0"
 dependencies = [
@@ -4917,9 +4971,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -4981,7 +5035,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.8+spec-1.1.0",
+ "toml_edit 0.25.10+spec-1.1.0",
 ]
 
 [[package]]
@@ -6002,9 +6056,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -6341,9 +6395,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -7006,7 +7060,7 @@ dependencies = [
  "tensorzero-optimizers",
  "tokio",
  "tokio-stream",
- "toml 1.1.0+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -7133,6 +7187,7 @@ dependencies = [
  "tensorzero-derive",
  "tensorzero-error",
  "tensorzero-provider-types",
+ "tensorzero-stored-config",
  "tensorzero-types",
  "tensorzero-types-providers",
  "tensorzero-unsafe-helpers",
@@ -7140,7 +7195,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "toml 1.1.0+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tonic",
  "tracing",
  "tracing-futures",
@@ -7295,6 +7350,20 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "uuid",
+]
+
+[[package]]
+name = "tensorzero-stored-config"
+version = "2026.4.0"
+dependencies = [
+ "futures",
+ "googletest",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sqlx",
+ "tensorzero-types",
  "uuid",
 ]
 
@@ -7487,9 +7556,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -7588,17 +7657,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned 1.1.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -7612,9 +7681,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -7635,26 +7704,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned 1.1.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -7665,9 +7734,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -7897,7 +7966,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 1.1.0+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -7928,12 +7997,12 @@ dependencies = [
 
 [[package]]
 name = "tui-logger"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9384df20a5244a6ab204bc4b6959b41f37f0ee7b5e0f2feb7a8a78f58e684d06"
+checksum = "1a6965ab2d37d9bcb0de9eb62631540ff4043048785f35136c58ef233f887a50"
 dependencies = [
- "chrono",
  "env_filter",
+ "jiff",
  "lazy_static",
  "log",
  "parking_lot",
@@ -8202,9 +8271,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8216,9 +8285,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8226,9 +8295,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8236,9 +8305,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8249,9 +8318,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -8318,9 +8387,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8721,9 +8790,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -8878,9 +8947,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -8889,9 +8958,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8901,18 +8970,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8921,18 +8990,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8948,9 +9017,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -8959,9 +9028,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -8970,9 +9039,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "tensorzero-mcp",
     "tensorzero-node",
     "tensorzero-optimizers",
+    "tensorzero-stored-config",
     "tensorzero-python",  # TODO: remove from workspace when we migrate to Stainless
     "tensorzero-ts-types",
     "tensorzero-types",
@@ -49,7 +50,7 @@ reqwest = { version = "0.12.28", features = [
 ], default-features = false }
 serde = { version = "1.0.204", features = ["derive", "rc"] }
 serde_path_to_error = "0.1.17"
-serde_with = "3.18.0"
+serde_with = { version = "3.18.0", default-features = false, features = ["macros"] }
 uuid = { version = "1.22.0", features = ["serde", "v7"] }
 serde_json = { version = "1.0.143", features = ["preserve_order"] }
 secrecy = { version = "0.10.2", features = ["serde"] }

--- a/crates/tensorzero-core/Cargo.toml
+++ b/crates/tensorzero-core/Cargo.toml
@@ -94,6 +94,7 @@ tensorzero-types = { path = "../tensorzero-types" }
 tensorzero-error = { path = "../tensorzero-error", features = ["axum", "otel", "sqlx", "redis", "autopilot-client"] }
 tensorzero-config-paths = { path = "../tensorzero-config-paths" }
 tensorzero-types-providers = { path = "../tensorzero-types-providers" }
+tensorzero-stored-config = { path = "../tensorzero-stored-config" }
 minijinja-utils = { path = "../minijinja-utils" }
 clap = { workspace = true }
 opentelemetry_sdk = "0.31.0"

--- a/crates/tensorzero-core/src/config/mod.rs
+++ b/crates/tensorzero-core/src/config/mod.rs
@@ -30,6 +30,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tensorzero_derive::TensorZeroDeserialize;
+use tensorzero_stored_config::StoredTimeoutsConfig;
 use tracing::Span;
 use tracing::instrument;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -219,6 +220,20 @@ impl TimeoutsConfig {
         }
 
         Ok(())
+    }
+}
+
+impl From<StoredTimeoutsConfig> for TimeoutsConfig {
+    fn from(stored: StoredTimeoutsConfig) -> Self {
+        TimeoutsConfig {
+            non_streaming: stored.non_streaming.map(|ns| NonStreamingTimeouts {
+                total_ms: ns.total_ms,
+            }),
+            streaming: stored.streaming.map(|s| StreamingTimeouts {
+                ttft_ms: s.ttft_ms,
+                total_ms: s.total_ms,
+            }),
+        }
     }
 }
 

--- a/crates/tensorzero-core/src/evaluations/mod.rs
+++ b/crates/tensorzero-core/src/evaluations/mod.rs
@@ -5,6 +5,10 @@ use schemars::JsonSchema;
 use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
 use tensorzero_derive::TensorZeroDeserialize;
+use tensorzero_stored_config::{
+    StoredExactMatchConfig, StoredLLMJudgeIncludeConfig, StoredLLMJudgeInputFormat,
+    StoredLLMJudgeOptimize, StoredLLMJudgeOutputType, StoredRegexConfig, StoredToolUseConfig,
+};
 
 use crate::variant::chain_of_thought::ChainOfThoughtConfig;
 
@@ -298,6 +302,73 @@ impl From<LLMJudgeOptimize> for MetricConfigOptimize {
         match optimize {
             LLMJudgeOptimize::Min => MetricConfigOptimize::Min,
             LLMJudgeOptimize::Max => MetricConfigOptimize::Max,
+        }
+    }
+}
+
+// ─── Stored → Uninitialized conversions (simple types) ───────────────────────
+
+impl From<StoredLLMJudgeInputFormat> for LLMJudgeInputFormat {
+    fn from(stored: StoredLLMJudgeInputFormat) -> Self {
+        match stored {
+            StoredLLMJudgeInputFormat::Serialized => LLMJudgeInputFormat::Serialized,
+            StoredLLMJudgeInputFormat::Messages => LLMJudgeInputFormat::Messages,
+        }
+    }
+}
+
+impl From<StoredLLMJudgeOutputType> for LLMJudgeOutputType {
+    fn from(stored: StoredLLMJudgeOutputType) -> Self {
+        match stored {
+            StoredLLMJudgeOutputType::Float => LLMJudgeOutputType::Float,
+            StoredLLMJudgeOutputType::Boolean => LLMJudgeOutputType::Boolean,
+        }
+    }
+}
+
+impl From<StoredLLMJudgeOptimize> for LLMJudgeOptimize {
+    fn from(stored: StoredLLMJudgeOptimize) -> Self {
+        match stored {
+            StoredLLMJudgeOptimize::Min => LLMJudgeOptimize::Min,
+            StoredLLMJudgeOptimize::Max => LLMJudgeOptimize::Max,
+        }
+    }
+}
+
+impl From<StoredLLMJudgeIncludeConfig> for LLMJudgeIncludeConfig {
+    fn from(stored: StoredLLMJudgeIncludeConfig) -> Self {
+        LLMJudgeIncludeConfig {
+            reference_output: stored.reference_output,
+        }
+    }
+}
+
+#[expect(deprecated)]
+impl From<StoredExactMatchConfig> for ExactMatchConfig {
+    fn from(stored: StoredExactMatchConfig) -> Self {
+        ExactMatchConfig {
+            cutoff: stored.cutoff,
+        }
+    }
+}
+
+impl From<StoredRegexConfig> for RegexConfig {
+    fn from(stored: StoredRegexConfig) -> Self {
+        RegexConfig {
+            must_match: stored.must_match,
+            must_not_match: stored.must_not_match,
+        }
+    }
+}
+
+impl From<StoredToolUseConfig> for ToolUseConfig {
+    fn from(stored: StoredToolUseConfig) -> Self {
+        match stored {
+            StoredToolUseConfig::None => ToolUseConfig::None,
+            StoredToolUseConfig::NoneOf { tools } => ToolUseConfig::NoneOf { tools },
+            StoredToolUseConfig::Any => ToolUseConfig::Any,
+            StoredToolUseConfig::AnyOf { tools } => ToolUseConfig::AnyOf { tools },
+            StoredToolUseConfig::AllOf { tools } => ToolUseConfig::AllOf { tools },
         }
     }
 }

--- a/crates/tensorzero-core/src/inference/types/extra_body.rs
+++ b/crates/tensorzero-core/src/inference/types/extra_body.rs
@@ -8,6 +8,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tensorzero_derive::export_schema;
+use tensorzero_stored_config::{
+    StoredExtraBodyConfig, StoredExtraBodyReplacement, StoredExtraBodyReplacementKind,
+};
 
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize)]
@@ -394,6 +397,34 @@ pub mod dynamic {
 }
 
 pub use dynamic::ExtraBody as DynamicExtraBody;
+
+// ─── Stored → Uninitialized conversions ──────────────────────────────────────
+
+impl From<StoredExtraBodyReplacementKind> for ExtraBodyReplacementKind {
+    fn from(stored: StoredExtraBodyReplacementKind) -> Self {
+        match stored {
+            StoredExtraBodyReplacementKind::Value(v) => ExtraBodyReplacementKind::Value(v),
+            StoredExtraBodyReplacementKind::Delete => ExtraBodyReplacementKind::Delete,
+        }
+    }
+}
+
+impl From<StoredExtraBodyReplacement> for ExtraBodyReplacement {
+    fn from(stored: StoredExtraBodyReplacement) -> Self {
+        ExtraBodyReplacement {
+            pointer: stored.pointer,
+            kind: stored.kind.into(),
+        }
+    }
+}
+
+impl From<StoredExtraBodyConfig> for ExtraBodyConfig {
+    fn from(stored: StoredExtraBodyConfig) -> Self {
+        ExtraBodyConfig {
+            data: stored.data.into_iter().map(Into::into).collect(),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/tensorzero-core/src/inference/types/extra_headers.rs
+++ b/crates/tensorzero-core/src/inference/types/extra_headers.rs
@@ -1,6 +1,9 @@
 use super::{deserialize_delete, serialize_delete};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use tensorzero_stored_config::{
+    StoredExtraHeader, StoredExtraHeaderKind, StoredExtraHeadersConfig,
+};
 
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize)]
@@ -178,6 +181,34 @@ pub mod dynamic {
 }
 
 pub use dynamic::ExtraHeader as DynamicExtraHeader;
+
+// ─── Stored → Uninitialized conversions ──────────────────────────────────────
+
+impl From<StoredExtraHeaderKind> for ExtraHeaderKind {
+    fn from(stored: StoredExtraHeaderKind) -> Self {
+        match stored {
+            StoredExtraHeaderKind::Value(v) => ExtraHeaderKind::Value(v),
+            StoredExtraHeaderKind::Delete => ExtraHeaderKind::Delete,
+        }
+    }
+}
+
+impl From<StoredExtraHeader> for ExtraHeader {
+    fn from(stored: StoredExtraHeader) -> Self {
+        ExtraHeader {
+            name: stored.name,
+            kind: stored.kind.into(),
+        }
+    }
+}
+
+impl From<StoredExtraHeadersConfig> for ExtraHeadersConfig {
+    fn from(stored: StoredExtraHeadersConfig) -> Self {
+        ExtraHeadersConfig {
+            data: stored.data.into_iter().map(Into::into).collect(),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/tensorzero-core/src/utils/retries.rs
+++ b/crates/tensorzero-core/src/utils/retries.rs
@@ -3,6 +3,7 @@ use backon::{BackoffBuilder, ExponentialBuilder, Retryable};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{future::Future, time::Duration};
+use tensorzero_stored_config::StoredRetryConfig;
 
 use crate::error::Error;
 
@@ -103,5 +104,14 @@ impl RetryConfig {
             .with_jitter()
             .with_max_delay(Duration::from_secs_f32(self.max_delay_s))
             .with_max_times(self.num_retries)
+    }
+}
+
+impl From<StoredRetryConfig> for RetryConfig {
+    fn from(stored: StoredRetryConfig) -> Self {
+        RetryConfig {
+            num_retries: stored.num_retries as usize,
+            max_delay_s: stored.max_delay_s,
+        }
     }
 }

--- a/crates/tensorzero-stored-config/AGENTS.md
+++ b/crates/tensorzero-stored-config/AGENTS.md
@@ -1,0 +1,75 @@
+# Stored Config Types (`tensorzero-stored-config`)
+
+This crate contains types for database-persisted configs and the Postgres migrations for config tables. These types are distinct from the `Uninitialized*` types used for TOML config loading in `tensorzero-core`.
+
+## Key rules
+
+### Never reuse `Uninitialized*` types inside stored types
+
+Even if a type has no `ResolvedTomlPathData`, create a parallel `Stored*` type. The TOML types use `#[serde(deny_unknown_fields)]` which breaks forward compatibility. Stored types and TOML types evolve independently — decoupling them now avoids forced schema bumps later.
+
+### No `#[serde(deny_unknown_fields)]`
+
+Stored types must NOT use `deny_unknown_fields`. This allows additive field additions (new `Option<T>` fields) without a schema version bump. Old readers safely ignore unknown fields.
+
+### No `#[serde(default)]`
+
+Stored types must NOT use `#[serde(default)]`. The write path always writes the complete canonical form. On the read side:
+
+- `Option<T>` fields: missing keys deserialize to `None` naturally.
+- Non-`Option` collections (`Vec`, `HashMap`) and structs with defaults (`RetryConfig`): wrap in `Option<T>`. `None` means "this row predates the field"; `Some(vec![])` means "explicitly empty." The conversion to `Uninitialized*` maps `None` to the appropriate default.
+
+### No `#[serde(flatten)]`
+
+Stored types must NEVER use `#[serde(flatten)]`. Flatten has known edge cases with tagged enums and makes the JSON shape implicit rather than explicit. Instead:
+
+- If flattening an enum into a struct (e.g., variant config + timeouts), nest the enum under an explicit key (e.g., `variant: StoredLLMJudgeVariantConfig`).
+- If one struct wraps another (e.g., chain-of-thought wrapping chat completion), nest it under an explicit field name (e.g., `inner: StoredLLMJudgeChatCompletionVariantConfig`). Do not duplicate fields.
+
+### No custom serializers/deserializers
+
+Stored types must use only standard `#[derive(Serialize, Deserialize)]`. No `TensorZeroDeserialize` (because we don't care about error messages in this crate), no custom `impl Deserialize`, no `deserialize_with`. This keeps the serialization behavior trivially verifiable from the type definition alone.
+
+Because stored types use only standard serde derives with no `flatten` or custom (de)serializers, avoid exhaustive serde-shape tests that only restate the type definition. Small serde round-trip smoke tests are acceptable when they guard representative stored configs or a regression in the persisted shape.
+
+### No raw `serde_json::Value` unless the database shape is map-like
+
+Do not serialize raw `serde_json::Value` in stored types unless the data is intentionally represented as a `HashMap`-like structure in the database. Prefer explicit stored structs and enums so the persisted JSON shape remains typed, reviewable, and forward-compatible.
+
+### Use `#[serde_with::skip_serializing_none]` on all structs
+
+Use `#[serde_with::skip_serializing_none]` on all stored structs to automatically apply `#[serde(skip_serializing_if = "Option::is_none")]` to every `Option<T>` field. This keeps JSONB compact and avoids two representations for "absent" (missing key vs. `null`). Using the struct-level attribute instead of per-field annotations prevents forgetting it on new fields.
+
+### `PartialEq` on all stored types
+
+Derive `PartialEq` on all stored types for use in conversion tests and assertions.
+
+### No dependency on `tensorzero-core`
+
+This crate must not depend on `tensorzero-core` (it would be circular). Types from core that appear in stored configs (e.g., `ExtraBodyConfig`, `ExtraHeadersConfig`) have parallel stored equivalents in this crate. Types from `tensorzero-types` (e.g., `JsonMode`, `ServiceTier`) can be used directly. We should soon move all config types in here.
+
+### Schema revision policy
+
+Each config table has a `schema_revision` column. Each stored config type defines its own `SCHEMA_REVISION` constant.
+
+**Additive changes** (new `Option<T>` fields) do NOT require a revision bump — old readers ignore unknown fields, new readers get `None` for missing fields.
+
+**Breaking changes** REQUIRE a revision bump. A change is breaking if an old reader cannot correctly deserialize a row written by a new writer. Examples:
+
+- Renaming or removing a field
+- Changing enum variant tag strings or discriminator values
+- Changing nesting structure (e.g., moving a field into a sub-object)
+- Promoting an `Option<T>` to required (after backfill)
+
+Never change a field's type or semantics; always add a new field (safe), and remove the old one (breaking).
+
+When bumping a revision, follow the expand-and-contract cycle: the new code must read both old and new revisions, write the old revision during the overlap period, then contract to the new revision once old writers are drained.
+
+**New enum variants** do NOT require a revision bump. Old rows never contain the new variant, so old readers are unaffected. However, new variants require a two-phase deploy:
+
+1. **Phase 1 (expand):** Deploy code that can _read_ the new variant but does not yet _write_ it.
+2. **Phase 2 (write):** Deploy code that writes the new variant. All running readers can now handle it.
+
+## Migrations
+
+SQL migrations for config tables live in `src/postgres/migrations/`. The migration runner in `tensorzero-core` calls `tensorzero_stored_config::postgres::make_migrator()` to apply them. Migrations use a dedicated tracking table (`tensorzero_stored_config__sqlx_migrations`).

--- a/crates/tensorzero-stored-config/CLAUDE.md
+++ b/crates/tensorzero-stored-config/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/crates/tensorzero-stored-config/Cargo.toml
+++ b/crates/tensorzero-stored-config/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "tensorzero-stored-config"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+futures.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_with.workspace = true
+sqlx = { workspace = true }
+tensorzero-types = { path = "../tensorzero-types" }
+uuid.workspace = true
+
+[features]
+e2e_tests = ["tensorzero-types/e2e_tests"]
+
+[dev-dependencies]
+googletest = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/tensorzero-stored-config/src/lib.rs
+++ b/crates/tensorzero-stored-config/src/lib.rs
@@ -1,0 +1,24 @@
+mod stored_evaluation_config;
+mod stored_extra_body;
+mod stored_extra_headers;
+mod stored_prompt_template;
+mod stored_tool_config;
+
+pub use stored_evaluation_config::{
+    StoredEvaluationConfig, StoredEvaluatorConfig, StoredExactMatchConfig,
+    StoredInferenceEvaluationConfig, StoredLLMJudgeBestOfNVariantConfig,
+    StoredLLMJudgeChainOfThoughtVariantConfig, StoredLLMJudgeChatCompletionVariantConfig,
+    StoredLLMJudgeConfig, StoredLLMJudgeDiclVariantConfig, StoredLLMJudgeIncludeConfig,
+    StoredLLMJudgeInputFormat, StoredLLMJudgeMixtureOfNVariantConfig, StoredLLMJudgeOptimize,
+    StoredLLMJudgeOutputType, StoredLLMJudgeVariantConfig, StoredLLMJudgeVariantInfo,
+    StoredNonStreamingTimeouts, StoredRegexConfig, StoredRetryConfig, StoredStreamingTimeouts,
+    StoredTimeoutsConfig, StoredToolUseConfig,
+};
+pub use stored_extra_body::{
+    StoredExtraBodyConfig, StoredExtraBodyReplacement, StoredExtraBodyReplacementKind,
+};
+pub use stored_extra_headers::{
+    StoredExtraHeader, StoredExtraHeaderKind, StoredExtraHeadersConfig,
+};
+pub use stored_prompt_template::StoredPromptRef;
+pub use stored_tool_config::StoredToolConfig;

--- a/crates/tensorzero-stored-config/src/stored_evaluation_config.rs
+++ b/crates/tensorzero-stored-config/src/stored_evaluation_config.rs
@@ -1,0 +1,224 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tensorzero_types::inference_params::{JsonMode, ServiceTier};
+
+use crate::StoredPromptRef;
+
+// --- Top-level evaluation config ---
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub enum StoredEvaluationConfig {
+    Inference(StoredInferenceEvaluationConfig),
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredInferenceEvaluationConfig {
+    pub evaluators: Option<HashMap<String, StoredEvaluatorConfig>>,
+    pub function_name: String,
+    pub description: Option<String>,
+}
+
+// --- Evaluator config (tagged enum) ---
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub enum StoredEvaluatorConfig {
+    ExactMatch(StoredExactMatchConfig),
+    #[serde(rename = "llm_judge")]
+    LLMJudge(StoredLLMJudgeConfig),
+    ToolUse(StoredToolUseConfig),
+    Regex(StoredRegexConfig),
+}
+
+// --- Simple evaluator stored types ---
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredExactMatchConfig {
+    pub cutoff: Option<f32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "behavior")]
+#[serde(rename_all = "snake_case")]
+pub enum StoredToolUseConfig {
+    None,
+    NoneOf { tools: Vec<String> },
+    Any,
+    AnyOf { tools: Vec<String> },
+    AllOf { tools: Vec<String> },
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredRegexConfig {
+    pub must_match: Option<String>,
+    pub must_not_match: Option<String>,
+}
+
+// --- LLM judge config ---
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredLLMJudgeConfig {
+    pub input_format: Option<StoredLLMJudgeInputFormat>,
+    pub variants: Option<HashMap<String, StoredLLMJudgeVariantInfo>>,
+    pub output_type: StoredLLMJudgeOutputType,
+    pub optimize: StoredLLMJudgeOptimize,
+    pub cutoff: Option<f32>,
+    pub include: Option<StoredLLMJudgeIncludeConfig>,
+    pub description: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StoredLLMJudgeInputFormat {
+    Serialized,
+    Messages,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StoredLLMJudgeOutputType {
+    Float,
+    Boolean,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StoredLLMJudgeOptimize {
+    Min,
+    Max,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredLLMJudgeIncludeConfig {
+    pub reference_output: bool,
+}
+
+// --- LLM judge variant types ---
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredLLMJudgeVariantInfo {
+    pub variant: StoredLLMJudgeVariantConfig,
+    pub timeouts: Option<StoredTimeoutsConfig>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub enum StoredLLMJudgeVariantConfig {
+    ChatCompletion(StoredLLMJudgeChatCompletionVariantConfig),
+    #[serde(rename = "experimental_best_of_n_sampling")]
+    BestOfNSampling(StoredLLMJudgeBestOfNVariantConfig),
+    #[serde(rename = "experimental_mixture_of_n")]
+    MixtureOfNSampling(StoredLLMJudgeMixtureOfNVariantConfig),
+    #[serde(rename = "experimental_dynamic_in_context_learning")]
+    Dicl(StoredLLMJudgeDiclVariantConfig),
+    #[serde(rename = "experimental_chain_of_thought")]
+    ChainOfThought(StoredLLMJudgeChainOfThoughtVariantConfig),
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredLLMJudgeChatCompletionVariantConfig {
+    pub active: Option<bool>,
+    pub model: Arc<str>,
+    pub system_instructions: StoredPromptRef,
+    pub temperature: Option<f32>,
+    pub top_p: Option<f32>,
+    pub max_tokens: Option<u32>,
+    pub presence_penalty: Option<f32>,
+    pub frequency_penalty: Option<f32>,
+    pub seed: Option<u32>,
+    pub json_mode: JsonMode,
+    pub stop_sequences: Option<Vec<String>>,
+    pub reasoning_effort: Option<String>,
+    pub service_tier: Option<ServiceTier>,
+    pub thinking_budget_tokens: Option<i32>,
+    pub verbosity: Option<String>,
+    pub retries: Option<StoredRetryConfig>,
+    pub extra_body: Option<crate::StoredExtraBodyConfig>,
+    pub extra_headers: Option<crate::StoredExtraHeadersConfig>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredLLMJudgeBestOfNVariantConfig {
+    pub active: Option<bool>,
+    pub timeout_s: Option<f64>,
+    pub candidates: Option<Vec<String>>,
+    pub evaluator: StoredLLMJudgeChatCompletionVariantConfig,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredLLMJudgeMixtureOfNVariantConfig {
+    pub active: Option<bool>,
+    pub timeout_s: Option<f64>,
+    pub candidates: Option<Vec<String>>,
+    pub fuser: StoredLLMJudgeChatCompletionVariantConfig,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredLLMJudgeDiclVariantConfig {
+    pub active: Option<bool>,
+    pub embedding_model: String,
+    pub k: u32,
+    pub model: String,
+    pub system_instructions: Option<StoredPromptRef>,
+    pub temperature: Option<f32>,
+    pub top_p: Option<f32>,
+    pub presence_penalty: Option<f32>,
+    pub frequency_penalty: Option<f32>,
+    pub max_tokens: Option<u32>,
+    pub seed: Option<u32>,
+    pub json_mode: Option<JsonMode>,
+    pub stop_sequences: Option<Vec<String>>,
+    pub extra_body: Option<crate::StoredExtraBodyConfig>,
+    pub retries: Option<StoredRetryConfig>,
+    pub extra_headers: Option<crate::StoredExtraHeadersConfig>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredLLMJudgeChainOfThoughtVariantConfig {
+    pub inner: StoredLLMJudgeChatCompletionVariantConfig,
+}
+
+// --- Shared stored types ---
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredRetryConfig {
+    pub num_retries: u32,
+    pub max_delay_s: f32,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredTimeoutsConfig {
+    pub non_streaming: Option<StoredNonStreamingTimeouts>,
+    pub streaming: Option<StoredStreamingTimeouts>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredNonStreamingTimeouts {
+    pub total_ms: Option<u64>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredStreamingTimeouts {
+    pub ttft_ms: Option<u64>,
+    pub total_ms: Option<u64>,
+}

--- a/crates/tensorzero-stored-config/src/stored_extra_body.rs
+++ b/crates/tensorzero-stored-config/src/stored_extra_body.rs
@@ -1,0 +1,20 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct StoredExtraBodyConfig {
+    pub data: Vec<StoredExtraBodyReplacement>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredExtraBodyReplacement {
+    pub pointer: String,
+    pub kind: StoredExtraBodyReplacementKind,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StoredExtraBodyReplacementKind {
+    Value(serde_json::Value),
+    Delete,
+}

--- a/crates/tensorzero-stored-config/src/stored_extra_headers.rs
+++ b/crates/tensorzero-stored-config/src/stored_extra_headers.rs
@@ -1,0 +1,20 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct StoredExtraHeadersConfig {
+    pub data: Vec<StoredExtraHeader>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredExtraHeader {
+    pub name: String,
+    pub kind: StoredExtraHeaderKind,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StoredExtraHeaderKind {
+    Value(String),
+    Delete,
+}

--- a/crates/tensorzero-stored-config/src/stored_prompt_template.rs
+++ b/crates/tensorzero-stored-config/src/stored_prompt_template.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredPromptRef {
+    pub prompt_template_version_id: Uuid,
+    pub template_key: String,
+}

--- a/crates/tensorzero-stored-config/src/stored_tool_config.rs
+++ b/crates/tensorzero-stored-config/src/stored_tool_config.rs
@@ -1,0 +1,12 @@
+use serde::{Deserialize, Serialize};
+
+use crate::StoredPromptRef;
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredToolConfig {
+    pub description: String,
+    pub parameters: StoredPromptRef,
+    pub name: Option<String>,
+    pub strict: bool,
+}


### PR DESCRIPTION
First of a series of PRs towards #7128.

This adds a new crate, `tensorzero-stored-config`, to handle config-in-database types and any conversions. Sets up database migrations and some leaf-ish types (Prompt templates, evaluations, tools) as well as some placeholder database roundtrip tests (not sure if these are useful yet).

It doesn't write them yet (and we don't have any writer functions defined yet).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new database-backed config crate and wires its migrations into gateway startup/migration flows, which can affect Postgres initialization and deployment compatibility. Remaining changes are mostly type conversions and dependency bumps with limited runtime surface area.
> 
> **Overview**
> Adds a new `tensorzero-stored-config` crate to model *database-persisted* (JSONB) configuration for tools and evaluations, including forward-compatible `Stored*` types and a dedicated `sqlx` migrator/migration tracking table.
> 
> Wires the new crate into `tensorzero-core`: runs and validates `tensorzero-stored-config` migrations alongside existing core/auth migrations, and introduces `Stored* →` runtime config conversions for timeouts, retry config, extra headers/body, and evaluation evaluator config enums.
> 
> Also updates workspace dependencies (e.g., `serde_with` feature flags) and refreshes `Cargo.lock` with minor crate version bumps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b487c5552d8957ecf120e95733c65a9f45bd09f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->