### PR TITLE
Remove ClientInferenceParams usage from ts-executor-pool

### DIFF
--- a/crates/tensorzero-core/src/client/mod.rs
+++ b/crates/tensorzero-core/src/client/mod.rs
@@ -33,7 +33,7 @@ use url::Url;
 pub use client_inference_params::{ClientInferenceParams, ClientSecretString};
 pub use input_handling::resolved_input_to_client_input;
 mod tool_context;
-pub use tool_context::ToolContextHelper;
+pub use tool_context::{ToolContextHelper, checkpointed_inference};
 
 pub use crate::cache::CacheParamsOptions;
 pub use crate::endpoints::feedback::FeedbackResponse;

--- a/crates/tensorzero-core/src/client/tool_context.rs
+++ b/crates/tensorzero-core/src/client/tool_context.rs
@@ -6,8 +6,10 @@
 use async_trait::async_trait;
 use durable::SpawnOptions;
 use serde_json::Value as JsonValue;
+use tensorzero_types::ToolError;
 use tensorzero_types::ToolHandle;
 use tensorzero_types::tool_error::ToolResult;
+use tensorzero_types::tool_failure::NonControlToolError;
 use uuid::Uuid;
 
 use super::ClientInferenceParams;
@@ -32,4 +34,21 @@ pub trait ToolContextHelper: Send + Sync {
     ) -> ToolResult<ToolHandle>;
     async fn inference(&mut self, params: ClientInferenceParams) -> ToolResult<InferenceResponse>;
     async fn heartbeat(&mut self) -> ToolResult<()>;
+}
+
+/// Run a checkpointed inference call via [`ToolContextHelper`].
+///
+/// Validates that `episode_id` is `None` (it will be set from the context),
+/// then delegates to [`ToolContextHelper::inference`].
+pub async fn checkpointed_inference(
+    ctx: &mut dyn ToolContextHelper,
+    mut params: ClientInferenceParams,
+) -> ToolResult<InferenceResponse> {
+    if params.episode_id.is_some() {
+        return Err(ToolError::NonControl(NonControlToolError::Internal {
+            message: "episode_id must be None when using checkpointed_inference".to_string(),
+        }));
+    }
+    params.episode_id = Some(ctx.episode_id());
+    ctx.inference(params).await
 }

--- a/crates/ts-executor-pool/src/inference.rs
+++ b/crates/ts-executor-pool/src/inference.rs
@@ -1,18 +1,13 @@
-//! Centralized inference functions with automatic organization/workspace tagging
+//! Centralized inference function with automatic organization/workspace tagging
 //! and UUID substitution.
 //!
-//! This module provides two entry points for calling TensorZero inference:
-//! - [`run_inference`] — direct (non-checkpointed) call for use outside durable execution
-//! - [`run_inference_checkpointed`] — checkpointed call via [`ToolContext`] for durable execution
-//!
-//! Both share [`build_inference_params`] to ensure consistent parameter construction and tagging,
-//! and both apply UUID-to-BIP39-triple substitution to improve LLM reliability with identifiers.
+//! [`run_inference`] is a direct (non-checkpointed) call for use outside durable
+//! execution. For checkpointed inference via a [`ToolContextHelper`], see
+//! [`tensorzero_core::client::checkpointed_inference`].
 
 use crate::ExtraInferenceTags;
-use crate::runtime::ToolContextHelper;
-use crate::tensorzero_client::TensorZeroClient;
+use crate::tensorzero_client::{PoolInferenceParams, TensorZeroClient};
 use bip39_uuid_substitution::{UuidSubstituter, postprocess_response, preprocess_message};
-use tensorzero_core::client::ClientInferenceParams;
 use tensorzero_core::endpoints::inference::InferenceResponse;
 use tensorzero_types::ToolError;
 use tensorzero_types::tool_error::ToolResult;
@@ -22,8 +17,8 @@ use tracing::debug;
 
 async fn run_inference_inner<F: Future<Output = ToolResult<InferenceResponse>>>(
     extra_inference_tags: &ExtraInferenceTags,
-    mut params: ClientInferenceParams,
-    run_inference_fn: impl FnOnce(ClientInferenceParams) -> F,
+    mut params: PoolInferenceParams,
+    run_inference_fn: impl FnOnce(PoolInferenceParams) -> F,
 ) -> ToolResult<InferenceResponse> {
     let mut substituter = UuidSubstituter::new();
     params.input.messages = params
@@ -62,7 +57,7 @@ async fn run_inference_inner<F: Future<Output = ToolResult<InferenceResponse>>>(
 ///
 /// Returns an error if the inference call fails.
 pub async fn run_inference(
-    params: ClientInferenceParams,
+    params: PoolInferenceParams,
     extra_inference_tags: &ExtraInferenceTags,
     client: &dyn TensorZeroClient,
 ) -> ToolResult<InferenceResponse> {
@@ -74,27 +69,4 @@ pub async fn run_inference(
         })
     })
     .await
-}
-
-/// Run inference via [`ToolContext`] (checkpointed) with automatic organization/workspace tagging
-/// and UUID substitution.
-///
-/// This uses the durable execution context for checkpointed inference calls.
-/// The `episode_id` is automatically set from the context.
-///
-/// # Errors
-///
-/// Returns an error if the inference call fails or if the output is empty.
-pub async fn run_inference_checkpointed(
-    mut params: ClientInferenceParams,
-    extra_inference_tags: &ExtraInferenceTags,
-    ctx: &mut dyn ToolContextHelper,
-) -> ToolResult<InferenceResponse> {
-    if params.episode_id.is_some() {
-        return Err(ToolError::NonControl(NonControlToolError::Internal {
-            message: "episode_id must be None when using run_inference_checkpointed".to_string(),
-        }));
-    }
-    params.episode_id = Some(ctx.episode_id());
-    run_inference_inner(extra_inference_tags, params, |params| ctx.inference(params)).await
 }

--- a/crates/ts-executor-pool/src/llm_query.rs
+++ b/crates/ts-executor-pool/src/llm_query.rs
@@ -11,13 +11,12 @@ use crate::runtime::{
     RuntimeMode, RuntimeParams, spawn_child_runtime,
 };
 use crate::state::OomSnapshotConfig;
-use crate::tensorzero_client::TensorZeroClient;
+use crate::tensorzero_client::{PoolInferenceParams, TensorZeroClient};
 use crate::ts_checker::TsCheckerPool;
 use durable::ControlFlow;
-use tensorzero_core::client::ClientInferenceParams;
 use tensorzero_core::endpoints::inference::{ChatInferenceResponse, InferenceResponse};
 use tensorzero_core::inference::types::ContentBlockChatOutput;
-use tensorzero_types::{Input, InputMessage, InputMessageContent, Role};
+use tensorzero_types::{Input, InputMessage, InputMessageContent, Role, Text};
 
 /// Shared implementation for `op_llm_query` and `op_llm_query_batched`.
 ///
@@ -129,7 +128,7 @@ async fn llm_query_inner(
         let messages = vec![make_user_message(vec![user_text])];
         let response = rlm_permit
             .run_with_cancellation(run_inference(
-                ClientInferenceParams {
+                PoolInferenceParams {
                     function_name: Some("rlm_text_analysis".to_string()),
                     episode_id: Some(rlm_state.episode_id),
                     input: Input {
@@ -182,7 +181,7 @@ pub fn make_user_message(text: impl IntoIterator<Item = String>) -> InputMessage
         role: Role::User,
         content: text
             .into_iter()
-            .map(|t| InputMessageContent::Text(tensorzero_core::inference::types::Text { text: t }))
+            .map(|t| InputMessageContent::Text(Text { text: t }))
             .collect(),
     }
 }
@@ -191,8 +190,6 @@ pub fn make_user_message(text: impl IntoIterator<Item = String>) -> InputMessage
 pub fn make_assistant_message(text: impl Into<String>) -> InputMessage {
     InputMessage {
         role: Role::Assistant,
-        content: vec![InputMessageContent::Text(
-            tensorzero_core::inference::types::Text { text: text.into() },
-        )],
+        content: vec![InputMessageContent::Text(Text { text: text.into() })],
     }
 }

--- a/crates/ts-executor-pool/src/runtime/mod.rs
+++ b/crates/ts-executor-pool/src/runtime/mod.rs
@@ -1229,7 +1229,7 @@ mod tests {
         }
     }
 
-    fn first_inference_text(params: &tensorzero_core::client::ClientInferenceParams) -> String {
+    fn first_inference_text(params: &crate::tensorzero_client::PoolInferenceParams) -> String {
         params
             .input
             .messages

--- a/crates/ts-executor-pool/src/tensorzero_client.rs
+++ b/crates/ts-executor-pool/src/tensorzero_client.rs
@@ -2,13 +2,34 @@
 //!
 //! This provides the subset of the full `durable_tools::TensorZeroClient` that
 //! `ts-executor-pool` actually requires: just the `inference` method.
+//!
+//! [`PoolInferenceParams`] is a lightweight version of
+//! `tensorzero_core::client::ClientInferenceParams` containing only the fields
+//! that this crate reads or writes. Implementations convert to the full
+//! `ClientInferenceParams` at the call-site boundary.
+
+use std::collections::HashMap;
 
 use async_trait::async_trait;
-use tensorzero_core::client::ClientInferenceParams;
 use tensorzero_core::endpoints::inference::InferenceResponse;
+use tensorzero_types::Input;
+use uuid::Uuid;
 
 #[cfg(test)]
 use mockall::automock;
+
+/// Minimal inference parameters used within `ts-executor-pool`.
+///
+/// This contains only the fields that this crate actually accesses.
+/// Implementations of [`TensorZeroClient`] are responsible for converting
+/// this into the full `ClientInferenceParams` before calling the gateway.
+#[derive(Debug, Clone, Default)]
+pub struct PoolInferenceParams {
+    pub function_name: Option<String>,
+    pub episode_id: Option<Uuid>,
+    pub input: Input,
+    pub tags: HashMap<String, String>,
+}
 
 /// Minimal client trait for running TensorZero inference.
 ///
@@ -20,6 +41,6 @@ pub trait TensorZeroClient: Send + Sync + 'static {
     /// Run inference with the given parameters.
     async fn inference(
         &self,
-        params: ClientInferenceParams,
+        params: PoolInferenceParams,
     ) -> Result<InferenceResponse, Box<dyn std::error::Error + Send + Sync>>;
 }


### PR DESCRIPTION
We don't need all of the options that this type providers - in particular, the 'internal_dynamic_variant_config' field forces us to depend on lots of config types.

We now define a minimal `PoolInferenceParams` type, which moves us one step closer to breaking the `ts-executor-pool -> tensorzero-core` dependency edge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a type-level refactor and helper relocation; behavior change is limited to centralized validation of `episode_id` for checkpointed calls.
> 
> **Overview**
> Decouples `ts-executor-pool` from `tensorzero-core`’s full `ClientInferenceParams` by introducing a minimal `PoolInferenceParams` and updating inference call sites/tests to use it.
> 
> Removes the pool’s checkpointed inference wrapper (`run_inference_checkpointed`) and instead adds/exports `tensorzero_core::client::checkpointed_inference`, which enforces `episode_id` is unset and then populates it from the `ToolContextHelper` before delegating to `inference`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aff8b9985262936e0c580fe7f311dcbd51ee6e74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->