### PR TITLE
Switch to meta-llama/Llama-3.3-70B-Instruct-Turbo for together e2e tests

### DIFF
--- a/crates/tensorzero-core/tests/e2e/config/tensorzero.models.toml
+++ b/crates/tensorzero-core/tests/e2e/config/tensorzero.models.toml
@@ -423,7 +423,7 @@ routing = ["together"]
 
 [models."llama4-maverick-instruct-together".providers.together]
 type = "together"
-model_name = "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8"
+model_name = "meta-llama/Llama-3.3-70B-Instruct-Turbo"
 
 [models."Qwen/Qwen3-1.7B"]
 routing = ["sglang"]


### PR DESCRIPTION
The previous model meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 is no longer available in serverless mode on Together

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that only affects Together-backed E2E test runs; main risk is test flakiness or behavior differences due to the new model.
> 
> **Overview**
> Updates the Together E2E test model mapping for `llama4-maverick-instruct-together` to use `meta-llama/Llama-3.3-70B-Instruct-Turbo` instead of the previously configured Llama-4 Maverick serverless model.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b0aa9254d7b531a9f4830dc23cc3286c4707871. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->