### PR TITLE
ts-executor-pool: add RlmResult, initial_messages, oversize guard

### DIFF
--- a/crates/ts-executor-pool/src/llm_query.rs
+++ b/crates/ts-executor-pool/src/llm_query.rs
@@ -19,6 +19,13 @@ use tensorzero_core::endpoints::inference::{ChatInferenceResponse, InferenceResp
 use tensorzero_core::inference::types::ContentBlockChatOutput;
 use tensorzero_types::{Input, InputMessage, InputMessageContent, Role};
 
+/// Maximum prompt length (in chars) accepted by `llm_query_with_timeout`.
+///
+/// Roughly matches the context compaction token budget (~300k tokens ≈ 1.2M chars).
+/// Prompts exceeding this are rejected early with a JS-visible error instead of
+/// being sent to the inference provider (which would fail with a payload-too-large error).
+const MAX_LLM_QUERY_INPUT_CHARS: usize = 1_200_000;
+
 /// Shared implementation for `op_llm_query` and `op_llm_query_batched`.
 ///
 /// At `depth < max_depth`, spawns a child RLM loop with the prompt as context.
@@ -35,6 +42,16 @@ pub async fn llm_query_with_timeout(
     exposed_tools: Option<ExposedTools>,
     oom_snapshot_config: Option<OomSnapshotConfig>,
 ) -> Result<Result<String, ControlFlow>, TsError> {
+    let prompt_char_count = prompt.chars().count();
+    if prompt_char_count > MAX_LLM_QUERY_INPUT_CHARS {
+        return Err(TsError::Execution {
+            message: format!(
+                "`llm_query` input too large ({prompt_char_count} chars, limit {MAX_LLM_QUERY_INPUT_CHARS}). \
+                 Try again with less data (e.g. use smaller limits or more specific filters).",
+            ),
+        });
+    }
+
     let timeout = std::time::Duration::from_secs(rlm_state.execution_timeout_secs);
     Box::pin(tokio::time::timeout(
         timeout,
@@ -116,10 +133,12 @@ async fn llm_query_inner(
                 ts_checker: &ts_checker,
                 exposed_tools: exposed_tools.as_ref(),
                 function_name: "rlm_recursive_query",
+                initial_messages: vec![],
             })),
         )
         .await
         .and_then(|r| r)
+        .map(|r| r.map(|rlm_result| rlm_result.answer))
     } else {
         // Leaf: single-shot inference via rlm_text_analysis.
         let user_text = format!(

--- a/crates/ts-executor-pool/src/runtime/mod.rs
+++ b/crates/ts-executor-pool/src/runtime/mod.rs
@@ -19,6 +19,7 @@ use deno_core::v8::IsolateHandle;
 use deno_core::{JsRuntime, OpState, PollEventLoopOptions, RuntimeOptions};
 use deno_error::JsErrorBox;
 use durable::{ControlFlow, async_trait};
+use tensorzero_types::InputMessage;
 use tensorzero_types::tool_error::ToolResult;
 use tokio::runtime::Handle;
 use tracing::Span;
@@ -64,6 +65,21 @@ pub struct RlmLoopParams<'a> {
     pub exposed_tools: Option<&'a ExposedTools>,
     /// The TensorZero function name to use for code generation inference calls.
     pub function_name: &'a str,
+    /// Optional message history from a previous RLM session to prepend.
+    /// When provided, these messages are placed before the initial prompt
+    /// so the LLM has context from prior interactions.
+    pub initial_messages: Vec<InputMessage>,
+}
+
+/// Result of an RLM loop execution, containing both the final answer
+/// and the full message history for potential reuse.
+#[derive(Debug)]
+pub struct RlmResult {
+    /// The final answer produced by `FINAL()`.
+    pub answer: String,
+    /// The complete message history from this RLM session,
+    /// including any initial messages that were prepended.
+    pub messages: Vec<InputMessage>,
 }
 
 /// Trait abstracting the RLM loop execution within `llm_query`.
@@ -72,7 +88,10 @@ pub struct RlmLoopParams<'a> {
 /// implementation delegates to `run_rlm_loop`.
 #[async_trait]
 pub trait RlmQuery: Send + Sync {
-    async fn run(&self, params: RlmLoopParams<'_>) -> Result<Result<String, ControlFlow>, TsError>;
+    async fn run(
+        &self,
+        params: RlmLoopParams<'_>,
+    ) -> Result<Result<RlmResult, ControlFlow>, TsError>;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- adds `RlmResult { answer, messages }` and widens `RlmQuery::run` to return it
- adds `initial_messages` to `RlmLoopParams` so callers can seed an RLM loop from a prior session
- rejects prompts over 1.2M chars early in `llm_query_with_timeout` with a JS-visible `TsError::Execution`

Unblocks autopilot session-persistence work (originally authored on [`viraj/prompt-improvements`](https://github.com/tensorzero/autopilot/pull/974)).

## Test plan
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] `cargo test-unit-fast -p ts-executor-pool`
- [ ] local autopilot-ca build passes after bumping the `ts-executor-pool` rev in `Cargo.toml`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the RLM query trait return type and loop parameters, which can ripple to any callers/implementations and subtly affect recursion behavior. Adds an early prompt-size rejection that changes error behavior for very large inputs but is otherwise low-impact.
> 
> **Overview**
> Adds an explicit oversize-input guard to `llm_query_with_timeout`, rejecting prompts over **1.2M characters** with a JS-visible `TsError::Execution` before calling the inference provider.
> 
> Extends the recursive RLM-loop plumbing by introducing `RlmResult { answer, messages }` as the `RlmQuery::run` output and adding `initial_messages` to `RlmLoopParams` so callers can seed a loop with prior message history; `llm_query` now extracts `answer` from the returned result for its existing `String` API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cac0ff5bcfdd10d703a4cb40f408d9f28b6ba0db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->