### PR TITLE
Add function/variant version tables and stored types

### DIFF
--- a/crates/tensorzero-stored-config/src/lib.rs
+++ b/crates/tensorzero-stored-config/src/lib.rs
@@ -6,6 +6,7 @@ mod stored_embedding_model_config;
 mod stored_evaluation_config;
 mod stored_extra_body;
 mod stored_extra_headers;
+mod stored_function_config;
 mod stored_gateway_config;
 mod stored_metric_config;
 pub mod stored_model_config;
@@ -16,6 +17,7 @@ mod stored_provider_types_config;
 mod stored_rate_limiting_config;
 mod stored_storage_kind;
 mod stored_tool_config;
+pub mod stored_variant_config;
 
 pub use stored_autopilot_config::StoredAutopilotConfig;
 pub use stored_clickhouse_config::StoredClickHouseConfig;
@@ -44,6 +46,12 @@ pub use stored_extra_body::{
 };
 pub use stored_extra_headers::{
     StoredExtraHeader, StoredExtraHeaderKind, StoredExtraHeadersConfig,
+};
+pub use stored_function_config::{
+    StoredAdaptiveExperimentationAlgorithm, StoredAdaptiveExperimentationConfig,
+    StoredChatFunctionConfig, StoredExperimentationConfig,
+    StoredExperimentationConfigWithNamespaces, StoredFunctionConfig, StoredJsonFunctionConfig,
+    StoredStaticExperimentationConfig, StoredToolChoice,
 };
 pub use stored_gateway_config::{
     StoredAuthConfig, StoredBatchWritesConfig, StoredExportConfig, StoredGatewayAuthCacheConfig,
@@ -86,3 +94,8 @@ pub use stored_rate_limiting_config::{
 };
 pub use stored_storage_kind::StoredStorageKind;
 pub use stored_tool_config::StoredToolConfig;
+pub use stored_variant_config::{
+    StoredBestOfNVariantConfig, StoredChatCompletionVariantConfig, StoredDiclVariantConfig,
+    StoredInputWrappers, StoredMixtureOfNVariantConfig, StoredVariantConfig, StoredVariantRef,
+    StoredVariantVersionConfig,
+};

--- a/crates/tensorzero-stored-config/src/stored_function_config.rs
+++ b/crates/tensorzero-stored-config/src/stored_function_config.rs
@@ -1,0 +1,268 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{StoredEvaluatorConfig, StoredPromptRef, StoredVariantRef};
+
+/// Stored in `function_versions_config.config`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "lowercase")]
+pub enum StoredFunctionConfig {
+    Chat(StoredChatFunctionConfig),
+    Json(StoredJsonFunctionConfig),
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredChatFunctionConfig {
+    pub variants: Option<HashMap<String, StoredVariantRef>>,
+    pub system_schema: Option<StoredPromptRef>,
+    pub user_schema: Option<StoredPromptRef>,
+    pub assistant_schema: Option<StoredPromptRef>,
+    pub schemas: Option<HashMap<String, StoredPromptRef>>,
+    pub tools: Option<Vec<String>>,
+    pub tool_choice: Option<StoredToolChoice>,
+    pub parallel_tool_calls: Option<bool>,
+    pub description: Option<String>,
+    pub experimentation: Option<StoredExperimentationConfigWithNamespaces>,
+    pub evaluators: Option<HashMap<String, StoredEvaluatorConfig>>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredJsonFunctionConfig {
+    pub variants: Option<HashMap<String, StoredVariantRef>>,
+    pub system_schema: Option<StoredPromptRef>,
+    pub user_schema: Option<StoredPromptRef>,
+    pub assistant_schema: Option<StoredPromptRef>,
+    pub schemas: Option<HashMap<String, StoredPromptRef>>,
+    pub output_schema: Option<StoredPromptRef>,
+    pub description: Option<String>,
+    pub experimentation: Option<StoredExperimentationConfigWithNamespaces>,
+    pub evaluators: Option<HashMap<String, StoredEvaluatorConfig>>,
+}
+
+// --- ToolChoice ---
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StoredToolChoice {
+    None,
+    Auto,
+    Required,
+    Specific(String),
+}
+
+// --- Experimentation ---
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredExperimentationConfigWithNamespaces {
+    pub base: StoredExperimentationConfig,
+    pub namespaces: Option<HashMap<String, StoredExperimentationConfig>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub enum StoredExperimentationConfig {
+    Static(StoredStaticExperimentationConfig),
+    Adaptive(StoredAdaptiveExperimentationConfig),
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredStaticExperimentationConfig {
+    /// Always stored as a map of variant name → weight.
+    pub candidate_variants: Option<HashMap<String, f64>>,
+    pub fallback_variants: Option<Vec<String>>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredAdaptiveExperimentationConfig {
+    pub algorithm: Option<StoredAdaptiveExperimentationAlgorithm>,
+    pub metric: String,
+    pub candidate_variants: Option<Vec<String>>,
+    pub fallback_variants: Option<Vec<String>>,
+    pub min_samples_per_variant: Option<u64>,
+    pub delta: Option<f64>,
+    pub epsilon: Option<f64>,
+    pub update_period_s: Option<u64>,
+    pub min_prob: Option<f64>,
+    pub max_samples_per_variant: Option<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StoredAdaptiveExperimentationAlgorithm {
+    TrackAndStop,
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(
+        clippy::unnecessary_wraps,
+        reason = "`#[gtest]` tests return `googletest::Result<()>`"
+    )]
+
+    use std::collections::HashMap;
+
+    use googletest::prelude::*;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::{StoredPromptRef, StoredVariantRef};
+
+    fn make_prompt_ref() -> StoredPromptRef {
+        StoredPromptRef {
+            prompt_template_version_id: Uuid::now_v7(),
+            template_key: "tpl".to_string(),
+        }
+    }
+
+    fn make_variant_ref() -> StoredVariantRef {
+        StoredVariantRef {
+            variant_version_id: Uuid::now_v7(),
+        }
+    }
+
+    fn assert_round_trip(config: StoredFunctionConfig) {
+        let serialized = serde_json::to_value(config.clone()).expect("serialize stored config");
+        let round_tripped: StoredFunctionConfig =
+            serde_json::from_value(serialized).expect("deserialize stored config");
+        expect_that!(&round_tripped, eq(&config));
+    }
+
+    #[gtest]
+    fn chat_function_full_round_trip() -> Result<()> {
+        let config = StoredFunctionConfig::Chat(StoredChatFunctionConfig {
+            variants: Some(HashMap::from([
+                ("v1".to_string(), make_variant_ref()),
+                ("v2".to_string(), make_variant_ref()),
+            ])),
+            system_schema: Some(make_prompt_ref()),
+            user_schema: Some(make_prompt_ref()),
+            assistant_schema: None,
+            schemas: Some(HashMap::from([("custom".to_string(), make_prompt_ref())])),
+            tools: Some(vec!["search".to_string(), "calculate".to_string()]),
+            tool_choice: Some(StoredToolChoice::Auto),
+            parallel_tool_calls: Some(true),
+            description: Some("A chat function".to_string()),
+            experimentation: Some(StoredExperimentationConfigWithNamespaces {
+                base: StoredExperimentationConfig::Static(StoredStaticExperimentationConfig {
+                    candidate_variants: Some(HashMap::from([
+                        ("v1".to_string(), 0.7),
+                        ("v2".to_string(), 0.3),
+                    ])),
+                    fallback_variants: Some(vec!["v1".to_string()]),
+                }),
+                namespaces: None,
+            }),
+            evaluators: Some(HashMap::from([(
+                "exact".to_string(),
+                StoredEvaluatorConfig::ExactMatch(crate::StoredExactMatchConfig { cutoff: None }),
+            )])),
+        });
+        assert_round_trip(config);
+        Ok(())
+    }
+
+    #[gtest]
+    fn json_function_round_trip() -> Result<()> {
+        let config = StoredFunctionConfig::Json(StoredJsonFunctionConfig {
+            variants: Some(HashMap::from([("v1".to_string(), make_variant_ref())])),
+            system_schema: None,
+            user_schema: Some(make_prompt_ref()),
+            assistant_schema: None,
+            schemas: None,
+            output_schema: Some(make_prompt_ref()),
+            description: None,
+            experimentation: None,
+            evaluators: None,
+        });
+        assert_round_trip(config);
+        Ok(())
+    }
+
+    #[gtest]
+    fn minimal_chat_function_round_trip() -> Result<()> {
+        let config = StoredFunctionConfig::Chat(StoredChatFunctionConfig {
+            variants: Some(HashMap::from([("v1".to_string(), make_variant_ref())])),
+            system_schema: None,
+            user_schema: None,
+            assistant_schema: None,
+            schemas: None,
+            tools: None,
+            tool_choice: None,
+            parallel_tool_calls: None,
+            description: None,
+            experimentation: None,
+            evaluators: None,
+        });
+        assert_round_trip(config);
+        Ok(())
+    }
+
+    #[gtest]
+    fn function_with_adaptive_experimentation_round_trip() -> Result<()> {
+        let config = StoredFunctionConfig::Chat(StoredChatFunctionConfig {
+            variants: Some(HashMap::from([
+                ("v1".to_string(), make_variant_ref()),
+                ("v2".to_string(), make_variant_ref()),
+            ])),
+            system_schema: None,
+            user_schema: None,
+            assistant_schema: None,
+            schemas: None,
+            tools: None,
+            tool_choice: None,
+            parallel_tool_calls: None,
+            description: None,
+            experimentation: Some(StoredExperimentationConfigWithNamespaces {
+                base: StoredExperimentationConfig::Adaptive(StoredAdaptiveExperimentationConfig {
+                    algorithm: Some(StoredAdaptiveExperimentationAlgorithm::TrackAndStop),
+                    metric: "quality".to_string(),
+                    candidate_variants: Some(vec!["v1".to_string(), "v2".to_string()]),
+                    fallback_variants: Some(vec!["v1".to_string()]),
+                    min_samples_per_variant: Some(10),
+                    delta: Some(0.05),
+                    epsilon: Some(0.0),
+                    update_period_s: Some(60),
+                    min_prob: Some(0.01),
+                    max_samples_per_variant: Some(1000),
+                }),
+                namespaces: Some(HashMap::from([(
+                    "premium".to_string(),
+                    StoredExperimentationConfig::Static(StoredStaticExperimentationConfig {
+                        candidate_variants: Some(HashMap::from([("v1".to_string(), 1.0)])),
+                        fallback_variants: None,
+                    }),
+                )])),
+            }),
+            evaluators: None,
+        });
+        assert_round_trip(config);
+        Ok(())
+    }
+
+    #[gtest]
+    fn function_with_tool_choice_specific_round_trip() -> Result<()> {
+        let config = StoredFunctionConfig::Chat(StoredChatFunctionConfig {
+            variants: Some(HashMap::from([("v1".to_string(), make_variant_ref())])),
+            system_schema: None,
+            user_schema: None,
+            assistant_schema: None,
+            schemas: None,
+            tools: Some(vec!["search".to_string()]),
+            tool_choice: Some(StoredToolChoice::Specific("search".to_string())),
+            parallel_tool_calls: Some(false),
+            description: None,
+            experimentation: None,
+            evaluators: None,
+        });
+        assert_round_trip(config);
+        Ok(())
+    }
+}

--- a/crates/tensorzero-stored-config/src/stored_variant_config.rs
+++ b/crates/tensorzero-stored-config/src/stored_variant_config.rs
@@ -1,0 +1,349 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tensorzero_types::inference_params::{JsonMode, ServiceTier};
+use uuid::Uuid;
+
+use crate::{
+    StoredExtraBodyConfig, StoredExtraHeadersConfig, StoredPromptRef, StoredRetryConfig,
+    StoredTimeoutsConfig,
+};
+
+/// Reference to a `variant_versions_config` row.
+/// Replaces inline variant configs in stored function config.
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredVariantRef {
+    pub variant_version_id: Uuid,
+}
+
+/// Wrapper stored in `variant_versions_config.config`.
+/// Uses an explicit `variant` field instead of `#[serde(flatten)]`.
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredVariantVersionConfig {
+    pub variant: StoredVariantConfig,
+    pub timeouts: Option<StoredTimeoutsConfig>,
+    pub namespace: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "config")]
+pub enum StoredVariantConfig {
+    #[serde(rename = "chat_completion")]
+    ChatCompletion(StoredChatCompletionVariantConfig),
+    #[serde(rename = "experimental_best_of_n_sampling")]
+    BestOfNSampling(StoredBestOfNVariantConfig),
+    #[serde(rename = "experimental_mixture_of_n")]
+    MixtureOfN(StoredMixtureOfNVariantConfig),
+    #[serde(rename = "experimental_dynamic_in_context_learning")]
+    Dicl(StoredDiclVariantConfig),
+    #[serde(rename = "experimental_chain_of_thought")]
+    ChainOfThought(StoredChatCompletionVariantConfig),
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredChatCompletionVariantConfig {
+    pub weight: Option<f64>,
+    pub model: Arc<str>,
+    pub system_template: Option<StoredPromptRef>,
+    pub user_template: Option<StoredPromptRef>,
+    pub assistant_template: Option<StoredPromptRef>,
+    pub input_wrappers: Option<StoredInputWrappers>,
+    pub templates: Option<HashMap<String, StoredPromptRef>>,
+    pub temperature: Option<f32>,
+    pub top_p: Option<f32>,
+    pub max_tokens: Option<u32>,
+    pub presence_penalty: Option<f32>,
+    pub frequency_penalty: Option<f32>,
+    pub seed: Option<u32>,
+    pub json_mode: Option<JsonMode>,
+    pub stop_sequences: Option<Vec<String>>,
+    pub reasoning_effort: Option<String>,
+    pub service_tier: Option<ServiceTier>,
+    pub thinking_budget_tokens: Option<i32>,
+    pub verbosity: Option<String>,
+    pub retries: Option<StoredRetryConfig>,
+    pub extra_body: Option<StoredExtraBodyConfig>,
+    pub extra_headers: Option<StoredExtraHeadersConfig>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredInputWrappers {
+    pub user: Option<StoredPromptRef>,
+    pub assistant: Option<StoredPromptRef>,
+    pub system: Option<StoredPromptRef>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredBestOfNVariantConfig {
+    pub weight: Option<f64>,
+    pub timeout_s: Option<f64>,
+    pub candidates: Option<Vec<String>>,
+    pub evaluator: StoredChatCompletionVariantConfig,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredMixtureOfNVariantConfig {
+    pub weight: Option<f64>,
+    pub timeout_s: Option<f64>,
+    pub candidates: Option<Vec<String>>,
+    pub fuser: StoredChatCompletionVariantConfig,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredDiclVariantConfig {
+    pub weight: Option<f64>,
+    pub embedding_model: String,
+    pub k: u32,
+    pub model: String,
+    pub system_instructions: Option<StoredPromptRef>,
+    pub temperature: Option<f32>,
+    pub top_p: Option<f32>,
+    pub max_tokens: Option<u32>,
+    pub presence_penalty: Option<f32>,
+    pub frequency_penalty: Option<f32>,
+    pub seed: Option<u32>,
+    pub json_mode: Option<JsonMode>,
+    pub stop_sequences: Option<Vec<String>>,
+    pub reasoning_effort: Option<String>,
+    pub thinking_budget_tokens: Option<i32>,
+    pub verbosity: Option<String>,
+    pub max_distance: Option<f32>,
+    pub retries: Option<StoredRetryConfig>,
+    pub extra_body: Option<StoredExtraBodyConfig>,
+    pub extra_headers: Option<StoredExtraHeadersConfig>,
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(
+        clippy::unnecessary_wraps,
+        reason = "`#[gtest]` tests return `googletest::Result<()>`"
+    )]
+
+    use googletest::prelude::*;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::{StoredNonStreamingTimeouts, StoredStreamingTimeouts};
+
+    fn make_prompt_ref() -> StoredPromptRef {
+        StoredPromptRef {
+            prompt_template_version_id: Uuid::now_v7(),
+            template_key: "tpl".to_string(),
+        }
+    }
+
+    fn make_chat_completion() -> StoredChatCompletionVariantConfig {
+        StoredChatCompletionVariantConfig {
+            weight: Some(1.0),
+            model: "gpt-4".into(),
+            system_template: Some(make_prompt_ref()),
+            user_template: Some(make_prompt_ref()),
+            assistant_template: None,
+            input_wrappers: None,
+            templates: None,
+            temperature: Some(0.7),
+            top_p: None,
+            max_tokens: Some(1024),
+            presence_penalty: None,
+            frequency_penalty: None,
+            seed: None,
+            json_mode: Some(JsonMode::Off),
+            stop_sequences: None,
+            reasoning_effort: None,
+            service_tier: None,
+            thinking_budget_tokens: None,
+            verbosity: None,
+            retries: Some(StoredRetryConfig {
+                num_retries: 3,
+                max_delay_s: 5.0,
+            }),
+            extra_body: None,
+            extra_headers: None,
+        }
+    }
+
+    fn assert_round_trip(config: StoredVariantVersionConfig) {
+        let serialized = serde_json::to_value(config.clone()).expect("serialize stored config");
+        let round_tripped: StoredVariantVersionConfig =
+            serde_json::from_value(serialized).expect("deserialize stored config");
+        expect_that!(&round_tripped, eq(&config));
+    }
+
+    #[gtest]
+    fn chat_completion_round_trip() -> Result<()> {
+        let config = StoredVariantVersionConfig {
+            variant: StoredVariantConfig::ChatCompletion(make_chat_completion()),
+            timeouts: Some(StoredTimeoutsConfig {
+                non_streaming: Some(StoredNonStreamingTimeouts {
+                    total_ms: Some(5000),
+                }),
+                streaming: Some(StoredStreamingTimeouts {
+                    ttft_ms: Some(1000),
+                    total_ms: Some(10000),
+                }),
+            }),
+            namespace: Some("default".to_string()),
+        };
+        assert_round_trip(config);
+        Ok(())
+    }
+
+    #[gtest]
+    fn chat_completion_minimal_round_trip() -> Result<()> {
+        let config = StoredVariantVersionConfig {
+            variant: StoredVariantConfig::ChatCompletion(StoredChatCompletionVariantConfig {
+                weight: None,
+                model: "gpt-3.5-turbo".into(),
+                system_template: None,
+                user_template: None,
+                assistant_template: None,
+                input_wrappers: None,
+                templates: None,
+                temperature: None,
+                top_p: None,
+                max_tokens: None,
+                presence_penalty: None,
+                frequency_penalty: None,
+                seed: None,
+                json_mode: None,
+                stop_sequences: None,
+                reasoning_effort: None,
+                service_tier: None,
+                thinking_budget_tokens: None,
+                verbosity: None,
+                retries: None,
+                extra_body: None,
+                extra_headers: None,
+            }),
+            timeouts: None,
+            namespace: None,
+        };
+        assert_round_trip(config);
+        Ok(())
+    }
+
+    #[gtest]
+    fn best_of_n_round_trip() -> Result<()> {
+        let config = StoredVariantVersionConfig {
+            variant: StoredVariantConfig::BestOfNSampling(StoredBestOfNVariantConfig {
+                weight: Some(1.0),
+                timeout_s: Some(30.0),
+                candidates: Some(vec!["c1".to_string(), "c2".to_string()]),
+                evaluator: make_chat_completion(),
+            }),
+            timeouts: None,
+            namespace: None,
+        };
+        assert_round_trip(config);
+        Ok(())
+    }
+
+    #[gtest]
+    fn mixture_of_n_round_trip() -> Result<()> {
+        let config = StoredVariantVersionConfig {
+            variant: StoredVariantConfig::MixtureOfN(StoredMixtureOfNVariantConfig {
+                weight: Some(1.0),
+                timeout_s: None,
+                candidates: Some(vec!["c1".to_string()]),
+                fuser: make_chat_completion(),
+            }),
+            timeouts: None,
+            namespace: None,
+        };
+        assert_round_trip(config);
+        Ok(())
+    }
+
+    #[gtest]
+    fn dicl_round_trip() -> Result<()> {
+        let config = StoredVariantVersionConfig {
+            variant: StoredVariantConfig::Dicl(StoredDiclVariantConfig {
+                weight: Some(0.5),
+                embedding_model: "text-embedding-ada-002".to_string(),
+                k: 5,
+                model: "gpt-4".to_string(),
+                system_instructions: Some(make_prompt_ref()),
+                temperature: Some(0.5),
+                top_p: None,
+                max_tokens: Some(512),
+                presence_penalty: None,
+                frequency_penalty: None,
+                seed: None,
+                json_mode: None,
+                stop_sequences: None,
+                reasoning_effort: None,
+                thinking_budget_tokens: None,
+                verbosity: None,
+                max_distance: Some(0.8),
+                retries: None,
+                extra_body: None,
+                extra_headers: None,
+            }),
+            timeouts: None,
+            namespace: Some("experiment_ns".to_string()),
+        };
+        assert_round_trip(config);
+        Ok(())
+    }
+
+    #[gtest]
+    fn chain_of_thought_round_trip() -> Result<()> {
+        let config = StoredVariantVersionConfig {
+            variant: StoredVariantConfig::ChainOfThought(make_chat_completion()),
+            timeouts: None,
+            namespace: None,
+        };
+        assert_round_trip(config);
+        Ok(())
+    }
+
+    #[gtest]
+    fn chat_completion_with_templates_and_wrappers() -> Result<()> {
+        let config = StoredVariantVersionConfig {
+            variant: StoredVariantConfig::ChatCompletion(StoredChatCompletionVariantConfig {
+                weight: Some(1.0),
+                model: "gpt-4".into(),
+                system_template: None,
+                user_template: None,
+                assistant_template: None,
+                input_wrappers: Some(StoredInputWrappers {
+                    user: Some(make_prompt_ref()),
+                    assistant: None,
+                    system: Some(make_prompt_ref()),
+                }),
+                templates: Some(HashMap::from([
+                    ("custom_role".to_string(), make_prompt_ref()),
+                    ("another_role".to_string(), make_prompt_ref()),
+                ])),
+                temperature: None,
+                top_p: None,
+                max_tokens: None,
+                presence_penalty: None,
+                frequency_penalty: None,
+                seed: None,
+                json_mode: Some(JsonMode::Strict),
+                stop_sequences: Some(vec!["END".to_string()]),
+                reasoning_effort: Some("high".to_string()),
+                service_tier: Some(ServiceTier::Default),
+                thinking_budget_tokens: Some(1000),
+                verbosity: Some("verbose".to_string()),
+                retries: None,
+                extra_body: None,
+                extra_headers: None,
+            }),
+            timeouts: None,
+            namespace: None,
+        };
+        assert_round_trip(config);
+        Ok(())
+    }
+}


### PR DESCRIPTION
Add migration for functions_config, function_versions_config, and variant_versions_config tables with FK relationships.

Add stored types:
- StoredFunctionConfig with schemas, tools, experimentation, evaluators
- StoredVariantVersionConfig wrapping StoredVariantConfig enum
- All variant types: ChatCompletion, BestOfN, MixtureOfN, Dicl, ChainOfThought
- Experimentation types: Static, Adaptive (track-and-stop)
- StoredToolChoice, StoredInputWrappers

Includes sqlx round-trip tests for all variant and function config types.