### PR TITLE
Add 'gateway_id' to howdy

### DIFF
--- a/crates/tensorzero-core/src/howdy.rs
+++ b/crates/tensorzero-core/src/howdy.rs
@@ -30,6 +30,7 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{Level, debug, info};
+use uuid::Uuid;
 
 use crate::db::clickhouse::ClickHouseConnectionInfo;
 use crate::db::clickhouse::clickhouse_client::ClickHouseClientType;
@@ -77,6 +78,7 @@ pub async fn howdy_loop(
     let db =
         DelegatingDatabaseConnection::new(clickhouse.clone(), postgres.clone(), primary_datastore);
     let client = Client::new();
+    let gateway_id = Uuid::now_v7();
     let deployment_id = match get_deployment_id(&clickhouse, &postgres, primary_datastore).await {
         Ok(deployment_id) => deployment_id,
         Err(()) => {
@@ -100,6 +102,7 @@ pub async fn howdy_loop(
                 &copied_client,
                 &copied_deployment_id,
                 primary_datastore,
+                gateway_id,
             )
             .await
             {
@@ -115,9 +118,10 @@ async fn send_howdy(
     client: &Client,
     deployment_id: &str,
     primary_datastore: PrimaryDatastore,
+    gateway_id: Uuid,
 ) -> Result<(), String> {
     let howdy_url = HOWDY_URL.clone();
-    let howdy_report = get_howdy_report(db, deployment_id, primary_datastore).await?;
+    let howdy_report = get_howdy_report(db, deployment_id, primary_datastore, gateway_id).await?;
     if let Err(e) = client.post(&howdy_url).json(&howdy_report).send().await {
         return Err(format!("Failed to send howdy: {e}"));
     }
@@ -179,6 +183,7 @@ pub async fn get_howdy_report<'a>(
     db: &(dyn HowdyQueries + Sync),
     deployment_id: &'a str,
     primary_datastore: PrimaryDatastore,
+    gateway_id: Uuid,
 ) -> Result<HowdyReportBody<'a>, String> {
     let dryrun = cfg!(any(test, feature = "e2e_tests"));
     let (inference_counts, feedback_counts, token_totals) = try_join!(
@@ -212,6 +217,7 @@ pub async fn get_howdy_report<'a>(
         demonstration_feedback_count: Some(
             feedback_counts.demonstration_feedback_count.to_string(),
         ),
+        gateway_id,
         observability_backend: primary_datastore,
         dryrun,
     })
@@ -220,6 +226,7 @@ pub async fn get_howdy_report<'a>(
 #[derive(Debug, Serialize)]
 pub struct HowdyReportBody<'a> {
     pub deployment_id: &'a str,
+    pub gateway_id: Uuid,
     pub inference_count: String,
     pub feedback_count: String,
     pub gateway_version: &'static str,

--- a/crates/tensorzero-core/tests/e2e/howdy.rs
+++ b/crates/tensorzero-core/tests/e2e/howdy.rs
@@ -24,6 +24,7 @@ use tensorzero_core::http::TensorzeroHttpClient;
 use tensorzero_core::inference::types::{Arguments, System, Template, Text};
 use tensorzero_core::utils::gateway::GatewayHandle;
 use tokio::time::Duration;
+use uuid::Uuid;
 
 #[gtest]
 #[tokio::test(flavor = "multi_thread")]
@@ -88,9 +89,14 @@ async fn test_get_howdy_report() {
     )
     .await
     .unwrap();
-    let howdy_report = get_howdy_report(&clickhouse, &deployment_id, PrimaryDatastore::ClickHouse)
-        .await
-        .unwrap();
+    let howdy_report = get_howdy_report(
+        &clickhouse,
+        &deployment_id,
+        PrimaryDatastore::ClickHouse,
+        Uuid::now_v7(),
+    )
+    .await
+    .unwrap();
     assert_eq!(howdy_report.inference_count, "0");
     assert_eq!(howdy_report.feedback_count, "0");
     assert!(howdy_report.input_token_total.is_none());
@@ -180,10 +186,14 @@ async fn test_get_howdy_report() {
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     // Get the howdy report again
-    let new_howdy_report =
-        get_howdy_report(&clickhouse, &deployment_id, PrimaryDatastore::ClickHouse)
-            .await
-            .unwrap();
+    let new_howdy_report = get_howdy_report(
+        &clickhouse,
+        &deployment_id,
+        PrimaryDatastore::ClickHouse,
+        Uuid::now_v7(),
+    )
+    .await
+    .unwrap();
     assert!(!new_howdy_report.inference_count.is_empty());
     assert!(!new_howdy_report.feedback_count.is_empty());
     // Since we're in an e2e test, this should be true


### PR DESCRIPTION
Don't merge this until we do a Howdy deploy
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new `gateway_id` field to the Howdy analytics payload and threads it through the send/report functions, which could impact compatibility with the external Howdy service if it doesn’t tolerate the additional field.
> 
> **Overview**
> Howdy usage reporting now generates a per-process `gateway_id` (`Uuid::now_v7()`) and includes it in every report sent to the Howdy service.
> 
> This updates the Howdy report builder/signatures to accept and serialize `gateway_id`, and adjusts the e2e Howdy tests to pass a UUID when calling `get_howdy_report`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57cab995cdf5d128283cbc0df2d22e3d67604c74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->