### PR TITLE
Ignore RUSTSEC-2026-0097 for now

### DIFF
--- a/crates/deny.toml
+++ b/crates/deny.toml
@@ -24,6 +24,7 @@ multiple-versions = "allow"
 ignore = [
     "RUSTSEC-2024-0436", # We don't care that 'paste' is unmaintained
     "RUSTSEC-2025-0141", # `bincode` is unmaintained but is a transitive dep of `deno_core`
+    "RUSTSEC-2026-0097", # `rand` vulnerability in transitive deps (https://github.com/tensorzero/tensorzero/issues/7273)
 ]
 
 [licenses]


### PR DESCRIPTION
We've bumped all of the transitive deps that we can. I've opened a github issue to track removing this ignore once the remaining transitive deps update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low code risk since this only updates `cargo-deny` configuration, but it temporarily suppresses a known `rand` security advisory for transitive dependencies so it can mask vulnerability detection until dependencies are updated.
> 
> **Overview**
> Updates `crates/deny.toml` to **ignore advisory `RUSTSEC-2026-0097`** (a `rand` vulnerability in transitive deps), preventing `cargo-deny` from failing on that report for now.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c732c047cd6ced7506bbfeeaf266d051bcad8a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->