### PR TITLE
Add postgres advisory lock to write_stored_config

### DIFF
--- a/crates/tensorzero-core/src/db/postgres/stored_config_writes.rs
+++ b/crates/tensorzero-core/src/db/postgres/stored_config_writes.rs
@@ -61,6 +61,16 @@ async fn write_stored_config_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     params: WriteStoredConfigParams<'_>,
 ) -> Result<(), Error> {
+    // Acquire a single global advisory lock to serialize concurrent
+    // whole-config writes. This mirrors the per-function advisory lock in
+    // `write_function_config_in_tx`, and prevents two whole-config writes
+    // from interleaving across the many tables this function touches. The
+    // per-function lock is still acquired separately inside
+    // `write_function_config_in_tx`, so a whole-config write will also
+    // conflict with concurrent single-function writes for any function it
+    // touches.
+    acquire_stored_config_advisory_lock(tx).await?;
+
     // Exhaustive destructure so the compiler forces us to handle every field
     // when new ones are added to `WriteStoredConfigParams`.
     let WriteStoredConfigParams {
@@ -284,6 +294,42 @@ async fn write_stored_config_in_tx(
         .await?;
     }
 
+    Ok(())
+}
+
+// ── Advisory lock ─────────────────────────────────────────────────────────────
+
+/// Fixed advisory-lock key for whole-config writes. Derived once from the
+/// BLAKE3 hash of `"tensorzero::stored_config::global"` (first 8 bytes
+/// interpreted as a little-endian `i64`). Using a single fixed key means
+/// every whole-config writer agrees on the same lock.
+static STORED_CONFIG_ADVISORY_LOCK_KEY: std::sync::LazyLock<i64> = std::sync::LazyLock::new(|| {
+    // BLAKE3 output is always 32 bytes; read the first 8 as a little-endian i64.
+    let hash = blake3::hash(b"tensorzero::stored_config::global");
+    let bytes: [u8; 8] = hash.as_bytes()[..8].try_into().unwrap_or([0u8; 8]);
+    i64::from_le_bytes(bytes)
+});
+
+/// Acquires a transaction-level exclusive advisory lock that serializes all
+/// concurrent whole-config writes. The lock is released automatically when
+/// the transaction ends.
+async fn acquire_stored_config_advisory_lock(
+    tx: &mut Transaction<'_, Postgres>,
+) -> Result<(), Error> {
+    let acquired: bool = sqlx::query_scalar("SELECT pg_try_advisory_xact_lock($1)")
+        .bind(*STORED_CONFIG_ADVISORY_LOCK_KEY)
+        .fetch_one(&mut **tx)
+        .await
+        .map_err(|e| {
+            postgres_query_error("Failed to acquire advisory lock for stored config", e)
+        })?;
+    if !acquired {
+        return Err(Error::new(ErrorDetails::PostgresQuery {
+            message:
+                "Failed to lock stored config for update; another client is writing the config. Please retry."
+                    .to_string(),
+        }));
+    }
     Ok(())
 }
 

--- a/crates/tensorzero-core/tests/e2e/db/postgres/stored_configs/write_config.rs
+++ b/crates/tensorzero-core/tests/e2e/db/postgres/stored_configs/write_config.rs
@@ -747,3 +747,57 @@ async fn write_stored_config_round_trips_via_load_config_from_db(pool: PgPool) {
         some(eq(&tool))
     );
 }
+
+// ── Tests: advisory lock ──────────────────────────────────────────────────────
+
+/// `write_stored_config` should fail with a clear error if another client is
+/// holding the global stored-config advisory lock. This verifies that the
+/// lock acquisition path in `write_stored_config_in_tx` actually serializes
+/// concurrent writers via `pg_try_advisory_xact_lock`.
+#[sqlx::test(migrator = "tensorzero_stored_config::postgres::MIGRATOR")]
+async fn write_stored_config_fails_when_advisory_lock_held(pool: PgPool) {
+    let postgres = PostgresConnectionInfo::new_with_pool(pool.clone());
+
+    // Reproduce the lock key: BLAKE3 hash of `tensorzero::stored_config::global`,
+    // first 8 bytes as little-endian i64.
+    let hash = blake3::hash(b"tensorzero::stored_config::global");
+    let lock_key_bytes: [u8; 8] = hash.as_bytes()[..8]
+        .try_into()
+        .expect("BLAKE3 output is always 32 bytes");
+    let lock_key = i64::from_le_bytes(lock_key_bytes);
+
+    // Hold the lock from a separate transaction on a separate connection.
+    let mut blocking_tx = pool
+        .begin()
+        .await
+        .expect("blocking transaction should start");
+    let acquired: bool = sqlx::query_scalar("SELECT pg_try_advisory_xact_lock($1)")
+        .bind(lock_key)
+        .fetch_one(&mut *blocking_tx)
+        .await
+        .expect("blocking lock acquisition should succeed");
+    assert_that!(acquired, eq(true));
+
+    // While the lock is held elsewhere, the writer should fail fast rather
+    // than block (we use `pg_try_advisory_xact_lock`).
+    let config = UninitializedConfig::default();
+    let err = postgres
+        .write_stored_config(default_write_params(&config))
+        .await
+        .expect_err("write should fail while another client holds the lock");
+    assert_that!(
+        format!("{err}"),
+        contains_substring("another client is writing the config")
+    );
+
+    // Releasing the lock (by ending the blocking transaction) should let a
+    // subsequent write succeed.
+    blocking_tx
+        .rollback()
+        .await
+        .expect("rollback should release the advisory lock");
+    postgres
+        .write_stored_config(default_write_params(&config))
+        .await
+        .expect("write should succeed once the lock is released");
+}


### PR DESCRIPTION
Mirrors the per-function advisory lock used by write_function_config_in_tx so that concurrent whole-config writes are serialized via a single fixed key derived from BLAKE3("tensorzero::stored_config::global"). The per-function lock is still acquired separately inside write_function_config_in_tx, so a whole-config write also conflicts with concurrent single-function writes for any function it touches.

Adds an e2e test that holds the advisory lock from a separate connection and verifies write_stored_config fails fast with a clear error message, and succeeds again once the lock is released.

Fixes #7213