### PR TITLE
Docs: Claude Code plugin

### DIFF
--- a/docs/development/integrate-with-your-coding-agents.mdx
+++ b/docs/development/integrate-with-your-coding-agents.mdx
@@ -15,7 +15,7 @@ Support other agents like Codex and Cursor is coming very soon.
 
 Install the TensorZero plugin for Claude Code:
 
-```bash title="Terminal" icon="file-terminal"
+```bash title="Terminal" icon="terminal"
 claude plugin marketplace add tensorzero/for-agents
 claude plugin install tensorzero@tensorzero
 ```
@@ -23,7 +23,7 @@ claude plugin install tensorzero@tensorzero
 You can optionally pin the plugin to your TensorZero version to ensure Claude Code doesn't try to use features unavailable in your deployment.
 For example, if your deployment version is `2026.4.0`:
 
-```bash title="Terminal" highlight={1} icon="file-terminal"
+```bash title="Terminal" highlight={1} icon="terminal"
 claude plugin marketplace add tensorzero/for-agents#2026.4.0
 claude plugin install tensorzero@tensorzero
 ```

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -15,9 +15,6 @@
   "banner": {
     "content": "**[TensorZero Autopilot](https://www.tensorzero.com)** is an automated AI engineer that analyzes LLM observability data, optimizes prompts and models, sets up evals, and runs A/B tests. **[Schedule a demo →](https://www.tensorzero.com/schedule-demo)**"
   },
-  "icons": {
-    "library": "lucide"
-  },
   "navigation": {
     "tabs": [
       {


### PR DESCRIPTION
**Do not merge** until https://github.com/tensorzero/tensorzero/pull/7145 + `2026.4.0` are out.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; the only potential issue is incorrect install/version-pinning instructions or navigation placement.
> 
> **Overview**
> Adds a new *Development* guide, `development/integrate-with-your-coding-agents`, documenting how to install the TensorZero Claude Code plugin, optionally pin it to a specific TensorZero version, and invoke skills (e.g. `/tensorzero:deploy`).
> 
> Updates `docs.json` navigation to include this new page under a **Development** section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b8b8fd9853073aab8b0345a4261c830fce25817. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->