### PR TITLE
Adjust prompt in test_reasoning_inference_request_simple_nonstreaming

### DIFF
--- a/crates/tensorzero-core/tests/e2e/providers/reasoning.rs
+++ b/crates/tensorzero-core/tests/e2e/providers/reasoning.rs
@@ -255,7 +255,8 @@ pub async fn test_reasoning_inference_request_simple_nonstreaming_with_provider(
     let expected_input_messages = vec![StoredRequestMessage {
         role: Role::User,
         content: vec![StoredContentBlock::Text(Text {
-            text: "Think before responding. What is 34 * 57 + 21 / 3? Answer with just the number.".to_string(),
+            text: "Think before responding. What is 34 * 57 + 21 / 3? Answer with just the number."
+                .to_string(),
         })],
     }];
     assert_eq!(input_messages, expected_input_messages);

--- a/crates/tensorzero-core/tests/e2e/providers/reasoning.rs
+++ b/crates/tensorzero-core/tests/e2e/providers/reasoning.rs
@@ -42,7 +42,7 @@ pub async fn test_reasoning_inference_request_simple_nonstreaming_with_provider(
                "messages": [
                 {
                     "role": "user",
-                    "content": "What is 34 * 57 + 21 / 3? Answer with just the number."
+                    "content": "Think before responding. What is 34 * 57 + 21 / 3? Answer with just the number."
                 }
             ]},
         "extra_headers": extra_headers,
@@ -143,7 +143,7 @@ pub async fn test_reasoning_inference_request_simple_nonstreaming_with_provider(
         "messages": [
             {
                 "role": "user",
-                "content": [{"type": "text", "text": "What is 34 * 57 + 21 / 3? Answer with just the number."}]
+                "content": [{"type": "text", "text": "Think before responding. What is 34 * 57 + 21 / 3? Answer with just the number."}]
             }
         ]
     });
@@ -255,7 +255,7 @@ pub async fn test_reasoning_inference_request_simple_nonstreaming_with_provider(
     let expected_input_messages = vec![StoredRequestMessage {
         role: Role::User,
         content: vec![StoredContentBlock::Text(Text {
-            text: "What is 34 * 57 + 21 / 3? Answer with just the number.".to_string(),
+            text: "Think before responding. What is 34 * 57 + 21 / 3? Answer with just the number.".to_string(),
         })],
     }];
     assert_eq!(input_messages, expected_input_messages);


### PR DESCRIPTION
This should hopefully fix the Gemini test that started failing recently

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates an e2e test prompt/expected stored input strings, with no production code changes. Main risk is slight behavior sensitivity if providers treat the new instruction differently.
> 
> **Overview**
> Adjusts the non-streaming reasoning provider e2e test to prepend `Think before responding.` to the user prompt, and updates the corresponding expected `input`/`input_messages` assertions so stored request verification matches the new prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3517bcac34747a06f6b5aa7fff3c7d0c8aa0474. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->