### PR TITLE
Allow adding/editing files not referenced by config

### DIFF
--- a/crates/tensorzero-core/src/db/postgres/stored_config_queries.rs
+++ b/crates/tensorzero-core/src/db/postgres/stored_config_queries.rs
@@ -971,8 +971,11 @@ pub async fn load_config_from_db(pool: &PgPool) -> Result<UninitializedConfig, V
 ///
 /// Used by the config editor to build the full `path_contents` map — both
 /// files referenced in the TOML and "free" files the user added but has not
-/// yet referenced. The `DISTINCT ON … ORDER BY created_at DESC` pattern
-/// relies on `idx_stored_files_editor_latest`.
+/// yet referenced. The `DISTINCT ON … ORDER BY created_at DESC, id DESC`
+/// pattern relies on `idx_stored_files_editor_latest`. The secondary `id
+/// DESC` sort ensures deterministic row selection when rows share a
+/// `created_at` timestamp (which can happen within a single transaction,
+/// since `NOW()` is transaction-stable).
 pub async fn load_editor_path_contents(pool: &PgPool) -> Result<HashMap<String, String>, Error> {
     #[derive(FromRow)]
     struct EditorFileRow {
@@ -984,7 +987,7 @@ pub async fn load_editor_path_contents(pool: &PgPool) -> Result<HashMap<String, 
         SELECT DISTINCT ON (file_path) file_path, source_body
         FROM tensorzero.stored_files
         WHERE deleted_at IS NULL
-        ORDER BY file_path, created_at DESC
+        ORDER BY file_path, created_at DESC, id DESC
         ",
     )
     .fetch_all(pool)

--- a/crates/tensorzero-core/src/db/postgres/stored_config_queries.rs
+++ b/crates/tensorzero-core/src/db/postgres/stored_config_queries.rs
@@ -965,3 +965,37 @@ pub async fn load_config_from_db(pool: &PgPool) -> Result<UninitializedConfig, V
 
     Ok(config)
 }
+
+/// Loads the latest non-tombstoned version of every file in `stored_files`,
+/// keyed by `file_path`.
+///
+/// Used by the config editor to build the full `path_contents` map — both
+/// files referenced in the TOML and "free" files the user added but has not
+/// yet referenced. The `DISTINCT ON … ORDER BY created_at DESC` pattern
+/// relies on `idx_stored_files_editor_latest`.
+pub async fn load_editor_path_contents(pool: &PgPool) -> Result<HashMap<String, String>, Error> {
+    #[derive(FromRow)]
+    struct EditorFileRow {
+        file_path: String,
+        source_body: String,
+    }
+    let rows = sqlx::query_as::<_, EditorFileRow>(
+        r"
+        SELECT DISTINCT ON (file_path) file_path, source_body
+        FROM tensorzero.stored_files
+        WHERE deleted_at IS NULL
+        ORDER BY file_path, created_at DESC
+        ",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| {
+        Error::new(ErrorDetails::PostgresQuery {
+            message: format!("Failed to load editor path contents: {e}"),
+        })
+    })?;
+    Ok(rows
+        .into_iter()
+        .map(|r| (r.file_path, r.source_body))
+        .collect())
+}

--- a/crates/tensorzero-core/src/endpoints/internal/config_toml.rs
+++ b/crates/tensorzero-core/src/endpoints/internal/config_toml.rs
@@ -4,18 +4,21 @@
 //! TOML document, validate edits against the config-loading pipeline, and
 //! apply them back to the stored-config tables with compare-and-swap.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use axum::Json;
 use axum::extract::State;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use sqlx::Postgres;
+use sqlx::{Postgres, QueryBuilder};
 use tracing::instrument;
+use uuid::Uuid;
 
 use crate::config::editable::{config_to_toml, toml_to_config};
 use crate::config::{Config, UninitializedConfig};
-use crate::db::postgres::stored_config_queries::{load_config_from_db, merge_load_config_errors};
+use crate::db::postgres::stored_config_queries::{
+    load_config_from_db, load_editor_path_contents, merge_load_config_errors,
+};
 use crate::db::postgres::stored_config_writes::{
     WriteStoredConfigParams, write_stored_config_in_tx,
 };
@@ -53,8 +56,13 @@ impl GetConfigTomlResponse {
         config: UninitializedConfig,
         hash: String,
         tags: HashMap<String, String>,
+        free_files: HashMap<String, String>,
     ) -> Result<Self, Error> {
-        let (toml, path_contents) = config_to_toml(&config)?;
+        let (toml, canonical_path_contents) = config_to_toml(&config)?;
+        // Merge free files with referenced files. Canonical (referenced) entries
+        // take precedence if a key appears in both.
+        let mut path_contents = free_files;
+        path_contents.extend(canonical_path_contents);
         let base_signature = editable_config_signature(&toml, &path_contents)?;
         Ok(Self {
             toml,
@@ -123,8 +131,20 @@ async fn load_db_authoritative_uninitialized_config(
 async fn load_db_authoritative_config_toml(
     app_state: &ResolvedAppStateData,
 ) -> Result<GetConfigTomlResponse, Error> {
-    let (uninitialized, hash) = load_db_authoritative_uninitialized_config(app_state).await?;
-    GetConfigTomlResponse::from_uninitialized(uninitialized, hash, HashMap::new())
+    let pool = app_state
+        .postgres_connection_info
+        .get_pool_result()
+        .map_err(|e| e.log())?;
+    let ((uninitialized, hash), all_path_contents) = tokio::try_join!(
+        load_db_authoritative_uninitialized_config(app_state),
+        load_editor_path_contents(pool)
+    )?;
+    GetConfigTomlResponse::from_uninitialized(
+        uninitialized,
+        hash,
+        HashMap::new(),
+        all_path_contents,
+    )
 }
 
 async fn acquire_config_editor_lock(tx: &mut sqlx::Transaction<'_, Postgres>) -> Result<(), Error> {
@@ -215,7 +235,6 @@ pub async fn apply_config_toml_handler(
     let app_state = swap_state.load_latest();
     let edited_config = toml_to_config(&request.toml, &request.path_contents)?;
     let (canonical_toml, canonical_path_contents) = config_to_toml(&edited_config)?;
-    let canonical_signature = editable_config_signature(&canonical_toml, &canonical_path_contents)?;
 
     let pool = app_state
         .postgres_connection_info
@@ -234,17 +253,42 @@ pub async fn apply_config_toml_handler(
     // observe uncommitted state on `tx` — but that is fine here: at this
     // point `tx` has only acquired the lock, not written anything, so the
     // committed baseline is exactly what we want to CAS against.
-    let current_uninitialized = load_config_from_db(pool)
-        .await
-        .map_err(merge_load_config_errors)?;
-    let (current_toml, current_path_contents) = config_to_toml(&current_uninitialized)?;
-    let current_signature = editable_config_signature(&current_toml, &current_path_contents)?;
+    let (current_uninitialized, current_all_path_contents) = tokio::try_join!(
+        async {
+            load_config_from_db(pool)
+                .await
+                .map_err(merge_load_config_errors)
+        },
+        load_editor_path_contents(pool)
+    )?;
+    let (current_toml, current_canonical_path_contents) = config_to_toml(&current_uninitialized)?;
+    // Compute the CAS signature the same way from_uninitialized does: start
+    // with all editor files, then let canonical entries overwrite. This ensures
+    // referenced files always use the version the config was built from, not a
+    // newer row for the same path that a content-addressed write may have left
+    // in stored_files.
+    let mut current_effective_path_contents = current_all_path_contents;
+    current_effective_path_contents.extend(current_canonical_path_contents.clone());
+    let current_signature =
+        editable_config_signature(&current_toml, &current_effective_path_contents)?;
 
     if current_signature != request.base_signature {
         return Err(Error::new(ErrorDetails::ConfigCompareAndSwapConflict {
             message: "Config changed underneath you, reload the latest snapshot before applying your edits.".to_string(),
         }));
     }
+
+    // Files in the request that are not referenced by the canonical config are
+    // "free files" — they live in the UI editor but are not yet wired up to any
+    // config entry. Persist them into stored_files so they survive the
+    // normalize round-trip.
+    let new_free_files: HashMap<String, String> = request
+        .path_contents
+        .iter()
+        .filter(|(k, _)| !canonical_path_contents.contains_key(k.as_str()))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    let all_new_paths: HashSet<String> = request.path_contents.keys().cloned().collect();
 
     // `write_stored_config_in_tx` validates `edited_config` internally and
     // returns the resulting `UnwrittenConfig`, so we can hot-swap the live
@@ -261,6 +305,8 @@ pub async fn apply_config_toml_handler(
         },
     ))
     .await?;
+
+    write_free_files_in_tx(&mut tx, &new_free_files, &all_new_paths, "ui-config-editor").await?;
 
     // Write the config snapshot and build new runtime dependencies **before**
     // committing the transaction, so a runtime-dependency failure (e.g. bad
@@ -283,12 +329,73 @@ pub async fn apply_config_toml_handler(
     // Infallible: all fallible work was done in `prepare_config_swap` above.
     swap_state.swap_config(prepared);
 
+    // Build the response path_contents: merge free files over canonical so
+    // the client sees all files. Canonical entries take precedence.
+    let mut response_path_contents = new_free_files.clone();
+    response_path_contents.extend(canonical_path_contents);
+    let response_signature = editable_config_signature(&canonical_toml, &response_path_contents)?;
+
     Ok(Json(ApplyConfigTomlResponse {
         toml: canonical_toml,
-        path_contents: canonical_path_contents,
+        path_contents: response_path_contents,
         hash: written_hash,
-        base_signature: canonical_signature,
+        base_signature: response_signature,
     }))
+}
+
+/// Inserts free files (files in `path_contents` not referenced by the TOML)
+/// into `tensorzero.stored_files` and tombstones files that were present in
+/// the editor but are absent from the new `path_contents`.
+///
+/// `stored_files` rows referenced by UUID from config tables are never
+/// queried with a `deleted_at` filter, so tombstoning only affects the
+/// editor view — it does not break any live config references.
+async fn write_free_files_in_tx(
+    tx: &mut sqlx::Transaction<'_, Postgres>,
+    free_files: &HashMap<String, String>,
+    all_new_paths: &HashSet<String>,
+    creation_source: &str,
+) -> Result<(), Error> {
+    // Tombstone all non-deleted rows for file paths that the user removed
+    // from the editor (absent from the new path_contents entirely).
+    sqlx::query(
+        r"
+        UPDATE tensorzero.stored_files
+        SET deleted_at = NOW()
+        WHERE deleted_at IS NULL
+          AND file_path NOT IN (SELECT unnest($1::text[]))
+        ",
+    )
+    .bind(all_new_paths.iter().cloned().collect::<Vec<_>>())
+    .execute(&mut **tx)
+    .await
+    .map_err(|e| {
+        Error::new(ErrorDetails::PostgresQuery {
+            message: format!("Failed to tombstone removed files in stored_files: {e}"),
+        })
+    })?;
+
+    // Insert free files (not handled by write_stored_config_in_tx).
+    if !free_files.is_empty() {
+        let mut qb = QueryBuilder::new(
+            "INSERT INTO tensorzero.stored_files (id, file_path, source_body, content_hash, creation_source) ",
+        );
+        qb.push_values(free_files, |mut b, (path, body)| {
+            let hash = blake3::hash(body.as_bytes()).as_bytes().to_vec();
+            b.push_bind(Uuid::now_v7())
+                .push_bind(path)
+                .push_bind(body)
+                .push_bind(hash)
+                .push_bind(creation_source);
+        });
+        qb.build().execute(&mut **tx).await.map_err(|e| {
+            Error::new(ErrorDetails::PostgresQuery {
+                message: format!("Failed to insert free files into stored_files: {e}"),
+            })
+        })?;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -340,6 +447,7 @@ mod tests {
         let response = GetConfigTomlResponse::from_uninitialized(
             config,
             "test-hash".to_string(),
+            HashMap::new(),
             HashMap::new(),
         )
         .expect("TOML response generation should succeed");

--- a/crates/tensorzero-core/src/endpoints/internal/config_toml.rs
+++ b/crates/tensorzero-core/src/endpoints/internal/config_toml.rs
@@ -10,7 +10,7 @@ use axum::Json;
 use axum::extract::State;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use sqlx::{Postgres, QueryBuilder};
+use sqlx::Postgres;
 use tracing::instrument;
 use uuid::Uuid;
 
@@ -350,6 +350,10 @@ pub async fn apply_config_toml_handler(
 /// `stored_files` rows referenced by UUID from config tables are never
 /// queried with a `deleted_at` filter, so tombstoning only affects the
 /// editor view — it does not break any live config references.
+///
+/// At most one active row per `file_path` is maintained: if the content is
+/// unchanged the existing row is reused; if the content changed the old row
+/// is tombstoned before the new one is inserted.
 async fn write_free_files_in_tx(
     tx: &mut sqlx::Transaction<'_, Postgres>,
     free_files: &HashMap<String, String>,
@@ -375,25 +379,61 @@ async fn write_free_files_in_tx(
         })
     })?;
 
-    // Insert free files (not handled by write_stored_config_in_tx).
-    if !free_files.is_empty() {
-        let mut qb = QueryBuilder::new(
-            "INSERT INTO tensorzero.stored_files (id, file_path, source_body, content_hash, creation_source) ",
-        );
-        qb.push_values(free_files, |mut b, (path, body)| {
-            let hash = blake3::hash(body.as_bytes()).as_bytes().to_vec();
-            b.push_bind(Uuid::now_v7())
-                .push_bind(path)
-                .push_bind(body)
-                .push_bind(hash)
-                .push_bind(creation_source);
-        });
-        qb.build().execute(&mut **tx).await.map_err(|e| {
-            Error::new(ErrorDetails::PostgresQuery {
-                message: format!("Failed to insert free files into stored_files: {e}"),
-            })
-        })?;
+    if free_files.is_empty() {
+        return Ok(());
     }
+
+    // Precompute IDs and hashes for all free files.
+    let ids: Vec<Uuid> = free_files.keys().map(|_| Uuid::now_v7()).collect();
+    let paths: Vec<&str> = free_files.keys().map(String::as_str).collect();
+    let bodies: Vec<&str> = free_files.values().map(String::as_str).collect();
+    let hashes: Vec<Vec<u8>> = bodies
+        .iter()
+        .map(|body| blake3::hash(body.as_bytes()).as_bytes().to_vec())
+        .collect();
+
+    // In a single CTE:
+    //   1. Insert rows where no active row with the same (file_path, content_hash)
+    //      already exists — content-hash dedup in one SQL round-trip.
+    //   2. Tombstone any previously active rows for the same paths, so there is
+    //      never more than one active row per file_path.
+    sqlx::query(
+        r"
+        WITH new_rows AS (
+            INSERT INTO tensorzero.stored_files
+                (id, file_path, source_body, content_hash, creation_source)
+            SELECT input.id, input.file_path, input.source_body,
+                   input.content_hash, $5
+            FROM UNNEST($1::uuid[], $2::text[], $3::text[], $4::bytea[])
+                 AS input(id, file_path, source_body, content_hash)
+            WHERE NOT EXISTS (
+                SELECT 1 FROM tensorzero.stored_files t
+                WHERE t.file_path  = input.file_path
+                  AND t.content_hash = input.content_hash
+                  AND t.deleted_at IS NULL
+            )
+            RETURNING id, file_path
+        )
+        UPDATE tensorzero.stored_files t
+        SET deleted_at = NOW()
+        FROM new_rows n
+        WHERE t.file_path  = n.file_path
+          AND t.deleted_at IS NULL
+          AND t.id        != n.id
+        ",
+    )
+    .bind(&ids)
+    .bind(&paths)
+    .bind(&bodies)
+    .bind(&hashes)
+    .bind(creation_source)
+    .execute(&mut **tx)
+    .await
+    .map_err(|e| {
+        Error::new(ErrorDetails::PostgresQuery {
+            message: format!("Failed to upsert free files into stored_files: {e}"),
+        })
+    })?;
 
     Ok(())
 }

--- a/crates/tensorzero-core/tests/e2e/config_editing/stored_config.rs
+++ b/crates/tensorzero-core/tests/e2e/config_editing/stored_config.rs
@@ -5,6 +5,8 @@
 //!
 //! - `GET  /internal/config_toml`          (`get_live_config_toml_handler`)
 //! - `POST /internal/config_toml/validate` (`validate_config_toml_handler`)
+//! - `POST /internal/config_toml/apply`    (`apply_config_toml_handler`)
+//!   (free-file behavior only; full apply coverage lives in `mod.rs`)
 //!
 //! These endpoints are part of the "config in database" stack: they return
 //! human-editable TOML (with file-backed contents extracted into a separate
@@ -23,12 +25,47 @@
 
 use std::collections::HashMap;
 
-use reqwest::Client;
+use googletest::prelude::*;
+use reqwest::{Client, StatusCode};
+use serde_json::json;
 use tensorzero_core::endpoints::internal::config_toml::{
-    GetConfigTomlResponse, ValidateConfigTomlRequest, ValidateConfigTomlResponse,
+    ApplyConfigTomlResponse, GetConfigTomlResponse, ValidateConfigTomlRequest,
+    ValidateConfigTomlResponse,
 };
 
 use crate::common::get_gateway_endpoint;
+
+/// Helper: GET /internal/config_toml and return the parsed response.
+async fn get_config_toml(client: &Client) -> GetConfigTomlResponse {
+    let resp = client
+        .get(get_gateway_endpoint("/internal/config_toml"))
+        .send()
+        .await
+        .expect("GET /internal/config_toml should reach the gateway");
+    assert_that!(resp.status(), eq(StatusCode::OK));
+    resp.json::<GetConfigTomlResponse>()
+        .await
+        .expect("GET /internal/config_toml should deserialize as GetConfigTomlResponse")
+}
+
+/// Helper: POST /internal/config_toml/apply and return the raw response.
+async fn apply_config_toml(
+    client: &Client,
+    toml: &str,
+    path_contents: &HashMap<String, String>,
+    base_signature: &str,
+) -> reqwest::Response {
+    client
+        .post(get_gateway_endpoint("/internal/config_toml/apply"))
+        .json(&json!({
+            "toml": toml,
+            "path_contents": path_contents,
+            "base_signature": base_signature,
+        }))
+        .send()
+        .await
+        .expect("POST /internal/config_toml/apply should send")
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_live_config_toml() {
@@ -181,5 +218,277 @@ model = "nonexistent_model_for_validate_toml"
         "validate should reject a config whose variant references a nonexistent model, \
          got status={}",
         resp.status()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Free-file tests (files in path_contents not referenced by the TOML config)
+// ---------------------------------------------------------------------------
+
+const FREE_FILE_PATH: &str = "e2e_stored_config/free_file.txt";
+
+/// Applying a config with a file in `path_contents` that is not referenced by
+/// any TOML entry (a "free file") should succeed, and a subsequent GET should
+/// include that file in `path_contents`.
+#[gtest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_free_file_appears_in_get_after_apply() {
+    let client = Client::new();
+    let original = get_config_toml(&client).await;
+
+    let mut path_contents = original.path_contents.clone();
+    path_contents.insert(FREE_FILE_PATH.to_string(), "free file v1".to_string());
+
+    let apply_resp = apply_config_toml(
+        &client,
+        &original.toml,
+        &path_contents,
+        &original.base_signature,
+    )
+    .await;
+    let apply_status = apply_resp.status();
+    let apply_body = apply_resp.text().await.expect("apply body should decode");
+    assert_that!(
+        apply_status,
+        eq(StatusCode::OK),
+        "apply with free file should succeed; body={apply_body}"
+    );
+
+    // The file should now show up in a fresh GET.
+    let after = get_config_toml(&client).await;
+    expect_that!(
+        after.path_contents.get(FREE_FILE_PATH),
+        some(eq("free file v1")),
+        "GET after apply should include the free file in path_contents"
+    );
+
+    // Restore: remove the free file by not including it in path_contents.
+    let restore_resp = apply_config_toml(
+        &client,
+        &original.toml,
+        &original.path_contents,
+        &after.base_signature,
+    )
+    .await;
+    assert_that!(
+        restore_resp.status(),
+        eq(StatusCode::OK),
+        "restore (remove free file) should succeed"
+    );
+}
+
+/// The `base_signature` returned by `apply` must match the `base_signature`
+/// returned by a subsequent GET, ensuring the client can continue editing
+/// without fetching a fresh snapshot.
+#[gtest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_free_file_apply_response_base_signature_matches_get() {
+    let client = Client::new();
+    let original = get_config_toml(&client).await;
+
+    let mut path_contents = original.path_contents.clone();
+    path_contents.insert(FREE_FILE_PATH.to_string(), "sig-check content".to_string());
+
+    let apply_resp = apply_config_toml(
+        &client,
+        &original.toml,
+        &path_contents,
+        &original.base_signature,
+    )
+    .await;
+    assert_that!(
+        apply_resp.status(),
+        eq(StatusCode::OK),
+        "apply with free file should succeed"
+    );
+    let apply_parsed: ApplyConfigTomlResponse = apply_resp
+        .json()
+        .await
+        .expect("apply response should deserialize as ApplyConfigTomlResponse");
+
+    // The apply response must contain the free file so the client does not
+    // need to re-fetch.
+    expect_that!(
+        apply_parsed.path_contents.get(FREE_FILE_PATH),
+        some(eq("sig-check content")),
+        "apply response path_contents should include the free file"
+    );
+
+    // A fresh GET should return the same base_signature.
+    let after = get_config_toml(&client).await;
+    expect_that!(
+        apply_parsed.base_signature.as_str(),
+        eq(after.base_signature.as_str()),
+        "apply response base_signature should match the subsequent GET base_signature"
+    );
+
+    // Restore.
+    let restore_resp = apply_config_toml(
+        &client,
+        &original.toml,
+        &original.path_contents,
+        &after.base_signature,
+    )
+    .await;
+    assert_that!(
+        restore_resp.status(),
+        eq(StatusCode::OK),
+        "restore should succeed"
+    );
+}
+
+/// Omitting a previously-applied free file from `path_contents` in a
+/// subsequent apply should tombstone it, so a follow-up GET no longer returns
+/// it.
+#[gtest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_free_file_tombstoned_when_omitted_from_apply() {
+    let client = Client::new();
+    let original = get_config_toml(&client).await;
+
+    // Apply #1: add the free file.
+    let mut with_free_file = original.path_contents.clone();
+    with_free_file.insert(FREE_FILE_PATH.to_string(), "to be removed".to_string());
+
+    let apply1_resp = apply_config_toml(
+        &client,
+        &original.toml,
+        &with_free_file,
+        &original.base_signature,
+    )
+    .await;
+    assert_that!(
+        apply1_resp.status(),
+        eq(StatusCode::OK),
+        "apply #1 (add free file) should succeed"
+    );
+
+    let after_add = get_config_toml(&client).await;
+    assert_that!(
+        after_add.path_contents.contains_key(FREE_FILE_PATH),
+        eq(true),
+        "free file must be present after apply #1 before testing removal"
+    );
+
+    // Apply #2: omit the free file (use original path_contents, which does
+    // not include it).
+    let apply2_resp = apply_config_toml(
+        &client,
+        &original.toml,
+        &original.path_contents,
+        &after_add.base_signature,
+    )
+    .await;
+    assert_that!(
+        apply2_resp.status(),
+        eq(StatusCode::OK),
+        "apply #2 (remove free file) should succeed"
+    );
+
+    let after_remove = get_config_toml(&client).await;
+    expect_that!(
+        after_remove.path_contents.contains_key(FREE_FILE_PATH),
+        eq(false),
+        "tombstoned free file must not appear in GET after removal"
+    );
+}
+
+/// Applying the same TOML twice with updated free-file content should result
+/// in the latest content being returned by GET.
+#[gtest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_free_file_content_updated_on_edit() {
+    let client = Client::new();
+    let original = get_config_toml(&client).await;
+
+    // Apply #1: insert v1.
+    let mut with_v1 = original.path_contents.clone();
+    with_v1.insert(FREE_FILE_PATH.to_string(), "version 1".to_string());
+
+    let apply1_resp =
+        apply_config_toml(&client, &original.toml, &with_v1, &original.base_signature).await;
+    assert_that!(
+        apply1_resp.status(),
+        eq(StatusCode::OK),
+        "apply #1 (v1) should succeed"
+    );
+
+    let after_v1 = get_config_toml(&client).await;
+
+    // Apply #2: update to v2.
+    let mut with_v2 = original.path_contents.clone();
+    with_v2.insert(FREE_FILE_PATH.to_string(), "version 2".to_string());
+
+    let apply2_resp =
+        apply_config_toml(&client, &original.toml, &with_v2, &after_v1.base_signature).await;
+    assert_that!(
+        apply2_resp.status(),
+        eq(StatusCode::OK),
+        "apply #2 (v2) should succeed"
+    );
+
+    let after_v2 = get_config_toml(&client).await;
+    expect_that!(
+        after_v2.path_contents.get(FREE_FILE_PATH),
+        some(eq("version 2")),
+        "GET after edit should return the updated free file content"
+    );
+
+    // Restore.
+    let restore_resp = apply_config_toml(
+        &client,
+        &original.toml,
+        &original.path_contents,
+        &after_v2.base_signature,
+    )
+    .await;
+    assert_that!(
+        restore_resp.status(),
+        eq(StatusCode::OK),
+        "restore should succeed"
+    );
+}
+
+/// Validate should accept a config TOML paired with extra free files in
+/// `path_contents` — free files are not referenced by the config but must not
+/// cause validation to fail.
+#[gtest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_validate_config_toml_accepts_free_files_in_path_contents() {
+    let client = Client::new();
+    let live = get_config_toml(&client).await;
+
+    // Add a file that is not referenced by any TOML entry.
+    let mut path_contents_with_free = live.path_contents.clone();
+    path_contents_with_free.insert(
+        "e2e_stored_config/extra_validate_free_file.txt".to_string(),
+        "this file is not referenced by any config entry".to_string(),
+    );
+
+    let request = ValidateConfigTomlRequest {
+        toml: live.toml,
+        path_contents: path_contents_with_free,
+    };
+
+    let resp = client
+        .post(get_gateway_endpoint("/internal/config_toml/validate"))
+        .json(&request)
+        .send()
+        .await
+        .expect("POST /internal/config_toml/validate should reach the gateway");
+    let status = resp.status();
+    let body = resp.text().await.expect("response body should be readable");
+    assert_that!(
+        status,
+        eq(StatusCode::OK),
+        "validate should accept a config with free files in path_contents; body={body}"
+    );
+
+    let parsed: ValidateConfigTomlResponse =
+        serde_json::from_str(&body).expect("response should parse as ValidateConfigTomlResponse");
+    expect_that!(
+        parsed.valid,
+        eq(true),
+        "validate should report `valid = true` when path_contents includes unreferenced free files"
     );
 }

--- a/crates/tensorzero-stored-config/src/postgres/migrations/20260413120001_allow_unreferenced_and_soft_delete_files.sql
+++ b/crates/tensorzero-stored-config/src/postgres/migrations/20260413120001_allow_unreferenced_and_soft_delete_files.sql
@@ -1,0 +1,16 @@
+-- Add soft-delete support to stored_files so the config editor can track
+-- which files are currently "active" (free or referenced) and tombstone
+-- files the user removes. Config loading queries stored_files by UUID and
+-- never filters on deleted_at, so tombstoning a row does not affect the
+-- live config — it only affects the editor view.
+ALTER TABLE tensorzero.stored_files ADD COLUMN deleted_at TIMESTAMPTZ;
+
+-- Partial index supporting the editor's "latest non-deleted version per
+-- file path" query:
+--   SELECT DISTINCT ON (file_path) file_path, source_body
+--   FROM tensorzero.stored_files
+--   WHERE deleted_at IS NULL
+--   ORDER BY file_path, created_at DESC
+CREATE INDEX idx_stored_files_editor_latest
+    ON tensorzero.stored_files (file_path, created_at DESC)
+    WHERE deleted_at IS NULL;

--- a/ui/e2e_tests/config_editing.spec.ts
+++ b/ui/e2e_tests/config_editing.spec.ts
@@ -203,4 +203,68 @@ test.describe("Config Editor @config-editing", () => {
     const content = await fileEditor.textContent();
     expect(content).toContain("{{ user_text }}!");
   });
+
+  test("can add an unreferenced file and reload it", async ({ page }) => {
+    await page.goto("/config");
+    await page.waitForLoadState("networkidle");
+
+    const newFilePath = "playwright-unreferenced-file";
+
+    await page.getByLabel("New file").click();
+    await page.getByLabel("File name").fill(newFilePath);
+    await page.getByRole("button", { name: "Rename", exact: true }).click();
+
+    await expect(filePathLabel(page, newFilePath)).toBeVisible();
+
+    const fileEditor = page.locator(
+      `[aria-label="Editable content for ${newFilePath}"] .cm-content`,
+    );
+    await expect(fileEditor).toBeVisible();
+    await fileEditor.click();
+    await page.keyboard.type("playwright-unreferenced-file-content");
+
+    await page.getByRole("button", { name: "Save config and files" }).click();
+    await expect(page.getByText("Config applied").first()).toBeVisible();
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    await expect(filePathLabel(page, newFilePath)).toBeVisible();
+    await filePathLabel(page, newFilePath).click();
+    await expect(fileEditor).toBeVisible();
+    const content = await fileEditor.textContent();
+    expect(content).toContain("playwright-unreferenced-file-content");
+  });
+
+  test("can rename a file", async ({ page }) => {
+    await page.goto("/config");
+    await page.waitForLoadState("networkidle");
+
+    const originalPath = "playwright-rename-source.txt";
+    const renamedPath = "playwright-rename-target.txt";
+
+    await page.getByLabel("New file").click();
+    await page.getByLabel("File name").fill(originalPath);
+    await page.getByRole("button", { name: "Rename", exact: true }).click();
+
+    await expect(filePathLabel(page, originalPath)).toBeVisible();
+    await expect(page.getByLabel("File name")).toHaveValue(originalPath);
+
+    // Update the file name input and click Rename
+    await page.getByLabel("File name").fill(renamedPath);
+    await page.getByRole("button", { name: "Rename", exact: true }).click();
+
+    // Sidebar should show the new name, not the old one
+    await expect(filePathLabel(page, renamedPath)).toBeVisible();
+    await expect(filePathLabel(page, originalPath)).not.toBeVisible();
+    await expect(page.getByLabel("File name")).toHaveValue(renamedPath);
+
+    await page.getByRole("button", { name: "Save config and files" }).click();
+    await expect(page.getByText("Config applied").first()).toBeVisible();
+
+    // Reload and verify the rename persisted
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    await expect(filePathLabel(page, renamedPath)).toBeVisible();
+    await expect(filePathLabel(page, originalPath)).not.toBeVisible();
+  });
 });


### PR DESCRIPTION
We add "deleted_at" to stored files so we can show all latest version of the same file that are not deleted, regardless  of whether it's referenced in the config toml. This allows persisting files that are created but not yet referenced in the config toml (users may want to write a file, save it, then change the config to reference it).
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit cf0aad6fb82ff9a010d6be45c3094453e971f336. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->