### PR TITLE
refactor: decouple GCP provider constructors from core credential infra

### DIFF
--- a/crates/tensorzero-core/src/model.rs
+++ b/crates/tensorzero-core/src/model.rs
@@ -2323,17 +2323,21 @@ impl UninitializedProviderConfig {
                 project_id,
                 credential_location: api_key_location,
                 provider_tools,
-            } => ProviderConfig::GCPVertexAnthropic(
-                GCPVertexAnthropicProvider::new(
+            } => {
+                let credentials = crate::model_table::GCPVertexAnthropicKind
+                    .get_defaulted_credential(
+                        api_key_location.as_ref(),
+                        provider_type_default_credentials,
+                    )
+                    .await?;
+                ProviderConfig::GCPVertexAnthropic(GCPVertexAnthropicProvider::new(
                     model_id,
                     location,
                     project_id,
-                    api_key_location,
-                    provider_type_default_credentials,
+                    credentials,
                     provider_tools,
-                )
-                .await?,
-            ),
+                ))
+            }
             UninitializedProviderConfig::GCPVertexGemini {
                 model_id,
                 endpoint_id,
@@ -2341,16 +2345,38 @@ impl UninitializedProviderConfig {
                 project_id,
                 credential_location: api_key_location,
             } => {
+                let credentials = crate::model_table::GCPVertexGeminiKind
+                    .get_defaulted_credential(
+                        api_key_location.as_ref(),
+                        provider_type_default_credentials,
+                    )
+                    .await?;
+                let batch_config = match &provider_types.gcp_vertex_gemini {
+                    Some(crate::config::provider_types::GCPVertexGeminiProviderTypeConfig {
+                        batch:
+                            Some(crate::config::provider_types::GCPBatchConfigType::CloudStorage(
+                                crate::config::provider_types::GCPBatchConfigCloudStorage {
+                                    input_uri_prefix,
+                                    output_uri_prefix,
+                                },
+                            )),
+                        ..
+                    }) => Some(crate::providers::gcp_vertex_gemini::BatchConfig::new(
+                        &project_id,
+                        &location,
+                        input_uri_prefix.clone(),
+                        output_uri_prefix.clone(),
+                    )),
+                    _ => None,
+                };
                 let provider = GCPVertexGeminiProvider::new(
                     model_id,
                     endpoint_id,
                     location,
                     project_id,
-                    api_key_location,
-                    provider_types,
-                    provider_type_default_credentials,
-                )
-                .await?;
+                    credentials,
+                    batch_config,
+                )?;
 
                 ProviderConfig::GCPVertexGemini(provider)
             }
@@ -3462,12 +3488,24 @@ impl ShorthandModelConfig for ModelConfig {
                         .await?,
                 )?)
             }
-            "gcp_vertex_gemini" => ProviderConfig::GCPVertexGemini(
-                GCPVertexGeminiProvider::new_shorthand(model_name, default_credentials).await?,
-            ),
-            "gcp_vertex_anthropic" => ProviderConfig::GCPVertexAnthropic(
-                GCPVertexAnthropicProvider::new_shorthand(model_name, default_credentials).await?,
-            ),
+            "gcp_vertex_gemini" => {
+                let credentials = crate::model_table::GCPVertexGeminiKind
+                    .get_defaulted_credential(None, default_credentials)
+                    .await?;
+                ProviderConfig::GCPVertexGemini(GCPVertexGeminiProvider::new_shorthand(
+                    model_name,
+                    credentials,
+                )?)
+            }
+            "gcp_vertex_anthropic" => {
+                let credentials = crate::model_table::GCPVertexAnthropicKind
+                    .get_defaulted_credential(None, default_credentials)
+                    .await?;
+                ProviderConfig::GCPVertexAnthropic(GCPVertexAnthropicProvider::new_shorthand(
+                    model_name,
+                    credentials,
+                )?)
+            }
             "groq" => ProviderConfig::Groq(GroqProvider::new(
                 model_name,
                 GroqKind

--- a/crates/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
+++ b/crates/tensorzero-core/src/providers/gcp_vertex_anthropic.rs
@@ -12,7 +12,6 @@ use tokio::time::Instant;
 use super::helpers::{
     inject_extra_request_data_and_send, inject_extra_request_data_and_send_eventsource,
 };
-use crate::config::{e2e_skip_credential_validation, skip_credential_validation};
 use crate::endpoints::inference::InferenceCredentials;
 use crate::error::{DisplayOrDebugGateway, Error, ErrorDetails};
 use crate::http::{TensorZeroEventSource, TensorzeroHttpClient};
@@ -32,10 +31,12 @@ use crate::inference::types::{
     FunctionType, Latency, ModelInferenceRequestJsonMode,
     batch::StartBatchProviderInferenceResponse,
 };
-use crate::model::CredentialLocationWithFallback;
 use crate::model::{ModelProviderRequestInfo, ProviderInferenceRequest};
+use tensorzero_inference_types::credential_validation::{
+    e2e_skip_credential_validation, skip_credential_validation,
+};
 
-use crate::model_table::{GCPVertexAnthropicKind, ProviderType, ProviderTypeDefaultCredentials};
+use crate::model_table::ProviderType;
 use crate::providers::anthropic::{
     AnthropicStreamMessage, AnthropicToolChoice, anthropic_to_tensorzero_stream_message,
     handle_anthropic_error,
@@ -112,16 +113,17 @@ impl GCPVertexAnthropicProvider {
     // Constructs a provider from a shorthand string of the form:
     // * 'projects/<project_id>/locations/<location>/publishers/anthropic/models/XXX'
     // * 'projects/<project_id>/locations/<location>/endpoints/XXX'
-    //
-    // This is *not* a full url - we append ':generateContent' or ':streamGenerateContent' to the end of the path as needed.
-    pub async fn new_shorthand(
+    /// Constructor that takes pre-resolved credentials directly.
+    /// Credential resolution from `ProviderTypeDefaultCredentials` lives in
+    /// `crate::model::build_gcp_vertex_anthropic_provider` so this file can
+    /// stay independent of core's credential infrastructure.
+    ///
+    /// `project_url_path` is *not* a full url - we append ':generateContent'
+    /// or ':streamGenerateContent' to the path as needed.
+    pub fn new_shorthand(
         project_url_path: String,
-        default_credentials: &ProviderTypeDefaultCredentials,
+        credentials: GCPVertexCredentials,
     ) -> Result<Self, Error> {
-        let credentials = GCPVertexAnthropicKind
-            .get_defaulted_credential(None, default_credentials)
-            .await?;
-
         // We only support model urls with the publisher 'anthropic'
         let shorthand_url = parse_shorthand_url(&project_url_path, "anthropic")?;
         let (location, model_id) = match shorthand_url {
@@ -152,18 +154,13 @@ impl GCPVertexAnthropicProvider {
         })
     }
 
-    pub async fn new(
+    pub fn new(
         model_id: String,
         location: String,
         project_id: String,
-        api_key_location: Option<CredentialLocationWithFallback>,
-        default_credentials: &ProviderTypeDefaultCredentials,
+        credentials: GCPVertexCredentials,
         provider_tools: Vec<serde_json::Value>,
-    ) -> Result<Self, Error> {
-        let credentials = GCPVertexAnthropicKind
-            .get_defaulted_credential(api_key_location.as_ref(), default_credentials)
-            .await?;
-
+    ) -> Self {
         let location_prefix = location_subdomain_prefix(&location);
 
         let request_url = format!(
@@ -174,14 +171,14 @@ impl GCPVertexAnthropicProvider {
         );
         let audience = format!("https://{location_prefix}aiplatform.googleapis.com/");
 
-        Ok(GCPVertexAnthropicProvider {
+        GCPVertexAnthropicProvider {
             model_id,
             request_url,
             streaming_request_url,
             audience,
             credentials,
             provider_tools,
-        })
+        }
     }
 
     pub fn model_id(&self) -> &str {

--- a/crates/tensorzero-core/src/providers/gcp_vertex_gemini/mod.rs
+++ b/crates/tensorzero-core/src/providers/gcp_vertex_gemini/mod.rs
@@ -30,10 +30,6 @@ use super::helpers::check_new_tool_call_name;
 use super::helpers::{
     inject_extra_request_data_and_send, inject_extra_request_data_and_send_eventsource,
 };
-use crate::config::provider_types::{
-    GCPBatchConfigCloudStorage, GCPBatchConfigType, GCPVertexGeminiProviderTypeConfig,
-    ProviderTypesConfig,
-};
 use crate::endpoints::inference::InferenceCredentials;
 use crate::error::{
     DisplayOrDebugGateway, Error, ErrorDetails, IMPOSSIBLE_ERROR_MESSAGE,
@@ -60,9 +56,9 @@ use crate::inference::types::{
     ProviderInferenceResponse, ProviderInferenceResponseArgs, ProviderInferenceResponseChunk,
     RequestMessage, Usage, batch::StartBatchProviderInferenceResponse, serialize_or_log,
 };
-use crate::model::{Credential, CredentialLocationWithFallback};
+use crate::model::Credential;
 use crate::model::{ModelProviderRequestInfo, ProviderInferenceRequest};
-use crate::model_table::{GCPVertexGeminiKind, ProviderType, ProviderTypeDefaultCredentials};
+use crate::model_table::ProviderType;
 #[cfg(test)]
 use crate::tool::{AllowedTools, AllowedToolsChoice};
 use tensorzero_inference_types::{FunctionToolDef, ProviderToolCallConfig};
@@ -109,10 +105,39 @@ pub struct GCPVertexGeminiProvider {
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "ts-bindings", ts(export))]
-struct BatchConfig {
+pub struct BatchConfig {
     input_uri_prefix: String,
     output_uri_prefix: String,
     batch_request_url: String,
+}
+
+impl BatchConfig {
+    /// Construct a `BatchConfig` from the user-provided URI prefixes plus the project / location.
+    /// Lives here so that the URL-building logic stays close to the rest of the GCP code,
+    /// while letting credential / config resolution happen in `crate::model`.
+    pub fn new(
+        project_id: &str,
+        location: &str,
+        input_uri_prefix: String,
+        output_uri_prefix: String,
+    ) -> Self {
+        let location_prefix = location_subdomain_prefix(location);
+        let batch_request_url = if let Some(api_base) = get_mock_provider_api_base("") {
+            format!(
+                "{}/v1/projects/{project_id}/locations/{location}/batchPredictionJobs",
+                api_base.as_str().trim_end_matches('/')
+            )
+        } else {
+            format!(
+                "https://{location_prefix}aiplatform.googleapis.com/v1/projects/{project_id}/locations/{location}/batchPredictionJobs"
+            )
+        };
+        Self {
+            input_uri_prefix,
+            output_uri_prefix,
+            batch_request_url,
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -474,14 +499,13 @@ impl GCPVertexGeminiProvider {
     // * 'projects/<project_id>/locations/<location>/endpoints/XXX'
     //
     // This is *not* a full url - we append ':generateContent' or ':streamGenerateContent' to the end of the path as needed.
-    pub async fn new_shorthand(
+    /// Constructor that takes pre-resolved credentials directly.
+    /// Credential resolution lives in `crate::model` so this file can stay
+    /// independent of core's credential infrastructure.
+    pub fn new_shorthand(
         project_url_path: String,
-        default_credentials: &ProviderTypeDefaultCredentials,
+        credentials: GCPVertexCredentials,
     ) -> Result<Self, Error> {
-        let credentials = GCPVertexGeminiKind
-            .get_defaulted_credential(None, default_credentials)
-            .await?;
-
         let shorthand_url = parse_shorthand_url(&project_url_path, "google")?;
         let (location, model_id, endpoint_id, model_or_endpoint_id) = match shorthand_url {
             ShorthandUrl::Publisher { location, model_id } => (
@@ -532,19 +556,14 @@ impl GCPVertexGeminiProvider {
         })
     }
 
-    pub async fn new(
+    pub fn new(
         model_id: Option<String>,
         endpoint_id: Option<String>,
         location: String,
         project_id: String,
-        api_key_location: Option<CredentialLocationWithFallback>,
-        provider_types: &ProviderTypesConfig,
-        default_credentials: &ProviderTypeDefaultCredentials,
+        credentials: GCPVertexCredentials,
+        batch_config: Option<BatchConfig>,
     ) -> Result<Self, Error> {
-        let credentials = GCPVertexGeminiKind
-            .get_defaulted_credential(api_key_location.as_ref(), default_credentials)
-            .await?;
-
         let location_prefix = location_subdomain_prefix(&location);
 
         // Use mock API base for testing if set, otherwise default API base
@@ -598,35 +617,6 @@ impl GCPVertexGeminiProvider {
 
         let audience = format!("https://{location_prefix}aiplatform.googleapis.com/");
 
-        let batch_config = match &provider_types.gcp_vertex_gemini {
-            Some(GCPVertexGeminiProviderTypeConfig {
-                batch:
-                    Some(GCPBatchConfigType::CloudStorage(GCPBatchConfigCloudStorage {
-                        input_uri_prefix,
-                        output_uri_prefix,
-                    })),
-                ..
-            }) => {
-                // Use mock API base for testing if set, otherwise default API base
-                let batch_request_url = if let Some(api_base) = get_mock_provider_api_base("") {
-                    format!(
-                        "{}/v1/projects/{project_id}/locations/{location}/batchPredictionJobs",
-                        api_base.as_str().trim_end_matches('/')
-                    )
-                } else {
-                    format!(
-                        "https://{location_prefix}aiplatform.googleapis.com/v1/projects/{project_id}/locations/{location}/batchPredictionJobs"
-                    )
-                };
-
-                Some(BatchConfig {
-                    input_uri_prefix: input_uri_prefix.clone(),
-                    output_uri_prefix: output_uri_prefix.clone(),
-                    batch_request_url,
-                })
-            }
-            _ => None,
-        };
         Ok(GCPVertexGeminiProvider {
             api_v1_base_url,
             request_url,


### PR DESCRIPTION
## Summary

Move GCP credential resolution and `BatchConfig` building out of the GCP provider constructors and into `crate::model` callers. The provider constructors now take pre-resolved `GCPVertexCredentials` and `Option<BatchConfig>` directly, removing their dependency on `crate::config::provider_types::*` and `crate::model_table::{GCPVertexAnthropicKind, GCPVertexGeminiKind, ProviderTypeDefaultCredentials}`.

This is prep work for extracting providers into a standalone crate.

**3 files, ~200 lines changed.**

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)