### PR TITLE
bumped version to 2026.3.5

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -544,7 +544,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot-client"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "chrono",
  "durable-tools-spawn",
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-tools"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "anyhow",
  "arrow",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "autopilot-worker"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "config-applier"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "pathdiff",
  "schemars 1.2.1",
@@ -2215,7 +2215,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "durable-tools-spawn"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "async-trait",
  "durable",
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "evaluations"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "feedback-load-test"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "async-stream",
  "autopilot-client",
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "googletest-matchers"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "googletest",
  "serde_json",
@@ -4153,7 +4153,7 @@ dependencies = [
 
 [[package]]
 name = "minijinja-utils"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "minijinja",
  "serde",
@@ -4898,7 +4898,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postgres-inference-load-test"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5487,7 +5487,7 @@ dependencies = [
 
 [[package]]
 name = "rate-limit-load-test"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "reqwest-sse-stream"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "async-stream",
  "futures",
@@ -6987,7 +6987,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "async-trait",
  "clap",
@@ -7014,7 +7014,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-auth"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "axum",
  "chrono",
@@ -7034,11 +7034,11 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-config-paths"
-version = "2026.3.4"
+version = "2026.3.5"
 
 [[package]]
 name = "tensorzero-core"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -7167,7 +7167,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-error"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "autopilot-client",
  "axum",
@@ -7190,7 +7190,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-mcp"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "async-trait",
  "autopilot-client",
@@ -7208,7 +7208,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-node"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "config-applier",
  "napi",
@@ -7223,7 +7223,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-optimizers"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -7260,7 +7260,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-provider-types"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "futures",
  "mime 0.4.0-a.0",
@@ -7280,7 +7280,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-python"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "evaluations",
  "futures",
@@ -7298,11 +7298,11 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-ts-types"
-version = "2026.3.4"
+version = "2026.3.5"
 
 [[package]]
 name = "tensorzero-types"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "aws-smithy-types",
  "blake3",
@@ -7330,7 +7330,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-types-providers"
-version = "2026.3.4"
+version = "2026.3.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -7340,7 +7340,7 @@ dependencies = [
 
 [[package]]
 name = "tensorzero-unsafe-helpers"
-version = "2026.3.4"
+version = "2026.3.5"
 
 [[package]]
 name = "termcolor"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -35,7 +35,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2026.3.4"
+version = "2026.3.5"
 rust-version = "1.93.0"
 license = "Apache-2.0"
 edition = "2024"

--- a/examples/production-deployment-k8s-helm/Chart.yaml
+++ b/examples/production-deployment-k8s-helm/Chart.yaml
@@ -3,4 +3,4 @@ name: tensorzero
 description: A Helm chart for Kubernetes with deployment, secret, configmap, service, and ingress
 type: application
 version: 0.0.0 # updated by CI
-appVersion: "2026.3.4"
+appVersion: "2026.3.5"

--- a/examples/production-deployment-k8s-helm/tests/__snapshot__/snapshots_test.yaml.snap
+++ b/examples/production-deployment-k8s-helm/tests/__snapshot__/snapshots_test.yaml.snap
@@ -19,7 +19,7 @@ should match snapshot with all features enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.4
+        app.kubernetes.io/version: 2026.3.5
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero
   2: |
@@ -33,7 +33,7 @@ should match snapshot with all features enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.4
+        app.kubernetes.io/version: 2026.3.5
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-gateway
     spec:
@@ -58,7 +58,7 @@ should match snapshot with all features enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.4
+        app.kubernetes.io/version: 2026.3.5
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-gateway
     spec:
@@ -81,7 +81,7 @@ should match snapshot with all features enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.4
+        app.kubernetes.io/version: 2026.3.5
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-gateway
     spec:
@@ -121,7 +121,7 @@ should match snapshot with all features enabled:
                     secretKeyRef:
                       key: OPENAI_API_KEY
                       name: tensorzero-secret
-              image: tensorzero/gateway:2026.3.4
+              image: tensorzero/gateway:2026.3.5
               imagePullPolicy: IfNotPresent
               name: tensorzero
               ports:
@@ -159,7 +159,7 @@ should match snapshot with all features enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.4
+        app.kubernetes.io/version: 2026.3.5
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-storage
     spec:
@@ -178,7 +178,7 @@ should match snapshot with all features enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.4
+        app.kubernetes.io/version: 2026.3.5
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-ui
     spec:
@@ -203,7 +203,7 @@ should match snapshot with all features enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.4
+        app.kubernetes.io/version: 2026.3.5
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-ui
     spec:
@@ -226,7 +226,7 @@ should match snapshot with all features enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.4
+        app.kubernetes.io/version: 2026.3.5
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-ui
     spec:
@@ -252,7 +252,7 @@ should match snapshot with all features enabled:
                     secretKeyRef:
                       key: TENSORZERO_GATEWAY_URL
                       name: tensorzero-secret
-              image: tensorzero/ui:2026.3.4
+              image: tensorzero/ui:2026.3.5
               imagePullPolicy: IfNotPresent
               name: ui
               ports:
@@ -297,7 +297,7 @@ should match snapshot with default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.4
+        app.kubernetes.io/version: 2026.3.5
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero
   2: |
@@ -309,7 +309,7 @@ should match snapshot with default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.4
+        app.kubernetes.io/version: 2026.3.5
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-gateway
     spec:
@@ -333,7 +333,7 @@ should match snapshot with default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.4
+        app.kubernetes.io/version: 2026.3.5
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-gateway
     spec:
@@ -356,7 +356,7 @@ should match snapshot with default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.4
+        app.kubernetes.io/version: 2026.3.5
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-gateway
     spec:
@@ -396,7 +396,7 @@ should match snapshot with default values:
                     secretKeyRef:
                       key: OPENAI_API_KEY
                       name: tensorzero-secret
-              image: tensorzero/gateway:2026.3.4
+              image: tensorzero/gateway:2026.3.5
               imagePullPolicy: IfNotPresent
               name: tensorzero
               ports:
@@ -428,7 +428,7 @@ should match snapshot with default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.4
+        app.kubernetes.io/version: 2026.3.5
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-ui
     spec:
@@ -452,7 +452,7 @@ should match snapshot with default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.4
+        app.kubernetes.io/version: 2026.3.5
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-ui
     spec:
@@ -475,7 +475,7 @@ should match snapshot with default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.4
+        app.kubernetes.io/version: 2026.3.5
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-ui
     spec:
@@ -501,7 +501,7 @@ should match snapshot with default values:
                     secretKeyRef:
                       key: TENSORZERO_GATEWAY_URL
                       name: tensorzero-secret
-              image: tensorzero/ui:2026.3.4
+              image: tensorzero/ui:2026.3.5
               imagePullPolicy: IfNotPresent
               name: ui
               ports:
@@ -545,7 +545,7 @@ should match snapshot with minimal config (no UI, no ingress, no persistence):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.4
+        app.kubernetes.io/version: 2026.3.5
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero
   2: |
@@ -557,7 +557,7 @@ should match snapshot with minimal config (no UI, no ingress, no persistence):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.4
+        app.kubernetes.io/version: 2026.3.5
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-gateway
     spec:
@@ -580,7 +580,7 @@ should match snapshot with minimal config (no UI, no ingress, no persistence):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tensorzero
-        app.kubernetes.io/version: 2026.3.4
+        app.kubernetes.io/version: 2026.3.5
         helm.sh/chart: tensorzero-0.0.0
       name: RELEASE-NAME-tensorzero-gateway
     spec:
@@ -620,7 +620,7 @@ should match snapshot with minimal config (no UI, no ingress, no persistence):
                     secretKeyRef:
                       key: OPENAI_API_KEY
                       name: tensorzero-secret
-              image: tensorzero/gateway:2026.3.4
+              image: tensorzero/gateway:2026.3.5
               imagePullPolicy: IfNotPresent
               name: tensorzero
               ports:

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorzero-ui",
-  "version": "2026.3.4",
+  "version": "2026.3.5",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version metadata update affecting build/deploy labeling and image tags, with no functional code changes.
> 
> **Overview**
> **Release bump to `2026.3.5`.** Updates the Rust workspace version (and lockfile crate versions), the UI `package.json` version, and the Helm chart `appVersion`/test snapshots including gateway/UI image tags and Kubernetes `app.kubernetes.io/version` labels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c0b708a1eb863f3eb737ae6565ff3c589218db4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->