### PR TITLE
Increase timeout for OpenRouter e2e tests

### DIFF
--- a/crates/.config/nextest.toml
+++ b/crates/.config/nextest.toml
@@ -238,3 +238,8 @@ retries = { backoff = "exponential", count = 8, delay = "5s", jitter = true, max
 # xAI reasoning multi-turn tests are slow due to reasoning model response times
 filter = 'binary(e2e) and test(test_reasoning_multi_turn_)'
 slow-timeout = { period = "60s", terminate-after = 2 }
+
+[[profile.default.overrides]]
+# OpenRouter proxies to other providers and can be slow, especially for tool use and parallel requests
+filter = 'binary(e2e) and test(providers::openrouter::)'
+slow-timeout = { period = "60s", terminate-after = 2 }


### PR DESCRIPTION
## Summary
- Adds a nextest override for OpenRouter e2e tests with `slow-timeout = { period = "60s", terminate-after = 2 }` (120s total)
- OpenRouter proxies to other providers, making it inherently slower than direct API calls
- Tests were frequently timing out at the default 60s e2e limit, especially `test_bad_auth_extra_headers`, `test_multi_turn_parallel_tool_use_inference_request`, `test_parallel_tool_use_streaming_inference_request`, and `test_streaming_invalid_request`
- Matches existing overrides for other slow providers (vLLM, SGLang, image inference)

## Test plan
- [x] Verify the override applies: `cargo nextest show-config test-groups --features e2e_tests`
- [ ] CI should no longer time out on OpenRouter tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)