### PR TITLE
Add config-in-database live-tests workflow and config editing e2e tests

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1407,6 +1407,23 @@ jobs:
     uses: ./.github/workflows/live-tests.yml
     secrets: inherit
 
+  live-tests-config-in-database:
+    if: ${{ needs.detect-changes.outputs.live-tests == 'true' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')) }}
+    needs:
+      [
+        detect-changes,
+        build-gateway-container,
+        build-gateway-e2e-container,
+        build-fixtures-container,
+        build-provider-proxy-container,
+        build-live-tests-container,
+      ]
+    permissions:
+      contents: read
+      actions: read
+    uses: ./.github/workflows/live-tests-config-in-database.yml
+    secrets: inherit
+
   inference-cache-tests:
     if: ${{ needs.detect-changes.outputs.code == 'true' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')) }}
     needs:
@@ -1547,6 +1564,7 @@ jobs:
         inference-cache-tests,
         lint-rust,
         live-tests,
+        live-tests-config-in-database,
         k3d,
         mock-optimization-tests,
         mocked-batch-tests,

--- a/.github/workflows/live-tests-config-in-database.yml
+++ b/.github/workflows/live-tests-config-in-database.yml
@@ -1,0 +1,159 @@
+name: Live Tests (Config in Database)
+
+on:
+  workflow_call:
+
+env:
+  CARGO_INCREMENTAL: 0
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+  AWS_REGION: "us-east-1"
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AZURE_API_KEY: ${{ secrets.AZURE_API_KEY_NEW }}
+  DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+  FIREWORKS_ACCOUNT_ID: ${{ secrets.FIREWORKS_ACCOUNT_ID }}
+  FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+  FORCE_COLOR: 1
+  GCP_STORAGE_ACCESS_KEY_ID: ${{ secrets.GCP_STORAGE_ACCESS_KEY_ID }}
+  GCP_STORAGE_SECRET_ACCESS_KEY: ${{ secrets.GCP_STORAGE_SECRET_ACCESS_KEY }}
+  GCP_VERTEX_CREDENTIALS_PATH: ${{ github.workspace }}/gcp_jwt_key.json
+  GOOGLE_AI_STUDIO_API_KEY: ${{ secrets.GOOGLE_AI_STUDIO_API_KEY }}
+  GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/gcp_jwt_key.json
+  GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+  HYPERBOLIC_API_KEY: ${{secrets.HYPERBOLIC_API_KEY}}
+  MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+  MODAL_KEY: ${{ secrets.MODAL_KEY }}
+  MODAL_SECRET: ${{ secrets.MODAL_SECRET }}
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+  R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+  R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+  SGLANG_API_KEY: ${{ secrets.SGLANG_API_KEY }}
+  TGI_API_KEY: ${{ secrets.TGI_API_KEY }}
+  TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
+  VLLM_API_BASE: ${{ secrets.VLLM_API_BASE }}
+  VLLM_API_KEY: ${{ secrets.VLLM_API_KEY }}
+  VLLM_MODEL_NAME: "microsoft/Phi-3.5-mini-instruct"
+  VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
+  XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+  OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: https://localhost:4316
+  SQLX_OFFLINE: 1
+  TENSORZERO_E2E_PROXY: http://localhost:3003
+  TENSORZERO_COMMIT_TAG: sha-${{ github.sha }}
+  TENSORZERO_GATEWAY_TAG: sha-${{ github.sha }}
+  TENSORZERO_MOCK_PROVIDER_API_TAG: sha-${{ github.sha }}
+  TENSORZERO_CI: 1
+  CARGO_NEXTEST_FLAKY_TESTS: ${{ vars.CARGO_NEXTEST_FLAKY_TESTS }}
+  # Force Postgres as the primary datastore — the config-in-database feature
+  # only supports Postgres.
+  TENSORZERO_INTERNAL_TEST_OBSERVABILITY_BACKEND: postgres
+  # Two compose files are merged: the standard live setup plus the override
+  # that swaps the gateway onto the config-in-database boot path.
+  COMPOSE_FILES: "-f crates/tensorzero-core/tests/e2e/docker-compose.live.yml -f crates/tensorzero-core/tests/e2e/docker-compose.config-in-db.yml"
+
+jobs:
+  live-tests-config-in-database:
+    if: github.repository == 'tensorzero/tensorzero'
+    name: "live-tests-config-in-database"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Cleanup disk space
+        run: bash ci/free-disk-space.sh
+
+      - name: Login to DockerHub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        with:
+          username: tensorzero
+          password: ${{ secrets.DOCKERHUB_LIMITED_TOKEN }}
+
+      - name: Pull container images
+        run: |
+          ./ci/docker-pull-with-retry.sh \
+            tensorzero/gateway-dev:sha-${{ github.sha }} \
+            tensorzero/provider-proxy:sha-${{ github.sha }} \
+            tensorzero/gateway-e2e:sha-${{ github.sha }} \
+            tensorzero/live-tests:sha-${{ github.sha }} \
+            tensorzero/fixtures:sha-${{ github.sha }}
+          docker tag tensorzero/gateway-dev:sha-${{ github.sha }} tensorzero/gateway:sha-${{ github.sha }}
+          docker tag tensorzero/fixtures:sha-${{ github.sha }} tensorzero/fixtures-postgres:sha-${{ github.sha }}
+
+      - name: Restore provider-proxy cache
+        if: github.event_name != 'schedule'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: ./ci/provider-proxy-cache/
+          key: provider-proxy-cache-${{ github.run_id }}
+          restore-keys: provider-proxy-cache-
+
+      - name: Download provider-proxy cache
+        if: github.event_name != 'schedule'
+        run: |
+          AWS_ACCESS_KEY_ID=$R2_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$R2_SECRET_ACCESS_KEY PROVIDER_PROXY_CACHE_BUCKET=provider-proxy-cache ./ci/download-provider-proxy-cache.sh
+
+      - name: Write GCP JWT key to file
+        env:
+          GCP_JWT_KEY: ${{ secrets.GCP_JWT_KEY }}
+        run: echo "$GCP_JWT_KEY" > $GITHUB_WORKSPACE/gcp_jwt_key.json
+
+      - name: Pull images referenced by the compose files
+        run: docker compose ${{ env.COMPOSE_FILES }} --profile provider-proxy pull --ignore-pull-failures
+
+      - name: Run live tests against config-in-database gateway
+        run: |
+          DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) docker compose ${{ env.COMPOSE_FILES }} --profile provider-proxy run --rm \
+            -e TENSORZERO_CI=1 \
+            -e TENSORZERO_CLICKHOUSE_BATCH_WRITES=false \
+            -e TENSORZERO_INTERNAL_TEST_OBSERVABILITY_BACKEND=postgres \
+            live-tests
+
+      - name: Run config editing e2e tests
+        # The config-editing profile filters down to tests that mutate
+        # gateway-wide config via `/internal/config_toml/apply`. They run
+        # after the main live suite so they don't race with concurrent tests.
+        run: |
+          DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) docker compose ${{ env.COMPOSE_FILES }} --profile provider-proxy run --rm \
+            -e TENSORZERO_CI=1 \
+            -e TENSORZERO_INTERNAL_TEST_OBSERVABILITY_BACKEND=postgres \
+            live-tests \
+            sh -c "cargo-nextest nextest run --no-fail-fast --archive-file tests.tar.zst --workspace-remap /app/crates --config-file /app/crates/.config/nextest.toml --profile config-editing -j 1"
+
+      - name: Print gateway and test logs
+        if: always()
+        run: docker compose ${{ env.COMPOSE_FILES }} --profile provider-proxy logs -t
+
+      - name: Check e2e logs for impossible error messages
+        run: |
+          LOGS=$(docker compose ${{ env.COMPOSE_FILES }} --profile provider-proxy logs gateway)
+          if [ -z "$LOGS" ]; then
+            echo "ERROR: Gateway logs are empty"
+            exit 1
+          fi
+          grep --invert-match -i "please file a bug report" <<< "$LOGS"
+
+      - name: Check gateway loaded config from database
+        run: |
+          LOGS=$(docker compose ${{ env.COMPOSE_FILES }} --profile provider-proxy logs gateway)
+          if [ -z "$LOGS" ]; then
+            echo "ERROR: Gateway logs are empty"
+            exit 1
+          fi
+          # When ENABLE_CONFIG_IN_DATABASE is on and no --config-file is passed,
+          # main.rs prints a "Configuration: database" banner line. Fail fast
+          # if that path wasn't exercised (means the override wasn't applied).
+          grep -q "Configuration: database" <<< "$LOGS" || {
+            echo "ERROR: Gateway does not appear to have loaded its config from the database"
+            exit 1
+          }
+
+      - name: Upload provider-proxy cache
+        if: github.event_name == 'merge_group' || github.event_name == 'schedule'
+        run: |
+          AWS_ACCESS_KEY_ID=$R2_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$R2_SECRET_ACCESS_KEY PROVIDER_PROXY_CACHE_BUCKET=provider-proxy-cache ./ci/upload-provider-proxy-cache.sh

--- a/crates/.config/nextest.toml
+++ b/crates/.config/nextest.toml
@@ -31,12 +31,26 @@ slow-timeout = { period = "20s", terminate-after = 5 }
 # - optimization mock tests run separately in mock-optimization-tests with the mock gateway config
 # - binding generation
 # - evaluation tests run separately with a database matrix in the evaluation-tests CI job
+# - config editing tests run separately in the live-tests-config-in-database CI job because
+#   they mutate gateway-wide config state
 [profile.e2e]
 retries = { backoff = "exponential", count = 4, delay = "5s", jitter = true, max-delay = "60s" }
 slow-timeout = { period = "30s", terminate-after = 2 }
 default-filter = '''
-not (test(batch) | test(test_dummy_only) | test(clickhouse::) | (test(db::) & !test(postgres) & !test(valkey)) | test(export_bindings_) | test(export_schema_) | binary(optimization-mock) | package(tensorzero-derive) | package(evaluations))
+not (test(batch) | test(test_dummy_only) | test(clickhouse::) | (test(db::) & !test(postgres) & !test(valkey)) | test(export_bindings_) | test(export_schema_) | binary(optimization-mock) | package(tensorzero-derive) | package(evaluations) | test(config_editing::))
 '''
+junit.path = "junit.xml"
+
+# Run only the config editing e2e tests. These mutate gateway-wide config state
+# via `/internal/config_toml/apply`, so they must not race with the main e2e
+# suite and run after it finishes in the live-tests-config-in-database workflow.
+[profile.config-editing]
+default-filter = 'binary(e2e) and test(config_editing::)'
+# These tests all mutate gateway-wide config state, so they must run one at a
+# time even within the profile.
+test-threads = 1
+retries = { backoff = "exponential", count = 2, delay = "5s", jitter = true, max-delay = "30s" }
+slow-timeout = { period = "30s", terminate-after = 2 }
 junit.path = "junit.xml"
 
 [profile.live-batch]

--- a/crates/tensorzero-core/tests/e2e/config_editing.rs
+++ b/crates/tensorzero-core/tests/e2e/config_editing.rs
@@ -1,0 +1,535 @@
+//! End-to-end coverage for writing config via `/internal/config_toml/apply`.
+//!
+//! These tests mutate gateway-wide config state, so they live in their own
+//! `config-editing` nextest profile (see `crates/.config/nextest.toml`) and
+//! run after the main live test suite finishes. Each test fetches the live
+//! editable TOML on entry and re-applies it on the way out so the fixture is
+//! restored regardless of which test runs next.
+
+use std::collections::HashMap;
+
+use googletest::prelude::*;
+use reqwest::{Client, StatusCode};
+use serde_json::{Value, json};
+use tensorzero_core::db::delegating_connection::DelegatingDatabaseConnection;
+use tensorzero_core::db::model_inferences::ModelInferenceQueries;
+use tensorzero_core::db::test_helpers::TestDatabaseHelpers;
+use tensorzero_core::endpoints::internal::config::{
+    ApplyConfigTomlResponse, GetConfigTomlResponse,
+};
+use uuid::Uuid;
+
+use crate::common::get_gateway_endpoint;
+
+/// Name used by the add/remove round-trip test.
+const THROWAWAY_FUNCTION_NAME: &str = "e2e_config_editing_throwaway_function";
+
+/// Name used by the add-variant round-trip test.
+const ADD_VARIANT_FUNCTION_NAME: &str = "e2e_config_editing_add_variant_function";
+const EXTRA_VARIANT_NAME: &str = "extra_variant";
+
+async fn get_config_toml(client: &Client) -> GetConfigTomlResponse {
+    let response = client
+        .get(get_gateway_endpoint("/internal/config_toml"))
+        .send()
+        .await
+        .expect("GET /internal/config_toml should succeed");
+    assert_that!(response.status(), eq(StatusCode::OK));
+    response
+        .json::<GetConfigTomlResponse>()
+        .await
+        .expect("GET /internal/config_toml should deserialize as GetConfigTomlResponse")
+}
+
+async fn apply_config_toml(
+    client: &Client,
+    toml: &str,
+    path_contents: &HashMap<String, String>,
+    base_signature: &str,
+) -> reqwest::Response {
+    client
+        .post(get_gateway_endpoint("/internal/config_toml/apply"))
+        .json(&json!({
+            "toml": toml,
+            "path_contents": path_contents,
+            "base_signature": base_signature,
+        }))
+        .send()
+        .await
+        .expect("POST /internal/config_toml/apply should send")
+}
+
+async fn run_inference_with_variant(
+    client: &Client,
+    function_name: &str,
+    variant_name: Option<&str>,
+) -> reqwest::Response {
+    let mut payload = json!({
+        "function_name": function_name,
+        "episode_id": Uuid::now_v7(),
+        "input": {
+            "messages": [
+                { "role": "user", "content": "Hello, world!" }
+            ]
+        },
+        "stream": false,
+    });
+    if let Some(variant) = variant_name {
+        payload["variant_name"] = json!(variant);
+    }
+    client
+        .post(get_gateway_endpoint("/inference"))
+        .json(&payload)
+        .send()
+        .await
+        .expect("POST /inference should send")
+}
+
+async fn run_inference(client: &Client, function_name: &str) -> reqwest::Response {
+    run_inference_with_variant(client, function_name, None).await
+}
+
+/// Appends a minimal chat function (no schema, no templates) with a single
+/// `test` variant that points at the `test` dummy model. Keeping the block
+/// textually trivial avoids any TOML serialization round-trip issues.
+fn append_new_function_block(original_toml: &str, name: &str) -> String {
+    let block = format!(
+        r#"
+
+[functions.{name}]
+type = "chat"
+
+[functions.{name}.variants.test]
+type = "chat_completion"
+model = "test"
+"#
+    );
+    format!("{original_toml}{block}")
+}
+
+/// Appends an extra variant on the function added via
+/// `append_new_function_block`, also pointing at the `test` dummy model.
+fn append_extra_variant_block(toml: &str, function_name: &str, variant_name: &str) -> String {
+    let block = format!(
+        r#"
+
+[functions.{function_name}.variants.{variant_name}]
+type = "chat_completion"
+model = "test"
+"#
+    );
+    format!("{toml}{block}")
+}
+
+/// Appends a function whose only variant references a model that does not
+/// exist. Used to trigger validation failure inside `apply_config_toml`.
+fn append_invalid_function_block(original_toml: &str) -> String {
+    let block = r#"
+
+[functions.e2e_config_editing_invalid_function]
+type = "chat"
+
+[functions.e2e_config_editing_invalid_function.variants.invalid]
+type = "chat_completion"
+model = "this_model_definitely_does_not_exist_e2e"
+"#;
+    format!("{original_toml}{block}")
+}
+
+#[gtest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_config_editing_add_then_remove_function() {
+    let client = Client::new();
+    let original = get_config_toml(&client).await;
+
+    assert_that!(
+        original
+            .toml
+            .contains(&format!("[functions.{THROWAWAY_FUNCTION_NAME}]")),
+        eq(false),
+        "throwaway function name must not already exist in base e2e config"
+    );
+
+    // --- Add a new function and confirm inference works against it ---
+    let toml_with_new_function = append_new_function_block(&original.toml, THROWAWAY_FUNCTION_NAME);
+    let apply_response = apply_config_toml(
+        &client,
+        &toml_with_new_function,
+        &original.path_contents,
+        &original.base_signature,
+    )
+    .await;
+    let apply_status = apply_response.status();
+    let apply_body = apply_response
+        .text()
+        .await
+        .expect("apply response body should decode");
+    assert_that!(
+        apply_status,
+        eq(StatusCode::OK),
+        "apply (add) failed: {apply_body}"
+    );
+
+    let inference_after_add = run_inference(&client, THROWAWAY_FUNCTION_NAME).await;
+    let add_status = inference_after_add.status();
+    let add_body = inference_after_add
+        .text()
+        .await
+        .expect("inference body should decode");
+    expect_that!(
+        add_status,
+        eq(StatusCode::OK),
+        "inference against newly-added function should succeed; body={add_body}"
+    );
+
+    // --- Remove the function and confirm inference now fails ---
+    let post_add = get_config_toml(&client).await;
+    let restore_response = apply_config_toml(
+        &client,
+        &original.toml,
+        &original.path_contents,
+        &post_add.base_signature,
+    )
+    .await;
+    assert_that!(
+        restore_response.status(),
+        eq(StatusCode::OK),
+        "restoring original config failed"
+    );
+
+    let inference_after_remove = run_inference(&client, THROWAWAY_FUNCTION_NAME).await;
+    let remove_status = inference_after_remove.status();
+    let remove_body = inference_after_remove
+        .text()
+        .await
+        .expect("inference body should decode");
+    expect_that!(
+        remove_status.is_success(),
+        eq(false),
+        "inference against removed function should fail; status={remove_status}, body={remove_body}"
+    );
+}
+
+/// Exercises the "add a variant to an already-stored function" flow. Because
+/// the base e2e config has no unschema'd function we can safely graft onto,
+/// the test first applies a throwaway function (apply #1) and then adds a
+/// second variant to that now-existing function (apply #2).
+#[gtest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_config_editing_add_variant_to_existing_function() {
+    let client = Client::new();
+    let original = get_config_toml(&client).await;
+
+    // Apply #1: create the host function with one variant.
+    let toml_with_function = append_new_function_block(&original.toml, ADD_VARIANT_FUNCTION_NAME);
+    let apply1 = apply_config_toml(
+        &client,
+        &toml_with_function,
+        &original.path_contents,
+        &original.base_signature,
+    )
+    .await;
+    let apply1_status = apply1.status();
+    let apply1_body = apply1.text().await.expect("apply #1 body should decode");
+    assert_that!(
+        apply1_status,
+        eq(StatusCode::OK),
+        "apply #1 (create host function) failed: {apply1_body}"
+    );
+
+    // Apply #2: add a second variant to the now-existing function.
+    let after_first_apply = get_config_toml(&client).await;
+    let toml_with_extra_variant = append_extra_variant_block(
+        &toml_with_function,
+        ADD_VARIANT_FUNCTION_NAME,
+        EXTRA_VARIANT_NAME,
+    );
+    let apply2 = apply_config_toml(
+        &client,
+        &toml_with_extra_variant,
+        &after_first_apply.path_contents,
+        &after_first_apply.base_signature,
+    )
+    .await;
+    let apply2_status = apply2.status();
+    let apply2_body = apply2.text().await.expect("apply #2 body should decode");
+    assert_that!(
+        apply2_status,
+        eq(StatusCode::OK),
+        "apply #2 (add variant) failed: {apply2_body}"
+    );
+
+    // Inference against the newly-added variant should succeed and should
+    // report the variant name back in the response.
+    let inference_response =
+        run_inference_with_variant(&client, ADD_VARIANT_FUNCTION_NAME, Some(EXTRA_VARIANT_NAME))
+            .await;
+    let status = inference_response.status();
+    let body = inference_response
+        .text()
+        .await
+        .expect("inference body should decode");
+    assert_that!(
+        status,
+        eq(StatusCode::OK),
+        "inference against newly-added variant should succeed; body={body}"
+    );
+    let parsed: Value = serde_json::from_str(&body).expect("inference body should be JSON");
+    expect_that!(
+        parsed["variant_name"].as_str(),
+        some(eq(EXTRA_VARIANT_NAME)),
+        "inference should have used the newly-added variant"
+    );
+
+    // Restore the original config.
+    let post_apply = get_config_toml(&client).await;
+    let restore_response = apply_config_toml(
+        &client,
+        &original.toml,
+        &original.path_contents,
+        &post_apply.base_signature,
+    )
+    .await;
+    assert_that!(
+        restore_response.status(),
+        eq(StatusCode::OK),
+        "restoring original config failed"
+    );
+}
+
+/// An apply with a stale base_signature that also doesn't match the canonical
+/// signature of the submitted TOML must be rejected with 409 Conflict, and
+/// must not mutate the stored config.
+#[gtest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_config_editing_cas_conflict_rejects_stale_signature() {
+    let client = Client::new();
+    let original = get_config_toml(&client).await;
+
+    // Build a TOML that introduces a real change so the canonical signature
+    // of the submitted TOML also won't match the current DB signature — this
+    // forces the apply handler down the conflict path rather than the no-op
+    // short-circuit.
+    let toml_with_new_function =
+        append_new_function_block(&original.toml, "e2e_config_editing_cas_conflict_function");
+
+    let stale_signature = "0000000000000000000000000000000000000000000000000000000000000000";
+    let response = apply_config_toml(
+        &client,
+        &toml_with_new_function,
+        &original.path_contents,
+        stale_signature,
+    )
+    .await;
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .expect("cas conflict response body should decode");
+    expect_that!(
+        status,
+        eq(StatusCode::CONFLICT),
+        "stale base_signature should trigger 409 Conflict; body={body}"
+    );
+
+    // The rejected apply must not have mutated stored state.
+    let after = get_config_toml(&client).await;
+    expect_that!(
+        after.hash.as_str(),
+        eq(original.hash.as_str()),
+        "rejected CAS apply should leave the config hash unchanged"
+    );
+    expect_that!(
+        after.base_signature.as_str(),
+        eq(original.base_signature.as_str()),
+        "rejected CAS apply should leave the base_signature unchanged"
+    );
+}
+
+/// A semantically invalid TOML (e.g. a variant pointing at a nonexistent
+/// model) must be rejected before any state is written. A follow-up GET must
+/// return the same hash and base_signature as before the failed apply.
+#[gtest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_config_editing_validation_failure_leaves_state_unchanged() {
+    let client = Client::new();
+    let original = get_config_toml(&client).await;
+
+    let invalid_toml = append_invalid_function_block(&original.toml);
+    let response = apply_config_toml(
+        &client,
+        &invalid_toml,
+        &original.path_contents,
+        &original.base_signature,
+    )
+    .await;
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .expect("validation failure response body should decode");
+    expect_that!(
+        status.is_success(),
+        eq(false),
+        "apply with invalid model reference should fail; status={status}, body={body}"
+    );
+
+    let after = get_config_toml(&client).await;
+    expect_that!(
+        after.hash.as_str(),
+        eq(original.hash.as_str()),
+        "failed validation apply should leave config hash unchanged"
+    );
+    expect_that!(
+        after.base_signature.as_str(),
+        eq(original.base_signature.as_str()),
+        "failed validation apply should leave base_signature unchanged"
+    );
+}
+
+/// Modifies a variant's system prompt via `/internal/config_toml/apply` and
+/// verifies the rendered system prompt on the resulting `ModelInference` row
+/// contains the new marker, proving the gateway actually re-loaded and used
+/// the modified template for subsequent inferences.
+#[gtest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_config_editing_modify_prompt_updates_inference_system() {
+    let client = Client::new();
+    let original = get_config_toml(&client).await;
+
+    let function_name = "e2e_config_editing_prompt_modify_function";
+    let template_path = "e2e_config_editing/prompt_modify_system_template.minijinja";
+    let marker = "PROMPT_MARKER_E2E_CONFIG_EDITING";
+    let template_body = format!("You are a helpful assistant. {marker}");
+
+    // The path_contents map is a content-addressed store keyed by the path
+    // string in the TOML body — no filesystem resolution happens for keys
+    // that are present in the map, so we can register a synthetic path.
+    let mut path_contents = original.path_contents.clone();
+    path_contents.insert(template_path.to_string(), template_body.clone());
+
+    let new_function_block = format!(
+        r#"
+
+[functions.{function_name}]
+type = "chat"
+
+[functions.{function_name}.variants.test]
+type = "chat_completion"
+model = "test"
+system_template = "{template_path}"
+"#
+    );
+    let new_toml = format!("{}{}", original.toml, new_function_block);
+
+    let apply_response =
+        apply_config_toml(&client, &new_toml, &path_contents, &original.base_signature).await;
+    let apply_status = apply_response.status();
+    let apply_body = apply_response
+        .text()
+        .await
+        .expect("apply body should decode");
+    assert_that!(
+        apply_status,
+        eq(StatusCode::OK),
+        "apply (modify prompt) failed: {apply_body}"
+    );
+
+    // Run inference against the new function and capture the inference id so
+    // we can look up the rendered system prompt on the `ModelInference` row.
+    let inference_response = run_inference(&client, function_name).await;
+    let inference_status = inference_response.status();
+    let inference_body = inference_response
+        .text()
+        .await
+        .expect("inference body should decode");
+    assert_that!(
+        inference_status,
+        eq(StatusCode::OK),
+        "inference against prompt-modified function should succeed; body={inference_body}"
+    );
+    let parsed: Value =
+        serde_json::from_str(&inference_body).expect("inference body should be JSON");
+    let inference_id: Uuid = parsed["inference_id"]
+        .as_str()
+        .expect("inference_id should be a string")
+        .parse()
+        .expect("inference_id should be a UUID");
+
+    let conn = DelegatingDatabaseConnection::new_for_e2e_test().await;
+    conn.flush_pending_writes().await;
+    conn.sleep_for_writes_to_be_visible().await;
+    let model_inferences = conn
+        .get_model_inferences_by_inference_id(inference_id)
+        .await
+        .expect("model inferences lookup should succeed");
+    assert_that!(
+        model_inferences.len(),
+        eq(1),
+        "expected exactly one model inference for the test call"
+    );
+    let rendered_system = model_inferences[0]
+        .system
+        .as_deref()
+        .expect("model inference should have a rendered system prompt");
+    expect_that!(
+        rendered_system,
+        contains_substring(marker),
+        "rendered system prompt should contain the marker from the modified template"
+    );
+
+    // Restore the original config.
+    let post_apply = get_config_toml(&client).await;
+    let restore_response = apply_config_toml(
+        &client,
+        &original.toml,
+        &original.path_contents,
+        &post_apply.base_signature,
+    )
+    .await;
+    assert_that!(
+        restore_response.status(),
+        eq(StatusCode::OK),
+        "restoring original config failed"
+    );
+}
+
+/// Re-applying the canonical editable TOML should be a 200 no-op that
+/// preserves the hash. This covers the short-circuit branch in
+/// `apply_config_toml_handler` where `current_signature == canonical_signature`.
+#[gtest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_config_editing_noop_apply_preserves_hash() {
+    let client = Client::new();
+    let original = get_config_toml(&client).await;
+
+    let response = apply_config_toml(
+        &client,
+        &original.toml,
+        &original.path_contents,
+        &original.base_signature,
+    )
+    .await;
+    let status = response.status();
+    let body_text = response
+        .text()
+        .await
+        .expect("noop apply response body should decode");
+    assert_that!(
+        status,
+        eq(StatusCode::OK),
+        "noop apply should succeed; body={body_text}"
+    );
+    let parsed: ApplyConfigTomlResponse = serde_json::from_str(&body_text)
+        .expect("noop apply body should deserialize as ApplyConfigTomlResponse");
+    expect_that!(
+        parsed.hash.as_str(),
+        eq(original.hash.as_str()),
+        "noop apply should return the same hash as the pre-apply GET"
+    );
+    expect_that!(
+        parsed.base_signature.as_str(),
+        eq(original.base_signature.as_str()),
+        "noop apply should return the same base_signature as the pre-apply GET"
+    );
+}

--- a/crates/tensorzero-core/tests/e2e/docker-compose.config-in-db.yml
+++ b/crates/tensorzero-core/tests/e2e/docker-compose.config-in-db.yml
@@ -1,0 +1,45 @@
+# Override for docker-compose.live.yml that runs the live gateway against the
+# config-in-database read path instead of a --config-file glob.
+#
+# Usage:
+#   docker compose -f docker-compose.live.yml -f docker-compose.config-in-db.yml ...
+#
+# This override:
+#   1. Adds a one-shot `gateway-store-config` service that loads the same config
+#      glob used by the Postgres live-tests matrix (`{tensorzero,postgres}.*.toml`)
+#      into the stored_config tables via `gateway --store-config`.
+#   2. Rewires the main `gateway` service to boot from the database instead of a
+#      config file glob by clearing its `command` list and setting
+#      `TENSORZERO_INTERNAL_FLAG_ENABLE_CONFIG_IN_DATABASE=true`.
+
+services:
+  gateway-store-config:
+    image: tensorzero/gateway-e2e:${TENSORZERO_COMMIT_TAG}
+    environment:
+      TENSORZERO_POSTGRES_URL: postgres://postgres:postgres@postgres:5432/${TENSORZERO_E2E_TESTS_DATABASE:-tensorzero-e2e-tests}
+    volumes:
+      - ./:/app/tensorzero-core/tests/e2e:ro
+      - ../../fixtures:/app/tensorzero-core/fixtures:ro
+      - ../../../../ui/fixtures:/app/ui/fixtures:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+      gateway-postgres-migrations:
+        condition: service_healthy
+    command:
+      [
+        --store-config,
+        "tensorzero-core/tests/e2e/config/{tensorzero,postgres}.*.toml",
+      ]
+    restart: "no"
+
+  gateway:
+    environment:
+      TENSORZERO_INTERNAL_FLAG_ENABLE_CONFIG_IN_DATABASE: "true"
+    # Clear the `--config-file` args from docker-compose.live.yml so the gateway
+    # loads from Postgres instead. main.rs falls through to the DB load path
+    # when no config flag is set and the feature flag is enabled.
+    command: []
+    depends_on:
+      gateway-store-config:
+        condition: service_completed_successfully

--- a/crates/tensorzero-core/tests/e2e/tests.rs
+++ b/crates/tensorzero-core/tests/e2e/tests.rs
@@ -12,6 +12,7 @@ mod cache;
 mod clickhouse;
 mod common;
 mod config;
+mod config_editing;
 mod cost;
 mod db;
 mod dicl;


### PR DESCRIPTION
Introduce a new CI workflow that exercises the config-in-database read/write path end-to-end. Unlike `live-tests.yml`, this workflow has no batch_writes matrix: it boots Postgres, stores the Postgres live-tests config glob via `gateway --store-config`, then runs the full live suite against a gateway booted from the database with `TENSORZERO_INTERNAL_FLAG_ENABLE_CONFIG_IN_DATABASE=true`.

Wiring:
- `docker-compose.config-in-db.yml` override adds a one-shot `gateway-store-config` service and rewires the gateway to clear `--config-file` and load from the database instead.
- New `live-tests-config-in-database.yml` workflow reuses the prebuilt e2e images and grep-asserts the gateway banner reports `Configuration: database`.
- Wired into `general.yml` alongside the existing live-tests job.

Also adds a dedicated e2e test (`config_editing::`) that round-trips a throwaway function through `/internal/config_toml/apply`:
  1. Append a new function block to the current editable TOML and apply.
  2. Run inference against it and assert success.
  3. Re-apply the original TOML to delete the function.
  4. Run inference again and assert failure.

These tests mutate gateway-wide config state, so they run in a new `config-editing` nextest profile (filtered to `test(config_editing::)` and excluded from the default `e2e` profile) as a second serial pass after the main live suite finishes in the new workflow.