### PR TITLE
Simplify GatewayHandle drop logic when waiting for tasks

### DIFF
--- a/crates/tensorzero-core/src/rate_limiting/rate_limiting_manager.rs
+++ b/crates/tensorzero-core/src/rate_limiting/rate_limiting_manager.rs
@@ -324,8 +324,11 @@ impl RateLimitingManager {
 
     /// Shutdown the rate limiting manager.
     /// This is a no-op in direct mode (no tokens to return).
-    pub fn shutdown(&self) -> Result<(), Error> {
-        Ok(())
+    // This method is async in preparation for supporting a non-direct mode where we
+    // actually need to do work during shutdown.
+    pub async fn shutdown(&self) {
+        tracing::info!("Returning unused rate limit tokens to database");
+        tracing::info!("Rate limit token return complete");
     }
 }
 

--- a/crates/tensorzero-core/src/utils/gateway.rs
+++ b/crates/tensorzero-core/src/utils/gateway.rs
@@ -92,19 +92,23 @@ impl Drop for GatewayHandle {
             let clickhouse_handle = app_state.clickhouse_connection_info.batcher_join_handle();
             let pg_handle = app_state.postgres_connection_info.batcher_join_handle();
 
-            // Return unused rate limit tokens while Postgres is still active.
-            if !app_state.rate_limiting_manager.is_empty() {
-                tracing::info!("Returning unused rate limit tokens to database");
-                if let Err(e) = app_state.rate_limiting_manager.shutdown() {
-                    tracing::warn!("Error returning rate limit tokens on shutdown: {e}");
-                }
-                tracing::info!("Rate limit token return complete");
-            }
-
             // Move the deferred task tracker out before dropping app state so we can
             // still close/wait on it below.
             let deferred_tasks =
                 std::mem::replace(&mut app_state.deferred_tasks, TaskTracker::new());
+
+            let rate_limiting_manager = std::mem::replace(
+                &mut app_state.rate_limiting_manager,
+                Arc::new(RateLimitingManager::new(
+                    Arc::new(RateLimitingConfig::default()),
+                    Arc::new(DisabledRateLimitQueries),
+                )),
+            );
+
+            // Return unused rate limit tokens while Postgres is still active.
+            if !rate_limiting_manager.is_empty() {
+                deferred_tasks.spawn(async move { rate_limiting_manager.shutdown().await });
+            }
 
             // Drop all remaining state before waiting on batch writers. This releases
             // all sender/reference holders (cache backends, rate-limit backends, and any
@@ -112,34 +116,22 @@ impl Drop for GatewayHandle {
             // calls for each one.
             drop(app_state);
             if let Some(clickhouse_handle) = clickhouse_handle {
-                tracing::info!("Waiting for ClickHouse batch writer to finish");
-                // This could block forever if:
-                // * We spawn a long-lived `tokio::task` that holds on to a `ClickhouseConnectionInfo`,
-                //   and isn't using our `CancellationToken` to exit.
-                // * The `GatewayHandle` is dropped from a task that's running other futures
-                //   concurrently (e.g. a `try_join_all` where one of the futures somehow drops a `GatewayHandle`).
-                //   In this case, the `block_in_place` call would prevent those futures from ever making progress,
-                //   causing a `ClickhouseConnectionInfo` (and therefore the `Arc<BatchSender>`) to never be dropped.
-                //   This is very unlikely, as we only create a `GatewayHandle` in a few places (the main gateway
-                //   and embedded client), and drop it when we're exiting.
-                //
-                // We err on the side of hanging the server on shutdown, rather than potentially exiting while
-                // we still have batched writes in-flight (or about to be written via an active `ClickhouseConnectionInfo`).
-                tokio::task::block_in_place(|| {
-                    if let Err(e) = Handle::current().block_on(clickhouse_handle) {
+                deferred_tasks.spawn(async move {
+                    tracing::info!("Waiting for ClickHouse batch writer to finish");
+                    if let Err(e) = clickhouse_handle.await {
                         tracing::error!("Error in batch writer: {e}");
                     }
+                    tracing::info!("ClickHouse batch writer finished");
                 });
-                tracing::info!("ClickHouse batch writer finished");
             }
             if let Some(pg_handle) = pg_handle {
-                tracing::info!("Waiting for Postgres batch writer to finish");
-                tokio::task::block_in_place(|| {
-                    if let Err(e) = Handle::current().block_on(pg_handle) {
+                deferred_tasks.spawn(async move {
+                    tracing::info!("Waiting for Postgres batch writer to finish");
+                    if let Err(e) = pg_handle.await {
                         tracing::error!("Error in Postgres batch writer: {e}");
                     }
+                    tracing::info!("Postgres batch writer finished");
                 });
-                tracing::info!("Postgres batch writer finished");
             }
 
             deferred_tasks.close();


### PR DESCRIPTION
We now just spawn additional tasks on our `deferred_tasks` (including the 'Waiting for ClickHouse' and 'ClickHouse batch writer finished' message) during shutdown. In a future PR, we can re-use this logic to allow hot-swaping these fields by immediately spawning the shutdown tasks for the *old* handles onto `deferred_tasks`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gateway shutdown sequencing by moving join-handle waits and rate-limit token return into async tasks tracked by `deferred_tasks`, which could affect shutdown ordering and error visibility. Also changes `RateLimitingManager::shutdown` to async, requiring call sites/tests to adapt.
> 
> **Overview**
> Refactors `GatewayHandle` shutdown to **spawn** waiting for ClickHouse/Postgres batch-writer join handles onto `deferred_tasks` instead of blocking in-place, consolidating shutdown coordination under the task tracker.
> 
> Updates rate-limit token return to run as a deferred async task by swapping out `app_state.rate_limiting_manager` before dropping state, and changes `RateLimitingManager::shutdown` from a `Result`-returning sync method to an async method (currently a no-op placeholder with logging).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6e9254f1e6230e48e9912fc2bbc35d2552c4487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->