### PR TITLE
Quote database identifier in migration_0050 for ClickHouse names with hyphens

### DIFF
--- a/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0050.rs
+++ b/crates/tensorzero-core/src/db/clickhouse/migration_manager/migrations/migration_0050.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use super::check_table_exists;
 use crate::db::clickhouse::ClickHouseConnectionInfo;
 use crate::db::clickhouse::migration_manager::migration_trait::Migration;
@@ -44,12 +46,12 @@ impl Migration for Migration0050<'_> {
         // Check if the migration manager has already recorded this migration as successful.
         // If so, skip it. Otherwise, run it once so the manager writes the row.
         let query = format!(
-            "SELECT 1 FROM {}.TensorZeroMigration WHERE migration_id = {MIGRATION_ID} LIMIT 1",
-            self.clickhouse.database()
+            "SELECT 1 FROM {{db_name:Identifier}}.TensorZeroMigration WHERE migration_id = {MIGRATION_ID} LIMIT 1"
         );
+        let params = HashMap::from([("db_name", self.clickhouse.database())]);
         let response = self
             .clickhouse
-            .run_query_synchronous_no_params_delayed_err(query)
+            .run_query_synchronous_delayed_err(query, &params)
             .await?;
         Ok(response.response.trim() != "1")
     }

--- a/crates/tensorzero-core/tests/e2e/clickhouse.rs
+++ b/crates/tensorzero-core/tests/e2e/clickhouse.rs
@@ -1299,6 +1299,39 @@ async fn test_bad_clickhouse_write() {
     );
 }
 
+/// Like `get_clean_clickhouse`, but with a custom database name.
+/// Useful for testing database names that contain special characters (e.g. hyphens).
+pub async fn get_clean_clickhouse_with_name(
+    database: String,
+    allow_db_missing: bool,
+) -> (ClickHouseConnectionInfo, DeleteDbOnDrop) {
+    let mut clickhouse_url = url::Url::parse(&CLICKHOUSE_URL).unwrap();
+    clickhouse_url.set_path(&database);
+    let clickhouse_url = clickhouse_url.to_string();
+    let clickhouse = ClickHouseConnectionInfo::new(
+        &clickhouse_url,
+        BatchWritesConfig {
+            enabled: false,
+            __force_allow_embedded_batch_writes: Some(false),
+            flush_interval_ms: Some(1000),
+            max_rows: Some(100),
+            max_rows_postgres: None,
+            write_queue_capacity: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    (
+        clickhouse.clone(),
+        DeleteDbOnDrop {
+            database,
+            client: clickhouse,
+            allow_db_missing,
+        },
+    )
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_clean_clickhouse_start() {
     let (clickhouse, _cleanup_db) = get_clean_clickhouse(false).await;
@@ -1346,6 +1379,43 @@ async fn test_clean_clickhouse_start() {
             assert_eq!(replica_count, 2);
         }
     }
+}
+
+/// Regression test for issue #6996: ClickHouse database names containing hyphens
+/// caused SQL syntax errors because `migration_0050.rs` used an unquoted database
+/// identifier in a `FROM db.table` clause.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_clean_clickhouse_start_hyphenated_db_name() {
+    let database = format!(
+        "tensorzero-e2e-tests-hyphen-{}",
+        Uuid::now_v7().simple()
+    );
+    let (clickhouse, _cleanup_db) =
+        get_clean_clickhouse_with_name(database, false).await;
+    let is_manual = clickhouse.is_cluster_configured();
+    migration_manager::run(RunMigrationManagerArgs {
+        clickhouse: &clickhouse,
+        is_manual_run: is_manual,
+        disable_automatic_migrations: false,
+    })
+    .await
+    .unwrap();
+
+    // Verify the migration table was created
+    let response = clickhouse
+        .run_query_synchronous_no_params("SHOW TABLES".to_string())
+        .await
+        .unwrap();
+    let tables: Vec<&str> = response
+        .response
+        .split('\n')
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .collect();
+    assert!(
+        tables.contains(&"TensorZeroMigration"),
+        "TensorZeroMigration table should exist after migrations"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Extends the database identifier quoting from #5630 to cover `migration_0050`, which was added after that PR landed.

Fixes #6996

## What's broken?

When the ClickHouse database name contains a hyphen (e.g. `autopilot-e2e`), the gateway fails to start with a SQL syntax error during migration checks:

```
Syntax error: failed at position 24 (-): -e2e.TensorZeroMigration WHERE migration_id = 0050 LIMIT 1
```

## Who is affected?

Anyone using a ClickHouse database name that contains hyphens. Database names without hyphens (underscores, alphanumeric) are not affected.

## When does it trigger?

Every time the gateway starts and runs migration checks — 100% reproducible with a hyphenated database name.

## Where is the bug?

`migration_0050.rs`, line 47 — `should_apply()` uses an unquoted database name as a SQL identifier:

```rust
// Before
let query = format!(
    "SELECT 1 FROM {}.TensorZeroMigration WHERE migration_id = {MIGRATION_ID} LIMIT 1",
    self.clickhouse.database()
);
```

## Why does it happen?

PR #5630 introduced `{db_name:Identifier}` parameterized syntax for `CREATE DATABASE` and `DROP DATABASE`. Migration 0050 was added later and used the older unquoted `format!` interpolation pattern. ClickHouse parses `autopilot-e2e.TensorZeroMigration` as `autopilot` **minus** `e2e.TensorZeroMigration`.

## How did we fix it?

Switch to `{db_name:Identifier}` parameterized syntax via `run_query_synchronous_delayed_err`, matching the pattern from #5630:

```rust
// After
let query = format!(
    "SELECT 1 FROM {{db_name:Identifier}}.TensorZeroMigration WHERE migration_id = {MIGRATION_ID} LIMIT 1"
);
let params = HashMap::from([("db_name", self.clickhouse.database())]);
let response = self
    .clickhouse
    .run_query_synchronous_delayed_err(query, &params)
    .await?;
```

`{{db_name:Identifier}}` is Rust `format!` escape syntax — produces the literal `{db_name:Identifier}` for ClickHouse's HTTP parameter substitution, which backtick-quotes the database name. `{MIGRATION_ID}` remains a Rust format arg expanded to the raw integer `0050`.

## Testing

Added `test_clean_clickhouse_start_hyphenated_db_name` e2e test that creates a ClickHouse database with a hyphenated name (`tensorzero-e2e-tests-hyphen-{uuid}`) and runs the full migration suite against it, verifying all migrations complete successfully.

cc @Aaron1011
