### PR TITLE
Move some types from tensorzero-core to leaf crates

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -8407,6 +8407,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "tensorzero-derive",
+ "tensorzero-types",
 ]
 
 [[package]]

--- a/crates/tensorzero-core/src/endpoints/batch_inference.rs
+++ b/crates/tensorzero-core/src/endpoints/batch_inference.rs
@@ -20,6 +20,7 @@ use uuid::Uuid;
 use super::inference::{
     ChatInferenceResponse, InferenceClients, InferenceCredentials, InferenceDatabaseInsertMetadata,
     InferenceIds, InferenceModels, InferenceParams, InferenceResponse, JsonInferenceResponse,
+    inference_response_from_result,
 };
 use crate::cache::{CacheEnabledMode, CacheOptions};
 use crate::config::Config;
@@ -1184,7 +1185,7 @@ pub async fn write_completed_batch_inference<'a>(
                 None,
             )
             .await?;
-        let inference_response = InferenceResponse::new(
+        let inference_response = inference_response_from_result(
             inference_result.clone(),
             episode_id,
             variant_name.to_string(),

--- a/crates/tensorzero-core/src/endpoints/datasets/v1/conversion_utils.rs
+++ b/crates/tensorzero-core/src/endpoints/datasets/v1/conversion_utils.rs
@@ -8,7 +8,9 @@ use crate::endpoints::datasets::v1::types::{
 };
 use crate::error::{Error, ErrorDetails};
 use crate::function::FunctionConfig;
-use crate::inference::types::{FetchContext, InputExt, JsonInferenceOutput};
+use crate::inference::types::{
+    FetchContext, InputExt, JsonInferenceOutput, validate_content_block_chat_output,
+};
 use crate::jsonschema_util::JSONSchema;
 use crate::tool::ToolCallConfigDatabaseInsert;
 
@@ -46,7 +48,7 @@ impl CreateChatDatapointRequest {
         let validated_output = if let Some(output) = self.output {
             let validation_futures = output
                 .into_iter()
-                .map(|output| output.into_validated(tool_config.as_ref()));
+                .map(|output| validate_content_block_chat_output(output, tool_config.as_ref()));
             let validated_output = join_all(validation_futures).await;
             Some(validated_output)
         } else {

--- a/crates/tensorzero-core/src/endpoints/inference.rs
+++ b/crates/tensorzero-core/src/endpoints/inference.rs
@@ -72,6 +72,8 @@ use crate::variant::{InferenceConfig, Variant, VariantConfig, VariantInfo};
 use tensorzero_auth::middleware::RequestApiKeyExtension;
 use tensorzero_types::inference_params::JsonMode;
 
+pub use tensorzero_types::{ChatInferenceResponse, InferenceResponse, JsonInferenceResponse};
+
 use crate::endpoints::namespace::{
     validate_model_namespace, validate_variant_namespace_at_inference,
 };
@@ -967,7 +969,7 @@ async fn infer_variant(args: InferVariantArgs<'_>) -> Result<InferenceOutput, Er
             }
         }
 
-        let response = InferenceResponse::new(
+        let response = inference_response_from_result(
             result,
             episode_id,
             variant_name.clone(),
@@ -1689,219 +1691,112 @@ async fn write_inference<T: InferenceQueries + ModelInferenceQueries + Send + Sy
     futures::future::join_all(futures).await;
 }
 
-/// InferenceResponse and InferenceResultChunk determine what gets serialized and sent to the client
-#[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "ts-bindings", ts(export))]
-#[serde(untagged, rename_all = "snake_case")]
-pub enum InferenceResponse {
-    Chat(ChatInferenceResponse),
-    Json(JsonInferenceResponse),
-}
+pub fn inference_response_from_result(
+    inference_result: InferenceResult,
+    episode_id: Uuid,
+    variant_name: String,
+    include_raw_usage: bool,
+    include_original_response: bool,
+    include_raw_response: bool,
+) -> InferenceResponse {
+    let usage = inference_result.usage_considering_cached();
 
-#[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "ts-bindings", ts(export))]
-pub struct ChatInferenceResponse {
-    pub inference_id: Uuid,
-    pub episode_id: Uuid,
-    pub variant_name: String,
-    pub content: Vec<ContentBlockChatOutput>,
-    pub usage: Usage,
-    #[cfg_attr(feature = "ts-bindings", ts(optional))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub raw_usage: Option<Vec<RawUsageEntry>>,
-    /// DEPRECATED (#5697 / 2026.4+): Use `raw_response` instead.
-    #[cfg_attr(feature = "ts-bindings", ts(optional))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub original_response: Option<String>,
-    #[cfg_attr(feature = "ts-bindings", ts(optional))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub raw_response: Option<Vec<RawResponseEntry>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub finish_reason: Option<FinishReason>,
-}
+    // Build raw_usage if requested
+    // Returns Some(entries) if requested (even if empty when all cached), None if not requested
+    let raw_usage = if include_raw_usage {
+        let entries: Vec<RawUsageEntry> = inference_result
+            .model_inference_results()
+            .iter()
+            .filter(|r| !r.cached) // Exclude TensorZero cache hits
+            .flat_map(|r| r.raw_usage.clone().unwrap_or_default())
+            .collect();
+        Some(entries)
+    } else {
+        None
+    };
 
-#[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "ts-bindings", ts(export))]
-pub struct JsonInferenceResponse {
-    pub inference_id: Uuid,
-    pub episode_id: Uuid,
-    pub variant_name: String,
-    pub output: JsonInferenceOutput,
-    pub usage: Usage,
-    #[cfg_attr(feature = "ts-bindings", ts(optional))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub raw_usage: Option<Vec<RawUsageEntry>>,
-    /// DEPRECATED (#5697 / 2026.4+): Use `raw_response` instead.
-    #[cfg_attr(feature = "ts-bindings", ts(optional))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub original_response: Option<String>,
-    #[cfg_attr(feature = "ts-bindings", ts(optional))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub raw_response: Option<Vec<RawResponseEntry>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub finish_reason: Option<FinishReason>,
-}
-
-impl InferenceResponse {
-    pub fn new(
-        inference_result: InferenceResult,
-        episode_id: Uuid,
-        variant_name: String,
-        include_raw_usage: bool,
-        include_original_response: bool,
-        include_raw_response: bool,
-    ) -> Self {
-        let usage = inference_result.usage_considering_cached();
-
-        // Build raw_usage if requested
-        // Returns Some(entries) if requested (even if empty when all cached), None if not requested
-        let raw_usage = if include_raw_usage {
-            let entries: Vec<RawUsageEntry> = inference_result
-                .model_inference_results()
-                .iter()
-                .filter(|r| !r.cached) // Exclude TensorZero cache hits
-                .flat_map(|r| r.raw_usage.clone().unwrap_or_default())
-                .collect();
-            Some(entries)
-        } else {
-            None
-        };
-
-        // Build raw_response if requested
-        // Returns Some(entries) if requested (even if empty when all cached), None if not requested
-        let raw_response = if include_raw_response {
-            let mut entries: Vec<RawResponseEntry> = Vec::new();
-            for r in inference_result.model_inference_results() {
-                // Include failed provider attempts (model-level fallback) for this inference
-                entries.extend(r.failed_raw_response.clone());
-                // Include successful provider response
-                if !r.cached {
-                    if let Some(passed_through) = &r.relay_raw_response {
-                        entries.extend(passed_through.clone());
-                    } else {
-                        // Relay sets `provider_type` to `"tensorzero::relay"` because the real
-                        // downstream provider is unknown at that level. The actual provider type is
-                        // carried inside `relay_raw_response` entries (handled in the branch above).
-                        // So we should never reach this branch for relay responses.
-                        debug_assert!(
-                            &*r.provider_type != "tensorzero::relay",
-                            "Relay responses should always have `relay_raw_response` populated; \
+    // Build raw_response if requested
+    // Returns Some(entries) if requested (even if empty when all cached), None if not requested
+    let raw_response = if include_raw_response {
+        let mut entries: Vec<RawResponseEntry> = Vec::new();
+        for r in inference_result.model_inference_results() {
+            // Include failed provider attempts (model-level fallback) for this inference
+            entries.extend(r.failed_raw_response.clone());
+            // Include successful provider response
+            if !r.cached {
+                if let Some(passed_through) = &r.relay_raw_response {
+                    entries.extend(passed_through.clone());
+                } else {
+                    // Relay sets `provider_type` to `"tensorzero::relay"` because the real
+                    // downstream provider is unknown at that level. The actual provider type is
+                    // carried inside `relay_raw_response` entries (handled in the branch above).
+                    // So we should never reach this branch for relay responses.
+                    debug_assert!(
+                        &*r.provider_type != "tensorzero::relay",
+                        "Relay responses should always have `relay_raw_response` populated; \
                              got `provider_type`={} without `relay_raw_response`",
-                            r.provider_type
-                        );
-                        let api_type = r
-                            .raw_usage
-                            .as_ref()
-                            .and_then(|entries| entries.first())
-                            .map(|entry| entry.api_type)
-                            .unwrap_or(ApiType::ChatCompletions);
-                        entries.push(RawResponseEntry {
-                            model_inference_id: Some(r.id),
-                            provider_type: r.provider_type.to_string(),
-                            api_type,
-                            data: r.raw_response.clone(),
-                        });
-                    }
+                        r.provider_type
+                    );
+                    let api_type = r
+                        .raw_usage
+                        .as_ref()
+                        .and_then(|entries| entries.first())
+                        .map(|entry| entry.api_type)
+                        .unwrap_or(ApiType::ChatCompletions);
+                    entries.push(RawResponseEntry {
+                        model_inference_id: Some(r.id),
+                        provider_type: r.provider_type.to_string(),
+                        api_type,
+                        data: r.raw_response.clone(),
+                    });
                 }
             }
-            Some(entries)
-        } else {
-            None
-        };
-
-        match inference_result {
-            InferenceResult::Chat(result) => {
-                // Populate original_response if deprecated flag was set
-                let original_response = if include_original_response {
-                    result.original_response
-                } else {
-                    None
-                };
-                InferenceResponse::Chat(ChatInferenceResponse {
-                    inference_id: result.inference_id,
-                    episode_id,
-                    variant_name,
-                    content: result.content,
-                    usage,
-                    raw_usage: raw_usage.clone(),
-                    original_response,
-                    raw_response: raw_response.clone(),
-                    finish_reason: result.finish_reason,
-                })
-            }
-            InferenceResult::Json(result) => {
-                let InternalJsonInferenceOutput { raw, parsed, .. } = result.output;
-                let output = JsonInferenceOutput { raw, parsed };
-                // Populate original_response if deprecated flag was set
-                let original_response = if include_original_response {
-                    result.original_response
-                } else {
-                    None
-                };
-                InferenceResponse::Json(JsonInferenceResponse {
-                    inference_id: result.inference_id,
-                    episode_id,
-                    variant_name,
-                    output,
-                    usage,
-                    raw_usage,
-                    original_response,
-                    raw_response,
-                    finish_reason: result.finish_reason,
-                })
-            }
         }
-    }
+        Some(entries)
+    } else {
+        None
+    };
 
-    pub fn usage(&self) -> Usage {
-        match self {
-            InferenceResponse::Chat(c) => c.usage,
-            InferenceResponse::Json(j) => j.usage,
+    match inference_result {
+        InferenceResult::Chat(result) => {
+            // Populate original_response if deprecated flag was set
+            let original_response = if include_original_response {
+                result.original_response
+            } else {
+                None
+            };
+            InferenceResponse::Chat(ChatInferenceResponse {
+                inference_id: result.inference_id,
+                episode_id,
+                variant_name,
+                content: result.content,
+                usage,
+                raw_usage: raw_usage.clone(),
+                original_response,
+                raw_response: raw_response.clone(),
+                finish_reason: result.finish_reason,
+            })
         }
-    }
-
-    pub fn raw_usage(&self) -> Option<&Vec<RawUsageEntry>> {
-        match self {
-            InferenceResponse::Chat(c) => c.raw_usage.as_ref(),
-            InferenceResponse::Json(j) => j.raw_usage.as_ref(),
-        }
-    }
-
-    pub fn raw_response(&self) -> Option<&Vec<RawResponseEntry>> {
-        match self {
-            InferenceResponse::Chat(c) => c.raw_response.as_ref(),
-            InferenceResponse::Json(j) => j.raw_response.as_ref(),
-        }
-    }
-
-    pub fn finish_reason(&self) -> Option<FinishReason> {
-        match self {
-            InferenceResponse::Chat(c) => c.finish_reason,
-            InferenceResponse::Json(j) => j.finish_reason,
-        }
-    }
-
-    pub fn variant_name(&self) -> &str {
-        match self {
-            InferenceResponse::Chat(c) => &c.variant_name,
-            InferenceResponse::Json(j) => &j.variant_name,
-        }
-    }
-
-    pub fn inference_id(&self) -> Uuid {
-        match self {
-            InferenceResponse::Chat(c) => c.inference_id,
-            InferenceResponse::Json(j) => j.inference_id,
-        }
-    }
-
-    pub fn episode_id(&self) -> Uuid {
-        match self {
-            InferenceResponse::Chat(c) => c.episode_id,
-            InferenceResponse::Json(j) => j.episode_id,
+        InferenceResult::Json(result) => {
+            let InternalJsonInferenceOutput { raw, parsed, .. } = result.output;
+            let output = JsonInferenceOutput { raw, parsed };
+            // Populate original_response if deprecated flag was set
+            let original_response = if include_original_response {
+                result.original_response
+            } else {
+                None
+            };
+            InferenceResponse::Json(JsonInferenceResponse {
+                inference_id: result.inference_id,
+                episode_id,
+                variant_name,
+                output,
+                usage,
+                raw_usage,
+                original_response,
+                raw_response,
+                finish_reason: result.finish_reason,
+            })
         }
     }
 }
@@ -3553,7 +3448,7 @@ mod tests {
             finish_reason: None,
         });
 
-        let response = InferenceResponse::new(
+        let response = inference_response_from_result(
             inference_result,
             Uuid::now_v7(),
             "test_variant".to_string(),

--- a/crates/tensorzero-core/src/inference/types/mod.rs
+++ b/crates/tensorzero-core/src/inference/types/mod.rs
@@ -53,7 +53,8 @@ pub use file::{
 };
 // Re-export content types from tensorzero-types
 pub use tensorzero_types::{
-    Arguments, FunctionType, RawText, System, Template, Text, Thought, ThoughtSummaryBlock, Unknown,
+    Arguments, ContentBlockChatOutput, FunctionType, JsonInferenceOutput, RawText, System,
+    Template, Text, Thought, ThoughtSummaryBlock, Unknown,
 };
 // Re-export message types from tensorzero-types
 use futures::FutureExt;
@@ -61,15 +62,10 @@ use futures::future::{join_all, try_join_all};
 use itertools::Itertools;
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
-#[cfg(feature = "pyo3")]
-use pyo3::types::PyAny;
-#[cfg(feature = "pyo3")]
-use pyo3_helpers::serialize_to_dict;
 pub use resolved_input::{
     LazyFileExt, ResolvedInput, ResolvedInputMessage, ResolvedInputMessageContent,
 };
 use rust_decimal::Decimal;
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{
@@ -77,7 +73,7 @@ use std::{
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
-use tensorzero_derive::{TensorZeroDeserialize, export_schema};
+use tensorzero_derive::TensorZeroDeserialize;
 pub use tensorzero_types::{Input, InputMessage, InputMessageContent, TextKind, ToolCallWrapper};
 use uuid::Uuid;
 
@@ -925,50 +921,28 @@ enum ContentBlockOutputType {
     Unknown,
 }
 
-/// Defines the types of content block that can come from a `chat` function
-#[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
-#[derive(Clone, Debug, JsonSchema, PartialEq, Serialize, TensorZeroDeserialize)]
-#[cfg_attr(feature = "ts-bindings", ts(export, optional_fields))]
-#[serde(tag = "type")]
-#[serde(rename_all = "snake_case")]
-#[export_schema]
-pub enum ContentBlockChatOutput {
-    #[schemars(title = "ContentBlockChatOutputText")]
-    Text(Text),
-    #[schemars(title = "ContentBlockChatOutputToolCall")]
-    ToolCall(InferenceResponseToolCall),
-    #[schemars(title = "ContentBlockChatOutputThought")]
-    Thought(Thought),
-    #[schemars(title = "ContentBlockChatOutputUnknown")]
-    Unknown(Unknown),
-}
-
-impl ContentBlockChatOutput {
-    /// Validates a `ContentBlockChatOutput` and re-validate and re-parse structured fields.
-    /// (e.g. ToolCallOutput.name and .arguments). Returns a new `ContentBlockChatOutput` with the validated fields.
-    ///
-    /// This is used in CreateChatDatapointRequest, which accepts a ContentBlockChatOutput. In these cases where a
-    /// user specifies it, we cannot trust raw and parsed values agree, and we use the raw fields as the source of truth
-    /// and re-validate.
-    pub async fn into_validated(
-        self,
-        tool_call_config: Option<&ToolCallConfig>,
-    ) -> ContentBlockChatOutput {
-        if let ContentBlockChatOutput::ToolCall(input_tool_call) = self {
-            let unvalidated_tool_call = ToolCall {
-                name: input_tool_call.raw_name,
-                arguments: input_tool_call.raw_arguments,
-                id: input_tool_call.id,
-            };
-            let validated_tool_call = InferenceResponseToolCall::new_from_tool_call(
-                unvalidated_tool_call,
-                tool_call_config,
-            )
-            .await;
-            ContentBlockChatOutput::ToolCall(validated_tool_call)
-        } else {
-            self
-        }
+/// Validates a `ContentBlockChatOutput` and re-validate and re-parse structured fields.
+/// (e.g. ToolCallOutput.name and .arguments). Returns a new `ContentBlockChatOutput` with the validated fields.
+///
+/// This is used in CreateChatDatapointRequest, which accepts a ContentBlockChatOutput. In these cases where a
+/// user specifies it, we cannot trust raw and parsed values agree, and we use the raw fields as the source of truth
+/// and re-validate.
+pub async fn validate_content_block_chat_output(
+    output: ContentBlockChatOutput,
+    tool_call_config: Option<&ToolCallConfig>,
+) -> ContentBlockChatOutput {
+    if let ContentBlockChatOutput::ToolCall(input_tool_call) = output {
+        let unvalidated_tool_call = ToolCall {
+            name: input_tool_call.raw_name,
+            arguments: input_tool_call.raw_arguments,
+            id: input_tool_call.id,
+        };
+        let validated_tool_call =
+            InferenceResponseToolCall::new_from_tool_call(unvalidated_tool_call, tool_call_config)
+                .await;
+        ContentBlockChatOutput::ToolCall(validated_tool_call)
+    } else {
+        output
     }
 }
 
@@ -1263,43 +1237,6 @@ pub struct JsonInferenceResult {
     pub finish_reason: Option<FinishReason>,
 }
 
-#[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
-#[export_schema]
-#[cfg_attr(feature = "ts-bindings", ts(export))]
-#[cfg_attr(feature = "pyo3", pyclass(str))]
-pub struct JsonInferenceOutput {
-    /// This is never omitted from the response even if it's None. A `null` value indicates no output from the model.
-    /// It's rare and unexpected from the model, but it's possible.
-    pub raw: Option<String>,
-    /// This is never omitted from the response even if it's None.
-    pub parsed: Option<Value>,
-}
-
-impl std::fmt::Display for JsonInferenceOutput {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let json = serde_json::to_string_pretty(self).map_err(|_| std::fmt::Error)?;
-        write!(f, "{json}")
-    }
-}
-
-#[cfg(feature = "pyo3")]
-#[pymethods]
-impl JsonInferenceOutput {
-    #[getter]
-    fn get_raw(&self) -> Option<String> {
-        self.raw.clone()
-    }
-
-    #[getter]
-    fn get_parsed<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        Ok(match &self.parsed {
-            Some(value) => serialize_to_dict(py, value)?.into_bound(py),
-            None => py.None().into_bound(py),
-        })
-    }
-}
-
 #[derive(Clone, Debug, PartialEq)]
 pub struct InternalJsonInferenceOutput {
     pub raw: Option<String>,
@@ -1447,13 +1384,6 @@ impl From<String> for ResolvedInputMessageContent {
 impl From<String> for LazyResolvedInputMessageContent {
     fn from(text: String) -> Self {
         LazyResolvedInputMessageContent::Text(Text { text })
-    }
-}
-
-#[cfg(any(test, feature = "e2e_tests"))]
-impl From<String> for ContentBlockChatOutput {
-    fn from(text: String) -> Self {
-        ContentBlockChatOutput::Text(Text { text })
     }
 }
 
@@ -1914,32 +1844,6 @@ pub fn current_timestamp() -> u64 {
         .duration_since(UNIX_EPOCH)
         .expect("Time went backwards")
         .as_secs()
-}
-
-impl From<ContentBlockChatOutput> for ContentBlock {
-    fn from(output: ContentBlockChatOutput) -> Self {
-        match output {
-            ContentBlockChatOutput::Text(text) => ContentBlock::Text(text),
-            ContentBlockChatOutput::ToolCall(inference_response_tool_call) => {
-                ContentBlock::ToolCall(inference_response_tool_call.into_tool_call())
-            }
-            ContentBlockChatOutput::Thought(thought) => ContentBlock::Thought(thought),
-            ContentBlockChatOutput::Unknown(unknown) => ContentBlock::Unknown(unknown),
-        }
-    }
-}
-
-impl From<ContentBlockChatOutput> for ContentBlockOutput {
-    fn from(output: ContentBlockChatOutput) -> Self {
-        match output {
-            ContentBlockChatOutput::Text(text) => ContentBlockOutput::Text(text),
-            ContentBlockChatOutput::ToolCall(tool_call) => {
-                ContentBlockOutput::ToolCall(tool_call.into_tool_call())
-            }
-            ContentBlockChatOutput::Thought(thought) => ContentBlockOutput::Thought(thought),
-            ContentBlockChatOutput::Unknown(unknown) => ContentBlockOutput::Unknown(unknown),
-        }
-    }
 }
 
 /// Serializes a value that implements `Serialize` into a JSON string.

--- a/crates/tensorzero-inference-types/src/lib.rs
+++ b/crates/tensorzero-inference-types/src/lib.rs
@@ -28,19 +28,16 @@ use futures::Stream;
 use futures::future::Shared;
 use futures::stream::Peekable;
 use mime::MediaType;
-use rust_decimal::Decimal;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize, Serializer};
 use serde_json::Value;
 use tensorzero_derive::{TensorZeroDeserialize, export_schema};
 use tensorzero_error::Error;
 use tensorzero_types::inference_params::JsonMode;
-use tensorzero_types::{ApiType, Text, Thought, ToolCall, Unknown};
-use tensorzero_types_providers::deepseek::DeepSeekUsage;
-use tensorzero_types_providers::fireworks::FireworksFinishReason;
-use tensorzero_types_providers::openai::{OpenAIFinishReason, OpenAIUsage};
-use tensorzero_types_providers::together::TogetherFinishReason;
-use tensorzero_types_providers::xai::XAIUsage;
+use tensorzero_types::{Text, Thought, ToolCall, Unknown};
+
+// Re-export types that were moved to tensorzero-types
+pub use tensorzero_types::{FinishReason, RawUsageEntry, Usage, raw_usage_entries_from_value};
 use url::Url;
 use uuid::Uuid;
 
@@ -59,131 +56,6 @@ pub enum Latency {
         response_time: Duration,
     },
     Batch,
-}
-
-// =============================================================================
-// Usage
-// =============================================================================
-
-#[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
-#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize)]
-#[cfg_attr(feature = "ts-bindings", ts(export, optional_fields))]
-pub struct Usage {
-    pub input_tokens: Option<u32>,
-    pub output_tokens: Option<u32>,
-    // Omit from serialized output when None (per AGENTS.md convention for optional fields).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub provider_cache_read_input_tokens: Option<u32>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub provider_cache_write_input_tokens: Option<u32>,
-    #[serde(default, with = "decimal_float_option")]
-    #[cfg_attr(feature = "ts-bindings", ts(type = "number | null"))]
-    pub cost: Option<Decimal>,
-}
-
-/// Custom serde module for `Option<Decimal>` as float.
-///
-/// Serializes identically to `rust_decimal::serde::float_option`.
-/// Deserializes via `Option<f64>` instead of `deserialize_option` so that
-/// serde's untagged-enum `ContentDeserializer` (which maps JSON `null` to
-/// `Content::Unit` → `visit_unit`) is handled correctly.  The upstream
-/// `OptionDecimalVisitor` only implements `visit_none`, not `visit_unit`,
-/// which causes failures inside `#[serde(untagged)]` enums.
-mod decimal_float_option {
-    use rust_decimal::Decimal;
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    // Signature is required by serde's `with` attribute.
-    #[expect(clippy::ref_option)]
-    pub fn serialize<S>(value: &Option<Decimal>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        rust_decimal::serde::float_option::serialize(value, serializer)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Decimal>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Option::<f64>::deserialize(deserializer)?
-            .map(|f| Decimal::try_from(f).map_err(serde::de::Error::custom))
-            .transpose()
-    }
-}
-
-impl Usage {
-    /// Returns a `Usage` with core fields at zero and cache fields at `None`.
-    ///
-    /// Cache fields start as `None` (meaning "not reported") because not all
-    /// providers support prompt caching. The lenient aggregation helpers
-    /// (`aggregate_usage_across_model_inferences`, `sum_usage_strict`) will
-    /// preserve any `Some` value they encounter rather than contaminating to `None`.
-    pub fn zero() -> Usage {
-        Usage {
-            input_tokens: Some(0),
-            output_tokens: Some(0),
-            provider_cache_read_input_tokens: None,
-            provider_cache_write_input_tokens: None,
-            cost: Some(Decimal::ZERO),
-        }
-    }
-
-    pub fn total_tokens(&self) -> Option<u32> {
-        match (self.input_tokens, self.output_tokens) {
-            (Some(input), Some(output)) => Some(input + output),
-            _ => None,
-        }
-    }
-}
-
-// =============================================================================
-// RawUsageEntry
-// =============================================================================
-
-/// A single entry in the raw usage array, representing usage data from one model inference.
-/// This preserves the original provider-specific usage object for fields that TensorZero
-/// normalizes away (e.g., OpenAI's `reasoning_tokens`, Anthropic's `cache_read_input_tokens`).
-#[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "ts-bindings", ts(export))]
-pub struct RawUsageEntry {
-    pub model_inference_id: Uuid,
-    pub provider_type: String,
-    pub api_type: ApiType,
-    pub data: Value,
-}
-
-pub fn raw_usage_entries_from_value(
-    model_inference_id: Uuid,
-    provider_type: &str,
-    api_type: ApiType,
-    usage: Value,
-) -> Vec<RawUsageEntry> {
-    vec![RawUsageEntry {
-        model_inference_id,
-        provider_type: provider_type.to_string(),
-        api_type,
-        data: usage,
-    }]
-}
-
-// =============================================================================
-// FinishReason
-// =============================================================================
-
-#[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize, sqlx::Type)]
-#[cfg_attr(feature = "ts-bindings", ts(export))]
-#[serde(rename_all = "snake_case")]
-#[sqlx(type_name = "text", rename_all = "snake_case")]
-pub enum FinishReason {
-    Stop,
-    StopSequence,
-    Length,
-    ToolCall,
-    ContentFilter,
-    Unknown,
 }
 
 // =============================================================================
@@ -614,6 +486,40 @@ pub enum ContentBlock {
     Unknown(Unknown),
 }
 
+impl From<tensorzero_types::ContentBlockChatOutput> for ContentBlock {
+    fn from(output: tensorzero_types::ContentBlockChatOutput) -> Self {
+        match output {
+            tensorzero_types::ContentBlockChatOutput::Text(text) => ContentBlock::Text(text),
+            tensorzero_types::ContentBlockChatOutput::ToolCall(tool_call) => {
+                ContentBlock::ToolCall(tool_call.into_tool_call())
+            }
+            tensorzero_types::ContentBlockChatOutput::Thought(thought) => {
+                ContentBlock::Thought(thought)
+            }
+            tensorzero_types::ContentBlockChatOutput::Unknown(unknown) => {
+                ContentBlock::Unknown(unknown)
+            }
+        }
+    }
+}
+
+impl From<tensorzero_types::ContentBlockChatOutput> for ContentBlockOutput {
+    fn from(output: tensorzero_types::ContentBlockChatOutput) -> Self {
+        match output {
+            tensorzero_types::ContentBlockChatOutput::Text(text) => ContentBlockOutput::Text(text),
+            tensorzero_types::ContentBlockChatOutput::ToolCall(tool_call) => {
+                ContentBlockOutput::ToolCall(tool_call.into_tool_call())
+            }
+            tensorzero_types::ContentBlockChatOutput::Thought(thought) => {
+                ContentBlockOutput::Thought(thought)
+            }
+            tensorzero_types::ContentBlockChatOutput::Unknown(unknown) => {
+                ContentBlockOutput::Unknown(unknown)
+            }
+        }
+    }
+}
+
 // =============================================================================
 // LazyFile, FileUrl, PendingObjectStoreFile, FileFuture
 // =============================================================================
@@ -728,104 +634,6 @@ impl From<JsonMode> for ModelInferenceRequestJsonMode {
             JsonMode::Strict => ModelInferenceRequestJsonMode::Strict,
             JsonMode::Tool => ModelInferenceRequestJsonMode::Off,
             JsonMode::Off => ModelInferenceRequestJsonMode::Off,
-        }
-    }
-}
-
-impl From<OpenAIUsage> for Usage {
-    fn from(usage: OpenAIUsage) -> Self {
-        Usage {
-            input_tokens: usage.prompt_tokens,
-            output_tokens: usage.completion_tokens,
-            provider_cache_read_input_tokens: usage
-                .prompt_tokens_details
-                .and_then(|d| d.cached_tokens),
-            provider_cache_write_input_tokens: None,
-            cost: None,
-        }
-    }
-}
-
-impl From<Option<OpenAIUsage>> for Usage {
-    fn from(usage: Option<OpenAIUsage>) -> Self {
-        match usage {
-            Some(u) => u.into(),
-            None => Usage::default(),
-        }
-    }
-}
-
-impl From<OpenAIFinishReason> for FinishReason {
-    fn from(reason: OpenAIFinishReason) -> Self {
-        match reason {
-            OpenAIFinishReason::Stop => FinishReason::Stop,
-            OpenAIFinishReason::Length => FinishReason::Length,
-            OpenAIFinishReason::ContentFilter => FinishReason::ContentFilter,
-            OpenAIFinishReason::ToolCalls => FinishReason::ToolCall,
-            OpenAIFinishReason::FunctionCall => FinishReason::ToolCall,
-            OpenAIFinishReason::Unknown => FinishReason::Unknown,
-        }
-    }
-}
-
-impl From<FireworksFinishReason> for FinishReason {
-    fn from(reason: FireworksFinishReason) -> Self {
-        match reason {
-            FireworksFinishReason::Stop => FinishReason::Stop,
-            FireworksFinishReason::Length => FinishReason::Length,
-            FireworksFinishReason::ToolCalls => FinishReason::ToolCall,
-            FireworksFinishReason::ContentFilter => FinishReason::ContentFilter,
-            FireworksFinishReason::Unknown => FinishReason::Unknown,
-        }
-    }
-}
-
-impl From<TogetherFinishReason> for FinishReason {
-    fn from(reason: TogetherFinishReason) -> Self {
-        match reason {
-            TogetherFinishReason::Stop => FinishReason::Stop,
-            TogetherFinishReason::Eos => FinishReason::Stop,
-            TogetherFinishReason::Length => FinishReason::Length,
-            TogetherFinishReason::ToolCalls => FinishReason::ToolCall,
-            TogetherFinishReason::FunctionCall => FinishReason::ToolCall,
-            TogetherFinishReason::Unknown => FinishReason::Unknown,
-        }
-    }
-}
-
-impl From<XAIUsage> for Usage {
-    fn from(usage: XAIUsage) -> Self {
-        // Add `reasoning_tokens` to `completion_tokens` for total output tokens
-        let output_tokens = match (usage.completion_tokens, usage.completion_tokens_details) {
-            (Some(completion), Some(details)) => {
-                Some(completion + details.reasoning_tokens.unwrap_or(0))
-            }
-            (Some(completion), None) => Some(completion),
-            (None, Some(details)) => details.reasoning_tokens,
-            (None, None) => None,
-        };
-        Usage {
-            input_tokens: usage.prompt_tokens,
-            output_tokens,
-            provider_cache_read_input_tokens: usage
-                .prompt_tokens_details
-                .and_then(|d| d.cached_tokens),
-            provider_cache_write_input_tokens: None,
-            cost: None,
-        }
-    }
-}
-
-impl From<DeepSeekUsage> for Usage {
-    fn from(usage: DeepSeekUsage) -> Self {
-        Usage {
-            input_tokens: usage.prompt_tokens,
-            output_tokens: usage.completion_tokens,
-            provider_cache_read_input_tokens: usage.prompt_cache_hit_tokens,
-            // DeepSeek's `prompt_cache_miss_tokens` = tokens not in cache, which are
-            // written to cache for future requests, so we map miss → write.
-            provider_cache_write_input_tokens: usage.prompt_cache_miss_tokens,
-            cost: None,
         }
     }
 }
@@ -1238,7 +1046,7 @@ mod tests {
     use rust_decimal::Decimal;
     use serde_json::json;
     use std::time::Duration;
-    use tensorzero_types::ToolChoice;
+    use tensorzero_types::{ApiType, ToolChoice};
     use uuid::Uuid;
 
     // =========================================================================
@@ -1350,58 +1158,6 @@ mod tests {
         expect_that!(deserialized.input_tokens, eq(Some(100)));
         expect_that!(deserialized.output_tokens, eq(Some(50)));
         expect_that!(deserialized.cost, eq(Some(Decimal::new(15, 4))));
-    }
-
-    // =========================================================================
-    // FinishReason conversions from provider types
-    // =========================================================================
-
-    #[gtest]
-    fn test_finish_reason_from_openai() {
-        expect_that!(
-            FinishReason::from(OpenAIFinishReason::Stop),
-            eq(FinishReason::Stop)
-        );
-        expect_that!(
-            FinishReason::from(OpenAIFinishReason::Length),
-            eq(FinishReason::Length)
-        );
-        expect_that!(
-            FinishReason::from(OpenAIFinishReason::ToolCalls),
-            eq(FinishReason::ToolCall)
-        );
-        expect_that!(
-            FinishReason::from(OpenAIFinishReason::ContentFilter),
-            eq(FinishReason::ContentFilter)
-        );
-    }
-
-    #[gtest]
-    fn test_finish_reason_from_fireworks() {
-        expect_that!(
-            FinishReason::from(FireworksFinishReason::Stop),
-            eq(FinishReason::Stop)
-        );
-        expect_that!(
-            FinishReason::from(FireworksFinishReason::ToolCalls),
-            eq(FinishReason::ToolCall)
-        );
-    }
-
-    #[gtest]
-    fn test_finish_reason_from_together() {
-        expect_that!(
-            FinishReason::from(TogetherFinishReason::Stop),
-            eq(FinishReason::Stop)
-        );
-        expect_that!(
-            FinishReason::from(TogetherFinishReason::Eos),
-            eq(FinishReason::Stop)
-        );
-        expect_that!(
-            FinishReason::from(TogetherFinishReason::ToolCalls),
-            eq(FinishReason::ToolCall)
-        );
     }
 
     // =========================================================================

--- a/crates/tensorzero-node/lib/bindings/InferenceResponse.ts
+++ b/crates/tensorzero-node/lib/bindings/InferenceResponse.ts
@@ -3,6 +3,6 @@ import type { ChatInferenceResponse } from "./ChatInferenceResponse";
 import type { JsonInferenceResponse } from "./JsonInferenceResponse";
 
 /**
- * InferenceResponse and InferenceResultChunk determine what gets serialized and sent to the client
+ * InferenceResponse determines what gets serialized and sent to the client
  */
 export type InferenceResponse = ChatInferenceResponse | JsonInferenceResponse;

--- a/crates/tensorzero-types-providers/Cargo.toml
+++ b/crates/tensorzero-types-providers/Cargo.toml
@@ -10,6 +10,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_path_to_error.workspace = true
 tensorzero-derive = { path = "../tensorzero-derive" }
+tensorzero-types = { path = "../tensorzero-types" }
 
 [lints]
 workspace = true

--- a/crates/tensorzero-types-providers/src/conversions.rs
+++ b/crates/tensorzero-types-providers/src/conversions.rs
@@ -1,0 +1,81 @@
+//! `From` implementations converting provider-specific types into TensorZero core types.
+
+use tensorzero_types::{FinishReason, Usage};
+
+use crate::deepseek::DeepSeekUsage;
+use crate::fireworks::FireworksFinishReason;
+use crate::openai::OpenAIFinishReason;
+use crate::together::TogetherFinishReason;
+use crate::xai::XAIUsage;
+
+impl From<OpenAIFinishReason> for FinishReason {
+    fn from(reason: OpenAIFinishReason) -> Self {
+        match reason {
+            OpenAIFinishReason::Stop => FinishReason::Stop,
+            OpenAIFinishReason::Length => FinishReason::Length,
+            OpenAIFinishReason::ContentFilter => FinishReason::ContentFilter,
+            OpenAIFinishReason::ToolCalls => FinishReason::ToolCall,
+            OpenAIFinishReason::FunctionCall => FinishReason::ToolCall,
+            OpenAIFinishReason::Unknown => FinishReason::Unknown,
+        }
+    }
+}
+
+impl From<FireworksFinishReason> for FinishReason {
+    fn from(reason: FireworksFinishReason) -> Self {
+        match reason {
+            FireworksFinishReason::Stop => FinishReason::Stop,
+            FireworksFinishReason::Length => FinishReason::Length,
+            FireworksFinishReason::ToolCalls => FinishReason::ToolCall,
+            FireworksFinishReason::ContentFilter => FinishReason::ContentFilter,
+            FireworksFinishReason::Unknown => FinishReason::Unknown,
+        }
+    }
+}
+
+impl From<TogetherFinishReason> for FinishReason {
+    fn from(reason: TogetherFinishReason) -> Self {
+        match reason {
+            TogetherFinishReason::Stop => FinishReason::Stop,
+            TogetherFinishReason::Eos => FinishReason::Stop,
+            TogetherFinishReason::Length => FinishReason::Length,
+            TogetherFinishReason::ToolCalls => FinishReason::ToolCall,
+            TogetherFinishReason::FunctionCall => FinishReason::ToolCall,
+            TogetherFinishReason::Unknown => FinishReason::Unknown,
+        }
+    }
+}
+
+impl From<XAIUsage> for Usage {
+    fn from(usage: XAIUsage) -> Self {
+        let output_tokens = match (usage.completion_tokens, usage.completion_tokens_details) {
+            (Some(completion), Some(details)) => {
+                Some(completion + details.reasoning_tokens.unwrap_or(0))
+            }
+            (Some(completion), None) => Some(completion),
+            (None, Some(details)) => details.reasoning_tokens,
+            (None, None) => None,
+        };
+        Usage {
+            input_tokens: usage.prompt_tokens,
+            output_tokens,
+            provider_cache_read_input_tokens: usage
+                .prompt_tokens_details
+                .and_then(|d| d.cached_tokens),
+            provider_cache_write_input_tokens: None,
+            cost: None,
+        }
+    }
+}
+
+impl From<DeepSeekUsage> for Usage {
+    fn from(usage: DeepSeekUsage) -> Self {
+        Usage {
+            input_tokens: usage.prompt_tokens,
+            output_tokens: usage.completion_tokens,
+            provider_cache_read_input_tokens: usage.prompt_cache_hit_tokens,
+            provider_cache_write_input_tokens: usage.prompt_cache_miss_tokens,
+            cost: None,
+        }
+    }
+}

--- a/crates/tensorzero-types-providers/src/lib.rs
+++ b/crates/tensorzero-types-providers/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod aws_bedrock;
 pub mod cache;
+pub mod conversions;
 pub mod deepseek;
 pub mod fireworks;
 pub mod groq;

--- a/crates/tensorzero-types-providers/src/openai.rs
+++ b/crates/tensorzero-types-providers/src/openai.rs
@@ -6,18 +6,8 @@
 use serde::{Deserialize, Serialize};
 use tensorzero_derive::TensorZeroDeserialize;
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
-pub struct OpenAIPromptTokensDetails {
-    pub cached_tokens: Option<u32>,
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct OpenAIUsage {
-    pub prompt_tokens: Option<u32>,
-    pub completion_tokens: Option<u32>,
-    #[serde(default)]
-    pub prompt_tokens_details: Option<OpenAIPromptTokensDetails>,
-}
+// Re-export usage types that were moved to tensorzero-types
+pub use tensorzero_types::{OpenAIPromptTokensDetails, OpenAIUsage};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]

--- a/crates/tensorzero-types/src/inference_response.rs
+++ b/crates/tensorzero-types/src/inference_response.rs
@@ -1,0 +1,205 @@
+//! Types for inference responses.
+//!
+//! These types define the wire format for inference responses sent back to clients.
+
+#[cfg(feature = "pyo3")]
+use pyo3::prelude::*;
+#[cfg(feature = "pyo3")]
+use pyo3::types::PyModule;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tensorzero_derive::{TensorZeroDeserialize, export_schema};
+use uuid::Uuid;
+
+use crate::content::{Text, Thought, Unknown};
+use crate::tool::InferenceResponseToolCall;
+use crate::usage::{FinishReason, RawResponseEntry, RawUsageEntry, Usage};
+
+// =============================================================================
+// ContentBlockChatOutput
+// =============================================================================
+
+/// Defines the types of content block that can come from a `chat` function
+#[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
+#[derive(Clone, Debug, JsonSchema, PartialEq, Serialize, TensorZeroDeserialize)]
+#[cfg_attr(feature = "ts-bindings", ts(export, optional_fields))]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+#[export_schema]
+pub enum ContentBlockChatOutput {
+    #[schemars(title = "ContentBlockChatOutputText")]
+    Text(Text),
+    #[schemars(title = "ContentBlockChatOutputToolCall")]
+    ToolCall(InferenceResponseToolCall),
+    #[schemars(title = "ContentBlockChatOutputThought")]
+    Thought(Thought),
+    #[schemars(title = "ContentBlockChatOutputUnknown")]
+    Unknown(Unknown),
+}
+
+impl From<String> for ContentBlockChatOutput {
+    fn from(text: String) -> Self {
+        ContentBlockChatOutput::Text(Text { text })
+    }
+}
+
+// =============================================================================
+// JsonInferenceOutput
+// =============================================================================
+
+#[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
+#[export_schema]
+#[cfg_attr(feature = "ts-bindings", ts(export))]
+#[cfg_attr(feature = "pyo3", pyclass(str))]
+pub struct JsonInferenceOutput {
+    /// This is never omitted from the response even if it's None. A `null` value indicates no output from the model.
+    /// It's rare and unexpected from the model, but it's possible.
+    pub raw: Option<String>,
+    /// This is never omitted from the response even if it's None.
+    pub parsed: Option<Value>,
+}
+
+impl std::fmt::Display for JsonInferenceOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let json = serde_json::to_string_pretty(self).map_err(|_| std::fmt::Error)?;
+        write!(f, "{json}")
+    }
+}
+
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl JsonInferenceOutput {
+    #[getter]
+    fn get_raw(&self) -> Option<String> {
+        self.raw.clone()
+    }
+
+    #[getter]
+    fn get_parsed<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, pyo3::types::PyAny>> {
+        Ok(match &self.parsed {
+            Some(value) => {
+                let json_str = serde_json::to_string(value).map_err(|e| {
+                    pyo3::exceptions::PyValueError::new_err(format!(
+                        "Failed to serialize parsed value: {e}"
+                    ))
+                })?;
+                let json = PyModule::import(py, "json")?;
+                json.call_method1("loads", (json_str,))?
+            }
+            None => py.None().into_bound(py),
+        })
+    }
+}
+
+// =============================================================================
+// InferenceResponse types
+// =============================================================================
+
+/// InferenceResponse determines what gets serialized and sent to the client
+#[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-bindings", ts(export))]
+#[serde(untagged, rename_all = "snake_case")]
+pub enum InferenceResponse {
+    Chat(ChatInferenceResponse),
+    Json(JsonInferenceResponse),
+}
+
+#[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-bindings", ts(export))]
+pub struct ChatInferenceResponse {
+    pub inference_id: Uuid,
+    pub episode_id: Uuid,
+    pub variant_name: String,
+    pub content: Vec<ContentBlockChatOutput>,
+    pub usage: Usage,
+    #[cfg_attr(feature = "ts-bindings", ts(optional))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw_usage: Option<Vec<RawUsageEntry>>,
+    /// DEPRECATED (#5697 / 2026.4+): Use `raw_response` instead.
+    #[cfg_attr(feature = "ts-bindings", ts(optional))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original_response: Option<String>,
+    #[cfg_attr(feature = "ts-bindings", ts(optional))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw_response: Option<Vec<RawResponseEntry>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<FinishReason>,
+}
+
+#[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-bindings", ts(export))]
+pub struct JsonInferenceResponse {
+    pub inference_id: Uuid,
+    pub episode_id: Uuid,
+    pub variant_name: String,
+    pub output: JsonInferenceOutput,
+    pub usage: Usage,
+    #[cfg_attr(feature = "ts-bindings", ts(optional))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw_usage: Option<Vec<RawUsageEntry>>,
+    /// DEPRECATED (#5697 / 2026.4+): Use `raw_response` instead.
+    #[cfg_attr(feature = "ts-bindings", ts(optional))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original_response: Option<String>,
+    #[cfg_attr(feature = "ts-bindings", ts(optional))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw_response: Option<Vec<RawResponseEntry>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<FinishReason>,
+}
+
+impl InferenceResponse {
+    pub fn usage(&self) -> Usage {
+        match self {
+            InferenceResponse::Chat(c) => c.usage,
+            InferenceResponse::Json(j) => j.usage,
+        }
+    }
+
+    pub fn raw_usage(&self) -> Option<&Vec<RawUsageEntry>> {
+        match self {
+            InferenceResponse::Chat(c) => c.raw_usage.as_ref(),
+            InferenceResponse::Json(j) => j.raw_usage.as_ref(),
+        }
+    }
+
+    pub fn raw_response(&self) -> Option<&Vec<RawResponseEntry>> {
+        match self {
+            InferenceResponse::Chat(c) => c.raw_response.as_ref(),
+            InferenceResponse::Json(j) => j.raw_response.as_ref(),
+        }
+    }
+
+    pub fn finish_reason(&self) -> Option<FinishReason> {
+        match self {
+            InferenceResponse::Chat(c) => c.finish_reason,
+            InferenceResponse::Json(j) => j.finish_reason,
+        }
+    }
+
+    pub fn variant_name(&self) -> &str {
+        match self {
+            InferenceResponse::Chat(c) => &c.variant_name,
+            InferenceResponse::Json(j) => &j.variant_name,
+        }
+    }
+
+    pub fn inference_id(&self) -> Uuid {
+        match self {
+            InferenceResponse::Chat(c) => c.inference_id,
+            InferenceResponse::Json(j) => j.inference_id,
+        }
+    }
+
+    pub fn episode_id(&self) -> Uuid {
+        match self {
+            InferenceResponse::Chat(c) => c.episode_id,
+            InferenceResponse::Json(j) => j.episode_id,
+        }
+    }
+}

--- a/crates/tensorzero-types/src/lib.rs
+++ b/crates/tensorzero-types/src/lib.rs
@@ -9,6 +9,7 @@ pub mod error;
 pub mod file;
 pub mod inference_filters;
 pub mod inference_params;
+pub mod inference_response;
 pub mod message;
 pub mod rate_limiting_types;
 pub mod role;
@@ -38,6 +39,10 @@ pub use file::{
     Base64File, Base64FileMetadata, Detail, File, ObjectStorageError, ObjectStorageFile,
     ObjectStoragePointer, UrlFile,
 };
+pub use inference_response::{
+    ChatInferenceResponse, ContentBlockChatOutput, InferenceResponse, JsonInferenceOutput,
+    JsonInferenceResponse,
+};
 pub use message::{Input, InputMessage, InputMessageContent, TextKind};
 pub use role::{
     ASSISTANT_TEXT_TEMPLATE_VAR, Role, SYSTEM_TEXT_TEMPLATE_VAR, USER_TEXT_TEMPLATE_VAR,
@@ -50,7 +55,10 @@ pub use tool::{InferenceResponseToolCall, ToolCall, ToolCallWrapper, ToolChoice,
 pub use tool_error::ToolError;
 pub use tool_failure::{NonControlToolError, ToolFailure};
 pub use tool_handle::ToolHandle;
-pub use usage::{ApiType, RawResponseEntry};
+pub use usage::{
+    ApiType, FinishReason, OpenAIPromptTokensDetails, OpenAIUsage, RawResponseEntry, RawUsageEntry,
+    Usage, raw_usage_entries_from_value,
+};
 use uuid::Uuid;
 
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]

--- a/crates/tensorzero-types/src/usage.rs
+++ b/crates/tensorzero-types/src/usage.rs
@@ -1,5 +1,9 @@
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use uuid::Uuid;
+
+use crate::serde_utils::decimal_float_option;
 
 /// The type of API used for a model inference.
 /// Used in raw usage reporting to help consumers interpret provider-specific usage data.
@@ -25,4 +29,138 @@ pub struct RawResponseEntry {
     pub provider_type: String,
     pub api_type: ApiType,
     pub data: String,
+}
+
+// =============================================================================
+// Usage
+// =============================================================================
+
+#[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "ts-bindings", ts(export, optional_fields))]
+pub struct Usage {
+    pub input_tokens: Option<u32>,
+    pub output_tokens: Option<u32>,
+    // Omit from serialized output when None (per AGENTS.md convention for optional fields).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_cache_read_input_tokens: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_cache_write_input_tokens: Option<u32>,
+    #[serde(default, with = "decimal_float_option")]
+    #[cfg_attr(feature = "ts-bindings", ts(type = "number | null"))]
+    pub cost: Option<Decimal>,
+}
+
+impl Usage {
+    /// Returns a `Usage` with core fields at zero and cache fields at `None`.
+    ///
+    /// Cache fields start as `None` (meaning "not reported") because not all
+    /// providers support prompt caching. The lenient aggregation helpers
+    /// (`aggregate_usage_across_model_inferences`, `sum_usage_strict`) will
+    /// preserve any `Some` value they encounter rather than contaminating to `None`.
+    pub fn zero() -> Usage {
+        Usage {
+            input_tokens: Some(0),
+            output_tokens: Some(0),
+            provider_cache_read_input_tokens: None,
+            provider_cache_write_input_tokens: None,
+            cost: Some(Decimal::ZERO),
+        }
+    }
+
+    pub fn total_tokens(&self) -> Option<u32> {
+        match (self.input_tokens, self.output_tokens) {
+            (Some(input), Some(output)) => Some(input + output),
+            _ => None,
+        }
+    }
+}
+
+// =============================================================================
+// OpenAI-compatible usage types
+// =============================================================================
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct OpenAIPromptTokensDetails {
+    pub cached_tokens: Option<u32>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct OpenAIUsage {
+    pub prompt_tokens: Option<u32>,
+    pub completion_tokens: Option<u32>,
+    #[serde(default)]
+    pub prompt_tokens_details: Option<OpenAIPromptTokensDetails>,
+}
+
+impl From<OpenAIUsage> for Usage {
+    fn from(usage: OpenAIUsage) -> Self {
+        Usage {
+            input_tokens: usage.prompt_tokens,
+            output_tokens: usage.completion_tokens,
+            provider_cache_read_input_tokens: usage
+                .prompt_tokens_details
+                .and_then(|d| d.cached_tokens),
+            provider_cache_write_input_tokens: None,
+            cost: None,
+        }
+    }
+}
+
+impl From<Option<OpenAIUsage>> for Usage {
+    fn from(usage: Option<OpenAIUsage>) -> Self {
+        match usage {
+            Some(u) => u.into(),
+            None => Usage::default(),
+        }
+    }
+}
+
+// =============================================================================
+// RawUsageEntry
+// =============================================================================
+
+/// A single entry in the raw usage array, representing usage data from one model inference.
+/// This preserves the original provider-specific usage object for fields that TensorZero
+/// normalizes away (e.g., OpenAI's `reasoning_tokens`, Anthropic's `cache_read_input_tokens`).
+#[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-bindings", ts(export))]
+pub struct RawUsageEntry {
+    pub model_inference_id: Uuid,
+    pub provider_type: String,
+    pub api_type: ApiType,
+    pub data: Value,
+}
+
+pub fn raw_usage_entries_from_value(
+    model_inference_id: Uuid,
+    provider_type: &str,
+    api_type: ApiType,
+    usage: Value,
+) -> Vec<RawUsageEntry> {
+    vec![RawUsageEntry {
+        model_inference_id,
+        provider_type: provider_type.to_string(),
+        api_type,
+        data: usage,
+    }]
+}
+
+// =============================================================================
+// FinishReason
+// =============================================================================
+
+#[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize, sqlx::Type)]
+#[cfg_attr(feature = "ts-bindings", ts(export))]
+#[serde(rename_all = "snake_case")]
+#[sqlx(type_name = "text", rename_all = "snake_case")]
+pub enum FinishReason {
+    Stop,
+    StopSequence,
+    Length,
+    ToolCall,
+    ContentFilter,
+    Unknown,
 }


### PR DESCRIPTION
This is progress towards removing the `tensorzero-core` dependency from `ts-executor-pool`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it relocates API-facing response/usage types across crates and rewires conversions, which could impact serialization/TS bindings if any field/tag behavior changes.
> 
> **Overview**
> Refactors API-facing inference response types by moving `InferenceResponse`, `ChatInferenceResponse`, `JsonInferenceResponse`, `ContentBlockChatOutput`, and `JsonInferenceOutput` out of `tensorzero-core` into `tensorzero-types` (new `inference_response` module), and updating core endpoints to construct responses via a shared `inference_response_from_result` helper.
> 
> Moves usage-related types (`Usage`, `RawUsageEntry`, `FinishReason`, OpenAI usage structs) into `tensorzero-types::usage`, removes their duplicates from `tensorzero-inference-types`, and adds a new `tensorzero-types-providers::conversions` module to host provider-specific `From` conversions into these shared types. Also updates dataset datapoint validation to use the new `validate_content_block_chat_output` helper and adjusts generated Node bindings/docstrings accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffdadafd9114cbfb95e894faae6718aa119e5bf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->