### PR TITLE
Skip heavy CI checks in `for-agents/`

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -49,12 +49,14 @@ jobs:
               - '!**/README.md'
               - '!docs/**'
               - '!examples/**'
+              - '!for-agents/**'
               - '!recipes/**'
               - '!ui/**'
             code:
               - '**'
               - '!**/README.md'
               - '!docs/**'
+              - '!for-agents/**'
             docs:
               - 'docs/**'
             live-tests:
@@ -62,6 +64,7 @@ jobs:
               - '!**/README.md'
               - '!docs/**'
               - '!examples/**'
+              - '!for-agents/**'
               - '!recipes/**'
               - '!ui/**'
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it could reduce coverage by skipping tests when `for-agents/` edits actually impact code or clients.
> 
> **Overview**
> Updates `.github/workflows/general.yml` change detection to *exclude* `for-agents/**` from the `code`, `client-tests`, and `live-tests` filters, so PRs that only touch that directory won’t run the heavier CI jobs tied to those outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df57622da57292d0207578c3d791544ada5e56c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->