### PR TITLE
Document `content_type_overrides` in config reference

### DIFF
--- a/docs/gateway/configuration-reference.mdx
+++ b/docs/gateway/configuration-reference.mdx
@@ -1836,6 +1836,39 @@ api_type = "responses"
 # ...
 ```
 
+##### `content_type_overrides`
+
+- **Type:** map of string to string
+- **Required:** no (default: `{}`)
+
+Overrides the default MIME type to content block type mapping when serializing file inputs for the OpenAI API.
+
+By default, TensorZero maps `image/*` MIME types to `image_url` blocks, `audio/*` to `input_audio` blocks, and everything else to `file` blocks.
+Some OpenAI-compatible providers don't support `file` blocks but accept certain file types (e.g. PDFs) as `image_url` blocks with `data:` URIs.
+Use this option to override the mapping for specific MIME types.
+
+Each key is a MIME type string (e.g. `"application/pdf"`) and each value is one of: `"image_url"`, `"file"`, or `"input_audio"`.
+
+**Common use case: Vertex AI with PDFs.**
+When using Vertex AI's OpenAI-compatible endpoint (`type = "openai"` with `api_base` pointing at Vertex AI), sending PDFs fails with an error like:
+
+```
+Unrecognized 'type' field in an object element of an array 'content' field; found: 'file'.
+```
+
+This happens because TensorZero converts PDFs to `type: "file"` content blocks, but Vertex AI only accepts PDFs as `image_url` blocks with `data:application/pdf;base64,...` data URIs.
+To fix this, add a `content_type_overrides` entry that maps `"application/pdf"` to `"image_url"`:
+
+```toml title="tensorzero.toml"
+[models.gemini-flash.providers.vertex]
+type = "openai"
+model_name = "google/gemini-2.0-flash"
+api_base = "https://aiplatform.googleapis.com/v1beta1/projects/my-project/locations/us-central1/endpoints/openapi"
+
+[models.gemini-flash.providers.vertex.content_type_overrides]
+"application/pdf" = "image_url"  # Send PDFs as image_url blocks (required for Vertex AI)
+```
+
 ##### `include_encrypted_reasoning`
 
 - **Type:** boolean
@@ -1870,39 +1903,6 @@ See [OpenAI's documentation](https://platform.openai.com/docs/models) for the li
 type = "openai"
 model_name = "gpt-4o-mini-2024-07-18"
 # ...
-```
-
-##### `content_type_overrides`
-
-- **Type:** map of string to string
-- **Required:** no (default: `{}`)
-
-Overrides the default MIME type to content block type mapping when serializing file inputs for the OpenAI API.
-
-By default, TensorZero maps `image/*` MIME types to `image_url` blocks, `audio/*` to `input_audio` blocks, and everything else to `file` blocks.
-Some OpenAI-compatible providers don't support `file` blocks but accept certain file types (e.g. PDFs) as `image_url` blocks with `data:` URIs.
-Use this option to override the mapping for specific MIME types.
-
-Each key is a MIME type string (e.g. `"application/pdf"`) and each value is one of: `"image_url"`, `"file"`, or `"input_audio"`.
-
-**Common use case: Vertex AI with PDFs.**
-When using Vertex AI's OpenAI-compatible endpoint (`type = "openai"` with `api_base` pointing at Vertex AI), sending PDFs fails with an error like:
-
-```
-Unrecognized 'type' field in an object element of an array 'content' field; found: 'file'.
-```
-
-This happens because TensorZero converts PDFs to `type: "file"` content blocks, but Vertex AI only accepts PDFs as `image_url` blocks with `data:application/pdf;base64,...` data URIs.
-To fix this, add a `content_type_overrides` entry that maps `"application/pdf"` to `"image_url"`:
-
-```toml title="tensorzero.toml"
-[models.gemini-flash.providers.vertex]
-type = "openai"
-model_name = "google/gemini-2.0-flash"
-api_base = "https://aiplatform.googleapis.com/v1beta1/projects/my-project/locations/us-central1/endpoints/openapi"
-
-[models.gemini-flash.providers.vertex.content_type_overrides]
-"application/pdf" = "image_url"  # Send PDFs as image_url blocks (required for Vertex AI)
 ```
 
 ##### `provider_tools`


### PR DESCRIPTION
## Summary
- Documents the new `content_type_overrides` option in the OpenAI provider configuration reference
- Includes example for Vertex AI PDF support (the primary use case from #7159)

Follow-up to #7164.

## Test plan
- [x] Docs render correctly (MDX syntax, code blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)