### PR TITLE
Actually use batch_writes setting in live tests job

### DIFF
--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -111,6 +111,14 @@ jobs:
           echo "TENSORZERO_INTERNAL_TEST_OBSERVABILITY_BACKEND=postgres" >> $GITHUB_ENV
           echo "GATEWAY_CONFIG_GLOB={tensorzero,postgres}.*.toml" >> $GITHUB_ENV
 
+      - name: Configure batch writes in tensorzero.toml
+        if: matrix.batch_writes == true
+        run: |
+          echo "[gateway.observability.batch_writes]" >> crates/tensorzero-core/tests/e2e/config/tensorzero.misc.toml
+          echo "enabled = true" >> crates/tensorzero-core/tests/e2e/config/tensorzero.misc.toml
+          echo "flush_interval_ms = 80" >> crates/tensorzero-core/tests/e2e/config/tensorzero.misc.toml
+          echo "__force_allow_embedded_batch_writes = true" >> crates/tensorzero-core/tests/e2e/config/tensorzero.misc.toml
+
       - name: Pull images referenced by the compose file
         run: docker compose -f crates/tensorzero-core/tests/e2e/docker-compose.live.yml --profile provider-proxy pull --ignore-pull-failures
 
@@ -118,6 +126,7 @@ jobs:
         run: |
           DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) docker compose -f crates/tensorzero-core/tests/e2e/docker-compose.live.yml --profile provider-proxy run --rm \
             -e TENSORZERO_CI=1 \
+            -e TENSORZERO_CLICKHOUSE_BATCH_WRITES=${{ matrix.batch_writes }} \
             -e TENSORZERO_INTERNAL_TEST_OBSERVABILITY_BACKEND=${TENSORZERO_INTERNAL_TEST_OBSERVABILITY_BACKEND:-} \
             live-tests
 
@@ -133,6 +142,21 @@ jobs:
             exit 1
           fi
           grep --invert-match -i "please file a bug report" <<< "$LOGS"
+
+      - name: Check gateway started with correct batch writes mode
+        run: |
+          LOGS=$(docker compose -f crates/tensorzero-core/tests/e2e/docker-compose.live.yml --profile provider-proxy logs gateway)
+          if [ -z "$LOGS" ]; then
+            echo "ERROR: Gateway logs are empty"
+            exit 1
+          fi
+          if [ "${{ matrix.batch_writes }}" = "true" ]; then
+            echo "Checking that batch writes are enabled..."
+            grep "Batch Writes: enabled" <<< "$LOGS"
+          else
+            echo "Checking that batch writes are disabled..."
+            grep "Batch Writes: disabled" <<< "$LOGS"
+          fi
 
       # TODO - re-enable this: https://github.com/tensorzero/tensorzero/issues/3989
       # - name: Check e2e logs for deprecation warnings (gateway e2e tests only)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the GitHub Actions live-tests workflow, affecting only CI behavior. Main risk is potential flakiness or false failures if log messages/config file mutations don’t match expectations.
> 
> **Overview**
> Makes the `live-tests` CI matrix actually toggle ClickHouse batch writes.
> 
> When `matrix.batch_writes` is true, the workflow appends a `[gateway.observability.batch_writes]` section to `tensorzero.misc.toml`, passes `TENSORZERO_CLICKHOUSE_BATCH_WRITES` into the live-tests container, and adds a post-run assertion that gateway logs report *Batch Writes enabled/disabled* matching the matrix value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ec6904f83520d6355cec2522a0a83f6db28c32f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->