### PR TITLE
Add tensorzero_input_tokens_total and tensorzero_output_tokens_total

### DIFF
--- a/crates/gateway/tests/prometheus.rs
+++ b/crates/gateway/tests/prometheus.rs
@@ -132,6 +132,19 @@ async fn test_prometheus_metrics_inference_helper(stream: bool) {
             "Expected bucket with le=\"{bucket}\" not found"
         );
     }
+
+    // Verify token metrics are present and non-zero
+    let input_tokens: u64 = metrics["tensorzero_input_tokens_total"].parse().unwrap();
+    assert!(
+        input_tokens > 0,
+        "Input tokens should be greater than 0, got {input_tokens}"
+    );
+
+    let output_tokens: u64 = metrics["tensorzero_output_tokens_total"].parse().unwrap();
+    assert!(
+        output_tokens > 0,
+        "Output tokens should be greater than 0, got {output_tokens}"
+    );
 }
 
 #[tokio::test]

--- a/crates/tensorzero-core/src/embeddings.rs
+++ b/crates/tensorzero-core/src/embeddings.rs
@@ -708,6 +708,7 @@ impl EmbeddingProviderInfo {
         } else {
             response_fut.await?
         };
+        crate::model::record_usage_metrics(&response.usage);
         let resource_usage = response.resource_usage();
         // Make sure that we finish updating rate-limiting tickets if the gateway shuts down
         clients.deferred_tasks.spawn(

--- a/crates/tensorzero-core/src/model.rs
+++ b/crates/tensorzero-core/src/model.rs
@@ -74,6 +74,7 @@ use crate::{
         types::{ModelInferenceRequest, ModelInferenceResponse, ProviderInferenceResponse},
     },
 };
+use metrics::counter;
 use serde::{Deserialize, Serialize};
 
 use crate::providers::{
@@ -84,6 +85,15 @@ use crate::providers::{
     openrouter::OpenRouterProvider, together::TogetherProvider, vllm::VLLMProvider,
     xai::XAIProvider,
 };
+
+pub(crate) fn record_usage_metrics(usage: &Usage) {
+    if let Some(input_tokens) = usage.input_tokens {
+        counter!("tensorzero_input_tokens_total").increment(input_tokens as u64);
+    }
+    if let Some(output_tokens) = usage.output_tokens {
+        counter!("tensorzero_output_tokens_total").increment(output_tokens as u64);
+    }
+}
 
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
 #[derive(Debug, Serialize)]
@@ -945,6 +955,8 @@ fn wrap_provider_stream(
                     }
                 }
             };
+
+            record_usage_metrics(&aggregated_usage);
 
             if let Err(e) = ticket_borrow.return_tickets(usage).await {
                 tracing::error!("Failed to return rate limit tickets: {}", e);
@@ -2088,6 +2100,7 @@ impl ModelProvider {
         };
         self.apply_otlp_span_fields_output(request.otlp_config, &span, &res);
         let provider_inference_response = res?;
+        record_usage_metrics(&provider_inference_response.usage);
         if let Ok(actual_resource_usage) = provider_inference_response.resource_usage() {
             // Make sure that we finish updating rate-limiting tickets if the gateway shuts down
             clients.deferred_tasks.spawn(

--- a/crates/tensorzero-core/src/observability/mod.rs
+++ b/crates/tensorzero-core/src/observability/mod.rs
@@ -1257,6 +1257,18 @@ pub fn setup_metrics(metrics_config: Option<&MetricsConfig>) -> Result<Prometheu
         "Inferences performed by TensorZero",
     );
 
+    describe_counter!(
+        "tensorzero_input_tokens_total",
+        Unit::Count,
+        "Input tokens consumed by TensorZero inferences",
+    );
+
+    describe_counter!(
+        "tensorzero_output_tokens_total",
+        Unit::Count,
+        "Output tokens consumed by TensorZero inferences",
+    );
+
     if !buckets.is_empty() {
         describe_histogram!(
             "tensorzero_inference_latency_overhead_seconds",

--- a/crates/tensorzero-core/tests/e2e/prometheus.rs
+++ b/crates/tensorzero-core/tests/e2e/prometheus.rs
@@ -16,6 +16,8 @@ async fn test_prometheus_metrics_inference_nonstreaming() {
     let client = Client::new();
 
     let request_count_before = get_metric_u32(&client, prometheus_metric_name).await;
+    let input_tokens_before = get_metric_u64(&client, "tensorzero_input_tokens_total").await;
+    let output_tokens_before = get_metric_u64(&client, "tensorzero_output_tokens_total").await;
 
     // Run inference (standard)
     let inference_payload = serde_json::json!({
@@ -44,6 +46,18 @@ async fn test_prometheus_metrics_inference_nonstreaming() {
         request_count_after,
         request_count_before + 1,
         "Inference request count should have increased by 1"
+    );
+
+    let input_tokens_after = get_metric_u64(&client, "tensorzero_input_tokens_total").await;
+    let output_tokens_after = get_metric_u64(&client, "tensorzero_output_tokens_total").await;
+
+    assert!(
+        input_tokens_after > input_tokens_before,
+        "Input tokens should have increased after inference"
+    );
+    assert!(
+        output_tokens_after > output_tokens_before,
+        "Output tokens should have increased after inference"
     );
 }
 
@@ -93,6 +107,8 @@ async fn test_prometheus_metrics_inference_streaming() {
     let client = Client::new();
 
     let request_count_before = get_metric_u32(&client, prometheus_metric_name).await;
+    let input_tokens_before = get_metric_u64(&client, "tensorzero_input_tokens_total").await;
+    let output_tokens_before = get_metric_u64(&client, "tensorzero_output_tokens_total").await;
 
     // Run inference (streaming)
     let inference_payload = serde_json::json!({
@@ -122,6 +138,18 @@ async fn test_prometheus_metrics_inference_streaming() {
         request_count_after,
         request_count_before + 1,
         "Inference request count should have increased by 1"
+    );
+
+    let input_tokens_after = get_metric_u64(&client, "tensorzero_input_tokens_total").await;
+    let output_tokens_after = get_metric_u64(&client, "tensorzero_output_tokens_total").await;
+
+    assert!(
+        input_tokens_after > input_tokens_before,
+        "Input tokens should have increased after streaming inference"
+    );
+    assert!(
+        output_tokens_after > output_tokens_before,
+        "Output tokens should have increased after streaming inference"
     );
 }
 
@@ -716,6 +744,16 @@ async fn get_metric_u32(client: &Client, metric_name: &str) -> u32 {
         .map(std::string::String::as_str)
         .unwrap_or("0")
         .parse::<u32>()
+        .unwrap()
+}
+
+async fn get_metric_u64(client: &Client, metric_name: &str) -> u64 {
+    let metrics = get_metrics(client).await;
+    metrics
+        .get(metric_name)
+        .map(std::string::String::as_str)
+        .unwrap_or("0")
+        .parse::<u64>()
         .unwrap()
 }
 


### PR DESCRIPTION
These new Prometheus metrics track the total input/output token counts (using the same computation as for rate limiting)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two new Prometheus counters and increments them from existing `Usage` fields during inference/embedding responses, with no behavior changes beyond metric emission.
> 
> **Overview**
> Adds two new Prometheus counters, `tensorzero_input_tokens_total` and `tensorzero_output_tokens_total`, to track cumulative token usage.
> 
> Token counts are recorded by a new `record_usage_metrics` helper and invoked after provider responses for chat/inference (including streaming aggregation) and embeddings, and the counters are registered in observability.
> 
> Tests are updated/added to assert these token metrics exist and increase (or are non-zero) alongside existing Prometheus overhead/request metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f18f98dead23b260251912971ad359933f090a45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->