### PR TITLE
ui: add dark theme and modernize component styling

### DIFF
--- a/ui/app/components/autopilot/TopKEvaluationViz.tsx
+++ b/ui/app/components/autopilot/TopKEvaluationViz.tsx
@@ -12,7 +12,7 @@ import {
 import { ChartContainer, ChartTooltip } from "~/components/ui/chart";
 import { Markdown } from "~/components/ui/markdown";
 import type { TopKEvaluationVisualization } from "~/types/tensorzero";
-import { CHART_COLORS, formatChartNumber } from "~/utils/chart";
+import { getChartColor, formatChartNumber } from "~/utils/chart";
 
 type TopKEvaluationVizProps = {
   data: TopKEvaluationVisualization;
@@ -97,7 +97,7 @@ function DotWithErrorBar(props: {
     return null;
 
   const cx = x + width / 2;
-  const color = payload.color ?? CHART_COLORS[0];
+  const color = payload.color ?? getChartColor(0);
   const opacity = payload.failed ? FAILED_OPACITY : 1;
 
   // Calculate error bar positions based on the chart scale
@@ -388,10 +388,7 @@ export default function TopKEvaluationViz({ data }: TopKEvaluationVizProps) {
 
     // Create color map based on alphabetical order (for all variants)
     const colorMap = new Map(
-      sortedAlphabetically.map(([name], index) => [
-        name,
-        CHART_COLORS[index % CHART_COLORS.length],
-      ]),
+      sortedAlphabetically.map(([name], index) => [name, getChartColor(index)]),
     );
 
     // Sort non-failed by mean estimate (descending - best first)
@@ -427,7 +424,7 @@ export default function TopKEvaluationViz({ data }: TopKEvaluationVizProps) {
         // Error bar values are relative to the mean: [lower error, upper error]
         error: [mean - lower, upper - mean],
         count,
-        color: colorMap.get(name) ?? CHART_COLORS[0],
+        color: colorMap.get(name) ?? getChartColor(0),
         failed,
       };
     });

--- a/ui/app/components/autopilot/YoloModeToggle.tsx
+++ b/ui/app/components/autopilot/YoloModeToggle.tsx
@@ -27,7 +27,7 @@ export function YoloModeToggle({
             )}
           >
             {checked && <AlertTriangle className="h-3.5 w-3.5" />}
-            YOLO Mode
+            Auto-Approve
           </span>
           <Switch
             checked={checked}

--- a/ui/app/components/dataset/AddToDatasetButton.tsx
+++ b/ui/app/components/dataset/AddToDatasetButton.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useFetcher, Link } from "react-router";
 import { DatasetSelect } from "~/components/dataset/DatasetSelect";
 import {
@@ -46,6 +47,7 @@ export function AddToDatasetButton({
   const fetcher = useFetcher();
   const { toast } = useToast();
   const isReadOnly = useReadOnly();
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     if (fetcher.state === "idle" && fetcher.data) {
@@ -56,6 +58,7 @@ export function AddToDatasetButton({
         });
         return () => dismiss({ immediate: true });
       } else if (fetcher.data.redirectTo) {
+        queryClient.invalidateQueries({ queryKey: ["DATASETS_COUNT"] });
         const { dismiss } = toast.success({
           title: "New Datapoint",
           description: "A datapoint was created successfully.",
@@ -69,7 +72,7 @@ export function AddToDatasetButton({
       }
     }
     return;
-  }, [fetcher.state, fetcher.data, toast]);
+  }, [fetcher.state, fetcher.data, toast, queryClient]);
 
   // Helper function to handle dataset selection
   const handleDatasetAction = (
@@ -118,34 +121,54 @@ export function AddToDatasetButton({
 
   const alertDialog = (
     <AlertDialog open={outputDialogOpen} onOpenChange={setOutputDialogOpen}>
-      <AlertDialogContent className="min-w-[600px]">
+      <AlertDialogContent className="max-w-md">
         <AlertDialogHeader>
-          <AlertDialogTitle>
-            What should be the datapoint's output?
-          </AlertDialogTitle>
+          <AlertDialogTitle>Datapoint output</AlertDialogTitle>
           <AlertDialogDescription>
-            Each datapoint includes an optional output field. The choice should
-            depend on your use case. For example, you might prefer
-            demonstrations for fine-tuning.
+            Choose what to use as the output for this datapoint.
           </AlertDialogDescription>
         </AlertDialogHeader>
-        <AlertDialogFooter className="flex justify-center gap-4">
-          <AlertDialogCancel onClick={() => setOutputDialogOpen(false)}>
-            Cancel
-          </AlertDialogCancel>
-          <AlertDialogAction onClick={() => handleOutputSelect("inherit")}>
-            Inference Output
+        <div className="flex flex-col gap-2 py-2">
+          <AlertDialogAction
+            onClick={() => handleOutputSelect("inherit")}
+            className="bg-bg-secondary text-fg-primary hover:bg-bg-tertiary border-border h-auto justify-start rounded-lg border px-4 py-3 text-left font-normal shadow-none"
+          >
+            <div>
+              <div className="text-sm font-medium">Inference Output</div>
+              <div className="text-fg-muted mt-0.5 text-xs">
+                Use the model&apos;s original response as-is
+              </div>
+            </div>
           </AlertDialogAction>
           {hasDemonstration && (
             <AlertDialogAction
               onClick={() => handleOutputSelect("demonstration")}
+              className="bg-bg-secondary text-fg-primary hover:bg-bg-tertiary border-border h-auto justify-start rounded-lg border px-4 py-3 text-left font-normal shadow-none"
             >
-              Demonstration
+              <div>
+                <div className="text-sm font-medium">Demonstration</div>
+                <div className="text-fg-muted mt-0.5 text-xs">
+                  Use the human-curated demonstration
+                </div>
+              </div>
             </AlertDialogAction>
           )}
-          <AlertDialogAction onClick={() => handleOutputSelect("none")}>
-            None
+          <AlertDialogAction
+            onClick={() => handleOutputSelect("none")}
+            className="bg-bg-secondary text-fg-primary hover:bg-bg-tertiary border-border h-auto justify-start rounded-lg border px-4 py-3 text-left font-normal shadow-none"
+          >
+            <div>
+              <div className="text-sm font-medium">None</div>
+              <div className="text-fg-muted mt-0.5 text-xs">
+                Input only — no output attached
+              </div>
+            </div>
           </AlertDialogAction>
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={() => setOutputDialogOpen(false)}>
+            Cancel
+          </AlertDialogCancel>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/ui/app/components/experimentation/PieChart.tsx
+++ b/ui/app/components/experimentation/PieChart.tsx
@@ -59,12 +59,14 @@ export const ExperimentationPieChart = memo(function ExperimentationPieChart({
     0,
   );
 
-  // Transform data for the pie chart
-  const data = variantWeights.map((variant) => ({
-    variant_name: variant.variant_name,
-    weight: variant.weight,
-    percentage: `${((variant.weight / totalWeight) * 100).toFixed(1)}%`,
-  }));
+  // Transform data for the pie chart, filtering out 0-weight variants
+  const data = variantWeights
+    .filter((variant) => variant.weight > 0)
+    .map((variant) => ({
+      variant_name: variant.variant_name,
+      weight: variant.weight,
+      percentage: `${((variant.weight / totalWeight) * 100).toFixed(1)}%`,
+    }));
 
   return (
     <Card>
@@ -84,8 +86,34 @@ export const ExperimentationPieChart = memo(function ExperimentationPieChart({
               nameKey="variant_name"
               cx="50%"
               cy="50%"
-              outerRadius={100}
-              label={({ percentage }) => percentage}
+              outerRadius={80}
+              label={({
+                cx,
+                cy,
+                midAngle,
+                outerRadius: or,
+                percentage,
+                fill,
+              }) => {
+                const RADIAN = Math.PI / 180;
+                const radius = or + 18;
+                const x = cx + radius * Math.cos(-midAngle * RADIAN);
+                const y = cy + radius * Math.sin(-midAngle * RADIAN);
+                return (
+                  <text
+                    x={x}
+                    y={y}
+                    fill={fill}
+                    textAnchor="middle"
+                    dominantBaseline="central"
+                    fontSize={12}
+                    fontWeight={600}
+                  >
+                    {percentage}
+                  </text>
+                );
+              }}
+              labelLine={false}
               isAnimationActive={false}
             >
               {data.map((entry) => (

--- a/ui/app/components/function/variant/VariantPerformanceChart.tsx
+++ b/ui/app/components/function/variant/VariantPerformanceChart.tsx
@@ -5,7 +5,7 @@ import {
   formatDetailedNumber,
   formatXAxisTimestamp,
   formatTooltipTimestamp,
-  CHART_COLORS,
+  getChartColor,
 } from "~/utils/chart";
 import {
   ChartContainer,
@@ -38,9 +38,7 @@ export function VariantPerformanceChart({
         ...config,
         [variantName]: {
           label: variantName,
-          color: singleVariantMode
-            ? CHART_COLORS[0]
-            : CHART_COLORS[index % CHART_COLORS.length],
+          color: singleVariantMode ? getChartColor(0) : getChartColor(index),
         },
       }),
       {},
@@ -98,7 +96,7 @@ export function VariantPerformanceChart({
               key={variantNames[0]}
               dataKey={variantNames[0]}
               name={variantNames[0]}
-              fill={CHART_COLORS[0]}
+              fill={getChartColor(0)}
               radius={4}
               maxBarSize={100}
             >
@@ -127,9 +125,9 @@ export function VariantPerformanceChart({
         items={variantNames}
         colors={
           singleVariantMode
-            ? [CHART_COLORS[0]]
+            ? [getChartColor(0)]
             : variantNames.map(
-                (name) => chartConfig[name]?.color ?? CHART_COLORS[0],
+                (name) => chartConfig[name]?.color ?? getChartColor(0),
               )
         }
       />

--- a/ui/app/components/function/variant/VariantThroughput.tsx
+++ b/ui/app/components/function/variant/VariantThroughput.tsx
@@ -1,7 +1,7 @@
 import type { VariantThroughput } from "~/types/tensorzero";
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import {
-  CHART_COLORS,
+  getChartColor,
   formatChartNumber,
   formatXAxisTimestamp,
   formatTooltipTimestamp,
@@ -33,7 +33,7 @@ export function VariantThroughput({
         ...config,
         [variantName]: {
           label: variantName,
-          color: CHART_COLORS[index % CHART_COLORS.length],
+          color: getChartColor(index),
         },
       }),
       {},
@@ -143,7 +143,7 @@ export function VariantThroughput({
               ))}
             </AreaChart>
           </ChartContainer>
-          <ChartLegend items={variantNames} colors={CHART_COLORS} />
+          <ChartLegend items={variantNames} colorFn={getChartColor} />
         </CardContent>
       </Card>
     </div>

--- a/ui/app/components/inference/TryWithSelect.tsx
+++ b/ui/app/components/inference/TryWithSelect.tsx
@@ -18,7 +18,7 @@ export function TryWithSelect({
   isDefaultFunction,
 }: TryWithSelectProps) {
   const isReadOnly = useReadOnly();
-  const isDisabled = isLoading || isReadOnly;
+  const isDisabled = isLoading || isReadOnly || options.length === 0;
 
   const label = isDefaultFunction ? "model" : "variant";
 

--- a/ui/app/components/input_output/content_blocks/TextContentBlock.tsx
+++ b/ui/app/components/input_output/content_blocks/TextContentBlock.tsx
@@ -1,8 +1,23 @@
-import { AlignLeftIcon } from "lucide-react";
+import { AlignLeftIcon, EyeIcon, CodeIcon } from "lucide-react";
 import { useFormattedJson } from "~/components/ui/code-editor";
 import { VirtualizedCodeEditor } from "~/components/ui/virtualized-code-editor";
-import { type ReactNode } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 import { ContentBlockLabel } from "~/components/input_output/content_blocks/ContentBlockLabel";
+import { Markdown } from "~/components/ui/markdown";
+
+/** Simple check for markdown-like content */
+function looksLikeMarkdown(text: string): boolean {
+  return (
+    text.includes("# ") ||
+    text.includes("## ") ||
+    text.includes("**") ||
+    text.includes("__") ||
+    (text.includes("[") && text.includes("](")) ||
+    text.includes("```") ||
+    /^\d+\.\s/m.test(text) ||
+    /^[-*]\s/m.test(text)
+  );
+}
 
 interface TextContentBlockProps {
   label: string;
@@ -15,29 +30,55 @@ interface TextContentBlockProps {
 export function TextContentBlock({
   label,
   text,
-  // footer,
   isEditing,
   onChange,
   actionBar,
 }: TextContentBlockProps) {
-  // TODO (GabrielBianconi): there's gotta be a better way to handle this...
-  // The following function formats JSON nicely, if it detects JSON in the text.
-  // This is a vanilla text content block but people often include JSON.
   const formattedText = useFormattedJson(text);
+  const isMarkdown = useMemo(() => looksLikeMarkdown(text), [text]);
+  const [showRendered, setShowRendered] = useState(false);
+
+  const renderToggle =
+    isMarkdown && !isEditing ? (
+      <button
+        type="button"
+        className="text-fg-muted hover:text-fg-primary ml-auto flex cursor-pointer items-center gap-1 text-xs transition-colors"
+        onClick={() => setShowRendered((v) => !v)}
+        title={showRendered ? "Show source" : "Show rendered"}
+      >
+        {showRendered ? (
+          <CodeIcon className="h-3 w-3" />
+        ) : (
+          <EyeIcon className="h-3 w-3" />
+        )}
+        {showRendered ? "Source" : "Preview"}
+      </button>
+    ) : null;
 
   return (
     <div className="flex max-w-240 min-w-80 flex-col gap-1">
       <ContentBlockLabel
         icon={<AlignLeftIcon className="text-fg-muted h-3 w-3" />}
-        actionBar={actionBar}
+        actionBar={
+          <>
+            {actionBar}
+            {renderToggle}
+          </>
+        }
       >
         {label}
       </ContentBlockLabel>
-      <VirtualizedCodeEditor
-        value={formattedText}
-        readOnly={!isEditing}
-        onChange={onChange}
-      />
+      {showRendered && !isEditing ? (
+        <div className="bg-bg-primary border-border max-h-[400px] overflow-auto rounded-md border px-4 py-3">
+          <Markdown>{text}</Markdown>
+        </div>
+      ) : (
+        <VirtualizedCodeEditor
+          value={formattedText}
+          readOnly={!isEditing}
+          onChange={onChange}
+        />
+      )}
     </div>
   );
 }

--- a/ui/app/components/layout/BasicInfoLayout.tsx
+++ b/ui/app/components/layout/BasicInfoLayout.tsx
@@ -1,7 +1,11 @@
 import { Skeleton } from "~/components/ui/skeleton";
 
 export function BasicInfoLayout({ children }: React.PropsWithChildren) {
-  return <div className="flex flex-col gap-4 md:gap-2">{children}</div>;
+  return (
+    <div className="bg-bg-secondary border-border flex flex-col gap-4 rounded-lg border px-5 py-4 md:gap-2">
+      {children}
+    </div>
+  );
 }
 
 export function BasicInfoItem({ children }: React.PropsWithChildren) {

--- a/ui/app/components/layout/app.sidebar.tsx
+++ b/ui/app/components/layout/app.sidebar.tsx
@@ -13,7 +13,7 @@ import {
   SidebarCollapse,
   SidebarExpand,
 } from "~/components/icons/Icons";
-import { FileCode2, KeyRound, LayoutGrid, Plus } from "lucide-react";
+import { FileCode2, KeyRound, LayoutGrid, Moon, Plus, Sun } from "lucide-react";
 import {
   Sidebar,
   SidebarContent,
@@ -36,6 +36,7 @@ import { Link } from "react-router";
 import type { IconProps } from "~/components/icons/Icons";
 import TensorZeroStatusIndicator from "./TensorZeroStatusIndicator";
 import { ReadOnlyBadge } from "./ReadOnlyBadge";
+import { useTheme } from "~/context/theme";
 
 interface NavigationItem {
   title: string;
@@ -126,15 +127,16 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const activePathUtils = useActivePath();
   const autopilotAvailable = useAutopilotAvailable();
   const config = useConfig();
+  const { theme, setTheme } = useTheme();
 
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarHeader className="pb-4">
         <SidebarMenu>
-          <SidebarMenuItem>
+          <SidebarMenuItem className="flex items-center justify-between">
             <SidebarMenuButton
               asChild
-              className="text-black hover:bg-transparent focus-visible:bg-transparent active:bg-transparent"
+              className="text-sidebar-foreground hover:bg-transparent focus-visible:bg-transparent active:bg-transparent"
             >
               <Link to="/" className="flex items-center gap-2">
                 <TensorZeroLogo size={16} />
@@ -143,6 +145,17 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 </span>
               </Link>
             </SidebarMenuButton>
+            <button
+              aria-label="Toggle theme"
+              className="text-sidebar-foreground hover:text-fg-primary shrink-0 cursor-pointer rounded-md p-1.5 transition-colors group-data-[collapsible=icon]:hidden"
+              onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+            >
+              {theme === "dark" ? (
+                <Sun className="h-4 w-4" />
+              ) : (
+                <Moon className="h-4 w-4" />
+              )}
+            </button>
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarHeader>

--- a/ui/app/components/model/ModelLatency.tsx
+++ b/ui/app/components/model/ModelLatency.tsx
@@ -15,7 +15,7 @@ import React, { useState, useMemo } from "react";
 import { Await, useAsyncError, isRouteErrorResponse } from "react-router";
 import { SectionErrorNotice } from "~/components/ui/error/ErrorContentPrimitives";
 import { AlertCircle } from "lucide-react";
-import { CHART_COLORS } from "~/utils/chart";
+import { getChartColor } from "~/utils/chart";
 import {
   Select,
   SelectItem,
@@ -153,7 +153,7 @@ export function LatencyQuantileChart({
           ...config,
           [modelName]: {
             label: modelName,
-            color: CHART_COLORS[index % CHART_COLORS.length],
+            color: getChartColor(index),
           },
         }),
         {},
@@ -201,7 +201,7 @@ export function LatencyQuantileChart({
               type="monotone"
               dataKey={name}
               name={name}
-              stroke={CHART_COLORS[index % CHART_COLORS.length]}
+              stroke={getChartColor(index)}
               strokeWidth={2}
               dot={false}
               connectNulls={false}
@@ -210,7 +210,7 @@ export function LatencyQuantileChart({
           ))}
         </LineChart>
       </ChartContainer>
-      <ChartLegend items={modelNames} colors={CHART_COLORS} />
+      <ChartLegend items={modelNames} colorFn={getChartColor} />
     </>
   );
 }

--- a/ui/app/components/model/ModelUsage.tsx
+++ b/ui/app/components/model/ModelUsage.tsx
@@ -5,7 +5,7 @@ import {
   formatDetailedNumber,
   formatXAxisTimestamp,
   formatTooltipTimestamp,
-  CHART_COLORS,
+  getChartColor,
 } from "~/utils/chart";
 import { useState, Suspense } from "react";
 import { Await, useAsyncError, isRouteErrorResponse } from "react-router";
@@ -163,7 +163,7 @@ export function ModelUsage({
                   ...config,
                   [modelName]: {
                     label: modelName,
-                    color: CHART_COLORS[index % CHART_COLORS.length],
+                    color: getChartColor(index),
                   },
                 }),
                 {},
@@ -287,14 +287,14 @@ export function ModelUsage({
                           key={modelName}
                           dataKey={modelName}
                           name={modelName}
-                          fill={CHART_COLORS[index % CHART_COLORS.length]}
+                          fill={getChartColor(index)}
                           radius={4}
                           maxBarSize={100}
                         />
                       ))}
                     </BarChart>
                   </ChartContainer>
-                  <ChartLegend items={modelNames} colors={CHART_COLORS} />
+                  <ChartLegend items={modelNames} colorFn={getChartColor} />
                 </>
               );
             }}

--- a/ui/app/components/ui/Chip.tsx
+++ b/ui/app/components/ui/Chip.tsx
@@ -32,10 +32,12 @@ const Chip: React.FC<ChipProps> = ({
   onClick,
 }) => {
   const baseClasses =
-    "inline-flex text-sm text-fg-primary px-0 md:px-2 gap-1.5 rounded-md whitespace-nowrap overflow-hidden";
+    "inline-flex items-center text-sm text-fg-primary bg-bg-secondary border border-border px-2 py-0.5 gap-1.5 rounded-md whitespace-nowrap overflow-hidden";
   const hoverClasses =
-    link || onClick ? "md:hover:bg-bg-hover cursor-pointer" : "";
-  const fontClasses = font === "mono" ? "font-mono" : "font-sans";
+    link || onClick
+      ? "hover:bg-bg-hover hover:border-border-accent cursor-pointer"
+      : "";
+  const fontClasses = font === "mono" ? "font-mono text-xs" : "font-sans";
   const combinedClasses = cn(baseClasses, hoverClasses, fontClasses, className);
 
   const content = (

--- a/ui/app/components/ui/TableItems.tsx
+++ b/ui/app/components/ui/TableItems.tsx
@@ -31,7 +31,7 @@ function TableItemShortUuid({ id, link }: TableItemShortUuidProps) {
           <Link
             to={link}
             aria-label={id}
-            className="block no-underline transition-colors duration-300 hover:text-gray-500"
+            className="block no-underline transition-colors duration-300 hover:text-orange-600"
           >
             {content}
           </Link>
@@ -97,7 +97,7 @@ function TableItemFunction({
       >
         {functionIconConfig.icon}
       </span>
-      <span className="text-fg-primary inline-block truncate transition-colors duration-300 group-hover:text-gray-500">
+      <span className="text-fg-primary inline-block truncate transition-colors duration-300 group-hover:text-orange-600">
         {functionName}
       </span>
     </>

--- a/ui/app/components/ui/button.tsx
+++ b/ui/app/components/ui/button.tsx
@@ -12,15 +12,15 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90",
+          "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 dark:bg-orange-600 dark:text-white dark:hover:bg-orange-700",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input text-fg bg-bg hover:bg-bg-hover hover:text-accent-foreground",
+          "border border-input text-fg bg-card hover:bg-bg-hover hover:text-accent-foreground",
         destructiveOutline:
-          "border border-red-300 text-red-600 bg-bg hover:bg-red-50",
+          "border border-red-300 text-red-600 bg-bg hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950",
         successOutline:
-          "border border-green-500 text-green-700 bg-green-50 hover:bg-green-100",
+          "border border-green-500 text-green-700 bg-green-50 hover:bg-green-100 dark:border-green-800 dark:text-green-400 dark:bg-green-950 dark:hover:bg-green-900",
         secondary: "bg-bg-hover text-secondary-foreground hover:bg-bg-hover/80",
         ghost: "hover:bg-accent text-fg hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",

--- a/ui/app/components/ui/chart.tsx
+++ b/ui/app/components/ui/chart.tsx
@@ -317,9 +317,11 @@ function getPayloadConfigFromPayload(
 function ChartLegend({
   items,
   colors,
+  colorFn,
 }: {
   items: string[];
-  colors: readonly string[];
+  colors?: readonly string[];
+  colorFn?: (index: number) => string;
 }) {
   return (
     <div className="flex flex-wrap items-center justify-center gap-4 pt-6">
@@ -328,7 +330,11 @@ function ChartLegend({
           <div
             className="h-2 w-2 shrink-0 rounded-[2px]"
             style={{
-              backgroundColor: colors[index % colors.length],
+              backgroundColor: colorFn
+                ? colorFn(index)
+                : colors
+                  ? colors[index % colors.length]
+                  : undefined,
             }}
           />
           <span className="font-mono text-xs">{name}</span>

--- a/ui/app/components/ui/code-editor.tsx
+++ b/ui/app/components/ui/code-editor.tsx
@@ -6,7 +6,7 @@ import { json } from "@codemirror/lang-json";
 import { markdown } from "@codemirror/lang-markdown";
 import { StreamLanguage } from "@codemirror/language";
 import { jinja2 } from "@codemirror/legacy-modes/mode/jinja2";
-import { githubLightInit } from "@uiw/codemirror-theme-github";
+import { githubLightInit, githubDarkInit } from "@uiw/codemirror-theme-github";
 import { EditorView } from "@codemirror/view";
 import { search } from "@codemirror/search";
 import type { Extension } from "@codemirror/state";
@@ -116,7 +116,7 @@ const CUSTOM_EDITOR_THEME = EditorView.theme({
 // causing all tokens to render in the default foreground color (no colors).
 // Fix: add `"@lezer/highlight": "<version>"` to `pnpm.overrides` in the
 // workspace-root `package.json` to deduplicate.
-const THEME_MONO = githubLightInit({
+const THEME_MONO_LIGHT = githubLightInit({
   settings: {
     fontFamily: "var(--font-mono)",
     fontSize: "var(--text-xs)",
@@ -124,6 +124,32 @@ const THEME_MONO = githubLightInit({
     background: "transparent",
   },
 });
+
+const THEME_MONO_DARK = githubDarkInit({
+  settings: {
+    fontFamily: "var(--font-mono)",
+    fontSize: "var(--text-xs)",
+    gutterBorder: "transparent",
+    background: "transparent",
+    gutterBackground: "transparent",
+  },
+});
+
+function useIsDarkMode() {
+  const [isDark, setIsDark] = useState(false);
+  useEffect(() => {
+    const check = () =>
+      setIsDark(document.documentElement.classList.contains("dark"));
+    check();
+    const observer = new MutationObserver(check);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => observer.disconnect();
+  }, []);
+  return isDark;
+}
 
 // Cache for extension combinations (max 16 combinations: 4 languages × 2 wordWrap × 2 readOnly)
 const extensionCache = new Map<string, Extension[]>();
@@ -336,7 +362,8 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   const buttonClassName =
     "flex h-6 w-6 cursor-pointer items-center justify-center p-3 text-xs";
 
-  const theme = THEME_MONO;
+  const isDark = useIsDarkMode();
+  const theme = isDark ? THEME_MONO_DARK : THEME_MONO_LIGHT;
 
   // Use cached basicSetup (shared across all CodeEditor instances)
   const basicSetup = getBasicSetup(showLineNumbers, readOnly);
@@ -415,7 +442,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
       {/* `overflow-clip` so gutter does not render on top of focus ring */}
       <div
         className={cn(
-          "overflow-clip rounded-sm bg-gray-50 transition focus-within:ring-2 focus-within:ring-blue-500",
+          "bg-bg-secondary overflow-clip rounded-sm transition focus-within:ring-2 focus-within:ring-blue-500",
           height && "h-full",
         )}
       >

--- a/ui/app/components/ui/table.tsx
+++ b/ui/app/components/ui/table.tsx
@@ -61,7 +61,7 @@ const TableRow = React.forwardRef<
   <tr
     ref={ref}
     className={cn(
-      "data-[state=selected]:bg-muted h-12 border-b transition-colors",
+      "data-[state=selected]:bg-muted h-12 border-b transition-colors hover:bg-bg-hover",
       className,
     )}
     {...props}

--- a/ui/app/components/utils/PageButtons.tsx
+++ b/ui/app/components/utils/PageButtons.tsx
@@ -31,7 +31,7 @@ export default function PageButtons(props: PageButtonsProps) {
         size="icon"
         onClick={onPreviousPage}
         disabled={disablePrevious}
-        className="rounded-md bg-white p-2"
+        className="rounded-md p-2"
       >
         <ChevronLeft className="h-4 w-4" />
       </Button>
@@ -40,7 +40,7 @@ export default function PageButtons(props: PageButtonsProps) {
         size="icon"
         onClick={onNextPage}
         disabled={disableNext}
-        className="rounded-md bg-white p-2"
+        className="rounded-md p-2"
       >
         <ChevronRight className="h-4 w-4" />
       </Button>

--- a/ui/app/context/theme.tsx
+++ b/ui/app/context/theme.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { createContext, use, useCallback, useEffect, useState } from "react";
+
+export type Theme = "light" | "dark" | "system";
+
+const THEME_COOKIE_NAME = "theme";
+const THEME_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
+
+const ThemeContext = createContext<{
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}>({ theme: "system", setTheme: () => {} });
+
+export function useTheme() {
+  return use(ThemeContext);
+}
+
+function applyTheme(theme: Theme) {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  const isDark =
+    theme === "dark" ||
+    (theme === "system" &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches);
+  root.classList.toggle("dark", isDark);
+}
+
+export function ThemeProvider({
+  children,
+  defaultTheme = "system",
+}: {
+  children: React.ReactNode;
+  defaultTheme?: Theme;
+}) {
+  const [theme, setThemeState] = useState<Theme>(defaultTheme);
+
+  const setTheme = useCallback((newTheme: Theme) => {
+    setThemeState(newTheme);
+    document.cookie = `${THEME_COOKIE_NAME}=${newTheme}; path=/; max-age=${THEME_COOKIE_MAX_AGE}`;
+    applyTheme(newTheme);
+  }, []);
+
+  // Apply theme on mount and listen for system preference changes
+  useEffect(() => {
+    applyTheme(theme);
+
+    if (theme !== "system") return;
+
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => applyTheme("system");
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [theme]);
+
+  return <ThemeContext value={{ theme, setTheme }}>{children}</ThemeContext>;
+}

--- a/ui/app/contexts/AutopilotSessionContext.tsx
+++ b/ui/app/contexts/AutopilotSessionContext.tsx
@@ -2,7 +2,11 @@ import { createContext, useContext, type ReactNode } from "react";
 import { useLocalStorage } from "~/hooks/use-local-storage";
 
 interface AutopilotSessionContextValue {
+  autoApprove: boolean;
+  setAutoApprove: (value: boolean) => void;
+  /** @deprecated Use `autoApprove` instead */
   yoloMode: boolean;
+  /** @deprecated Use `setAutoApprove` instead */
   setYoloMode: (value: boolean) => void;
 }
 
@@ -14,13 +18,20 @@ export function AutopilotSessionProvider({
 }: {
   children: ReactNode;
 }) {
-  const [yoloMode, setYoloMode] = useLocalStorage<boolean>(
-    "tensorzero-yolo-mode",
+  const [autoApprove, setAutoApprove] = useLocalStorage<boolean>(
+    "tensorzero-auto-approve",
     false,
   );
 
   return (
-    <AutopilotSessionContext.Provider value={{ yoloMode, setYoloMode }}>
+    <AutopilotSessionContext.Provider
+      value={{
+        autoApprove,
+        setAutoApprove,
+        yoloMode: autoApprove,
+        setYoloMode: setAutoApprove,
+      }}
+    >
       {children}
     </AutopilotSessionContext.Provider>
   );

--- a/ui/app/hooks/use-auto-approval.ts
+++ b/ui/app/hooks/use-auto-approval.ts
@@ -196,7 +196,7 @@ function getRetryDelay(retryCount: number): number {
  * ## Cleanup
  *
  * Requests are cancelled and state is reset when:
- * - YOLO mode is disabled (enabled=false)
+ * - Auto-approve is disabled (enabled=false)
  * - Session changes
  * - Component unmounts
  */

--- a/ui/app/providers/app-providers.tsx
+++ b/ui/app/providers/app-providers.tsx
@@ -12,6 +12,7 @@ import {
   DEFAULT_FEATURE_FLAGS,
   type FeatureFlags,
 } from "~/context/feature-flags";
+import { ThemeProvider, type Theme } from "~/context/theme";
 import type { UiConfig } from "~/types/tensorzero";
 
 export interface AppProvidersLoaderData {
@@ -19,6 +20,7 @@ export interface AppProvidersLoaderData {
   autopilotAvailable?: boolean;
   config?: UiConfig;
   featureFlags?: FeatureFlags;
+  theme?: Theme;
 }
 
 interface AppProvidersProps {
@@ -32,27 +34,29 @@ interface AppProvidersProps {
  */
 export function AppProviders({ children, loaderData }: AppProvidersProps) {
   return (
-    <ReactQueryProvider>
-      <GlobalToastProvider>
-        <ReadOnlyProvider value={loaderData?.isReadOnly ?? false}>
-          <AutopilotAvailableProvider
-            value={loaderData?.autopilotAvailable ?? false}
-          >
-            <FeatureFlagsProvider
-              value={loaderData?.featureFlags ?? DEFAULT_FEATURE_FLAGS}
+    <ThemeProvider defaultTheme={loaderData?.theme ?? "system"}>
+      <ReactQueryProvider>
+        <GlobalToastProvider>
+          <ReadOnlyProvider value={loaderData?.isReadOnly ?? false}>
+            <AutopilotAvailableProvider
+              value={loaderData?.autopilotAvailable ?? false}
             >
-              <ConfigProvider value={loaderData?.config ?? EMPTY_CONFIG}>
-                <SidebarProvider>
-                  <TooltipProvider delayDuration={250}>
-                    <EntitySheetProvider>{children}</EntitySheetProvider>
-                  </TooltipProvider>
-                </SidebarProvider>
-              </ConfigProvider>
-            </FeatureFlagsProvider>
-          </AutopilotAvailableProvider>
-        </ReadOnlyProvider>
-        <Toaster />
-      </GlobalToastProvider>
-    </ReactQueryProvider>
+              <FeatureFlagsProvider
+                value={loaderData?.featureFlags ?? DEFAULT_FEATURE_FLAGS}
+              >
+                <ConfigProvider value={loaderData?.config ?? EMPTY_CONFIG}>
+                  <SidebarProvider>
+                    <TooltipProvider delayDuration={250}>
+                      <EntitySheetProvider>{children}</EntitySheetProvider>
+                    </TooltipProvider>
+                  </SidebarProvider>
+                </ConfigProvider>
+              </FeatureFlagsProvider>
+            </AutopilotAvailableProvider>
+          </ReadOnlyProvider>
+          <Toaster />
+        </GlobalToastProvider>
+      </ReactQueryProvider>
+    </ThemeProvider>
   );
 }

--- a/ui/app/root.tsx
+++ b/ui/app/root.tsx
@@ -50,6 +50,7 @@ import {
   isSecureRequest,
   runWithRequest,
 } from "./utils/api-key-override.server";
+import type { Theme } from "./context/theme";
 
 export const links: Route.LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -60,7 +61,7 @@ export const links: Route.LinksFunction = () => [
   },
   {
     rel: "stylesheet",
-    href: "https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&family=Geist:wght@100..900&display=swap",
+    href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap",
   },
   {
     rel: "icon",
@@ -87,6 +88,13 @@ interface LoaderData {
   autopilotAvailable: boolean;
   featureFlags: FeatureFlags;
   infraError: ClassifiedError | null;
+  theme: Theme;
+}
+
+function getThemeFromCookies(request: Request): Theme {
+  const cookies = request.headers.get("Cookie") ?? "";
+  const match = cookies.match(/(?:^|;\s*)theme=(light|dark|system)/);
+  return (match?.[1] as Theme) ?? "system";
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -94,6 +102,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   startPeriodicCleanup();
   const isReadOnly = isReadOnlyMode();
   const featureFlags = loadFeatureFlags();
+  const theme = getThemeFromCookies(request);
   try {
     // Fetch config and autopilot availability in parallel
     const [config, autopilotAvailable] = await Promise.all([
@@ -106,6 +115,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       autopilotAvailable,
       featureFlags,
       infraError: null,
+      theme,
     };
   } catch (e) {
     // Graceful degradation for infrastructure errors:
@@ -118,6 +128,7 @@ export async function loader({ request }: Route.LoaderArgs) {
         autopilotAvailable: false,
         featureFlags,
         infraError: { type: InfraErrorType.GatewayUnavailable },
+        theme,
       };
     }
     if (isAuthenticationError(e)) {
@@ -127,6 +138,7 @@ export async function loader({ request }: Route.LoaderArgs) {
         autopilotAvailable: false,
         featureFlags,
         infraError: { type: InfraErrorType.GatewayAuthFailed },
+        theme,
       };
       // Clear stale cookie so the auth dialog starts fresh
       if (await getApiKeyFromRequest(request)) {
@@ -152,6 +164,7 @@ export async function loader({ request }: Route.LoaderArgs) {
           type: InfraErrorType.ClickHouseUnavailable,
           message,
         },
+        theme,
       };
     }
     throw e;
@@ -160,8 +173,14 @@ export async function loader({ request }: Route.LoaderArgs) {
 
 // Global Layout
 export function Layout({ children }: { children: React.ReactNode }) {
+  // Read the theme cookie for SSR to avoid flash of wrong theme.
+  // The ThemeProvider will take over on the client.
+  const loaderData = useRouteLoaderData<typeof loader>("root");
+  const theme = loaderData?.theme ?? "system";
+  const htmlClass = theme === "dark" ? "dark" : "";
+
   return (
-    <html lang="en">
+    <html lang="en" className={htmlClass}>
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/ui/app/routes/observability/episodes/EpisodesTable.tsx
+++ b/ui/app/routes/observability/episodes/EpisodesTable.tsx
@@ -8,29 +8,22 @@ import {
   TableRow,
   TableEmptyState,
 } from "~/components/ui/table";
-import { TableItemShortUuid } from "~/components/ui/TableItems";
-import { toEpisodeUrl } from "~/utils/urls";
+import { TableItemShortUuid, TableItemTime } from "~/components/ui/TableItems";
+import { toEpisodeUrl, toInferenceUrl } from "~/utils/urls";
 import { Suspense } from "react";
 import { useLocation, Await } from "react-router";
 import { Skeleton } from "~/components/ui/skeleton";
+import { Badge } from "~/components/ui/badge";
 import type { EpisodesData } from "./route";
 
-const formatTimeRange = (startTime: Date, endTime: Date, count: number) => {
-  const formatOptions: Intl.DateTimeFormatOptions = {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  };
-  const start = startTime.toLocaleString("en-US", formatOptions);
-  if (count === 1) {
-    return start;
-  }
-  const end = endTime.toLocaleString("en-US", formatOptions);
-  return `${start} — ${end}`;
-};
+function formatDuration(startTime: Date, endTime: Date): string {
+  const diffMs = endTime.getTime() - startTime.getTime();
+  if (diffMs < 1000) return `${diffMs}ms`;
+  if (diffMs < 60_000) return `${(diffMs / 1000).toFixed(1)}s`;
+  if (diffMs < 3_600_000)
+    return `${Math.floor(diffMs / 60_000)}m ${Math.floor((diffMs % 60_000) / 1000)}s`;
+  return `${Math.floor(diffMs / 3_600_000)}h ${Math.floor((diffMs % 3_600_000) / 60_000)}m`;
+}
 
 function SkeletonRows() {
   return (
@@ -41,10 +34,16 @@ function SkeletonRows() {
             <Skeleton className="h-4 w-24" />
           </TableCell>
           <TableCell>
+            <Skeleton className="h-4 w-12" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-4 w-24" />
+          </TableCell>
+          <TableCell>
             <Skeleton className="h-4 w-16" />
           </TableCell>
           <TableCell>
-            <Skeleton className="h-4 w-48" />
+            <Skeleton className="h-4 w-32" />
           </TableCell>
         </TableRow>
       ))}
@@ -61,26 +60,44 @@ function TableRows({ data }: { data: EpisodesData }) {
 
   return (
     <>
-      {episodes.map((episode) => (
-        <TableRow key={episode.episode_id} id={episode.episode_id}>
-          <TableCell className="max-w-[200px] lg:max-w-none">
-            <TableItemShortUuid
-              id={episode.episode_id}
-              link={toEpisodeUrl(episode.episode_id)}
-            />
-          </TableCell>
-          <TableCell>{episode.count}</TableCell>
-          <TableCell className="max-w-[200px] lg:max-w-none">
-            <span className="block overflow-hidden text-ellipsis whitespace-nowrap">
-              {formatTimeRange(
-                new Date(episode.start_time),
-                new Date(episode.end_time),
-                Number(episode.count),
-              )}
-            </span>
-          </TableCell>
-        </TableRow>
-      ))}
+      {episodes.map((episode) => {
+        const startTime = new Date(episode.start_time);
+        const endTime = new Date(episode.end_time);
+        const count = Number(episode.count);
+
+        return (
+          <TableRow key={episode.episode_id} id={episode.episode_id}>
+            <TableCell className="max-w-[200px] lg:max-w-none">
+              <TableItemShortUuid
+                id={episode.episode_id}
+                link={toEpisodeUrl(episode.episode_id)}
+              />
+            </TableCell>
+            <TableCell>
+              <Badge
+                variant="secondary"
+                className="font-mono text-xs font-normal"
+              >
+                {count}
+              </Badge>
+            </TableCell>
+            <TableCell className="max-w-[120px] lg:max-w-none">
+              <TableItemShortUuid
+                id={episode.last_inference_id}
+                link={toInferenceUrl(episode.last_inference_id)}
+              />
+            </TableCell>
+            <TableCell>
+              <span className="text-fg-secondary whitespace-nowrap text-xs">
+                {count > 1 ? formatDuration(startTime, endTime) : "—"}
+              </span>
+            </TableCell>
+            <TableCell>
+              <TableItemTime timestamp={episode.start_time} />
+            </TableCell>
+          </TableRow>
+        );
+      })}
     </>
   );
 }
@@ -98,8 +115,10 @@ export default function EpisodesTable({
         <TableHeader>
           <TableRow>
             <TableHead>Episode ID</TableHead>
-            <TableHead>Inference Count</TableHead>
-            <TableHead>Time</TableHead>
+            <TableHead>Inferences</TableHead>
+            <TableHead>Last Inference</TableHead>
+            <TableHead>Duration</TableHead>
+            <TableHead>Started</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -108,7 +127,7 @@ export default function EpisodesTable({
               resolve={data}
               errorElement={
                 <TableAsyncErrorState
-                  colSpan={3}
+                  colSpan={5}
                   defaultMessage="Failed to load episodes"
                 />
               }

--- a/ui/app/routes/observability/functions/$function_name/FunctionExperimentation.tsx
+++ b/ui/app/routes/observability/functions/$function_name/FunctionExperimentation.tsx
@@ -13,7 +13,7 @@ import { FeedbackMeansTimeseries } from "~/components/function/variant/FeedbackM
 import { useTimeGranularityParam } from "~/hooks/use-time-granularity-param";
 import { transformFeedbackTimeseries } from "~/components/function/variant/FeedbackSamplesTimeseries";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
-import { CHART_COLORS } from "~/utils/chart";
+import { getChartColor } from "~/utils/chart";
 
 interface FunctionExperimentationProps {
   functionConfig: FunctionConfig;
@@ -92,7 +92,7 @@ export const FunctionExperimentation = memo(function FunctionExperimentation({
         ...config,
         [variantName]: {
           label: variantName,
-          color: CHART_COLORS[index % CHART_COLORS.length],
+          color: getChartColor(index),
         },
       }),
       {},

--- a/ui/app/routes/observability/functions/$function_name/FunctionVariantTable.tsx
+++ b/ui/app/routes/observability/functions/$function_name/FunctionVariantTable.tsx
@@ -1,4 +1,4 @@
-import { Code } from "~/components/ui/code";
+import { Badge } from "~/components/ui/badge";
 import {
   Table,
   TableBody,
@@ -45,7 +45,7 @@ export default function FunctionVariantTable({
             variantName={info.getValue()}
             functionName={function_name}
           >
-            <code className="block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-gray-500">
+            <code className="text-fg-primary block overflow-hidden rounded font-mono text-ellipsis whitespace-nowrap transition-colors duration-300 hover:text-orange-600">
               {info.getValue()}
             </code>
           </VariantLink>
@@ -53,7 +53,11 @@ export default function FunctionVariantTable({
       }),
       columnHelper.accessor("type", {
         header: "Type",
-        cell: (info) => <Code>{info.getValue()}</Code>,
+        cell: (info) => (
+          <Badge variant="secondary" className="font-mono text-xs font-normal">
+            {info.getValue()}
+          </Badge>
+        ),
       }),
       columnHelper.accessor("inference_count", {
         header: "Count",

--- a/ui/app/routes/observability/inferences/$inference_id/InferenceActionBar.tsx
+++ b/ui/app/routes/observability/inferences/$inference_id/InferenceActionBar.tsx
@@ -154,7 +154,10 @@ function TryWithVariantActionStreaming({
             ...config.model_names,
           ]);
           const models = [...modelsSet].sort();
-          const options = isDefault ? models : variants;
+          const allOptions = isDefault ? models : variants;
+          const options = allOptions.filter(
+            (o) => o !== inference.variant_name,
+          );
 
           return (
             <TryWithVariantAction

--- a/ui/app/tailwind.css
+++ b/ui/app/tailwind.css
@@ -6,9 +6,9 @@
 
 @theme {
   --font-sans:
-    Geist, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif;
+    Inter, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif;
   --font-mono:
-    Geist Mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 
   --font-weight-thin: var(--font-weight-thin);
   --font-weight-light: var(--font-weight-light);
@@ -203,15 +203,23 @@
   ::file-selector-button {
     border-color: var(--color-gray-200, currentcolor);
   }
+
+  :is(.dark) *,
+  :is(.dark) ::after,
+  :is(.dark) ::before,
+  :is(.dark) ::backdrop,
+  :is(.dark) ::file-selector-button {
+    border-color: hsl(var(--border));
+  }
 }
 
 @layer utilities {
   :root {
     --font-weight-thin: 100;
     --font-weight-light: 300;
-    --font-weight-normal: 450;
+    --font-weight-normal: 400;
     --font-weight-medium: 500;
-    --font-weight-semibold: 620;
+    --font-weight-semibold: 600;
     --font-weight-bold: 700;
     --font-weight-black: 900;
   }
@@ -219,11 +227,14 @@
   html,
   body {
     @apply bg-background dark:bg-background;
-    font-weight: var(--font-weight-normal);
+    font-family: var(--font-sans);
+    font-size: 14px;
+    line-height: 1.5;
+    font-feature-settings: "cv02", "cv03", "cv04", "cv11";
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
-    @media (prefers-color-scheme: dark) {
+    .dark & {
       color-scheme: dark;
     }
   }
@@ -251,11 +262,11 @@
   }
 
   :root {
-    --background-primary: 0 0% 100%;
-    --background-secondary: 0 0% 99%;
-    --background-tertiary: 0 0% 96%;
+    --background-primary: 20 20% 99%;
+    --background-secondary: 20 14% 97%;
+    --background-tertiary: 20 10% 95%;
     --background-muted: 0 0% 91%;
-    --background-hover: 0 0% 95%;
+    --background-hover: 20 10% 94%;
     --foreground-primary: 0 0% 0%;
     --foreground-secondary: 0 0% 32%;
     --foreground-tertiary: 0 0% 48%;
@@ -278,18 +289,18 @@
     --border-accent: 0 0% 80%;
     --input: 0 0% 88%;
     --ring: 222.2 84% 4.9%;
-    --chart-1: 12 76% 61%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
+    --chart-1: 17 92% 52%;
+    --chart-2: 210 75% 48%;
+    --chart-3: 160 55% 42%;
+    --chart-4: 265 60% 52%;
+    --chart-5: 38 85% 50%;
     --radius: 0.5rem;
     --sidebar-background: 0 0% 96%;
     --sidebar-foreground: 240 5.3% 26.1%;
     --sidebar-primary: 240 5.9% 10%;
     --sidebar-primary-foreground: 0 0% 98%;
-    --sidebar-accent: 0 0% 91%;
-    --sidebar-accent-foreground: 240 5.9% 10%;
+    --sidebar-accent: var(--orange-50);
+    --sidebar-accent-foreground: var(--orange-950);
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 217.2 91.2% 59.8%;
 
@@ -351,50 +362,60 @@
   }
 
   .dark {
-    --bg-primary: 222.2 84% 4.9%;
-    --bg-secondary: 215 28% 17%;
-    --background-tertiary: 217.2 32.6% 17.5%;
-    --background-hover: 217.2 32.6% 18%;
-    --foreground-primary: 0 0% 100%;
-    --foreground-secondary: 0 0% 70%;
-    --foreground-tertiary: 0 0% 45%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 0 0% 65%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 0 0% 14.9%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
+    /* Neutral dark theme matching Mintlify docs site */
+    /* background-dark: rgb(14,12,13), grays from rgb(17,12,10) to rgb(250,245,242) */
+    --background-primary: 0 0% 5%;
+    --background-secondary: 0 0% 10%;
+    --background-tertiary: 0 0% 13%;
+    --background-muted: 0 0% 22%;
+    --background-hover: 0 0% 15%;
+    --foreground-primary: 0 0% 95%;
+    --foreground-secondary: 0 0% 65%;
+    --foreground-tertiary: 0 0% 48%;
+    --foreground-muted: 0 0% 55%;
+    --card: 0 0% 10%;
+    --card-foreground: 0 0% 95%;
+    --popover: 0 0% 10%;
+    --popover-foreground: 0 0% 95%;
+    --primary: 0 0% 95%;
+    --primary-foreground: 0 0% 5%;
+    --secondary: 0 0% 13%;
+    --secondary-foreground: 0 0% 95%;
+    --muted: 0 0% 13%;
+    --muted-foreground: 0 0% 55%;
+    --accent: 0 0% 13%;
+    --accent-foreground: 0 0% 95%;
+    --destructive: 0 63% 31%;
+    --destructive-foreground: 0 0% 95%;
+    --border: 0 0% 15%;
+    --border-accent: 0 0% 22%;
+    --input: 0 0% 20%;
+    --ring: 0 0% 65%;
+    --chart-1: 17 85% 58%;
+    --chart-2: 200 70% 55%;
+    --chart-3: 160 45% 50%;
+    --chart-4: 270 50% 60%;
+    --chart-5: 45 70% 55%;
+    --sidebar-background: 0 0% 5%;
+    --sidebar-foreground: 0 0% 85%;
+    --sidebar-primary: 17 100% 50%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --sidebar-accent: 0 0% 15%;
+    --sidebar-accent-foreground: var(--orange-400);
+    --sidebar-border: 0 0% 15%;
+    --sidebar-ring: 20 80% 55%;
 
-    --menu-highlight: var(--orange-900);
-    --menu-highlight-foreground: var(--orange-100);
-    --menu-highlight-icon: var(--orange-200);
-    --menu-highlight-badge: var(--orange-800);
-    --menu-highlight-badge-foreground: var(--orange-200);
+    /* Dark mode overrides for type icon colors */
+    --emerald-100: 150 30% 18%;
+    --emerald-600: 150 50% 55%;
+    --blue-100: 208 30% 18%;
+    --blue-600: 208 50% 55%;
+
+    --menu-highlight: 0 0% 18%;
+    --menu-highlight-foreground: 0 0% 95%;
+    --menu-highlight-icon: var(--orange-400);
+    --menu-highlight-badge: 0 0% 22%;
+    --menu-highlight-badge-foreground: 0 0% 85%;
     --card-highlight: var(--orange-900);
     --card-highlight-icon: var(--orange-200);
     --card-highlight-icon-bg: var(--orange-800);

--- a/ui/app/utils/chart.ts
+++ b/ui/app/utils/chart.ts
@@ -1,6 +1,7 @@
 /**
- * Standard chart colors for consistent theming across all charts
- * Uses CSS custom properties defined in the theme
+ * Base chart colors from CSS custom properties.
+ * For more than 5 series, use `getChartColor(index)` which generates
+ * unlimited distinct colors via golden-angle hue rotation.
  */
 export const CHART_COLORS = [
   "hsl(var(--chart-1))",
@@ -9,6 +10,19 @@ export const CHART_COLORS = [
   "hsl(var(--chart-4))",
   "hsl(var(--chart-5))",
 ] as const;
+
+/**
+ * Get a chart color by index. Returns themed CSS colors for the first 5,
+ * then generates additional distinct colors using the golden angle.
+ */
+export function getChartColor(index: number): string {
+  if (index < CHART_COLORS.length) {
+    return CHART_COLORS[index];
+  }
+  // Golden angle (~137.5°) produces maximally spaced hues
+  const hue = ((index - CHART_COLORS.length) * 137.508 + 60) % 360;
+  return `hsl(${hue.toFixed(0)} 55% 55%)`;
+}
 
 /**
  * Format numbers for chart axes to avoid overflow with large numbers
@@ -97,23 +111,40 @@ export function formatXAxisTimestamp(
   date: Date,
   granularity: "minute" | "hour" | "day" | "week" | "month" | "cumulative",
 ): string {
-  const month = pad(date.getMonth() + 1);
-  const day = pad(date.getDate());
   const hours = pad(date.getHours());
   const minutes = pad(date.getMinutes());
 
+  const MONTH_SHORT = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+
   switch (granularity) {
     case "minute":
-      // Format: MM-DD HH:mm
-      return `${month}-${day} ${hours}:${minutes}`;
+      // Format: Mar 30 14:05
+      return `${MONTH_SHORT[date.getMonth()]} ${date.getDate()} ${hours}:${minutes}`;
     case "hour":
-      // Format: MM-DD HH:00
-      return `${month}-${day} ${hours}:00`;
+      // Format: Mar 30 14:00
+      return `${MONTH_SHORT[date.getMonth()]} ${date.getDate()} ${hours}:00`;
     case "day":
+      // Format: Mar 30
+      return `${MONTH_SHORT[date.getMonth()]} ${date.getDate()}`;
     case "week":
+      // Format: Mar 29 (week start date, like Grafana/Datadog)
+      return `${MONTH_SHORT[date.getMonth()]} ${date.getDate()}`;
     case "month":
-      // Format: YYYY-MM-DD
-      return `${date.getFullYear()}-${month}-${day}`;
+      // Format: Mar 2026
+      return `${MONTH_SHORT[date.getMonth()]} ${date.getFullYear()}`;
     case "cumulative":
       return "All time";
   }
@@ -128,23 +159,40 @@ export function formatTooltipTimestamp(
   granularity: "minute" | "hour" | "day" | "week" | "month" | "cumulative",
 ): string {
   const year = date.getFullYear();
-  const month = pad(date.getMonth() + 1);
-  const day = pad(date.getDate());
   const hours = pad(date.getHours());
   const minutes = pad(date.getMinutes());
 
+  const MONTH_LONG = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ];
+
   switch (granularity) {
     case "minute":
-      // Format: YYYY-MM-DD HH:mm
-      return `${year}-${month}-${day} ${hours}:${minutes}`;
+      // Format: March 30, 2026 14:05
+      return `${MONTH_LONG[date.getMonth()]} ${date.getDate()}, ${year} ${hours}:${minutes}`;
     case "hour":
-      // Format: YYYY-MM-DD HH:00
-      return `${year}-${month}-${day} ${hours}:00`;
+      // Format: March 30, 2026 14:00
+      return `${MONTH_LONG[date.getMonth()]} ${date.getDate()}, ${year} ${hours}:00`;
     case "day":
+      // Format: March 30, 2026
+      return `${MONTH_LONG[date.getMonth()]} ${date.getDate()}, ${year}`;
     case "week":
+      // Format: Week of March 29, 2026
+      return `Week of ${MONTH_LONG[date.getMonth()]} ${date.getDate()}, ${year}`;
     case "month":
-      // Format: YYYY-MM-DD
-      return `${year}-${month}-${day}`;
+      // Format: March 2026
+      return `${MONTH_LONG[date.getMonth()]} ${year}`;
     case "cumulative":
       return "All time";
   }

--- a/ui/app/utils/date.ts
+++ b/ui/app/utils/date.ts
@@ -90,6 +90,25 @@ export const getTimestampTooltipData = (timestamp: string | number | Date) => {
 };
 
 /**
+ * Format a timestamp as a compact relative time string.
+ * Returns "just now", "2m ago", "3h ago", "5d ago" for recent times,
+ * or a short date (e.g. "Mar 30") for timestamps older than a week.
+ */
+export function formatRelativeTime(timestamp: string): string {
+  const now = Date.now();
+  const then = new Date(timestamp).getTime();
+  const diffMs = now - then;
+  if (diffMs < 60_000) return "just now";
+  if (diffMs < 3_600_000) return `${Math.floor(diffMs / 60_000)}m ago`;
+  if (diffMs < 86_400_000) return `${Math.floor(diffMs / 3_600_000)}h ago`;
+  if (diffMs < 604_800_000) return `${Math.floor(diffMs / 86_400_000)}d ago`;
+  return new Date(timestamp).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/**
  * Time window units for time series granularity
  */
 export type TimeWindow =


### PR DESCRIPTION
## Summary

Extracts the styling-only changes from #7154, leaving the new dashboard widgets (stats bars, home page additions, function-type filter, variant comparison feature) for a separate PR.

### What's in this PR

**Dark theme infrastructure**
- New `ThemeProvider` (`ui/app/context/theme.tsx`) with system preference detection and cookie persistence
- Dark mode toggle in the sidebar
- SSR-aware theme integration in `root.tsx` and `app-providers.tsx`
- Tailwind palette and typography refresh (Inter / JetBrains Mono, dark color tokens)

**Component restyling for dark theme**
- `Chip`, `button`, `table`, `chart`, `code-editor`, `TableItems`, `PageButtons`, `BasicInfoLayout`

**Chart improvements**
- `getChartColor()` utility — unlimited series via golden-angle color rotation
- Migrate `VariantPerformanceChart`, `VariantThroughput`, `ModelLatency`, `ModelUsage`, `TopKEvaluationViz`, `FunctionExperimentation` to use it
- Fix `PieChart` label overlap and skip zero-weight variants

**UX polish**
- `formatRelativeTime()` utility in `ui/app/utils/date.ts`
- Rename "YOLO Mode" → "Auto-Approve" with backward-compatible aliases
- Markdown render toggle in `TextContentBlock`
- Episodes table uses `TableItemTime` and `Badge` for cleaner display
- `AddToDatasetButton` dialog redesign + cache invalidation for `DATASETS_COUNT`
- Filter current variant from "Try with variant" options (bug fix)

### What's NOT in this PR (deferred)

- `StatsBar` component and stats-bar additions to home, datasets, inferences, functions, models routes
- New home page sections (`OverviewStatsBar`)
- Function-type filter in `FunctionsTable`
- New variant comparison modal (`VariantResponseModal` +338 lines, TextDiff, etc.)
- `diff` package dependency

## Test plan

- [ ] Toggle dark/light theme and verify all pages render correctly
- [ ] Verify charts use the new color rotation across many series
- [ ] Verify pie chart labels don't overlap
- [ ] Verify `AddToDatasetButton` dialog shows new options and dataset count refreshes
- [ ] Verify "Try with variant" doesn't show current variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<img width="3406" height="1578" alt="CleanShot 2026-04-13 at 15 20 28@2x" src="https://github.com/user-attachments/assets/2896c386-d8b0-48e5-8059-8892e69da485" />
<img width="3442" height="1946" alt="CleanShot 2026-04-13 at 15 20 36@2x" src="https://github.com/user-attachments/assets/c81818a9-481d-4907-9e2b-659b9d057c33" />

