### PR TITLE
Add 'ReadOnlyRequireHit' mode to provider-proxy

### DIFF
--- a/crates/provider-proxy/src/lib.rs
+++ b/crates/provider-proxy/src/lib.rs
@@ -246,7 +246,7 @@ async fn check_cache<
     let mut file_mtime = None;
 
     let mut use_cache = || match args.mode {
-        CacheMode::ReadOnly => Ok::<_, anyhow::Error>(true),
+        CacheMode::ReadOnly | CacheMode::ReadOnlyRequireHit => Ok::<_, anyhow::Error>(true),
         CacheMode::ReadWrite => Ok(true),
         CacheMode::ReadOldWriteNew => {
             let current_file_mtime = std::fs::metadata(&path)
@@ -306,6 +306,18 @@ async fn check_cache<
             "Cache miss: {}",
             path_str,
         );
+        if matches!(args.mode, CacheMode::ReadOnlyRequireHit) {
+            tracing::error!("Cache miss in ReadOnlyRequireHit mode: {path_str}");
+            let body = Full::new(Bytes::from(format!(
+                "provider-proxy: Cache miss in ReadOnlyRequireHit mode: {path_str}"
+            )));
+            let mut resp = http::Response::builder()
+                .status(http::StatusCode::BAD_GATEWAY)
+                .body(BoxBody::new(body.map_err(|e| match e {})))
+                .with_context(|| "Failed to build response")?;
+            resp.headers_mut().insert(CACHE_HEADER_NAME, HEADER_FALSE);
+            return Ok(resp);
+        }
         let response = match missing().await {
             Ok(response) => response,
             Err(e) => {
@@ -327,7 +339,7 @@ async fn check_cache<
             hyper_response.extensions_mut().clear();
 
             let write = match args.mode {
-                CacheMode::ReadOnly => false,
+                CacheMode::ReadOnly | CacheMode::ReadOnlyRequireHit => false,
                 CacheMode::ReadWrite => true,
                 CacheMode::ReadOldWriteNew => true,
             };
@@ -376,8 +388,10 @@ async fn check_cache<
 
 #[derive(ValueEnum, Clone, Debug)]
 pub enum CacheMode {
-    /// Only read from the cache, never write to it.
+    /// Only read from the cache, never write to it. Misses are proxied, but the response is not cached.
     ReadOnly,
+    /// Only read from the cache, never write to it. If a cache miss occurs, return a 502 Bad Gateway error.
+    ReadOnlyRequireHit,
     /// Read from the cache, and write to it when a cache miss occurs.
     ReadWrite,
     /// Read entries from the cache that were created before the provider-proxy start time.

--- a/crates/provider-proxy/tests/e2e/tests.rs
+++ b/crates/provider-proxy/tests/e2e/tests.rs
@@ -511,6 +511,142 @@ async fn test_dropped_stream_body() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_read_only_require_hit() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    // Phase 1: Populate the cache using a ReadWrite proxy
+    let (server_started_tx, server_started_rx) = oneshot::channel();
+    // We don't care about shutdown handling in this test
+    #[expect(clippy::disallowed_methods)]
+    let _proxy_handle = tokio::spawn(run_server(
+        Args {
+            cache_path: temp_dir.path().to_path_buf(),
+            port: 0,
+            sanitize_traceparent: true,
+            sanitize_bearer_auth: true,
+            sanitize_aws_sigv4: true,
+            health_port: 0,
+            sanitize_model_headers: true,
+            remove_user_agent_non_amazon: false,
+            mode: CacheMode::ReadWrite,
+            save_request_body: true,
+        },
+        server_started_tx,
+    ));
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let shutdown_fut = async {
+        shutdown_rx.await.unwrap();
+    };
+
+    let (target_server_addr, target_server_handle) = start_target_server(shutdown_fut).await;
+
+    let proxy_addr = server_started_rx.await.unwrap();
+
+    let client = reqwest::Client::builder()
+        .proxy(reqwest::Proxy::all(format!("http://{proxy_addr}")).unwrap())
+        .danger_accept_invalid_certs(true)
+        .build()
+        .unwrap();
+
+    let request_body = r#"{"test": "read_only_require_hit"}"#;
+    let first_response = client
+        .post(format!("http://{target_server_addr}/timestamp-good"))
+        .body(request_body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(first_response.status(), 200);
+    let cached = first_response
+        .headers()
+        .get("x-tensorzero-provider-proxy-cache")
+        .unwrap();
+    assert_eq!(cached, "false");
+    let first_response_body = first_response.text().await.unwrap();
+
+    // Wait for the cache file to be written to disk
+    loop {
+        let temp_path = temp_dir.path().to_path_buf();
+        let found = tokio::task::spawn_blocking(move || {
+            std::fs::read_dir(temp_path)
+                .unwrap()
+                .any(|f| f.unwrap().path().to_string_lossy().contains("127.0.0.1"))
+        })
+        .await
+        .unwrap();
+        if found {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    // Phase 2: Start a ReadOnlyRequireHit proxy with the same cache directory
+    let (server_started_tx, server_started_rx) = oneshot::channel();
+    // We don't care about shutdown handling in this test
+    #[expect(clippy::disallowed_methods)]
+    let _proxy_handle2 = tokio::spawn(run_server(
+        Args {
+            cache_path: temp_dir.path().to_path_buf(),
+            port: 0,
+            sanitize_traceparent: true,
+            sanitize_bearer_auth: true,
+            sanitize_aws_sigv4: true,
+            health_port: 0,
+            sanitize_model_headers: true,
+            remove_user_agent_non_amazon: false,
+            mode: CacheMode::ReadOnlyRequireHit,
+            save_request_body: true,
+        },
+        server_started_tx,
+    ));
+
+    let proxy_addr2 = server_started_rx.await.unwrap();
+
+    let client2 = reqwest::Client::builder()
+        .proxy(reqwest::Proxy::all(format!("http://{proxy_addr2}")).unwrap())
+        .danger_accept_invalid_certs(true)
+        .build()
+        .unwrap();
+
+    // A request that hits the cache should succeed
+    let hit_response = client2
+        .post(format!("http://{target_server_addr}/timestamp-good"))
+        .body(request_body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(hit_response.status(), 200);
+    let cached = hit_response
+        .headers()
+        .get("x-tensorzero-provider-proxy-cache")
+        .unwrap();
+    assert_eq!(cached, "true");
+    let hit_response_body = hit_response.text().await.unwrap();
+    assert_eq!(first_response_body, hit_response_body);
+
+    // A request to a fixed dummy address that misses the cache should return a 502.
+    // We use a fixed address so the hash (and thus the error message) is deterministic.
+    let miss_response = client2
+        .post("http://127.0.0.1:99/timestamp-good")
+        .body(r#"{"test": "different body causes cache miss"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(miss_response.status(), 502);
+    let miss_body = miss_response.text().await.unwrap();
+    let temp_dir_str = temp_dir.path().to_string_lossy();
+    assert_eq!(
+        miss_body,
+        format!(
+            "provider-proxy: Cache miss in ReadOnlyRequireHit mode: {temp_dir_str}/127.0.0.1-956f127f4ff98a5480c095dba545cef89dda20a6a3f4b9fd147abdee5d7db4ff"
+        )
+    );
+
+    shutdown_tx.send(()).unwrap();
+    target_server_handle.await.unwrap().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_stream_body() {
     let (server_started_tx, server_started_rx) = oneshot::channel();
 


### PR DESCRIPTION
We can use this to test (and later enforce) that e2e tests don't make any uncached requests when run with a populated provider-proxy cache

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk and largely additive: introduces a new cache mode that only changes behavior when explicitly selected, returning a 502 on cache misses instead of proxying through.
> 
> **Overview**
> Adds a new `CacheMode::ReadOnlyRequireHit` to `provider-proxy` that **requires** a cache hit: on a miss it now returns `502 Bad Gateway` with a deterministic error body and `x-tensorzero-provider-proxy-cache: false`, and it is treated as read-only (no cache writes).
> 
> Extends the e2e suite with a two-phase test that first populates the cache in `ReadWrite` mode, then verifies cache hits succeed and cache misses fail in `ReadOnlyRequireHit` mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a124d5ae3668025e50b5240e4067e71c6681c18d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->