### PR TITLE
Bump some `rand` dependencies to help with RUSTSEC-2026-0097

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
  "mockall",
  "object_store",
  "parquet",
- "rand 0.10.0",
+ "rand 0.10.1",
  "schemars 1.2.1",
  "serde",
  "serde_arrow",
@@ -2627,7 +2627,7 @@ dependencies = [
  "chrono",
  "futures",
  "hostname",
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde",
  "serde_json",
  "serde_with",
@@ -3405,7 +3405,7 @@ dependencies = [
  "google-cloud-wkt",
  "http 1.4.0",
  "pin-project",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3489,7 +3489,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.3",
  "smallvec",
  "spinning_top",
  "web-time 1.1.0",
@@ -4781,7 +4781,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "metrics",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -4887,7 +4887,7 @@ dependencies = [
  "futures",
  "mimalloc",
  "object_store",
- "rand 0.10.0",
+ "rand 0.10.1",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
@@ -5227,7 +5227,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.10.0",
+ "rand 0.10.1",
  "reqwest 0.12.28",
  "ring",
  "rustls-pki-types",
@@ -5356,7 +5356,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.3",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -5762,7 +5762,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -5812,7 +5812,7 @@ dependencies = [
  "hyper-util",
  "moka",
  "pin-project",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rcgen",
  "reqwest 0.13.2",
  "reqwest-sse-stream",
@@ -6003,7 +6003,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls 0.23.37",
@@ -6078,9 +6078,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6088,9 +6088,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -6148,7 +6148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -6275,7 +6275,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -6379,7 +6379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c44e98700033fcce3c3774ab8e4f31b9cebb2761df3298600f4be30a95d2f2a"
 dependencies = [
  "futures",
- "rand 0.9.2",
+ "rand 0.9.3",
  "redis",
  "socket2 0.6.3",
  "tempfile",
@@ -6702,7 +6702,7 @@ dependencies = [
  "http-body-util",
  "pastey 0.2.1",
  "pin-project-lite",
- "rand 0.10.0",
+ "rand 0.10.1",
  "reqwest 0.13.2",
  "rmcp-macros",
  "schemars 1.2.1",
@@ -7954,7 +7954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -8029,7 +8029,7 @@ dependencies = [
  "futures",
  "hex",
  "moka",
- "rand 0.10.0",
+ "rand 0.10.1",
  "secrecy",
  "serde",
  "serde_json",
@@ -8120,7 +8120,7 @@ dependencies = [
  "paste",
  "pin-project",
  "pyo3",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_distr",
  "redis",
  "redis-test",
@@ -8305,7 +8305,7 @@ dependencies = [
  "minijinja",
  "object_store",
  "paste",
- "rand 0.10.0",
+ "rand 0.10.1",
  "reqwest 0.13.2",
  "schemars 1.2.1",
  "secrecy",


### PR DESCRIPTION
This bump our rand 0.9 and 0.10 dependencies. It unfortunately does not fully fix the advisory, as we're still pulling in rand 0.8 via some transitive dependencies

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this is a lockfile-only patch-level dependency update; behavior changes are unlikely but could affect any code paths relying on random number generation or temp file creation.
> 
> **Overview**
> Updates `crates/Cargo.lock` to bump transitive and direct `rand` versions from `0.9.2`→`0.9.3` and `0.10.0`→`0.10.1` across multiple crates to help address `RUSTSEC-2026-0097`.
> 
> Also adjusts related lockfile resolution (notably `tempfile` now depends on `getrandom 0.3.4` instead of `0.4.2`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 966a5c1336e0a9d70ea1ae62deda06e394c2ff99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->