### PR TITLE
Use Howdy even with no database connection

### DIFF
--- a/crates/tensorzero-core/src/endpoints/batch_inference.rs
+++ b/crates/tensorzero-core/src/endpoints/batch_inference.rs
@@ -12,6 +12,7 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 use std::iter::repeat;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use tokio::try_join;
 use tracing::instrument;
 use uuid::Uuid;
@@ -50,6 +51,7 @@ use crate::inference::types::{
 use crate::inference::types::{Input, InputExt, batch::StartBatchModelInferenceWithMetadata};
 use crate::jsonschema_util::JSONSchema;
 use crate::model::ModelTable;
+use crate::observability::internal_metrics::TENSORZERO_INFERENCES_TOTAL;
 use crate::rate_limiting::ScopeInfo;
 use crate::relay::TensorzeroRelay;
 use crate::tool::{
@@ -237,6 +239,7 @@ pub async fn start_batch_inference(
         "function_name" => params.function_name.to_string(),
     )
     .increment(num_inferences as u64);
+    TENSORZERO_INFERENCES_TOTAL.fetch_add(num_inferences as u64, Ordering::Relaxed);
 
     // Keep track of which variants failed
     let mut variant_errors = IndexMap::new();

--- a/crates/tensorzero-core/src/endpoints/embeddings.rs
+++ b/crates/tensorzero-core/src/endpoints/embeddings.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{Arc, atomic::Ordering},
+};
 
 use axum::Extension;
 use serde::{Deserialize, Serialize};
@@ -19,6 +22,7 @@ use crate::{
         Usage,
         usage::{ApiType, RawResponseEntry},
     },
+    observability::internal_metrics::TENSORZERO_INFERENCES_TOTAL,
     rate_limiting::{RateLimitingManager, ScopeInfo},
 };
 use tensorzero_auth::middleware::RequestApiKeyExtension;
@@ -110,6 +114,7 @@ pub async fn embeddings(
             "model_name" => params.model_name.clone(),
         )
         .increment(num_inputs as u64);
+        TENSORZERO_INFERENCES_TOTAL.fetch_add(num_inputs as u64, Ordering::Relaxed);
     }
     let clients = InferenceClients {
         http_client: http_client.clone(),

--- a/crates/tensorzero-core/src/endpoints/feedback/mod.rs
+++ b/crates/tensorzero-core/src/endpoints/feedback/mod.rs
@@ -1,5 +1,6 @@
 use std::cmp::max;
 use std::collections::HashMap;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
@@ -28,6 +29,7 @@ use crate::inference::types::{
     ContentBlockChatOutput, ContentBlockOutput, Text, parse_chat_output,
 };
 use crate::jsonschema_util::JSONSchema;
+use crate::observability::internal_metrics::TENSORZERO_FEEDBACKS_TOTAL;
 use crate::tool::{StaticToolConfig, ToolCall, ToolCallConfig};
 use crate::utils::gateway::{AppState, AppStateData, StructuredJson};
 use crate::utils::uuid::uuid_elapsed;
@@ -207,6 +209,7 @@ async fn feedback_inner(
             "metric_name" => params.metric_name.to_string()
         )
         .increment(1);
+        TENSORZERO_FEEDBACKS_TOTAL.fetch_add(1, Ordering::Relaxed);
     }
 
     match feedback_metadata.r#type {

--- a/crates/tensorzero-core/src/endpoints/inference.rs
+++ b/crates/tensorzero-core/src/endpoints/inference.rs
@@ -14,6 +14,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tokio::time::Instant;
 use tokio_stream::StreamExt;
@@ -59,6 +60,7 @@ use crate::inference::types::{
 use crate::jsonschema_util::JSONSchema;
 use crate::minijinja_util::TemplateConfig;
 use crate::model::ModelTable;
+use crate::observability::internal_metrics::TENSORZERO_INFERENCES_TOTAL;
 use crate::observability::request_logging::HttpMetricData;
 use crate::rate_limiting::{RateLimitingManager, ScopeInfo};
 use crate::relay::TensorzeroRelay;
@@ -464,6 +466,7 @@ pub async fn inference(
         }
         counter!("tensorzero_requests_total", &labels).increment(1);
         counter!("tensorzero_inferences_total", &labels).increment(1);
+        TENSORZERO_INFERENCES_TOTAL.fetch_add(1, Ordering::Relaxed);
     }
 
     // Should we stream the inference?

--- a/crates/tensorzero-core/src/howdy.rs
+++ b/crates/tensorzero-core/src/howdy.rs
@@ -23,7 +23,7 @@
 use lazy_static::lazy_static;
 use reqwest::Client;
 use serde::Serialize;
-use std::env;
+use std::{env, sync::atomic::Ordering};
 use tokio::{
     time::{self, Duration},
     try_join,
@@ -33,11 +33,17 @@ use tracing::{Level, debug, info};
 use uuid::Uuid;
 
 use crate::db::clickhouse::ClickHouseConnectionInfo;
-use crate::db::clickhouse::clickhouse_client::ClickHouseClientType;
 use crate::db::delegating_connection::{DelegatingDatabaseConnection, PrimaryDatastore};
 use crate::db::postgres::PostgresConnectionInfo;
 use crate::db::{DeploymentIdQueries, HowdyQueries};
 use crate::{config::Config, utils::spawn_ignoring_shutdown};
+use crate::{
+    db::clickhouse::clickhouse_client::ClickHouseClientType,
+    observability::internal_metrics::{
+        TENSORZERO_FEEDBACKS_TOTAL, TENSORZERO_INFERENCES_TOTAL, TENSORZERO_INPUT_TOKENS_TOTAL,
+        TENSORZERO_OUTPUT_TOKENS_TOTAL,
+    },
+};
 
 lazy_static! {
     /// The URL to send usage data to.
@@ -62,9 +68,6 @@ pub fn setup_howdy(
         return;
     }
 
-    if primary_datastore == PrimaryDatastore::Disabled {
-        return;
-    }
     spawn_ignoring_shutdown(howdy_loop(clickhouse, postgres, primary_datastore, token));
 }
 
@@ -75,16 +78,28 @@ pub async fn howdy_loop(
     primary_datastore: PrimaryDatastore,
     token: CancellationToken,
 ) {
-    let db =
-        DelegatingDatabaseConnection::new(clickhouse.clone(), postgres.clone(), primary_datastore);
+    let db = if primary_datastore == PrimaryDatastore::Disabled {
+        None
+    } else {
+        Some(DelegatingDatabaseConnection::new(
+            clickhouse.clone(),
+            postgres.clone(),
+            primary_datastore,
+        ))
+    };
     let client = Client::new();
     let gateway_id = Uuid::now_v7();
-    let deployment_id = match get_deployment_id(&clickhouse, &postgres, primary_datastore).await {
-        Ok(deployment_id) => deployment_id,
-        Err(()) => {
-            return;
+    let deployment_id = if primary_datastore == PrimaryDatastore::Disabled {
+        None
+    } else {
+        match get_deployment_id(&clickhouse, &postgres, primary_datastore).await {
+            Ok(deployment_id) => Some(deployment_id),
+            Err(()) => {
+                return;
+            }
         }
     };
+
     let mut interval = time::interval(Duration::from_secs(6 * 60 * 60));
     loop {
         let copied_db = db.clone();
@@ -98,9 +113,9 @@ pub async fn howdy_loop(
         }
         spawn_ignoring_shutdown(async move {
             if let Err(e) = send_howdy(
-                &copied_db,
+                copied_db.as_ref(),
                 &copied_client,
-                &copied_deployment_id,
+                copied_deployment_id.as_ref(),
                 primary_datastore,
                 gateway_id,
             )
@@ -114,14 +129,21 @@ pub async fn howdy_loop(
 
 /// Sends usage data to the Howdy service.
 async fn send_howdy(
-    db: &DelegatingDatabaseConnection,
+    db: Option<&DelegatingDatabaseConnection>,
     client: &Client,
-    deployment_id: &str,
+    deployment_id: Option<&String>,
     primary_datastore: PrimaryDatastore,
     gateway_id: Uuid,
 ) -> Result<(), String> {
     let howdy_url = HOWDY_URL.clone();
-    let howdy_report = get_howdy_report(db, deployment_id, primary_datastore, gateway_id).await?;
+    let db: Option<&(dyn HowdyQueries + Sync)> = db.map(|d| d as &(dyn HowdyQueries + Sync));
+    let howdy_report = get_howdy_report(
+        db,
+        deployment_id.map(|s| s.as_str()),
+        primary_datastore,
+        gateway_id,
+    )
+    .await?;
     if let Err(e) = client.post(&howdy_url).json(&howdy_report).send().await {
         return Err(format!("Failed to send howdy: {e}"));
     }
@@ -180,52 +202,87 @@ pub async fn get_deployment_id(
 /// It contains the deployment ID, the number of inferences, and the number of feedbacks.
 /// It is also configurable to run in dryrun mode for testing.
 pub async fn get_howdy_report<'a>(
-    db: &(dyn HowdyQueries + Sync),
-    deployment_id: &'a str,
+    db: Option<&(dyn HowdyQueries + Sync)>,
+    deployment_id: Option<&'a str>,
     primary_datastore: PrimaryDatastore,
     gateway_id: Uuid,
 ) -> Result<HowdyReportBody<'a>, String> {
     let dryrun = cfg!(any(test, feature = "e2e_tests"));
-    let (inference_counts, feedback_counts, token_totals) = try_join!(
-        db.count_inferences_for_howdy(),
-        db.count_feedbacks_for_howdy(),
-        db.get_token_totals_for_howdy()
-    )
-    .map_err(|e| e.to_string())?;
+    match db {
+        Some(db) => {
+            let (inference_counts, feedback_counts, token_totals) = try_join!(
+                db.count_inferences_for_howdy(),
+                db.count_feedbacks_for_howdy(),
+                db.get_token_totals_for_howdy()
+            )
+            .map_err(|e| e.to_string())?;
 
-    let inference_count =
-        inference_counts.chat_inference_count + inference_counts.json_inference_count;
-    let feedback_count = feedback_counts.boolean_metric_feedback_count
-        + feedback_counts.float_metric_feedback_count
-        + feedback_counts.comment_feedback_count
-        + feedback_counts.demonstration_feedback_count;
+            let inference_count =
+                inference_counts.chat_inference_count + inference_counts.json_inference_count;
+            let feedback_count = feedback_counts.boolean_metric_feedback_count
+                + feedback_counts.float_metric_feedback_count
+                + feedback_counts.comment_feedback_count
+                + feedback_counts.demonstration_feedback_count;
 
-    Ok(HowdyReportBody {
-        deployment_id,
-        inference_count: inference_count.to_string(),
-        feedback_count: feedback_count.to_string(),
-        gateway_version: crate::endpoints::status::TENSORZERO_VERSION,
-        input_token_total: token_totals.input_tokens.map(|x| x.to_string()),
-        output_token_total: token_totals.output_tokens.map(|x| x.to_string()),
-        chat_inference_count: Some(inference_counts.chat_inference_count.to_string()),
-        json_inference_count: Some(inference_counts.json_inference_count.to_string()),
-        float_metric_feedback_count: Some(feedback_counts.float_metric_feedback_count.to_string()),
-        boolean_metric_feedback_count: Some(
-            feedback_counts.boolean_metric_feedback_count.to_string(),
-        ),
-        comment_feedback_count: Some(feedback_counts.comment_feedback_count.to_string()),
-        demonstration_feedback_count: Some(
-            feedback_counts.demonstration_feedback_count.to_string(),
-        ),
-        gateway_id,
-        observability_backend: primary_datastore,
-        dryrun,
-    })
+            Ok(HowdyReportBody {
+                deployment_id,
+                inference_count: inference_count.to_string(),
+                feedback_count: feedback_count.to_string(),
+                gateway_version: crate::endpoints::status::TENSORZERO_VERSION,
+                input_token_total: token_totals.input_tokens.map(|x| x.to_string()),
+                output_token_total: token_totals.output_tokens.map(|x| x.to_string()),
+                chat_inference_count: Some(inference_counts.chat_inference_count.to_string()),
+                json_inference_count: Some(inference_counts.json_inference_count.to_string()),
+                float_metric_feedback_count: Some(
+                    feedback_counts.float_metric_feedback_count.to_string(),
+                ),
+                boolean_metric_feedback_count: Some(
+                    feedback_counts.boolean_metric_feedback_count.to_string(),
+                ),
+                comment_feedback_count: Some(feedback_counts.comment_feedback_count.to_string()),
+                demonstration_feedback_count: Some(
+                    feedback_counts.demonstration_feedback_count.to_string(),
+                ),
+                gateway_id,
+                observability_backend: primary_datastore,
+                dryrun,
+            })
+        }
+        None => Ok(HowdyReportBody {
+            deployment_id,
+            inference_count: TENSORZERO_INFERENCES_TOTAL
+                .load(Ordering::Relaxed)
+                .to_string(),
+            feedback_count: TENSORZERO_FEEDBACKS_TOTAL
+                .load(Ordering::Relaxed)
+                .to_string(),
+            gateway_version: crate::endpoints::status::TENSORZERO_VERSION,
+            input_token_total: Some(
+                TENSORZERO_INPUT_TOKENS_TOTAL
+                    .load(Ordering::Relaxed)
+                    .to_string(),
+            ),
+            output_token_total: Some(
+                TENSORZERO_OUTPUT_TOKENS_TOTAL
+                    .load(Ordering::Relaxed)
+                    .to_string(),
+            ),
+            chat_inference_count: None,
+            json_inference_count: None,
+            float_metric_feedback_count: None,
+            boolean_metric_feedback_count: None,
+            comment_feedback_count: None,
+            demonstration_feedback_count: None,
+            gateway_id,
+            observability_backend: primary_datastore,
+            dryrun,
+        }),
+    }
 }
 
 #[derive(Debug, Serialize)]
 pub struct HowdyReportBody<'a> {
-    pub deployment_id: &'a str,
+    pub deployment_id: Option<&'a str>,
     pub gateway_id: Uuid,
     pub inference_count: String,
     pub feedback_count: String,

--- a/crates/tensorzero-core/src/model.rs
+++ b/crates/tensorzero-core/src/model.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 use strum::VariantNames;
 use tensorzero_derive::TensorZeroDeserialize;
@@ -33,6 +34,9 @@ use crate::endpoints::inference::InferenceClients;
 use crate::http::TensorzeroHttpClient;
 use crate::inference::types::usage::aggregate_usage_from_single_streaming_model_inference;
 use crate::model_table::ProviderKind;
+use crate::observability::internal_metrics::{
+    TENSORZERO_INPUT_TOKENS_TOTAL, TENSORZERO_OUTPUT_TOKENS_TOTAL,
+};
 use crate::providers::aws_bedrock::build_aws_bedrock_provider_config;
 use crate::providers::aws_sagemaker::{AWSSagemakerProvider, build_aws_sagemaker_config};
 #[cfg(any(test, feature = "e2e_tests"))]
@@ -89,9 +93,11 @@ use crate::providers::{
 pub(crate) fn record_usage_metrics(usage: &Usage) {
     if let Some(input_tokens) = usage.input_tokens {
         counter!("tensorzero_input_tokens_total").increment(input_tokens as u64);
+        TENSORZERO_INPUT_TOKENS_TOTAL.fetch_add(input_tokens as u64, Ordering::Relaxed);
     }
     if let Some(output_tokens) = usage.output_tokens {
         counter!("tensorzero_output_tokens_total").increment(output_tokens as u64);
+        TENSORZERO_OUTPUT_TOKENS_TOTAL.fetch_add(output_tokens as u64, Ordering::Relaxed);
     }
 }
 

--- a/crates/tensorzero-core/src/observability/internal_metrics.rs
+++ b/crates/tensorzero-core/src/observability/internal_metrics.rs
@@ -1,0 +1,12 @@
+//! Internal metrics (currently reported to Howdy)
+//! These are intentionally *not* persisted to the databsae across restarts
+//! We use atomic counters, rather than go through the `metrics` crate,
+//! as this turns out to be simpler than stripping out the labels we use when normally
+//! recording metrics.
+
+use std::sync::atomic::AtomicU64;
+
+pub static TENSORZERO_INFERENCES_TOTAL: AtomicU64 = AtomicU64::new(0);
+pub static TENSORZERO_FEEDBACKS_TOTAL: AtomicU64 = AtomicU64::new(0);
+pub static TENSORZERO_INPUT_TOKENS_TOTAL: AtomicU64 = AtomicU64::new(0);
+pub static TENSORZERO_OUTPUT_TOKENS_TOTAL: AtomicU64 = AtomicU64::new(0);

--- a/crates/tensorzero-core/src/observability/mod.rs
+++ b/crates/tensorzero-core/src/observability/mod.rs
@@ -94,6 +94,7 @@ use crate::observability::tracing_bug::apply_filter_fixing_tracing_bug;
 
 mod disjoint_intervals;
 mod exporter_wrapper;
+pub mod internal_metrics;
 pub mod overhead_timing;
 pub mod request_logging;
 mod span_leak_detector;

--- a/crates/tensorzero-core/tests/e2e/howdy.rs
+++ b/crates/tensorzero-core/tests/e2e/howdy.rs
@@ -13,6 +13,7 @@ use tensorzero::InputMessageContent;
 use tensorzero::Role;
 use tensorzero::{ClientInferenceParams, Input};
 use tensorzero_core::config::{Config, ConfigFileGlob};
+use tensorzero_core::db::HowdyQueries;
 use tensorzero_core::db::clickhouse::ClickHouseConnectionInfo;
 use tensorzero_core::db::clickhouse::migration_manager;
 use tensorzero_core::db::clickhouse::migration_manager::RunMigrationManagerArgs;
@@ -90,8 +91,8 @@ async fn test_get_howdy_report() {
     .await
     .unwrap();
     let howdy_report = get_howdy_report(
-        &clickhouse,
-        &deployment_id,
+        Some(&clickhouse as &(dyn HowdyQueries + Sync)),
+        Some(deployment_id.as_str()),
         PrimaryDatastore::ClickHouse,
         Uuid::now_v7(),
     )
@@ -187,8 +188,8 @@ async fn test_get_howdy_report() {
 
     // Get the howdy report again
     let new_howdy_report = get_howdy_report(
-        &clickhouse,
-        &deployment_id,
+        Some(&clickhouse as &(dyn HowdyQueries + Sync)),
+        Some(deployment_id.as_str()),
         PrimaryDatastore::ClickHouse,
         Uuid::now_v7(),
     )


### PR DESCRIPTION
When a database is not enabled, we report ephemeral metrics for:
* Total inference count
* Total feedback count
* Total input token count
* Total output token count

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes Howdy reporting to work when the primary datastore is disabled by falling back to in-process atomic counters instead of DB queries; risk is mainly around correctness of reported usage counts and concurrency semantics, not core inference behavior.
> 
> **Overview**
> Howdy usage analytics now runs even when `PrimaryDatastore::Disabled`: the Howdy loop no longer bails without a DB, and `get_howdy_report` falls back to internal in-memory atomic counters for inference/feedback/token totals.
> 
> Adds `observability::internal_metrics` (`AtomicU64` counters) and wires increments into `inference`, `batch_inference`, `embeddings`, `feedback`, and `record_usage_metrics`, then updates e2e tests to pass optional DB/deployment id inputs accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f59b39b8354f72b59c3fda1ce8e49f57ff1154e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->