### PR TITLE
Add function/variant/prompt stored types

### DIFF
--- a/crates/tensorzero-stored-config/src/lib.rs
+++ b/crates/tensorzero-stored-config/src/lib.rs
@@ -6,6 +6,7 @@ mod stored_embedding_model_config;
 mod stored_evaluation_config;
 mod stored_extra_body;
 mod stored_extra_headers;
+mod stored_function_config;
 mod stored_gateway_config;
 mod stored_metric_config;
 pub mod stored_model_config;
@@ -16,6 +17,7 @@ mod stored_provider_types_config;
 mod stored_rate_limiting_config;
 mod stored_storage_kind;
 mod stored_tool_config;
+pub mod stored_variant_config;
 
 pub use stored_autopilot_config::StoredAutopilotConfig;
 pub use stored_clickhouse_config::StoredClickHouseConfig;
@@ -45,6 +47,12 @@ pub use stored_extra_body::{
 pub use stored_extra_headers::{
     StoredExtraHeader, StoredExtraHeaderKind, StoredExtraHeadersConfig,
 };
+pub use stored_function_config::{
+    StoredAdaptiveExperimentationAlgorithm, StoredAdaptiveExperimentationConfig,
+    StoredChatFunctionConfig, StoredExperimentationConfig,
+    StoredExperimentationConfigWithNamespaces, StoredFunctionConfig, StoredJsonFunctionConfig,
+    StoredStaticExperimentationConfig, StoredToolChoice,
+};
 pub use stored_gateway_config::{
     StoredAuthConfig, StoredBatchWritesConfig, StoredExportConfig, StoredGatewayAuthCacheConfig,
     StoredGatewayConfig, StoredGatewayMetricsConfig, StoredInferenceCacheBackend,
@@ -69,7 +77,9 @@ pub use stored_optimizer_info::{
     StoredTogetherTrainingMethod, StoredTogetherTrainingType,
 };
 pub use stored_postgres_config::StoredPostgresConfig;
-pub use stored_prompt_template::StoredPromptRef;
+pub use stored_prompt_template::{
+    StoredPromptRef, StoredPromptTemplate, StoredPromptTemplateDependency,
+};
 pub use stored_provider_types_config::{
     StoredApiKeyDefaults, StoredFireworksProviderSFTConfig, StoredFireworksProviderTypeConfig,
     StoredGCPBatchConfigCloudStorage, StoredGCPBatchConfigType, StoredGCPCredentialDefaults,
@@ -84,3 +94,8 @@ pub use stored_rate_limiting_config::{
 };
 pub use stored_storage_kind::StoredStorageKind;
 pub use stored_tool_config::StoredToolConfig;
+pub use stored_variant_config::{
+    StoredBestOfNVariantConfig, StoredChatCompletionVariantConfig, StoredDiclVariantConfig,
+    StoredInputWrappers, StoredMixtureOfNVariantConfig, StoredVariantConfig, StoredVariantRef,
+    StoredVariantVersionConfig,
+};

--- a/crates/tensorzero-stored-config/src/stored_function_config.rs
+++ b/crates/tensorzero-stored-config/src/stored_function_config.rs
@@ -1,0 +1,101 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{StoredEvaluatorConfig, StoredPromptRef, StoredVariantRef};
+
+/// Stored in `function_versions_config.config`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "lowercase")]
+pub enum StoredFunctionConfig {
+    Chat(StoredChatFunctionConfig),
+    Json(StoredJsonFunctionConfig),
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredChatFunctionConfig {
+    pub variants: Option<HashMap<String, StoredVariantRef>>,
+    pub system_schema: Option<StoredPromptRef>,
+    pub user_schema: Option<StoredPromptRef>,
+    pub assistant_schema: Option<StoredPromptRef>,
+    pub schemas: Option<HashMap<String, StoredPromptRef>>,
+    pub tools: Option<Vec<String>>,
+    pub tool_choice: Option<StoredToolChoice>,
+    pub parallel_tool_calls: Option<bool>,
+    pub description: Option<String>,
+    pub experimentation: Option<StoredExperimentationConfigWithNamespaces>,
+    pub evaluators: Option<HashMap<String, StoredEvaluatorConfig>>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredJsonFunctionConfig {
+    pub variants: Option<HashMap<String, StoredVariantRef>>,
+    pub system_schema: Option<StoredPromptRef>,
+    pub user_schema: Option<StoredPromptRef>,
+    pub assistant_schema: Option<StoredPromptRef>,
+    pub schemas: Option<HashMap<String, StoredPromptRef>>,
+    pub output_schema: Option<StoredPromptRef>,
+    pub description: Option<String>,
+    pub experimentation: Option<StoredExperimentationConfigWithNamespaces>,
+    pub evaluators: Option<HashMap<String, StoredEvaluatorConfig>>,
+}
+
+// --- ToolChoice ---
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum StoredToolChoice {
+    None,
+    Auto,
+    Required,
+    Specific { name: String },
+}
+
+// --- Experimentation ---
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredExperimentationConfigWithNamespaces {
+    pub base: StoredExperimentationConfig,
+    pub namespaces: Option<HashMap<String, StoredExperimentationConfig>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub enum StoredExperimentationConfig {
+    Static(StoredStaticExperimentationConfig),
+    Adaptive(StoredAdaptiveExperimentationConfig),
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredStaticExperimentationConfig {
+    /// Always stored as a map of variant name → weight.
+    pub candidate_variants: Option<HashMap<String, f64>>,
+    pub fallback_variants: Option<Vec<String>>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredAdaptiveExperimentationConfig {
+    pub algorithm: Option<StoredAdaptiveExperimentationAlgorithm>,
+    pub metric: String,
+    pub candidate_variants: Option<Vec<String>>,
+    pub fallback_variants: Option<Vec<String>>,
+    pub min_samples_per_variant: Option<u64>,
+    pub delta: Option<f64>,
+    pub epsilon: Option<f64>,
+    pub update_period_s: Option<u64>,
+    pub min_prob: Option<f64>,
+    pub max_samples_per_variant: Option<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StoredAdaptiveExperimentationAlgorithm {
+    TrackAndStop,
+}

--- a/crates/tensorzero-stored-config/src/stored_prompt_template.rs
+++ b/crates/tensorzero-stored-config/src/stored_prompt_template.rs
@@ -1,8 +1,35 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+/// Reference to a `prompt_template_versions_config` row.
+/// Replaces `ResolvedTomlPathData` in all stored config types.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StoredPromptRef {
     pub prompt_template_version_id: Uuid,
     pub template_key: String,
+}
+
+/// A prompt template version stored in the database.
+/// This is the stored equivalent of `ResolvedTomlPathData`, which eagerly loads
+/// file contents from disk. The stored version keeps the template body inline
+/// and tracks its identity via a UUID.
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredPromptTemplate {
+    pub id: Uuid,
+    pub template_key: String,
+    pub source_body: String,
+    /// BLAKE3 hash of `source_body`, used to deduplicate identical template content.
+    pub content_hash: Vec<u8>,
+    pub creation_source: String,
+    pub source_autopilot_session_id: Option<Uuid>,
+}
+
+/// A dependency edge between two prompt template versions.
+/// Used when one template includes or extends another.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredPromptTemplateDependency {
+    pub prompt_template_version_id: Uuid,
+    pub dependency_prompt_template_version_id: Uuid,
+    pub dependency_key: String,
 }

--- a/crates/tensorzero-stored-config/src/stored_variant_config.rs
+++ b/crates/tensorzero-stored-config/src/stored_variant_config.rs
@@ -1,0 +1,122 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tensorzero_types::inference_params::{JsonMode, ServiceTier};
+use uuid::Uuid;
+
+use crate::{
+    StoredExtraBodyConfig, StoredExtraHeadersConfig, StoredPromptRef, StoredRetryConfig,
+    StoredTimeoutsConfig,
+};
+
+/// Reference to a `variant_versions_config` row.
+/// Replaces inline variant configs in stored function config.
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredVariantRef {
+    pub variant_version_id: Uuid,
+}
+
+/// Wrapper stored in `variant_versions_config.config`.
+/// Uses an explicit `variant` field instead of `#[serde(flatten)]`.
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredVariantVersionConfig {
+    pub variant: StoredVariantConfig,
+    pub timeouts: Option<StoredTimeoutsConfig>,
+    pub namespace: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "config")]
+pub enum StoredVariantConfig {
+    #[serde(rename = "chat_completion")]
+    ChatCompletion(StoredChatCompletionVariantConfig),
+    #[serde(rename = "experimental_best_of_n_sampling")]
+    BestOfNSampling(StoredBestOfNVariantConfig),
+    #[serde(rename = "experimental_mixture_of_n")]
+    MixtureOfN(StoredMixtureOfNVariantConfig),
+    #[serde(rename = "experimental_dynamic_in_context_learning")]
+    Dicl(StoredDiclVariantConfig),
+    #[serde(rename = "experimental_chain_of_thought")]
+    ChainOfThought(StoredChatCompletionVariantConfig),
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredChatCompletionVariantConfig {
+    pub weight: Option<f64>,
+    pub model: Arc<str>,
+    pub system_template: Option<StoredPromptRef>,
+    pub user_template: Option<StoredPromptRef>,
+    pub assistant_template: Option<StoredPromptRef>,
+    pub input_wrappers: Option<StoredInputWrappers>,
+    pub templates: Option<HashMap<String, StoredPromptRef>>,
+    pub temperature: Option<f32>,
+    pub top_p: Option<f32>,
+    pub max_tokens: Option<u32>,
+    pub presence_penalty: Option<f32>,
+    pub frequency_penalty: Option<f32>,
+    pub seed: Option<u32>,
+    pub json_mode: Option<JsonMode>,
+    pub stop_sequences: Option<Vec<String>>,
+    pub reasoning_effort: Option<String>,
+    pub service_tier: Option<ServiceTier>,
+    pub thinking_budget_tokens: Option<i32>,
+    pub verbosity: Option<String>,
+    pub retries: Option<StoredRetryConfig>,
+    pub extra_body: Option<StoredExtraBodyConfig>,
+    pub extra_headers: Option<StoredExtraHeadersConfig>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredInputWrappers {
+    pub user: Option<StoredPromptRef>,
+    pub assistant: Option<StoredPromptRef>,
+    pub system: Option<StoredPromptRef>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredBestOfNVariantConfig {
+    pub weight: Option<f64>,
+    pub timeout_s: Option<f64>,
+    pub candidates: Option<Vec<String>>,
+    pub evaluator: StoredChatCompletionVariantConfig,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredMixtureOfNVariantConfig {
+    pub weight: Option<f64>,
+    pub timeout_s: Option<f64>,
+    pub candidates: Option<Vec<String>>,
+    pub fuser: StoredChatCompletionVariantConfig,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredDiclVariantConfig {
+    pub weight: Option<f64>,
+    pub embedding_model: String,
+    pub k: u32,
+    pub model: String,
+    pub system_instructions: Option<StoredPromptRef>,
+    pub temperature: Option<f32>,
+    pub top_p: Option<f32>,
+    pub max_tokens: Option<u32>,
+    pub presence_penalty: Option<f32>,
+    pub frequency_penalty: Option<f32>,
+    pub seed: Option<u32>,
+    pub json_mode: Option<JsonMode>,
+    pub stop_sequences: Option<Vec<String>>,
+    pub reasoning_effort: Option<String>,
+    pub thinking_budget_tokens: Option<i32>,
+    pub verbosity: Option<String>,
+    pub max_distance: Option<f32>,
+    pub retries: Option<StoredRetryConfig>,
+    pub extra_body: Option<StoredExtraBodyConfig>,
+    pub extra_headers: Option<StoredExtraHeadersConfig>,
+}


### PR DESCRIPTION
Add stored types for functions, variants, and prompts (the key types we need Autopilot to compare-and-swap as a unit. These types replace the tree structure of Functions => Variants => Prompts with refs: StoredVariantRef is a foreign key to the variants table (later), and StoredPromptRef is a foreign key to the prompts table.