### PR TITLE
Switch from GLM 4.7 to GLM 5 on Together

### DIFF
--- a/crates/tensorzero-core/tests/e2e/config/tensorzero.functions.basic_test.toml
+++ b/crates/tensorzero-core/tests/e2e/config/tensorzero.functions.basic_test.toml
@@ -621,7 +621,7 @@ max_tokens = 100
 
 [functions.basic_test.variants.together-tool]
 type = "chat_completion"
-model = "glm-4.7-together"
+model = "glm-5-together"
 system_template = "../../../fixtures/config/functions/basic_test/prompt/system_template.minijinja"
 max_tokens = 500
 

--- a/crates/tensorzero-core/tests/e2e/config/tensorzero.functions.toml
+++ b/crates/tensorzero-core/tests/e2e/config/tensorzero.functions.toml
@@ -381,7 +381,7 @@ system_template = "../../../fixtures/config/functions/weather_helper_parallel/pr
 
 [functions.weather_helper_parallel.variants.together-tool]
 type = "chat_completion"
-model = "glm-4.7-together"
+model = "glm-5-together"
 system_template = "../../../fixtures/config/functions/weather_helper_parallel/prompt/system_template.minijinja"
 
 [functions.weather_helper_parallel.variants.vllm]

--- a/crates/tensorzero-core/tests/e2e/config/tensorzero.functions.weather_helper.toml
+++ b/crates/tensorzero-core/tests/e2e/config/tensorzero.functions.weather_helper.toml
@@ -264,7 +264,7 @@ max_tokens = 100
 
 [functions.weather_helper.variants.together-tool]
 type = "chat_completion"
-model = "glm-4.7-together"
+model = "glm-5-together"
 system_template = "../../../fixtures/config/functions/weather_helper/prompt/system_template.minijinja"
 max_tokens = 500
 

--- a/crates/tensorzero-core/tests/e2e/config/tensorzero.models.toml
+++ b/crates/tensorzero-core/tests/e2e/config/tensorzero.models.toml
@@ -418,12 +418,12 @@ type = "together"
 model_name = "Qwen/Qwen3-Next-80B-A3B-Instruct"
 api_key_location = "dynamic::together_api_key"
 
-[models."glm-4.7-together"]
+[models."glm-5-together"]
 routing = ["together"]
 
-[models."glm-4.7-together".providers.together]
+[models."glm-5-together".providers.together]
 type = "together"
-model_name = "zai-org/GLM-4.7"
+model_name = "zai-org/GLM-5"
 
 [models."Qwen/Qwen3-1.7B"]
 routing = ["sglang"]

--- a/crates/tensorzero-core/tests/e2e/providers/together.rs
+++ b/crates/tensorzero-core/tests/e2e/providers/together.rs
@@ -73,7 +73,7 @@ async fn get_providers() -> E2ETestProviders {
     let tool_providers = vec![E2ETestProvider {
         supports_batch_inference: false,
         variant_name: "together-tool".to_string(),
-        model_name: "glm-4.7-together".into(),
+        model_name: "glm-5-together".into(),
         model_provider_name: "together".into(),
         credentials: HashMap::new(),
     }];


### PR DESCRIPTION
Together seems to have removed serverless support for glm-4.7 yesterday, so let's switch to GLM 5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to E2E test configs and provider test wiring, but may affect CI stability if `GLM-5` has different tool-calling behavior or availability on Together.
> 
> **Overview**
> Updates the Together *tool-use* E2E coverage to use **GLM-5** instead of **GLM-4.7**.
> 
> This renames the model entry in `tensorzero.models.toml` to `glm-5-together` (pointing at `zai-org/GLM-5`) and updates all references in function variant configs and the Together provider test (`tests/e2e/providers/together.rs`) to match.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ced4fb12124e1e0d05286aa924c7fae5a40bd50e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->