### PR TITLE
Rename 'tensorzero-node' to '@tensorzero/tensorzero-node'

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -275,7 +275,7 @@ jobs:
           retention-days: 7
 
       - name: Check tensorzero-node bindings are properly exported
-        run: pnpm --filter=tensorzero-node run check-exports
+        run: pnpm --filter=@tensorzero/tensorzero-node run check-exports
 
   check-python-schemas:
     needs: [detect-changes]
@@ -570,13 +570,13 @@ jobs:
         run: pnpm -r build
 
       - name: Format tensorzero-node package
-        run: pnpm --filter=tensorzero-node run format:check
+        run: pnpm --filter=@tensorzero/tensorzero-node run format:check
 
       - name: Lint tensorzero-node package
-        run: pnpm --filter=tensorzero-node run lint:check
+        run: pnpm --filter=@tensorzero/tensorzero-node run lint:check
 
       - name: Typecheck tensorzero-node package
-        run: pnpm --filter=tensorzero-node run typecheck
+        run: pnpm --filter=@tensorzero/tensorzero-node run typecheck
 
       - name: Run oxlint + ESLint
         run: pnpm --filter=tensorzero-ui run lint:check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
 
       - id: "oxfmt: tensorzero-node"
         name: "oxfmt: tensorzero-node"
-        entry: bash -c 'pnpm --filter=tensorzero-node run format'
+        entry: bash -c 'pnpm --filter=@tensorzero/tensorzero-node run format'
         language: node
         language_version: "24.13.0"
         types_or:
@@ -124,7 +124,7 @@ repos:
 
       - id: "eslint: tensorzero-node"
         name: "eslint: tensorzero-node"
-        entry: bash -c 'pnpm --filter=tensorzero-node run lint'
+        entry: bash -c 'pnpm --filter=@tensorzero/tensorzero-node run lint'
         language: node
         language_version: "24.13.0"
         types_or: [javascript, jsx, ts, tsx]
@@ -156,7 +156,7 @@ repos:
 
       - id: "tsc: tensorzero-node"
         name: "tsc: tensorzero-node"
-        entry: bash -c 'pnpm --filter=tensorzero-node run typecheck'
+        entry: bash -c 'pnpm --filter=@tensorzero/tensorzero-node run typecheck'
         language: node
         language_version: "24.13.0"
         types_or: [ts, tsx]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 - The Cargo workspace root is `crates/`. Run all `cargo` commands from that directory (e.g. `cd crates && cargo check`).
 - Use `cargo check` for quick verification, restrict further (e.g. `cargo check --package tensorzero-core`) if appropriate. For complex changes, you might want to run `cargo check --all-targets --all-features`. Test suite compilation is slow.
-- If you update Rust types or functions used in TypeScript, regenerate bindings with `pnpm build-bindings` (from root), then rebuild the NAPI bindings with `pnpm --filter=tensorzero-node build`. Run `cargo check` first to catch compilation errors.
+- If you update Rust types or functions used in TypeScript, regenerate bindings with `pnpm build-bindings` (from root), then rebuild the NAPI bindings with `pnpm --filter=@tensorzero/tensorzero-node build`. Run `cargo check` first to catch compilation errors.
 - If you change a signature of a struct, function, and so on, use `grep` to find all instances in the codebase. For example, search for `StructName {` when updating struct fields.
 - Place crate imports at the top of the file or module using `use crate::...`. Avoid imports inside functions or tests. Avoid long inline crate paths.
 - Once you're done with your work, make sure to:
@@ -63,7 +63,7 @@ We use `uv` to manage Python dependencies.
 We use `ts-rs` and `n-api` for TypeScript-Rust interoperability.
 
 - To generate TypeScript type definitions from Rust types, run `pnpm build-bindings`. Then, rebuild `tensorzero-node` with `pnpm -r build`. The generated type definitions will live in `crates/tensorzero-node/lib/bindings/`.
-- To generate implementations for `n-api` functions to be called in TypeScript, and package types in `crates/tensorzero-node` for UI, run `pnpm --filter=tensorzero-node run build`.
+- To generate implementations for `n-api` functions to be called in TypeScript, and package types in `crates/tensorzero-node` for UI, run `pnpm --filter=@tensorzero/tensorzero-node run build`.
 - Remember to run `pnpm -r typecheck` to make sure TypeScript and Rust implementations agree on types. Prefer to maintain all types in Rust.
 
 # CI/CD

--- a/crates/tensorzero-node/package.json
+++ b/crates/tensorzero-node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tensorzero-node",
+  "name": "@tensorzero/tensorzero-node",
   "version": "0.0.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "format": "oxfmt \"**/*.{md,mdx,yaml,yml,json}\"",
     "format:check": "oxfmt --check \"**/*.{md,mdx,yaml,yml,json}\"",
-    "build-bindings": "pnpm --filter=tensorzero-node build-bindings",
+    "build-bindings": "pnpm --filter=@tensorzero/tensorzero-node build-bindings",
     "generate-python-schemas": "cd crates/tensorzero-python && uv run --no-project generate_schema_types.py",
     "ui:dev": "pnpm --filter=tensorzero-ui dev",
     "ui:storybook": "pnpm --filter=tensorzero-ui storybook",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tensorzero/tensorzero-node':
+        specifier: file:../crates/tensorzero-node
+        version: link:../crates/tensorzero-node
       '@uiw/codemirror-theme-github':
         specifier: ^4.24.0
         version: 4.25.8(@codemirror/language@6.12.2)(@codemirror/state@6.5.4)(@codemirror/view@6.40.0)
@@ -178,9 +181,6 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.2.1)
-      tensorzero-node:
-        specifier: file:../crates/tensorzero-node
-        version: link:../crates/tensorzero-node
       type-fest:
         specifier: ^4.41.0
         version: 4.41.0

--- a/ui/app/routes/api/autopilot/sessions/$session_id/config-apply/apply-all.route.ts
+++ b/ui/app/routes/api/autopilot/sessions/$session_id/config-apply/apply-all.route.ts
@@ -1,5 +1,5 @@
 import type { ActionFunctionArgs } from "react-router";
-import { ConfigApplier } from "tensorzero-node";
+import { ConfigApplier } from "@tensorzero/tensorzero-node";
 import { getEnv } from "~/utils/env.server";
 import { getAutopilotClient } from "~/utils/get-autopilot-client.server";
 import { logger } from "~/utils/logger";

--- a/ui/app/routes/api/autopilot/sessions/$session_id/config-apply/apply.route.ts
+++ b/ui/app/routes/api/autopilot/sessions/$session_id/config-apply/apply.route.ts
@@ -1,5 +1,5 @@
 import type { ActionFunctionArgs } from "react-router";
-import { ConfigApplier } from "tensorzero-node";
+import { ConfigApplier } from "@tensorzero/tensorzero-node";
 import type { GatewayEvent } from "~/types/tensorzero";
 import { getEnv } from "~/utils/env.server";
 import { logger } from "~/utils/logger";

--- a/ui/app/types/tensorzero.ts
+++ b/ui/app/types/tensorzero.ts
@@ -1,16 +1,17 @@
 /**
- * Re-export tensorzero-node types through a local module so UI code can import
- * them without forcing Vite/Storybook to bundle the native client.
+ * Re-export `@tensorzero/tensorzero-node` types through a local module so UI
+ * code can import them without forcing Vite/Storybook to bundle the native
+ * client.
  *
  * Because this file only uses `export type`, the generated JavaScript tree
- * contains no runtime import of `tensorzero-node`.
+ * contains no runtime import of `@tensorzero/tensorzero-node`.
  *
  * When importing Rust binding types in browser components, prefer this module.
  *
- * BAD: `import type { StoredInput } from "tensorzero-node";`
+ * BAD: `import type { StoredInput } from "@tensorzero/tensorzero-node";`
  * GOOD: `import type { StoredInput } from "~/types/tensorzero";`
  */
-export type * from "tensorzero-node";
+export type * from "@tensorzero/tensorzero-node";
 
 /**
  * Response for the autopilot status endpoint.

--- a/ui/app/utils/postgres.server.ts
+++ b/ui/app/utils/postgres.server.ts
@@ -1,4 +1,4 @@
-import { PostgresClient } from "tensorzero-node";
+import { PostgresClient } from "@tensorzero/tensorzero-node";
 import { getEnv } from "./env.server";
 
 let _postgresClient: PostgresClient | undefined;

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -64,15 +64,15 @@ export default [
         },
         {
           selector:
-            "ImportDeclaration[source.value='tensorzero-node'][importKind='type']",
+            "ImportDeclaration[source.value='@tensorzero/tensorzero-node'][importKind='type']",
           message:
-            "Do not import types directly from 'tensorzero-node'. Use 'import type { ... } from \"~/types/tensorzero\"' instead to avoid bundling the native client in browser code.",
+            "Do not import types directly from '@tensorzero/tensorzero-node'. Use 'import type { ... } from \"~/types/tensorzero\"' instead to avoid bundling the native client in browser code.",
         },
         {
           selector:
-            "ImportDeclaration[source.value='tensorzero-node'] ImportSpecifier[importKind='type']",
+            "ImportDeclaration[source.value='@tensorzero/tensorzero-node'] ImportSpecifier[importKind='type']",
           message:
-            "Do not import types directly from 'tensorzero-node'. Use 'import type { ... } from \"~/types/tensorzero\"' instead to avoid bundling the native client in browser code.",
+            "Do not import types directly from '@tensorzero/tensorzero-node'. Use 'import type { ... } from \"~/types/tensorzero\"' instead to avoid bundling the native client in browser code.",
         },
         {
           selector:

--- a/ui/package.json
+++ b/ui/package.json
@@ -38,6 +38,7 @@
     "@tailwindcss/vite": "^4.1.15",
     "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-table": "^8.21.3",
+    "@tensorzero/tensorzero-node": "file:../crates/tensorzero-node",
     "@uiw/codemirror-theme-github": "^4.24.0",
     "@uiw/react-codemirror": "^4.24.0",
     "@vitejs/plugin-react": "^5.0.4",
@@ -63,7 +64,6 @@
     "smol-toml": "^1.4.1",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
-    "tensorzero-node": "file:../crates/tensorzero-node",
     "type-fest": "^4.41.0",
     "uuid": "^11.1.0",
     "zod": "^3.25.76"


### PR DESCRIPTION
We own the 'tensorzero' organization on NPM, which will block anyone else from squatting on this package

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the published package name and updates workspace filters/import paths; any missed reference could break builds, CI checks, or UI server routes that load the native module.
> 
> **Overview**
> Renames the Node NAPI package from `tensorzero-node` to the scoped `@tensorzero/tensorzero-node` and updates workspace usage accordingly.
> 
> CI (`general.yml`), pre-commit hooks, and root scripts now target the new package name via `pnpm --filter=@tensorzero/tensorzero-node`. The UI switches runtime imports (`ConfigApplier`, `PostgresClient`) and the type re-export module/eslint restrictions to the scoped package, and `ui/package.json`/`pnpm-lock.yaml` are updated to depend on `@tensorzero/tensorzero-node` instead of `tensorzero-node`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2856f0a8f6f20ee162fcdfafb09f84bdc77fc826. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->