### PR TITLE
Support `path::` file credentials for `api_key_location` (docs + config reference)

### DIFF
--- a/crates/tensorzero-core/src/model_table.rs
+++ b/crates/tensorzero-core/src/model_table.rs
@@ -636,7 +636,7 @@ fn load_credential(
             }
         }
         CredentialLocation::Path(path) => match fs::read_to_string(path) {
-            Ok(contents) => Ok(Credential::FileContents(SecretString::from(contents))),
+            Ok(contents) => Ok(Credential::Static(SecretString::from(contents))),
             Err(e) => {
                 if skip_credential_validation() {
                     if e2e_skip_credential_validation() {

--- a/docs/gateway/configuration-reference.mdx
+++ b/docs/gateway/configuration-reference.mdx
@@ -313,7 +313,7 @@ If unset, no API key will be sent.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE`, `dynamic::ARGUMENT_NAME`, and `none`.
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, `dynamic::ARGUMENT_NAME`, and `none`.
 
 See [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details.
 
@@ -831,7 +831,7 @@ Defines the location of the API key for the Anthropic provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE`, `dynamic::ARGUMENT_NAME`, and `none`.
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, `dynamic::ARGUMENT_NAME`, and `none`.
 
 See [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details.
 
@@ -1243,7 +1243,7 @@ Defines the location of the API key for the Azure OpenAI provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE`, `dynamic::ARGUMENT_NAME`, and `none`.
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, `dynamic::ARGUMENT_NAME`, and `none`.
 
 See [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details.
 
@@ -1305,7 +1305,7 @@ Defines the location of the API key for the DeepSeek provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [models.deepseek_chat.providers.deepseek]
@@ -1346,7 +1346,7 @@ Defines the location of the API key for the Fireworks provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [models."llama-3.1-8b-instruct".providers.fireworks]
@@ -1585,7 +1585,7 @@ Defines the location of the API key for the Google AI Studio Gemini provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [models."gemini-2.5-flash".providers.google_ai_studio_gemini]
@@ -1627,7 +1627,7 @@ Defines the location of the API key for the Groq provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [models.llama4_scout_17b_16e_instruct.providers.groq]
@@ -1687,7 +1687,7 @@ Defines the location of the API key for the Hyperbolic provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [models."openai/gpt-oss-20b".providers.hyperbolic]
@@ -1729,7 +1729,7 @@ Defines the location of the API key for the Mistral provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [models."open-mistral-nemo".providers.mistral]
@@ -1806,7 +1806,7 @@ Defines the location of the API key for the OpenAI provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE`, `dynamic::ARGUMENT_NAME`, and `none` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, `dynamic::ARGUMENT_NAME`, and `none` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [models.gpt-4o-mini.providers.openai]
@@ -1941,7 +1941,7 @@ Defines the location of the API key for the OpenRouter provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [models.gpt4_turbo.providers.openrouter]
@@ -1998,7 +1998,7 @@ Defines the location of the API key for the SGLang provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE`, `dynamic::ARGUMENT_NAME`, and `none` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, `dynamic::ARGUMENT_NAME`, and `none` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [models.llama.providers.sglang]
@@ -2024,7 +2024,7 @@ Defines the location of the API key for the Together AI provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [models.llama3_3_70b_instruct_turbo.providers.together]
@@ -2098,7 +2098,7 @@ Defines the location of the API key for the vLLM provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE`, `dynamic::ARGUMENT_NAME`, and `none` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, `dynamic::ARGUMENT_NAME`, and `none` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [models."phi-3.5-mini-instruct".providers.vllm]
@@ -2124,7 +2124,7 @@ Defines the location of the API key for the xAI provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [models.grok_4_1_fast_non_reasoning.providers.xai]
@@ -2181,7 +2181,7 @@ Defines the location of the API key for the TGI provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE`, `dynamic::ARGUMENT_NAME`, and `none` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, `dynamic::ARGUMENT_NAME`, and `none` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [models.phi_4.providers.tgi]
@@ -2425,7 +2425,7 @@ Defines the location of the API key for the OpenAI provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE`, `dynamic::ARGUMENT_NAME`, and `none` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, `dynamic::ARGUMENT_NAME`, and `none` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [embedding_models.openai-text-embedding-3-small.providers.openai]
@@ -2472,7 +2472,7 @@ Defines the default location of the API key for Anthropic models.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.anthropic.defaults]
@@ -2496,7 +2496,7 @@ Defines the default location of the API key for Azure models.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.azure.defaults]
@@ -2519,7 +2519,7 @@ Defines the location of the API key for the DeepSeek provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.deepseek.defaults]
@@ -2542,7 +2542,7 @@ Defines the location of the API key for the Fireworks provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.fireworks.defaults]
@@ -2713,7 +2713,7 @@ Defines the location of the API key for the Google AI Studio provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.google_ai_studio.defaults]
@@ -2736,7 +2736,7 @@ Defines the location of the API key for the Groq provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.groq.defaults]
@@ -2759,7 +2759,7 @@ Defines the location of the API key for the Hyperbolic provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.hyperbolic.defaults]
@@ -2782,7 +2782,7 @@ Defines the location of the API key for the Mistral provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.mistral.defaults]
@@ -2805,7 +2805,7 @@ Defines the location of the API key for the OpenAI provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.openai.defaults]
@@ -2828,7 +2828,7 @@ Defines the location of the API key for the OpenRouter provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.openrouter.defaults]
@@ -2851,7 +2851,7 @@ Defines the location of the API key for the Together provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.together.defaults]
@@ -2909,7 +2909,7 @@ Defines the location of the API key for the xAI provider.
 
 This field can be either a string for a single credential location, or an object with `default` and `fallback` fields for credential fallback support.
 
-The supported locations are `env::ENVIRONMENT_VARIABLE` and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
+The supported locations are `env::ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, and `dynamic::ARGUMENT_NAME` (see [the API reference](/gateway/api-reference/inference/#credentials) and [Credential Management](/operations/manage-credentials/#configure-credential-fallbacks) for more details).
 
 ```toml title="tensorzero.toml"
 [provider_types.xai.defaults]

--- a/docs/integrations/model-providers/anthropic.mdx
+++ b/docs/integrations/model-providers/anthropic.mdx
@@ -81,7 +81,7 @@ See the [list of models available on Anthropic](https://docs.anthropic.com/en/do
 
 You must set the `ANTHROPIC_API_KEY` environment variable before running the gateway.
 
-You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE` or `dynamic::ARGUMENT_NAME`.
+You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, or `dynamic::ARGUMENT_NAME`.
 See the [Credential Management](/operations/manage-credentials/) guide and [Configuration Reference](/gateway/configuration-reference/) for more information.
 
 ### Deployment (Docker Compose)

--- a/docs/integrations/model-providers/azure.mdx
+++ b/docs/integrations/model-providers/azure.mdx
@@ -57,7 +57,7 @@ If you need to configure the endpoint at runtime, you can set it to `endpoint = 
 
 You must set the `AZURE_API_KEY` environment variable before running the gateway.
 
-You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE` or `dynamic::ARGUMENT_NAME`.
+You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, or `dynamic::ARGUMENT_NAME`.
 See the [Credential Management](/operations/manage-credentials/) guide and [Configuration Reference](/gateway/configuration-reference/) for more information.
 
 ### Deployment (Docker Compose)

--- a/docs/integrations/model-providers/deepseek.mdx
+++ b/docs/integrations/model-providers/deepseek.mdx
@@ -79,7 +79,7 @@ model = "deepseek_chat"
 
 You must set the `DEEPSEEK_API_KEY` environment variable before running the gateway.
 
-You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE` or `dynamic::ARGUMENT_NAME`.
+You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, or `dynamic::ARGUMENT_NAME`.
 See the [Credential Management](/operations/manage-credentials/) guide and [Configuration Reference](/gateway/configuration-reference/) for more information.
 
 ### Deployment (Docker Compose)

--- a/docs/integrations/model-providers/fireworks.mdx
+++ b/docs/integrations/model-providers/fireworks.mdx
@@ -82,7 +82,7 @@ Custom models are also supported.
 
 You must set the `FIREWORKS_API_KEY` environment variable before running the gateway.
 
-You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE` or `dynamic::ARGUMENT_NAME`.
+You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, or `dynamic::ARGUMENT_NAME`.
 See the [Credential Management](/operations/manage-credentials/) guide and [Configuration Reference](/gateway/configuration-reference/) for more information.
 
 ### Deployment (Docker Compose)

--- a/docs/integrations/model-providers/google-ai-studio-gemini.mdx
+++ b/docs/integrations/model-providers/google-ai-studio-gemini.mdx
@@ -81,7 +81,7 @@ See the [list of models available on Google AI Studio (Gemini API)](https://ai.g
 
 You must set the `GOOGLE_AI_STUDIO_API_KEY` environment variable before running the gateway.
 
-You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE` or `dynamic::ARGUMENT_NAME`.
+You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, or `dynamic::ARGUMENT_NAME`.
 See the [Credential Management](/operations/manage-credentials/) guide and [Configuration Reference](/gateway/configuration-reference/) for more information.
 
 ### Deployment (Docker Compose)

--- a/docs/integrations/model-providers/groq.mdx
+++ b/docs/integrations/model-providers/groq.mdx
@@ -84,7 +84,7 @@ See the [Configuration Reference](/gateway/configuration-reference/) for more de
 
 You must set the `GROQ_API_KEY` environment variable before running the gateway.
 
-You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE` or `dynamic::ARGUMENT_NAME`.
+You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, or `dynamic::ARGUMENT_NAME`.
 See the [Credential Management](/operations/manage-credentials/) guide and [Configuration Reference](/gateway/configuration-reference/) for more information.
 
 ### Deployment (Docker Compose)

--- a/docs/integrations/model-providers/hyperbolic.mdx
+++ b/docs/integrations/model-providers/hyperbolic.mdx
@@ -80,7 +80,7 @@ See the [list of models available on Hyperbolic](https://app.hyperbolic.xyz/mode
 
 You must set the `HYPERBOLIC_API_KEY` environment variable before running the gateway.
 
-You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE` or `dynamic::ARGUMENT_NAME`.
+You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, or `dynamic::ARGUMENT_NAME`.
 See the [Credential Management](/operations/manage-credentials/) guide and [Configuration Reference](/gateway/configuration-reference/) for more information.
 
 ### Deployment (Docker Compose)

--- a/docs/integrations/model-providers/mistral.mdx
+++ b/docs/integrations/model-providers/mistral.mdx
@@ -97,7 +97,7 @@ When `prompt_mode` is set, reasoning output from the model will be returned as t
 
 You must set the `MISTRAL_API_KEY` environment variable before running the gateway.
 
-You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE` or `dynamic::ARGUMENT_NAME`.
+You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, or `dynamic::ARGUMENT_NAME`.
 See the [Credential Management](/operations/manage-credentials/) guide and [Configuration Reference](/gateway/configuration-reference/) for more information.
 
 ### Deployment (Docker Compose)

--- a/docs/integrations/model-providers/openai.mdx
+++ b/docs/integrations/model-providers/openai.mdx
@@ -113,7 +113,7 @@ See the [Configuration Reference](/gateway/configuration-reference/) for optiona
 
 You must set the `OPENAI_API_KEY` environment variable before running the gateway.
 
-You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE` or `dynamic::ARGUMENT_NAME`.
+You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, or `dynamic::ARGUMENT_NAME`.
 See the [Credential Management](/operations/manage-credentials/) guide and [Configuration Reference](/gateway/configuration-reference/) for more information.
 
 Additionally, see the [OpenAI-Compatible](/integrations/model-providers/openai-compatible/) guide for more information on how to use other OpenAI-Compatible providers.

--- a/docs/integrations/model-providers/openrouter.mdx
+++ b/docs/integrations/model-providers/openrouter.mdx
@@ -81,7 +81,7 @@ See the [list of models available on OpenRouter](https://openrouter.ai/models).
 
 You must set the `OPENROUTER_API_KEY` environment variable before running the gateway.
 
-You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE` or `dynamic::ARGUMENT_NAME`.
+You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, or `dynamic::ARGUMENT_NAME`.
 See the [Credential Management](/operations/manage-credentials/) guide and [Configuration Reference](/gateway/configuration-reference/) for more information.
 
 ### Deployment (Docker Compose)

--- a/docs/integrations/model-providers/tgi.mdx
+++ b/docs/integrations/model-providers/tgi.mdx
@@ -74,7 +74,7 @@ The `api_key_location` field in your model provider configuration specifies how 
   api_key_location = "none"
   ```
 
-- If your endpoint requires an API key, you have two options:
+- If your endpoint requires an API key, you have three options:
   1. Configure it in advance through an environment variable:
 
      ```toml
@@ -83,7 +83,15 @@ The `api_key_location` field in your model provider configuration specifies how 
 
      You'll need to set the environment variable before starting the gateway.
 
-  2. Provide it at inference time:
+  2. Configure it in advance through a file path:
+
+      ```toml
+      api_key_location = "path::/path/to/api_key_file"
+      ```
+
+      The gateway reads the API key from the file at startup.
+
+  3. Provide it at inference time:
      ```toml
      api_key_location = "dynamic::ARGUMENT_NAME"
      ```

--- a/docs/integrations/model-providers/together.mdx
+++ b/docs/integrations/model-providers/together.mdx
@@ -84,7 +84,7 @@ See the [Configuration Reference](/gateway/configuration-reference/) for optiona
 
 You must set the `TOGETHER_API_KEY` environment variable before running the gateway.
 
-You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE` or `dynamic::ARGUMENT_NAME`.
+You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, or `dynamic::ARGUMENT_NAME`.
 See the [Credential Management](/operations/manage-credentials/) guide and [Configuration Reference](/gateway/configuration-reference/) for more information.
 
 ### Deployment (Docker Compose)

--- a/docs/integrations/model-providers/vllm.mdx
+++ b/docs/integrations/model-providers/vllm.mdx
@@ -61,7 +61,7 @@ The `api_key_location` field in your model provider configuration specifies how 
   api_key_location = "none"
   ```
 
-- If your endpoint requires an API key, you have two options:
+- If your endpoint requires an API key, you have three options:
   1. Configure it in advance through an environment variable:
 
      ```toml
@@ -70,7 +70,15 @@ The `api_key_location` field in your model provider configuration specifies how 
 
      You'll need to set the environment variable before starting the gateway.
 
-  2. Provide it at inference time:
+  2. Configure it in advance through a file path:
+
+      ```toml
+      api_key_location = "path::/path/to/api_key_file"
+      ```
+
+      The gateway reads the API key from the file at startup.
+
+  3. Provide it at inference time:
      ```toml
      api_key_location = "dynamic::ARGUMENT_NAME"
      ```

--- a/docs/integrations/model-providers/xai.mdx
+++ b/docs/integrations/model-providers/xai.mdx
@@ -81,7 +81,7 @@ See the [list of models available on xAI](https://docs.x.ai/docs/models).
 
 You must set the `XAI_API_KEY` environment variable before running the gateway.
 
-You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE` or `dynamic::ARGUMENT_NAME`.
+You can customize the credential location by setting the `api_key_location` to `env::YOUR_ENVIRONMENT_VARIABLE`, `path::FILE_PATH`, or `dynamic::ARGUMENT_NAME`.
 See the [Credential Management](/operations/manage-credentials/) guide and [Configuration Reference](/gateway/configuration-reference/) for more information.
 
 ### Deployment (Docker Compose)


### PR DESCRIPTION
## Summary
This PR adds support for configuring model provider api key locations via file path using the `path::` prefix, in addition to existing `env::` and `dynamic::` options.

## What changed
- Updated credential loading in `model_table.rs` to support `path::` for `api_key_location`.
- Updated gateway configuration docs to document `path::` as a supported `api_key_location` source in configuration-reference.mdx.
- Updated provider integration docs to include path:: in credential configuration guidance:
  - anthropic.mdx
  - azure.mdx
  - deepseek.mdx
  - fireworks.mdx
  - google-ai-studio-gemini.mdx
  - groq.mdx
  - hyperbolic.mdx
  - mistral.mdx
  - openai.mdx
  - openrouter.mdx
  - together.mdx
  - tgi.mdx
  - vllm.mdx
  - xai.mdx

## Related discussion
- https://github.com/tensorzero/tensorzero/discussions/7295