### PR TITLE
refactor: move provider-needed types to shared crates

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -8253,6 +8253,7 @@ dependencies = [
  "tensorzero-stored-config",
  "tensorzero-types",
  "tensorzero-types-providers",
+ "tokio",
  "tracing",
  "ts-rs",
  "url",

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -8249,6 +8249,7 @@ dependencies = [
  "sqlx",
  "tensorzero-derive",
  "tensorzero-error",
+ "tensorzero-http",
  "tensorzero-stored-config",
  "tensorzero-types",
  "tensorzero-types-providers",

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -8238,6 +8238,7 @@ dependencies = [
  "futures",
  "googletest",
  "mime 0.4.0-a.0",
+ "mime_guess",
  "pyo3",
  "rust_decimal",
  "schemars 1.2.1",

--- a/crates/tensorzero-core/src/config/mod.rs
+++ b/crates/tensorzero-core/src/config/mod.rs
@@ -91,29 +91,9 @@ pub mod unwritten;
 
 pub use namespace::Namespace;
 
-tokio::task_local! {
-    /// When set, we skip performing credential validation in model providers
-    /// This is used when running in e2e test mode, and by the 'evaluations' binary
-    /// We need to access this from async code (e.g. when looking up GCP SDK credentials),
-    /// so this needs to be a tokio task-local (as a task may be moved between threads)
-    ///
-    /// Since this needs to be accessed from a `Deserialize` impl, it needs to
-    /// be stored in a `static`, since we cannot pass in extra parameters when calling `Deserialize::deserialize`
-    static SKIP_CREDENTIAL_VALIDATION: ();
-}
-
-pub fn skip_credential_validation() -> bool {
-    // tokio::task_local doesn't have an 'is_set' method, so we call 'try_with'
-    // (which returns an `Err` if the task-local is not set)
-    SKIP_CREDENTIAL_VALIDATION.try_with(|()| ()).is_ok()
-}
-
-/// Runs the provider future with credential validation disabled
-/// This is safe to repeatedly nest (e.g. `with_skip_credential_validation(async move { with_skip_credential_validation(f).await })`),
-/// the original credential validation behavior will be restored after the outermost future completes
-pub async fn with_skip_credential_validation<T>(f: impl Future<Output = T>) -> T {
-    SKIP_CREDENTIAL_VALIDATION.scope((), f).await
-}
+pub use tensorzero_inference_types::credential_validation::{
+    skip_credential_validation, with_skip_credential_validation,
+};
 
 /// Configuration for the autopilot system.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
@@ -1354,14 +1334,7 @@ async fn process_uninitialized_config(
     })
 }
 
-/// In e2e test mode, we skip credential validation by default.
-/// This can be overridden by setting the `TENSORZERO_E2E_CREDENTIAL_VALIDATION` environment variable to `1`.
-/// Outside of e2e test mode, we leave the behavior unchanged (other parts of the codebase might still
-/// skip credential validation, e.g. when running in relay mode).
-pub fn e2e_skip_credential_validation() -> bool {
-    cfg!(any(test, feature = "e2e_tests"))
-        && !std::env::var("TENSORZERO_E2E_CREDENTIAL_VALIDATION").is_ok_and(|x| x == "1")
-}
+pub use tensorzero_inference_types::credential_validation::e2e_skip_credential_validation;
 
 impl Config {
     /// Constructs a new `Config`, as if from an empty config file.

--- a/crates/tensorzero-core/src/config/tests.rs
+++ b/crates/tensorzero-core/src/config/tests.rs
@@ -2396,13 +2396,11 @@ async fn test_missing_json_mode_chat() {
         "#;
     let config = toml::from_str(config_str).expect("Failed to parse sample config");
 
-    let err = SKIP_CREDENTIAL_VALIDATION
-        .scope(
-            (),
-            Box::pin(Config::load_unwritten_config(ConfigInput::Fresh(config))),
-        )
-        .await
-        .unwrap_err();
+    let err = with_skip_credential_validation(Box::pin(Config::load_unwritten_config(
+        ConfigInput::Fresh(config),
+    )))
+    .await
+    .unwrap_err();
 
     assert_eq!(
         err.to_string(),
@@ -2440,13 +2438,11 @@ async fn test_missing_json_mode_dicl() {
         "#;
     let config = toml::from_str(config_str).expect("Failed to parse sample config");
 
-    let err = SKIP_CREDENTIAL_VALIDATION
-        .scope(
-            (),
-            Box::pin(Config::load_unwritten_config(ConfigInput::Fresh(config))),
-        )
-        .await
-        .unwrap_err();
+    let err = with_skip_credential_validation(Box::pin(Config::load_unwritten_config(
+        ConfigInput::Fresh(config),
+    )))
+    .await
+    .unwrap_err();
 
     assert_eq!(
         err.to_string(),
@@ -2485,13 +2481,11 @@ async fn test_missing_json_mode_mixture_of_n() {
         "#;
     let config = toml::from_str(config_str).expect("Failed to parse sample config");
 
-    let err = SKIP_CREDENTIAL_VALIDATION
-        .scope(
-            (),
-            Box::pin(Config::load_unwritten_config(ConfigInput::Fresh(config))),
-        )
-        .await
-        .unwrap_err();
+    let err = with_skip_credential_validation(Box::pin(Config::load_unwritten_config(
+        ConfigInput::Fresh(config),
+    )))
+    .await
+    .unwrap_err();
 
     assert_eq!(
         err.to_string(),
@@ -2532,13 +2526,11 @@ async fn test_missing_json_mode_best_of_n() {
     let config = toml::from_str(config_str).expect("Failed to parse sample config");
 
     // This should succeed (evaluator's `json_mode` is optional)
-    SKIP_CREDENTIAL_VALIDATION
-        .scope(
-            (),
-            Box::pin(Config::load_unwritten_config(ConfigInput::Fresh(config))),
-        )
-        .await
-        .expect("Config should load successfully with missing evaluator json_mode");
+    with_skip_credential_validation(Box::pin(Config::load_unwritten_config(ConfigInput::Fresh(
+        config,
+    ))))
+    .await
+    .expect("Config should load successfully with missing evaluator json_mode");
 }
 
 #[tokio::test]
@@ -2598,13 +2590,11 @@ async fn test_gcp_no_endpoint_and_model() {
         "#;
     let config = toml::from_str(config_str).expect("Failed to parse sample config");
 
-    let err = SKIP_CREDENTIAL_VALIDATION
-        .scope(
-            (),
-            Box::pin(Config::load_unwritten_config(ConfigInput::Fresh(config))),
-        )
-        .await
-        .unwrap_err();
+    let err = with_skip_credential_validation(Box::pin(Config::load_unwritten_config(
+        ConfigInput::Fresh(config),
+    )))
+    .await
+    .unwrap_err();
 
     let err_msg = err.to_string();
     assert!(

--- a/crates/tensorzero-core/src/embeddings.rs
+++ b/crates/tensorzero-core/src/embeddings.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, HashMap};
-use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -15,7 +14,7 @@ use crate::inference::types::RequestMessagesOrBatch;
 use crate::inference::types::extra_body::ExtraBodyConfig;
 use crate::inference::types::extra_headers::ExtraHeadersConfig;
 use crate::inference::types::{ContentBlock, Text};
-use crate::model::{ModelProviderRequestInfo, UninitializedProviderConfig};
+use crate::model::UninitializedProviderConfig;
 use crate::model_table::{BaseModelTable, ProviderKind, ProviderTypeDefaultCredentials};
 use crate::model_table::{OpenAIKind, OpenRouterKind, ShorthandModelConfig};
 use crate::providers::azure::AzureProvider;
@@ -381,34 +380,7 @@ impl EmbeddingModelConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-pub enum EmbeddingInput {
-    Single(String),
-    Batch(Vec<String>),
-    SingleTokens(Vec<u32>),
-    BatchTokens(Vec<Vec<u32>>),
-}
-
-impl EmbeddingInput {
-    pub fn num_inputs(&self) -> usize {
-        match self {
-            EmbeddingInput::Single(_) => 1,
-            EmbeddingInput::Batch(texts) => texts.len(),
-            EmbeddingInput::SingleTokens(_) => 1,
-            EmbeddingInput::BatchTokens(tokens) => tokens.len(),
-        }
-    }
-
-    pub fn first(&self) -> Option<&String> {
-        match self {
-            EmbeddingInput::Single(text) => Some(text),
-            EmbeddingInput::Batch(texts) => texts.first(),
-            EmbeddingInput::SingleTokens(_) => None,
-            EmbeddingInput::BatchTokens(_) => None,
-        }
-    }
-}
+pub use tensorzero_inference_types::embeddings::EmbeddingInput;
 
 impl RateLimitedInputContent for EmbeddingInput {
     fn estimated_input_token_usage(&self) -> u64 {
@@ -426,19 +398,6 @@ impl RateLimitedInputContent for EmbeddingInput {
                 .sum::<u64>(),
         }
     }
-}
-
-impl From<String> for EmbeddingInput {
-    fn from(text: String) -> Self {
-        EmbeddingInput::Single(text)
-    }
-}
-
-#[derive(Debug, PartialEq, Serialize)]
-pub struct EmbeddingRequest {
-    pub input: EmbeddingInput,
-    pub dimensions: Option<u32>,
-    pub encoding_format: EmbeddingEncodingFormat,
 }
 
 impl RateLimitedRequest for EmbeddingRequest {
@@ -479,27 +438,11 @@ impl RateLimitedRequest for EmbeddingRequest {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct EmbeddingProviderRequest<'request> {
-    pub request: &'request EmbeddingRequest,
-    pub model_name: &'request str,
-    pub provider_name: &'request str,
-}
-
 pub use tensorzero_inference_types::EmbeddingEncodingFormat;
-
-#[derive(Debug, PartialEq)]
-pub struct EmbeddingProviderResponse {
-    pub id: Uuid,
-    pub input: EmbeddingInput,
-    pub embeddings: Vec<Embedding>,
-    pub created: u64,
-    pub raw_request: String,
-    pub raw_response: String,
-    pub usage: Usage,
-    pub latency: Latency,
-    pub raw_usage: Option<Vec<RawUsageEntry>>,
-}
+pub use tensorzero_inference_types::embeddings::{
+    Embedding, EmbeddingProvider, EmbeddingProviderRequest, EmbeddingProviderRequestInfo,
+    EmbeddingProviderResponse, EmbeddingRequest,
+};
 
 impl RateLimitedResponse for EmbeddingProviderResponse {
     fn resource_usage(&self) -> RateLimitResourceUsage {
@@ -678,15 +621,6 @@ impl TryFrom<EmbeddingResponseWithMetadata> for ModelInferenceResponseWithMetada
         })
     }
 }
-pub trait EmbeddingProvider {
-    fn embed(
-        &self,
-        request: &EmbeddingRequest,
-        client: &TensorzeroHttpClient,
-        dynamic_api_keys: &InferenceCredentials,
-        model_provider_data: &EmbeddingProviderRequestInfo,
-    ) -> impl Future<Output = Result<EmbeddingProviderResponse, Error>> + Send;
-}
 
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
 #[derive(Debug, Serialize)]
@@ -726,30 +660,12 @@ pub struct EmbeddingProviderInfo {
     pub cost: Option<CostConfig>,
 }
 
-#[derive(Clone, Debug)]
-pub struct EmbeddingProviderRequestInfo {
-    pub provider_name: Arc<str>,
-    pub extra_body: Option<ExtraBodyConfig>,
-    pub extra_headers: Option<ExtraHeadersConfig>,
-}
-
 impl From<&EmbeddingProviderInfo> for EmbeddingProviderRequestInfo {
     fn from(val: &EmbeddingProviderInfo) -> Self {
         EmbeddingProviderRequestInfo {
             provider_name: val.provider_name.clone(),
             extra_body: val.extra_body.clone(),
             extra_headers: val.extra_headers.clone(),
-        }
-    }
-}
-
-impl From<&EmbeddingProviderRequestInfo> for ModelProviderRequestInfo {
-    fn from(val: &EmbeddingProviderRequestInfo) -> Self {
-        crate::model::ModelProviderRequestInfo {
-            provider_name: val.provider_name.clone(),
-            extra_headers: val.extra_headers.clone(),
-            extra_body: val.extra_body.clone(),
-            discard_unknown_chunks: false,
         }
     }
 }
@@ -919,53 +835,6 @@ impl EmbeddingProvider for EmbeddingProviderConfig {
                     .embed(request, client, dynamic_api_keys, model_provider_data)
                     .await
             }
-        }
-    }
-}
-
-impl EmbeddingProviderResponse {
-    pub fn new(
-        embeddings: Vec<Embedding>,
-        input: EmbeddingInput,
-        raw_request: String,
-        raw_response: String,
-        usage: Usage,
-        latency: Latency,
-        raw_usage: Option<Vec<RawUsageEntry>>,
-    ) -> Self {
-        Self {
-            id: Uuid::now_v7(),
-            input,
-            embeddings,
-            created: current_timestamp(),
-            raw_request,
-            raw_response,
-            usage,
-            latency,
-            raw_usage,
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(untagged)]
-pub enum Embedding {
-    Float(Vec<f32>),
-    Base64(String),
-}
-
-impl<'a> Embedding {
-    pub fn as_float(&'a self) -> Option<&'a Vec<f32>> {
-        match self {
-            Embedding::Float(vec) => Some(vec),
-            Embedding::Base64(_) => None,
-        }
-    }
-
-    pub fn ndims(&self) -> usize {
-        match self {
-            Embedding::Float(vec) => vec.len(),
-            Embedding::Base64(encoded) => encoded.len() * 3 / 16,
         }
     }
 }

--- a/crates/tensorzero-core/src/embeddings.rs
+++ b/crates/tensorzero-core/src/embeddings.rs
@@ -486,13 +486,7 @@ pub struct EmbeddingProviderRequest<'request> {
     pub provider_name: &'request str,
 }
 
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
-pub enum EmbeddingEncodingFormat {
-    #[default]
-    Float,
-    Base64,
-}
+pub use tensorzero_inference_types::EmbeddingEncodingFormat;
 
 #[derive(Debug, PartialEq)]
 pub struct EmbeddingProviderResponse {

--- a/crates/tensorzero-core/src/inference/types/file.rs
+++ b/crates/tensorzero-core/src/inference/types/file.rs
@@ -242,64 +242,7 @@ impl FileExt for File {
     }
 }
 
-/// Tries to convert a mime type to a file extension, picking an arbitrary extension if there are multiple
-/// extensions for the mime type.
-/// This is used when writing a file input to object storage, and when determining the file name
-/// to provide to OpenAI (which doesn't accept mime types for file input)
-pub fn mime_type_to_ext(mime_type: &MediaType) -> Result<Option<&'static str>, Error> {
-    Ok(match mime_type {
-        _ if mime_type == "image/jpeg" => Some("jpg"),
-        _ if mime_type == "image/png" => Some("png"),
-        _ if mime_type == "image/gif" => Some("gif"),
-        _ if mime_type == "application/pdf" => Some("pdf"),
-        _ if mime_type == "image/webp" => Some("webp"),
-        _ if mime_type == "text/plain" => Some("txt"),
-        _ if mime_type == "audio/midi" => Some("mid"),
-        _ if mime_type == "audio/mpeg" || mime_type == "audio/mp3" => Some("mp3"),
-        _ if mime_type == "audio/m4a" || mime_type == "audio/mp4" => Some("m4a"),
-        _ if mime_type == "audio/ogg" => Some("ogg"),
-        _ if mime_type == "audio/x-flac" || mime_type == "audio/flac" => Some("flac"),
-        _ if mime_type == "audio/x-wav"
-            || mime_type == "audio/wav"
-            || mime_type == "audio/wave" =>
-        {
-            Some("wav")
-        }
-        _ if mime_type == "audio/amr" => Some("amr"),
-        _ if mime_type == "audio/aac" || mime_type == "audio/x-aac" => Some("aac"),
-        _ if mime_type == "audio/x-aiff" || mime_type == "audio/aiff" => Some("aiff"),
-        _ if mime_type == "audio/x-dsf" => Some("dsf"),
-        _ if mime_type == "audio/x-ape" => Some("ape"),
-        _ if mime_type == "audio/webm" => Some("webm"),
-        _ => {
-            let guess = mime_guess::get_mime_extensions_str(mime_type.as_ref())
-                .and_then(|types| types.last());
-            if guess.is_some() {
-                tracing::warn!(
-                    "Guessed file extension `{guess:?}` for MIME type `{mime_type}`. This may not be correct."
-                );
-            }
-            guess.copied()
-        }
-    })
-}
-
-/// Converts audio MIME types to OpenAI's audio format strings.
-pub fn mime_type_to_audio_format(mime_type: &MediaType) -> Result<&'static str, Error> {
-    if mime_type.type_() != mime::AUDIO {
-        return Err(Error::new(ErrorDetails::InvalidMessage {
-            message: format!("Expected audio MIME type, got: {mime_type}"),
-        }));
-    }
-
-    mime_type_to_ext(mime_type)?.ok_or_else(|| {
-        Error::new(ErrorDetails::InvalidMessage {
-            message: format!(
-                "Unsupported audio MIME type: {mime_type}. Supported types: audio/midi, audio/mpeg, audio/m4a, audio/mp4, audio/ogg, audio/x-flac, audio/x-wav, audio/amr, audio/aac, audio/x-aiff, audio/x-dsf, audio/x-ape. Please open a feature request if your provider supports another audio format: https://github.com/tensorzero/tensorzero/discussions/categories/feature-requests"
-            ),
-        })
-    })
-}
+pub use tensorzero_inference_types::{mime_type_to_audio_format, mime_type_to_ext};
 
 #[cfg(test)]
 mod tests {

--- a/crates/tensorzero-core/src/inference/types/resolved_input.rs
+++ b/crates/tensorzero-core/src/inference/types/resolved_input.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::future::Future;
 use std::pin::Pin;
 
@@ -38,25 +37,7 @@ pub struct LazyResolvedInputMessage {
     pub content: Vec<LazyResolvedInputMessageContent>,
 }
 
-pub use tensorzero_inference_types::{FileFuture, FileUrl, LazyFile};
-
-pub trait LazyFileExt {
-    async fn resolve(&self) -> Result<Cow<'_, ObjectStorageFile>, Error>;
-}
-
-impl LazyFileExt for LazyFile {
-    async fn resolve(&self) -> Result<Cow<'_, ObjectStorageFile>, Error> {
-        match self {
-            LazyFile::Url {
-                future,
-                file_url: _,
-            } => Ok(Cow::Owned(future.clone().await?)),
-            LazyFile::Base64(pending) => Ok(Cow::Borrowed(&pending.0)),
-            LazyFile::ObjectStoragePointer { future, .. } => Ok(Cow::Owned(future.clone().await?)),
-            LazyFile::ObjectStorage(resolved) => Ok(Cow::Borrowed(resolved)),
-        }
-    }
-}
+pub use tensorzero_inference_types::{FileFuture, FileUrl, LazyFile, LazyFileExt};
 
 #[derive(Clone, Debug)]
 pub enum LazyResolvedInputMessageContent {

--- a/crates/tensorzero-core/src/model_table.rs
+++ b/crates/tensorzero-core/src/model_table.rs
@@ -82,52 +82,7 @@ pub trait ProviderKind {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum ProviderType {
-    Anthropic,
-    Azure,
-    Deepseek,
-    Fireworks,
-    AWSBedrock,
-    GCPVertexAnthropic,
-    GCPVertexGemini,
-    GoogleAIStudioGemini,
-    Groq,
-    Hyperbolic,
-    Mistral,
-    OpenAI,
-    OpenRouter,
-    SGLang,
-    TGI,
-    Together,
-    VLLM,
-    XAI,
-}
-
-impl Display for ProviderType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ProviderType::Anthropic => write!(f, "Anthropic"),
-            ProviderType::Azure => write!(f, "Azure"),
-            ProviderType::Deepseek => write!(f, "Deepseek"),
-            ProviderType::Fireworks => write!(f, "Fireworks"),
-            ProviderType::AWSBedrock => write!(f, "AWSBedrock"),
-            ProviderType::GCPVertexAnthropic => write!(f, "GCPVertexAnthropic"),
-            ProviderType::GCPVertexGemini => write!(f, "GCPVertexGemini"),
-            ProviderType::GoogleAIStudioGemini => write!(f, "GoogleAIStudioGemini"),
-            ProviderType::Groq => write!(f, "Groq"),
-            ProviderType::Hyperbolic => write!(f, "Hyperbolic"),
-            ProviderType::Mistral => write!(f, "Mistral"),
-            ProviderType::OpenAI => write!(f, "OpenAI"),
-            ProviderType::OpenRouter => write!(f, "OpenRouter"),
-            ProviderType::SGLang => write!(f, "SGLang"),
-            ProviderType::TGI => write!(f, "TGI"),
-            ProviderType::Together => write!(f, "Together"),
-            ProviderType::VLLM => write!(f, "VLLM"),
-            ProviderType::XAI => write!(f, "XAI"),
-        }
-    }
-}
+pub use tensorzero_inference_types::credentials::ProviderType;
 
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
 #[derive(Serialize, Debug)]

--- a/crates/tensorzero-core/src/providers/chat_completions.rs
+++ b/crates/tensorzero-core/src/providers/chat_completions.rs
@@ -12,7 +12,7 @@ use tensorzero_inference_types::{FunctionToolDef, ProviderToolCallConfig};
 
 use crate::error::Error;
 use crate::inference::types::ModelInferenceRequest;
-use crate::tool::{FunctionTool, FunctionToolConfig, ToolChoice};
+use crate::tool::{FunctionTool, ToolChoice};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -93,20 +93,6 @@ type PreparedChatCompletionToolsResult<'a> = (
     Option<ChatCompletionToolChoice<'a>>,
     Option<bool>,
 );
-
-impl<'a> From<&'a FunctionToolConfig> for ChatCompletionTool<'a> {
-    fn from(tool: &'a FunctionToolConfig) -> Self {
-        ChatCompletionTool {
-            r#type: ChatCompletionToolType::Function,
-            function: ChatCompletionFunction {
-                name: tool.name(),
-                description: Some(tool.description()),
-                parameters: tool.parameters(),
-            },
-            strict: tool.strict(),
-        }
-    }
-}
 
 impl<'a> From<&'a FunctionToolDef> for ChatCompletionTool<'a> {
     fn from(tool: &'a FunctionToolDef) -> Self {
@@ -272,23 +258,6 @@ mod tests {
         }
     }
 
-    fn create_dynamic_tool_config() -> FunctionToolConfig {
-        use crate::jsonschema_util::JSONSchema;
-        use crate::tool::DynamicToolConfig;
-
-        FunctionToolConfig::Dynamic(DynamicToolConfig {
-            name: "dynamic_tool".to_string(),
-            description: "A dynamic tool".to_string(),
-            parameters: JSONSchema::compile_background(json!({
-                "type": "object",
-                "properties": {
-                    "param1": {"type": "string"}
-                }
-            })),
-            strict: true,
-        })
-    }
-
     // Test serialization of ChatCompletionToolType
     #[test]
     fn test_chat_completion_tool_type_serialization() {
@@ -416,37 +385,24 @@ mod tests {
 
     // Test From implementations
     #[test]
-    fn test_from_function_tool_config_static() {
-        use crate::jsonschema_util::JSONSchema;
-        use crate::tool::StaticToolConfig;
-        use std::sync::Arc;
-        let tool_config = FunctionToolConfig::Static(Arc::new(StaticToolConfig {
+    fn test_from_function_tool_def() {
+        use tensorzero_inference_types::FunctionToolDef;
+        let tool_def = FunctionToolDef {
             name: "test_tool".to_string(),
-            key: "test_tool".to_string(),
             description: "A test tool".to_string(),
-            parameters: JSONSchema::from_value(json!({
+            parameters: json!({
                 "type": "object",
                 "properties": {
                     "param1": {"type": "string"}
                 }
-            }))
-            .unwrap(),
+            }),
             strict: true,
-        }));
-        let chat_tool: ChatCompletionTool = (&tool_config).into();
+        };
+        let chat_tool: ChatCompletionTool = (&tool_def).into();
 
         assert_eq!(chat_tool.function.name, "test_tool");
         assert_eq!(chat_tool.function.description, Some("A test tool"));
         assert!(chat_tool.strict);
-        assert!(matches!(chat_tool.r#type, ChatCompletionToolType::Function));
-    }
-
-    #[tokio::test]
-    async fn test_from_function_tool_config_dynamic() {
-        let tool_config = create_dynamic_tool_config();
-        let chat_tool: ChatCompletionTool = (&tool_config).into();
-
-        assert_eq!(chat_tool.function.name, "dynamic_tool");
         assert!(matches!(chat_tool.r#type, ChatCompletionToolType::Function));
     }
 

--- a/crates/tensorzero-core/src/providers/fireworks/mod.rs
+++ b/crates/tensorzero-core/src/providers/fireworks/mod.rs
@@ -44,7 +44,7 @@ use crate::{
         },
     },
     model::{Credential, ModelProviderRequestInfo, ProviderInferenceRequest},
-    tool::{FunctionToolConfig, ToolCall, ToolCallChunk},
+    tool::{ToolCall, ToolCallChunk},
 };
 use tensorzero_inference_types::FunctionToolDef;
 use uuid::Uuid;
@@ -801,19 +801,6 @@ impl<'a> From<&'a FunctionTool> for FireworksTool<'a> {
                 name: &tool.name,
                 description: Some(&tool.description),
                 parameters: &tool.parameters,
-            },
-        }
-    }
-}
-
-impl<'a> From<&'a FunctionToolConfig> for FireworksTool<'a> {
-    fn from(tool: &'a FunctionToolConfig) -> Self {
-        FireworksTool {
-            r#type: OpenAIToolType::Function,
-            function: OpenAIFunction {
-                name: tool.name(),
-                description: Some(tool.description()),
-                parameters: tool.parameters(),
             },
         }
     }

--- a/crates/tensorzero-core/src/providers/gcp_vertex_gemini/mod.rs
+++ b/crates/tensorzero-core/src/providers/gcp_vertex_gemini/mod.rs
@@ -67,7 +67,7 @@ use crate::model_table::{GCPVertexGeminiKind, ProviderType, ProviderTypeDefaultC
 use crate::tool::{AllowedTools, AllowedToolsChoice};
 use tensorzero_inference_types::{FunctionToolDef, ProviderToolCallConfig};
 
-use crate::tool::{FunctionTool, FunctionToolConfig, ToolCall, ToolCallChunk, ToolChoice};
+use crate::tool::{FunctionTool, ToolCall, ToolCallChunk, ToolChoice};
 use crate::utils::mock::get_mock_provider_api_base;
 
 use super::helpers::{JsonlBatchFileInfo, convert_stream_error, parse_jsonl_batch_file};
@@ -1752,16 +1752,6 @@ pub enum GCPVertexGeminiTool<'a> {
     FunctionDeclarations(Vec<GCPVertexGeminiFunctionDeclaration<'a>>),
 }
 
-impl<'a> From<&'a FunctionToolConfig> for GCPVertexGeminiFunctionDeclaration<'a> {
-    fn from(tool: &'a FunctionToolConfig) -> Self {
-        GCPVertexGeminiFunctionDeclaration {
-            name: tool.name(),
-            description: Some(tool.description()),
-            parameters: Some(process_jsonschema_for_gcp_vertex_gemini(tool.parameters())),
-        }
-    }
-}
-
 impl<'a> From<&'a FunctionToolDef> for GCPVertexGeminiFunctionDeclaration<'a> {
     fn from(tool: &'a FunctionToolDef) -> Self {
         GCPVertexGeminiFunctionDeclaration {
@@ -1769,14 +1759,6 @@ impl<'a> From<&'a FunctionToolDef> for GCPVertexGeminiFunctionDeclaration<'a> {
             description: Some(&tool.description),
             parameters: Some(process_jsonschema_for_gcp_vertex_gemini(&tool.parameters)),
         }
-    }
-}
-
-impl<'a> From<&'a Vec<FunctionToolConfig>> for GCPVertexGeminiTool<'a> {
-    fn from(tools: &'a Vec<FunctionToolConfig>) -> Self {
-        let function_declarations: Vec<GCPVertexGeminiFunctionDeclaration<'a>> =
-            tools.iter().map(Into::into).collect();
-        GCPVertexGeminiTool::FunctionDeclarations(function_declarations)
     }
 }
 
@@ -3260,12 +3242,13 @@ mod tests {
     use crate::jsonschema_util::JSONSchema;
     use tensorzero_inference_types::ProviderToolCallConfig;
 
-    use crate::providers::test_helpers::{MULTI_TOOL_CONFIG, QUERY_TOOL, WEATHER_TOOL};
-    use crate::tool::{StaticToolConfig, ToolResult};
+    use crate::providers::test_helpers::{
+        MULTI_PROVIDER_TOOL_CONFIG, MULTI_TOOL_CONFIG, QUERY_TOOL, WEATHER_TOOL,
+    };
+    use crate::tool::ToolResult;
     use googletest::prelude::*;
     use serde_json::json;
     use std::borrow::Cow;
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_gcp_vertex_content_try_from() {
@@ -3370,23 +3353,28 @@ mod tests {
 
     #[test]
     fn test_from_vec_tool() {
-        let tools_vec: Vec<&FunctionToolConfig> =
-            MULTI_TOOL_CONFIG.tools_available().unwrap().collect();
-        let tools_vec_owned: Vec<FunctionToolConfig> =
-            tools_vec.iter().map(|&t| t.clone()).collect();
-        let tool = GCPVertexGeminiTool::from(&tools_vec_owned);
+        let tools_vec: Vec<&FunctionToolDef> = MULTI_PROVIDER_TOOL_CONFIG
+            .tools_available()
+            .unwrap()
+            .collect();
+        let tool = GCPVertexGeminiTool::FunctionDeclarations(
+            tools_vec
+                .iter()
+                .map(|&t| GCPVertexGeminiFunctionDeclaration::from(t))
+                .collect(),
+        );
         assert_eq!(
             tool,
             GCPVertexGeminiTool::FunctionDeclarations(vec![
                 GCPVertexGeminiFunctionDeclaration {
                     name: "get_temperature",
                     description: Some("Get the current temperature in a given location"),
-                    parameters: Some(tools_vec[0].parameters().clone()),
+                    parameters: Some(tools_vec[0].parameters.clone()),
                 },
                 GCPVertexGeminiFunctionDeclaration {
                     name: "query_articles",
                     description: Some("Query articles from Wikipedia"),
-                    parameters: Some(tools_vec[1].parameters().clone()),
+                    parameters: Some(tools_vec[1].parameters.clone()),
                 }
             ])
         );
@@ -4612,18 +4600,15 @@ mod tests {
 
         let tool_schema = JSONSchema::from_value(tool_schema_value).unwrap();
 
-        let static_tool = StaticToolConfig {
+        let tool_def = FunctionToolDef {
             name: "test_tool".to_string(),
-            key: "test_tool".to_string(),
             description: "A test tool".to_string(),
-            parameters: tool_schema,
+            parameters: tool_schema.value,
             strict: false,
         };
 
-        let tool_config = FunctionToolConfig::Static(Arc::new(static_tool));
-
-        // Convert the tool config to GCPVertexGeminiFunctionDeclaration
-        let function_declaration = GCPVertexGeminiFunctionDeclaration::from(&tool_config);
+        // Convert the tool def to GCPVertexGeminiFunctionDeclaration
+        let function_declaration = GCPVertexGeminiFunctionDeclaration::from(&tool_def);
 
         // The parameters should have all $schema and additionalProperties removed recursively
         let expected_parameters = json!({

--- a/crates/tensorzero-core/src/providers/google_ai_studio_gemini.rs
+++ b/crates/tensorzero-core/src/providers/google_ai_studio_gemini.rs
@@ -43,8 +43,6 @@ use crate::providers::gcp_vertex_gemini::GCPVertexGeminiRole;
 use tensorzero_inference_types::{FunctionToolDef, ProviderToolCallConfig};
 
 #[cfg(test)]
-use crate::tool::FunctionToolConfig;
-#[cfg(test)]
 use crate::tool::{AllowedTools, AllowedToolsChoice};
 use crate::tool::{ToolCall, ToolCallChunk, ToolChoice};
 
@@ -429,17 +427,6 @@ struct GeminiTool<'a> {
 }
 
 impl<'a> GeminiFunctionDeclaration<'a> {
-    #[cfg(test)]
-    fn from_tool_config(tool: &'a FunctionToolConfig) -> Self {
-        let parameters = process_jsonschema_for_gcp_vertex_gemini(tool.parameters());
-
-        GeminiFunctionDeclaration {
-            name: tool.name(),
-            description: tool.description(),
-            parameters,
-        }
-    }
-
     fn from_function_tool_def(tool: &'a FunctionToolDef) -> Self {
         let parameters = process_jsonschema_for_gcp_vertex_gemini(&tool.parameters);
 
@@ -1294,9 +1281,7 @@ mod tests {
     };
     use tensorzero_inference_types::ProviderToolCallConfig;
 
-    use crate::providers::test_helpers::{
-        MULTI_PROVIDER_TOOL_CONFIG, MULTI_TOOL_CONFIG, QUERY_TOOL, WEATHER_TOOL,
-    };
+    use crate::providers::test_helpers::{MULTI_PROVIDER_TOOL_CONFIG, QUERY_TOOL, WEATHER_TOOL};
     use crate::utils::testing::capture_logs;
 
     #[test]
@@ -1355,12 +1340,14 @@ mod tests {
 
     #[test]
     fn test_from_vec_tool() {
-        let tools_vec: Vec<&FunctionToolConfig> =
-            MULTI_TOOL_CONFIG.tools_available().unwrap().collect();
+        let tools_vec: Vec<&FunctionToolDef> = MULTI_PROVIDER_TOOL_CONFIG
+            .tools_available()
+            .unwrap()
+            .collect();
         let tool = GeminiTool {
             function_declarations: tools_vec
                 .iter()
-                .map(|&t| GeminiFunctionDeclaration::from_tool_config(t))
+                .map(|&t| GeminiFunctionDeclaration::from_function_tool_def(t))
                 .collect(),
         };
         assert_eq!(
@@ -1370,12 +1357,12 @@ mod tests {
                     GeminiFunctionDeclaration {
                         name: "get_temperature",
                         description: "Get the current temperature in a given location",
-                        parameters: tools_vec[0].parameters().clone(),
+                        parameters: tools_vec[0].parameters.clone(),
                     },
                     GeminiFunctionDeclaration {
                         name: "query_articles",
                         description: "Query articles from Wikipedia",
-                        parameters: tools_vec[1].parameters().clone(),
+                        parameters: tools_vec[1].parameters.clone(),
                     }
                 ]
             }

--- a/crates/tensorzero-core/src/providers/groq.rs
+++ b/crates/tensorzero-core/src/providers/groq.rs
@@ -35,7 +35,8 @@ use crate::inference::types::{
 use crate::inference::{InferenceProvider, TensorZeroEventError};
 use crate::model::Credential;
 use crate::model::{ModelProviderRequestInfo, ProviderInferenceRequest};
-use crate::tool::{FunctionToolConfig, ToolCall, ToolCallChunk, ToolChoice};
+use crate::tool::{ToolCall, ToolCallChunk, ToolChoice};
+use tensorzero_inference_types::FunctionToolDef;
 use uuid::Uuid;
 
 use crate::providers::chat_completions::prepare_chat_completion_tools;
@@ -965,16 +966,16 @@ pub(super) struct GroqTool<'a> {
     pub(super) strict: bool,
 }
 
-impl<'a> From<&'a FunctionToolConfig> for GroqTool<'a> {
-    fn from(tool: &'a FunctionToolConfig) -> Self {
+impl<'a> From<&'a FunctionToolDef> for GroqTool<'a> {
+    fn from(tool: &'a FunctionToolDef) -> Self {
         GroqTool {
             r#type: GroqToolType::Function,
             function: GroqFunction {
-                name: tool.name(),
-                description: Some(tool.description()),
-                parameters: tool.parameters(),
+                name: &tool.name,
+                description: Some(&tool.description),
+                parameters: &tool.parameters,
             },
-            strict: tool.strict(),
+            strict: tool.strict,
         }
     }
 }

--- a/crates/tensorzero-core/src/providers/mistral.rs
+++ b/crates/tensorzero-core/src/providers/mistral.rs
@@ -45,7 +45,7 @@ use crate::{
         check_new_tool_call_name, convert_stream_error, inject_extra_request_data_and_send,
         inject_extra_request_data_and_send_eventsource,
     },
-    tool::{FunctionToolConfig, ToolCall, ToolCallChunk, ToolChoice},
+    tool::{ToolCall, ToolCallChunk, ToolChoice},
 };
 use tensorzero_inference_types::FunctionToolDef;
 use uuid::Uuid;
@@ -651,19 +651,6 @@ impl<'a> From<&'a ToolChoice> for MistralToolChoice<'a> {
 pub(super) struct MistralTool<'a> {
     r#type: OpenAIToolType,
     function: OpenAIFunction<'a>,
-}
-
-impl<'a> From<&'a FunctionToolConfig> for MistralTool<'a> {
-    fn from(tool: &'a FunctionToolConfig) -> Self {
-        MistralTool {
-            r#type: OpenAIToolType::Function,
-            function: OpenAIFunction {
-                name: tool.name(),
-                description: Some(tool.description()),
-                parameters: tool.parameters(),
-            },
-        }
-    }
 }
 
 impl<'a> From<&'a FunctionToolDef> for MistralTool<'a> {

--- a/crates/tensorzero-core/src/providers/openai/mod.rs
+++ b/crates/tensorzero-core/src/providers/openai/mod.rs
@@ -67,8 +67,7 @@ use crate::providers::openai::responses::{
 use tensorzero_inference_types::{FunctionToolDef, ProviderToolCallConfig};
 
 use crate::tool::{
-    FunctionTool, FunctionToolConfig, OpenAICustomTool, ToolCall, ToolCallChunk, ToolChoice,
-    ToolConfigRef,
+    FunctionTool, OpenAICustomTool, ToolCall, ToolCallChunk, ToolChoice, ToolConfigRef,
 };
 
 use super::helpers::{JsonlBatchFileInfo, parse_jsonl_batch_file};
@@ -2402,19 +2401,6 @@ pub enum OpenAITool<'a> {
     Custom {
         custom: &'a OpenAICustomTool,
     },
-}
-
-impl<'a> From<&'a FunctionToolConfig> for OpenAITool<'a> {
-    fn from(tool: &'a FunctionToolConfig) -> Self {
-        OpenAITool::Function {
-            function: OpenAIFunction {
-                name: tool.name(),
-                description: Some(tool.description()),
-                parameters: tool.parameters(),
-            },
-            strict: tool.strict(),
-        }
-    }
 }
 
 impl<'a> From<&'a FunctionToolDef> for OpenAITool<'a> {

--- a/crates/tensorzero-core/src/providers/openrouter.rs
+++ b/crates/tensorzero-core/src/providers/openrouter.rs
@@ -43,7 +43,8 @@ use crate::inference::types::{
 };
 use crate::model::Credential;
 use crate::model::{ModelProviderRequestInfo, ProviderInferenceRequest};
-use crate::tool::{FunctionToolConfig, ToolCall, ToolCallChunk, ToolChoice};
+use crate::tool::{ToolCall, ToolCallChunk, ToolChoice};
+use tensorzero_inference_types::FunctionToolDef;
 use tensorzero_types::content::{Thought, ThoughtSummaryBlock};
 use tensorzero_types_providers::openrouter::{
     ReasoningConfig as OpenRouterReasoningConfig, ReasoningDetail as OpenRouterReasoningDetail,
@@ -1311,16 +1312,16 @@ pub(super) struct OpenRouterTool<'a> {
     pub(super) strict: bool,
 }
 
-impl<'a> From<&'a FunctionToolConfig> for OpenRouterTool<'a> {
-    fn from(tool: &'a FunctionToolConfig) -> Self {
+impl<'a> From<&'a FunctionToolDef> for OpenRouterTool<'a> {
+    fn from(tool: &'a FunctionToolDef) -> Self {
         OpenRouterTool {
             r#type: OpenRouterToolType::Function,
             function: OpenRouterFunction {
-                name: tool.name(),
-                description: Some(tool.description()),
-                parameters: tool.parameters(),
+                name: &tool.name,
+                description: Some(&tool.description),
+                parameters: &tool.parameters,
             },
-            strict: tool.strict(),
+            strict: tool.strict,
         }
     }
 }

--- a/crates/tensorzero-inference-types/Cargo.toml
+++ b/crates/tensorzero-inference-types/Cargo.toml
@@ -20,6 +20,7 @@ sqlx.workspace = true
 tensorzero-derive = { path = "../tensorzero-derive" }
 tracing.workspace = true
 tensorzero-error = { path = "../tensorzero-error" }
+tensorzero-http = { path = "../tensorzero-http" }
 tensorzero-stored-config = { path = "../tensorzero-stored-config" }
 tensorzero-types = { path = "../tensorzero-types" }
 tensorzero-types-providers = { path = "../tensorzero-types-providers" }

--- a/crates/tensorzero-inference-types/Cargo.toml
+++ b/crates/tensorzero-inference-types/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 derive_builder.workspace = true
 futures.workspace = true
 mime.workspace = true
+mime_guess = "2.0.5"
 rust_decimal = { workspace = true }
 schemars.workspace = true
 secrecy.workspace = true

--- a/crates/tensorzero-inference-types/Cargo.toml
+++ b/crates/tensorzero-inference-types/Cargo.toml
@@ -18,6 +18,7 @@ serde_json.workspace = true
 serde_path_to_error.workspace = true
 sqlx.workspace = true
 tensorzero-derive = { path = "../tensorzero-derive" }
+tokio.workspace = true
 tracing.workspace = true
 tensorzero-error = { path = "../tensorzero-error" }
 tensorzero-http = { path = "../tensorzero-http" }

--- a/crates/tensorzero-inference-types/src/credential_validation.rs
+++ b/crates/tensorzero-inference-types/src/credential_validation.rs
@@ -1,0 +1,34 @@
+use std::future::Future;
+
+tokio::task_local! {
+    /// When set, we skip performing credential validation in model providers.
+    /// This is used when running in e2e test mode, and by the 'evaluations' binary.
+    /// We need to access this from async code (e.g. when looking up GCP SDK credentials),
+    /// so this needs to be a tokio task-local (as a task may be moved between threads).
+    ///
+    /// Since this needs to be accessed from a `Deserialize` impl, it needs to
+    /// be stored in a `static`, since we cannot pass in extra parameters when calling `Deserialize::deserialize`.
+    static SKIP_CREDENTIAL_VALIDATION: ();
+}
+
+pub fn skip_credential_validation() -> bool {
+    // tokio::task_local doesn't have an 'is_set' method, so we call 'try_with'
+    // (which returns an `Err` if the task-local is not set)
+    SKIP_CREDENTIAL_VALIDATION.try_with(|()| ()).is_ok()
+}
+
+/// Runs the provider future with credential validation disabled.
+/// This is safe to repeatedly nest — the original credential validation
+/// behavior will be restored after the outermost future completes.
+pub async fn with_skip_credential_validation<T>(f: impl Future<Output = T>) -> T {
+    SKIP_CREDENTIAL_VALIDATION.scope((), f).await
+}
+
+/// In e2e test mode, we skip credential validation by default.
+/// This can be overridden by setting the `TENSORZERO_E2E_CREDENTIAL_VALIDATION` environment variable to `1`.
+/// Outside of e2e test mode, we leave the behavior unchanged (other parts of the codebase might still
+/// skip credential validation, e.g. when running in relay mode).
+pub fn e2e_skip_credential_validation() -> bool {
+    cfg!(any(test, feature = "e2e_tests"))
+        && !std::env::var("TENSORZERO_E2E_CREDENTIAL_VALIDATION").is_ok_and(|x| x == "1")
+}

--- a/crates/tensorzero-inference-types/src/credentials.rs
+++ b/crates/tensorzero-inference-types/src/credentials.rs
@@ -354,6 +354,57 @@ impl Clone for ProviderInferenceRequest<'_> {
 }
 
 // =============================================================================
+// ProviderType
+// =============================================================================
+
+#[derive(Debug, Clone, Copy)]
+pub enum ProviderType {
+    Anthropic,
+    Azure,
+    Deepseek,
+    Fireworks,
+    AWSBedrock,
+    GCPVertexAnthropic,
+    GCPVertexGemini,
+    GoogleAIStudioGemini,
+    Groq,
+    Hyperbolic,
+    Mistral,
+    OpenAI,
+    OpenRouter,
+    SGLang,
+    TGI,
+    Together,
+    VLLM,
+    XAI,
+}
+
+impl std::fmt::Display for ProviderType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProviderType::Anthropic => write!(f, "Anthropic"),
+            ProviderType::Azure => write!(f, "Azure"),
+            ProviderType::Deepseek => write!(f, "Deepseek"),
+            ProviderType::Fireworks => write!(f, "Fireworks"),
+            ProviderType::AWSBedrock => write!(f, "AWSBedrock"),
+            ProviderType::GCPVertexAnthropic => write!(f, "GCPVertexAnthropic"),
+            ProviderType::GCPVertexGemini => write!(f, "GCPVertexGemini"),
+            ProviderType::GoogleAIStudioGemini => write!(f, "GoogleAIStudioGemini"),
+            ProviderType::Groq => write!(f, "Groq"),
+            ProviderType::Hyperbolic => write!(f, "Hyperbolic"),
+            ProviderType::Mistral => write!(f, "Mistral"),
+            ProviderType::OpenAI => write!(f, "OpenAI"),
+            ProviderType::OpenRouter => write!(f, "OpenRouter"),
+            ProviderType::SGLang => write!(f, "SGLang"),
+            ProviderType::TGI => write!(f, "TGI"),
+            ProviderType::Together => write!(f, "Together"),
+            ProviderType::VLLM => write!(f, "VLLM"),
+            ProviderType::XAI => write!(f, "XAI"),
+        }
+    }
+}
+
+// =============================================================================
 // Stored ↔ Credential type conversions
 // =============================================================================
 

--- a/crates/tensorzero-inference-types/src/embeddings.rs
+++ b/crates/tensorzero-inference-types/src/embeddings.rs
@@ -1,0 +1,192 @@
+use std::future::Future;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::credentials::ModelProviderRequestInfo;
+use crate::extra_body::ExtraBodyConfig;
+use crate::extra_headers::ExtraHeadersConfig;
+use crate::{EmbeddingEncodingFormat, Latency, RawUsageEntry, Usage};
+use tensorzero_error::Error;
+use tensorzero_http::TensorzeroHttpClient;
+use tensorzero_types::inference_params::InferenceCredentials;
+
+// =============================================================================
+// Embedding
+// =============================================================================
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum Embedding {
+    Float(Vec<f32>),
+    Base64(String),
+}
+
+impl Embedding {
+    pub fn as_float(&self) -> Option<&Vec<f32>> {
+        match self {
+            Embedding::Float(vec) => Some(vec),
+            Embedding::Base64(_) => None,
+        }
+    }
+
+    pub fn ndims(&self) -> usize {
+        match self {
+            Embedding::Float(vec) => vec.len(),
+            Embedding::Base64(encoded) => encoded.len() * 3 / 16,
+        }
+    }
+}
+
+// =============================================================================
+// EmbeddingInput
+// =============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum EmbeddingInput {
+    Single(String),
+    Batch(Vec<String>),
+    SingleTokens(Vec<u32>),
+    BatchTokens(Vec<Vec<u32>>),
+}
+
+impl EmbeddingInput {
+    pub fn num_inputs(&self) -> usize {
+        match self {
+            EmbeddingInput::Single(_) => 1,
+            EmbeddingInput::Batch(texts) => texts.len(),
+            EmbeddingInput::SingleTokens(_) => 1,
+            EmbeddingInput::BatchTokens(tokens) => tokens.len(),
+        }
+    }
+
+    pub fn first(&self) -> Option<&String> {
+        match self {
+            EmbeddingInput::Single(text) => Some(text),
+            EmbeddingInput::Batch(texts) => texts.first(),
+            EmbeddingInput::SingleTokens(_) => None,
+            EmbeddingInput::BatchTokens(_) => None,
+        }
+    }
+
+    pub fn estimated_input_token_usage(&self) -> u64 {
+        match self {
+            EmbeddingInput::Single(text) => (text.len() as u64) / 2,
+            EmbeddingInput::Batch(texts) => texts.iter().map(|t| (t.len() as u64) / 2).sum(),
+            EmbeddingInput::SingleTokens(tokens) => tokens.len() as u64,
+            EmbeddingInput::BatchTokens(token_arrays) => {
+                token_arrays.iter().map(|t| t.len() as u64).sum()
+            }
+        }
+    }
+}
+
+impl From<String> for EmbeddingInput {
+    fn from(text: String) -> Self {
+        EmbeddingInput::Single(text)
+    }
+}
+
+// =============================================================================
+// EmbeddingRequest, EmbeddingProviderRequest
+// =============================================================================
+
+#[derive(Debug, PartialEq, Serialize)]
+pub struct EmbeddingRequest {
+    pub input: EmbeddingInput,
+    pub dimensions: Option<u32>,
+    pub encoding_format: EmbeddingEncodingFormat,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct EmbeddingProviderRequest<'request> {
+    pub request: &'request EmbeddingRequest,
+    pub model_name: &'request str,
+    pub provider_name: &'request str,
+}
+
+// =============================================================================
+// EmbeddingProviderResponse
+// =============================================================================
+
+#[derive(Debug, PartialEq)]
+pub struct EmbeddingProviderResponse {
+    pub id: Uuid,
+    pub input: EmbeddingInput,
+    pub embeddings: Vec<Embedding>,
+    pub created: u64,
+    pub raw_request: String,
+    pub raw_response: String,
+    pub usage: Usage,
+    pub latency: Latency,
+    pub raw_usage: Option<Vec<RawUsageEntry>>,
+}
+
+impl EmbeddingProviderResponse {
+    #[expect(clippy::missing_panics_doc)]
+    pub fn new(
+        embeddings: Vec<Embedding>,
+        input: EmbeddingInput,
+        raw_request: String,
+        raw_response: String,
+        usage: Usage,
+        latency: Latency,
+        raw_usage: Option<Vec<RawUsageEntry>>,
+    ) -> Self {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        #[expect(clippy::expect_used)]
+        let created = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs();
+        Self {
+            id: Uuid::now_v7(),
+            input,
+            embeddings,
+            created,
+            raw_request,
+            raw_response,
+            usage,
+            latency,
+            raw_usage,
+        }
+    }
+}
+
+// =============================================================================
+// EmbeddingProviderRequestInfo
+// =============================================================================
+
+#[derive(Clone, Debug)]
+pub struct EmbeddingProviderRequestInfo {
+    pub provider_name: Arc<str>,
+    pub extra_body: Option<ExtraBodyConfig>,
+    pub extra_headers: Option<ExtraHeadersConfig>,
+}
+
+impl From<&EmbeddingProviderRequestInfo> for ModelProviderRequestInfo {
+    fn from(val: &EmbeddingProviderRequestInfo) -> Self {
+        ModelProviderRequestInfo {
+            provider_name: val.provider_name.clone(),
+            extra_headers: val.extra_headers.clone(),
+            extra_body: val.extra_body.clone(),
+            discard_unknown_chunks: false,
+        }
+    }
+}
+
+// =============================================================================
+// EmbeddingProvider trait
+// =============================================================================
+
+pub trait EmbeddingProvider {
+    fn embed(
+        &self,
+        request: &EmbeddingRequest,
+        client: &TensorzeroHttpClient,
+        dynamic_api_keys: &InferenceCredentials,
+        model_provider_data: &EmbeddingProviderRequestInfo,
+    ) -> impl Future<Output = Result<EmbeddingProviderResponse, Error>> + Send;
+}

--- a/crates/tensorzero-inference-types/src/lib.rs
+++ b/crates/tensorzero-inference-types/src/lib.rs
@@ -7,6 +7,7 @@
 //! - Tighter incremental compilation boundaries
 
 pub mod credentials;
+pub mod embeddings;
 pub mod extra_body;
 pub mod extra_headers;
 pub(crate) mod serde_helpers;

--- a/crates/tensorzero-inference-types/src/lib.rs
+++ b/crates/tensorzero-inference-types/src/lib.rs
@@ -198,6 +198,105 @@ pub enum ModelInferenceRequestJsonMode {
 }
 
 // =============================================================================
+// EmbeddingEncodingFormat
+// =============================================================================
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum EmbeddingEncodingFormat {
+    #[default]
+    Float,
+    Base64,
+}
+
+// =============================================================================
+// MIME type helpers
+// =============================================================================
+
+/// Tries to convert a mime type to a file extension, picking an arbitrary extension if there are multiple
+/// extensions for the mime type.
+/// This is used when writing a file input to object storage, and when determining the file name
+/// to provide to OpenAI (which doesn't accept mime types for file input)
+pub fn mime_type_to_ext(mime_type: &MediaType) -> Result<Option<&'static str>, Error> {
+    Ok(match mime_type {
+        _ if mime_type == "image/jpeg" => Some("jpg"),
+        _ if mime_type == "image/png" => Some("png"),
+        _ if mime_type == "image/gif" => Some("gif"),
+        _ if mime_type == "application/pdf" => Some("pdf"),
+        _ if mime_type == "image/webp" => Some("webp"),
+        _ if mime_type == "text/plain" => Some("txt"),
+        _ if mime_type == "audio/midi" => Some("mid"),
+        _ if mime_type == "audio/mpeg" || mime_type == "audio/mp3" => Some("mp3"),
+        _ if mime_type == "audio/m4a" || mime_type == "audio/mp4" => Some("m4a"),
+        _ if mime_type == "audio/ogg" => Some("ogg"),
+        _ if mime_type == "audio/x-flac" || mime_type == "audio/flac" => Some("flac"),
+        _ if mime_type == "audio/x-wav"
+            || mime_type == "audio/wav"
+            || mime_type == "audio/wave" =>
+        {
+            Some("wav")
+        }
+        _ if mime_type == "audio/amr" => Some("amr"),
+        _ if mime_type == "audio/aac" || mime_type == "audio/x-aac" => Some("aac"),
+        _ if mime_type == "audio/x-aiff" || mime_type == "audio/aiff" => Some("aiff"),
+        _ if mime_type == "audio/x-dsf" => Some("dsf"),
+        _ if mime_type == "audio/x-ape" => Some("ape"),
+        _ if mime_type == "audio/webm" => Some("webm"),
+        _ => {
+            let guess = mime_guess::get_mime_extensions_str(mime_type.as_ref())
+                .and_then(|types| types.last());
+            if guess.is_some() {
+                tracing::warn!(
+                    "Guessed file extension `{guess:?}` for MIME type `{mime_type}`. This may not be correct."
+                );
+            }
+            guess.copied()
+        }
+    })
+}
+
+/// Converts audio MIME types to OpenAI's audio format strings.
+pub fn mime_type_to_audio_format(mime_type: &MediaType) -> Result<&'static str, Error> {
+    if mime_type.type_() != mime::AUDIO {
+        return Err(Error::new(tensorzero_error::ErrorDetails::InvalidMessage {
+            message: format!("Expected audio MIME type, got: {mime_type}"),
+        }));
+    }
+
+    mime_type_to_ext(mime_type)?.ok_or_else(|| {
+        Error::new(tensorzero_error::ErrorDetails::InvalidMessage {
+            message: format!(
+                "Unsupported audio MIME type: {mime_type}. Supported types: audio/midi, audio/mpeg, audio/m4a, audio/mp4, audio/ogg, audio/x-flac, audio/x-wav, audio/amr, audio/aac, audio/x-aiff, audio/x-dsf, audio/x-ape. Please open a feature request if your provider supports another audio format: https://github.com/tensorzero/tensorzero/discussions/categories/feature-requests"
+            ),
+        })
+    })
+}
+
+// =============================================================================
+// LazyFileExt
+// =============================================================================
+
+pub trait LazyFileExt {
+    fn resolve(
+        &self,
+    ) -> impl Future<Output = Result<Cow<'_, tensorzero_types::ObjectStorageFile>, Error>> + Send;
+}
+
+impl LazyFileExt for LazyFile {
+    async fn resolve(&self) -> Result<Cow<'_, tensorzero_types::ObjectStorageFile>, Error> {
+        match self {
+            LazyFile::Url {
+                future,
+                file_url: _,
+            } => Ok(Cow::Owned(future.clone().await?)),
+            LazyFile::Base64(pending) => Ok(Cow::Borrowed(&pending.0)),
+            LazyFile::ObjectStoragePointer { future, .. } => Ok(Cow::Owned(future.clone().await?)),
+            LazyFile::ObjectStorage(resolved) => Ok(Cow::Borrowed(resolved)),
+        }
+    }
+}
+
+// =============================================================================
 // ContentBlockOutput
 // =============================================================================
 

--- a/crates/tensorzero-inference-types/src/lib.rs
+++ b/crates/tensorzero-inference-types/src/lib.rs
@@ -6,6 +6,7 @@
 //! - Isolated serde derive expansion
 //! - Tighter incremental compilation boundaries
 
+pub mod credential_validation;
 pub mod credentials;
 pub mod embeddings;
 pub mod extra_body;


### PR DESCRIPTION
## Summary

Move types that providers depend on out of tensorzero-core into shared crates, preparing for the providers crate extraction.

### Changes

**Remove `FunctionToolConfig` dependency from providers:**
- Delete all `From<&FunctionToolConfig>` impls (keep `From<&FunctionToolDef>` which is in inference-types)
- Providers only need `FunctionToolDef` fields (name, description, parameters, strict)
- `FunctionToolConfig` has heavy deps (JSONSchema → jsonschema::Validator) that providers don't need

**Move types to `tensorzero-inference-types`:**
- `EmbeddingEncodingFormat` — simple enum used by 4 embedding providers
- `mime_type_to_ext` / `mime_type_to_audio_format` — file extension helpers
- `LazyFileExt` trait — file resolution used by providers

### Remaining blockers for providers crate (follow-up PRs)

- `EmbeddingProvider` trait + types (4 providers) — coupled to `RateLimitedRequest`
- `skip_credential_validation` (2 GCP providers) — needs to become a parameter
- `ProviderType` / model_table types (2 GCP providers) — needs extraction

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)