### PR TITLE
Remove some fragile max-token parameter checks from batch tests

### DIFF
--- a/crates/tensorzero-core/tests/e2e/providers/batch.rs
+++ b/crates/tensorzero-core/tests/e2e/providers/batch.rs
@@ -789,19 +789,6 @@ pub async fn test_start_simple_image_batch_inference_request_with_provider(
     let inference_params = inference_params.get("chat_completion").unwrap();
     assert!(inference_params.get("temperature").is_none());
     assert!(inference_params.get("seed").is_none());
-    let expected_max_tokens = if provider.model_name.starts_with("o1") {
-        1000
-    } else {
-        100
-    };
-    assert_eq!(
-        inference_params
-            .get("max_tokens")
-            .unwrap()
-            .as_u64()
-            .unwrap(),
-        expected_max_tokens
-    );
 
     let model_name = result.get("model_name").unwrap().as_str().unwrap();
     assert_eq!(model_name, provider.model_name);
@@ -2264,21 +2251,6 @@ pub async fn test_allowed_tools_batch_inference_request_with_provider(provider: 
     });
     assert_eq!(tool_params, expected_tool_params);
 
-    let inference_params = result.get("inference_params").unwrap().as_str().unwrap();
-    let inference_params: Value = serde_json::from_str(inference_params).unwrap();
-    let inference_params = inference_params.get("chat_completion").unwrap();
-    let expected_max_tokens = if provider.model_name.starts_with("o1") {
-        1000
-    } else {
-        100
-    };
-    let max_tokens = inference_params
-        .get("max_tokens")
-        .unwrap()
-        .as_u64()
-        .unwrap();
-    assert_eq!(max_tokens, expected_max_tokens);
-
     let model_name = result.get("model_name").unwrap().as_str().unwrap();
     assert_eq!(model_name, &provider.model_name);
 
@@ -3481,21 +3453,6 @@ pub async fn test_dynamic_tool_use_batch_inference_request_with_provider(
         "parallel_tool_calls": null
     });
     assert_eq!(tool_params, expected_tool_params);
-
-    let inference_params = result.get("inference_params").unwrap().as_str().unwrap();
-    let inference_params: Value = serde_json::from_str(inference_params).unwrap();
-    let inference_params = inference_params.get("chat_completion").unwrap();
-    let expected_max_tokens = if provider.model_name.starts_with("o1") {
-        1000
-    } else {
-        100
-    };
-    let max_tokens = inference_params
-        .get("max_tokens")
-        .unwrap()
-        .as_u64()
-        .unwrap();
-    assert_eq!(max_tokens, expected_max_tokens);
 
     let model_name = result.get("model_name").unwrap().as_str().unwrap();
     assert_eq!(model_name, provider.model_name);


### PR DESCRIPTION
These are failing because we now have a wider variety of max_tokens configured across our various e2e test model definitions. We still have tests that check for 'max_tokens' in the serialized batch row, so we don't need to test it again here

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only relaxes E2E test assertions and doesn’t change runtime inference or storage logic; the main risk is reduced coverage around default `max_tokens` serialization in a few batch test cases.
> 
> **Overview**
> Removes several *provider-dependent* `max_tokens` assertions from batch E2E tests (`crates/tensorzero-core/tests/e2e/providers/batch.rs`) that were branching on model name prefixes (e.g. `o1`).
> 
> The affected tests still validate other serialized `inference_params` fields (e.g. absence of `temperature`/`seed`) and continue to assert stored request/response metadata, but no longer enforce a single expected default `max_tokens` value in these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c5f763abb2003fc632c52717d5e7d60fa37bff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->