### PR TITLE
Increase max_tokens for claude-haiku-4-5-thinking e2e test

### DIFF
--- a/crates/tensorzero-core/tests/e2e/config/tensorzero.functions.json_math.toml
+++ b/crates/tensorzero-core/tests/e2e/config/tensorzero.functions.json_math.toml
@@ -8,7 +8,7 @@ type = "chat_completion"
 model = "claude-haiku-4-5-thinking"
 system_template = "../../../fixtures/config/functions/json_success/prompt/system_template.minijinja"
 json_mode = "strict"
-max_tokens = 2048
+max_tokens = 4096
 thinking_budget_tokens = 1024
 
 [functions.json_math.variants.anthropic-sonnet-4-6-reasoning]


### PR DESCRIPTION
We had a PR flake in the merge queue due to the output hitting max_tokens, so let's bump it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only configuration change that only affects token limits for one e2e variant; minimal product/runtime risk.
> 
> **Overview**
> In the `json_math` e2e test config, increases the `max_tokens` limit for the `anthropic-haiku-4-5-thinking` variant from 2048 to 4096 to reduce test flakiness from token truncation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fa84e4298048c4e717e191bdcb0715902dfcb2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->