### PR TITLE
Bump durable for error type refactor

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -155,7 +155,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -166,7 +166,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2194,7 +2194,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 [[package]]
 name = "durable"
 version = "0.1.0"
-source = "git+https://github.com/tensorzero/durable?rev=03f2c5f820b57dff2bdcb60c081533d03605519f#03f2c5f820b57dff2bdcb60c081533d03605519f"
+source = "git+https://github.com/tensorzero/durable?rev=b5f2664bc12e154a3ed00281c1a14a8c7406eae1#b5f2664bc12e154a3ed00281c1a14a8c7406eae1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2376,7 +2376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4393,7 +4393,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6034,7 +6034,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6093,7 +6093,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6553,7 +6553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6983,7 +6983,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8410,7 +8410,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -121,7 +121,7 @@ schemars = "1.1.0"
 serde_arrow = { version = "0.14", features = ["arrow-58"] }
 blake3 = "1.8.4"
 moka = { version = "0.12.15", features = ["sync"] }
-durable = { git = "https://github.com/tensorzero/durable", rev = "03f2c5f820b57dff2bdcb60c081533d03605519f" }
+durable = { git = "https://github.com/tensorzero/durable", rev = "b5f2664bc12e154a3ed00281c1a14a8c7406eae1" }
 durable-tools-spawn = { path = "durable-tools-spawn" }
 tensorzero = { path = "tensorzero-client" }
 tensorzero-core = { path = "tensorzero-core" }

--- a/crates/durable-tools/src/error.rs
+++ b/crates/durable-tools/src/error.rs
@@ -1,4 +1,4 @@
-use durable::{ControlFlow, DurableError, TaskError};
+use durable::{ControlFlow, DurableError, NonControlTaskError, TaskError};
 use serde::de::Error as _;
 use tensorzero_core::error::IMPOSSIBLE_ERROR_MESSAGE;
 use thiserror::Error;
@@ -68,52 +68,58 @@ impl From<TaskError> for ToolError {
     fn from(err: TaskError) -> Self {
         match err {
             TaskError::Control(cf) => ToolError::Control(cf),
-            TaskError::Database(e) => ToolError::Database(e),
-            TaskError::Serialization(e) => {
-                ToolError::NonControl(NonControlToolError::Serialization {
-                    message: e.to_string(),
-                })
-            }
-            TaskError::Timeout { step_name } => {
-                ToolError::NonControl(NonControlToolError::Timeout { step_name })
-            }
-            TaskError::Step { base_name, error } => {
-                ToolError::NonControl(NonControlToolError::Step {
-                    base_name,
-                    error: error.to_string(),
-                })
-            }
-            TaskError::User {
-                message,
-                error_data,
-            } => ToolError::NonControl(NonControlToolError::User {
-                message,
-                error_data,
-            }),
-            TaskError::Validation { message } => {
-                ToolError::NonControl(NonControlToolError::Validation { message })
-            }
-            TaskError::TaskPanicked { message } => {
-                ToolError::NonControl(NonControlToolError::TaskPanicked { message })
-            }
-            TaskError::ChildFailed { step_name, message } => {
-                ToolError::NonControl(NonControlToolError::ChildFailed { step_name, message })
-            }
-            TaskError::ChildCancelled { step_name } => {
-                ToolError::NonControl(NonControlToolError::ChildCancelled { step_name })
-            }
-            TaskError::SubtaskSpawnFailed { name, error } => {
-                ToolError::NonControl(NonControlToolError::SubtaskSpawnFailed {
-                    name,
-                    error: error.to_string(),
-                })
-            }
-            TaskError::EmitEventFailed { event_name, error } => {
-                ToolError::NonControl(NonControlToolError::EmitEventFailed {
-                    event_name,
-                    error: error.to_string(),
-                })
-            }
+            TaskError::NonControl(e) => non_control_task_error_to_tool_error(e),
+        }
+    }
+}
+
+fn non_control_task_error_to_tool_error(err: NonControlTaskError) -> ToolError {
+    match err {
+        NonControlTaskError::Database(e) => ToolError::Database(e),
+        NonControlTaskError::Serialization(e) => {
+            ToolError::NonControl(NonControlToolError::Serialization {
+                message: e.to_string(),
+            })
+        }
+        NonControlTaskError::Timeout { step_name } => {
+            ToolError::NonControl(NonControlToolError::Timeout { step_name })
+        }
+        NonControlTaskError::Step { base_name, error } => {
+            ToolError::NonControl(NonControlToolError::Step {
+                base_name,
+                error: error.to_string(),
+            })
+        }
+        NonControlTaskError::User {
+            message,
+            error_data,
+        } => ToolError::NonControl(NonControlToolError::User {
+            message,
+            error_data,
+        }),
+        NonControlTaskError::Validation { message } => {
+            ToolError::NonControl(NonControlToolError::Validation { message })
+        }
+        NonControlTaskError::TaskPanicked { message } => {
+            ToolError::NonControl(NonControlToolError::TaskPanicked { message })
+        }
+        NonControlTaskError::ChildFailed { step_name, message } => {
+            ToolError::NonControl(NonControlToolError::ChildFailed { step_name, message })
+        }
+        NonControlTaskError::ChildCancelled { step_name } => {
+            ToolError::NonControl(NonControlToolError::ChildCancelled { step_name })
+        }
+        NonControlTaskError::SubtaskSpawnFailed { name, error } => {
+            ToolError::NonControl(NonControlToolError::SubtaskSpawnFailed {
+                name,
+                error: error.to_string(),
+            })
+        }
+        NonControlTaskError::EmitEventFailed { event_name, error } => {
+            ToolError::NonControl(NonControlToolError::EmitEventFailed {
+                event_name,
+                error: error.to_string(),
+            })
         }
     }
 }
@@ -122,7 +128,7 @@ impl From<ToolError> for TaskError {
     fn from(err: ToolError) -> Self {
         match err {
             ToolError::Control(cf) => TaskError::Control(cf),
-            ToolError::Database(e) => TaskError::Database(e),
+            ToolError::Database(e) => NonControlTaskError::Database(e).into(),
             ToolError::NonControl(e) => non_control_tool_error_to_task_error(e),
         }
     }
@@ -135,29 +141,37 @@ impl From<ToolError> for TaskError {
 /// in `durable`, so the orphan rule prevents an impl here.
 pub fn non_control_tool_error_to_task_error(err: NonControlToolError) -> TaskError {
     match err {
-        NonControlToolError::Step { base_name, error } => TaskError::Step {
+        NonControlToolError::Step { base_name, error } => NonControlTaskError::Step {
             base_name,
             error: anyhow::anyhow!(error),
-        },
-        NonControlToolError::Timeout { step_name } => TaskError::Timeout { step_name },
+        }
+        .into(),
+        NonControlToolError::Timeout { step_name } => {
+            NonControlTaskError::Timeout { step_name }.into()
+        }
         NonControlToolError::User {
             message,
             error_data,
-        } => TaskError::User {
+        } => NonControlTaskError::User {
             message,
             error_data,
-        },
-        NonControlToolError::Validation { message } => TaskError::Validation { message },
+        }
+        .into(),
+        NonControlToolError::Validation { message } => {
+            NonControlTaskError::Validation { message }.into()
+        }
         NonControlToolError::ChildFailed { step_name, message } => {
-            TaskError::ChildFailed { step_name, message }
+            NonControlTaskError::ChildFailed { step_name, message }.into()
         }
         NonControlToolError::ChildCancelled { step_name } => {
-            TaskError::ChildCancelled { step_name }
+            NonControlTaskError::ChildCancelled { step_name }.into()
         }
         NonControlToolError::Serialization { message } => {
-            TaskError::Serialization(serde_json::Error::custom(message))
+            TaskError::from(serde_json::Error::custom(message))
         }
-        NonControlToolError::TaskPanicked { message } => TaskError::TaskPanicked { message },
+        NonControlToolError::TaskPanicked { message } => {
+            NonControlTaskError::TaskPanicked { message }.into()
+        }
         // For all other variants, use the Serialize impl to generate error_data
         other => {
             let error_data = serde_json::to_value(&other).unwrap_or_else(|e| {
@@ -167,10 +181,11 @@ pub fn non_control_tool_error_to_task_error(err: NonControlToolError) -> TaskErr
                 })
             });
             let message = other.to_string();
-            TaskError::User {
+            NonControlTaskError::User {
                 message,
                 error_data,
             }
+            .into()
         }
     }
 }
@@ -261,21 +276,23 @@ mod tests {
         tool_error.into()
     }
 
+    use durable::NonControlTaskError;
+
     #[test]
     fn step_error_retryable_after_round_trip() {
-        let err = TaskError::Step {
+        let err = TaskError::NonControl(NonControlTaskError::Step {
             base_name: "my_step".to_string(),
             error: anyhow::anyhow!("transient failure"),
-        };
+        });
         assert!(
             err.retryable(),
             "Step should be retryable before round-trip"
         );
 
-        let back = round_trip(TaskError::Step {
+        let back = round_trip(TaskError::NonControl(NonControlTaskError::Step {
             base_name: "my_step".to_string(),
             error: anyhow::anyhow!("transient failure"),
-        });
+        }));
         assert!(
             back.retryable(),
             "Step must remain retryable after round-trip through ToolError, got: {back}"
@@ -284,68 +301,68 @@ mod tests {
 
     #[test]
     fn timeout_retryable_after_round_trip() {
-        let back = round_trip(TaskError::Timeout {
+        let back = round_trip(TaskError::NonControl(NonControlTaskError::Timeout {
             step_name: "wait_for_event".to_string(),
-        });
+        }));
         assert!(back.retryable());
     }
 
     #[test]
     fn user_error_not_retryable_after_round_trip() {
-        let back = round_trip(TaskError::User {
+        let back = round_trip(TaskError::NonControl(NonControlTaskError::User {
             message: "bad input".to_string(),
             error_data: serde_json::json!({"message": "bad input"}),
-        });
+        }));
         assert!(!back.retryable());
     }
 
     #[test]
     fn validation_not_retryable_after_round_trip() {
-        let back = round_trip(TaskError::Validation {
+        let back = round_trip(TaskError::NonControl(NonControlTaskError::Validation {
             message: "invalid".to_string(),
-        });
+        }));
         assert!(!back.retryable());
     }
 
     #[test]
     fn serialization_not_retryable_after_round_trip() {
-        let back = round_trip(TaskError::Serialization(serde_json::Error::custom(
-            "bad json",
+        let back = round_trip(TaskError::NonControl(NonControlTaskError::Serialization(
+            serde_json::Error::custom("bad json"),
         )));
         assert!(!back.retryable());
     }
 
     #[test]
     fn task_panicked_not_retryable_after_round_trip() {
-        let back = round_trip(TaskError::TaskPanicked {
+        let back = round_trip(TaskError::NonControl(NonControlTaskError::TaskPanicked {
             message: "panic".to_string(),
-        });
+        }));
         assert!(!back.retryable());
     }
 
     #[test]
     fn child_failed_not_retryable_after_round_trip() {
-        let back = round_trip(TaskError::ChildFailed {
+        let back = round_trip(TaskError::NonControl(NonControlTaskError::ChildFailed {
             step_name: "child".to_string(),
             message: "failed".to_string(),
-        });
+        }));
         assert!(!back.retryable());
     }
 
     #[test]
     fn child_cancelled_not_retryable_after_round_trip() {
-        let back = round_trip(TaskError::ChildCancelled {
+        let back = round_trip(TaskError::NonControl(NonControlTaskError::ChildCancelled {
             step_name: "child".to_string(),
-        });
+        }));
         assert!(!back.retryable());
     }
 
     #[test]
     fn step_error_preserves_message_after_round_trip() {
-        let back = round_trip(TaskError::Step {
+        let back = round_trip(TaskError::NonControl(NonControlTaskError::Step {
             base_name: "fetch_data".to_string(),
             error: anyhow::anyhow!("connection refused"),
-        });
+        }));
         let msg = format!("{back}");
         assert!(msg.contains("fetch_data"), "expected base_name in: {msg}");
         assert!(
@@ -357,8 +374,8 @@ mod tests {
 
     #[test]
     fn serialization_error_preserves_message_after_round_trip() {
-        let back = round_trip(TaskError::Serialization(serde_json::Error::custom(
-            "bad json",
+        let back = round_trip(TaskError::NonControl(NonControlTaskError::Serialization(
+            serde_json::Error::custom("bad json"),
         )));
         let msg = format!("{back}");
         assert!(msg.contains("bad json"), "expected error message in: {msg}");

--- a/crates/durable-tools/src/tests.rs
+++ b/crates/durable-tools/src/tests.rs
@@ -662,7 +662,7 @@ mod builder_tests {
 
 mod error_tests {
     use super::*;
-    use durable::{ControlFlow, TaskError};
+    use durable::{ControlFlow, NonControlTaskError, TaskError};
 
     // TODO - re-enable this after adding test helpers to `durable`
     // around `ControlFlow::Suspend`
@@ -697,7 +697,7 @@ mod error_tests {
         let task_err: TaskError = tool_err.into();
 
         match task_err {
-            TaskError::User { message, .. } => {
+            TaskError::NonControl(NonControlTaskError::User { message, .. }) => {
                 assert_eq!(message, "test error");
             }
             _ => panic!("Expected User"),
@@ -725,7 +725,7 @@ mod error_tests {
         let task_err: TaskError = tool_err.into();
 
         match task_err {
-            TaskError::User { message, .. } => {
+            TaskError::NonControl(NonControlTaskError::User { message, .. }) => {
                 assert!(message.contains("missing_tool"));
             }
             _ => panic!("Expected User"),
@@ -740,7 +740,7 @@ mod error_tests {
         let task_err: TaskError = tool_err.into();
 
         match task_err {
-            TaskError::User { message, .. } => {
+            TaskError::NonControl(NonControlTaskError::User { message, .. }) => {
                 assert!(message.contains("bad params"));
             }
             _ => panic!("Expected User"),
@@ -756,7 +756,7 @@ mod error_tests {
         let task_err: TaskError = tool_err.into();
 
         match task_err {
-            TaskError::Serialization(e) => {
+            TaskError::NonControl(NonControlTaskError::Serialization(e)) => {
                 assert!(
                     e.to_string().contains("expected ident at line 1 column 2"),
                     "unexpected error message: {e}"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates the durable dependency and rewires tool↔task error conversions to the new `TaskError::NonControl(NonControlTaskError)` shape, which could affect retryability and error classification if mappings are wrong.
> 
> **Overview**
> Bumps the `durable` git dependency to a newer revision (and refreshes `Cargo.lock`, including a `windows-sys` downgrade in transitive deps).
> 
> Refactors `durable-tools` error conversion to match durable’s new `TaskError::NonControl(NonControlTaskError)` split, centralizing non-control mappings in a helper and updating tests to assert round-trip retryability/message preservation under the new error shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb2cdb3fb138a7fc967b0f09515dea2b8914ddfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->