### PR TITLE
Switch Together e2e tests from llama to GLM

### DIFF
--- a/crates/tensorzero-core/tests/e2e/config/tensorzero.functions.basic_test.toml
+++ b/crates/tensorzero-core/tests/e2e/config/tensorzero.functions.basic_test.toml
@@ -621,9 +621,9 @@ max_tokens = 100
 
 [functions.basic_test.variants.together-tool]
 type = "chat_completion"
-model = "llama4-maverick-instruct-together"
+model = "glm-4.7-together"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
-max_tokens = 100
+max_tokens = 500
 
 [functions.basic_test.variants.sglang]
 type = "chat_completion"

--- a/crates/tensorzero-core/tests/e2e/config/tensorzero.functions.toml
+++ b/crates/tensorzero-core/tests/e2e/config/tensorzero.functions.toml
@@ -381,7 +381,7 @@ system_template = "../../../fixtures/config/functions/weather_helper_parallel/pr
 
 [functions.weather_helper_parallel.variants.together-tool]
 type = "chat_completion"
-model = "llama4-maverick-instruct-together"
+model = "glm-4.7-together"
 system_template = "../../../fixtures/config/functions/weather_helper_parallel/prompt/system_template.minijinja"
 
 [functions.weather_helper_parallel.variants.vllm]

--- a/crates/tensorzero-core/tests/e2e/config/tensorzero.functions.weather_helper.toml
+++ b/crates/tensorzero-core/tests/e2e/config/tensorzero.functions.weather_helper.toml
@@ -264,9 +264,9 @@ max_tokens = 100
 
 [functions.weather_helper.variants.together-tool]
 type = "chat_completion"
-model = "llama4-maverick-instruct-together"
+model = "glm-4.7-together"
 system_template = "../../../fixtures/config/functions/weather_helper/prompt/system_template.minijinja"
-max_tokens = 100
+max_tokens = 500
 
 [functions.weather_helper.variants.sglang]
 type = "chat_completion"

--- a/crates/tensorzero-core/tests/e2e/config/tensorzero.models.toml
+++ b/crates/tensorzero-core/tests/e2e/config/tensorzero.models.toml
@@ -418,12 +418,12 @@ type = "together"
 model_name = "Qwen/Qwen3-Next-80B-A3B-Instruct"
 api_key_location = "dynamic::together_api_key"
 
-[models."llama4-maverick-instruct-together"]
+[models."glm-4.7-together"]
 routing = ["together"]
 
-[models."llama4-maverick-instruct-together".providers.together]
+[models."glm-4.7-together".providers.together]
 type = "together"
-model_name = "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8"
+model_name = "zai-org/GLM-4.7"
 
 [models."Qwen/Qwen3-1.7B"]
 routing = ["sglang"]

--- a/crates/tensorzero-core/tests/e2e/providers/common.rs
+++ b/crates/tensorzero-core/tests/e2e/providers/common.rs
@@ -10410,16 +10410,18 @@ pub async fn check_parallel_tool_use_inference_response(
 
     let is_openrouter = provider.model_provider_name == "openrouter";
     let is_groq = provider.model_provider_name == "groq";
-    if is_openrouter || is_groq {
-        // For Groq and OpenRouter, check that there are at least 2 tool calls
-        // (these providers may include an empty text block)
+    let is_together = provider.model_provider_name == "together";
+    if is_openrouter || is_groq || is_together {
+        let provider_name = &provider.model_provider_name;
+        // For Groq, OpenRouter, and Together, check that there are at least 2 tool calls
+        // (these providers may include an empty text block or thought block)
         let tool_calls = output
             .iter()
             .filter(|block| matches!(block, StoredContentBlock::ToolCall(_)))
             .count();
         assert_eq!(
             tool_calls, 2,
-            "Expected 2 tool calls for OpenRouter, got {tool_calls}"
+            "Expected 2 tool calls for {provider_name}, got {tool_calls}"
         );
     } else {
         // For other providers, expect exactly 2 blocks total
@@ -10444,6 +10446,10 @@ pub async fn check_parallel_tool_use_inference_response(
             }
             StoredContentBlock::Text(text) if text.text.trim().is_empty() && is_groq => {
                 // Skip empty text blocks for Groq
+                continue;
+            }
+            StoredContentBlock::Thought(_thought) => {
+                // Skip thought blocks
                 continue;
             }
             _ => {

--- a/crates/tensorzero-core/tests/e2e/providers/together.rs
+++ b/crates/tensorzero-core/tests/e2e/providers/together.rs
@@ -73,7 +73,7 @@ async fn get_providers() -> E2ETestProviders {
     let tool_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "together-tool".to_string(),
-        model_name: "llama4-maverick-instruct-together".into(),
+        model_name: "glm-4.7-together".into(),
         model_provider_name: "together".into(),
         credentials: HashMap::new(),
     }];


### PR DESCRIPTION
Together removed serverless support from a Llama model, and it's hard to get all our tool-calling tests to pass with any of the remaining serverless llama models

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to E2E test configs and assertions, mainly updating the Together model used for tool-calling and relaxing output parsing to tolerate provider-specific extra blocks.
> 
> **Overview**
> Updates Together E2E tool-calling variants to use `glm-4.7-together` (and adds the corresponding model mapping to `zai-org/GLM-4.7`), replacing the previous Llama-based model across the `basic_test`, `weather_helper`, and `weather_helper_parallel` configs.
> 
> Adjusts Together tool-use test expectations by increasing `max_tokens` for Together tool variants and making the parallel tool-use assertions tolerant of Together responses that include extra non-tool blocks (e.g., `Thought`), while still requiring exactly two tool calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ffda15762b19752e8b895e12754f615510725c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->