### PR TITLE
Split autopilot Failed status into two variants

### DIFF
--- a/crates/autopilot-client/src/types/mod.rs
+++ b/crates/autopilot-client/src/types/mod.rs
@@ -148,6 +148,15 @@ pub enum AutopilotStatus {
     WaitingForAutoEvalExampleLabelingAnswers,
     WaitingForAutoEvalBehaviorSpecAnswers,
     WaitingForRetry,
+    /// The session emitted an error event but the underlying durable task
+    /// has not yet transitioned to a terminal state. The session may still
+    /// recover — the worker often emits follow-up events after a transient
+    /// internal error (e.g. a database connection blip) and resumes work.
+    /// Clients should keep polling; the status will transition either to an
+    /// actionable state on recovery, or to `Failed` if the task ultimately
+    /// dies. Distinct from `Failed` so clients can tell "task is gone" from
+    /// "task errored but is still running."
+    ErroredInProgress,
     Failed,
 }
 

--- a/crates/tensorzero-node/lib/bindings/AutopilotStatus.ts
+++ b/crates/tensorzero-node/lib/bindings/AutopilotStatus.ts
@@ -12,4 +12,5 @@ export type AutopilotStatus =
   | { status: "waiting_for_auto_eval_example_labeling_answers" }
   | { status: "waiting_for_auto_eval_behavior_spec_answers" }
   | { status: "waiting_for_retry" }
+  | { status: "errored_in_progress" }
   | { status: "failed" };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "oxfmt": "^0.35.0",
     "typescript": "^5.9.3"
   },
-  "packageManager": "pnpm@10.15.0",
+  "packageManager": "pnpm@10.33.0",
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild",

--- a/ui/app/components/autopilot/EventStream.tsx
+++ b/ui/app/components/autopilot/EventStream.tsx
@@ -990,6 +990,11 @@ function getStatusLabel(status: AutopilotStatus): {
       return { text: "Waiting for your response", showEllipsis: false };
     case "waiting_for_retry":
       return { text: "Something went wrong. Retrying", showEllipsis: true };
+    case "errored_in_progress":
+      return {
+        text: "Something went wrong. Attempting to recover",
+        showEllipsis: true,
+      };
     case "failed":
       return {
         text: "Something went wrong. Please try again.",


### PR DESCRIPTION
This distinguishes terminal failure from potentially transient failures, which is useful for downstream clients.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new API/status enum variant that downstream clients must handle; missing exhaustiveness could cause runtime/compile issues in consumers until updated.
> 
> **Overview**
> Splits Autopilot’s error handling into two distinct statuses by adding `ErroredInProgress` / `errored_in_progress` to the `AutopilotStatus` wire type, allowing clients to distinguish *recoverable, still-running* failures from terminal `Failed`.
> 
> Updates the generated TS bindings and the UI status label rendering (`EventStream.tsx`) to display a dedicated “attempting to recover” message for this new state, and bumps the repo `pnpm` version in `package.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13306cbb515fecf5aa12fb6dd803f8defd41fff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->