### PR TITLE
Explicily name all variants in non_control_tool_error_to_task_error

### DIFF
--- a/crates/durable-tools/src/error.rs
+++ b/crates/durable-tools/src/error.rs
@@ -172,8 +172,17 @@ pub fn non_control_tool_error_to_task_error(err: NonControlToolError) -> TaskErr
         NonControlToolError::TaskPanicked { message } => {
             NonControlTaskError::TaskPanicked { message }.into()
         }
-        // For all other variants, use the Serialize impl to generate error_data
-        other => {
+        // For remaining variants, use the Serialize impl to generate error_data
+        other @ (NonControlToolError::ToolNotFound { .. }
+        | NonControlToolError::DuplicateToolName { .. }
+        | NonControlToolError::InvalidParams { .. }
+        | NonControlToolError::SchemaGeneration { .. }
+        | NonControlToolError::Internal { .. }
+        | NonControlToolError::InvalidConfiguration { .. }
+        | NonControlToolError::ReservedHeaderPrefix { .. }
+        | NonControlToolError::InvalidEventName { .. }
+        | NonControlToolError::SubtaskSpawnFailed { .. }
+        | NonControlToolError::EmitEventFailed { .. }) => {
             let error_data = serde_json::to_value(&other).unwrap_or_else(|e| {
                 serde_json::json!({
                     "kind": "error_serialization_failed",


### PR DESCRIPTION
Fixes https://github.com/tensorzero/tensorzero/issues/7148

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk refactor to make `non_control_tool_error_to_task_error` explicitly enumerate the variants routed through the generic serialization path, improving exhaustiveness without changing behavior.
> 
> **Overview**
> Updates `non_control_tool_error_to_task_error` to replace the catch-all `other => ...` arm with an explicit match over the remaining `NonControlToolError` variants that are converted into a `User` `TaskError` via `serde_json` serialization.
> 
> This makes the conversion logic *exhaustive-by-construction* so newly added `NonControlToolError` variants won’t silently fall into the generic path without being deliberately handled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e541f6891624c47b94d474cd8224e3eada7020c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->