### PR TITLE
Add thorough conversion for UninitializedConfigs and StoredConfigs

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -7397,6 +7397,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sqlx",
+ "tensorzero-error",
  "tensorzero-types",
  "uuid",
 ]

--- a/crates/tensorzero-core/src/config/gateway.rs
+++ b/crates/tensorzero-core/src/config/gateway.rs
@@ -434,6 +434,72 @@ impl From<StoredEndpointLocation> for EndpointLocation {
     }
 }
 
+impl From<&CredentialLocation> for StoredCredentialLocation {
+    fn from(loc: &CredentialLocation) -> Self {
+        match loc {
+            CredentialLocation::Env(inner) => Self::Env {
+                value: inner.clone(),
+            },
+            CredentialLocation::PathFromEnv(inner) => Self::PathFromEnv {
+                value: inner.clone(),
+            },
+            CredentialLocation::Dynamic(inner) => Self::Dynamic {
+                value: inner.clone(),
+            },
+            CredentialLocation::Path(inner) => Self::Path {
+                value: inner.clone(),
+            },
+            CredentialLocation::Sdk => Self::Sdk,
+            CredentialLocation::None => Self::None,
+        }
+    }
+}
+
+impl From<&CredentialLocationWithFallback> for StoredCredentialLocationWithFallback {
+    fn from(loc: &CredentialLocationWithFallback) -> Self {
+        match loc {
+            CredentialLocationWithFallback::Single(inner) => Self::Single {
+                location: inner.into(),
+            },
+            CredentialLocationWithFallback::WithFallback { default, fallback } => {
+                Self::WithFallback {
+                    default: default.into(),
+                    fallback: fallback.into(),
+                }
+            }
+        }
+    }
+}
+
+impl From<&CredentialLocationOrHardcoded> for StoredCredentialLocationOrHardcoded {
+    fn from(loc: &CredentialLocationOrHardcoded) -> Self {
+        match loc {
+            CredentialLocationOrHardcoded::Hardcoded(value) => Self::Hardcoded {
+                value: value.clone(),
+            },
+            CredentialLocationOrHardcoded::Location(inner) => Self::Location {
+                location: inner.into(),
+            },
+        }
+    }
+}
+
+impl From<&EndpointLocation> for StoredEndpointLocation {
+    fn from(loc: &EndpointLocation) -> Self {
+        match loc {
+            EndpointLocation::Env(value) => Self::Env {
+                value: value.clone(),
+            },
+            EndpointLocation::Dynamic(value) => Self::Dynamic {
+                value: value.clone(),
+            },
+            EndpointLocation::Static(value) => Self::Static {
+                value: value.clone(),
+            },
+        }
+    }
+}
+
 impl TryFrom<StoredRelayConfig> for UninitializedRelayConfig {
     type Error = Error;
 
@@ -495,6 +561,35 @@ impl TryFrom<StoredGatewayConfig> for UninitializedGatewayConfig {
     }
 }
 
+impl From<ObservabilityBackend> for StoredObservabilityBackend {
+    fn from(backend: ObservabilityBackend) -> Self {
+        match backend {
+            ObservabilityBackend::Auto => StoredObservabilityBackend::Auto,
+            ObservabilityBackend::ClickHouse => StoredObservabilityBackend::ClickHouse,
+            ObservabilityBackend::Postgres => StoredObservabilityBackend::Postgres,
+        }
+    }
+}
+
+impl From<OtlpTracesFormat> for StoredOtlpTracesFormat {
+    fn from(format: OtlpTracesFormat) -> Self {
+        match format {
+            OtlpTracesFormat::OpenTelemetry => StoredOtlpTracesFormat::OpenTelemetry,
+            OtlpTracesFormat::OpenInference => StoredOtlpTracesFormat::OpenInference,
+        }
+    }
+}
+
+impl From<InferenceCacheBackend> for StoredInferenceCacheBackend {
+    fn from(backend: InferenceCacheBackend) -> Self {
+        match backend {
+            InferenceCacheBackend::Auto => StoredInferenceCacheBackend::Auto,
+            InferenceCacheBackend::ClickHouse => StoredInferenceCacheBackend::ClickHouse,
+            InferenceCacheBackend::Valkey => StoredInferenceCacheBackend::Valkey,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize)]
 pub struct GatewayConfig {
     pub bind_address: Option<std::net::SocketAddr>,
@@ -553,5 +648,115 @@ where
     match addr {
         Some(addr) => serializer.serialize_str(&addr.to_string()),
         None => serializer.serialize_none(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use googletest::prelude::*;
+
+    #[gtest]
+    fn test_observability_backend_round_trip() {
+        for variant in [
+            ObservabilityBackend::Auto,
+            ObservabilityBackend::ClickHouse,
+            ObservabilityBackend::Postgres,
+        ] {
+            let stored: StoredObservabilityBackend = variant.into();
+            let restored: ObservabilityBackend = stored.into();
+            expect_that!(restored, eq(variant));
+        }
+    }
+
+    #[gtest]
+    fn test_otlp_traces_format_round_trip() {
+        for variant in &[
+            OtlpTracesFormat::OpenTelemetry,
+            OtlpTracesFormat::OpenInference,
+        ] {
+            let stored: StoredOtlpTracesFormat = variant.clone().into();
+            let restored: OtlpTracesFormat = stored.into();
+            expect_that!(restored, eq(variant));
+        }
+    }
+
+    #[gtest]
+    fn test_inference_cache_backend_round_trip() {
+        for variant in [
+            InferenceCacheBackend::Auto,
+            InferenceCacheBackend::ClickHouse,
+            InferenceCacheBackend::Valkey,
+        ] {
+            let stored: StoredInferenceCacheBackend = variant.into();
+            let restored: InferenceCacheBackend = stored.into();
+            expect_that!(restored, eq(variant));
+        }
+    }
+
+    // ── CredentialLocationWithFallback ─────────────────────────────────
+
+    fn credential_location_variants() -> Vec<CredentialLocation> {
+        vec![
+            CredentialLocation::Env("MY_KEY".to_string()),
+            CredentialLocation::PathFromEnv("MY_KEY_PATH".to_string()),
+            CredentialLocation::Dynamic("dyn_key".to_string()),
+            CredentialLocation::Path("/etc/keys/key.pem".to_string()),
+            CredentialLocation::Sdk,
+            CredentialLocation::None,
+        ]
+    }
+
+    #[gtest]
+    fn test_credential_location_with_fallback_single_round_trip() {
+        for loc in credential_location_variants() {
+            let original = CredentialLocationWithFallback::Single(loc);
+            let stored: StoredCredentialLocationWithFallback = (&original).into();
+            let restored: CredentialLocationWithFallback = stored.into();
+            expect_that!(restored, eq(&original));
+        }
+    }
+
+    #[gtest]
+    fn test_credential_location_with_fallback_with_fallback_round_trip() {
+        let original = CredentialLocationWithFallback::WithFallback {
+            default: CredentialLocation::Env("PRIMARY".to_string()),
+            fallback: CredentialLocation::PathFromEnv("BACKUP_PATH".to_string()),
+        };
+        let stored: StoredCredentialLocationWithFallback = (&original).into();
+        let restored: CredentialLocationWithFallback = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_credential_location_with_fallback_all_fallback_combos_round_trip() {
+        // Cover the full cross-product of default × fallback to make sure each
+        // variant survives the encode/decode through stored form.
+        for default in credential_location_variants() {
+            for fallback in credential_location_variants() {
+                let original = CredentialLocationWithFallback::WithFallback {
+                    default: default.clone(),
+                    fallback: fallback.clone(),
+                };
+                let stored: StoredCredentialLocationWithFallback = (&original).into();
+                let restored: CredentialLocationWithFallback = stored.into();
+                expect_that!(restored, eq(&original));
+            }
+        }
+    }
+
+    // ── EndpointLocation ───────────────────────────────────────────────
+
+    #[gtest]
+    fn test_endpoint_location_round_trip() {
+        for variant in [
+            EndpointLocation::Env("MY_ENDPOINT".to_string()),
+            EndpointLocation::Dynamic("dyn_endpoint".to_string()),
+            EndpointLocation::Static("https://api.example.com".to_string()),
+        ] {
+            let stored: StoredEndpointLocation = (&variant).into();
+            let restored: EndpointLocation = stored.into();
+            expect_that!(restored, eq(&variant));
+        }
     }
 }

--- a/crates/tensorzero-core/src/config/mod.rs
+++ b/crates/tensorzero-core/src/config/mod.rs
@@ -31,13 +31,15 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tensorzero_derive::TensorZeroDeserialize;
 use tensorzero_stored_config::{
-    StoredNonStreamingTimeouts, StoredStreamingTimeouts, StoredTimeoutsConfig,
+    StoredMetricLevel, StoredMetricOptimize, StoredMetricType, StoredNonStreamingTimeouts,
+    StoredPromptRef, StoredStreamingTimeouts, StoredTimeoutsConfig, StoredToolConfig,
 };
 use tracing::Span;
 use tracing::instrument;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use unwritten::UnwrittenConfig;
 use url::Url;
+use uuid::Uuid;
 
 use crate::config::gateway::{GatewayConfig, UninitializedGatewayConfig};
 use crate::config::path::{ResolvedTomlPathData, ResolvedTomlPathDirectory};
@@ -187,6 +189,23 @@ pub struct TimeoutsConfig {
     pub streaming: Option<StreamingTimeouts>,
 }
 
+impl From<&TimeoutsConfig> for StoredTimeoutsConfig {
+    fn from(config: &TimeoutsConfig) -> Self {
+        StoredTimeoutsConfig {
+            non_streaming: config
+                .non_streaming
+                .as_ref()
+                .map(|ns| StoredNonStreamingTimeouts {
+                    total_ms: ns.total_ms,
+                }),
+            streaming: config.streaming.as_ref().map(|s| StoredStreamingTimeouts {
+                ttft_ms: s.ttft_ms,
+                total_ms: s.total_ms,
+            }),
+        }
+    }
+}
+
 impl TimeoutsConfig {
     pub fn validate(&self, global_outbound_http_timeout: &Duration) -> Result<(), Error> {
         let total_ms = self.non_streaming.as_ref().and_then(|ns| ns.total_ms);
@@ -232,23 +251,6 @@ impl TimeoutsConfig {
         }
 
         Ok(())
-    }
-}
-
-impl From<&TimeoutsConfig> for StoredTimeoutsConfig {
-    fn from(config: &TimeoutsConfig) -> Self {
-        StoredTimeoutsConfig {
-            non_streaming: config
-                .non_streaming
-                .as_ref()
-                .map(|ns| StoredNonStreamingTimeouts {
-                    total_ms: ns.total_ms,
-                }),
-            streaming: config.streaming.as_ref().map(|s| StoredStreamingTimeouts {
-                ttft_ms: s.ttft_ms,
-                total_ms: s.total_ms,
-            }),
-        }
     }
 }
 
@@ -675,6 +677,15 @@ pub enum MetricConfigType {
     Float,
 }
 
+impl From<MetricConfigType> for StoredMetricType {
+    fn from(value: MetricConfigType) -> Self {
+        match value {
+            MetricConfigType::Boolean => Self::Boolean,
+            MetricConfigType::Float => Self::Float,
+        }
+    }
+}
+
 impl MetricConfigType {
     pub fn to_clickhouse_table_name(&self) -> &'static str {
         match self {
@@ -702,6 +713,15 @@ pub enum MetricConfigOptimize {
     Max,
 }
 
+impl From<MetricConfigOptimize> for StoredMetricOptimize {
+    fn from(value: MetricConfigOptimize) -> Self {
+        match value {
+            MetricConfigOptimize::Min => Self::Min,
+            MetricConfigOptimize::Max => Self::Max,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
@@ -717,6 +737,15 @@ impl std::fmt::Display for MetricConfigLevel {
         let serialized = serde_json::to_string(self).map_err(|_| std::fmt::Error)?;
         // Remove the quotes around the string
         write!(f, "{}", serialized.trim_matches('"'))
+    }
+}
+
+impl From<&MetricConfigLevel> for StoredMetricLevel {
+    fn from(value: &MetricConfigLevel) -> Self {
+        match value {
+            MetricConfigLevel::Inference => Self::Inference,
+            MetricConfigLevel::Episode => Self::Episode,
+        }
     }
 }
 
@@ -2849,6 +2878,36 @@ pub struct UninitializedToolConfig {
 }
 
 impl UninitializedToolConfig {
+    #[expect(dead_code)]
+    pub(crate) fn prompt_templates_for_db(&self) -> [&ResolvedTomlPathData; 1] {
+        [&self.parameters]
+    }
+
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn convert_for_db(
+        &self,
+        prompt_template_version_ids: &HashMap<String, Uuid>,
+    ) -> Result<StoredToolConfig, Error> {
+        let template_key = self.parameters.get_template_key();
+        let Some(prompt_template_version_id) = prompt_template_version_ids.get(&template_key)
+        else {
+            return Err(Error::new(ErrorDetails::Config {
+                message: format!(
+                    "Missing prompt template version ID for template key `{template_key}`."
+                ),
+            }));
+        };
+        Ok(StoredToolConfig {
+            description: self.description.clone(),
+            parameters: StoredPromptRef {
+                prompt_template_version_id: *prompt_template_version_id,
+                template_key,
+            },
+            name: self.name.clone(),
+            strict: self.strict,
+        })
+    }
+
     pub fn load(self, key: String) -> Result<StaticToolConfig, Error> {
         let parameters = JSONSchema::from_path(self.parameters)?;
         Ok(StaticToolConfig {
@@ -2930,5 +2989,146 @@ impl From<tensorzero_stored_config::StoredPostgresConfig> for PostgresConfig {
             inference_metadata_retention_days: stored.inference_metadata_retention_days,
             inference_data_retention_days: stored.inference_data_retention_days,
         }
+    }
+}
+
+#[cfg(test)]
+mod round_trip_tests {
+    use std::path::PathBuf;
+
+    use googletest::prelude::*;
+
+    use super::*;
+    use crate::config::path::ResolvedTomlPathData;
+
+    // ── TimeoutsConfig ─────────────────────────────────────────────────
+
+    #[gtest]
+    fn test_timeouts_config_round_trip_full() {
+        let original = TimeoutsConfig {
+            non_streaming: Some(NonStreamingTimeouts {
+                total_ms: Some(5000),
+            }),
+            streaming: Some(StreamingTimeouts {
+                ttft_ms: Some(1000),
+                total_ms: Some(30000),
+            }),
+        };
+        let stored = StoredTimeoutsConfig::from(&original);
+        let restored: TimeoutsConfig = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_timeouts_config_round_trip_empty() {
+        let original = TimeoutsConfig::default();
+        let stored = StoredTimeoutsConfig::from(&original);
+        let restored: TimeoutsConfig = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    // ── MetricConfig ───────────────────────────────────────────────────
+
+    #[gtest]
+    fn test_metric_config_type_round_trip() {
+        for variant in [MetricConfigType::Boolean, MetricConfigType::Float] {
+            let stored: StoredMetricType = variant.into();
+            let restored: MetricConfigType = stored.into();
+            expect_that!(restored, eq(variant));
+        }
+    }
+
+    #[gtest]
+    fn test_metric_config_optimize_round_trip() {
+        for variant in [MetricConfigOptimize::Min, MetricConfigOptimize::Max] {
+            let stored: StoredMetricOptimize = variant.into();
+            let restored: MetricConfigOptimize = stored.into();
+            expect_that!(restored, eq(variant));
+        }
+    }
+
+    #[gtest]
+    fn test_metric_config_level_round_trip() {
+        for variant in &[MetricConfigLevel::Inference, MetricConfigLevel::Episode] {
+            let stored = StoredMetricLevel::from(variant);
+            let restored: MetricConfigLevel = stored.into();
+            expect_that!(restored, eq(variant));
+        }
+    }
+
+    #[gtest]
+    fn test_metric_config_round_trip() {
+        let original = MetricConfig {
+            r#type: MetricConfigType::Float,
+            optimize: MetricConfigOptimize::Max,
+            level: MetricConfigLevel::Inference,
+            description: Some("test metric".to_string()),
+        };
+        let stored = tensorzero_stored_config::StoredMetricConfig {
+            r#type: original.r#type.into(),
+            optimize: original.optimize.into(),
+            level: (&original.level).into(),
+            description: original.description.clone(),
+        };
+        let restored: MetricConfig = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    // ── UninitializedToolConfig ────────────────────────────────────────
+    //
+    // `UninitializedToolConfig` only has a forward conversion to
+    // `StoredToolConfig` (the reverse requires looking up a prompt template
+    // by ID), so this verifies the forward conversion preserves all fields
+    // and resolves the prompt template version ID correctly.
+
+    #[gtest]
+    fn test_uninitialized_tool_config_convert_for_db() {
+        let parameters_json = r#"{"type":"object","properties":{}}"#.to_string();
+        let parameters = ResolvedTomlPathData::new_for_tests(
+            PathBuf::from("tools/my_tool.json"),
+            Some(parameters_json),
+        );
+        let template_key = parameters.get_template_key();
+
+        let original = UninitializedToolConfig {
+            description: "Tool description".to_string(),
+            parameters,
+            name: Some("my_tool".to_string()),
+            strict: true,
+        };
+
+        let template_id = Uuid::now_v7();
+        let mut prompt_template_version_ids = HashMap::new();
+        prompt_template_version_ids.insert(template_key.clone(), template_id);
+
+        let stored = original
+            .convert_for_db(&prompt_template_version_ids)
+            .expect("conversion should succeed when template id is present");
+
+        expect_that!(stored.description, eq(&original.description));
+        expect_that!(stored.name.as_deref(), some(eq("my_tool")));
+        expect_that!(stored.strict, eq(true));
+        expect_that!(stored.parameters.template_key, eq(&template_key));
+        expect_that!(
+            stored.parameters.prompt_template_version_id,
+            eq(template_id)
+        );
+    }
+
+    #[gtest]
+    fn test_uninitialized_tool_config_convert_for_db_missing_template() {
+        let parameters = ResolvedTomlPathData::new_for_tests(
+            PathBuf::from("tools/missing.json"),
+            Some(r#"{"type":"object"}"#.to_string()),
+        );
+        let original = UninitializedToolConfig {
+            description: "x".to_string(),
+            parameters,
+            name: None,
+            strict: false,
+        };
+
+        let result = original.convert_for_db(&HashMap::new());
+        expect_that!(result.is_err(), eq(true));
     }
 }

--- a/crates/tensorzero-core/src/config/provider_types.rs
+++ b/crates/tensorzero-core/src/config/provider_types.rs
@@ -32,6 +32,82 @@ pub struct ProviderTypesConfig {
     pub xai: Option<XAIProviderTypeConfig>,
 }
 
+#[cfg(test)]
+fn convert_simple_provider_type_config(
+    defaults: &impl ApiKeyDefaultsConfig,
+) -> StoredSimpleProviderTypeConfig {
+    StoredSimpleProviderTypeConfig {
+        defaults: Some(StoredApiKeyDefaults::from(defaults.api_key_location())),
+    }
+}
+
+impl From<&CredentialLocationWithFallback> for StoredApiKeyDefaults {
+    fn from(api_key_location: &CredentialLocationWithFallback) -> Self {
+        StoredApiKeyDefaults {
+            api_key_location: Some(api_key_location.into()),
+        }
+    }
+}
+
+impl From<&CredentialLocationWithFallback> for StoredGCPCredentialDefaults {
+    fn from(credential_location: &CredentialLocationWithFallback) -> Self {
+        StoredGCPCredentialDefaults {
+            credential_location: Some(credential_location.into()),
+        }
+    }
+}
+
+impl From<&GCPBatchConfigType> for StoredGCPBatchConfigType {
+    fn from(batch: &GCPBatchConfigType) -> Self {
+        match batch {
+            GCPBatchConfigType::None => StoredGCPBatchConfigType::None,
+            GCPBatchConfigType::CloudStorage(config) => {
+                StoredGCPBatchConfigType::CloudStorage(StoredGCPBatchConfigCloudStorage {
+                    input_uri_prefix: config.input_uri_prefix.clone(),
+                    output_uri_prefix: config.output_uri_prefix.clone(),
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+trait ApiKeyDefaultsConfig {
+    fn api_key_location(&self) -> &CredentialLocationWithFallback;
+}
+
+#[cfg(test)]
+macro_rules! impl_api_key_defaults_config {
+    ($($defaults:ty),* $(,)?) => {
+        $(
+            impl ApiKeyDefaultsConfig for $defaults {
+                fn api_key_location(&self) -> &CredentialLocationWithFallback {
+                    &self.api_key_location
+                }
+            }
+        )*
+    };
+}
+
+#[cfg(test)]
+impl_api_key_defaults_config!(
+    AnthropicDefaults,
+    AzureDefaults,
+    DeepSeekDefaults,
+    FireworksDefaults,
+    GoogleAIStudioGeminiDefaults,
+    GroqDefaults,
+    HyperbolicDefaults,
+    MistralDefaults,
+    OpenAIDefaults,
+    OpenRouterDefaults,
+    SGLangDefaults,
+    TGIDefaults,
+    TogetherDefaults,
+    VLLMDefaults,
+    XAIDefaults,
+);
+
 // Anthropic
 
 #[serde_with::skip_serializing_none]
@@ -493,13 +569,13 @@ impl From<StoredProviderTypesConfig> for ProviderTypesConfig {
     }
 }
 
-fn convert_api_key_defaults(
+fn convert_stored_api_key_defaults(
     stored: Option<StoredApiKeyDefaults>,
 ) -> Option<CredentialLocationWithFallback> {
     stored.and_then(|d| d.api_key_location.map(Into::into))
 }
 
-fn convert_gcp_credential_defaults(
+fn convert_stored_gcp_credential_defaults(
     stored: Option<StoredGCPCredentialDefaults>,
 ) -> Option<CredentialLocationWithFallback> {
     stored.and_then(|d| d.credential_location.map(Into::into))
@@ -512,7 +588,7 @@ macro_rules! impl_from_simple_provider_type {
         impl From<$stored> for $target {
             fn from(stored: $stored) -> Self {
                 Self {
-                    defaults: convert_api_key_defaults(stored.defaults)
+                    defaults: convert_stored_api_key_defaults(stored.defaults)
                         .map(|api_key_location| $defaults { api_key_location }),
                 }
             }
@@ -540,7 +616,7 @@ impl From<StoredFireworksProviderTypeConfig> for FireworksProviderTypeConfig {
     fn from(stored: StoredFireworksProviderTypeConfig) -> Self {
         Self {
             sft: stored.sft.map(Into::into),
-            defaults: convert_api_key_defaults(stored.defaults)
+            defaults: convert_stored_api_key_defaults(stored.defaults)
                 .map(|api_key_location| FireworksDefaults { api_key_location }),
         }
     }
@@ -559,11 +635,11 @@ impl From<StoredFireworksProviderSFTConfig> for FireworksSFTConfig {
 impl From<StoredGCPCredentialProviderTypeConfig> for GCPVertexAnthropicProviderTypeConfig {
     fn from(stored: StoredGCPCredentialProviderTypeConfig) -> Self {
         Self {
-            defaults: convert_gcp_credential_defaults(stored.defaults).map(|credential_location| {
-                GCPDefaults {
+            defaults: convert_stored_gcp_credential_defaults(stored.defaults).map(
+                |credential_location| GCPDefaults {
                     credential_location,
-                }
-            }),
+                },
+            ),
         }
     }
 }
@@ -575,11 +651,11 @@ impl From<StoredGCPVertexGeminiProviderTypeConfig> for GCPVertexGeminiProviderTy
         Self {
             batch: stored.batch.map(Into::into),
             sft: stored.sft.map(Into::into),
-            defaults: convert_gcp_credential_defaults(stored.defaults).map(|credential_location| {
-                GCPDefaults {
+            defaults: convert_stored_gcp_credential_defaults(stored.defaults).map(
+                |credential_location| GCPDefaults {
                     credential_location,
-                }
-            }),
+                },
+            ),
         }
     }
 }
@@ -621,7 +697,7 @@ impl From<StoredTogetherProviderTypeConfig> for TogetherProviderTypeConfig {
     fn from(stored: StoredTogetherProviderTypeConfig) -> Self {
         Self {
             sft: stored.sft.map(Into::into),
-            defaults: convert_api_key_defaults(stored.defaults)
+            defaults: convert_stored_api_key_defaults(stored.defaults)
                 .map(|api_key_location| TogetherDefaults { api_key_location }),
         }
     }
@@ -635,5 +711,163 @@ impl From<StoredTogetherProviderSFTConfig> for TogetherSFTConfig {
             wandb_project_name: stored.wandb_project_name,
             hf_api_token: stored.hf_api_token,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use googletest::prelude::*;
+
+    #[gtest]
+    fn test_simple_provider_type_config_round_trip() {
+        let defaults = OpenAIDefaults {
+            api_key_location: CredentialLocationWithFallback::Single(CredentialLocation::Env(
+                "OPENAI_API_KEY".to_string(),
+            )),
+        };
+        let stored = convert_simple_provider_type_config(&defaults);
+        let restored: OpenAIProviderTypeConfig = stored.into();
+        expect_that!(
+            restored
+                .defaults
+                .as_ref()
+                .expect("should have defaults")
+                .api_key_location,
+            eq(&defaults.api_key_location)
+        );
+    }
+
+    // ── GCP credentials defaults ───────────────────────────────────────
+
+    #[gtest]
+    fn test_gcp_credential_defaults_round_trip() {
+        let original = CredentialLocationWithFallback::Single(CredentialLocation::PathFromEnv(
+            "GCP_VERTEX_CREDENTIALS_PATH".to_string(),
+        ));
+        let stored = StoredGCPCredentialDefaults::from(&original);
+        let restored = stored
+            .credential_location
+            .map(CredentialLocationWithFallback::from)
+            .expect("stored credential_location should be present");
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_gcp_credential_defaults_with_fallback_round_trip() {
+        let original = CredentialLocationWithFallback::WithFallback {
+            default: CredentialLocation::PathFromEnv("GCP_VERTEX_CREDENTIALS_PATH".to_string()),
+            fallback: CredentialLocation::Sdk,
+        };
+        let stored = StoredGCPCredentialDefaults::from(&original);
+        let restored = stored
+            .credential_location
+            .map(CredentialLocationWithFallback::from)
+            .expect("stored credential_location should be present");
+        expect_that!(restored, eq(&original));
+    }
+
+    // ── GCP Vertex Anthropic provider type config ──────────────────────
+
+    #[gtest]
+    fn test_gcp_vertex_anthropic_provider_type_config_round_trip() {
+        let defaults = GCPDefaults {
+            credential_location: CredentialLocationWithFallback::Single(
+                CredentialLocation::PathFromEnv("GCP_VERTEX_CREDENTIALS_PATH".to_string()),
+            ),
+        };
+        let stored = StoredGCPCredentialProviderTypeConfig {
+            defaults: Some(StoredGCPCredentialDefaults::from(
+                &defaults.credential_location,
+            )),
+        };
+        let restored: GCPVertexAnthropicProviderTypeConfig = stored.into();
+        expect_that!(
+            restored
+                .defaults
+                .as_ref()
+                .expect("should have defaults")
+                .credential_location,
+            eq(&defaults.credential_location)
+        );
+    }
+
+    // ── GCP batch configs ──────────────────────────────────────────────
+
+    #[gtest]
+    fn test_gcp_batch_config_type_none_round_trip() {
+        let original = GCPBatchConfigType::None;
+        let stored = StoredGCPBatchConfigType::from(&original);
+        let restored: GCPBatchConfigType = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_gcp_batch_config_type_cloud_storage_round_trip() {
+        let original = GCPBatchConfigType::CloudStorage(GCPBatchConfigCloudStorage {
+            input_uri_prefix: "gs://my-bucket/inputs/".to_string(),
+            output_uri_prefix: "gs://my-bucket/outputs/".to_string(),
+        });
+        let stored = StoredGCPBatchConfigType::from(&original);
+        let restored: GCPBatchConfigType = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_gcp_batch_config_cloud_storage_round_trip() {
+        let original = GCPBatchConfigCloudStorage {
+            input_uri_prefix: "gs://my-bucket/in/".to_string(),
+            output_uri_prefix: "gs://my-bucket/out/".to_string(),
+        };
+        let stored = StoredGCPBatchConfigCloudStorage {
+            input_uri_prefix: original.input_uri_prefix.clone(),
+            output_uri_prefix: original.output_uri_prefix.clone(),
+        };
+        let restored: GCPBatchConfigCloudStorage = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    // ── GCP Vertex Gemini provider type config (full round trip) ───────
+
+    #[gtest]
+    fn test_gcp_vertex_gemini_provider_type_config_round_trip() {
+        let original = GCPVertexGeminiProviderTypeConfig {
+            batch: Some(GCPBatchConfigType::CloudStorage(
+                GCPBatchConfigCloudStorage {
+                    input_uri_prefix: "gs://b/in/".to_string(),
+                    output_uri_prefix: "gs://b/out/".to_string(),
+                },
+            )),
+            sft: Some(GCPSFTConfig {
+                project_id: "proj".to_string(),
+                region: "us-central1".to_string(),
+                bucket_name: "bucket".to_string(),
+                bucket_path_prefix: Some("prefix/".to_string()),
+                service_account: Some("svc@proj.iam".to_string()),
+                kms_key_name: Some("kms-key".to_string()),
+            }),
+            defaults: Some(GCPDefaults {
+                credential_location: CredentialLocationWithFallback::Single(
+                    CredentialLocation::PathFromEnv("GCP_VERTEX_CREDENTIALS_PATH".to_string()),
+                ),
+            }),
+        };
+        let stored = StoredGCPVertexGeminiProviderTypeConfig {
+            batch: original.batch.as_ref().map(StoredGCPBatchConfigType::from),
+            sft: original.sft.as_ref().map(|s| StoredGCPProviderSFTConfig {
+                project_id: s.project_id.clone(),
+                region: s.region.clone(),
+                bucket_name: s.bucket_name.clone(),
+                bucket_path_prefix: s.bucket_path_prefix.clone(),
+                service_account: s.service_account.clone(),
+                kms_key_name: s.kms_key_name.clone(),
+            }),
+            defaults: original
+                .defaults
+                .as_ref()
+                .map(|d| StoredGCPCredentialDefaults::from(&d.credential_location)),
+        };
+        let restored: GCPVertexGeminiProviderTypeConfig = stored.into();
+        expect_that!(restored, eq(&original));
     }
 }

--- a/crates/tensorzero-core/src/embeddings.rs
+++ b/crates/tensorzero-core/src/embeddings.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use indexmap::IndexMap;
-use tensorzero_stored_config::{StoredEmbeddingModelConfig, StoredEmbeddingProviderConfig};
 
 use crate::cache::{
     CacheData, CacheValidationInfo, EmbeddingCacheData, EmbeddingModelProviderRequest,
@@ -40,6 +39,11 @@ use crate::{
 };
 use futures::future::try_join_all;
 use serde::{Deserialize, Serialize};
+use tensorzero_stored_config::{StoredEmbeddingModelConfig, StoredEmbeddingProviderConfig};
+#[cfg(test)]
+use tensorzero_stored_config::{
+    StoredExtraBodyConfig, StoredExtraHeadersConfig, StoredProviderConfig, StoredUnifiedCostConfig,
+};
 use tensorzero_types::UninitializedUnifiedCostConfig;
 use tokio::time::error::Elapsed;
 use tracing::{Span, instrument};
@@ -195,6 +199,49 @@ impl TryFrom<StoredEmbeddingProviderConfig> for UninitializedEmbeddingProviderCo
             extra_headers: stored.extra_headers.map(ExtraHeadersConfig::from),
             cost,
         })
+    }
+}
+
+#[cfg(test)]
+impl TryFrom<&UninitializedEmbeddingModelConfig> for StoredEmbeddingModelConfig {
+    type Error = Error;
+
+    fn try_from(config: &UninitializedEmbeddingModelConfig) -> Result<Self, Error> {
+        let providers = config
+            .providers
+            .iter()
+            .map(|(provider_name, provider)| {
+                Ok::<_, Error>((
+                    provider_name.to_string(),
+                    StoredEmbeddingProviderConfig::from(provider),
+                ))
+            })
+            .collect::<Result<std::collections::BTreeMap<_, _>, _>>()?;
+
+        Ok(StoredEmbeddingModelConfig {
+            routing: config.routing.iter().map(ToString::to_string).collect(),
+            providers,
+            timeout_ms: config.timeout_ms,
+        })
+    }
+}
+
+#[cfg(test)]
+impl From<&UninitializedEmbeddingProviderConfig> for StoredEmbeddingProviderConfig {
+    fn from(provider: &UninitializedEmbeddingProviderConfig) -> Self {
+        StoredEmbeddingProviderConfig {
+            provider: StoredProviderConfig::from(&provider.config),
+            timeout_ms: provider.timeout_ms,
+            extra_body: provider
+                .extra_body
+                .as_ref()
+                .map(StoredExtraBodyConfig::from),
+            extra_headers: provider
+                .extra_headers
+                .as_ref()
+                .map(StoredExtraHeadersConfig::from),
+            cost: provider.cost.as_ref().map(StoredUnifiedCostConfig::from),
+        }
     }
 }
 
@@ -933,14 +980,16 @@ impl<'a> Embedding {
 
 #[cfg(test)]
 mod tests {
+    use googletest::{expect_that, matchers::eq};
+
+    use super::*;
     use crate::{
         cache::{CacheEnabledMode, CacheManager, CacheOptions},
         db::{clickhouse::ClickHouseConnectionInfo, postgres::PostgresConnectionInfo},
+        model::{CredentialLocation, CredentialLocationWithFallback},
         model_table::ProviderTypeDefaultCredentials,
         rate_limiting::{RateLimitingManager, ScopeInfo},
     };
-
-    use super::*;
     #[tokio::test]
     async fn test_embedding_fallbacks() {
         let logs_contain = crate::utils::testing::capture_logs();
@@ -1112,5 +1161,37 @@ mod tests {
         let loaded_extra_headers = provider_info.extra_headers.unwrap();
         assert_eq!(loaded_extra_headers.data.len(), 1);
         assert_eq!(loaded_extra_headers.data[0], replacement);
+    }
+
+    #[googletest::gtest]
+    fn test_embedding_model_config_round_trip() {
+        let original = UninitializedEmbeddingModelConfig {
+            routing: vec![Arc::from("emb_provider")],
+            providers: HashMap::from([(
+                Arc::from("emb_provider"),
+                UninitializedEmbeddingProviderConfig {
+                    config: UninitializedProviderConfig::OpenAI {
+                        model_name: "text-embedding-3-small".to_string(),
+                        api_base: None,
+                        api_key_location: Some(CredentialLocationWithFallback::Single(
+                            CredentialLocation::Env("OPENAI_API_KEY".to_string()),
+                        )),
+                        api_type: OpenAIAPIType::ChatCompletions,
+                        include_encrypted_reasoning: false,
+                        provider_tools: vec![],
+                        content_type_overrides: HashMap::new(),
+                    },
+                    extra_body: None,
+                    extra_headers: None,
+                    timeout_ms: None,
+                    cost: None,
+                },
+            )]),
+            timeout_ms: Some(5000),
+        };
+        let stored = StoredEmbeddingModelConfig::try_from(&original).expect("should serialize");
+        let restored: UninitializedEmbeddingModelConfig =
+            stored.try_into().expect("should convert back");
+        expect_that!(restored, eq(&original));
     }
 }

--- a/crates/tensorzero-core/src/inference/types/extra_body.rs
+++ b/crates/tensorzero-core/src/inference/types/extra_body.rs
@@ -1,6 +1,9 @@
 use crate::inference::types::extra_headers::{
     DynamicExtraHeader, ExtraHeaderKind, FullExtraHeadersConfig, UnfilteredInferenceExtraHeaders,
 };
+use tensorzero_stored_config::{
+    StoredExtraBodyConfig, StoredExtraBodyReplacement, StoredExtraBodyReplacementKind,
+};
 
 use super::{deserialize_delete, serialize_delete};
 use crate::inference::types::extra_body::dynamic::ExtraBody;
@@ -8,15 +11,32 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tensorzero_derive::export_schema;
-use tensorzero_stored_config::{
-    StoredExtraBodyConfig, StoredExtraBodyReplacement, StoredExtraBodyReplacementKind,
-};
 
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize)]
 #[serde(transparent)]
 pub struct ExtraBodyConfig {
     pub data: Vec<ExtraBodyReplacement>,
+}
+
+impl From<&ExtraBodyConfig> for StoredExtraBodyConfig {
+    fn from(config: &ExtraBodyConfig) -> Self {
+        StoredExtraBodyConfig {
+            data: config
+                .data
+                .iter()
+                .map(|replacement| StoredExtraBodyReplacement {
+                    pointer: replacement.pointer.clone(),
+                    kind: match &replacement.kind {
+                        ExtraBodyReplacementKind::Value(value) => {
+                            StoredExtraBodyReplacementKind::Value(value.clone())
+                        }
+                        ExtraBodyReplacementKind::Delete => StoredExtraBodyReplacementKind::Delete,
+                    },
+                })
+                .collect(),
+        }
+    }
 }
 
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
@@ -400,26 +420,6 @@ pub use dynamic::ExtraBody as DynamicExtraBody;
 
 // ─── Stored → Uninitialized conversions ──────────────────────────────────────
 
-impl From<&ExtraBodyConfig> for StoredExtraBodyConfig {
-    fn from(config: &ExtraBodyConfig) -> Self {
-        StoredExtraBodyConfig {
-            data: config
-                .data
-                .iter()
-                .map(|replacement| StoredExtraBodyReplacement {
-                    pointer: replacement.pointer.clone(),
-                    kind: match &replacement.kind {
-                        ExtraBodyReplacementKind::Value(value) => {
-                            StoredExtraBodyReplacementKind::Value(value.clone())
-                        }
-                        ExtraBodyReplacementKind::Delete => StoredExtraBodyReplacementKind::Delete,
-                    },
-                })
-                .collect(),
-        }
-    }
-}
-
 impl From<StoredExtraBodyReplacementKind> for ExtraBodyReplacementKind {
     fn from(stored: StoredExtraBodyReplacementKind) -> Self {
         match stored {
@@ -448,12 +448,14 @@ impl From<StoredExtraBodyConfig> for ExtraBodyConfig {
 
 #[cfg(test)]
 mod tests {
+    use googletest::{expect_that, matchers::eq};
+    use serde_json::json;
+    use tensorzero_stored_config::StoredExtraBodyConfig;
+
+    use super::*;
     use crate::inference::types::extra_headers::{
         ExtraHeader, ExtraHeadersConfig, FilteredInferenceExtraHeaders,
     };
-
-    use super::*;
-    use serde_json::json;
 
     #[test]
     fn test_inference_extra_body_all_deserialize() {
@@ -988,5 +990,24 @@ mod tests {
         let json = r"[]";
         let result: UnfilteredInferenceExtraBody = serde_json::from_str(json).unwrap();
         assert!(result.extra_body.is_empty());
+    }
+
+    #[googletest::gtest]
+    fn test_extra_body_config_round_trip() {
+        let original = ExtraBodyConfig {
+            data: vec![
+                ExtraBodyReplacement {
+                    pointer: "/temperature".to_string(),
+                    kind: ExtraBodyReplacementKind::Value(serde_json::json!(0.7)),
+                },
+                ExtraBodyReplacement {
+                    pointer: "/stop".to_string(),
+                    kind: ExtraBodyReplacementKind::Delete,
+                },
+            ],
+        };
+        let stored = StoredExtraBodyConfig::from(&original);
+        let restored: ExtraBodyConfig = stored.into();
+        expect_that!(restored, eq(&original));
     }
 }

--- a/crates/tensorzero-core/src/inference/types/extra_headers.rs
+++ b/crates/tensorzero-core/src/inference/types/extra_headers.rs
@@ -12,6 +12,26 @@ pub struct ExtraHeadersConfig {
     pub data: Vec<ExtraHeader>,
 }
 
+impl From<&ExtraHeadersConfig> for StoredExtraHeadersConfig {
+    fn from(config: &ExtraHeadersConfig) -> Self {
+        StoredExtraHeadersConfig {
+            data: config
+                .data
+                .iter()
+                .map(|header| StoredExtraHeader {
+                    name: header.name.clone(),
+                    kind: match &header.kind {
+                        ExtraHeaderKind::Value(value) => {
+                            StoredExtraHeaderKind::Value(value.clone())
+                        }
+                        ExtraHeaderKind::Delete => StoredExtraHeaderKind::Delete,
+                    },
+                })
+                .collect(),
+        }
+    }
+}
+
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
 pub struct ExtraHeader {
@@ -184,26 +204,6 @@ pub use dynamic::ExtraHeader as DynamicExtraHeader;
 
 // ─── Stored → Uninitialized conversions ──────────────────────────────────────
 
-impl From<&ExtraHeadersConfig> for StoredExtraHeadersConfig {
-    fn from(config: &ExtraHeadersConfig) -> Self {
-        StoredExtraHeadersConfig {
-            data: config
-                .data
-                .iter()
-                .map(|header| StoredExtraHeader {
-                    name: header.name.clone(),
-                    kind: match &header.kind {
-                        ExtraHeaderKind::Value(value) => {
-                            StoredExtraHeaderKind::Value(value.clone())
-                        }
-                        ExtraHeaderKind::Delete => StoredExtraHeaderKind::Delete,
-                    },
-                })
-                .collect(),
-        }
-    }
-}
-
 impl From<StoredExtraHeaderKind> for ExtraHeaderKind {
     fn from(stored: StoredExtraHeaderKind) -> Self {
         match stored {
@@ -232,6 +232,9 @@ impl From<StoredExtraHeadersConfig> for ExtraHeadersConfig {
 
 #[cfg(test)]
 mod tests {
+    use googletest::{expect_that, matchers::eq};
+    use tensorzero_stored_config::StoredExtraHeadersConfig;
+
     use super::*;
 
     #[test]
@@ -512,5 +515,24 @@ mod tests {
             result.is_err(),
             "Expected error when unknown fields are present"
         );
+    }
+
+    #[googletest::gtest]
+    fn test_extra_headers_config_round_trip() {
+        let original = ExtraHeadersConfig {
+            data: vec![
+                ExtraHeader {
+                    name: "x-custom-header".to_string(),
+                    kind: ExtraHeaderKind::Value("some-value".to_string()),
+                },
+                ExtraHeader {
+                    name: "x-remove-me".to_string(),
+                    kind: ExtraHeaderKind::Delete,
+                },
+            ],
+        };
+        let stored = StoredExtraHeadersConfig::from(&original);
+        let restored: ExtraHeadersConfig = stored.into();
+        expect_that!(restored, eq(&original));
     }
 }

--- a/crates/tensorzero-core/src/inference/types/storage.rs
+++ b/crates/tensorzero-core/src/inference/types/storage.rs
@@ -1,6 +1,5 @@
-use object_store::path::Path;
-
 use crate::error::{Error, ErrorDetails};
+use object_store::path::Path;
 
 use super::{Base64File, file::mime_type_to_ext};
 

--- a/crates/tensorzero-core/src/model.rs
+++ b/crates/tensorzero-core/src/model.rs
@@ -15,6 +15,11 @@ use tensorzero_stored_config::{
     StoredContentBlockType, StoredHostedProviderKind, StoredModelConfig, StoredModelProvider,
     StoredOpenAIAPIType, StoredProviderConfig,
 };
+#[cfg(test)]
+use tensorzero_stored_config::{
+    StoredCostConfig, StoredExtraBodyConfig, StoredExtraHeadersConfig, StoredTimeoutsConfig,
+    StoredUnifiedCostConfig,
+};
 use tokio::time::error::Elapsed;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{Level, Span, span};
@@ -263,6 +268,32 @@ impl TryFrom<StoredModelProvider> for UninitializedModelProvider {
     }
 }
 
+#[cfg(test)]
+impl TryFrom<&UninitializedModelConfig> for StoredModelConfig {
+    type Error = Error;
+
+    fn try_from(config: &UninitializedModelConfig) -> Result<Self, Error> {
+        let providers = config
+            .providers
+            .iter()
+            .map(|(provider_name, provider)| {
+                Ok::<_, Error>((
+                    provider_name.to_string(),
+                    StoredModelProvider::from(provider),
+                ))
+            })
+            .collect::<Result<std::collections::BTreeMap<_, _>, _>>()?;
+
+        Ok(StoredModelConfig {
+            routing: config.routing.iter().map(ToString::to_string).collect(),
+            providers,
+            timeouts: Some(StoredTimeoutsConfig::from(&config.timeouts)),
+            skip_relay: config.skip_relay,
+            namespace: config.namespace.as_ref().map(ToString::to_string),
+        })
+    }
+}
+
 impl From<StoredHostedProviderKind> for HostedProviderKind {
     fn from(stored: StoredHostedProviderKind) -> Self {
         match stored {
@@ -287,6 +318,16 @@ impl From<StoredContentBlockType> for ContentBlockType {
             StoredContentBlockType::ImageUrl => Self::ImageUrl,
             StoredContentBlockType::File => Self::File,
             StoredContentBlockType::InputAudio => Self::InputAudio,
+        }
+    }
+}
+
+impl From<&ContentBlockType> for StoredContentBlockType {
+    fn from(value: &ContentBlockType) -> Self {
+        match value {
+            ContentBlockType::ImageUrl => StoredContentBlockType::ImageUrl,
+            ContentBlockType::File => StoredContentBlockType::File,
+            ContentBlockType::InputAudio => StoredContentBlockType::InputAudio,
         }
     }
 }
@@ -519,6 +560,21 @@ impl TryFrom<StoredProviderConfig> for UninitializedProviderConfig {
             } => Ok(Self::DeepSeek {
                 model_name,
                 api_key_location: api_key_location.map(Into::into),
+            }),
+            #[cfg(any(test, feature = "e2e_tests"))]
+            StoredProviderConfig::Dummy {
+                model_name,
+                api_key_location,
+            } => Ok(Self::Dummy {
+                model_name,
+                api_key_location: api_key_location
+                    .map(serde_json::from_value)
+                    .transpose()
+                    .map_err(|e| {
+                        Error::new(ErrorDetails::Config {
+                            message: format!("invalid Dummy api_key_location: {e}"),
+                        })
+                    })?,
             }),
         }
     }
@@ -1348,6 +1404,30 @@ pub struct UninitializedModelProvider {
     pub batch_cost: Option<UninitializedUnifiedCostConfig>,
 }
 
+#[cfg(test)]
+impl From<&UninitializedModelProvider> for StoredModelProvider {
+    fn from(provider: &UninitializedModelProvider) -> Self {
+        StoredModelProvider {
+            provider: StoredProviderConfig::from(&provider.config),
+            extra_body: provider
+                .extra_body
+                .as_ref()
+                .map(StoredExtraBodyConfig::from),
+            extra_headers: provider
+                .extra_headers
+                .as_ref()
+                .map(StoredExtraHeadersConfig::from),
+            timeouts: Some(StoredTimeoutsConfig::from(&provider.timeouts)),
+            discard_unknown_chunks: Some(provider.discard_unknown_chunks),
+            cost: provider.cost.as_ref().map(StoredCostConfig::from),
+            batch_cost: provider
+                .batch_cost
+                .as_ref()
+                .map(StoredUnifiedCostConfig::from),
+        }
+    }
+}
+
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "ts-bindings", ts(export))]
@@ -1819,6 +1899,229 @@ pub enum UninitializedProviderConfig {
     },
 }
 
+impl From<&UninitializedProviderConfig> for StoredProviderConfig {
+    fn from(config: &UninitializedProviderConfig) -> Self {
+        match config {
+            UninitializedProviderConfig::Anthropic {
+                model_name,
+                api_base,
+                api_key_location,
+                beta_structured_outputs,
+                provider_tools,
+            } => StoredProviderConfig::Anthropic {
+                model_name: model_name.clone(),
+                api_base: api_base.as_ref().map(ToString::to_string),
+                api_key_location: api_key_location.as_ref().map(Into::into),
+                beta_structured_outputs: *beta_structured_outputs,
+                provider_tools: (!provider_tools.is_empty()).then(|| provider_tools.clone()),
+            },
+            UninitializedProviderConfig::AWSBedrock {
+                model_id,
+                region,
+                allow_auto_detect_region,
+                endpoint_url,
+                api_key,
+                access_key_id,
+                secret_access_key,
+                session_token,
+            } => StoredProviderConfig::AWSBedrock {
+                model_id: model_id.clone(),
+                region: region.as_ref().map(Into::into),
+                allow_auto_detect_region: Some(*allow_auto_detect_region),
+                endpoint_url: endpoint_url.as_ref().map(Into::into),
+                api_key: api_key.as_ref().map(Into::into),
+                access_key_id: access_key_id.as_ref().map(Into::into),
+                secret_access_key: secret_access_key.as_ref().map(Into::into),
+                session_token: session_token.as_ref().map(Into::into),
+            },
+            UninitializedProviderConfig::AWSSagemaker {
+                endpoint_name,
+                model_name,
+                region,
+                allow_auto_detect_region,
+                hosted_provider,
+                endpoint_url,
+                access_key_id,
+                secret_access_key,
+                session_token,
+            } => StoredProviderConfig::AWSSagemaker {
+                endpoint_name: endpoint_name.clone(),
+                model_name: model_name.clone(),
+                region: region.as_ref().map(Into::into),
+                allow_auto_detect_region: Some(*allow_auto_detect_region),
+                hosted_provider: hosted_provider.clone().into(),
+                endpoint_url: endpoint_url.as_ref().map(Into::into),
+                access_key_id: access_key_id.as_ref().map(Into::into),
+                secret_access_key: secret_access_key.as_ref().map(Into::into),
+                session_token: session_token.as_ref().map(Into::into),
+            },
+            UninitializedProviderConfig::Azure {
+                deployment_id,
+                endpoint,
+                api_key_location,
+            } => StoredProviderConfig::Azure {
+                deployment_id: deployment_id.clone(),
+                endpoint: endpoint.into(),
+                api_key_location: api_key_location.as_ref().map(Into::into),
+            },
+            UninitializedProviderConfig::GCPVertexAnthropic {
+                model_id,
+                location,
+                project_id,
+                credential_location,
+                provider_tools,
+            } => StoredProviderConfig::GCPVertexAnthropic {
+                model_id: model_id.clone(),
+                location: location.clone(),
+                project_id: project_id.clone(),
+                credential_location: credential_location.as_ref().map(Into::into),
+                provider_tools: (!provider_tools.is_empty()).then(|| provider_tools.clone()),
+            },
+            UninitializedProviderConfig::GCPVertexGemini {
+                model_id,
+                endpoint_id,
+                location,
+                project_id,
+                credential_location,
+            } => StoredProviderConfig::GCPVertexGemini {
+                model_id: model_id.clone(),
+                endpoint_id: endpoint_id.clone(),
+                location: location.clone(),
+                project_id: project_id.clone(),
+                credential_location: credential_location.as_ref().map(Into::into),
+            },
+            UninitializedProviderConfig::GoogleAIStudioGemini {
+                model_name,
+                api_key_location,
+            } => StoredProviderConfig::GoogleAIStudioGemini {
+                model_name: model_name.clone(),
+                api_key_location: api_key_location.as_ref().map(Into::into),
+            },
+            UninitializedProviderConfig::Groq {
+                model_name,
+                api_key_location,
+                reasoning_format,
+            } => StoredProviderConfig::Groq {
+                model_name: model_name.clone(),
+                api_key_location: api_key_location.as_ref().map(Into::into),
+                reasoning_format: reasoning_format.clone(),
+            },
+            UninitializedProviderConfig::Hyperbolic {
+                model_name,
+                api_key_location,
+            } => StoredProviderConfig::Hyperbolic {
+                model_name: model_name.clone(),
+                api_key_location: api_key_location.as_ref().map(Into::into),
+            },
+            UninitializedProviderConfig::Fireworks {
+                model_name,
+                api_key_location,
+                parse_think_blocks,
+            } => StoredProviderConfig::Fireworks {
+                model_name: model_name.clone(),
+                api_key_location: api_key_location.as_ref().map(Into::into),
+                parse_think_blocks: *parse_think_blocks,
+            },
+            UninitializedProviderConfig::Mistral {
+                model_name,
+                api_key_location,
+                prompt_mode,
+            } => StoredProviderConfig::Mistral {
+                model_name: model_name.clone(),
+                api_key_location: api_key_location.as_ref().map(Into::into),
+                prompt_mode: prompt_mode.clone(),
+            },
+            UninitializedProviderConfig::OpenAI {
+                model_name,
+                api_base,
+                api_key_location,
+                api_type,
+                include_encrypted_reasoning,
+                provider_tools,
+                content_type_overrides,
+            } => StoredProviderConfig::OpenAI {
+                model_name: model_name.clone(),
+                api_base: api_base.as_ref().map(ToString::to_string),
+                api_key_location: api_key_location.as_ref().map(Into::into),
+                api_type: Some((*api_type).into()),
+                include_encrypted_reasoning: Some(*include_encrypted_reasoning),
+                provider_tools: (!provider_tools.is_empty()).then(|| provider_tools.clone()),
+                content_type_overrides: (!content_type_overrides.is_empty()).then(|| {
+                    content_type_overrides
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.into()))
+                        .collect()
+                }),
+            },
+            UninitializedProviderConfig::OpenRouter {
+                model_name,
+                api_key_location,
+            } => StoredProviderConfig::OpenRouter {
+                model_name: model_name.clone(),
+                api_key_location: api_key_location.as_ref().map(Into::into),
+            },
+            UninitializedProviderConfig::Together {
+                model_name,
+                api_key_location,
+                parse_think_blocks,
+            } => StoredProviderConfig::Together {
+                model_name: model_name.clone(),
+                api_key_location: api_key_location.as_ref().map(Into::into),
+                parse_think_blocks: *parse_think_blocks,
+            },
+            UninitializedProviderConfig::VLLM {
+                model_name,
+                api_base,
+                api_key_location,
+            } => StoredProviderConfig::VLLM {
+                model_name: model_name.clone(),
+                api_base: api_base.to_string(),
+                api_key_location: api_key_location.as_ref().map(Into::into),
+            },
+            UninitializedProviderConfig::XAI {
+                model_name,
+                api_key_location,
+            } => StoredProviderConfig::XAI {
+                model_name: model_name.clone(),
+                api_key_location: api_key_location.as_ref().map(Into::into),
+            },
+            UninitializedProviderConfig::TGI {
+                api_base,
+                api_key_location,
+            } => StoredProviderConfig::TGI {
+                api_base: api_base.to_string(),
+                api_key_location: api_key_location.as_ref().map(Into::into),
+            },
+            UninitializedProviderConfig::SGLang {
+                model_name,
+                api_base,
+                api_key_location,
+            } => StoredProviderConfig::SGLang {
+                model_name: model_name.clone(),
+                api_base: api_base.to_string(),
+                api_key_location: api_key_location.as_ref().map(Into::into),
+            },
+            UninitializedProviderConfig::DeepSeek {
+                model_name,
+                api_key_location,
+            } => StoredProviderConfig::DeepSeek {
+                model_name: model_name.clone(),
+                api_key_location: api_key_location.as_ref().map(Into::into),
+            },
+            #[cfg(any(test, feature = "e2e_tests"))]
+            UninitializedProviderConfig::Dummy {
+                model_name,
+                api_key_location,
+            } => StoredProviderConfig::Dummy {
+                model_name: model_name.clone(),
+                api_key_location: api_key_location
+                    .as_ref()
+                    .and_then(|value| serde_json::to_value(value).ok()),
+            },
+        }
+    }
+}
+
 impl UninitializedProviderConfig {
     pub async fn load(
         self,
@@ -2195,6 +2498,24 @@ impl UninitializedProviderConfig {
                 api_key_location,
             } => ProviderConfig::Dummy(DummyProvider::new(model_name, api_key_location)?),
         })
+    }
+}
+
+impl From<HostedProviderKind> for StoredHostedProviderKind {
+    fn from(kind: HostedProviderKind) -> Self {
+        match kind {
+            HostedProviderKind::OpenAI => StoredHostedProviderKind::OpenAI,
+            HostedProviderKind::TGI => StoredHostedProviderKind::TGI,
+        }
+    }
+}
+
+impl From<OpenAIAPIType> for StoredOpenAIAPIType {
+    fn from(api_type: OpenAIAPIType) -> Self {
+        match api_type {
+            OpenAIAPIType::ChatCompletions => StoredOpenAIAPIType::ChatCompletions,
+            OpenAIAPIType::Responses => StoredOpenAIAPIType::Responses,
+        }
     }
 }
 
@@ -4804,5 +5125,249 @@ mod tests {
             provider.effective_batch_cost_config().is_none(),
             "should return None when both cost and batch_cost are absent"
         );
+    }
+
+    // ─── Round-trip tests: Uninitialized → Stored → Uninitialized ───────────
+
+    mod stored_round_trip {
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        use googletest::prelude::*;
+        use rust_decimal::Decimal;
+        use tensorzero_stored_config::{
+            StoredCostConfig, StoredModelConfig, StoredModelProvider, StoredProviderConfig,
+            StoredUnifiedCostConfig,
+        };
+        use tensorzero_types::{
+            CostPointerConfig, UnifiedCostPointerConfig, UninitializedCostConfig,
+            UninitializedCostConfigEntry, UninitializedCostRate, UninitializedUnifiedCostConfig,
+        };
+
+        use crate::config::{Namespace, NonStreamingTimeouts, TimeoutsConfig};
+        use crate::inference::types::extra_body::{
+            ExtraBodyConfig, ExtraBodyReplacement, ExtraBodyReplacementKind,
+        };
+        use crate::model::{
+            CredentialLocation, CredentialLocationWithFallback, UninitializedModelConfig,
+            UninitializedModelProvider, UninitializedProviderConfig,
+        };
+        use crate::providers::openai::OpenAIAPIType;
+
+        #[gtest]
+        fn test_credential_location_round_trip() {
+            let variants = vec![
+                CredentialLocation::Env("MY_API_KEY".to_string()),
+                CredentialLocation::Dynamic("x-custom-key".to_string()),
+                CredentialLocation::Sdk,
+                CredentialLocation::None,
+            ];
+            for original in &variants {
+                let stored: tensorzero_stored_config::StoredCredentialLocation = original.into();
+                let restored: CredentialLocation = stored.into();
+                expect_that!(restored, eq(original));
+            }
+        }
+
+        #[gtest]
+        fn test_credential_location_with_fallback_round_trip() {
+            let variants = vec![
+                CredentialLocationWithFallback::Single(CredentialLocation::Env(
+                    "MY_KEY".to_string(),
+                )),
+                CredentialLocationWithFallback::WithFallback {
+                    default: CredentialLocation::Dynamic("x-key".to_string()),
+                    fallback: CredentialLocation::Env("FALLBACK_KEY".to_string()),
+                },
+            ];
+            for original in &variants {
+                let stored: tensorzero_stored_config::StoredCredentialLocationWithFallback =
+                    original.into();
+                let restored: CredentialLocationWithFallback = stored.into();
+                expect_that!(restored, eq(original));
+            }
+        }
+
+        #[gtest]
+        fn test_provider_config_openai_round_trip() {
+            let original = UninitializedProviderConfig::OpenAI {
+                model_name: "gpt-4o".to_string(),
+                api_base: None,
+                api_key_location: Some(CredentialLocationWithFallback::Single(
+                    CredentialLocation::Env("OPENAI_API_KEY".to_string()),
+                )),
+                api_type: OpenAIAPIType::ChatCompletions,
+                include_encrypted_reasoning: false,
+                provider_tools: vec![],
+                content_type_overrides: HashMap::new(),
+            };
+            let stored = StoredProviderConfig::from(&original);
+            let restored: UninitializedProviderConfig =
+                stored.try_into().expect("should convert back");
+            expect_that!(restored, eq(&original));
+        }
+
+        #[gtest]
+        fn test_provider_config_anthropic_round_trip() {
+            let original = UninitializedProviderConfig::Anthropic {
+                model_name: "claude-sonnet-4-20250514".to_string(),
+                api_base: None,
+                api_key_location: Some(CredentialLocationWithFallback::Single(
+                    CredentialLocation::Env("ANTHROPIC_API_KEY".to_string()),
+                )),
+                beta_structured_outputs: Some(true),
+                provider_tools: vec![],
+            };
+            let stored = StoredProviderConfig::from(&original);
+            let restored: UninitializedProviderConfig =
+                stored.try_into().expect("should convert back");
+            expect_that!(restored, eq(&original));
+        }
+
+        #[gtest]
+        fn test_model_provider_round_trip() {
+            let original = UninitializedModelProvider {
+                config: UninitializedProviderConfig::OpenAI {
+                    model_name: "gpt-4o".to_string(),
+                    api_base: None,
+                    api_key_location: Some(CredentialLocationWithFallback::Single(
+                        CredentialLocation::Env("OPENAI_API_KEY".to_string()),
+                    )),
+                    api_type: OpenAIAPIType::ChatCompletions,
+                    include_encrypted_reasoning: false,
+                    provider_tools: vec![],
+                    content_type_overrides: HashMap::new(),
+                },
+                extra_body: Some(ExtraBodyConfig {
+                    data: vec![ExtraBodyReplacement {
+                        pointer: "/temperature".to_string(),
+                        kind: ExtraBodyReplacementKind::Value(serde_json::json!(0.5)),
+                    }],
+                }),
+                extra_headers: None,
+                timeouts: TimeoutsConfig {
+                    non_streaming: Some(NonStreamingTimeouts {
+                        total_ms: Some(30000),
+                    }),
+                    streaming: None,
+                },
+                discard_unknown_chunks: true,
+                cost: Some(vec![UninitializedCostConfigEntry {
+                    pointer: CostPointerConfig {
+                        pointer: Some("/usage/input_tokens".to_string()),
+                        pointer_nonstreaming: None,
+                        pointer_streaming: None,
+                    },
+                    rate: UninitializedCostRate {
+                        cost_per_million: Some(Decimal::new(3, 0)),
+                        cost_per_unit: None,
+                    },
+                    required: false,
+                }]),
+                batch_cost: None,
+            };
+            let stored = StoredModelProvider::from(&original);
+            let restored: UninitializedModelProvider =
+                stored.try_into().expect("should convert back");
+            expect_that!(restored, eq(&original));
+        }
+
+        #[gtest]
+        fn test_model_config_round_trip() {
+            let original = UninitializedModelConfig {
+                routing: vec![Arc::from("provider_a")],
+                providers: HashMap::from([(
+                    Arc::from("provider_a"),
+                    UninitializedModelProvider {
+                        config: UninitializedProviderConfig::Anthropic {
+                            model_name: "claude-sonnet-4-20250514".to_string(),
+                            api_base: None,
+                            api_key_location: Some(CredentialLocationWithFallback::Single(
+                                CredentialLocation::Env("ANTHROPIC_API_KEY".to_string()),
+                            )),
+                            beta_structured_outputs: None,
+                            provider_tools: vec![],
+                        },
+                        extra_body: None,
+                        extra_headers: None,
+                        timeouts: TimeoutsConfig::default(),
+                        discard_unknown_chunks: false,
+                        cost: None,
+                        batch_cost: None,
+                    },
+                )]),
+                timeouts: TimeoutsConfig::default(),
+                skip_relay: Some(true),
+                namespace: Some(
+                    Namespace::new("my_namespace".to_string()).expect("valid namespace"),
+                ),
+            };
+            let stored = StoredModelConfig::try_from(&original).expect("should serialize");
+            let restored: UninitializedModelConfig =
+                stored.try_into().expect("should convert back");
+            expect_that!(restored, eq(&original));
+        }
+
+        #[gtest]
+        fn test_cost_config_round_trip() {
+            let original: UninitializedCostConfig = vec![
+                UninitializedCostConfigEntry {
+                    pointer: CostPointerConfig {
+                        pointer: Some("/usage/input_tokens".to_string()),
+                        pointer_nonstreaming: None,
+                        pointer_streaming: Some("/usage/streaming_tokens".to_string()),
+                    },
+                    rate: UninitializedCostRate {
+                        cost_per_million: Some(Decimal::new(150, 2)),
+                        cost_per_unit: None,
+                    },
+                    required: false,
+                },
+                UninitializedCostConfigEntry {
+                    pointer: CostPointerConfig {
+                        pointer: None,
+                        pointer_nonstreaming: Some("/usage/nonstream".to_string()),
+                        pointer_streaming: None,
+                    },
+                    rate: UninitializedCostRate {
+                        cost_per_million: None,
+                        cost_per_unit: Some(Decimal::new(1, 6)),
+                    },
+                    required: true,
+                },
+            ];
+            let stored = StoredCostConfig::from(&original);
+            let restored: UninitializedCostConfig = stored.into();
+            expect_that!(restored, eq(&original));
+        }
+
+        #[gtest]
+        fn test_unified_cost_config_round_trip() {
+            let original: UninitializedUnifiedCostConfig = vec![
+                UninitializedCostConfigEntry {
+                    pointer: UnifiedCostPointerConfig {
+                        pointer: "/usage/input_tokens".to_string(),
+                    },
+                    rate: UninitializedCostRate {
+                        cost_per_million: Some(Decimal::new(150, 2)),
+                        cost_per_unit: None,
+                    },
+                    required: true,
+                },
+                UninitializedCostConfigEntry {
+                    pointer: UnifiedCostPointerConfig {
+                        pointer: "/usage/output_tokens".to_string(),
+                    },
+                    rate: UninitializedCostRate {
+                        cost_per_million: None,
+                        cost_per_unit: Some(Decimal::new(6, 6)),
+                    },
+                    required: false,
+                },
+            ];
+            let stored = StoredUnifiedCostConfig::from(&original);
+            let restored: UninitializedUnifiedCostConfig = stored.into();
+            expect_that!(restored, eq(&original));
+        }
     }
 }

--- a/crates/tensorzero-core/src/optimization/dicl.rs
+++ b/crates/tensorzero-core/src/optimization/dicl.rs
@@ -112,6 +112,24 @@ impl From<tensorzero_stored_config::StoredDiclOptimizationConfig>
     }
 }
 
+impl From<UninitializedDiclOptimizationConfig>
+    for tensorzero_stored_config::StoredDiclOptimizationConfig
+{
+    fn from(config: UninitializedDiclOptimizationConfig) -> Self {
+        tensorzero_stored_config::StoredDiclOptimizationConfig {
+            embedding_model: config.embedding_model,
+            variant_name: config.variant_name,
+            function_name: config.function_name,
+            dimensions: config.dimensions,
+            batch_size: Some(config.batch_size),
+            max_concurrency: Some(config.max_concurrency),
+            k: Some(config.k),
+            model: config.model,
+            append_to_existing_variants: Some(config.append_to_existing_variants),
+        }
+    }
+}
+
 #[cfg(feature = "pyo3")]
 #[pymethods]
 impl UninitializedDiclOptimizationConfig {
@@ -217,5 +235,46 @@ impl std::fmt::Display for DiclOptimizationJobHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let json = serde_json::to_string_pretty(self).map_err(|_| std::fmt::Error)?;
         write!(f, "{json}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use googletest::prelude::*;
+    use tensorzero_stored_config::StoredDiclOptimizationConfig;
+
+    #[gtest]
+    fn test_dicl_optimization_config_round_trip_full() {
+        let original = UninitializedDiclOptimizationConfig {
+            embedding_model: "openai::text-embedding-3-small".to_string(),
+            variant_name: "my_variant".to_string(),
+            function_name: "my_function".to_string(),
+            dimensions: Some(512),
+            batch_size: 64,
+            max_concurrency: 5,
+            k: 8,
+            model: Some("openai::gpt-4o-mini".to_string()),
+            append_to_existing_variants: true,
+        };
+        let stored: StoredDiclOptimizationConfig = original.clone().into();
+        let restored: UninitializedDiclOptimizationConfig = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_dicl_optimization_config_round_trip_minimal() {
+        // Note: defaults from `Default` are preserved through the round trip
+        // because the From<Uninitialized> for Stored writes them explicitly
+        // and the reverse direction reads them back.
+        let original = UninitializedDiclOptimizationConfig {
+            embedding_model: "openai::text-embedding-3-small".to_string(),
+            variant_name: "v".to_string(),
+            function_name: "f".to_string(),
+            ..Default::default()
+        };
+        let stored: StoredDiclOptimizationConfig = original.clone().into();
+        let restored: UninitializedDiclOptimizationConfig = stored.into();
+        expect_that!(restored, eq(&original));
     }
 }

--- a/crates/tensorzero-core/src/optimization/fireworks_sft/mod.rs
+++ b/crates/tensorzero-core/src/optimization/fireworks_sft/mod.rs
@@ -95,6 +95,30 @@ impl From<StoredFireworksOptimizerSFTConfig> for UninitializedFireworksSFTConfig
     }
 }
 
+impl From<UninitializedFireworksSFTConfig> for StoredFireworksOptimizerSFTConfig {
+    fn from(config: UninitializedFireworksSFTConfig) -> Self {
+        StoredFireworksOptimizerSFTConfig {
+            model: config.model,
+            early_stop: config.early_stop,
+            epochs: config.epochs,
+            learning_rate: config.learning_rate,
+            max_context_length: config.max_context_length,
+            lora_rank: config.lora_rank,
+            batch_size: config.batch_size,
+            display_name: config.display_name,
+            output_model: config.output_model,
+            warm_start_from: config.warm_start_from,
+            is_turbo: config.is_turbo,
+            eval_auto_carveout: config.eval_auto_carveout,
+            nodes: config.nodes,
+            mtp_enabled: config.mtp_enabled,
+            mtp_num_draft_tokens: config.mtp_num_draft_tokens,
+            mtp_freeze_base_model: config.mtp_freeze_base_model,
+            deploy_after_training: config.deploy_after_training,
+        }
+    }
+}
+
 #[cfg(feature = "pyo3")]
 #[pymethods]
 impl UninitializedFireworksSFTConfig {
@@ -231,5 +255,48 @@ impl std::fmt::Display for FireworksSFTJobHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let json = serde_json::to_string_pretty(self).map_err(|_| std::fmt::Error)?;
         write!(f, "{json}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use googletest::prelude::*;
+
+    #[gtest]
+    fn test_fireworks_sft_config_round_trip_full() {
+        let original = UninitializedFireworksSFTConfig {
+            model: "accounts/fireworks/models/llama".to_string(),
+            early_stop: Some(true),
+            epochs: Some(2),
+            learning_rate: Some(1e-5),
+            max_context_length: Some(8192),
+            lora_rank: Some(16),
+            batch_size: Some(4096),
+            display_name: Some("display".to_string()),
+            output_model: Some("out-model".to_string()),
+            warm_start_from: Some("warm".to_string()),
+            is_turbo: Some(false),
+            eval_auto_carveout: Some(true),
+            nodes: Some(2),
+            mtp_enabled: Some(true),
+            mtp_num_draft_tokens: Some(8),
+            mtp_freeze_base_model: Some(false),
+            deploy_after_training: Some(true),
+        };
+        let stored: StoredFireworksOptimizerSFTConfig = original.clone().into();
+        let restored: UninitializedFireworksSFTConfig = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_fireworks_sft_config_round_trip_minimal() {
+        let original = UninitializedFireworksSFTConfig {
+            model: "accounts/fireworks/models/llama".to_string(),
+            ..Default::default()
+        };
+        let stored: StoredFireworksOptimizerSFTConfig = original.clone().into();
+        let restored: UninitializedFireworksSFTConfig = stored.into();
+        expect_that!(restored, eq(&original));
     }
 }

--- a/crates/tensorzero-core/src/optimization/gcp_vertex_gemini_sft/mod.rs
+++ b/crates/tensorzero-core/src/optimization/gcp_vertex_gemini_sft/mod.rs
@@ -59,6 +59,20 @@ impl From<StoredGCPVertexGeminiOptimizerSFTConfig> for UninitializedGCPVertexGem
     }
 }
 
+impl From<UninitializedGCPVertexGeminiSFTConfig> for StoredGCPVertexGeminiOptimizerSFTConfig {
+    fn from(config: UninitializedGCPVertexGeminiSFTConfig) -> Self {
+        StoredGCPVertexGeminiOptimizerSFTConfig {
+            model: config.model,
+            learning_rate_multiplier: config.learning_rate_multiplier,
+            adapter_size: config.adapter_size,
+            n_epochs: config.n_epochs,
+            export_last_checkpoint_only: config.export_last_checkpoint_only,
+            seed: config.seed,
+            tuned_model_display_name: config.tuned_model_display_name,
+        }
+    }
+}
+
 #[cfg(feature = "pyo3")]
 #[pymethods]
 impl UninitializedGCPVertexGeminiSFTConfig {
@@ -146,5 +160,38 @@ impl std::fmt::Display for GCPVertexGeminiSFTJobHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let json = serde_json::to_string_pretty(self).map_err(|_| std::fmt::Error)?;
         write!(f, "{json}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use googletest::prelude::*;
+
+    #[gtest]
+    fn test_gcp_vertex_gemini_sft_config_round_trip_full() {
+        let original = UninitializedGCPVertexGeminiSFTConfig {
+            model: "gemini-1.5-pro".to_string(),
+            learning_rate_multiplier: Some(0.7),
+            adapter_size: Some(16),
+            n_epochs: Some(5),
+            export_last_checkpoint_only: Some(true),
+            seed: Some(123),
+            tuned_model_display_name: Some("my-tuned-gemini".to_string()),
+        };
+        let stored: StoredGCPVertexGeminiOptimizerSFTConfig = original.clone().into();
+        let restored: UninitializedGCPVertexGeminiSFTConfig = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_gcp_vertex_gemini_sft_config_round_trip_minimal() {
+        let original = UninitializedGCPVertexGeminiSFTConfig {
+            model: "gemini-1.5-pro".to_string(),
+            ..Default::default()
+        };
+        let stored: StoredGCPVertexGeminiOptimizerSFTConfig = original.clone().into();
+        let restored: UninitializedGCPVertexGeminiSFTConfig = stored.into();
+        expect_that!(restored, eq(&original));
     }
 }

--- a/crates/tensorzero-core/src/optimization/gepa.rs
+++ b/crates/tensorzero-core/src/optimization/gepa.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use tensorzero_stored_config::StoredGEPAConfig;
+use tensorzero_stored_config::{StoredGEPAConfig, StoredRetryConfig};
 
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
@@ -172,8 +172,8 @@ impl From<StoredGEPAConfig> for UninitializedGEPAConfig {
     fn from(stored: StoredGEPAConfig) -> Self {
         UninitializedGEPAConfig {
             function_name: stored.function_name,
-            evaluation_name: Some(stored.evaluation_name),
-            evaluator_names: None,
+            evaluation_name: stored.evaluation_name,
+            evaluator_names: stored.evaluator_names,
             initial_variants: stored.initial_variants,
             variant_prefix: stored.variant_prefix,
             batch_size: stored.batch_size.unwrap_or_else(default_batch_size),
@@ -190,6 +190,28 @@ impl From<StoredGEPAConfig> for UninitializedGEPAConfig {
                 .unwrap_or_else(default_include_inference_for_mutation),
             retries: stored.retries.map(RetryConfig::from).unwrap_or_default(),
             max_tokens: stored.max_tokens,
+        }
+    }
+}
+
+impl From<UninitializedGEPAConfig> for StoredGEPAConfig {
+    fn from(config: UninitializedGEPAConfig) -> Self {
+        StoredGEPAConfig {
+            function_name: config.function_name,
+            evaluation_name: config.evaluation_name,
+            evaluator_names: config.evaluator_names,
+            initial_variants: config.initial_variants,
+            variant_prefix: config.variant_prefix,
+            batch_size: Some(config.batch_size),
+            max_iterations: Some(config.max_iterations),
+            max_concurrency: Some(config.max_concurrency),
+            analysis_model: config.analysis_model,
+            mutation_model: config.mutation_model,
+            seed: config.seed,
+            timeout: Some(config.timeout),
+            include_inference_for_mutation: Some(config.include_inference_for_mutation),
+            retries: Some(StoredRetryConfig::from(config.retries)),
+            max_tokens: config.max_tokens,
         }
     }
 }
@@ -563,4 +585,72 @@ pub struct GepaEvaluatorStats {
     pub mean: f64,
     pub stdev: f64,
     pub count: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use googletest::prelude::*;
+
+    fn sample_full_config() -> UninitializedGEPAConfig {
+        UninitializedGEPAConfig {
+            function_name: "my_function".to_string(),
+            evaluation_name: Some("my_eval".to_string()),
+            evaluator_names: None,
+            initial_variants: Some(vec!["v1".to_string(), "v2".to_string()]),
+            variant_prefix: Some("gepa_".to_string()),
+            batch_size: 16,
+            max_iterations: 5,
+            max_concurrency: 4,
+            analysis_model: "anthropic::claude-sonnet-4-5".to_string(),
+            mutation_model: "anthropic::claude-sonnet-4-5".to_string(),
+            seed: Some(7),
+            timeout: 600,
+            include_inference_for_mutation: false,
+            retries: RetryConfig::default(),
+            max_tokens: Some(4096),
+        }
+    }
+
+    #[gtest]
+    fn test_gepa_config_round_trip_with_evaluation_name() {
+        let original = sample_full_config();
+        let stored: StoredGEPAConfig = original.clone().into();
+        let restored: UninitializedGEPAConfig = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_gepa_config_round_trip_with_evaluator_names() {
+        let mut original = sample_full_config();
+        original.evaluation_name = None;
+        original.evaluator_names = Some(vec!["a".to_string(), "b".to_string()]);
+        let stored: StoredGEPAConfig = original.clone().into();
+        let restored: UninitializedGEPAConfig = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_gepa_config_round_trip_minimal() {
+        let original = UninitializedGEPAConfig {
+            function_name: "f".to_string(),
+            evaluation_name: Some("e".to_string()),
+            evaluator_names: None,
+            initial_variants: None,
+            variant_prefix: None,
+            batch_size: default_batch_size(),
+            max_iterations: default_max_iterations(),
+            max_concurrency: default_max_concurrency(),
+            analysis_model: "m".to_string(),
+            mutation_model: "m".to_string(),
+            seed: None,
+            timeout: default_timeout(),
+            include_inference_for_mutation: default_include_inference_for_mutation(),
+            retries: RetryConfig::default(),
+            max_tokens: None,
+        };
+        let stored: StoredGEPAConfig = original.clone().into();
+        let restored: UninitializedGEPAConfig = stored.into();
+        expect_that!(restored, eq(&original));
+    }
 }

--- a/crates/tensorzero-core/src/optimization/mod.rs
+++ b/crates/tensorzero-core/src/optimization/mod.rs
@@ -264,6 +264,12 @@ impl UninitializedOptimizerInfo {
     }
 }
 
+impl From<UninitializedOptimizerInfo> for StoredOptimizerConfig {
+    fn from(info: UninitializedOptimizerInfo) -> Self {
+        info.inner.into()
+    }
+}
+
 impl TryFrom<StoredOptimizerConfig> for UninitializedOptimizerInfo {
     type Error = Error;
 
@@ -320,6 +326,30 @@ pub enum UninitializedOptimizerConfig {
     GEPA(UninitializedGEPAConfig),
     #[serde(rename = "together_sft")]
     TogetherSFT(Box<UninitializedTogetherSFTConfig>),
+}
+
+impl From<UninitializedOptimizerConfig> for StoredOptimizerConfig {
+    fn from(config: UninitializedOptimizerConfig) -> Self {
+        match config {
+            UninitializedOptimizerConfig::Dicl(c) => StoredOptimizerConfig::Dicl(c.into()),
+            UninitializedOptimizerConfig::OpenAISFT(c) => {
+                StoredOptimizerConfig::OpenAISFT(c.into())
+            }
+            UninitializedOptimizerConfig::OpenAIRFT(c) => {
+                StoredOptimizerConfig::OpenAIRFT(Box::new((*c).into()))
+            }
+            UninitializedOptimizerConfig::FireworksSFT(c) => {
+                StoredOptimizerConfig::FireworksSFT(c.into())
+            }
+            UninitializedOptimizerConfig::GCPVertexGeminiSFT(c) => {
+                StoredOptimizerConfig::GCPVertexGeminiSFT(c.into())
+            }
+            UninitializedOptimizerConfig::GEPA(c) => StoredOptimizerConfig::GEPA(c.into()),
+            UninitializedOptimizerConfig::TogetherSFT(c) => {
+                StoredOptimizerConfig::TogetherSFT(Box::new((*c).into()))
+            }
+        }
+    }
 }
 
 impl UninitializedOptimizerConfig {

--- a/crates/tensorzero-core/src/optimization/openai_rft/mod.rs
+++ b/crates/tensorzero-core/src/optimization/openai_rft/mod.rs
@@ -1,5 +1,8 @@
 #[cfg(feature = "pyo3")]
 use crate::inference::types::pyo3_helpers::deserialize_from_pyobj;
+use crate::providers::openai::grader::{
+    OpenAIModelGraderInput, OpenAIRFTRole, OpenAISimilarityMetric, OpenAIStringCheckOp,
+};
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 use schemars::JsonSchema;
@@ -257,6 +260,152 @@ impl From<StoredOpenAIRFTResponseFormat> for OpenAIRFTResponseFormat {
     }
 }
 
+// --- Reverse conversions: core -> stored ---
+
+impl From<OpenAIStringCheckOp> for StoredOpenAIStringCheckOp {
+    fn from(op: OpenAIStringCheckOp) -> Self {
+        match op {
+            OpenAIStringCheckOp::Eq => Self::Eq,
+            OpenAIStringCheckOp::Ne => Self::Ne,
+            OpenAIStringCheckOp::Like => Self::Like,
+            OpenAIStringCheckOp::Ilike => Self::Ilike,
+        }
+    }
+}
+
+impl From<OpenAISimilarityMetric> for StoredOpenAISimilarityMetric {
+    fn from(metric: OpenAISimilarityMetric) -> Self {
+        match metric {
+            OpenAISimilarityMetric::FuzzyMatch => Self::FuzzyMatch,
+            OpenAISimilarityMetric::Bleu => Self::Bleu,
+            OpenAISimilarityMetric::Gleu => Self::Gleu,
+            OpenAISimilarityMetric::Meteor => Self::Meteor,
+            OpenAISimilarityMetric::Rouge1 => Self::Rouge1,
+            OpenAISimilarityMetric::Rouge2 => Self::Rouge2,
+            OpenAISimilarityMetric::Rouge3 => Self::Rouge3,
+            OpenAISimilarityMetric::Rouge4 => Self::Rouge4,
+            OpenAISimilarityMetric::Rouge5 => Self::Rouge5,
+            OpenAISimilarityMetric::RougeL => Self::RougeL,
+        }
+    }
+}
+
+impl From<OpenAIRFTRole> for StoredOpenAIRFTRole {
+    fn from(role: OpenAIRFTRole) -> Self {
+        match role {
+            OpenAIRFTRole::Developer => Self::Developer,
+            OpenAIRFTRole::User => Self::User,
+        }
+    }
+}
+
+impl From<OpenAIModelGraderInput> for StoredOpenAIModelGraderInput {
+    fn from(input: OpenAIModelGraderInput) -> Self {
+        Self {
+            role: input.role.into(),
+            content: input.content,
+        }
+    }
+}
+
+impl From<OpenAIGrader> for StoredOpenAIGrader {
+    fn from(grader: OpenAIGrader) -> Self {
+        match grader {
+            OpenAIGrader::StringCheck {
+                name,
+                operation,
+                input,
+                reference,
+            } => Self::StringCheck {
+                name,
+                operation: operation.into(),
+                input,
+                reference,
+            },
+            OpenAIGrader::TextSimilarity {
+                name,
+                evaluation_metric,
+                input,
+                reference,
+            } => Self::TextSimilarity {
+                name,
+                evaluation_metric: evaluation_metric.into(),
+                input,
+                reference,
+            },
+            OpenAIGrader::ScoreModel {
+                name,
+                model,
+                input,
+                range,
+            } => Self::ScoreModel {
+                name,
+                model,
+                input: input.into_iter().map(Into::into).collect(),
+                range,
+            },
+            OpenAIGrader::LabelModel {
+                name,
+                model,
+                labels,
+                passing_labels,
+                input,
+            } => Self::LabelModel {
+                name,
+                model,
+                labels,
+                passing_labels,
+                input: input.into_iter().map(Into::into).collect(),
+            },
+            OpenAIGrader::Python {
+                name,
+                source,
+                image_tag,
+            } => Self::Python {
+                name,
+                source,
+                image_tag,
+            },
+            OpenAIGrader::Multi {
+                calculate_output,
+                graders,
+                name,
+            } => Self::Multi {
+                calculate_output,
+                graders: graders
+                    .into_iter()
+                    .map(|(k, v)| (k, Box::new((*v).into())))
+                    .collect(),
+                name,
+            },
+        }
+    }
+}
+
+impl From<JsonSchemaInfo> for StoredRFTJsonSchemaInfo {
+    fn from(info: JsonSchemaInfo) -> Self {
+        Self {
+            name: info.name,
+            description: info.description,
+            schema: info.schema,
+            strict: Some(info.strict),
+        }
+    }
+}
+
+impl From<OpenAIRFTResponseFormat> for StoredOpenAIRFTResponseFormat {
+    fn from(format: OpenAIRFTResponseFormat) -> Self {
+        match format {
+            OpenAIRFTResponseFormat::JsonSchema { json_schema } => {
+                let RFTJsonSchemaInfoOption::JsonSchema(info) = json_schema;
+                Self::JsonSchema {
+                    json_schema: info.into(),
+                }
+            }
+        }
+    }
+}
+
 impl From<StoredOpenAIRFTConfig> for UninitializedOpenAIRFTConfig {
     fn from(stored: StoredOpenAIRFTConfig) -> Self {
         UninitializedOpenAIRFTConfig {
@@ -272,6 +421,25 @@ impl From<StoredOpenAIRFTConfig> for UninitializedOpenAIRFTConfig {
             reasoning_effort: stored.reasoning_effort,
             seed: stored.seed,
             suffix: stored.suffix,
+        }
+    }
+}
+
+impl From<UninitializedOpenAIRFTConfig> for StoredOpenAIRFTConfig {
+    fn from(config: UninitializedOpenAIRFTConfig) -> Self {
+        StoredOpenAIRFTConfig {
+            model: config.model,
+            grader: config.grader.into(),
+            response_format: config.response_format.map(Into::into),
+            batch_size: config.batch_size,
+            compute_multiplier: config.compute_multiplier,
+            eval_interval: config.eval_interval,
+            eval_samples: config.eval_samples,
+            learning_rate_multiplier: config.learning_rate_multiplier,
+            n_epochs: config.n_epochs,
+            reasoning_effort: config.reasoning_effort,
+            seed: config.seed,
+            suffix: config.suffix,
         }
     }
 }
@@ -409,5 +577,213 @@ impl std::fmt::Display for OpenAIRFTJobHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let json = serde_json::to_string_pretty(self).map_err(|_| std::fmt::Error)?;
         write!(f, "{json}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use googletest::prelude::*;
+    use std::collections::HashMap;
+
+    fn sample_string_check_grader() -> OpenAIGrader {
+        OpenAIGrader::StringCheck {
+            name: "exact-match".to_string(),
+            operation: OpenAIStringCheckOp::Eq,
+            input: "{{output}}".to_string(),
+            reference: "{{reference}}".to_string(),
+        }
+    }
+
+    fn sample_score_model_grader() -> OpenAIGrader {
+        OpenAIGrader::ScoreModel {
+            name: "score-model".to_string(),
+            model: "gpt-4o".to_string(),
+            input: vec![OpenAIModelGraderInput {
+                role: OpenAIRFTRole::Developer,
+                content: "rate this".to_string(),
+            }],
+            range: Some([0.0, 1.0]),
+        }
+    }
+
+    #[gtest]
+    fn test_openai_string_check_op_round_trip() {
+        for original in [
+            OpenAIStringCheckOp::Eq,
+            OpenAIStringCheckOp::Ne,
+            OpenAIStringCheckOp::Like,
+            OpenAIStringCheckOp::Ilike,
+        ] {
+            let stored: StoredOpenAIStringCheckOp = original.clone().into();
+            let restored: OpenAIStringCheckOp = stored.into();
+            expect_that!(restored, eq(&original));
+        }
+    }
+
+    #[gtest]
+    fn test_openai_similarity_metric_round_trip() {
+        for original in [
+            OpenAISimilarityMetric::FuzzyMatch,
+            OpenAISimilarityMetric::Bleu,
+            OpenAISimilarityMetric::Gleu,
+            OpenAISimilarityMetric::Meteor,
+            OpenAISimilarityMetric::Rouge1,
+            OpenAISimilarityMetric::Rouge2,
+            OpenAISimilarityMetric::Rouge3,
+            OpenAISimilarityMetric::Rouge4,
+            OpenAISimilarityMetric::Rouge5,
+            OpenAISimilarityMetric::RougeL,
+        ] {
+            let stored: StoredOpenAISimilarityMetric = original.clone().into();
+            let restored: OpenAISimilarityMetric = stored.into();
+            expect_that!(restored, eq(&original));
+        }
+    }
+
+    #[gtest]
+    fn test_openai_rft_role_round_trip() {
+        for original in [OpenAIRFTRole::Developer, OpenAIRFTRole::User] {
+            let stored: StoredOpenAIRFTRole = original.into();
+            let restored: OpenAIRFTRole = stored.into();
+            expect_that!(restored, eq(original));
+        }
+    }
+
+    #[gtest]
+    fn test_openai_grader_string_check_round_trip() {
+        let original = sample_string_check_grader();
+        let stored: StoredOpenAIGrader = original.clone().into();
+        let restored: OpenAIGrader = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_openai_grader_text_similarity_round_trip() {
+        let original = OpenAIGrader::TextSimilarity {
+            name: "text-sim".to_string(),
+            evaluation_metric: OpenAISimilarityMetric::Bleu,
+            input: "{{output}}".to_string(),
+            reference: "{{reference}}".to_string(),
+        };
+        let stored: StoredOpenAIGrader = original.clone().into();
+        let restored: OpenAIGrader = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_openai_grader_score_model_round_trip() {
+        let original = sample_score_model_grader();
+        let stored: StoredOpenAIGrader = original.clone().into();
+        let restored: OpenAIGrader = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_openai_grader_label_model_round_trip() {
+        let original = OpenAIGrader::LabelModel {
+            name: "label-model".to_string(),
+            model: "gpt-4o".to_string(),
+            labels: vec!["good".to_string(), "bad".to_string()],
+            passing_labels: vec!["good".to_string()],
+            input: vec![OpenAIModelGraderInput {
+                role: OpenAIRFTRole::User,
+                content: "label this".to_string(),
+            }],
+        };
+        let stored: StoredOpenAIGrader = original.clone().into();
+        let restored: OpenAIGrader = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_openai_grader_python_round_trip() {
+        let original = OpenAIGrader::Python {
+            name: "py-grader".to_string(),
+            source: "def grade(): return 1.0".to_string(),
+            image_tag: Some("latest".to_string()),
+        };
+        let stored: StoredOpenAIGrader = original.clone().into();
+        let restored: OpenAIGrader = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_openai_grader_multi_round_trip() {
+        let mut graders = HashMap::new();
+        graders.insert("a".to_string(), Box::new(sample_string_check_grader()));
+        graders.insert("b".to_string(), Box::new(sample_score_model_grader()));
+        let original = OpenAIGrader::Multi {
+            calculate_output: "a + b".to_string(),
+            graders,
+            name: "combined".to_string(),
+        };
+        let stored: StoredOpenAIGrader = original.clone().into();
+        let restored: OpenAIGrader = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_openai_rft_response_format_round_trip() {
+        let original = OpenAIRFTResponseFormat::JsonSchema {
+            json_schema: RFTJsonSchemaInfoOption::JsonSchema(JsonSchemaInfo {
+                name: "schema".to_string(),
+                description: Some("desc".to_string()),
+                schema: Some(serde_json::json!({"type": "object"})),
+                strict: true,
+            }),
+        };
+        let stored: StoredOpenAIRFTResponseFormat = original.clone().into();
+        let restored: OpenAIRFTResponseFormat = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_openai_rft_config_round_trip_full() {
+        let original = UninitializedOpenAIRFTConfig {
+            model: "gpt-4o-mini".to_string(),
+            grader: sample_string_check_grader(),
+            response_format: Some(OpenAIRFTResponseFormat::JsonSchema {
+                json_schema: RFTJsonSchemaInfoOption::JsonSchema(JsonSchemaInfo {
+                    name: "schema".to_string(),
+                    description: None,
+                    schema: Some(serde_json::json!({"type": "object"})),
+                    strict: true,
+                }),
+            }),
+            batch_size: Some(8),
+            compute_multiplier: Some(1.5),
+            eval_interval: Some(10),
+            eval_samples: Some(100),
+            learning_rate_multiplier: Some(0.5),
+            n_epochs: Some(3),
+            reasoning_effort: Some("low".to_string()),
+            seed: Some(42),
+            suffix: Some("rft-tune".to_string()),
+        };
+        let stored: StoredOpenAIRFTConfig = original.clone().into();
+        let restored: UninitializedOpenAIRFTConfig = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_openai_rft_config_round_trip_minimal() {
+        let original = UninitializedOpenAIRFTConfig {
+            model: "gpt-4o-mini".to_string(),
+            grader: sample_string_check_grader(),
+            response_format: None,
+            batch_size: None,
+            compute_multiplier: None,
+            eval_interval: None,
+            eval_samples: None,
+            learning_rate_multiplier: None,
+            n_epochs: None,
+            reasoning_effort: None,
+            seed: None,
+            suffix: None,
+        };
+        let stored: StoredOpenAIRFTConfig = original.clone().into();
+        let restored: UninitializedOpenAIRFTConfig = stored.into();
+        expect_that!(restored, eq(&original));
     }
 }

--- a/crates/tensorzero-core/src/optimization/openai_sft/mod.rs
+++ b/crates/tensorzero-core/src/optimization/openai_sft/mod.rs
@@ -55,6 +55,19 @@ impl From<tensorzero_stored_config::StoredOpenAISFTConfig> for UninitializedOpen
     }
 }
 
+impl From<UninitializedOpenAISFTConfig> for tensorzero_stored_config::StoredOpenAISFTConfig {
+    fn from(config: UninitializedOpenAISFTConfig) -> Self {
+        tensorzero_stored_config::StoredOpenAISFTConfig {
+            model: config.model,
+            batch_size: config.batch_size,
+            learning_rate_multiplier: config.learning_rate_multiplier,
+            n_epochs: config.n_epochs,
+            seed: config.seed,
+            suffix: config.suffix,
+        }
+    }
+}
+
 #[cfg(feature = "pyo3")]
 #[pymethods]
 impl UninitializedOpenAISFTConfig {
@@ -134,5 +147,42 @@ impl std::fmt::Display for OpenAISFTJobHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let json = serde_json::to_string_pretty(self).map_err(|_| std::fmt::Error)?;
         write!(f, "{json}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use googletest::prelude::*;
+    use tensorzero_stored_config::StoredOpenAISFTConfig;
+
+    #[gtest]
+    fn test_openai_sft_config_round_trip_full() {
+        let original = UninitializedOpenAISFTConfig {
+            model: "gpt-4o-mini".to_string(),
+            batch_size: Some(8),
+            learning_rate_multiplier: Some(0.5),
+            n_epochs: Some(3),
+            seed: Some(42),
+            suffix: Some("my-tune".to_string()),
+        };
+        let stored: StoredOpenAISFTConfig = original.clone().into();
+        let restored: UninitializedOpenAISFTConfig = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_openai_sft_config_round_trip_minimal() {
+        let original = UninitializedOpenAISFTConfig {
+            model: "gpt-4o-mini".to_string(),
+            batch_size: None,
+            learning_rate_multiplier: None,
+            n_epochs: None,
+            seed: None,
+            suffix: None,
+        };
+        let stored: StoredOpenAISFTConfig = original.clone().into();
+        let restored: UninitializedOpenAISFTConfig = stored.into();
+        expect_that!(restored, eq(&original));
     }
 }

--- a/crates/tensorzero-core/src/optimization/together_sft/mod.rs
+++ b/crates/tensorzero-core/src/optimization/together_sft/mod.rs
@@ -217,6 +217,61 @@ impl From<StoredTogetherTrainingMethod> for TogetherTrainingMethod {
     }
 }
 
+// --- Reverse conversions: core -> stored ---
+
+impl From<TogetherBatchSize> for StoredTogetherBatchSize {
+    fn from(batch_size: TogetherBatchSize) -> Self {
+        match batch_size {
+            TogetherBatchSize::Number(value) => Self::Number { value },
+            TogetherBatchSize::Description(TogetherBatchSizeDescription::Max) => Self::Max,
+        }
+    }
+}
+
+impl From<TogetherLRScheduler> for StoredTogetherLRScheduler {
+    fn from(scheduler: TogetherLRScheduler) -> Self {
+        match scheduler {
+            TogetherLRScheduler::Linear { min_lr_ratio } => Self::Linear {
+                min_lr_ratio: Some(min_lr_ratio),
+            },
+            TogetherLRScheduler::Cosine {
+                min_lr_ratio,
+                num_cycles,
+            } => Self::Cosine {
+                min_lr_ratio: Some(min_lr_ratio),
+                num_cycles: Some(num_cycles),
+            },
+        }
+    }
+}
+
+impl From<TogetherTrainingType> for StoredTogetherTrainingType {
+    fn from(training_type: TogetherTrainingType) -> Self {
+        match training_type {
+            TogetherTrainingType::Full {} => Self::Full,
+            TogetherTrainingType::Lora {
+                lora_r,
+                lora_alpha,
+                lora_dropout,
+                lora_trainable_modules,
+            } => Self::Lora {
+                lora_r,
+                lora_alpha,
+                lora_dropout,
+                lora_trainable_modules,
+            },
+        }
+    }
+}
+
+impl From<TogetherTrainingMethod> for StoredTogetherTrainingMethod {
+    fn from(method: TogetherTrainingMethod) -> Self {
+        match method {
+            TogetherTrainingMethod::Sft { train_on_inputs } => Self::Sft { train_on_inputs },
+        }
+    }
+}
+
 impl From<StoredTogetherOptimizerSFTConfig> for UninitializedTogetherSFTConfig {
     fn from(stored: StoredTogetherOptimizerSFTConfig) -> Self {
         UninitializedTogetherSFTConfig {
@@ -238,6 +293,31 @@ impl From<StoredTogetherOptimizerSFTConfig> for UninitializedTogetherSFTConfig {
             from_hf_model: stored.from_hf_model,
             hf_model_revision: stored.hf_model_revision,
             hf_output_repo_name: stored.hf_output_repo_name,
+        }
+    }
+}
+
+impl From<UninitializedTogetherSFTConfig> for StoredTogetherOptimizerSFTConfig {
+    fn from(config: UninitializedTogetherSFTConfig) -> Self {
+        StoredTogetherOptimizerSFTConfig {
+            model: config.model,
+            n_epochs: Some(config.n_epochs),
+            n_checkpoints: Some(config.n_checkpoints),
+            n_evals: config.n_evals,
+            batch_size: Some(config.batch_size.into()),
+            learning_rate: Some(config.learning_rate),
+            warmup_ratio: Some(config.warmup_ratio),
+            max_grad_norm: Some(config.max_grad_norm),
+            weight_decay: Some(config.weight_decay),
+            suffix: config.suffix,
+            lr_scheduler: Some(config.lr_scheduler.into()),
+            wandb_name: config.wandb_name,
+            training_method: Some(config.training_method.into()),
+            training_type: Some(config.training_type.into()),
+            from_checkpoint: config.from_checkpoint,
+            from_hf_model: config.from_hf_model,
+            hf_model_revision: config.hf_model_revision,
+            hf_output_repo_name: config.hf_output_repo_name,
         }
     }
 }
@@ -496,5 +576,125 @@ impl Default for TogetherTrainingMethod {
         Self::Sft {
             train_on_inputs: Some("auto".to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use googletest::prelude::*;
+
+    fn sample_full_config() -> UninitializedTogetherSFTConfig {
+        UninitializedTogetherSFTConfig {
+            model: "meta-llama/Llama-3-8b".to_string(),
+            n_epochs: 4,
+            n_checkpoints: 2,
+            n_evals: Some(3),
+            batch_size: TogetherBatchSize::Number(64),
+            learning_rate: 1e-5,
+            warmup_ratio: 0.05,
+            max_grad_norm: 1.0,
+            weight_decay: 0.01,
+            suffix: Some("my-suffix".to_string()),
+            lr_scheduler: TogetherLRScheduler::Cosine {
+                min_lr_ratio: 0.1,
+                num_cycles: 0.5,
+            },
+            wandb_name: Some("my-run".to_string()),
+            training_method: TogetherTrainingMethod::Sft {
+                train_on_inputs: Some("true".to_string()),
+            },
+            training_type: TogetherTrainingType::Lora {
+                lora_r: Some(8),
+                lora_alpha: Some(16),
+                lora_dropout: Some(0.0),
+                lora_trainable_modules: Some("all-linear".to_string()),
+            },
+            from_checkpoint: Some("ckpt-id".to_string()),
+            from_hf_model: Some("hf-model".to_string()),
+            hf_model_revision: Some("rev".to_string()),
+            hf_output_repo_name: Some("repo".to_string()),
+        }
+    }
+
+    #[gtest]
+    fn test_together_sft_config_round_trip_full() {
+        let original = sample_full_config();
+        let stored: StoredTogetherOptimizerSFTConfig = original.clone().into();
+        let restored: UninitializedTogetherSFTConfig = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_together_sft_config_round_trip_full_training() {
+        let mut original = sample_full_config();
+        original.training_type = TogetherTrainingType::Full {};
+        let stored: StoredTogetherOptimizerSFTConfig = original.clone().into();
+        let restored: UninitializedTogetherSFTConfig = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_together_sft_config_round_trip_linear_scheduler_max_batch() {
+        let mut original = sample_full_config();
+        original.lr_scheduler = TogetherLRScheduler::Linear { min_lr_ratio: 0.2 };
+        original.batch_size = TogetherBatchSize::Description(TogetherBatchSizeDescription::Max);
+        let stored: StoredTogetherOptimizerSFTConfig = original.clone().into();
+        let restored: UninitializedTogetherSFTConfig = stored.into();
+        expect_that!(restored, eq(&original));
+    }
+
+    #[gtest]
+    fn test_together_batch_size_round_trip() {
+        for original in [
+            TogetherBatchSize::Number(32),
+            TogetherBatchSize::Description(TogetherBatchSizeDescription::Max),
+        ] {
+            let stored: StoredTogetherBatchSize = original.clone().into();
+            let restored: TogetherBatchSize = stored.into();
+            expect_that!(restored, eq(&original));
+        }
+    }
+
+    #[gtest]
+    fn test_together_lr_scheduler_round_trip() {
+        for original in [
+            TogetherLRScheduler::Linear { min_lr_ratio: 0.0 },
+            TogetherLRScheduler::Cosine {
+                min_lr_ratio: 0.1,
+                num_cycles: 0.5,
+            },
+        ] {
+            let stored: StoredTogetherLRScheduler = original.clone().into();
+            let restored: TogetherLRScheduler = stored.into();
+            expect_that!(restored, eq(&original));
+        }
+    }
+
+    #[gtest]
+    fn test_together_training_type_round_trip() {
+        for original in [
+            TogetherTrainingType::Full {},
+            TogetherTrainingType::Lora {
+                lora_r: Some(4),
+                lora_alpha: Some(8),
+                lora_dropout: Some(0.1),
+                lora_trainable_modules: Some("all-linear".to_string()),
+            },
+        ] {
+            let stored: StoredTogetherTrainingType = original.clone().into();
+            let restored: TogetherTrainingType = stored.into();
+            expect_that!(restored, eq(&original));
+        }
+    }
+
+    #[gtest]
+    fn test_together_training_method_round_trip() {
+        let original = TogetherTrainingMethod::Sft {
+            train_on_inputs: Some("auto".to_string()),
+        };
+        let stored: StoredTogetherTrainingMethod = original.clone().into();
+        let restored: TogetherTrainingMethod = stored.into();
+        expect_that!(restored, eq(&original));
     }
 }

--- a/crates/tensorzero-core/src/rate_limiting/mod.rs
+++ b/crates/tensorzero-core/src/rate_limiting/mod.rs
@@ -6,16 +6,17 @@ use std::sync::Arc;
 
 use axum::Extension;
 use serde::{Deserialize, Serialize};
-use tensorzero_stored_config::{
-    StoredRateLimitInterval, StoredRateLimitResource, StoredRateLimitingBackend,
-    StoredRateLimitingConfig,
-};
 use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::db::{ConsumeTicketsReceipt, ConsumeTicketsRequest, ReturnTicketsRequest};
 use crate::error::{Error, ErrorDetails, IMPOSSIBLE_ERROR_MESSAGE};
 use tensorzero_auth::middleware::RequestApiKeyExtension;
+#[cfg(test)]
+use tensorzero_stored_config::StoredRateLimitResource;
+use tensorzero_stored_config::{
+    StoredRateLimitInterval, StoredRateLimitingBackend, StoredRateLimitingConfig,
+};
 
 pub use tensorzero_error::rate_limiting_types::*;
 
@@ -165,32 +166,49 @@ impl Default for RateLimitingConfig {
     }
 }
 
-// These would ideally be `From` impls, but the orphan rule prevents it since both
-// types are defined in other crates (`tensorzero-error` and `tensorzero-stored-config`).
-fn convert_resource(stored: StoredRateLimitResource) -> RateLimitResource {
-    match stored {
-        StoredRateLimitResource::ModelInference => RateLimitResource::ModelInference,
-        StoredRateLimitResource::Token => RateLimitResource::Token,
-        StoredRateLimitResource::Cost => RateLimitResource::Cost,
+impl From<StoredRateLimitingBackend> for RateLimitingBackend {
+    fn from(stored: StoredRateLimitingBackend) -> Self {
+        match stored {
+            StoredRateLimitingBackend::Auto => RateLimitingBackend::Auto,
+            StoredRateLimitingBackend::Postgres => RateLimitingBackend::Postgres,
+            StoredRateLimitingBackend::Valkey => RateLimitingBackend::Valkey,
+        }
     }
 }
 
-fn convert_interval(stored: StoredRateLimitInterval) -> RateLimitInterval {
-    match stored {
-        StoredRateLimitInterval::Second => RateLimitInterval::Second,
-        StoredRateLimitInterval::Minute => RateLimitInterval::Minute,
-        StoredRateLimitInterval::Hour => RateLimitInterval::Hour,
-        StoredRateLimitInterval::Day => RateLimitInterval::Day,
-        StoredRateLimitInterval::Week => RateLimitInterval::Week,
-        StoredRateLimitInterval::Month => RateLimitInterval::Month,
+impl From<RateLimitingBackend> for StoredRateLimitingBackend {
+    fn from(backend: RateLimitingBackend) -> Self {
+        match backend {
+            RateLimitingBackend::Auto => Self::Auto,
+            RateLimitingBackend::Postgres => Self::Postgres,
+            RateLimitingBackend::Valkey => Self::Valkey,
+        }
     }
 }
 
-fn convert_backend(stored: StoredRateLimitingBackend) -> RateLimitingBackend {
-    match stored {
-        StoredRateLimitingBackend::Auto => RateLimitingBackend::Auto,
-        StoredRateLimitingBackend::Postgres => RateLimitingBackend::Postgres,
-        StoredRateLimitingBackend::Valkey => RateLimitingBackend::Valkey,
+impl From<StoredRateLimitInterval> for RateLimitInterval {
+    fn from(stored: StoredRateLimitInterval) -> Self {
+        match stored {
+            StoredRateLimitInterval::Second => RateLimitInterval::Second,
+            StoredRateLimitInterval::Minute => RateLimitInterval::Minute,
+            StoredRateLimitInterval::Hour => RateLimitInterval::Hour,
+            StoredRateLimitInterval::Day => RateLimitInterval::Day,
+            StoredRateLimitInterval::Week => RateLimitInterval::Week,
+            StoredRateLimitInterval::Month => RateLimitInterval::Month,
+        }
+    }
+}
+
+impl From<RateLimitInterval> for StoredRateLimitInterval {
+    fn from(interval: RateLimitInterval) -> Self {
+        match interval {
+            RateLimitInterval::Second => Self::Second,
+            RateLimitInterval::Minute => Self::Minute,
+            RateLimitInterval::Hour => Self::Hour,
+            RateLimitInterval::Day => Self::Day,
+            RateLimitInterval::Week => Self::Week,
+            RateLimitInterval::Month => Self::Month,
+        }
     }
 }
 
@@ -208,8 +226,8 @@ impl TryFrom<StoredRateLimitingConfig> for UninitializedRateLimitingConfig {
                     .into_iter()
                     .map(|limit| {
                         Ok(Arc::new(RateLimit {
-                            resource: convert_resource(limit.resource),
-                            interval: convert_interval(limit.interval),
+                            resource: limit.resource.into(),
+                            interval: limit.interval.into(),
                             capacity: limit.capacity,
                             refill_rate: limit.refill_rate,
                         }))
@@ -232,7 +250,7 @@ impl TryFrom<StoredRateLimitingConfig> for UninitializedRateLimitingConfig {
                 })
             })
             .collect::<Result<Vec<_>, Error>>()?;
-        let backend = stored.backend.map(convert_backend);
+        let backend = stored.backend.map(Into::into);
         Ok(UninitializedRateLimitingConfig {
             rules: Some(rules),
             enabled: stored.enabled,
@@ -241,7 +259,6 @@ impl TryFrom<StoredRateLimitingConfig> for UninitializedRateLimitingConfig {
         })
     }
 }
-
 // Utility struct to pass in at "check time"
 // This should contain the information about the current request
 // needed to determine if a rate limit is exceeded.
@@ -817,8 +834,11 @@ pub fn get_estimated_tokens(text: &str) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::collections::HashMap;
+
+    use googletest::{expect_that, gtest, matchers::eq};
+
+    use super::*;
 
     #[test]
     fn test_rate_limiting_config_scope_get_key_if_matches_tag_concrete_match() {
@@ -2301,5 +2321,49 @@ mod tests {
             0,
             "$0.00 should be 0 nano-dollars"
         );
+    }
+
+    // ─── Stored conversion round-trip tests ──────────────────────────────
+
+    #[gtest]
+    fn test_rate_limit_backend_round_trip() {
+        for variant in [
+            RateLimitingBackend::Auto,
+            RateLimitingBackend::Postgres,
+            RateLimitingBackend::Valkey,
+        ] {
+            let stored: StoredRateLimitingBackend = variant.into();
+            let restored: RateLimitingBackend = stored.into();
+            expect_that!(restored, eq(variant));
+        }
+    }
+
+    #[gtest]
+    fn test_rate_limit_resource_round_trip() {
+        for variant in [
+            RateLimitResource::ModelInference,
+            RateLimitResource::Token,
+            RateLimitResource::Cost,
+        ] {
+            let stored: StoredRateLimitResource = variant.into();
+            let restored: RateLimitResource = stored.into();
+            expect_that!(restored, eq(variant));
+        }
+    }
+
+    #[gtest]
+    fn test_rate_limit_interval_round_trip() {
+        for variant in [
+            RateLimitInterval::Second,
+            RateLimitInterval::Minute,
+            RateLimitInterval::Hour,
+            RateLimitInterval::Day,
+            RateLimitInterval::Week,
+            RateLimitInterval::Month,
+        ] {
+            let stored: StoredRateLimitInterval = variant.into();
+            let restored: RateLimitInterval = stored.into();
+            expect_that!(restored, eq(variant));
+        }
     }
 }

--- a/crates/tensorzero-core/src/utils/retries.rs
+++ b/crates/tensorzero-core/src/utils/retries.rs
@@ -115,3 +115,20 @@ impl From<StoredRetryConfig> for RetryConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use googletest::prelude::*;
+
+    #[gtest]
+    fn test_retry_config_round_trip() {
+        let original = RetryConfig {
+            num_retries: 3,
+            max_delay_s: 10.0,
+        };
+        let stored: StoredRetryConfig = original.into();
+        let restored: RetryConfig = stored.into();
+        expect_that!(restored, eq(original));
+    }
+}

--- a/crates/tensorzero-stored-config/Cargo.toml
+++ b/crates/tensorzero-stored-config/Cargo.toml
@@ -12,6 +12,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
 sqlx = { workspace = true }
+tensorzero-error = { path = "../tensorzero-error" }
 tensorzero-types = { path = "../tensorzero-types" }
 uuid.workspace = true
 

--- a/crates/tensorzero-stored-config/src/lib.rs
+++ b/crates/tensorzero-stored-config/src/lib.rs
@@ -89,8 +89,8 @@ pub use stored_provider_types_config::{
     StoredTogetherProviderTypeConfig,
 };
 pub use stored_rate_limiting_config::{
-    StoredRateLimitInterval, StoredRateLimitResource, StoredRateLimitingBackend,
-    StoredRateLimitingConfig,
+    StoredRateLimit, StoredRateLimitInterval, StoredRateLimitResource, StoredRateLimitingBackend,
+    StoredRateLimitingConfig, StoredRateLimitingRule,
 };
 pub use stored_storage_kind::StoredStorageKind;
 pub use stored_tool_config::StoredToolConfig;

--- a/crates/tensorzero-stored-config/src/stored_cost.rs
+++ b/crates/tensorzero-stored-config/src/stored_cost.rs
@@ -12,6 +12,24 @@ pub struct StoredCostConfig {
     pub entries: Vec<StoredCostConfigEntry>,
 }
 
+impl From<&UninitializedCostConfig> for StoredCostConfig {
+    fn from(config: &UninitializedCostConfig) -> Self {
+        StoredCostConfig {
+            entries: config
+                .iter()
+                .map(|entry| StoredCostConfigEntry {
+                    pointer: entry.pointer.pointer.clone(),
+                    pointer_nonstreaming: entry.pointer.pointer_nonstreaming.clone(),
+                    pointer_streaming: entry.pointer.pointer_streaming.clone(),
+                    cost_per_million: entry.rate.cost_per_million,
+                    cost_per_unit: entry.rate.cost_per_unit,
+                    required: Some(entry.required),
+                })
+                .collect(),
+        }
+    }
+}
+
 impl From<StoredCostConfig> for UninitializedCostConfig {
     fn from(stored: StoredCostConfig) -> Self {
         stored
@@ -51,6 +69,22 @@ pub struct StoredCostConfigEntry {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StoredUnifiedCostConfig {
     pub entries: Vec<StoredUnifiedCostConfigEntry>,
+}
+
+impl From<&UninitializedUnifiedCostConfig> for StoredUnifiedCostConfig {
+    fn from(config: &UninitializedUnifiedCostConfig) -> Self {
+        StoredUnifiedCostConfig {
+            entries: config
+                .iter()
+                .map(|entry| StoredUnifiedCostConfigEntry {
+                    pointer: entry.pointer.pointer.clone(),
+                    cost_per_million: entry.rate.cost_per_million,
+                    cost_per_unit: entry.rate.cost_per_unit,
+                    required: Some(entry.required),
+                })
+                .collect(),
+        }
+    }
 }
 
 impl From<StoredUnifiedCostConfig> for UninitializedUnifiedCostConfig {

--- a/crates/tensorzero-stored-config/src/stored_model_config.rs
+++ b/crates/tensorzero-stored-config/src/stored_model_config.rs
@@ -159,6 +159,11 @@ pub enum StoredProviderConfig {
         model_name: String,
         api_key_location: Option<StoredCredentialLocationWithFallback>,
     },
+    #[cfg(any(test, feature = "e2e_tests"))]
+    Dummy {
+        model_name: String,
+        api_key_location: Option<Value>,
+    },
 }
 
 // --- Stored versions of core-private types ---

--- a/crates/tensorzero-stored-config/src/stored_optimizer_info.rs
+++ b/crates/tensorzero-stored-config/src/stored_optimizer_info.rs
@@ -212,7 +212,8 @@ pub struct StoredGCPVertexGeminiOptimizerSFTConfig {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StoredGEPAConfig {
     pub function_name: String,
-    pub evaluation_name: String,
+    pub evaluation_name: Option<String>,
+    pub evaluator_names: Option<Vec<String>>,
     pub initial_variants: Option<Vec<String>>,
     pub variant_prefix: Option<String>,
     pub batch_size: Option<usize>,

--- a/crates/tensorzero-stored-config/src/stored_rate_limiting_config.rs
+++ b/crates/tensorzero-stored-config/src/stored_rate_limiting_config.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use tensorzero_error::rate_limiting_types::RateLimitResource;
 
 #[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -39,6 +40,29 @@ pub enum StoredRateLimitResource {
     ModelInference,
     Token,
     Cost,
+}
+
+// `RateLimitResource` lives in `tensorzero-error`, and `StoredRateLimitResource`
+// lives here, so this `From` impl has to live in this crate to satisfy the
+// orphan rule.
+impl From<StoredRateLimitResource> for RateLimitResource {
+    fn from(stored: StoredRateLimitResource) -> Self {
+        match stored {
+            StoredRateLimitResource::ModelInference => RateLimitResource::ModelInference,
+            StoredRateLimitResource::Token => RateLimitResource::Token,
+            StoredRateLimitResource::Cost => RateLimitResource::Cost,
+        }
+    }
+}
+
+impl From<RateLimitResource> for StoredRateLimitResource {
+    fn from(resource: RateLimitResource) -> Self {
+        match resource {
+            RateLimitResource::ModelInference => Self::ModelInference,
+            RateLimitResource::Token => Self::Token,
+            RateLimitResource::Cost => Self::Cost,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
Unfortunately this is mostly boilerplate, but we need this bidirectional to be lossless: we can write UninitializedConfig as StoredConfig (during initial storage and UI-driven editing), and we need to read StoredConfig into UninitializedConfig for normal config-in-db gateway operations.

This PR adds conversion and thorough tests.

#7128

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many config serialization paths (core ↔ stored) including model/provider, gateway, optimizer, and rate-limiting types; mistakes could cause lossy DB config persistence or incompatibility when reading existing stored configs. Mostly additive/boilerplate with extensive new round-trip tests to mitigate regressions.
> 
> **Overview**
> Adds **bidirectional, lossless conversions** between in-memory `Uninitialized*` config types and their `tensorzero-stored-config` representations across gateway config, model/provider config (incl. extra headers/body, timeouts, cost), embeddings config, provider type defaults, rate limiting, and multiple optimizer configs.
> 
> Updates stored schemas/exports where needed (e.g., GEPA stored config now supports optional `evaluation_name` plus `evaluator_names`, stored rate-limiting re-exports `StoredRateLimit`/`StoredRateLimitingRule`, and `tensorzero-stored-config` now depends on `tensorzero-error` for `RateLimitResource` conversions), and adds extensive **round-trip tests** to verify encode/decode preserves all variants and fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddde8c2724ff64e857f690690f83a3724b92f595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->