### PR TITLE
fix: resolve flaky word_wrap e2e test

### DIFF
--- a/ui/e2e_tests/word_wrap.spec.ts
+++ b/ui/e2e_tests/word_wrap.spec.ts
@@ -11,9 +11,11 @@ test("ensure word wrap persists between pages", async ({ page }) => {
   // Reload the page to avoid any quirks
   await page.reload();
 
-  await expect(page.getByText("Input")).toBeVisible();
-
   const getWordWrapToggle = () => page.getByTitle("Toggle word wrap").first();
+
+  // Wait for the word wrap toggle to be visible (ensures the real content has loaded,
+  // not just the Suspense skeleton which also has an "Input" heading)
+  await expect(getWordWrapToggle()).toBeVisible();
   const getWordWrap = async () =>
     await page.evaluate(() => localStorage.getItem("word-wrap"));
 
@@ -41,8 +43,8 @@ test("ensure word wrap persists between pages", async ({ page }) => {
   // ensure that it is still set to false on page reload...
   {
     await page.reload();
-    // Sleep to try to fix flakiness. TODO - figure out what event we should wait for.
-    await page.waitForTimeout(1000);
+    // Wait for the word wrap toggle to reappear after Suspense resolves
+    await expect(getWordWrapToggle()).toBeVisible();
 
     const button = getWordWrapToggle();
     expect(await button.getAttribute("aria-pressed")).toBe("false");


### PR DESCRIPTION
## Summary

- Replace `getByText('Input')` with `getByTitle('Toggle word wrap')` to avoid Playwright strict mode violation when both the Suspense skeleton and resolved content render an `<h2>Input</h2>` heading simultaneously
- Replace arbitrary `waitForTimeout(1000)` with a proper `toBeVisible()` wait on the toggle button after the second reload

## Root Cause

The datapoint detail page uses `<Suspense>` with a skeleton fallback. Both the skeleton (`DatapointContentSkeleton`) and the resolved content (`DatapointContent`) render `<SectionHeader heading="Input" />`. During page reload, there's a brief window where both `<h2>` elements are in the DOM, causing `getByText('Input')` to fail with a strict mode violation.

## Test plan

- [ ] `word_wrap.spec.ts` passes consistently in CI (previously failing intermittently)
- [ ] No other e2e tests affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Paperclip <noreply@paperclip.ing>