### PR TITLE
Stop using tensorzero_core re-exports in ts-executor-pool

### DIFF
--- a/crates/ts-executor-pool/src/inference.rs
+++ b/crates/ts-executor-pool/src/inference.rs
@@ -13,7 +13,7 @@ use crate::runtime::ToolContextHelper;
 use crate::tensorzero_client::TensorZeroClient;
 use bip39_uuid_substitution::{UuidSubstituter, postprocess_response, preprocess_message};
 use tensorzero_core::client::ClientInferenceParams;
-use tensorzero_core::endpoints::inference::InferenceResponse;
+use tensorzero_types::InferenceResponse;
 use tensorzero_types::ToolError;
 use tensorzero_types::tool_error::ToolResult;
 use tensorzero_types::tool_failure::NonControlToolError;

--- a/crates/ts-executor-pool/src/llm_query.rs
+++ b/crates/ts-executor-pool/src/llm_query.rs
@@ -15,9 +15,10 @@ use crate::tensorzero_client::TensorZeroClient;
 use crate::ts_checker::TsCheckerPool;
 use durable::ControlFlow;
 use tensorzero_core::client::ClientInferenceParams;
-use tensorzero_core::endpoints::inference::{ChatInferenceResponse, InferenceResponse};
-use tensorzero_core::inference::types::ContentBlockChatOutput;
-use tensorzero_types::{Input, InputMessage, InputMessageContent, Role};
+use tensorzero_types::{
+    ChatInferenceResponse, ContentBlockChatOutput, InferenceResponse, Input, InputMessage,
+    InputMessageContent, Role, Text,
+};
 
 /// Shared implementation for `op_llm_query` and `op_llm_query_batched`.
 ///
@@ -182,7 +183,7 @@ pub fn make_user_message(text: impl IntoIterator<Item = String>) -> InputMessage
         role: Role::User,
         content: text
             .into_iter()
-            .map(|t| InputMessageContent::Text(tensorzero_core::inference::types::Text { text: t }))
+            .map(|t| InputMessageContent::Text(Text { text: t }))
             .collect(),
     }
 }
@@ -191,8 +192,6 @@ pub fn make_user_message(text: impl IntoIterator<Item = String>) -> InputMessage
 pub fn make_assistant_message(text: impl Into<String>) -> InputMessage {
     InputMessage {
         role: Role::Assistant,
-        content: vec![InputMessageContent::Text(
-            tensorzero_core::inference::types::Text { text: text.into() },
-        )],
+        content: vec![InputMessageContent::Text(Text { text: text.into() })],
     }
 }

--- a/crates/ts-executor-pool/src/runtime/mod.rs
+++ b/crates/ts-executor-pool/src/runtime/mod.rs
@@ -1188,10 +1188,11 @@ mod tests {
     use super::*;
     use crate::llm_query::extract_text_from_response;
     use crate::tensorzero_client::MockTensorZeroClient;
-    use tensorzero_core::endpoints::inference::{ChatInferenceResponse, InferenceResponse};
-    use tensorzero_core::inference::types::ContentBlockChatOutput;
-    use tensorzero_core::inference::types::Usage;
-    use tensorzero_types::InputMessageContent;
+    use tensorzero_core::client::ClientInferenceParams;
+    use tensorzero_types::{
+        ChatInferenceResponse, ContentBlockChatOutput, InferenceResponse, InputMessageContent,
+        Usage,
+    };
 
     const TEST_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -1229,7 +1230,7 @@ mod tests {
         }
     }
 
-    fn first_inference_text(params: &tensorzero_core::client::ClientInferenceParams) -> String {
+    fn first_inference_text(params: &ClientInferenceParams) -> String {
         params
             .input
             .messages
@@ -1962,7 +1963,7 @@ mod tests {
     }
 
     fn mock_chat_response(texts: &[&str]) -> InferenceResponse {
-        use tensorzero_core::inference::types::Text as T0Text;
+        use tensorzero_types::Text as T0Text;
         InferenceResponse::Chat(ChatInferenceResponse {
             inference_id: Uuid::nil(),
             episode_id: Uuid::nil(),
@@ -2150,8 +2151,7 @@ mod tests {
 
     #[test]
     fn test_extract_text_json_response() {
-        use tensorzero_core::endpoints::inference::JsonInferenceResponse;
-        use tensorzero_core::inference::types::JsonInferenceOutput;
+        use tensorzero_types::{JsonInferenceOutput, JsonInferenceResponse};
         let response = InferenceResponse::Json(JsonInferenceResponse {
             inference_id: Uuid::nil(),
             episode_id: Uuid::nil(),

--- a/crates/ts-executor-pool/src/tensorzero_client.rs
+++ b/crates/ts-executor-pool/src/tensorzero_client.rs
@@ -5,7 +5,7 @@
 
 use async_trait::async_trait;
 use tensorzero_core::client::ClientInferenceParams;
-use tensorzero_core::endpoints::inference::InferenceResponse;
+use tensorzero_types::InferenceResponse;
 
 #[cfg(test)]
 use mockall::automock;


### PR DESCRIPTION
We now import types directly from the defining crates. This will help break the ts-executor-pool -> tensozero-core dependency edge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes type import paths (from `tensorzero_core` re-exports to `tensorzero_types`) without altering inference/runtime behavior. Main risk is compile or subtle type mismatch if the moved types diverge across crates.
> 
> **Overview**
> Stops relying on `tensorzero_core` re-exports in `ts-executor-pool` by switching inference-related types (`InferenceResponse`, chat/json response types, `Text`, `Usage`, etc.) to be imported directly from `tensorzero_types`.
> 
> Updates helper functions and runtime tests to construct/handle these `tensorzero_types` structs/enums (e.g., message creation and mocked inference responses), keeping behavior the same while reducing the `ts-executor-pool -> tensorzero-core` dependency surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d254a7d488d4f0083ff25957812997b9b1de6f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->